### PR TITLE
fix: add startup probe for ks-controller-manager

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -67,7 +67,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.51"
+CLI_VERSION="0.1.52"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the webhook for `users.iam.kubesphere.io`, embedded in the ks controller-manager takes some time to be up after it's running, and may cause a failure of user creation.

