### PR TITLE
fix: bump k3s to 1.21.5

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -67,7 +67,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.52"
+CLI_VERSION="0.1.53"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/publicRestoreInstaller.sh
+++ b/build/installer/publicRestoreInstaller.sh
@@ -872,7 +872,7 @@ run_install() {
     # env 'KUBE_TYPE' is specific the special kubernetes (k8s or k3s), default k3s
     [[ -z $KUBE_TYPE ]] && KUBE_TYPE="k3s"
     if [ x"$KUBE_TYPE" == x"k3s" ]; then
-        k8s_version=v1.21.4-k3s
+        k8s_version=v1.21.5-k3s
     fi
     create_cmd="./kk create cluster --with-kubernetes $k8s_version --container-manager containerd"  # --with-addon ${ADDON_CONFIG_FILE}
 

--- a/build/manifest/dependencies.amd64
+++ b/build/manifest/dependencies.amd64
@@ -43,7 +43,7 @@ https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd6
 
 https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz,helm/v3.9.0,,helm,helm-v3.9.0
 
-https://github.com/k3s-io/k3s/releases/download/v1.21.4+k3s1/k3s,kube/v1.21.4,,,k3s-v1.21.4
+https://github.com/k3s-io/k3s/releases/download/v1.21.5+k3s1/k3s,kube/v1.21.5,,,k3s-v1.21.5
 
 https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/amd64/kubeadm,kube/v1.22.10,,kubeadm,kubeadm-v1.22.10
 https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/amd64/kubelet,kube/v1.22.10,,kubelet,kubelet-v1.22.10

--- a/build/manifest/dependencies.arm64
+++ b/build/manifest/dependencies.arm64
@@ -43,7 +43,7 @@ https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-arm6
 
 https://get.helm.sh/helm-v3.9.0-linux-arm64.tar.gz,helm/v3.9.0,,helm,helm-v3.9.0
 
-https://github.com/k3s-io/k3s/releases/download/v1.21.4+k3s1/k3s-arm64,kube/v1.21.4,,,k3s-v1.21.4
+https://github.com/k3s-io/k3s/releases/download/v1.21.5+k3s1/k3s-arm64,kube/v1.21.5,,,k3s-v1.21.5
 
 https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/arm64/kubeadm,kube/v1.22.10,,kubeadm,kubeadm-v1.22.10
 https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/arm64/kubelet,kube/v1.22.10,,kubelet,kubelet-v1.22.10

--- a/build/manifest/pkgs
+++ b/build/manifest/pkgs
@@ -4,7 +4,7 @@ containerd-1.6.4.tar.gz,pkg/containerd/1.6.4,https://github.com/containerd/conta
 crictl-v1.24.0-linux-amd64.tar.gz,pkg/crictl/v1.24.0,https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.0/crictl-v1.24.0-linux-amd64.tar.gz,https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.0/crictl-v1.24.0-linux-arm64.tar.gz,crictl
 etcd-v3.4.13.tar.gz,pkg/etcd/v3.4.13,https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz,https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-arm64.tar.gz,etcd
 helm-v3.9.0.tar.gz,pkg/helm/v3.9.0,https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz,https://get.helm.sh/helm-v3.9.0-linux-arm64.tar.gz,helm
-k3s,pkg/kube/v1.21.4,https://github.com/k3s-io/k3s/releases/download/v1.21.4+k3s1/k3s,https://github.com/k3s-io/k3s/releases/download/v1.21.4+k3s1/k3s-arm64,k3s
+k3s,pkg/kube/v1.21.5,https://github.com/k3s-io/k3s/releases/download/v1.21.5+k3s1/k3s,https://github.com/k3s-io/k3s/releases/download/v1.21.5+k3s1/k3s-arm64,k3s
 kubeadm,pkg/kube/v1.22.10,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/amd64/kubeadm,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/arm64/kubeadm,kubeadm
 kubelet,pkg/kube/v1.22.10,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/amd64/kubelet,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/arm64/kubelet,kubelet
 kubectl,pkg/kube/v1.22.10,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/amd64/kubectl,https://storage.googleapis.com/kubernetes-release/release/v1.22.10/bin/linux/arm64/kubectl,kubectl


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
bump k3s version to 1.21.5 to avoid the bugs introduced in runc rc94 and fixed in 1.0, which causes the kubelet failing to start with errors like:

`
"Failed to start ContainerManager" err="failed to initialize top level QOS containers: failed to create top level Burstable QOS cgroup : error while starting unit \"kubepods-burstable.slice\" with properties [{Name:Description Value:\"libcontainer container kubepods-burstable.slice\"} {Name:Wants Value:[\"kubepods.slice\"]} {Name:MemoryAccounting Value:true} {Name:CPUAccounting Value:true} {Name:IOAccounting Value:true} {Name:TasksAccounting Value:true} {Name:DefaultDependencies Value:false}]: Unit kubepods-burstable.slice already exists."
`

see:
- https://github.com/kubernetes/kubernetes/issues/102676
- https://github.com/opencontainers/runc/issues/2996
