### PR TITLE
feat: add env for install.sh to choose between JuiceFS & local fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ go.work
 .dist
 .manifest
 install-wizard-*.tar.gz
+olares-cli-*.tar.gz
 !ks-console-*.tgz
 .vscode

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.68"
+CLI_VERSION="0.1.69"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"
@@ -103,7 +103,7 @@ else
     INSTALL_OLARES_CLI="/usr/local/bin/olares-cli"
     echo "unpacking Olares installer to $INSTALL_OLARES_CLI..."
     echo ""
-    tar -zxf ${CLI_FILE} && chmod +x olares-cli
+    tar -zxf ${CLI_FILE} olares-cli && chmod +x olares-cli
     if [[ x"$os_type" == x"Darwin" ]]; then
         if [ ! -f "/usr/local/Cellar/olares" ]; then
             current_user=$(whoami)
@@ -165,6 +165,9 @@ else
     # env 'REGISTRY_MIRRORS' is a docker image cache mirrors, separated by commas
     if [ x"$REGISTRY_MIRRORS" != x"" ]; then
         extra="--registry-mirrors $REGISTRY_MIRRORS"
+    fi
+    if [[ "$JUICEFS" == "1" ]]; then
+        extra="$extra --with-juicefs=true"
     fi
     $sh_c "olares-cli olares prepare $PARAMS $KUBE_PARAM $extra"
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
JuiceFs is always installed on Linux as a base storage for all Olares workloads.


* **What is the new behavior (if this is a feature change)?**
by default, JuiceFS is not installed and the local fs is used.
a new environment variable `JUICEFS` is added to the `install.sh` script, to let user choose between the local filesystem and JuiceFS as the base storage for Olares workloads.
if set to `1`, the option `--with-juicefs=true` is specified when invoking the `olares-cli olares prepare` command, and JuiceFS, along with its dependencies Redis/MinIO will be installed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
