### PR TITLE
feat: set default nat gateway ip in prompt for mac

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.66"
+CLI_VERSION="0.1.67"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the new behavior (if this is a feature change)?**
Get a valid IP address from the local network interfaces of MacOS, and use it as the default IP of NAT gateway, saves the hassle of typing the IP manually if it is the IP address the user wants.

```
2024-11-28T17:47:32.276+0800	[Module] GetNATGatewayIP
Enter the NAT gateway(the MacOS host)'s IP [default: 192.168.1.5]:
2024-11-28T17:56:31.627+0800	Nat Gateway IP: 192.168.1.5
2024-11-28T17:56:31.632+0800	[A] LocalHost: GetNATGatewayIP success (8m59.36280975s)
```