### PR TITLE
fix: choose nat ip as local domain dns record if present

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.54
+        image: beclab/bfl:v0.3.55
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the local IP address is added as a DNS record for local domain upon user activation, even when a NAT gateway IP address is set.  this will only be corrected some time later by another control loop.


* **What is the new behavior (if this is a feature change)?**
choose the NAT gateway IP address as the DNS record for the local domain during user activation, if one is present.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
none