### PR TITLE
fix: store & compare applied dns record of local domain

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.56
+        image: beclab/bfl:v0.3.57
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
store the currently applied DNS record of local domain, and update the DNS record only when it doesn't match with the desired IP, to avoid unnecessary requests, e.g. when the DNS record hasn't been propagated or the local DNS service is being hijacked.
