### PR TITLE
feat: configure coreDNS to serve record from node /etc/hosts

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.71"
+CLI_VERSION="0.1.72"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/manifest/images
+++ b/build/manifest/images
@@ -11,7 +11,6 @@ calico/node:v3.23.2
 calico/node:v3.27.3
 calico/pod2daemon-flexvol:v3.23.2
 beclab/citus:12.2
-coredns/coredns:1.8.0
 csiplugin/snapshot-controller:v4.0.0
 beclab/ks-installer-ext:v0.1.9-ext
 kubesphere/k8s-dns-node-cache:1.15.12
@@ -54,8 +53,6 @@ quay.io/argoproj/workflow-controller:v3.5.0
 redis:5.0.14-alpine
 beclab/velero:v1.11.3
 beclab/velero-plugin-for-terminus:v1.0.2
-rancher/coredns-coredns:1.8.3
-rancher/mirrored-coredns-coredns:1.9.1
 beclab/l4-bfl-proxy:v0.2.7
 gcr.io/k8s-minikube/storage-provisioner:v5
 owncloudci/wait-for:latest


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
coredns is managed by k3s/kubeadm
nodelocaldns is installed but not used in k3s
nodellocaldns blocks non-cluster DNS request to coredns in k8s
pods in cluster cannot resolve static hostname mapping from /etc/hosts in host machine


* **What is the new behavior (if this is a feature change)?**
manage coredns ourselves
disable nodelocaldns
make coredns read /etc/hosts file from host machine and serve its DNS records to pods in cluster

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
none
