### PR TITLE
fix: pioritize default route ip in all scenarios

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.72"
+CLI_VERSION="0.1.73"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
an IP address of a virtual network card might be chosen as the local IP of Olares, if the local hostname can resolve to it.


* **What is the new behavior (if this is a feature change)?**
prioritize the IP address related to the global default gateway in every local IP pick-up scenarios, rather than as a fallback.
this prevents the case where a local hostname resolves to multiple IPs and the first indexed IP is not what we want.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
none


* **Other information**:
