### PR TITLE
beclab/nvshare: remove cuCtxSynchronize in cuLaunchKernel to compatib…

### DIFF
--- a/build/installer/deploy/device-plugin.yaml
+++ b/build/installer/deploy/device-plugin.yaml
@@ -40,7 +40,7 @@ spec:
         - "[ -d /var/run/nvshare/libnvshare.so ] && rm -rf /var/run/nvshare/libnvshare.so || true"
       containers:
       - name: nvshare-lib
-        image: beclab/nvshare:libnvshare-v0.0.1
+        image: beclab/nvshare:libnvshare-v0.0.2
         command:
         - sleep
         - infinity

--- a/build/manifest/images
+++ b/build/manifest/images
@@ -58,7 +58,7 @@ gcr.io/k8s-minikube/storage-provisioner:v5
 owncloudci/wait-for:latest
 beclab/recommend-argotask:v0.0.12
 nvcr.io/nvidia/k8s-device-plugin:v0.16.1
-beclab/nvshare:libnvshare-v0.0.1
+beclab/nvshare:libnvshare-v0.0.2
 bytetrade/nvshare:nvshare-device-plugin
 bytetrade/nvshare:nvshare-scheduler
 beclab/nats-server-config-reloader:v1


### PR DESCRIPTION

* **Background**
the nvshare will call the api cuCtxSynchronize in cuLaunchKernel, to control the rate of kernel submissing. But it will cause the crash when Cuda stream APIs are used in other threads. 

* **Target Version for Merge**
main, release 1.10

* **Related Issues**
none of them

* **PRs Involving Sub-Systems** 
[fix: remove cuCtxSynchronize in cuLaunchKernel to compatible with cuda stream
](https://github.com/beclab/nvshare/commit/f06b480d18434a239c2a0f2e181edcaf586724c2)

* **Other information**:
