### PR TITLE
installer: upgrade cuda driver to 550

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.71"
+$CLI_VERSION = "0.1.74"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.73"
+CLI_VERSION="0.1.74"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
In order to run the latest Llama model with Ollama, we upgrade CUDA toolkit to 12.4, which is paired with the driver version 550.

* **Target Version for Merge**
1.10.5, 1.11.0

* ***Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/65

* **Other information**:
https://docs.nvidia.com/deploy/cuda-compatibility/#use-the-right-compat-package