### PR TITLE
settings,profile: merge profile server to settings server

### DIFF
--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -201,7 +201,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: profile-editor-init
-          image: beclab/profile-editor:v1.0.5
+          image: beclab/profile-editor:v0.2.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -213,7 +213,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: profile-preview-init
-          image: beclab/profile-preview:v1.0.5
+          image: beclab/profile-preview:v0.2.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -237,7 +237,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: settings-init
-          image: beclab/settings:v0.1.95
+          image: beclab/settings:v0.2.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -337,25 +337,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-        - name: profile-services
-          image: beclab/profile-services:v1.0.4
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 1000
-          ports:
-            - containerPort: 3020
-          env:
-          - name: OS_SYSTEM_SERVER
-            value: system-server.user-system-{{ .Values.bfl.username }}
-          - name: OS_APP_SECRET
-            value: '{{ .Values.os.profile.appSecret }}'
-          - name: OS_APP_KEY
-            value: {{ .Values.os.profile.appKey }}
-          - name: APP_SERVICE_SERVICE_HOST
-            value: app-service.os-system
-          - name: APP_SERVICE_SERVICE_PORT
-            value: '6755'
         - name: terminus-ws-sidecar
           image: 'beclab/ws-gateway:v1.0.3'
           imagePullPolicy: IfNotPresent
@@ -370,7 +351,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: settings-server
-          image: beclab/settings-server:v0.1.95
+          image: beclab/settings-server:v0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -962,7 +943,7 @@ data:
       }
 
       location /api {
-        proxy_pass http://127.0.0.1:3020;
+        proxy_pass http://127.0.0.1:3010;
 
         proxy_set_header            Host $host;
         proxy_set_header            X-real-ip $remote_addr;
@@ -1000,7 +981,7 @@ data:
       }
 
       location /api {
-            proxy_pass http://127.0.0.1:3020;
+            proxy_pass http://127.0.0.1:3010;
 
             proxy_set_header            Host $host;
             proxy_set_header            X-real-ip $remote_addr;


### PR DESCRIPTION
 * **Background**
The settings and profile servers both use NestJS, each requiring 70-90 MB of memory, and there is a lot of duplicate code. This modification merges the code repositories for settings and profile, as well as consolidates the servers for profile and settings.

* **Target Version for Merge**
v1.11.0

* ***Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/settings/releases/tag/v0.2.0

