### PR TITLE
olares: compatible with http 1.0 in image upload api

### DIFF
--- a/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
+++ b/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
@@ -490,6 +490,8 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                   stat_prefix: tapr_http
+                  http_protocol_options:
+                    accept_http_10: true
                   upgrade_configs:
                   - upgrade_type: websocket                  
                   skip_xff_append: false
@@ -662,6 +664,8 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                   stat_prefix: tapr_http
+                  http_protocol_options:
+                    accept_http_10: true
                   upgrade_configs:
                   - upgrade_type: websocket                  
                   skip_xff_append: false

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -757,6 +757,8 @@ data:
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: tapr_http
+                    http_protocol_options:
+                      accept_http_10: true
                     upgrade_configs:
                       - upgrade_type: websocket
                     skip_xff_append: false


### PR DESCRIPTION
* **Background**
Some image upload client uses the HTTP v1.0. To be compatible with these clients, add the option to envoy sidecar config.

* **Target Version for Merge**
main, release-1.10

* ***Related Issues**
Bug: Cannot upload images in profile editor


* **PRs Involving Sub-Systems** 
none

* **Other information**:
