### PR TITLE
installer: when changing ip, only restart pods related to host ip if juicefs disabled

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.74"
+$CLI_VERSION = "0.1.75"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.74"
+CLI_VERSION="0.1.75"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
On systems where JuiceFS is not enabled, there's no need to restart all of the pods after ip changing.
Only the pods whose `.hostNetwork` is set to true or are using node's IP as a env var should be restarted, and this shortens the time the change ip command takes.

* **Target Version for Merge**
1.11.0

* ***Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/66


* **Other information**:
none