### PR TITLE
bfl: reset password not applied and user initializing failed state

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.57
+        image: beclab/bfl:v0.3.59
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
1. In user initializing progress, if the user activates the HTTPS proxy, the initializing state will keep the running state even the progress has already failed.
2. When a user updates the password in Settings, the new password is not actually applied in the data store.

* **Target Version for Merge**
v1.11.0, v1.10.5

* **Related Issues**
Bug: user initializing is running for a long time.
Bug: reset user password not working

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/59
https://github.com/beclab/bfl/pull/60

* **Other information**:
