### PR TITLE
files: fix the bug when copying name with space for src xor dst is sync

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -70,7 +70,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.45'
+              value: 'beclab/files-server:v0.2.46'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -101,7 +101,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.45
+          image: beclab/files-server:v0.2.46
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -348,7 +348,7 @@ spec:
             chown -R 1000:1000 /appdata 
       containers:
         - name: files
-          image: beclab/files-server:v0.2.45
+          image: beclab/files-server:v0.2.46
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -283,7 +283,7 @@ spec:
 #        - /filebrowser
 #        - --noauth
       - name: files-frontend
-        image: beclab/files-frontend:v1.2.69
+        image: beclab/files-frontend:v1.3.2
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -225,7 +225,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: wise-init
-          image: beclab/wise:v1.2.69
+          image: beclab/wise:v1.3.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
+++ b/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
@@ -83,7 +83,7 @@ spec:
             value: os_system_vault
       containers:
       - name: vault-server
-        image: beclab/vault-server:v1.2.69
+        image: beclab/vault-server:v1.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
@@ -114,7 +114,7 @@ spec:
         - name: vault-attach
           mountPath: /padloc/packages/server/attachments
       - name: vault-admin
-        image: beclab/vault-admin:v1.2.69
+        image: beclab/vault-admin:v1.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010

--- a/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
+++ b/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
@@ -72,13 +72,13 @@ spec:
 
       containers:
       - name: vault-frontend
-        image: beclab/vault-frontend:v1.2.69
+        image: beclab/vault-frontend:v1.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       
       - name: notification-server
-        image: beclab/vault-notification:v1.2.69
+        image: beclab/vault-notification:v1.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**
1. When copying between sync and other drives, it fails if there are spaces in the name. This is involved in v0.2.40 which is also dealing with special characters.
2. When copying between sync and other drives recursively, it is newly presented that it fails because the inconsistent permission.
3. When uploading a file in a folder containing spaces, it will cause a path decoding error.

* **Target Version for Merge**
v1.12.0, v1.11.0, v1.10.5

* **Related Issues**

* **PRs Involving Sub-Systems** 
https://github.com/beclab/files/releases/tag/v0.2.46
https://github.com/beclab/TermiPass/releases/tag/v1.3.2

* **Other information**:
