### PR TITLE
olares: revert nvshare to v0.0.1

### DIFF
--- a/build/installer/deploy/device-plugin.yaml
+++ b/build/installer/deploy/device-plugin.yaml
@@ -40,7 +40,7 @@ spec:
         - "[ -d /var/run/nvshare/libnvshare.so ] && rm -rf /var/run/nvshare/libnvshare.so || true"
       containers:
       - name: nvshare-lib
-        image: beclab/nvshare:libnvshare-v0.0.2
+        image: beclab/nvshare:libnvshare-v0.0.1
         command:
         - sleep
         - infinity

--- a/build/manifest/images
+++ b/build/manifest/images
@@ -58,7 +58,7 @@ gcr.io/k8s-minikube/storage-provisioner:v5
 owncloudci/wait-for:latest
 beclab/recommend-argotask:v0.0.12
 nvcr.io/nvidia/k8s-device-plugin:v0.16.1
-beclab/nvshare:libnvshare-v0.0.2
+beclab/nvshare:libnvshare-v0.0.1
 bytetrade/nvshare:nvshare-device-plugin
 bytetrade/nvshare:nvshare-scheduler
 beclab/nats-server-config-reloader:v1


### PR DESCRIPTION
* **Background**
In the new version ollama, we can disable  cuda graph by setting the environment variable GGML_CUDA_DISABLE_GRAPHS=1.  
So, remove the function cuCtxSynchronize is unnecessary.


* **Target Version for Merge**
v1.12.0 v1.11.0 v1.10.5

* ***Related Issues**
https://github.com/beclab/Olares/pull/721

* **PRs Involving Sub-Systems** 
none

* **Other information**:
