### PR TITLE
market, app-service: support old version install app

### DIFF
--- a/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
+++ b/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
@@ -85,12 +85,12 @@ spec:
                 fieldPath: status.podIP
       containers:
       - name: appstore
-        image: beclab/market-frontend:v0.2.30
+        image: beclab/market-frontend:v0.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       - name: appstore-backend
-        image: beclab/market-backend:v0.2.30
+        image: beclab/market-backend:v0.3.0
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.58
+        image: beclab/app-service:0.2.59
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
The current market only supports obtaining and installing the latest version of the app. When the app is upgraded alongside the system's core components, there may be compatibility issues with older versions of the system. Additionally, older systems may be unable to upgrade due to technical reasons or user preferences, leading to situations where these users can no longer use the app.

* **Target Version for Merge**
v1.11.0 & v1.12.0 

* **PRs Involving Sub-Systems** 
https://github.com/beclab/market/commit/8b9dd1534c0717ee72d0a17268ce346cd9751c35
https://github.com/beclab/app-service/pull/115
