### PR TITLE
oalres: uninstall settings app in upgrade

### DIFF
--- a/build/installer/upgrade_cmd.sh
+++ b/build/installer/upgrade_cmd.sh
@@ -507,6 +507,12 @@ function upgrade_terminus(){
         gen_app_values ${user}
         close_apps ${user}
 
+        # uninstall settings app
+        local settings_app=$($sh_c "${KUBECTL} get deploy settings-deployment -n user-space-${user} -o jsonpath='{.metadata.name}'")
+        if [[ x"$settings_app" != x"" ]]; then
+            $sh_c "${HELM} uninstall settings -n user-space-${user}"
+        fi
+
         for appdir in "${BASE_DIR}/wizard/config/apps"/*/; do
           if [ -d "$appdir" ]; then
             releasename=$(basename "$appdir")


### PR DESCRIPTION
* **Background**
Since settings app is merged into system-frontend. System upgrade must uninstall the legacy settings app first.

* **Target Version for Merge**
v1.10.5

* ***Related Issues**
Bug: v1.10.5 upgrade failed.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
