### PR TITLE
installer: detect public ip during installation

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.76"
+$CLI_VERSION = "0.1.77"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.76"
+CLI_VERSION="0.1.77"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
detect public IP when installing Olares by:
1. check whether the machine has a local network interface to which a public IP is bound
2. if the machine is an AWS EC2 instance, check whether it has an associated public IP address by contacting the IMDS service
if a public IP is detected, the `selfhosted` setting is turned off when installing related components, and then reverse-proxy or tunnel is disabled automatically in activation.

* **Target Version for Merge**
v1.11.0 v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/68


* **Other information**:
none