### PR TITLE
knowledge and download: support LarePass donload and fix bilibili extract bug

### DIFF
--- a/apps/download/config/user/helm-charts/download/templates/download_deploy.yaml
+++ b/apps/download/config/user/helm-charts/download/templates/download_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: user_space_{{ .Values.bfl.username }}_knowledge
       containers:
       - name: aria2
-        image: "beclab/aria2:v0.0.3"
+        image: "beclab/aria2:v0.0.4"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false
@@ -172,7 +172,7 @@ spec:
             cpu: "1"
             memory: 300Mi
       - name: yt-dlp
-        image: "beclab/yt-dlp:v0.0.16"
+        image: "beclab/yt-dlp:v0.0.17"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -220,7 +220,7 @@ spec:
             cpu: "1"
             memory: 300Mi
       - name: download-spider
-        image: "beclab/download-spider:v0.0.15"
+        image: "beclab/download-spider:v0.0.16"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/apps/knowledge/config/user/helm-charts/knowledge/templates/knowledge_deployment.yaml
+++ b/apps/knowledge/config/user/helm-charts/knowledge/templates/knowledge_deployment.yaml
@@ -168,7 +168,7 @@ spec:
             value: user_space_{{ .Values.bfl.username }}_knowledge
       containers:
       - name: knowledge
-        image: "beclab/knowledge-base-api:v0.1.56"
+        image: "beclab/knowledge-base-api:v0.1.57"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -236,7 +236,7 @@ spec:
             memory: 1Gi
 
       - name: backend-server
-        image: "beclab/recommend-backend:v0.0.24"
+        image: "beclab/recommend-backend:v0.0.25"
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/apps/rss/config/cluster/deploy/rss_deploy.yaml
+++ b/apps/rss/config/cluster/deploy/rss_deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: rss-server
-          image: beclab/rsshub-server:v0.0.2
+          image: beclab/rsshub-server:v0.0.3
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 1200


### PR DESCRIPTION
Background
support LarePass download
support some bilibili subscriptions and their content parsing
reduce the size of the rsshub image

Target Version for Merge
v1.11

Related Issues
https://project.feishu.cn/terminus/issue/detail/5105792969
https://project.feishu.cn/terminus/issue/detail/4976580565
https://project.feishu.cn/terminus/issue/detail/5051040496

PRs Involving Sub-Systems
https://github.com/beclab/recommend-system-module/pull/74
https://github.com/beclab/recommend-system-module/pull/72

Other information:
None