### PR TITLE
fix(installer): add precheck for conflicting containerd and ports

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -68,22 +68,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Install coscmd
-        run: pip install coscmd        
-
-      - name: Configure coscmd
-        env:
-          TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
-          TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
-          COS_BUCKET: ${{ secrets.COS_BUCKET }}
-          COS_REGION: ${{ secrets.COS_REGION }}
-          END_POINT: ${{ secrets.END_POINT }}
-        run: |
-          coscmd config -a $TENCENT_SECRET_ID \
-                        -s $TENCENT_SECRET_KEY \
-                        -b $COS_BUCKET \
-                        -r $COS_REGION 
-
       # test
       - env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -103,22 +87,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Install coscmd
-        run: pip install coscmd        
-
-      - name: Configure coscmd
-        env:
-          TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
-          TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
-          COS_BUCKET: ${{ secrets.COS_BUCKET }}
-          COS_REGION: ${{ secrets.COS_REGION }}
-          END_POINT: ${{ secrets.END_POINT }}
-        run: |
-          export PATH=$PATH:/usr/local/bin:/home/ubuntu/.local/bin
-          coscmd config -m 10 -p 10 -a $TENCENT_SECRET_ID \
-                        -s $TENCENT_SECRET_KEY \
-                        -b $COS_BUCKET \
-                        -r $COS_REGION 
 
       - env: 
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -139,22 +107,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Install coscmd
-        run: pip install coscmd        
-
-      - name: Configure coscmd
-        env:
-          TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
-          TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
-          COS_BUCKET: ${{ secrets.COS_BUCKET }}
-          COS_REGION: ${{ secrets.COS_REGION }}
-          END_POINT: ${{ secrets.END_POINT }}
-        run: |
-          coscmd config -a $TENCENT_SECRET_ID \
-                        -s $TENCENT_SECRET_KEY \
-                        -b $COS_BUCKET \
-                        -r $COS_REGION 
 
       # test
       - env:
@@ -177,20 +129,6 @@ jobs:
 
       - name: Install coscmd
         run: pip install coscmd        
-
-      - name: Configure coscmd
-        env:
-          TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
-          TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
-          COS_BUCKET: ${{ secrets.COS_BUCKET }}
-          COS_REGION: ${{ secrets.COS_REGION }}
-          END_POINT: ${{ secrets.END_POINT }}
-        run: |
-          export PATH=$PATH:/usr/local/bin:/home/ubuntu/.local/bin
-          coscmd config -m 10 -p 10 -a $TENCENT_SECRET_ID \
-                        -s $TENCENT_SECRET_KEY \
-                        -b $COS_BUCKET \
-                        -r $COS_REGION 
 
       # test
       - env:

--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.77"
+$CLI_VERSION = "0.1.78"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.77"
+CLI_VERSION="0.1.78"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
If a containerd instance not managed by us is already installed on a system, conflicts may be encountered. A precheck before preparing is added to error out in this case.
Some ports in host machine network is required to expose service, if they're occupied, related pods cannot bind the ports and will fail to start. A prechck is also added to test whether these ports are able to bind and will error out if not.

* **Target Version for Merge**
v1.11.0, v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/75


* **Other information**:
none