### PR TITLE
ci: use stable runner ubuntu-22.04 rather than latest

### DIFF
--- a/.github/workflows/push-deps-to-s3.yml
+++ b/.github/workflows/push-deps-to-s3.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: "Checkout source code"

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: "Checkout source code"

--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   push-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 'Checkout source code'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 'Checkout source code'


### PR DESCRIPTION
* **Background**
The runner `ubuntu-latest` is updated from `ubuntu-22.04` to `ubuntu-24.04`, on which some jobs will fail to run.
In our case, the `configure coscmd` job called `coscmd` that's incompatible with the Python 3.12 shipped with Ubuntu 24.04.

* **Target Version for Merge**
main

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none


* **Other information**:
none