### PR TITLE
olares: add init container for nats to generate nats.conf

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/nats_deployment.yaml
+++ b/frameworks/tapr/config/cluster/deploy/nats_deployment.yaml
@@ -247,6 +247,24 @@ spec:
         app.kubernetes.io/name: nats
         app.kubernetes.io/instance: nats
     spec:
+      initContainers:
+        - name: generate-config
+          image: busybox:1.28
+          command:
+            - sh
+            - -c
+            - |
+              if [ ! -f /data/config/nats.conf ]; then
+                cat /etc/nats-config/nats.conf > /data/config/nats.conf
+              else
+                echo "nats config file already exists"
+              fi
+          volumeMounts:
+            - mountPath: /etc/nats-config
+              name: config
+              readOnly: false
+            - mountPath: /data
+              name: nats-data
       containers:
         - args:
             - --config


### PR DESCRIPTION
* **Background**
nats server may restart if nats.conf not exists.

* **Target Version for Merge**
1.10,1.11,1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Olares/pull/773


* **Other information**:
None