### PR TITLE
app-service: set gpu values

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.60
+        image: beclab/app-service:0.2.61
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- AI applications may start using either GPU or CPU
- AI applications may only support GPU startup
- Different versions of AI applications have different requirements for the runtime environment (CUDA)
* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/118


* **Other information**:
None