### PR TITLE
olares: fix redis password lost

### DIFF
--- a/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
+++ b/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
@@ -1,5 +1,4 @@
-{{- $namespace := printf "%s%s" "user-system-" .Values.bfl.username -}}
-{{- $market_secret := (lookup "v1" "Secret" $namespace "market-secrets") -}}
+{{- $market_secret := (lookup "v1" "Secret" .Release.Namespace "market-secrets") -}}
 
 {{- $redis_password := "" -}}
 {{ if $market_secret -}}


### PR DESCRIPTION

* **Background**
In the previous update, we changed the local database to Redis. To handle the situation of upgrading the market, the configuration for the Redis password involves first checking for an existing password. If none is found, a new random password will be generated. However, the location where the password is checked in the configuration is incorrect, which prevents the market from connecting to Redis after the upgrade.

* **Target Version for Merge**
v1.11.0 & v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none


