### PR TITLE
feat(installer): support setting registry mirrors for minikube

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.80"
+CLI_VERSION="0.1.81"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
the image-service needs to load the registry mirrors set in `/etc/containerd/config.toml` in order to pull image, the container runtime of MiniKube needs to be changed from Docker to Containerd, and registry mirrors should be injected into the inner containerd environment.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/83


* **Other information**:
none