### PR TITLE
fix(installer): reset config path of cri plugin in minikube

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.83"
+$CLI_VERSION = "0.1.84"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.83"
+CLI_VERSION="0.1.84"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
If the `config_path` is set in the `[plugins."io.containerd.grpc.v1.cri".registry]` section in containerd config, the `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]` will take no effect, so the `config_path` should be reset if we need to inject mirrors to the containerd config in MiniKube.

* **Target Version for Merge**
v1.110 v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/86


* **Other information**:
none