### PR TITLE
app-serivce: fix patch deploy/sts cause pod restart

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.60
+        image: beclab/app-service:0.2.62
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
after patch deploy  pod template would cause generate 2 replicaset and cause pod restart

* **Target Version for Merge**
1.11
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/119

* **Other information**:
None