### PR TITLE
feat(installer): add a separate command for all prechecks

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -19,7 +19,7 @@ if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.84"
+$CLI_VERSION = "0.1.86"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
 $CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.85"
+CLI_VERSION="0.1.86"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"
@@ -144,6 +144,12 @@ else
             fi
         fi
     else
+        echo "running system prechecks ..."
+        echo ""
+        $sh_c "$INSTALL_OLARES_CLI olares precheck $PARAMS"
+        if [[ $? -ne 0 ]]; then
+            exit 1
+        fi
         echo "downloading installation wizard..."
         echo ""
         $sh_c "$INSTALL_OLARES_CLI olares download wizard $PARAMS $KUBE_PARAM $CDN"


### PR DESCRIPTION
* **Background**
a separate `precheck` command which is responsible for running system checks and printing out all unsatisfied requirements is added and executed before other phases.

* **Target Version for Merge**
v1.12.0 v1.11.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/88


* **Other information**:
none