### PR TITLE
cherry pick of #789: feat(installer): seperate phase & command for storage installation

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -28,16 +28,16 @@ fi
 os_type=$(uname -s)
 os_arch=$(uname -m)
 
-case "$os_arch" in 
-    arm64) ARCH=arm64; ;; 
-    x86_64) ARCH=amd64; ;; 
-    armv7l) ARCH=arm; ;; 
-    aarch64) ARCH=arm64; ;; 
-    ppc64le) ARCH=ppc64le; ;; 
-    s390x) ARCH=s390x; ;; 
+case "$os_arch" in
+    arm64) ARCH=arm64; ;;
+    x86_64) ARCH=amd64; ;;
+    armv7l) ARCH=arm; ;;
+    aarch64) ARCH=arm64; ;;
+    ppc64le) ARCH=ppc64le; ;;
+    s390x) ARCH=s390x; ;;
     *) echo "error: unsupported arch \"$os_arch\"";
     exit 1; ;;
-esac 
+esac
 
 # set shell execute command
 user="$(id -un 2>/dev/null || true)"
@@ -167,9 +167,6 @@ else
     if [ x"$REGISTRY_MIRRORS" != x"" ]; then
         extra="--registry-mirrors $REGISTRY_MIRRORS"
     fi
-    if [[ "$JUICEFS" == "1" ]]; then
-        extra="$extra --with-juicefs=true"
-    fi
     $sh_c "$INSTALL_OLARES_CLI olares prepare $PARAMS $KUBE_PARAM $extra"
     if [[ $? -ne 0 ]]; then
         echo "error: failed to prepare installation environment"
@@ -186,9 +183,24 @@ if [ "$PREINSTALL" == "1" ]; then
     echo "Pre Install mode is specified by the \"PREINSTALL\" env var, skip installing"
     exit 0
 fi
+
+if [[ "$JUICEFS" == "1" ]]; then
+    echo "JuiceFS is enabled"
+    fsflag="--with-juicefs=true"
+    if [[ "$STORAGE" == "" ]]; then
+        echo "installing MinIO ..."
+    else
+        echo "checking storage config ..."
+    fi
+    $sh_c "$INSTALL_OLARES_CLI olares install storage $PARAMS"
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
+fi
+
 echo "installing Olares..."
 echo ""
-$sh_c "$INSTALL_OLARES_CLI olares install $PARAMS $KUBE_PARAM"
+$sh_c "$INSTALL_OLARES_CLI olares install $PARAMS $KUBE_PARAM $fsflag"
 
 if [[ $? -ne 0 ]]; then
     echo "error: failed to install Olares"


### PR DESCRIPTION
* **Background**
cherry pick of https://github.com/beclab/Olares/pull/789: extract installation/validation of object storage service out of `prepare` into a separate `install storage` phase, and move FS-related tasks to the `install` phase, a corresponding `storage` phase for uninstallation is also added.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/85


* **Other information**:
none