### PR TITLE
app-service: fix app suspend in os-system;image download bug

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.62
+        image: beclab/app-service:0.2.63
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -360,7 +360,7 @@ spec:
       hostNetwork: true
       containers:
         - name: image-service
-          image: beclab/image-service:0.2.51
+          image: beclab/image-service:0.2.63
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
* **Background**
- suspend app in os-system caused other deploy scaled to zero
- the progress of the image download may stall at a certain value
- the image may be considered downloaded even though it is not fully downloaded



* **Target Version for Merge**
1.11

* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/120
https://github.com/beclab/app-service/pull/121

* **Other information**:
None