### PR TITLE
feat(headscale): move acl.json to configmap

### DIFF
--- a/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -68,7 +68,7 @@ spec:
         - |
           chown -R 1000:1000 /headscale 
       - name: init
-        image: beclab/headscale-init:v0.1.7
+        image: beclab/headscale-init:v0.1.8
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -36,8 +36,6 @@ spec:
   selector:
     matchLabels:
       app: headscale
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:

--- a/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -291,3 +291,26 @@ spec:
   version: v1
 status:
   state: active
+
+---
+
+apiVersion: v1
+data:
+  acl.json: |
+    {
+      "acls":[
+        { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:443"] }
+      ],
+      "autoApprovers": {
+        "routes": {
+          "10.0.0.0/8": ["default"],
+          "172.16.0.0/12": ["default"],
+          "192.168.0.0/16": ["default"]
+        },
+        "exitNode": []
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: tailscale-acl
+  namespace: user-space-{{ .Values.bfl.username }}

--- a/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -109,6 +109,9 @@ spec:
           mountPath: /etc/headscale
         - name: headscale-data
           mountPath: /var/lib/headscale
+        - name: acl-config
+          mountPath: /etc/headscale/acl
+          readOnly: true
         ports:
         - containerPort: 8080
       - args:
@@ -141,6 +144,13 @@ spec:
         hostPath:
           type: DirectoryOrCreate
           path: {{ .Values.userspace.appCache  }}/headscale
+      - name: acl-config
+        configMap:
+          defaultMode: 420
+          items:
+          - key: acl.json
+            path: acl.json
+          name: tailscale-acl
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Title: headscale :  acl 
When users or applications want to control the opening permissions of the tailscale port, they can set it by dynamically controlling the headscale acl rules through k8s crd

* **Background**
Headscale sets up an ACL rule to restrict access to port 443. This cannot meet the needs in the following two scenarios
1. Users want to access the host for debugging through ssh via VPN
2. Users want to stream Steam through VPN
So, we hope that the system can set rules for ACL

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
