### PR TITLE
feat(installer): add firewall settings for Windows

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.86"
+CLI_VERSION="0.1.87"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
To install the version of Olares for WSL, firewall rules need to be set. During the installation process, users will be prompted to add the rules, but they can skip this step and set the firewall rules themselves.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.0 v1.11.1

* **Related Issues**
<!-- Reference any related issues here, if applicable -->
none

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Installer/pull/89


* **Other information**:
none
