### PR TITLE
fix(installer): install olares-cli.exe to the Windows global path

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -1,6 +1,10 @@
+$env:WSL_UTF8 = 1
+$OutputEncoding = [System.Text.Encoding]::UTF8
 $currentPath = Get-Location
 $architecture = $env:PROCESSOR_ARCHITECTURE
+$downloadCdnUrlFromEnv = $env:DOWNLOAD_CDN_URL
 $version = "#__VERSION__"
+$downloadUrl = "https://dc3p1870nn3cj.cloudfront.net"
 
 function Test-Wait {
   while ($true) {
@@ -14,36 +18,60 @@ if ($process) {
   Test-Wait
 }
 
+$distro = wsl --list | Select-String -Pattern "^Ubuntu$"
+if (-not $distro -eq "") {
+  Write-Host "Distro Olares exists, please unregister it first."
+  exit 1
+}
+
 $arch = "amd64"
 if ($architecture -like "ARM") {
   $arch = "arm64"
 }
 
-$CLI_VERSION = "0.1.86"
+if (-Not $downloadCdnUrlFromEnv -eq "") {
+  $downloadUrl = $downloadCdnUrlFromEnv
+}
+
+$CLI_PROGRAM_PATH = "{0}\AppData\Local\Microsoft\WindowsApps\" -f $currentPath
+if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
+  New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
+}
+
+$CLI_VERSION = "0.1.87"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
-$CLI_URL = "https://dc3p1870nn3cj.cloudfront.net/{0}" -f $CLI_FILE
-$CLI_PATH = "{0}\{1}"  -f $currentPath, $CLI_FILE
-if (-Not (Test-Path $CLI_FILE)) {
+$CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
+$CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE
+
+$download = 0
+if (Test-Path $CLI_PATH) {
+  tar -xzf $CLI_PATH -C $CLI_PROGRAM_PATH *> $null
+  if (-Not ($LASTEXITCODE -eq 0)) {
+    Remove-Item -Path $CLI_PATH
+    $download = 1
+  }
+} else {
+  $download = 1
+}
+
+if ($download -eq 1) {
   curl -Uri $CLI_URL -OutFile $CLI_PATH
+  Write-Host "Downloading olares-cli.exe..."
+  if (-Not (Test-Path $CLI_PATH)) {
+    Write-Host "Download olares-cli.exe failed."
+    exit 1
+  }
+  tar -xzf $CLI_PATH -C $CLI_PROGRAM_PATH *> $null
+  $cliPath = "{0}\olares-cli.exe" -f $CLI_PROGRAM_PATH
+  if ( -Not (Test-Path $cliPath)) {
+    Write-Host "olares-cli.exe not found."
+    exit 1
+  }
 }
-
-if (-Not (Test-Path $CLI_PATH)) {
-  Write-Host "Download olares-cli.exe failed."
-  exit 1
-}
-
-tar -xf $CLI_PATH
-$cliPath = "{0}\olares-cli.exe" -f $currentPath
-if ( -Not (Test-Path $cliPath)) {
-  Write-Host "olares-cli.exe not found."
-  exit 1
-}
-
-wsl --unregister Ubuntu *> $null
 
 Start-Sleep -Seconds 3
 Write-Host ("Preparing to start the installation of Olares {0}. Depending on your network conditions, this process may take several minutes." -f $version)
 
-$command = "{0} olares install --version {1}" -f $cliPath, $version
+$command = "{0}\olares-cli.exe olares install --version {1}" -f $CLI_PROGRAM_PATH, $version
 Start-Process cmd -ArgumentList '/k',$command -Wait -Verb RunAs
 


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
To uninstall Olares using olares-cli.exe on Windows, if olares-cli.exe is not installed in the global path, executing olares-cli.exe in any new Terminal or PowerShell will prompt that the program cannot be found.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.0 v1.11.1

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
none

* **Other information**:
none
