### PR TITLE
fix(installer): properly check cuda driver & gpu plugin

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -38,7 +38,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.89"
+$CLI_VERSION = "0.1.90"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.89"
+CLI_VERSION="0.1.90"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
GPU-related pods will not be created if the system has not enabled GPU, thus their Running status need not to be checked
handle the case where `nvidia-smi` tool is installed but CUDA is not
restart GPU plugins properly

* **Target Version for Merge**
v1.11.1 v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/95
https://github.com/beclab/Installer/pull/96

* **Other information**:
* none
