### PR TITLE
fix(installer): multiple GPU-related bugs

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -50,7 +50,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.92"
+$CLI_VERSION = "0.1.94"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.92"
+CLI_VERSION="0.1.94"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
nil pointer dereference panic when labelling GPU node
correct daemonset name when restarting Nvidia plugin pod
also disable GPU when uninstalling CUDA
more appropriate error message when CUDA version is too low
correct wrong basedir path when installing container-toolkit in WSL
support newer CUDA version with a warning message


* **Target Version for Merge**
v1.11.1 v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/100
https://github.com/beclab/Installer/pull/101
https://github.com/beclab/Installer/pull/103
https://github.com/beclab/Installer/pull/104
https://github.com/beclab/Installer/pull/105
https://github.com/beclab/Installer/pull/106

* **Other information**:
none