### PR TITLE
image-service: fix remove custom mirror connection check;only proxy docker.io

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -360,7 +360,7 @@ spec:
       hostNetwork: true
       containers:
         - name: image-service
-          image: beclab/image-service:0.2.63
+          image: beclab/image-service:0.2.66
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
* **Background**
- only replace image ref with custom mirror only if registry is docker.io
- turn off custom mirror connection check

* **Target Version for Merge**
1.11

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/124


* **Other information**:
None