### PR TITLE
auth: redirect to login portal following the request of local domain

### DIFF
--- a/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
@@ -337,7 +337,7 @@ spec:
 
       containers:      
       - name: authelia
-        image: beclab/auth:0.1.41
+        image: beclab/auth:0.1.42
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
If the non-auth request is a local domain, it should be redirected to the login portal following the request of the local domain

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Redirect the non-auth request of the local domain to the public domain login portal.

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/44c21a3091beed557eba892af5bd7a914c368844

* **Other information**:
