### PR TITLE
feat(installer): check the validity of resolv.conf before installation

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -50,7 +50,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.99"
+$CLI_VERSION = "0.1.100"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.99"
+CLI_VERSION="0.1.100"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
this is a cherry-pick of https://github.com/beclab/Olares/pull/851
A search domain other than the `"."` in the Linux's DNS resolver configuration causes the cluster DNS to malfunction, a check for this case is added to the precheck list to avoid a late failure.
Some native libs on Debian may conflict with an arbitrary version of Nvidia driver, the hard coded version should be removed to let the package manager decide what's the appropriate version to install.

* **Target Version for Merge**
v1.11.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/114
https://github.com/beclab/Installer/pull/113

* **Other information**:
none