### PR TITLE
app-service: delete cache dir when cancel installation;set nvshare env

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.67
+        image: beclab/app-service:0.2.68
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- delete cache dir when cancel app installation
- inject env NVSHARE_MANAGED_MEMORY when install app that need gpu

* **Target Version for Merge**
1.12
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/127
https://github.com/beclab/app-service/pull/128

* **Other information**:
None