### PR TITLE
fix(installer): fix multiple network-related bugs

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -50,7 +50,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.101"
+$CLI_VERSION = "0.1.102"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.101"
+CLI_VERSION="0.1.102"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
this is a cherry-pick of https://github.com/beclab/Olares/pull/859
the fetch of WSL IP from Windows host is sometimes messed up by other warning messages
the Windows host's IP is not shown as a default value when executing change-ip command
the url to check whether the machine's DNS server is working normally cannot be reached by CN users
add an option to specify mirrors when installing the Nvidia container toolkit

* **Target Version for Merge**
v1.11.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/119
https://github.com/beclab/Installer/pull/120
https://github.com/beclab/Installer/pull/117
https://github.com/beclab/Installer/pull/116
https://github.com/beclab/Installer/pull/118


* **Other information**:
none