### PR TITLE
fix(headscale): use postgres instead of sqlite for headscale rollingupdate

### DIFF
--- a/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/third-party/headscale/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -1,4 +1,42 @@
+{{- $namespace := printf "%s%s" "user-system-" .Values.bfl.username -}}
+{{- $headscale_secret := (lookup "v1" "Secret" $namespace "headscale-secrets") -}}
 
+{{- $pg_password := "" -}}
+{{ if $headscale_secret -}}
+{{ $pg_password = (index $headscale_secret "data" "pg_password") }}
+{{ else -}}
+{{ $pg_password = randAlphaNum 16 | b64enc }}
+{{- end -}}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: headscale-secrets
+  namespace: user-system-{{ .Values.bfl.username }}
+type: Opaque
+data:
+  pg_password: {{ $pg_password }}
+
+---
+apiVersion: apr.bytetrade.io/v1alpha1
+kind: MiddlewareRequest
+metadata:
+  name: headscale-pg
+  namespace: user-system-{{ .Values.bfl.username }}
+spec:
+  app: headscale
+  appNamespace: {{ .Release.Namespace }}
+  middleware: postgres
+  postgreSQL:
+    user: headscale_{{ .Values.bfl.username }}
+    password:
+      valueFrom:
+        secretKeyRef:
+          key: pg_password
+          name: headscale-secrets
+    databases:
+    - name: headscale
 
 ---
 apiVersion: v1
@@ -66,7 +104,7 @@ spec:
         - |
           chown -R 1000:1000 /headscale 
       - name: init
-        image: beclab/headscale-init:v0.1.8
+        image: beclab/headscale-init:v0.1.9
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -77,9 +115,39 @@ spec:
         {{- end }}
         - name: NAMESPACE
           value: bfl.user-space-{{ .Values.bfl.username }}
+        - name: PG_HOST
+          value: citus-master-svc.user-system-{{ .Values.bfl.username }}
+        - name: PG_PORT
+          value: "5432"
+        - name: PG_USER
+          value: headscale_{{ .Values.bfl.username }}
+        - name: PG_PASS
+          value: "{{ $pg_password | b64dec }}"
+        - name: PG_DB
+          value: user_space_{{ .Values.bfl.username }}_headscale
         volumeMounts:
         - name: config
           mountPath: /etc/headscale
+      - name: wait-for-postgres
+        image: postgres:16.0-alpine3.18
+        command:
+          - sh
+          - '-c'
+          - >-
+            echo -e "Checking for the availability of PostgreSQL Server deployment"; until psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDB
+            -c "SELECT 1"; do sleep 1; printf "-"; done; echo -e " >> PostgreSQL DB Server has started";
+        env:
+        - name: PGHOST
+          value: citus-master-svc.user-system-{{ .Values.bfl.username }}
+        - name: PGPORT
+          value: "5432"
+        - name: PGUSER
+          value: headscale_{{ .Values.bfl.username }}
+        - name: PGPASSWORD
+          value: "{{ $pg_password | b64dec }}"
+        - name: PGDB
+          value: user_space_{{ .Values.bfl.username }}_headscale
+        imagePullPolicy: IfNotPresent
       containers:
       - name: headscale
         image: headscale/headscale:0.22.3


### PR DESCRIPTION
Title: headscale:  db
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
When performing rolling update for headscale deployment, there is data conflict in SQLite.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
