### PR TITLE
fix(installer): dont wipe juicefs when uninstalling worker

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -50,7 +50,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.2.0"
+$CLI_VERSION = "0.2.1"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.2.0"
+CLI_VERSION="0.2.1"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/joincluster.sh
+++ b/build/installer/joincluster.sh
@@ -157,7 +157,7 @@ fi
 
 set_master_host_ssh_options
 
-CLI_VERSION="0.2.0"
+CLI_VERSION="0.2.1"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$CLI_VERSION" ]]; then


### PR DESCRIPTION
* **Background**
the current uninstallation process wipes out the JuiceFS rootfs, which is fine in a single-node environment but causes trouble in a multi-node environment because all nodes share a same view of the JuiceFS. When uninstalling worker node, the JuiceFS rootfs should be left untouched

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/124

* **Other information**:
none