### PR TITLE
bfl: fix headscale acl api path parameters

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.61
+        image: beclab/bfl:v0.3.62
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
`bfl` Headscale ACL API path parameters are mismatch

* **Target Version for Merge**
v1.12.0

* **Related Issues**
bfl headscale acl API not work

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/64

* **Other information**:
