### PR TITLE
olares,bfl: update critical pods priority class

### DIFF
--- a/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
+++ b/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
@@ -23,6 +23,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - args:
         - -it

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -137,6 +137,7 @@ spec:
         app: system-frontend
         io.bytetrade.app: "true"
     spec:
+      priorityClassName: "system-cluster-critical"
       initContainers:
         - args:
             - -it

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -146,6 +146,7 @@ spec:
     spec:
       serviceAccountName: os-internal
       serviceAccount: os-internal
+      priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
         image: beclab/app-service:0.2.63

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -215,6 +215,7 @@ spec:
             weight: 10
 {{ end }}            
       serviceAccountName: bytetrade-controller
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - name: init-userspace
         image: busybox:1.28
@@ -242,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.59
+        image: beclab/bfl:v0.3.63
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/frameworks/system-server/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
+++ b/frameworks/system-server/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
       serviceAccountName: bytetrade-sys-ops
       serviceAccount: bytetrade-sys-ops
+      priorityClassName: "system-cluster-critical"
       containers:
       - name: system-server
         image: beclab/system-server:0.1.19

--- a/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
@@ -306,6 +306,7 @@ spec:
     spec:
       serviceAccountName: os-internal
       serviceAccount: os-internal
+      priorityClassName: "system-cluster-critical"      
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'
@@ -423,6 +424,7 @@ spec:
       labels:
         app: redis
     spec:
+      priorityClassName: "system-cluster-critical"
       containers:
       - name: redis
         image: redis:6.2.13-alpine3.18

--- a/third-party/infisical/config/user/helm-charts/infisical/templates/infisical_deploy.yaml
+++ b/third-party/infisical/config/user/helm-charts/infisical/templates/infisical_deploy.yaml
@@ -192,6 +192,7 @@ spec:
         io.bytetrade.app: "true"
     spec:
       serviceAccountName: infisical-sa
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'


### PR DESCRIPTION
* **Background**
To avoid evicting some critical pods by k8s / k3s, mark these pods as `system-cluster-critical`

* **Target Version for Merge**
v1.11.3

* **Related Issues**
Some critical pods were evicted when the server had some resource pressure, causing the cluster not working  properly

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/65

* **Other information**:
