### PR TITLE
bfl, app-services, market, settings: add ACL rules for Headscale, display UDP ports, and show dependency warnings

### DIFF
--- a/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
+++ b/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
@@ -84,12 +84,12 @@ spec:
                 fieldPath: status.podIP
       containers:
       - name: appstore
-        image: beclab/market-frontend:v0.3.2
+        image: beclab/market-frontend:v0.3.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       - name: appstore-backend
-        image: beclab/market-backend:v0.3.2
+        image: beclab/market-backend:v0.3.3
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -237,7 +237,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: settings-init
-          image: beclab/settings:v0.2.6
+          image: beclab/settings:v0.2.8
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -351,7 +351,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: settings-server
-          image: beclab/settings-server:v0.2.6
+          image: beclab/settings-server:v0.2.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.63
+        image: beclab/app-service:0.2.70
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.59
+        image: beclab/bfl:v0.3.62
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
- Added the ability to configure ACL rules for Headscale.
- Implemented display of UDP ports in the interface.
- Added frontend warnings for missing application dependencies.
- Fix some market ui bugs.

* **Target Version for Merge**
1.11

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/settings/releases/tag/v0.2.7
https://github.com/beclab/settings/releases/tag/v0.2.8
https://github.com/beclab/market/releases/tag/v0.3.3
https://github.com/beclab/bfl/pull/63
https://github.com/beclab/app-service/pull/125
https://github.com/beclab/app-service/pull/130
https://github.com/beclab/app-service/pull/131

* **Other information**:
None