### PR TITLE
files&files server: disable nats and expand upload size limit to 100G

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -78,7 +78,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.50'
+              value: 'beclab/files-server:v0.2.51'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -114,7 +114,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.50
+          image: beclab/files-server:v0.2.51
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -239,7 +239,7 @@ spec:
             - name: UPLOAD_FILE_TYPE
               value: '*'
             - name: UPLOAD_LIMITED_SIZE
-              value: '49946775344'
+              value: '118111600640'
             - name: RESERVED_SPACE
               value: '1000'
           volumeMounts:
@@ -388,7 +388,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.50
+          image: beclab/files-server:v0.2.51
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -297,7 +297,7 @@ spec:
 #        - /filebrowser
 #        - --noauth
       - name: files-frontend
-        image: beclab/files-frontend:v1.3.20
+        image: beclab/files-frontend:v1.3.22
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -226,7 +226,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: wise-init
-          image: beclab/wise:v1.3.20
+          image: beclab/wise:v1.3.22
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
+++ b/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
@@ -83,7 +83,7 @@ spec:
             value: os_system_vault
       containers:
       - name: vault-server
-        image: beclab/vault-server:v1.3.20
+        image: beclab/vault-server:v1.3.22
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
@@ -114,7 +114,7 @@ spec:
         - name: vault-attach
           mountPath: /padloc/packages/server/attachments
       - name: vault-admin
-        image: beclab/vault-admin:v1.3.20
+        image: beclab/vault-admin:v1.3.22
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010

--- a/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
+++ b/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
@@ -88,13 +88,13 @@ spec:
 
       containers:
       - name: vault-frontend
-        image: beclab/vault-frontend:v1.3.20
+        image: beclab/vault-frontend:v1.3.22
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       
       - name: notification-server
-        image: beclab/vault-notification:v1.3.20
+        image: beclab/vault-notification:v1.3.22
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**
disable nats and expand upload size limit to 100G

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/326
https://github.com/beclab/TermiPass/pull/325

* **Other information**:
none
