### PR TITLE
fix(installer): wsl hangs on update

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -1,5 +1,3 @@
-$env:WSL_UTF8 = 1
-$OutputEncoding = [System.Text.Encoding]::UTF8
 $currentPath = Get-Location
 $architecture = $env:PROCESSOR_ARCHITECTURE
 $downloadCdnUrlFromEnv = $env:DOWNLOAD_CDN_URL
@@ -50,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.106"
+$CLI_VERSION = "0.1.107"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.106"
+CLI_VERSION="0.1.107"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
Due to network or other reasons, running wsl --update is unresponsive, possibly because Microsoft Store or GitHub is inaccessible. The new upgrade method has been adjusted to downloading an offline installation package for installation or upgrade.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.11

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Installer/pull/137


* **Other information**:
