### PR TITLE
app-service: inject nvshare environment duplicately

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.72
+        image: beclab/app-service:0.2.73
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
App-server will inject some environment duplicated if the environment value is empty 

* **Target Version for Merge**
v1.11.3 v1.12.0

* **Related Issues**


* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/135

* **Other information**:
