### PR TITLE
app-service: remove app cache path on the hosts directly

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -202,6 +202,8 @@ spec:
           name: certs
         - mountPath: /etc/containerd/config.toml
           name: configtoml
+        - mountPath: /Cache
+          name: app-cache
       initContainers:
       - name: generate-certs
         image: beclab/openssl:v3
@@ -225,6 +227,10 @@ spec:
           - name: certs
             mountPath: /etc/certs
       volumes:
+      - name: app-cache
+        hostPath:
+          path: {{ .Values.rootPath }}/userdata/Cache
+          type: DirectoryOrCreate
       - name: configtoml
         hostPath:
           path: /etc/containerd/config.toml

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.73
+        image: beclab/app-service:0.2.74
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
remove the application cache path on the hosts directly

* **Target Version for Merge**
v1.11.3 v1.12.0

* **Related Issues**
application's cache be removed inompletetly

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/136

* **Other information**:
