### PR TITLE
olares: upload the original file with md5 as a backup

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -5,7 +5,7 @@ name: Daily Build Release
 on:
   schedule:
     # This is a UTC time
-    - cron: "30 18 10 2 *"
+    - cron: "30 18 * * *"
   workflow_dispatch:
 
 jobs:

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -22,6 +22,10 @@ cat $1|while read image; do
 
             md5sum $name.tar.gz > $checksum
             backup_file=$(cat $checksum)
+            if [ x"$backup_file"  == x""  ]; then
+                echo  "invalid checksum"
+                exit 1
+            fi
 
             aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
             aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
@@ -51,6 +55,10 @@ cat $1|while read image; do
 
             md5sum $name.tar.gz > $checksum
             backup_file=$(cat $checksum)
+            if [ x"$backup_file"  == x""  ]; then
+                echo  "invalid checksum"
+                exit 1
+            fi
 
             aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
             aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -13,18 +13,28 @@ cat $1|while read image; do
 
     curl -fsSLI https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz > /dev/null
     if [ $? -ne 0 ]; then
-        set -e
-        docker pull $image
-        docker save $image -o $name.tar
-        gzip $name.tar
+        code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz)
+        if [ $code -eq 403 ]; then
+            set -e
+            docker pull $image
+            docker save $image -o $name.tar
+            gzip $name.tar
 
-        md5sum $name.tar.gz > $checksum
+            md5sum $name.tar.gz > $checksum
+            backup_file=$(cat $checksum)
 
-        aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
-        aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
-        echo "upload $name completed"
-        
-        set +e
+            aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
+            aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
+            aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
+            echo "upload $name completed"
+            
+            set +e
+        else
+            if [ $code -ne 200  ]; then
+                echo  "failed to check image"
+                exit -1
+            fi
+        fi
     fi
 
     
@@ -32,17 +42,27 @@ cat $1|while read image; do
     # re-upload checksum.txt
     curl -fsSLI https://dc3p1870nn3cj.cloudfront.net/$path$checksum > /dev/null
     if [ $? -ne 0 ]; then
-        set -e
-        docker pull $image
-        docker save $image -o $name.tar
-        gzip $name.tar
+        code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$checksum)
+        if [ $code -eq 403 ]; then
+            set -e
+            docker pull $image
+            docker save $image -o $name.tar
+            gzip $name.tar
 
-        md5sum $name.tar.gz > $checksum
+            md5sum $name.tar.gz > $checksum
+            backup_file=$(cat $checksum)
 
-        aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
-        aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
-        echo "upload $name completed"
-        set +e
+            aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
+            aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
+            aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
+            echo "upload $name completed"
+            set +e
+        else
+            if [ $code -ne 200  ]; then
+                echo  "failed to check image"
+                exit -1
+            fi
+        fi
     fi
 
     # upload to tencent cloud cos


### PR DESCRIPTION
* **Background**
To avoid image files and dependencies being contaminated, upload the original file as a backup.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
1. Checking caching files on s3 got the 503 error code
2. Caching file was contaminated by re-uploading

* **PRs Involving Sub-Systems** 
none

* **Other information**:
