### PR TITLE
tapr: add node affinity to citus and kvrocks

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.1.38
+        image: beclab/middleware-operator:0.1.39
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
* **Background**
Citus and KVRocks middleware data files are stored on the master node host path. So it needs to always schedule them to the master node.

* **Target Version for Merge**
v1.11.3 v1.12.0

* **Related Issues**
Citus loses data on multi-node cluster

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/35

* **Other information**:
