### PR TITLE
tapr: add node affinity to citus and kvrocks

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.1.38
+        image: beclab/middleware-operator:0.1.39
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -13,18 +13,32 @@ cat $1|while read image; do
 
     curl -fsSLI https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz > /dev/null
     if [ $? -ne 0 ]; then
-        set -e
-        docker pull $image
-        docker save $image -o $name.tar
-        gzip $name.tar
+        code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz)
+        if [ $code -eq 403 ]; then
+            set -e
+            docker pull $image
+            docker save $image -o $name.tar
+            gzip $name.tar
 
-        md5sum $name.tar.gz > $checksum
+            md5sum $name.tar.gz > $checksum
+            backup_file=$(cat $checksum)
+            if [ x"$backup_file"  == x""  ]; then
+                echo  "invalid checksum"
+                exit 1
+            fi
 
-        aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
-        aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
-        echo "upload $name completed"
-        
-        set +e
+            aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
+            aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
+            aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
+            echo "upload $name completed"
+            
+            set +e
+        else
+            if [ $code -ne 200  ]; then
+                echo  "failed to check image"
+                exit -1
+            fi
+        fi
     fi
 
     
@@ -32,17 +46,31 @@ cat $1|while read image; do
     # re-upload checksum.txt
     curl -fsSLI https://dc3p1870nn3cj.cloudfront.net/$path$checksum > /dev/null
     if [ $? -ne 0 ]; then
-        set -e
-        docker pull $image
-        docker save $image -o $name.tar
-        gzip $name.tar
+        code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$checksum)
+        if [ $code -eq 403 ]; then
+            set -e
+            docker pull $image
+            docker save $image -o $name.tar
+            gzip $name.tar
 
-        md5sum $name.tar.gz > $checksum
+            md5sum $name.tar.gz > $checksum
+            backup_file=$(cat $checksum)
+            if [ x"$backup_file"  == x""  ]; then
+                echo  "invalid checksum"
+                exit 1
+            fi
 
-        aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
-        aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
-        echo "upload $name completed"
-        set +e
+            aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
+            aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
+            aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
+            echo "upload $name completed"
+            set +e
+        else
+            if [ $code -ne 200  ]; then
+                echo  "failed to check image"
+                exit -1
+            fi
+        fi
     fi
 
     # upload to tencent cloud cos


### PR DESCRIPTION
* **Background**
Citus and KVRocks middleware data files are stored on the master node host path. So it needs to always schedule them to the master node.

* **Target Version for Merge**
v1.11.3

* **Related Issues**
Citus loses data on multi-node cluster

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/35

* **Other information**: