### PR TITLE
fix(installer): restart coredns when change ip, raise cri timeout

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.2.9"
+$CLI_VERSION = "0.2.10"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.2.9"
+CLI_VERSION="0.2.10"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/joincluster.sh
+++ b/build/installer/joincluster.sh
@@ -157,7 +157,7 @@ fi
 
 set_master_host_ssh_options
 
-CLI_VERSION="0.2.5"
+CLI_VERSION="0.2.10"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$CLI_VERSION" ]]; then


### PR DESCRIPTION
* **Background**
coredns also counts as a pod using host ip because the local network's gateway is often used as its upstream DNS server in the pod's `/etc/resolv.conf`, and it needs to be manually updated in case of a CIDR change
the default timeout period of CRI requests is `2m` in kubelet, and can time out during the middle of a normal operation like unpacking a large image on slow hardwares, we explicitly lift it to `5m` to make it more tolerable.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/142
https://github.com/beclab/Installer/pull/143

* **Other information**:
none