### PR TITLE
app-service: continue to resume op after restart; envoy inbound tcp proxy

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.74
+        image: beclab/app-service:0.2.76
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/scripts/upload-deps.sh
+++ b/scripts/upload-deps.sh
@@ -34,7 +34,7 @@ for deps in "components" "pkgs"; do
         name=$(echo -n "$filename"|md5sum|awk '{print $1}')
         checksum="$name.checksum.txt"
         md5sum $name > $checksum
-        backup_file=$(cat $checksum)
+        backup_file=$(awk '{print $1}' $checksum)
         if [ x"$backup_file"  == x""  ]; then
             echo  "invalid checksum"
             exit 1

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -15,24 +15,25 @@ cat $1|while read image; do
     if [ $? -ne 0 ]; then
         code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz)
         if [ $code -eq 403 ]; then
-            set -e
+            set -ex
             docker pull $image
             docker save $image -o $name.tar
             gzip $name.tar
 
             md5sum $name.tar.gz > $checksum
-            backup_file=$(cat $checksum)
+            backup_file=$(awk '{print $1}' $checksum)
             if [ x"$backup_file"  == x""  ]; then
                 echo  "invalid checksum"
                 exit 1
             fi
 
+            echo "start to upload [$name.tar.gz]"
             aws s3 cp $name.tar.gz s3://terminus-os-install/$path$name.tar.gz --acl=public-read
             aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
             aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
             echo "upload $name completed"
             
-            set +e
+            set +ex
         else
             if [ $code -ne 200  ]; then
                 echo  "failed to check image"
@@ -48,13 +49,13 @@ cat $1|while read image; do
     if [ $? -ne 0 ]; then
         code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$checksum)
         if [ $code -eq 403 ]; then
-            set -e
+            set -ex
             docker pull $image
             docker save $image -o $name.tar
             gzip $name.tar
 
             md5sum $name.tar.gz > $checksum
-            backup_file=$(cat $checksum)
+            backup_file=$(awk '{print $1}' $checksum)
             if [ x"$backup_file"  == x""  ]; then
                 echo  "invalid checksum"
                 exit 1
@@ -64,7 +65,7 @@ cat $1|while read image; do
             aws s3 cp $name.tar.gz s3://terminus-os-install/backup/$path$backup_file --acl=public-read
             aws s3 cp $checksum s3://terminus-os-install/$path$checksum --acl=public-read
             echo "upload $name completed"
-            set +e
+            set +ex
         else
             if [ $code -ne 200  ]; then
                 echo  "failed to check image"


### PR DESCRIPTION
* **Background**
- resume op failed after restart
- envoy inbound not support tcp
* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/139
https://github.com/beclab/app-service/pull/138


* **Other information**:
