### PR TITLE
bfl: increase l4 proxy nginx worker process to half of cpu cores

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -243,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.63
+        image: beclab/bfl:v0.3.64
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
Increase l4 proxy nginx worker process number to half of CPU cores

* **Target Version for Merge**
v1.11.4

* **Related Issues**
Bulk concurrent requests cause nginx to hang

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/68


* **Other information**:
