### PR TITLE
settings: hide user email entry

### DIFF
--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -238,7 +238,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: settings-init
-          image: beclab/settings:v0.2.10
+          image: beclab/settings:v0.2.11
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
**Background**
Directly set the user's account email as olaresID without displaying it, and hide the field.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/settings/pull/86


* **Other information**:
None
