### PR TITLE
market: allow paused apps to update

### DIFF
--- a/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
+++ b/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
@@ -85,12 +85,12 @@ spec:
                 fieldPath: status.podIP
       containers:
       - name: appstore
-        image: beclab/market-frontend:v0.3.4
+        image: beclab/market-frontend:v0.3.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       - name: appstore-backend
-        image: beclab/market-backend:v0.3.4
+        image: beclab/market-backend:v0.3.5
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
Apps that cannot be upgraded in the upgrade list are shown as paused.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/market/pull/65


* **Other information**:
None
