### PR TITLE
fix(desktop): disable PWA in safari on the desktop

### DIFF
--- a/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
+++ b/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
@@ -66,7 +66,7 @@ spec:
 
       containers:
       - name: edge-desktop
-        image: beclab/desktop:v0.2.47
+        image: beclab/desktop:v0.2.48
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false


### PR DESCRIPTION
* **Background**
Safari on desktop does not support PWA mode.

* **Target Version for Merge**
v1.11.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/desktop/pull/67


* **Other information**:
none