### PR TITLE
fix: drop async upload filesize error

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -319,7 +319,7 @@ spec:
         - name: userspace-dir
           mountPath: /data
       - name: drive-server
-        image: beclab/drive:v0.0.29
+        image: beclab/drive:v0.0.47
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER
@@ -340,7 +340,7 @@ spec:
         - name: userspace-app-dir
           mountPath: /data/Application
       - name: task-executor
-        image: beclab/driveexecutor:v0.0.29
+        image: beclab/driveexecutor:v0.0.47
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER


### PR DESCRIPTION
Title: aboveos/drive:  fix dropbox async upload size error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
when async upload file from terminus to dropbox, when upload compelete, upload redunat last chunk, but just need to upload empty chunk

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
release-1.1

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/drive/pull/85

* **Other information**:
