### PR TITLE
app-service: fix app installation can not be canceled after reboot

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.2
+        image: beclab/app-service:0.3.3
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/frameworks/tapr/config/cluster/deploy/lldap-deployment.yaml
+++ b/frameworks/tapr/config/cluster/deploy/lldap-deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - name: RUST_BACKTRACE
               value: "full"
           image: beclab/lldap:0.0.1
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: lldap
           ports:
             - containerPort: 3890


### PR DESCRIPTION

* **Background**
- app installation can not be canceled after reboot

* **Target Version for Merge**
1.12
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/149

* **Other information**:
