### PR TITLE
app-service: fix app installation can not be canceled after reboot

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.78
+        image: beclab/app-service:0.2.79
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION

* **Background**
- app installation can not be canceled after reboot

* **Target Version for Merge**
1.11
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/148

* **Other information**:
