### PR TITLE
bfl-ingress: increase keepalive requests of ingress

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -296,7 +296,7 @@ spec:
           value: {{ .Values.bfl.terminus_dns_service_api }}
 
       - name: ingress
-        image: beclab/bfl-ingress:v0.2.19
+        image: beclab/bfl-ingress:v0.2.21
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION
* **Background**
Bulk HTTP requests from a single page exceeding the max keep alive requests number of ingress cause the requests from the browser to broken


* **Target Version for Merge**
v1.11.5 

* **Related Issues**
Comfyui web client loading js requests broken

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/72

* **Other information**:
