### PR TITLE
app-service: custom allowed outbound port;tcp udp port

### DIFF
--- a/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
+++ b/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
@@ -517,9 +517,11 @@ data:
         
       clusters:
       - name: original_dst
-        connect_timeout: 5000s
+        connect_timeout: 120s
         type: ORIGINAL_DST
         lb_policy: CLUSTER_PROVIDED
+        common_http_protocol_options:
+          idle_timeout: 10s
       - name: authelia
         connect_timeout: 2s
         type: LOGICAL_DNS
@@ -692,6 +694,8 @@ data:
         connect_timeout: 5000s
         type: ORIGINAL_DST
         lb_policy: CLUSTER_PROVIDED
+        common_http_protocol_options:
+          idle_timeout: 10s
       - name: ws_original_dst
         connect_timeout: 5000s
         type: LOGICAL_DNS

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -849,9 +849,11 @@ data:
 
       clusters:
         - name: original_dst
-          connect_timeout: 5000s
+          connect_timeout: 120s
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED
+          common_http_protocol_options:
+            idle_timeout: 10s
         - name: upload_original_dst
           connect_timeout: 5000s
           type: LOGICAL_DNS

--- a/build/manifest/images
+++ b/build/manifest/images
@@ -70,3 +70,4 @@ rancher/mirrored-metrics-server:v0.5.2
 rancher/mirrored-pause:3.6
 beclab/reverse-proxy:v0.1.4
 beclab/upgrade-job:0.1.7
+bytetrade/envoy:v1.25.11.1

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.3
+        image: beclab/app-service:0.3.4
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.4
+        image: beclab/app-service:0.3.5
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- custom allowed outbound port
- tcp udp port can use same port
- add idle timeout to original_dst cluster

* **Target Version for Merge**
1.12
* **Related Issues**

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/153
https://github.com/beclab/app-service/pull/151
https://github.com/beclab/app-service/pull/154
* **Other information**:
