### PR TITLE
feat: add id-route for file info, fix file size limit when direct upload

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -319,7 +319,7 @@ spec:
         - name: userspace-dir
           mountPath: /data
       - name: drive-server
-        image: beclab/drive:v0.0.49
+        image: beclab/drive:v0.0.51
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER
@@ -340,7 +340,7 @@ spec:
         - name: userspace-app-dir
           mountPath: /data/Application
       - name: task-executor
-        image: beclab/driveexecutor:v0.0.49
+        image: beclab/driveexecutor:v0.0.51
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER


### PR DESCRIPTION
Title: aboveos/drive:  add id route for info,  fix file size limit
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. Add id route for fileinfo , for client to easy track for google cloud drive
2. Replace i32 with i64, remove upload filesize limit
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
release-1.11

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/drive/pull/89
https://github.com/Above-Os/drive/pull/88
* **Other information**:
