### PR TITLE
feat(bfl): add watcher to apply reverse proxy

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -243,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.65
+        image: beclab/bfl:v0.3.66
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
add a watcher for reverse proxy ConfigMap events, which is responsible for watching the `reverse-proxy-config` ConfigMap and applying the config if necessary.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/70


* **Other information**:
none