### PR TITLE
wise, file: update files & wise new version to 1.3.38

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -77,7 +77,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.57'
+              value: 'beclab/files-server:v0.2.60'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -113,7 +113,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.58
+          image: beclab/files-server:v0.2.60
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -217,6 +217,8 @@ spec:
               value: '1000'
             - name: OLARES_VERSION
               value: '1.12'
+            - name: FILE_CACHE_DIR
+              value: '/data/file_cache'
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -233,7 +235,7 @@ spec:
             - /filebrowser
             - --noauth
         - name: uploader
-          image: beclab/upload:v1.0.10
+          image: beclab/upload:v1.0.12
           env:
             - name: UPLOAD_FILE_TYPE
               value: '*'
@@ -393,7 +395,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.57
+          image: beclab/files-server:v0.2.60
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -746,7 +748,7 @@ data:
 
             client_body_timeout 600s;
             client_max_body_size 4000M;
-            proxy_request_buffering off;
+            proxy_request_buffering on;
             keepalive_timeout 750s;
             proxy_read_timeout 600s;
             proxy_send_timeout 600s;

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -297,7 +297,7 @@ spec:
 #        - /filebrowser
 #        - --noauth
       - name: files-frontend
-        image: beclab/files-frontend:v1.3.35
+        image: beclab/files-frontend:v1.3.38
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -226,7 +226,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: wise-init
-          image: beclab/wise:v1.3.35
+          image: beclab/wise:v1.3.38
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -352,7 +352,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: settings-server
-          image: beclab/settings-server:v0.2.10
+          image: beclab/settings-server:v0.2.12
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
+++ b/apps/vault/config/cluster/deploy/vault_server_deploy.yaml
@@ -83,7 +83,7 @@ spec:
             value: os_system_vault
       containers:
       - name: vault-server
-        image: beclab/vault-server:v1.3.35
+        image: beclab/vault-server:v1.3.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
@@ -114,7 +114,7 @@ spec:
         - name: vault-attach
           mountPath: /padloc/packages/server/attachments
       - name: vault-admin
-        image: beclab/vault-admin:v1.3.35
+        image: beclab/vault-admin:v1.3.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010

--- a/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
+++ b/apps/vault/config/user/helm-charts/vault/templates/vault_deploy.yaml
@@ -88,13 +88,13 @@ spec:
 
       containers:
       - name: vault-frontend
-        image: beclab/vault-frontend:v1.3.35
+        image: beclab/vault-frontend:v1.3.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
       
       - name: notification-server
-        image: beclab/vault-notification:v1.3.35
+        image: beclab/vault-notification:v1.3.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**
     - files：
         - add support for new field id_path for google drive stream
         - add CACHE_DIR to make appdata use the newest version correctly
         - same logic of getting mounted data for 1.11 and 1.12
     - uploader:
         - change offset judge method for SMB 499
         - improve uploading speed
     - wise:
         - add a filter feature to Wise
         - update the database

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
[feat: Cumulative updates for files_drives from 1.12 to feed newest drive_server and 1.11 by lovehunt](https://github.com/beclab/files/pull/5)
[fix: same logic of getting mounted data for 1.11 and 1.12 by lovehunter9 · Pull Request #6 · beclab/](https://github.com/beclab/files/pull/6)
[fix: lost uploading info when reseting and change offset judge method for SMB 499 by lovehunter9 · P](https://github.com/beclab/tapr/pull/39)
[fix: improve uploading speed by lovehunter9 · Pull Request #40 · beclab/tapr](https://github.com/beclab/tapr/pull/40)
https://github.com/beclab/TermiPass/pull/362
https://github.com/beclab/TermiPass/pull/355
https://github.com/beclab/TermiPass/pull/357
https://github.com/beclab/TermiPass/pull/360
https://github.com/beclab/TermiPass/pull/363


* **Other information**:
None
