### PR TITLE
fix(bfl): fetch current user object before every configure operation

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -243,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.69
+        image: beclab/bfl:v0.3.70
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
this is a cherry pick of https://github.com/beclab/Olares/pull/1021
fetch the latest user object because the one we're holding is likely outdated.

* **Target Version for Merge**
v1.11.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/79


* **Other information**:
none