### PR TITLE
app-service: change hostpath with type DirectoryOrCreate owner to 1000 by inject init container

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.6
+        image: beclab/app-service:0.3.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- hostpath with type DirectoryOrCreate exists with incorrect permission

* **Target Version for Merge**
1.12
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/158

* **Other information**:
