### PR TITLE
fix: add node shell image to pre download

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -70,3 +70,4 @@ rancher/mirrored-pause:3.6
 beclab/reverse-proxy:v0.1.4
 beclab/upgrade-job:0.1.7
 bytetrade/envoy:v1.25.11.1
+alpine:3.14


### PR DESCRIPTION
* **Background**
- add node shell image to pre download

* **Target Version for Merge**
1.11
* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
