### PR TITLE
fix: add node shell image to pre download

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -36,3 +36,4 @@ beclab/upgrade-job:0.1.7
 bytetrade/envoy:v1.25.11.1
 liangjw/kube-webhook-certgen:v1.1.1
 beclab/hami:v2.5.0
+alpine:3.14


### PR DESCRIPTION

* **Background**
- add node shell image to pre download

* **Target Version for Merge**
1.12
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
