### PR TITLE
feat(installer): support swap and zram configurations

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.2.16"
+$CLI_VERSION = "0.2.17"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.2.16"
+CLI_VERSION="0.2.17"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"
@@ -204,9 +204,24 @@ if [[ "$JUICEFS" == "1" ]]; then
     fi
 fi
 
+if [[ -n "$SWAPPINESS" ]]; then
+    swapflag="$swapflag --swappiness $SWAPPINESS"
+fi
+if [[ "$ENABLE_POD_SWAP" == "1" ]]; then
+    swapflag="$swapflag --enable-pod-swap"
+fi
+if [[ "$ENABLE_ZRAM" == "1" ]]; then
+    swapflag="$swapflag --enable-zram"
+fi
+if [[ -n "$ZRAM_SIZE" ]]; then
+    swapflag="$swapflag --zram-size $ZRAM_SIZE"
+fi
+if [[ -n "$ZRAM_SWAP_PRIORITY" ]]; then
+    swapflag="$swapflag --zram-swap-priority $ZRAM_SWAP_PRIORITY"
+fi
 echo "installing Olares..."
 echo ""
-$sh_c "$INSTALL_OLARES_CLI olares install $PARAMS $KUBE_PARAM $fsflag"
+$sh_c "$INSTALL_OLARES_CLI olares install $PARAMS $KUBE_PARAM $fsflag $swapflag"
 
 if [[ $? -ne 0 ]]; then
     echo "error: failed to install Olares"

--- a/build/installer/joincluster.sh
+++ b/build/installer/joincluster.sh
@@ -157,7 +157,7 @@ fi
 
 set_master_host_ssh_options
 
-CLI_VERSION="0.2.16"
+CLI_VERSION="0.2.17"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$CLI_VERSION" ]]; then


### PR DESCRIPTION
* **Background**
add support for swap & zram related configurations during installing Olares
the following environment variables can be set when executing `install.sh` in order to configure swap and ram

| env var name | explain | type | values | default |
| :--- | --- | --- | --- | --- |
| SWAPPINESS <br/> | Configure the Linux swappiness value | int | 0~100, refer to https://docs.kernel.org/admin-guide/sysctl/vm.html#swappiness | if not set, the current kernel configuration is left unchanged |
| ENABLE_POD_SWAP  | Enable pods on Kubernetes cluster to use swap, note that only pods of the Burstable QOS group can use swap due to K8s design | bool | 0, 1 | setting ENABLE_ZRAM, ZRAM_SIZE, or ZRAM_SWAP_PRIORITY implicitly enables this, regardless of the provided value |
| ENABLE_ZRAM | Set up a ZRAM device to be used for swap | bool | 0, 1 | setting ZRAM_SIZE or ZRAM_SWAP_PRIORITY implicitly enables this, regardless of the provided value |
| ZRAM_SIZE | Set the size of the ZRAM device | string | 1000, 10K, 10M, 1G, etc. that conform to the format of https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity | defaults to half of the total RAM if enabled but not set |
| ZRAM_SWAP_PRIORITY | Set the swap priority of the ZRAM device | int | -1 ~ 32767 | defaults to 100 if enabled but not set |

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/168


* **Other information**:
none