### PR TITLE
fix: add the missing kubernetes image

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -10,6 +10,7 @@ bitnami/kube-rbac-proxy:0.19.0
 registry.k8s.io/kube-apiserver:v1.32.2
 registry.k8s.io/kube-scheduler:v1.32.2
 registry.k8s.io/kube-proxy:v1.32.2
+registry.k8s.io/kube-controller-manager:v1.32.2
 registry.k8s.io/coredns/coredns:v1.11.3
 registry.k8s.io/pause:3.10
 kubesphere/prometheus-config-reloader:v0.55.1


### PR DESCRIPTION
* **Background**
the image `registry.k8s.io/kube-controller-manager:v1.32.2` was missed when updating images for K8s v1.32.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none


* **Other information**:
none