### PR TITLE
files: make the files server running as root

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -46,9 +46,8 @@ spec:
       serviceAccount: os-internal
       serviceAccountName: os-internal
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 0
+        runAsNonRoot: false
       initContainers:
         - name: init-data
           image: busybox:1.28
@@ -74,7 +73,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 1000
+            runAsUser: 0
           ports:
             - containerPort: 8080
           env:
@@ -99,7 +98,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
-            runAsUser: 1000
+            runAsUser: 0
             privileged: true
           ports:
           - containerPort: 9090
@@ -119,7 +118,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
-            runAsUser: 1000
+            runAsUser: 0
             privileged: true
           volumeMounts:
             - name: fb-data
@@ -273,7 +272,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
-            runAsUser: 1000
+            runAsUser: 0
             privileged: true
         - name: nginx
           image: 'nginx:stable-alpine3.17-slim'


### PR DESCRIPTION
* **Background**
Files-server runs as a cluster service to manage the files of all users and all apps.  It must get the root privileges to operate with all apps' stored files.

* **Target Version for Merge**
v1.11.6

* **Related Issues**
Insufficient privileges for reading/writing some app's stored files.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
