### PR TITLE
tapr: add missing fields of db table organizations in `Infisical` sidecar

### DIFF
--- a/third-party/infisical/config/cluster/deploy/infisical_deploy.yaml
+++ b/third-party/infisical/config/cluster/deploy/infisical_deploy.yaml
@@ -231,7 +231,7 @@ spec:
           subPath: nginx.conf
 
       - name: tapr-sidecar
-        image: beclab/secret-vault:0.1.8
+        image: beclab/secret-vault:0.1.9
         imagePullPolicy: IfNotPresent
         ports:
         - name: proxy


### PR DESCRIPTION

* **Background**
Some fields of the DB table `organizations` are missing in the OR mapping 

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Failed to restart Infisical sidecar

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/46

* **Other information**:
