### PR TITLE
olares: use the pod localhost address as the infisical server address to the infisical sidecar

### DIFF
--- a/third-party/infisical/config/user/helm-charts/infisical/templates/infisical_deploy.yaml
+++ b/third-party/infisical/config/user/helm-charts/infisical/templates/infisical_deploy.yaml
@@ -286,6 +286,8 @@ spec:
         - name: proxy
           containerPort: 8080
         env:
+        - name: INFISICAL_URL
+          value: http://localhost:4000
         - name: OWNER
           value: '{{ .Values.bfl.username }}'
         - name: PG_USER


### PR DESCRIPTION
* **Background**
Optimize the infisical sidecar performance, use the pod localhost address as the infisical server address to the infisical sidecar. 

* **Target Version for Merge**
v1.11.6

* **Related Issues**
No response of the list secrets API 

* **PRs Involving Sub-Systems** 
none

* **Other information**:
