### PR TITLE
olares: use the pod locahost address as the infisical server address to the infisical sidecar

### DIFF
--- a/third-party/infisical/config/cluster/deploy/infisical_deploy.yaml
+++ b/third-party/infisical/config/cluster/deploy/infisical_deploy.yaml
@@ -237,6 +237,8 @@ spec:
         - name: proxy
           containerPort: 8080
         env:
+        - name: INFISICAL_URL
+          value: http://localhost:4000
         - name: PG_USER
           value: infisical_os_system
         - name: PG_DB


### PR DESCRIPTION

* **Background**
Optimize the infisical sidecar performance, use the pod localhost address as the infisical server address to the infisical sidecar. 

* **Target Version for Merge**
v1.12.0

* **Related Issues**
No response of the list secrets API 

* **PRs Involving Sub-Systems** 
none

* **Other information**:
