### PR TITLE
feat(installer): support data backup, restore in olares-cli

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.2.17"
+CLI_VERSION="0.2.18"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
olares-cli adds a set of commands for data backup and restoration. You can use `olares-cli olares backups -h` to get command help information.

```
Olares backup tool-kit

Usage:
  olares-cli olares backups [command]

Available Commands:
  backup      Back up data to multiple storage targets: Space, S3, COS, and local
  download    Download the backup dependency tool Restic
  restore     Restore data from multiple storage targets: Space, S3, COS, and local
  snapshots   Manage and view backup snapshots

Flags:
  -h, --help   help for backups

Use "olares-cli olares backups [command] --help" for more information about a command.
```

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Installer/pull/171


* **Other information**:
