### PR TITLE
olares: fix the opentelemetry annotations configuration bugs

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -38,7 +38,7 @@ spec:
   selector:
     matchLabels:
       app: files
-template:
+  template:
     metadata:
       labels:
         app: files

--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -38,12 +38,13 @@ spec:
   selector:
     matchLabels:
       app: files
-    annotations:
-      instrumentation.opentelemetry.io/inject-go: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx-container-names: "nginx"    
-      instrumentation.opentelemetry.io/go-container-names: "gateway,files,uploader"    
-  template:
+      annotations:
+        # instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
+        # instrumentation.opentelemetry.io/inject-nginx-container-names: "nginx"    
+        instrumentation.opentelemetry.io/inject-go: "olares-instrumentation"
+        instrumentation.opentelemetry.io/go-container-names: "gateway,files,uploader"    
+        instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/filebrowser"
+template:
     metadata:
       labels:
         app: files

--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -38,16 +38,16 @@ spec:
   selector:
     matchLabels:
       app: files
+template:
+    metadata:
+      labels:
+        app: files
       annotations:
         # instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
         # instrumentation.opentelemetry.io/inject-nginx-container-names: "nginx"    
         instrumentation.opentelemetry.io/inject-go: "olares-instrumentation"
         instrumentation.opentelemetry.io/go-container-names: "gateway,files,uploader"    
         instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/filebrowser"
-template:
-    metadata:
-      labels:
-        app: files
     spec:
       serviceAccount: os-internal
       serviceAccountName: os-internal

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -112,9 +112,11 @@ spec:
       labels:
         app: files
         io.bytetrade.app: "true"
-    annotations:
-      instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx-container-names: "files-frontend"    
+      annotations:
+        # support nginx 1.24.3 1.25.3
+        # instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
+        # instrumentation.opentelemetry.io/inject-nginx-container-names: "files-frontend"    
+        # instrumentation.opentelemetry.io/otel-go-auto-target-exe: "drive"
     spec:
       serviceAccountName: bytetrade-controller
       securityContext:

--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -136,11 +136,11 @@ spec:
       labels:
         app: system-frontend
         io.bytetrade.app: "true"
-    annotations:
-      instrumentation.opentelemetry.io/inject-nodejs: "olares-instrumentation"
-      instrumentation.opentelemetry.io/nodejs-container-names: "settings-server"    
-      instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx-container-names: "system-frontend"    
+      annotations:
+        instrumentation.opentelemetry.io/inject-nodejs: "olares-instrumentation"
+        instrumentation.opentelemetry.io/nodejs-container-names: "settings-server"    
+        # instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
+        # instrumentation.opentelemetry.io/inject-nginx-container-names: "system-frontend"    
     spec:
       priorityClassName: "system-cluster-critical"
       initContainers:

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -199,11 +199,12 @@ spec:
     metadata:
       labels:
         tier: bfl
-    annotations:
-      instrumentation.opentelemetry.io/inject-go: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
-      instrumentation.opentelemetry.io/inject-nginx-container-names: "ingress"    
-      instrumentation.opentelemetry.io/go-container-names: "api"    
+      annotations:
+        instrumentation.opentelemetry.io/inject-go: "olares-instrumentation"
+        instrumentation.opentelemetry.io/go-container-names: "api"    
+        instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/bfl-api"
+        # instrumentation.opentelemetry.io/inject-nginx: "olares-instrumentation"
+        # instrumentation.opentelemetry.io/inject-nginx-container-names: "ingress"    
     spec:
 {{ if .Values.bfl.admin_user }}
       affinity:

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -551,6 +551,8 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
+            - --enable-nginx-instrumentation
+            - --enable-go-instrumentation
             - --collector-image=otel/opentelemetry-collector-k8s:0.118.0
           command:
             - /manager

--- a/third-party/opentelemetry/config/user/helm-charts/opentelmetry/templates/otel_define.yaml
+++ b/third-party/opentelemetry/config/user/helm-charts/opentelmetry/templates/otel_define.yaml
@@ -27,6 +27,15 @@ spec:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
+  nginx:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-storage-instance-collector.os-system:4318
+  go:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-storage-instance-collector.os-system:4318
+
 
 ---
 apiVersion: opentelemetry.io/v1alpha1
@@ -56,3 +65,12 @@ spec:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318        
+  nginx:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-storage-instance-collector.os-system:4318
+  go:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-storage-instance-collector.os-system:4318
+


### PR DESCRIPTION
* **Background**
Fix some opentelemetry annotations configuration bugs
1、otel nginx instrumentation only supports version 1.24.3 and 1.25.3, 
2、Golang auto instrumentation configuration must specify the exec filename

* **Target Version for Merge**
v1.12.0

* **Related Issues**
otel tracing not work

* **PRs Involving Sub-Systems** 
none

* **Other information**:
