### PR TITLE
olares: increase envoy idle timeout for files-frontend

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -768,6 +768,7 @@ data:
                               route:
                                 cluster: original_dst
                                 timeout: 1800s
+                                idle_timeout: 1800s
                     http_protocol_options:
                       accept_http_10: true
                     http_filters:


### PR DESCRIPTION
* **Background**
When copying and pasting a huge file in `Files`, the HTTP request gets a timeout response cause of the envoy reaches the 5 minutes idle timeout.

* **Target Version for Merge**
v1.11.6 v1.12.0

* **Related Issues**
`Files server` responses 504 timeout. 

* **PRs Involving Sub-Systems** 
none

* **Other information**:
