### PR TITLE
olares: uploading last chunk of a file got 504 timeout response

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -758,6 +758,8 @@ data:
                                 prefix: "/upload"
                               route:
                                 cluster: upload_original_dst
+                                timeout: 1800s
+                                idle_timeout: 1800s
                             - match:
                                 prefix: "/"
                               route:


### PR DESCRIPTION
* **Background**
When uploading the last chunk of a file,  `file-server` will copy the temporary file to the destination. Sometimes it will cause the upload API responsing 504 timeout.

* **Target Version for Merge**
v1.11.6

* **Related Issues**
uploading last chunk of a file got 504 timeout response

* **PRs Involving Sub-Systems** 
none

* **Other information**:
