### PR TITLE
authelia: fix cached redis session provider gc api

### DIFF
--- a/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/third-party/authelia/config/cluster/deploy/auth_backend_deploy.yaml
@@ -360,7 +360,7 @@ spec:
 
       containers:      
       - name: authelia
-        image: beclab/auth:0.1.43
+        image: beclab/auth:0.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Authelia redis session cache needs to be gc if expired

* **Target Version for Merge**
v1.11.6 v1.12.0

* **Related Issues**
Bulk anonymous session cause Authelia memory leak

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/6

* **Other information**:
