### PR TITLE
tapr: persist kvrocks namespace config

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.2.1
+        image: beclab/middleware-operator:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION

* **Background**
Adding a namespace to kvrocks should call `config rewrite` command to persist the configuration to config file

* **Target Version for Merge**
v1.11.6 v1.12.0

* **Related Issues**
kvrocks namespace config need to be recreated after restart

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/50

* **Other information**:
