### PR TITLE
fix: restore metadata when return to frontend

### DIFF
--- a/apps/search3/config/cluster/deploy/search3_server_deploy.yaml
+++ b/apps/search3/config/cluster/deploy/search3_server_deploy.yaml
@@ -199,7 +199,7 @@ spec:
             value: os_system_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.28
+        image: beclab/search3:v0.0.30
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Title: aboveos/search3:  restore metadata when return data
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
reduce metadat when return to frontend
* **Target Version for Merge**
release-1.11
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/48


* **Other information**:
