### PR TITLE
bfl, authelia, tapr: new solution for local domain

### DIFF
--- a/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
+++ b/apps/desktop/config/user/helm-charts/desktop/templates/desktop_deploy.yaml
@@ -450,6 +450,7 @@ data:
                               - prefix: x-unauth-
                               - exact: x-authorization
                               - exact: x-bfl-user
+                              - exact: x-real-ip
                               - exact: terminus-nonce
                           headers_to_add:
                             - key: X-Forwarded-Method
@@ -626,6 +627,7 @@ data:
                               - prefix: x-unauth-
                               - exact: x-authorization
                               - exact: x-bfl-user
+                              - exact: x-real-ip
                               - exact: terminus-nonce
                           headers_to_add:
                             - key: X-Forwarded-Method

--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -792,6 +792,7 @@ data:
                                   - prefix: x-unauth-
                                   - exact: x-authorization
                                   - exact: x-bfl-user
+                                  - exact: x-real-ip
                                   - exact: terminus-nonce
                               headers_to_add:
                                 - key: X-Forwarded-Method


### PR DESCRIPTION
* **Background**
The current solution of local domain in Olares is providing the two different domains to the user, `*.username.olares.com` and `*.local.username.olares.com`. 

In the new solution, the Larepass client of Olares will resolve the `*.username.olares.com` to a local IP of the node. The Olares user is unnecessary to switch the accessing domain between `*.username.olares.com` and `*.local.username.olares.com`


* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/8
https://github.com/beclab/bfl/pull/88
https://github.com/beclab/tapr/pull/51

* **Other information**:
