### PR TITLE
feat: support custom domain in both cloudflare and FRP tunnel

### DIFF
--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -243,7 +243,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: settings-init
-          image: beclab/settings:v0.2.15
+          image: beclab/settings:v0.2.16
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -357,7 +357,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: settings-server
-          image: beclab/settings-server:v0.2.15
+          image: beclab/settings-server:v0.2.16
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -295,7 +295,7 @@ spec:
         - name: L4_PROXY_IMAGE_VERSION
           value: v0.2.8
         - name: REVERSE_PROXY_AGENT_IMAGE_VERSION
-          value: v0.1.7
+          value: v0.1.8
         - name: TERMINUS_CERT_SERVICE_API
           value: {{ .Values.bfl.terminus_cert_service_api }}
         - name: TERMINUS_DNS_SERVICE_API


### PR DESCRIPTION
* **Background**
Currently, custom domain for an app entrance is only supported in CloudFlare tunnel mode, this PR adds support for both CloudFlare and FRP tunnel, and handles the switching between them.
In FRP mode, which is a layer-4 reverse proxy, the HTTPS certificate for the custom domain should be uploaded.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/85
https://github.com/beclab/bfl/pull/89
https://github.com/beclab/settings/pull/94

* **Other information**:
none