### PR TITLE
feat: support custom domain in both cloudflare and FRP tunnel

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -243,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.71
+        image: beclab/bfl:v0.3.73
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -289,14 +289,14 @@ spec:
         - name: L4_PROXY_IMAGE_VERSION
           value: v0.2.8
         - name: REVERSE_PROXY_AGENT_IMAGE_VERSION
-          value: v0.1.7
+          value: v0.1.9
         - name: TERMINUS_CERT_SERVICE_API
           value: {{ .Values.bfl.terminus_cert_service_api }}
         - name: TERMINUS_DNS_SERVICE_API
           value: {{ .Values.bfl.terminus_dns_service_api }}
 
       - name: ingress
-        image: beclab/bfl-ingress:v0.2.22
+        image: beclab/bfl-ingress:v0.2.23
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION
* **Background**
this is a cherry pick of https://github.com/beclab/Olares/pull/1126
Currently, custom domain for an app entrance is only supported in CloudFlare tunnel mode, this PR adds support for both CloudFlare and FRP tunnel, and handles the switching between them.
In FRP mode, which is a layer-4 reverse proxy, the HTTPS certificate for the custom domain should be uploaded.

* **Target Version for Merge**
1.11.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/85
https://github.com/beclab/bfl/pull/89
https://github.com/beclab/settings/pull/94

* **Other information**:
none