### PR TITLE
olares: change app name devbox to studio

### DIFF
--- a/build/installer/upgrade_cmd.sh
+++ b/build/installer/upgrade_cmd.sh
@@ -146,7 +146,7 @@ function get_app_key_secret(){
 
 function get_app_settings(){
     local username=$1
-    local apps=("vault" "desktop" "message" "wise" "search" "appstore" "notification" "dashboard" "settings" "devbox" "profile" "agent" "files")
+    local apps=("vault" "desktop" "message" "wise" "search" "appstore" "notification" "dashboard" "settings" "studio" "profile" "agent" "files")
     for a in ${apps[@]};do
         ks=($(get_app_key_secret "$username" "$a"))
         echo '


### PR DESCRIPTION

* **Background**
The app name of devbox has changed to studio, modify the upgrade script app name `devbox` to `studio`

* **Target Version for Merge**
v1.11.6

* **Related Issues**
System upgrade failed

* **PRs Involving Sub-Systems** 
none

* **Other information**:
