### PR TITLE
fix(installer): olares-cli restore path not specified

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.119"
+$CLI_VERSION = "0.1.121"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.119"
+CLI_VERSION="0.1.121"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix error when path is not specified during file restoration by olares-cli

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.11.6

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/Above-Os/backups-sdk/commit/3246e815b9de919985d255a3534aafbf4628162a


* **Other information**:
