### PR TITLE
olares: fix upgrading state not_running bug

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -243,7 +243,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.73
+        image: beclab/bfl:v0.3.74
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
When system upgrading, app-service may be upgraded, checking the upgrading state API  should not return `not_running` at this time.

* **Target Version for Merge**
v1.11.6

* **Related Issues**
The system upgrading page has been closed unexpectedly

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/94


* **Other information**:
