### PR TITLE
fix: fix cloud drive lock not released when some thread corrupted

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_fe_deploy.yaml
@@ -324,7 +324,7 @@ spec:
         - name: userspace-dir
           mountPath: /data
       - name: drive-server
-        image: beclab/drive:v0.0.70
+        image: beclab/drive:v0.0.72
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER
@@ -347,7 +347,7 @@ spec:
         - name: data-dir
           mountPath: /data
       - name: task-executor
-        image: beclab/driveexecutor:v0.0.70
+        image: beclab/driveexecutor:v0.0.72
         imagePullPolicy: IfNotPresent
         env:
         - name: OS_SYSTEM_SERVER


### PR DESCRIPTION
Title: aboveos/drive: fix locked not released when some thread corrupted
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. fix lock not released when direct upload file because of thread corruption
2. change async download chunk from 1 mb to 8mb
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
* https://github.com/Above-Os/drive/pull/111
* https://github.com/Above-Os/drive/pull/112


* **Other information**:
