### PR TITLE
app-service: fix cache delete not completely in some case;node status check before system upgrade

### DIFF
--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -149,7 +149,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.93
+        image: beclab/app-service:0.2.94
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- the app cache directory is not completely deleted in some case 
- check node status before system upgrade
* **Target Version for Merge**
1.11
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/192
https://github.com/beclab/app-service/pull/193

* **Other information**:
