### PR TITLE
olares: add quotes to username

### DIFF
--- a/build/installer/upgrade_cmd.sh
+++ b/build/installer/upgrade_cmd.sh
@@ -175,7 +175,7 @@ function gen_bfl_values(){
     echo '
 bfl:
   nodeport: '${user_bfl_port}'
-  username: '${username}'
+  username: "'${username}'"
 
   userspace_rand16: '${userspace_rand16}'
   userspace_pv: '${pvc_path[2]}'


### PR DESCRIPTION
* **Background**
Helm will format the numeric user name as scientific notation automatically, add the quotes to username in helm values

* **Target Version for Merge**
v1.11.6

* **Related Issues**
System upgrade failed if Olares has one numeric user

* **PRs Involving Sub-Systems** 
none

* **Other information**:
