### PR TITLE
olares: mark the market as cluster critical

### DIFF
--- a/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
+++ b/apps/market/config/user/helm-charts/market/templates/market_deploy.yaml
@@ -43,6 +43,7 @@ spec:
         app: appstore
         io.bytetrade.app: "true"
     spec:
+      priorityClassName: "system-cluster-critical"
       initContainers:
         - args:
           - -it


### PR DESCRIPTION
* **Background**
Mark the market app as cluster critical to avoid eviction by kubelet

* **Target Version for Merge**
v1.11.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
