### PR TITLE
tapr: add other query type response code

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
@@ -76,7 +76,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.2
+        image: beclab/sys-event:0.2.3
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_RANDOM_KEY


### PR DESCRIPTION
* **Background**
For the ios device, local domain resolver needs to response the other query type except type A. So add a template plugin to corefile to response  type ANY with response code NXDOMAIN

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Local domain solution not working on ios device

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/commit/d7a531e574178ae425ed6c0c15f3a2c3e58f844f

* **Other information**:
