### PR TITLE
tapr: ignore deleting the not exists namespace

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.1.41
+        image: beclab/middleware-operator:0.1.42
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION

* **Background**
When `tapr` is deleting the kvrocks' middleware request, if the namespace does not exist, the deletion should be ignored to avoid returning an error.

* **Target Version for Merge**
v1.11.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
