### PR TITLE
tapr: fix corefile updating bug

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
@@ -76,7 +76,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.3
+        image: beclab/sys-event:0.2.4
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_RANDOM_KEY


### PR DESCRIPTION
* **Background**
Updating the Coredns configuration corefile, the template args will be changed to the wrong format

* **Target Version for Merge**
v1.12.0

* **Related Issues**
When added a new user, the local domain not work

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/commit/3613d86ff3cebab4044ed238fac0cf9fe7d4fa66

* **Other information**:
