### PR TITLE
docs: update Olares platform support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,14 @@ Here is why and where you can count on Olares for private, powerful, and secure 
 ## Getting started
 
 ### System compatibility
-Olares has been tested and verified on the following platforms:
 
-| Platform            | Operating system                     | Notes                                                 |
-|---------------------|--------------------------------------|-------------------------------------------------------|
-| Linux               | Ubuntu 20.04 LTS or later <br/> Debian 11 or later |                                          |
-| Raspberry Pi        | RaspbianOS                           | Verified on Raspberry Pi 4 Model B and Raspberry Pi 5 |
-| Windows             | Windows 11 23H2 or later <br/>Windows 10 22H2 or later<br/> WSL2 |                                     |
-| Mac                 | Monterey (12) or later              |                                                        |
-| Proxmox VE (PVE)    | Proxmox Virtual Environment 8.0      |                                                       |
+Olares has been tested and verified on the following Linux platforms:
 
-> **Note**
-> 
-> If you successfully install Olares on an operating system that is not listed in the compatibility table, please let us know! You can [open an issue](https://github.com/beclab/Olares/issues/new) or submit a pull request on our GitHub repository.
+- Ubuntu 20.04 LTS or later 
+- Debian 11 or later
+
+> **Other installation options**
+> Olares can also be installed on other platforms like macOS, Windows, PVE, and Raspberry Pi, or installed via docker compose on Linux. However, these are only for **testing and development purposes**. For detailed instructions, visit [Additional installation options](https://docs.olares.xyz/developer/install/additional-installations.html).
 
 ### Set up Olares
 To get started with Olares on your own device, follow the [Getting Started Guide](https://docs.olares.xyz/manual/get-started/) for step-by-step instructions.

--- a/README_CN.md
+++ b/README_CN.md
@@ -62,25 +62,18 @@ Olares 是为本地端侧 AI 打造的开源私有云操作系统，可轻松将
 ## 快速开始
 
 ### 系统兼容性
-Olares 已在以下平台完成测试验证：
 
-| 平台            | 操作系统                     | 备注                                                 |
-|---------------------|--------------------------------------|-------------------------------------------------------|
-| Linux               | Ubuntu 20.04 LTS 及以上 <br/> Debian 11 及以上  |                                               |
-| Raspberry Pi        | RaspbianOS                           | 已在 Raspberry Pi 4 Model B 和 Raspberry Pi 5 上验证    |
-| Windows             | Windows 11 23H2 及以上 <br/>Windows 10 22H2 及以上 <br/>WSL2 |                                           |
-| Mac                  | macOS Monterey (12) 及以上             |                                                         |
-| Proxmox VE (PVE)    | Proxmox Virtual Environment 8.0      |                                                         |
+Olares 已在以下 Linux 平台完成测试与验证：
 
-> **注意**
-> 
-> 如果你在未列出的系统版本上成功安装了 Olares，请告诉我们！你可以在 GitHub 仓库中[提交 Issue](https://github.com/beclab/Olares/issues/new) 或发起 Pull Request。
+- Ubuntu 20.04 LTS 及以上版本
+- Debian 11 及以上版本
+
+> **其他安装方式**
+> Olares 也支持在 macOS、Windows、PVE、树莓派等平台上运行，或通过 Docker Compose 在 Linux 上部署。但请注意，这些方式**仅适用于开发和测试环境**。详细安装指南请参阅[其他安装方式](https://docs.joinolares.cn/zh/developer/install/additional-installations.html)。
 
 ### 安装 Olares
-
-> 当前文档仅有英文版本。
  
-参考[快速上手指南](https://docs.olares.xyz/manual/get-started/)安装并激活 Olares。
+参考[快速上手指南](https://docs.joinolares.cn/zh/manual/get-started/)安装并激活 Olares。
 
 ## 系统架构
 Olares 的架构设计遵循两个核心原则：

--- a/README_JP.md
+++ b/README_JP.md
@@ -63,19 +63,14 @@ Olaresを使用して、ハードウェアをAIホームサーバーに変換し
 ## はじめに
 
 ### システム互換性
-Olaresは以下のプラットフォームでテストおよび検証されています：
 
-| プラットフォーム            | オペレーティングシステム                     | 備考                                                 |
-|---------------------|--------------------------------------|-------------------------------------------------------|
-| Linux               | Ubuntu 20.04 LTS以降 <br/> Debian 11以降 |                                          |
-| Raspberry Pi        | RaspbianOS                           | Raspberry Pi 4 Model BおよびRaspberry Pi 5で検証済み |
-| Windows             | Windows 11 23H2以降 <br/>Windows 10 22H2以降<br/> WSL2 |                                     |
-| Mac                 | Monterey (12)以降              |                                                        |
-| Proxmox VE (PVE)    | Proxmox Virtual Environment 8.0      |                                                       |
+Olaresは以下のLinuxプラットフォームで動作検証を完了しています：
 
-> **注意**
-> 
-> 互換性テーブルに記載されていないオペレーティングシステムでOlaresを正常にインストールした場合は、お知らせください！GitHubリポジトリで[問題を開く](https://github.com/beclab/Olares/issues/new)か、プルリクエストを送信できます。
+- Ubuntu 20.04 LTS 以降
+- Debian 11 以降
+
+> **追加インストール手順**
+> Olares は macOS、Windows、PVE、Raspberry Pi などのプラットフォームや、Linux 上での Docker Compose を用いたインストールにも対応しています。>ただし、これらの方法は開発およびテスト環境専用です。詳しくは[追加インストール手順](https://docs.olares.xyz/developer/install/additional-installations.html)をご参照ください。
 
 ### Olaresのセットアップ
 自分のデバイスでOlaresを始めるには、[はじめにガイド](https://docs.olares.xyz/manual/get-started/)に従ってステップバイステップの手順を確認してください。


### PR DESCRIPTION

* **Background**
Update the support info to direct users to direct users to Linux as the official recommended platform.