### PR TITLE
backup-server: restore params invalid, api response data format

### DIFF
--- a/frameworks/backup-server/config/cluster/crds/sys.bytetrade.io_backups.yaml
+++ b/frameworks/backup-server/config/cluster/crds/sys.bytetrade.io_backups.yaml
@@ -66,12 +66,15 @@ spec:
                       type: string
                     timesOfDay:
                       type: string
+                    timespanOfDay:
+                      type: string
                   required:
                     - dateOfMonth
                     - dayOfWeek
                     - enabled
                     - snapshotFrequency
                     - timesOfDay
+                    - timespanOfDay
                   type: object
                 backupType:
                   additionalProperties:

--- a/frameworks/backup-server/config/cluster/deploy/backup_server.yaml
+++ b/frameworks/backup-server/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.15" }}
+{{ $backupVersion := "0.3.16" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 ---


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
missing resticSnapshotId in restoration process, fixed api bug, refined api response data format

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/backup-server/pull/16
https://github.com/Above-Os/backups-sdk/pull/12


* **Other information**:
