### PR TITLE
feat(installer): save metadata to and read from release file

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.122"
+$CLI_VERSION = "0.1.124"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.122"
+CLI_VERSION="0.1.124"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/joincluster.sh
+++ b/build/installer/joincluster.sh
@@ -157,7 +157,7 @@ fi
 
 set_master_host_ssh_options
 
-CLI_VERSION="0.1.122"
+CLI_VERSION="0.1.124"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$CLI_VERSION" ]]; then


### PR DESCRIPTION
* **Background**
Save the metadata value of basedir and version in the /etc/olares/release file with a dot env format, like the /etc/os-release file, so that users need not to specify these arguments explicitly, e.g.:
```
~ cat /etc/olares/release
OLARES_BASE_DIR="/home/keven/.olares"
OLARES_VERSION="1.11.7"
```
* **Target Version for Merge**
1.11.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Installer/pull/193

* **Other information**:
none