### PR TITLE
otel: run collector as user 1000

### DIFF
--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -862,6 +862,9 @@ spec:
   volumeMounts:
   - name: storage
     mountPath: /data
+
+  securityContext:
+    runAsUser: 1000
     
   ports:
   - name: jaeger


### PR DESCRIPTION
* **Background**
Specify Jaeger collector runs as user 1000 to get the port listening permission

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Sometimes Jaeger collector got the port listening permission denied error.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
