### PR TITLE
tapr: replace nxdomain with noerror

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/sys_event_deploy.yaml
@@ -76,7 +76,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.4
+        image: beclab/sys-event:0.2.5
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_RANDOM_KEY


### PR DESCRIPTION
* **Background**
Replace dns rcode NXDOMAIN with NOERROR in local domain

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/commit/3589e7cc85bd5ed22a45972edfe78ed2fe1e004c


* **Other information**:
