### PR TITLE
fix: settings frontend add ACL port ui bug

### DIFF
--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -256,7 +256,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: settings-init
-          image: beclab/settings:v0.2.18
+          image: beclab/settings:v0.2.19
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -385,7 +385,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: settings-server
-          image: beclab/settings-server:v0.2.18
+          image: beclab/settings-server:v0.2.19
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
When adding an ACL port, the second custom port confirmation button cannot be clicked

* **Target Version for Merge**
1.12

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/settings/pull/97

* **Other information**:
none
