### PR TITLE
ControlHub: fix workloads operation layout

### DIFF
--- a/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
+++ b/apps/system-apps/config/user/helm-charts/monitoring/templates/system-frontend.yaml
@@ -203,7 +203,7 @@ spec:
             - mountPath: /www
               name: www-dir
         - name: control-hub-init
-          image: beclab/admin-console-frontend-v1:v0.5.6
+          image: beclab/admin-console-frontend-v1:v0.5.8
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
after the revamp of the pod operation console for controlHub workloads, the issue of layout disorder on small screens has been optimized.

* **Target Version for Merge**
v1.11

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/system-apps/pull/37


* **Other information**:
none