### PR TITLE
tapr: force update kvrock workload definition

### DIFF
--- a/build/installer/upgrade_cmd.sh
+++ b/build/installer/upgrade_cmd.sh
@@ -594,6 +594,8 @@ function upgrade_terminus(){
     sleep 2 # wait for controller reconiling
     echo
 
+    # update kvrocks namespace
+    $sh_c "${KUBECTL} rollout restart deployment tapr-middleware -n os-system"
 
     for user in ${users[@]}; do
         check_appservice

--- a/frameworks/tapr/config/cluster/deploy/redixcluster_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/redixcluster_deploy.yaml
@@ -77,7 +77,7 @@ spec:
         memory: 1Gi
       requests:
         cpu: 20m
-        memory: 50Mi  
+        memory: 60Mi  
     
     
     


### PR DESCRIPTION
* **Background**
Force update kvrock workload definition 

* **Target Version for Merge**
v1.11.7

* **Related Issues**
System-upgrade does not update kvrocks configuration of namespace persistence

* **PRs Involving Sub-Systems** 
none

* **Other information**:
