### PR TITLE
fix(installer): add error message output when using cli backup

### DIFF
--- a/build/installer/install.ps1
+++ b/build/installer/install.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
   New-Item -Path $CLI_PROGRAM_PATH -ItemType Directory
 }
 
-$CLI_VERSION = "0.1.126"
+$CLI_VERSION = "0.1.127"
 $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -74,7 +74,7 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_VERSION="0.1.126"
+CLI_VERSION="0.1.127"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="olares-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/joincluster.sh
+++ b/build/installer/joincluster.sh
@@ -157,7 +157,7 @@ fi
 
 set_master_host_ssh_options
 
-CLI_VERSION="0.1.126"
+CLI_VERSION="0.1.127"
 CLI_FILE="olares-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$CLI_VERSION" ]]; then


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
add error message output when using cli for backup and restore, fix traceId is nil

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.11.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/Above-Os/backups-sdk/pull/19
https://github.com/Above-Os/backups-sdk/commit/c10ce08025932592aca0f90bb51fa718e4acd601


* **Other information**:
