### PR TITLE
fix: files-server rename and cut/paste of smb bugfix

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -81,7 +81,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.68'
+              value: 'beclab/files-server:v0.2.69'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -117,7 +117,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.68
+          image: beclab/files-server:v0.2.69
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -409,7 +409,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.68
+          image: beclab/files-server:v0.2.69
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
- Background
files:
add smb readonly field (not used by frontend for the time being)
add del all thumbs and renaming try to the beginning of moving folder
use rm -rf with ls retry for only smb when deleting at the ending of moving folder

- Target Version for Merge
v1.11.0

- Related Issues
none

- PRs Involving Sub-Systems
https://github.com/beclab/files/pull/14

- Other information:
none
