### PR TITLE
fix: create crd in helm post-install hook

### DIFF
--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -843,7 +843,10 @@ webhooks:
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
-  name: jaeger-storage-instance 
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
+  name: jaeger-storage-instance
   namespace: os-system
   labels:
     applications.app.bytetrade.io/author: bytetrade.io
@@ -934,6 +937,9 @@ spec:
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
   name: olares-instrumentation
   namespace: os-system
 spec:


### PR DESCRIPTION
* **Background**
the current manifest of the Otel-related CRDs do not specify a hook, and helm upgrade will fail to run because other resources are being recreated.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none