### PR TITLE
backup-server: abnormal restoration state, get space cos stats failed

### DIFF
--- a/frameworks/backup-server/config/cluster/deploy/backup_server.yaml
+++ b/frameworks/backup-server/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.21" }}
+{{ $backupVersion := "0.3.22" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 ---


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
abnormal restoration state, api interface improvement, resolved the repository size retrieval failure when backing up to Tencent COS space

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12.0

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/backup-server/pull/22
https://github.com/Above-Os/backups-sdk/pull/20


* **Other information**:
