### PR TITLE
fix: correct minVersion in version.hint to follow semver spec

### DIFF
--- a/build/installer/version.hint
+++ b/build/installer/version.hint
@@ -1,2 +1,2 @@
 upgrade:
-  minVersion: 1.12.0-0000000
+  minVersion: 1.12.0-1


### PR DESCRIPTION
* **Background**
The [semver spec on the pre-release version](https://semver.org/#spec-item-9) specifies that leading zeros are illegal.
We change the current `0000` to `1` so that any daily-build and RC release version satisfy the minVersion requirement.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none