### PR TITLE
feat: upgrade hami and use original libvgpu.so

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -36,7 +36,7 @@ beclab/reverse-proxy:v0.1.8
 beclab/upgrade-job:0.1.7
 bytetrade/envoy:v1.25.11.1
 liangjw/kube-webhook-certgen:v1.1.1
-beclab/hami:v2.5.1
+beclab/hami:v2.5.2
 alpine:3.14
 mirrorgooglecontainers/defaultbackend-amd64:1.4
 projecthami/hami-webui-fe-oss:v1.0.5

--- a/frameworks/GPU/config/gpu/hami/values.yaml
+++ b/frameworks/GPU/config/gpu/hami/values.yaml
@@ -3,7 +3,7 @@
 nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
-version: "v2.5.1"
+version: "v2.5.2"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"


### PR DESCRIPTION
* **Background**
merge updates of HAMi from upstream and temporarily revert libvgpu.so to the official version. (i.e., without nvshare)

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/c49e679dfa056862ffd4bb90eec977ab869647e5

* **Other information**:
none