### PR TITLE
olares: fix go instrumentation resource limit typo

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -306,7 +306,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.4
+        image: beclab/bfl-ingress:v0.3.5
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog

--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -60,7 +60,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resources:
+    resourceRequirements:
       limits:
         memory: 256Mi
 
@@ -126,7 +126,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resources:
+    resourceRequirements:
       limits:
         memory: 256Mi
 

--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -60,7 +60,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resource:
+    resources:
       limits:
         memory: 256Mi
 
@@ -126,7 +126,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resource:
+    resources:
       limits:
         memory: 256Mi
 

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -993,7 +993,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resource:
+    resources:
       limits:
         memory: 256Mi
 

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -993,7 +993,7 @@ spec:
         value: http/json
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
-    resources:
+    resourceRequirements:
       limits:
         memory: 256Mi
 


### PR DESCRIPTION
* **Background**
Fix go instrumentation resource limit typo

* **Target Version for Merge**
v1.12.0

* **Related Issues**
go instrumentation resource limit not working

* **PRs Involving Sub-Systems** 
none

* **Other information**:
