### PR TITLE
otel: nginx auto instrumentation config reload bug fix

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -43,5 +43,5 @@ projecthami/hami-webui-fe-oss:v1.0.5
 projecthami/hami-webui-be-oss:v1.0.5
 nvidia/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04
 ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
-bytetrade/autoinstrumentation-apache-httpd:1.0.4
+bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix
 ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0

--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -44,7 +44,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
@@ -110,7 +110,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -977,7 +977,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318


### PR DESCRIPTION
* **Background**
OpenTelemetry nginx auto-instrumentation will lose the context configuration when nginx reloads the config.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
BFL Ingress openresty auto-instrumentation not work

* **PRs Involving Sub-Systems** 
None

* **Other information**:
