### PR TITLE
fix(chart): remove redundant format symbol in template

### DIFF
--- a/apps/notifications/config/cluster/deploy/notification_deploy.yaml
+++ b/apps/notifications/config/cluster/deploy/notification_deploy.yaml
@@ -1,6 +1,6 @@
 
 
-{{- $namespace := printf "%s%s" "os-system" -}}
+{{- $namespace := printf "%s" "os-system" -}}
 {{- $notifications_secret := (lookup "v1" "Secret" $namespace "notifications-secrets") -}}
 
 {{- $pg_password := "" -}}


### PR DESCRIPTION
* **Background**
the current `{{- $namespace := printf "%s%s" "os-system" -}}` prints out an incorrect "os-system%!s(MISSING)" instead of "os-system"

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none