### PR TITLE
otel: bump the go auto-instrumentation image version

### DIFF
--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -53,11 +53,12 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   go:
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.20.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
-        value: http/json
+        value: http/protobuf
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
     resourceRequirements:

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -986,11 +986,12 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   go:
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.20.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
-        value: http/json
+        value: http/protobuf
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
     resourceRequirements:


### PR DESCRIPTION
* **Background**
Bump the go auto-instrumentation image version and change the API  protocol

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
