### PR TITLE
otel: fix nginx instrumentation too many headers

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -43,5 +43,5 @@ projecthami/hami-webui-fe-oss:v1.0.5
 projecthami/hami-webui-be-oss:v1.0.5
 nvidia/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04
 ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.20.0
-bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix1
+bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
 ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0

--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -44,7 +44,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix1
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
@@ -111,7 +111,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix1
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -977,7 +977,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix1
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318


### PR DESCRIPTION
* **Background**
Opentelemetry Nginx auto-instrumentation sets too many headers in the request.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Files can not mkdir

* **PRs Involving Sub-Systems** 
https://github.com/beclab/opentelemetry-cpp-contrib/commit/9363fe8f662a29ee0add0aaf5715d98f6ce32ab3

* **Other information**:
