### PR TITLE
otel: fix nginx instrumentation arm64 build script bug

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -43,5 +43,5 @@ projecthami/hami-webui-fe-oss:v1.0.5
 projecthami/hami-webui-be-oss:v1.0.5
 nvidia/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04
 ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.20.0
-bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
+bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3
 ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -246,6 +246,18 @@ spec:
           chown -R 1000:1000 /userspace/Home && \
           chown -R 1000:1000 /userspace/Data && \
           chown -R 1000:1000 /appdata 
+      - name: setsysctl
+        image: 'busybox:1.28'
+        command:
+          - sh
+          - '-c'
+          - |
+            sysctl -w net.core.somaxconn=65535
+            sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+            sysctl -w net.ipv4.tcp_tw_reuse=1
+            sysctl -w fs.file-max=1048576
+        securityContext:
+          privileged: true
 
       containers:
       - name: api

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -261,7 +261,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.5
+        image: beclab/bfl:v0.4.6
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/frameworks/bfl/config/launcher/templates/otel_define.yaml
+++ b/frameworks/bfl/config/launcher/templates/otel_define.yaml
@@ -44,7 +44,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
@@ -111,7 +111,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318

--- a/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/third-party/opentelemetry/config/cluster/deploy/opentelemetry_operator.yaml
@@ -977,7 +977,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nginx:
-    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix2
+    image: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318


### PR DESCRIPTION
* **Background**
Fix nginx instrumentation arm64 build script bug
Optimize bfl pod network sys config
Optimize dynamic client by using dynamic resource informer in BFL api

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Nginx instrumentation crashed when loading functions from the dynamic library

* **PRs Involving Sub-Systems** 
https://github.com/beclab/opentelemetry-cpp-contrib/commit/1cd1dfa523ff432eb58d7407c44bdd72bc272c64

* **Other information**:
