### PR TITLE
tapr: add roles to pg user

### DIFF
--- a/framework/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/framework/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.2.4
+        image: beclab/middleware-operator:0.2.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
* **Background**
`Knowledge` needs privileges to backup and download pg data on the server, add  two roles `pg_write_server_files`, `pg_read_server_files` to pg users


* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/58

* **Other information**:
