### PR TITLE
fix(ci): pass correct version var when deploying in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -184,7 +184,7 @@ jobs:
           url: 'https://cloud-dev-api.bttcdn.com/v1/resource/installTest'
           method: 'POST'
           customHeaders: '{"Authorization": "${{ secrets.INSTALL_SECRET }}"}'
-          data: 'versions=${{ needs.test-version.outputs.version }}&downloadUrl=https://dc3p1870nn3cj.cloudfront.net/install-wizard-v${{ steps.vars.outputs.tag_version }}.tar.gz'
+          data: 'versions=${{ needs.test-version.outputs.version }}&downloadUrl=https://dc3p1870nn3cj.cloudfront.net/install-wizard-v${{ needs.test-version.outputs.version }}.tar.gz'
           contentType: "application/x-www-form-urlencoded"
 
       - name: Check Result


### PR DESCRIPTION
* **Background**
the old version var in the download url for CI deploying test is missed when refactoring workflow file

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none