### PR TITLE
fix(otel): specify auto instrumentation image for nodejs service

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/otel_define.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/otel_define.yaml
@@ -36,6 +36,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nodejs:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.53.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318
@@ -103,6 +104,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nodejs:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.53.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318

--- a/platform/open-telemetry/.olares/Olares.yaml
+++ b/platform/open-telemetry/.olares/Olares.yaml
@@ -3,12 +3,8 @@ target: prebuilt
 output:
   containers:
     - 
-      name: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
+      name: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.20.0
     - 
-      name: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix1
+      name: bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3
     - 
-      name: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0
-      
-
-
-
+      name: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.53.0

--- a/platform/open-telemetry/.olares/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/platform/open-telemetry/.olares/config/cluster/deploy/opentelemetry_operator.yaml
@@ -969,6 +969,7 @@ spec:
       - name: OTEL_TRACES_SAMPLER_ARG
         value: "1.0"
   nodejs:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.53.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://jaeger-storage-instance-collector.os-system:4318


### PR DESCRIPTION
* **Background**
currently, the version of the nodejs image injected by otel operator is not the version collected when packaging Olares

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none