### PR TITLE
fix(cli): update CUDA version in node labels after upgrading GPU driver

### DIFF
--- a/cli/pkg/pipelines/gpu_upgrade.go
+++ b/cli/pkg/pipelines/gpu_upgrade.go
@@ -59,6 +59,7 @@ func UpgradeGpuDrivers(opt *options.InstallGpuOptions) error {
 				SkipCudaCheck: true,
 			},
 			&gpu.RestartContainerdModule{},
+			&gpu.NodeLabelingModule{},
 		},
 		Runtime: runtime,
 	}


### PR DESCRIPTION
* **Background**
the `gpu.bytetrade.io/cuda` label is set to the CUDA version on a node during installation, but not updated when upgrading through `olares-cli gpu upgrade`

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none