### PR TITLE
fix(cli): also consider 3D controller when detecting GPU by lspci

### DIFF
--- a/cli/pkg/gpu/prepares.go
+++ b/cli/pkg/gpu/prepares.go
@@ -118,7 +118,7 @@ func (p *NvidiaGraphicsCard) PreCheck(runtime connector.Runtime) (found bool, er
 		}
 	}()
 	output, err := runtime.GetRunner().SudoCmd(
-		"lspci | grep -i vga | grep -i nvidia", false, false)
+		"lspci | grep -i -e vga -e 3d | grep -i nvidia", false, false)
 	// an empty grep also results in the exit code to be 1
 	// and thus a non-nil err
 	if err != nil {


### PR DESCRIPTION
* **Background**
Some GPU cards declare themselves as a `3D controller` rather than `VGA compatible controller` to the PCI bus, which is not considered when detecting GPU cards in the machine. And it should also be considered.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none