### PR TITLE
fix(cli): remove the local flag in local release version

### DIFF
--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -10,7 +10,7 @@ function command_exists() {
 if [[ x"$VERSION" == x"" ]]; then
     if [[ "$LOCAL_RELEASE" == "1" ]]; then
         ts=$(date +%Y%m%d%H%M%S)
-        export VERSION="1.12.0-local-$ts"
+        export VERSION="1.12.0-$ts"
         echo "will build and use a local release of Olares with version: $VERSION"
         echo ""
     else

--- a/cli/cmd/ctl/os/release.go
+++ b/cli/cmd/ctl/os/release.go
@@ -48,7 +48,7 @@ func NewCmdRelease() *cobra.Command {
 			}
 
 			if version == "" {
-				version = fmt.Sprintf("1.12.0-local-%s", time.Now().Format("20060102150405"))
+				version = fmt.Sprintf("1.12.0-%s", time.Now().Format("20060102150405"))
 				fmt.Printf("--version unspecified, using: %s\n", version)
 				time.Sleep(1 * time.Second)
 			}


### PR DESCRIPTION
* **Background**
the current `local` flag in the auto-generated version of Olares local release results in the frontend to fail authentication

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none