### PR TITLE
bfl: add a new olares-info api

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -261,7 +261,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.6
+        image: beclab/bfl:v0.4.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -318,7 +318,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.5
+        image: beclab/bfl-ingress:v0.3.6
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION

* **Background**
1. Add a new api olares-info to replace the deprecated api terminus-info later
2. Change the ingress default fallback page to olares.xyz

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/101

* **Other information**:
