### PR TITLE
fix(cli): just install a single instance of GPU driver

### DIFF
--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -134,10 +134,6 @@ func (t *InstallCudaDriver) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "Failed to apt-get install nvidia-kernel-open-575")
 	}
 
-	if _, err := runtime.GetRunner().SudoCmd("apt-get -y install nvidia-driver-575", false, true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "Failed to apt-get install nvidia-driver-575")
-	}
-
 	if t.SkipNVMLCheckAfterInstall {
 		return nil
 	}


### PR DESCRIPTION
* **Background**
Currently, when installing GPU driver, the `nvidia-kernel-open` is installed first and then `nvidia-driver`, whereas they're actually a same driver, just an open-sourced one and a proprietary one. And they're also mutually exclusive, with the installation of the latter effectively removing the former.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
https://developer.download.nvidia.cn/compute/cuda/repos/ubuntu2204/x86_64/Packages