### PR TITLE
bfl: crash and bulk http clients

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -261,7 +261,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.7
+        image: beclab/bfl:v0.4.8
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
1. Adding scheme to k8s client go in the http api handler will cause the concurrent map writes issue
2. Bulk HTTP clients for app-service

* **Target Version for Merge**
v1.12.0

* **Related Issues**
bfl crashed when performance testing

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/102

* **Other information**:
