### PR TITLE
fix: files sync dir rename bug

### DIFF
--- a/apps/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/apps/.olares/config/cluster/deploy/files_deploy.yaml
@@ -97,7 +97,7 @@ spec:
 
       containers:
         - name: gateway
-          image: beclab/appdata-gateway:0.1.19
+          image: beclab/appdata-gateway:0.1.20
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -106,7 +106,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.70'
+              value: 'beclab/files-server:v0.2.71'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -142,7 +142,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.70
+          image: beclab/files-server:v0.2.71
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -437,7 +437,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.70
+          image: beclab/files-server:v0.2.71
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background

fix:

- files-server: sync (seafile) dir rename bug
- appdata-gateway: fatal error, concurrent map writes

Target Version for Merge
v1.12.0

Related Issues
none

PRs Involving Sub-Systems
https://github.com/beclab/files/pull/18
https://github.com/beclab/files/pull/19

Other information:
none