### PR TITLE
fix(ci): use correct daily release version for daemon

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -28,10 +28,11 @@ jobs:
       version: ${{ needs.daily-version.outputs.version }}
 
   release-daemon:
+    needs: daily-version
     uses: ./.github/workflows/release-daemon.yaml
     secrets: inherit
     with:
-      version: ${{ github.event.inputs.tags }}
+      version: ${{ needs.daily-version.outputs.version }}
 
   push-images:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
* **Background**
change the wrong version `github.event.input.tags` of normal release to the corrent version `needs.daily-version.outputs.version` of daily release.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none