### PR TITLE
fix(daemon): reset upgrade target when not upgrading

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -349,6 +349,7 @@ func CheckCurrentStatus(ctx context.Context) error {
 
 	// not upgrading, reset upgrading status
 	CurrentState.UpgradingState = ""
+	CurrentState.UpgradingTarget = ""
 	CurrentState.UpgradingRetryNum = 0
 	CurrentState.UpgradingStep = ""
 	CurrentState.UpgradingProgressNum = 0


### PR DESCRIPTION
* **Background**
currently, the `upgradeingTarget` field in the system state of olaresd is not reset when not upgrading.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none