### PR TITLE
fix(ci): pass in git ref when calling workflow for submodule

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -64,6 +64,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.test-version.outputs.version }}
+      ref: ${{ github.event.pull_request.head.ref }}
 
   upload-daemon:
     needs: test-version
@@ -71,6 +72,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.test-version.outputs.version }}
+      ref: ${{ github.event.pull_request.head.ref }}
 
   push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -6,6 +6,8 @@ on:
       version:
         type: string
         required: true
+      ref:
+        type: string
   workflow_dispatch:
 jobs:
   goreleaser:
@@ -15,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+          ref: ${{ inputs.ref }}
 
       - name: Add Local Git Tag For GoReleaser
         run: git tag ${{ inputs.version }}

--- a/.github/workflows/release-daemon.yaml
+++ b/.github/workflows/release-daemon.yaml
@@ -6,6 +6,8 @@ on:
       version:
         type: string
         required: true
+      ref:
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -16,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+          ref: ${{ inputs.ref }}
 
       - name: Add Local Git Tag For GoReleaser
         run: git tag ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,14 @@ jobs:
     secrets: inherit
     with:
       version: ${{ github.event.inputs.tags }}
+      ref: ${{ github.event.inputs.tags }}
 
   release-daemon:
     uses: ./.github/workflows/release-daemon.yaml
     secrets: inherit
     with:
       version: ${{ github.event.inputs.tags }}
+      ref: ${{ github.event.inputs.tags }}
 
   push:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
* **Background**
`actions/checkout` does not persist across workflow calls, and the git ref it checks out defaults to the default branch (main), which should be the HEAD of PR branch and release tag, respectively, when doing PR test and formal release.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none