### PR TITLE
fix: files-server bug when listing external if any smb folder is stated as host is down

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -106,7 +106,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.71'
+              value: 'beclab/files-server:v0.2.72'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -142,7 +142,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.71
+          image: beclab/files-server:v0.2.72
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -443,7 +443,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.71
+          image: beclab/files-server:v0.2.72
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background

fix:

- files-server: bug when listing external if any smb folder is stated as host is down

Target Version for Merge
v1.12.0

Related Issues
none

PRs Involving Sub-Systems
https://github.com/beclab/files/pull/20

Other information:
none