### PR TITLE
tapr: bump postgresql and citus version & optimize middleware api

### DIFF
--- a/framework/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/framework/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.2.6
+        image: beclab/middleware-operator:0.2.7
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/platform/postgresql/citus/.olares/Olares.yaml
+++ b/platform/postgresql/citus/.olares/Olares.yaml
@@ -3,6 +3,6 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/citus:12.2
+      name: beclab/citus:13.0.3
 
 # must have blank new line


### PR DESCRIPTION
* **Background**
1. Bump PostgreSQL version to 17
2. Bump Citus version to 13.0.3
3. Optimize middleware api for ControlHub


* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/60

* **Other information**:
