### PR TITLE
fix: fix movedto event error

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -238,7 +238,7 @@ spec:
             value: os_system_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.34
+        image: beclab/search3:v0.0.35
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -263,7 +263,7 @@ spec:
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: terminus.os-system.system.groups
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.34
+        image: beclab/search3monitor:v0.0.35
         imagePullPolicy: IfNotPresent
         env:
         - name: DATABASE_URL


### PR DESCRIPTION
Title: aboveos/search3: fix search3monitor error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**

1. delete exist resource_uri for moved to event
2.  limit search3 db pool max_connection

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/56
https://github.com/Above-Os/search3/pull/55
