### PR TITLE
fix(ci): copy back joincluster script before releasing

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -150,6 +150,7 @@ jobs:
           cp .dist/install-wizard/install.sh build/base-package
           cp build/base-package/install.sh build/base-package/publicInstaller.sh
           cp .dist/install-wizard/install.ps1 build/base-package
+          cp .dist/install-wizard/joincluster.sh build/base-package
 
       - name: Release public files
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,7 @@ jobs:
           cp build/base-package/install.sh build/base-package/publicInstaller.latest
           cp .dist/install-wizard/install.ps1 build/insbase-packagetaller
           cp build/base-package/install.ps1 build/base-package/publicInstaller.latest.ps1
+          cp .dist/install-wizard/joincluster.sh build/base-package
 
       - name: Release public files
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* **Background**
The `joincluster.sh` script is not copied back to the `build` directory after the Olares version placeholder has been substituted in the release CI, resulting the original script being released 

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none