### PR TITLE
feat(gpu): add APIs to manage GPU mode and app binding

### DIFF
--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -648,7 +648,7 @@ func (t *PrintPluginsStatus) Execute(runtime connector.Runtime) error {
 		}
 	}
 
-	gpuScheduler, err := client.Kubernetes().CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "name=gpu-scheduler"})
+	gpuScheduler, err := client.Kubernetes().CoreV1().Pods("gpu-system").List(context.Background(), metav1.ListOptions{LabelSelector: "name=gpu-scheduler"})
 	if err != nil {
 		logger.Error("get gpu-scheduler status error, ", err)
 	}
@@ -657,7 +657,7 @@ func (t *PrintPluginsStatus) Execute(runtime connector.Runtime) error {
 		logger.Info("gpu-scheduler not exists")
 	} else {
 		for _, scheduler := range gpuScheduler.Items {
-			logger.Infof("gpu-scheduler status: %s", scheduler.Status.Phase)
+			logger.Infof("node: %s gpu-scheduler status: %s", scheduler.Spec.NodeName, scheduler.Status.Phase)
 			break
 		}
 	}
@@ -675,7 +675,7 @@ func (t *RestartPlugin) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
-	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s rollout restart ds gpu-scheduler -n kube-system", kubectlpath), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s rollout restart ds gpu-scheduler -n gpu-system", kubectlpath), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to restart gpu-scheduler")
 	}
 

--- a/framework/gpu/.olares/config/gpu/hami/values.yaml
+++ b/framework/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.5.2-share-07"
+version: "v2.5.2-share-08"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"
@@ -54,6 +54,8 @@ scheduler:
   nodeName: ""
   # nodeLabelSelector:
   #  "gpu": "on"
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: "true"
   overwriteEnv: "false"
   defaultSchedulerPolicy:
     nodeSchedulerPolicy: binpack


### PR DESCRIPTION
* **Background**
Add APIs to manage GPU under the new GPU framework of Olares:
- `/gpus` to list GPU details and the applications currently bound to each GPU
- `/gpus/:id/mode` to switch mode of a specific GPU
- `/gpus/:id/assign` to assign a (or a slice of) GPU to a specific application 

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/0a02cd3102c287563e0ed3d951c02d8f64e5b8d9

* **Other information**:
none