### PR TITLE
fix: files-server copy task cancel bug

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -106,7 +106,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.74'
+              value: 'beclab/files-server:v0.2.75'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -142,7 +142,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.74
+          image: beclab/files-server:v0.2.75
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -443,7 +443,7 @@ spec:
           name: check-nats
       containers:
         - name: files
-          image: beclab/files-server:v0.2.74
+          image: beclab/files-server:v0.2.75
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background

fix:
- files-server: copy task cancel bug

Target Version for Merge
v1.12.0

Related Issues
none

PRs Involving Sub-Systems
https://github.com/beclab/files/pull/23

Other information:
none
