### PR TITLE
fix(gpu): use node affinity to select master node for hami-scheduler

### DIFF
--- a/framework/gpu/.olares/config/gpu/hami/templates/scheduler/deployment.yaml
+++ b/framework/gpu/.olares/config/gpu/hami/templates/scheduler/deployment.yaml
@@ -162,3 +162,10 @@ spec:
       {{- if .Values.scheduler.nodeName }}
       nodeName: {{ .Values.scheduler.nodeName }}
       {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists

--- a/framework/gpu/.olares/config/gpu/hami/values.yaml
+++ b/framework/gpu/.olares/config/gpu/hami/values.yaml
@@ -54,8 +54,6 @@ scheduler:
   nodeName: ""
   # nodeLabelSelector:
   #  "gpu": "on"
-  nodeSelector:
-    node-role.kubernetes.io/control-plane: "true"
   overwriteEnv: "false"
   defaultSchedulerPolicy:
     nodeSchedulerPolicy: binpack


### PR DESCRIPTION
* **Background**
the current way to schedule hami-scheduler pod to master node by specifying `.spec.nodeSelector` is not expressive enough and cannot handle the case where the label exists but with an empty value, we change it to node affinity to handle both cases, whether it has a value or not.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none