### PR TITLE
fix(manifest): add missing citus image

### DIFF
--- a/framework/tapr/.olares/Olares.yaml
+++ b/framework/tapr/.olares/Olares.yaml
@@ -4,6 +4,8 @@ output:
   containers:
     - 
       name: bytetrade/envoy:v1.25.11.1
+    -
+      name: beclab/citus:12.2
 
 
       


### PR DESCRIPTION
* **Background**
currently, citus image is not specified in the Olares manifest and has to be pulled from online registry on demand

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none