### PR TITLE
feat(gpu): auto-create GPUBindings for pods falling back to timeslicing GPUs

### DIFF
--- a/framework/gpu/.olares/config/gpu/hami/values.yaml
+++ b/framework/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.5.2-share-09"
+version: "v2.5.2-share-10"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.5.2-share-09
+      name: beclab/hami:v2.5.2-share-10
     - 
       name: projecthami/hami-webui-fe-oss:v1.0.5
     - 


### PR DESCRIPTION
* **Background**
Currently, pods belonging to Applications without any GPU binding specified by user will fallback to GPUs in time slicing mode, and their owner applications listed in the GPU status API by retrieving and parsing information of Running pods, mixed up with other applications with explicit GPU bindings, causing confusion. This behavior is now changed to auto-creation of GPU binding between the application and the fall back GPU.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/0a88e8f7e876a8cbbacf946f8d379876b1962200

* **Other information**:
none