### PR TITLE
fix: fix monitor document title detection language error

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -238,7 +238,7 @@ spec:
             value: os_system_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.36
+        image: beclab/search3:v0.0.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -263,7 +263,7 @@ spec:
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: terminus.os-system.system.groups
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.36
+        image: beclab/search3monitor:v0.0.38
         imagePullPolicy: IfNotPresent
         env:
         - name: DATABASE_URL

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -238,7 +238,7 @@ spec:
             value: os_system_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.38
+        image: beclab/search3:v0.0.39
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -263,7 +263,7 @@ spec:
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: terminus.os-system.system.groups
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.38
+        image: beclab/search3monitor:v0.0.39
         imagePullPolicy: IfNotPresent
         env:
         - name: DATABASE_URL


### PR DESCRIPTION
Title: aboveos/search3: fix search3monitor title document language detect error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. The original title language detection was based on a combination of Facebook's fastText and lingua-rs, striking a balance between memory usage and accuracy. However, for short texts like titles, there were still cases where the language could not be detected or was detected incorrectly. Now, the detection is based purely on lingua-rs, which offers highe accuracy at the cost of higher memory usage (with the model occupying around 400MB of memory resident at all times).

2.  When uploading a file to the Olares host, the file is assigned a temporary path or identifier. Because it only exists for a short period of time, the file may disappear from the disk before it is inserted into the database. This can lead to renaming errors. To fix this issue, when a renaming operation occurs and the original file information is not found in the database, a new document record should be created and inserted into the database directly
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/58
https://github.com/Above-Os/search3/pull/59
https://github.com/Above-Os/search3/pull/60

