### PR TITLE
fix: fix search3 error

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -238,7 +238,7 @@ spec:
             value: os_system_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.42
+        image: beclab/search3:v0.0.45
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -263,7 +263,7 @@ spec:
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: terminus.os-system.system.groups
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.42
+        image: beclab/search3monitor:v0.0.45
         imagePullPolicy: IfNotPresent
         env:
         - name: DATABASE_URL


### PR DESCRIPTION
Title: aboveos/search3: fix-search3-error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. Some batch operations on the database involve writing raw SQL statements, and certain filenames contain special characters that need to be escaped; otherwise, execution errors may occur.

2. For filenames like ‘bzhan Nars新计划 [BV1bMTYzrEz3].m.mp4’, a search using "nars" can find the file, but extracting the highlight phrase fails, resulting in nothing being returned to the frontend.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/62
https://github.com/Above-Os/search3/pull/63
https://github.com/Above-Os/search3/pull/64
https://github.com/Above-Os/search3/pull/65
https://github.com/Above-Os/search3/pull/66
https://github.com/Above-Os/search3/pull/67
https://github.com/Above-Os/search3/pull/68
https://github.com/Above-Os/search3/pull/69

