### PR TITLE
refactor(cli): distinguish between 32-bit and 64-bit arch in release ci

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -15,8 +15,6 @@ builds:
     goarm:
       - 7
     ignore:
-      - goos: linux
-        goarch: arm64
       - goos: darwin
         goarch: arm
       - goos: windows
@@ -29,10 +27,6 @@ dist: ./output
 archives:
   - id: olares-cli
     name_template: "{{ .ProjectName }}-v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      linux: linux
-      amd64: amd64
-      arm: arm64
 checksum:
   name_template: "checksums.txt"
 release:


### PR DESCRIPTION
* **Background**
Currently, ARMv7 version of olares-cli is built in release CI on all ARM-based systems regardless of specific arch, for some newer CPUs without ARMv7 backwards compatibility, it can fail to run.

* **Target Version for Merge**
1.12.0

* **Related Issues**
https://github.com/beclab/Olares/issues/1445

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none
