### PR TITLE
authelia: add SameSite option to set-cookie

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -389,7 +389,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.7
+        image: beclab/auth:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION

* **Background**
Add SameSite option to set-cookie to be compatible with the cross-domain login request

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Larepass desktop cannot log into the cluster

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/14

* **Other information**:
