### PR TITLE
feat(user-service, notification, analytics): put prisma library under node_moudles in dockers

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/system-frontend.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/system-frontend.yaml
@@ -623,7 +623,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.18
+          image: beclab/user-service:v0.0.19
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/framework/analytics/.olares/config/cluster/deploy/analytics_deploy.yaml
+++ b/framework/analytics/.olares/config/cluster/deploy/analytics_deploy.yaml
@@ -83,7 +83,7 @@ spec:
             value: os_framework_analytics
       containers:
       - name: analytics-server
-        image: beclab/analytics-api:v0.0.6
+        image: beclab/analytics-api:v0.0.7
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -156,7 +156,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.6
+        image: beclab/notifications-api:v1.12.7
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
**Background**

We use webpack to package a TypeScript project to reduce the Docker image size.
Specifically, since these projects use Prisma, we package the Prisma client library but not the Prisma core library in the Docker image.
When the program starts, the entrypoint calls npx prisma migrate, which triggers npm install. This causes two issues:
1. When the network is poor, the container fails to resolve [npmjs.org](https://npmjs.org/), preventing the Docker container from starting normally.
2. It takes up to a minute for the service to go online, which is time-consuming.

Therefore, we decided to package the Prisma core library into the Docker image, which increases each Dockerfile size by 70MB.
Considering that we plan to rewrite these three projects in Rust or Go, we are willing to accept this tradeoff.

