### PR TITLE
authelia: remove httponly option from set-cookie

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -389,7 +389,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.8
+        image: beclab/auth:0.2.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION

* **Background**
Remove httponly option from set-cookie, let the client can access the auth token

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Desktop websocket client not working

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/fa6ae141a46818b84dcca013382d921df305ef23

* **Other information**:
