### PR TITLE
fix(cli): do not wait for recreation of pods without owner when changing ip

### DIFF
--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -265,7 +265,7 @@ const (
 	CacheAppServicePod = "app_service_pod_name"
 	CacheAppValues     = "app_built_in_values"
 
-	CacheCountPodsUsingHostIP = "count_pods_using_host_ip"
+	CacheCountPodsWaitForRecreation = "count_pods_wait_for_recreation"
 
 	CacheUpgradeUsers     = "upgrade_users"
 	CacheUpgradeAdminUser = "upgrade_admin_user"


### PR DESCRIPTION
* **Background**
Currently, when changing IP, the number of pods deleted is tracked and their recreation waited, but standalone pods without owner may not be recreated immediately and thus should not be waited for, e.g., this is the case for Olares terminal pod which is created on-demand.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none