### PR TITLE
feat: search3 support multiple node for cache and external, run as daemonset

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.47
+        image: beclab/search3:v0.0.48
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -270,8 +270,27 @@ spec:
           value: os.users
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: os.groups
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: search3monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: search3monitor
+spec:
+  selector:
+    matchLabels:
+      app: search3monitor
+  template:
+    metadata:
+      labels:
+        app: search3monitor
+    spec:
+      serviceAccountName: os-internal
+      containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.47
+        image: beclab/search3monitor:v0.0.48
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP
@@ -282,6 +301,18 @@ spec:
           value: $(NODE_IP):18088  
         - name: DATABASE_URL
           value: postgres://search3_os_framework:{{ $pg_password | b64dec }}@citus-0.citus-headless.os-platform:5432/os_framework_search3
+        - name: SEARCH3_SERVER_ADDRESS
+          value: search3.os-framework:80
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         volumeMounts:
           - name: fb-data
             mountPath: /appdata
@@ -296,6 +327,24 @@ spec:
           privileged: true
           runAsUser: 0
           allowPrivilegeEscalation: true
+      volumes:
+        - name: userspace-dir
+          hostPath:
+            path: /olares/rootfs/userspace
+            type: Directory
+        - name: fb-data
+          hostPath:
+            path: /olares/userdata/Cache/files
+            type: DirectoryOrCreate
+        - name: upload-appdata
+          hostPath:
+            path: /olares/userdata/Cache
+            type: DirectoryOrCreate
+        - name: shared-lib
+          hostPath:
+            path: /olares/share
+            type: Directory
+
 ---
 apiVersion: v1
 kind: Service

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.48
+        image: beclab/search3:v0.0.49
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.48
+        image: beclab/search3monitor:v0.0.49
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: daemonset
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. search3monitor support multiple node for external and cache
2.  search3monitor run as daemonset

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/78

