### PR TITLE
feat(cli): set explicit image gc policy when installing K8s

### DIFF
--- a/cli/pkg/k3s/tasks.go
+++ b/cli/pkg/k3s/tasks.go
@@ -200,6 +200,8 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 		"containerd":              container.DefaultContainerdCRISocket,
 		"cgroup-driver":           "systemd",
 		"runtime-request-timeout": "5m",
+		"image-gc-high-threshold": "91",
+		"image-gc-low-threshold":  "90",
 	}
 	defaultKubeProxyArgs := map[string]string{
 		"proxy-mode": "ipvs",

--- a/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -307,6 +307,8 @@ func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeCon
 		"evictionPressureTransitionPeriod": "30s",
 		"featureGates":                     FeatureGatesDefaultConfiguration,
 		"runtimeRequestTimeout":            "5m",
+		"imageGCHighThresholdPercent":      91,
+		"imageGCLowThresholdPercent":       90,
 	}
 
 	if securityEnhancement {


### PR DESCRIPTION
* **Background**
So that kubelet will start image gc when available space of imagefs is less than 10%

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none