### PR TITLE
feat(tailscale): let tailscale run on the node where headscale is run…

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -247,6 +247,15 @@ spec:
       labels:
         app: tailscale
     spec:
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: headscale
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:


### PR DESCRIPTION
* **Background**
When k8s has multiple nodes, headscale and tailscale may be scheduled to different nodes

* **Target Version for Merge**
1.12.0

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
