### PR TITLE
olaresd: network interface api modifed and nvstream mdns bug fix

### DIFF
--- a/daemon/internel/mdns/server.go
+++ b/daemon/internel/mdns/server.go
@@ -43,6 +43,7 @@ func (s *server) Close() {
 	if s.server != nil {
 		klog.Info("mDNS server shutdown ")
 		s.server.Shutdown()
+		s.registeredIP = "" // clear the registered IP
 	}
 }
 

--- a/daemon/pkg/commands/upgrade/install_olaresd.go
+++ b/daemon/pkg/commands/upgrade/install_olaresd.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/daemon/pkg/cli"
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/nxadm/tail"
 	"k8s.io/klog/v2"
-	semver "github.com/Masterminds/semver/v3"
 )
 
 type prepareOlaresd struct {


### PR DESCRIPTION
* **Background**
1. Add more fields to network interfaces api when test-connectivity option is false
2. Fix nvstream mDNS service, for steam headless, restarting bug

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Cannot be discovered by Moonlight client

* **PRs Involving Sub-Systems** 
none

* **Other information**:
