### PR TITLE
fix(cli): set health host of felix to lo addr explicitly

### DIFF
--- a/cli/pkg/plugins/network/templates/calico_v1.16+.go
+++ b/cli/pkg/plugins/network/templates/calico_v1.16+.go
@@ -5993,6 +5993,8 @@ spec:
             # Enable or Disable VXLAN on the default IPv6 IP pool.
             - name: CALICO_IPV6POOL_VXLAN
               value: "Never"
+            - name: FELIX_HEALTHHOST
+              value: 127.0.0.1
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
* **Background**
The [HealthHost config](https://docs.tigera.io/calico/latest/reference/felix/configuration#process-health-port-and-timeouts) specifies which address the Felix health check service should bind to and defaults to `localhost`, although rare, this causes calico-node refusing to start on machines without a `localhost` entry in the `/etc/hosts`, by explicitly setting this to `127.0.0.1`, it can work normally on such machines, too.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none