### PR TITLE
perf(gpu): use our fork of dcgm-exporter with lower memory consumption

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/metrics-configmap.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/metrics-configmap.yaml
@@ -83,14 +83,14 @@ data:
       DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
       
       # DCP metrics
-      DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
+      # DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
       # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned.
       # DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM.
-      DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
-      DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+      # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+      # DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
       # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active.
       # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active.
       # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
-      DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
-      DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+      # DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
+      # DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
 {{- end }}

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -237,9 +237,9 @@ devices:
 
 dcgmExporter:
   image:
-    repository: nvidia/dcgm-exporter
+    repository: beclab/dcgm-exporter
     pullPolicy: IfNotPresent
-    tag: 4.1.1-4.0.4-ubuntu22.04
+    tag: 4.2.3-4.1.3-ubuntu22.04
 
   # Change the following reference to "/etc/dcgm-exporter/default-counters.csv"
   # to stop profiling metrics from DCGM


### PR DESCRIPTION
* **Background**
The official `nvidia/dcgm-exporter` we currently use takes ~500M of memory, which, upon analysis, is mostly contributed by the `libnvperf_dcgm_host.so`, a proprietary closed-source library, with a memory consumption of > 350M, even when its metrics are configured to not be collected.
Unfortunately, the `dcgm-exporter` runs an embedded engine of DCGM by calling `go-dcgm`, and neither project provides an API to disable the library, we can only make a fork of both repos and build our own version.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/go-dcgm/commit/65816b38785c5a2305f9e36049b2e6984ec4cd63
https://github.com/NVIDIA/dcgm-exporter/commit/ec0ed835bb630c9d29dde6f98c6e7df5796e49c8

* **Other information**:
none