### PR TITLE
fix(manifest): add missing app author label to argo deploy

### DIFF
--- a/framework/argo-workflow/.olares/config/cluster/deploy/server-deployment.yaml
+++ b/framework/argo-workflow/.olares/config/cluster/deploy/server-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: argoworkflows
+    applications.app.bytetrade.io/author: bytetrade.io
     app.kubernetes.io/managed-by: Helm
   annotations:
     applications.app.bytetrade.io/icon: https://argoproj.github.io/argo-workflows/assets/logo.png

--- a/framework/argo-workflow/.olares/config/cluster/deploy/workflow-controller-deployment.yaml
+++ b/framework/argo-workflow/.olares/config/cluster/deploy/workflow-controller-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: workflow-controller
+    applications.app.bytetrade.io/author: bytetrade.io
     app.kubernetes.io/instance: argo
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argoworkflows-workflow-controller


### PR DESCRIPTION
* **Background**
Add missing app author label `applications.app.bytetrade.io/author: bytetrade.io` to argo workflow deployments

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none