### PR TITLE
fix(manifest): update the missed reverse proxy image version

### DIFF
--- a/framework/reverse-proxy/.olares/Olares.yaml
+++ b/framework/reverse-proxy/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/reverse-proxy:v0.1.8
+      name: beclab/reverse-proxy:v0.1.10
 
 
       


### PR DESCRIPTION
* **Background**
in https://github.com/beclab/Olares/pull/1443, the version of reverse proxy image was updated to `0.1.10` in the bfl deployment manifest but left the Olares.yaml unchanged

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none