### PR TITLE
fix: 1. fix: like 'why-olares.md', if input 'why', 'olares', search w…

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.49
+        image: beclab/search3:v0.0.50
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.49
+        image: beclab/search3monitor:v0.0.50
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: fix search3,search3monitor error 
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. fix like 'why-olares.md', if input 'why', 'olares', search without result
2. fix when generate_monitor_folder_path_list for convert_from_physical_path_to_frontend_resource_uri not propagate error

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
* https://github.com/Above-Os/search3/pull/80
https://github.com/Above-Os/search3/pull/79

