### PR TITLE
infisical: crash when user not found

### DIFF
--- a/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
+++ b/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
@@ -231,7 +231,7 @@ spec:
           subPath: nginx.conf
 
       - name: tapr-sidecar
-        image: beclab/secret-vault:0.1.10
+        image: beclab/secret-vault:0.1.11
         imagePullPolicy: IfNotPresent
         ports:
         - name: proxy


### PR DESCRIPTION
* **Background**
When a user is not synced, responding `user not found` in the secret-list api.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Infisical got crashed when the secret-list api is called if the user is not synced

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/commit/58496077548269b33fccd5f66dabd72219f69dca

* **Other information**:
