### PR TITLE
bfl: do not change owner when restart

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -236,16 +236,19 @@ spec:
         - sh
         - -c
         - |
+          init=$(test -d /userspace/Home; echo $?) && \
           mkdir -p /userspace/Home/Documents && \
           mkdir -p /userspace/Home/Downloads && \
           mkdir -p /userspace/Home/Pictures && \
           mkdir -p /userspace/Home/Movies && \
           mkdir -p /userspace/Home/Music && \
           mkdir -p /userspace/Home/Code && \
-          mkdir -p /userspace/Data && \
+          mkdir -p /userspace/Data; \
+          if [ $init -ne 0 ]; then \
           chown -R 1000:1000 /userspace/Home && \
           chown -R 1000:1000 /userspace/Data && \
-          chown -R 1000:1000 /appdata 
+          chown -R 1000:1000 /appdata; \
+          fi 
       - name: setsysctl
         image: 'busybox:1.28'
         command:


### PR DESCRIPTION
* **Background**
When the new user is created, BFL will create the user's directory and change the owner to the user. When the cluster is restarted, it's unnecessary to change the owner again.

* **Target Version for Merge**
v1.12.0

* **Related Issues**
Some apps' data directory permissions were changed when the cluster was restarted.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
