### PR TITLE
feat(cli): auto enable GPU when adding new node

### DIFF
--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -263,30 +263,25 @@ type NodeLabelingModule struct {
 func (l *NodeLabelingModule) Init() {
 	l.Name = "NodeLabeling"
 
-	updateNode := &task.RemoteTask{
-		Name:  "UpdateNode",
-		Hosts: l.Runtime.GetHostsByRole(common.Master),
+	updateNode := &task.LocalTask{
+		Name: "UpdateNode",
 		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
 			new(CudaInstalled),
 			new(K8sNodeInstalled),
 		},
-		Action:   new(UpdateNodeLabels),
-		Parallel: false,
-		Retry:    1,
+		Action: new(UpdateNodeLabels),
+		Retry:  1,
 	}
 
-	restartPlugin := &task.RemoteTask{
-		Name:  "RestartPlugin",
-		Hosts: l.Runtime.GetHostsByRole(common.Master),
+	restartPlugin := &task.LocalTask{
+		Name: "RestartPlugin",
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
 			new(CudaInstalled),
 			new(K8sNodeInstalled),
 		},
-		Action:   new(RestartPlugin),
-		Parallel: false,
-		Retry:    1,
+		Action: new(RestartPlugin),
+		Retry:  1,
 	}
 
 	l.Tasks = []task.Interface{

--- a/cli/pkg/phase/cluster/add_node.go
+++ b/cli/pkg/phase/cluster/add_node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/core/pipeline"
+	"github.com/beclab/Olares/cli/pkg/gpu"
 	"github.com/beclab/Olares/cli/pkg/k3s"
 	"github.com/beclab/Olares/cli/pkg/kubernetes"
 	"github.com/beclab/Olares/cli/pkg/manifest"
@@ -75,6 +76,7 @@ func (m *AddNodeModule) Init() {
 			&k3s.JoinNodesModule{},
 		}
 	}
+	m.underlyingModules = append(m.underlyingModules, &gpu.NodeLabelingModule{})
 	for _, underlyingModule := range m.underlyingModules {
 		underlyingModule.Default(m.Runtime, m.PipelineCache, m.ModuleCache)
 		underlyingModule.AutoAssert()


### PR DESCRIPTION
* **Background**
Currently, if GPU is detected on a new node, the driver is installed but the GPU support has to be manually turned on, which should be automatic.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none