### PR TITLE
feat(headscale): let headscale run on the master node like l4-bfl-proxy

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -85,6 +85,18 @@ spec:
       labels:
         app: headscale
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            weight: 10
       serviceAccountName: tailscale
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION

* **Background**
When k8s has multiple nodes, headscale and tailscale may be scheduled to different nodes

* **Target Version for Merge**
1.12.0

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
