### PR TITLE
feat(cli): config endpoint_pod_names in coredns when installing

### DIFF
--- a/cli/pkg/plugins/dns/templates/coredns_service.go
+++ b/cli/pkg/plugins/dns/templates/coredns_service.go
@@ -65,6 +65,7 @@ data:
         health
         ready
         kubernetes {{ .DNSDomain }} in-addr.arpa ip6.arpa {
+          endpoint_pod_names
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
         }


### PR DESCRIPTION
* **Background**
The `endpoint_pod_names` config option in the [`Kubernetes` plugin](https://coredns.io/plugins/kubernetes/) of CoreDNS tells CoreDNS to serve A records resolved by pod names, in addition to service names, and allows us to proxy requests to specific pods, such as a files service on a specific node.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none