### PR TITLE
fix(daemon): handle empty pid files when check process running

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.4
 
 replace (
 	bytetrade.io/web3os/app-service => github.com/beclab/app-service v0.2.33
+	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.17
 	bytetrade.io/web3os/bfl => github.com/beclab/bfl v0.3.36
 	k8s.io/api => k8s.io/api v0.31.0
 	k8s.io/apimachinery => k8s.io/apimachinery v0.31.0

--- a/daemon/pkg/cluster/state/utils.go
+++ b/daemon/pkg/cluster/state/utils.go
@@ -88,6 +88,10 @@ func isProcessRunning(pidfile string) (bool, error) {
 		return false, err
 	}
 
+	if len(strings.TrimSpace(string(pidData))) == 0 {
+		return false, nil
+	}
+
 	pid, err := strconv.Atoi(string(pidData))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
* **Background**
when Olaresd checks whether a particular process is running, it reads and parses the corresponding pid file, if file exists but contains an empty string, strconv.Atoi("") will fail with "invalid syntax", causing Olaresd to stuck forever in the error state, this case should be checked first and return early.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none