### PR TITLE
fix(cli): clear upgrade-related state files when uninstalling

### DIFF
--- a/cli/pkg/phase/cluster/delete_cluster.go
+++ b/cli/pkg/phase/cluster/delete_cluster.go
@@ -105,6 +105,7 @@ func (p *phaseBuilder) phaseInstall() *phaseBuilder {
 			&certs.UninstallCertsFilesModule{},
 			&storage.DeleteUserDataModule{},
 			&terminus.DeleteWizardFilesModule{},
+			&terminus.DeleteUpgradeFilesModule{},
 			&storage.RemoveJuiceFSModule{},
 			&storage.DeletePhaseFlagModule{
 				PhaseFile: common.TerminusStateFileInstalled,

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -199,6 +199,23 @@ func (m *InstalledModule) Init() {
 	}
 }
 
+type DeleteUpgradeFilesModule struct {
+	common.KubeModule
+}
+
+func (d *DeleteUpgradeFilesModule) Init() {
+	d.Name = "DeleteUpgradeFiles"
+
+	deleteUpgradeFiles := &task.LocalTask{
+		Name:   "DeleteUpgradeFiles",
+		Action: &DeleteUpgradeFiles{},
+	}
+
+	d.Tasks = []task.Interface{
+		deleteUpgradeFiles,
+	}
+}
+
 type DeleteWizardFilesModule struct {
 	common.KubeModule
 }

--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -296,6 +296,30 @@ func (t *InstallFinished) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
+type DeleteUpgradeFiles struct {
+	common.KubeAction
+}
+
+func (d *DeleteUpgradeFiles) Execute(runtime connector.Runtime) error {
+	baseDir := runtime.GetBaseDir()
+
+	files, err := os.ReadDir(baseDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read directory %s", baseDir)
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "upgrade.") {
+			filePath := path.Join(baseDir, file.Name())
+			if err := os.RemoveAll(filePath); err != nil && !os.IsNotExist(err) {
+				logger.Warnf("failed to delete %s: %v", filePath, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 type DeleteWizardFiles struct {
 	common.KubeAction
 }


### PR DESCRIPTION
* **Background**
Currently there's no limit on uninstallation, which means uninstallation can also happen during upgrading, thus upgrade-related state files should also be cleared when uninstalling

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none