### PR TITLE
feat(upgrade): update sysconf for specific versions

### DIFF
--- a/cli/pkg/upgrade/task.go
+++ b/cli/pkg/upgrade/task.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -219,5 +220,69 @@ func (u *UpgradeSystemComponents) Execute(runtime connector.Runtime) error {
 	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameSettings, settingsChartPath, "", common.NamespaceDefault, nil, true); err != nil {
 		return err
 	}
+	return nil
+}
+
+type UpdateSysctlReservedPorts struct {
+	common.KubeAction
+}
+
+func (u *UpdateSysctlReservedPorts) Execute(runtime connector.Runtime) error {
+	const sysctlFile = "/etc/sysctl.conf"
+	const reservedPortsKey = "net.ipv4.ip_local_reserved_ports"
+	const expectedValue = "30000-32767,46800-50000"
+
+	content, err := os.ReadFile(sysctlFile)
+	if err != nil {
+		return fmt.Errorf("failed to read sysctl.conf: %v", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var foundKey bool
+	var needUpdate bool
+	var updatedLines []string
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, reservedPortsKey) {
+			foundKey = true
+			parts := strings.SplitN(trimmedLine, "=", 2)
+			if len(parts) == 2 {
+				currentValue := strings.TrimSpace(parts[1])
+				if currentValue != expectedValue {
+					logger.Infof("updating %s from %s to %s", reservedPortsKey, currentValue, expectedValue)
+					updatedLines = append(updatedLines, fmt.Sprintf("%s=%s", reservedPortsKey, expectedValue))
+					needUpdate = true
+				} else {
+					updatedLines = append(updatedLines, line)
+				}
+			} else {
+				updatedLines = append(updatedLines, line)
+			}
+		} else {
+			updatedLines = append(updatedLines, line)
+		}
+	}
+
+	if !foundKey {
+		logger.Infof("key %s not found in sysctl.conf, adding it", reservedPortsKey)
+		updatedLines = append(updatedLines, fmt.Sprintf("%s=%s", reservedPortsKey, expectedValue))
+		needUpdate = true
+	}
+
+	if needUpdate {
+		updatedContent := strings.Join(updatedLines, "\n")
+		if err := os.WriteFile(sysctlFile, []byte(updatedContent), 0644); err != nil {
+			return fmt.Errorf("failed to write updated sysctl.conf: %v", err)
+		}
+
+		if _, err := runtime.GetRunner().SudoCmd("sysctl -p", false, false); err != nil {
+			return fmt.Errorf("failed to reload sysctl: %v", err)
+		}
+		logger.Infof("updated and reloaded sysctl configuration")
+	} else {
+		logger.Debugf("%s already has the expected value: %s", reservedPortsKey, expectedValue)
+	}
+
 	return nil
 }

--- a/cli/pkg/upgrade/upgrade.go
+++ b/cli/pkg/upgrade/upgrade.go
@@ -18,7 +18,16 @@ type UpgradeModule struct {
 }
 
 var (
-	preTasks []*upgradeTask
+	preTasks = []*upgradeTask{
+		{
+			Task: &task.LocalTask{
+				Name:   "UpdateSysctlReservedPorts",
+				Action: new(UpdateSysctlReservedPorts),
+			},
+			Current: &explicitVersionMatcher{max: semver.New(1, 12, 0, "20250701", "")},
+			Target:  anyVersion,
+		},
+	}
 
 	coreTasks = []*upgradeTask{
 		{


### PR DESCRIPTION
* **Background**
Currently, the upgrade tasks are all the same regardless of the current version and the target version, in https://github.com/beclab/Olares/pull/1502 and https://github.com/beclab/Olares/pull/1506, the sysctl.conf is updated for Olares versions >= 1.12.0-20250702, but not for older versions, even if upgraded to the new version, this PR adds an upgrade task to update and apply the sysctl.conf, specifically for versions <= 1.12.0-20250701.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none