### PR TITLE
fix(ci): specify repo when checkout code for PR

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -65,6 +65,7 @@ jobs:
     with:
       version: ${{ needs.test-version.outputs.version }}
       ref: ${{ github.event.pull_request.head.ref }}
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
 
   upload-daemon:
     needs: test-version
@@ -73,6 +74,7 @@ jobs:
     with:
       version: ${{ needs.test-version.outputs.version }}
       ref: ${{ github.event.pull_request.head.ref }}
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
 
   push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -8,6 +8,8 @@ on:
         required: true
       ref:
         type: string
+      repository:
+        type: string
   workflow_dispatch:
 jobs:
   goreleaser:
@@ -18,6 +20,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository }}
 
       - name: Add Local Git Tag For GoReleaser
         run: git tag ${{ inputs.version }}

--- a/.github/workflows/release-daemon.yaml
+++ b/.github/workflows/release-daemon.yaml
@@ -8,6 +8,8 @@ on:
         required: true
       ref:
         type: string
+      repository:
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -19,6 +21,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository }}
 
       - name: Add Local Git Tag For GoReleaser
         run: git tag ${{ inputs.version }}


### PR DESCRIPTION
* **Background**
`repository` must be specified when calling [actions/checkout](https://github.com/actions/checkout), or it fails for PRs from a forked repo.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
