### PR TITLE
fix(daemon): apply filters correctly when listing users

### DIFF
--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -310,10 +310,15 @@ func ListUsers(ctx context.Context, client dynamic.Interface, filters ...Filter)
 
 	var userList []*unstructured.Unstructured
 	for _, u := range users.Items {
+		var skip bool
 		for _, filter := range filters {
 			if !filter(&u) {
-				continue
+				skip = true
+				break
 			}
+		}
+		if skip {
+			continue
 		}
 
 		userList = append(userList, &u)


### PR DESCRIPTION
* **Background**
The current user filter in olaresd has no actual effect in the two-level nested for loop

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none