### PR TITLE
fix(cli): remove state files of olaresd when uninstalling

### DIFF
--- a/cli/pkg/phase/cluster/delete_cluster.go
+++ b/cli/pkg/phase/cluster/delete_cluster.go
@@ -133,20 +133,9 @@ func (p *phaseBuilder) phasePrepare() *phaseBuilder {
 				PhaseFile: common.TerminusStateFilePrepared,
 				BaseDir:   p.runtime.GetBaseDir(),
 			},
+			&daemon.UninstallTerminusdModule{},
 			&terminus.RemoveReleaseFileModule{},
 		)
-	}
-	return p
-}
-
-func (p *phaseBuilder) phaseDownload() *phaseBuilder {
-	terminusdAction := &daemon.CheckTerminusdService{}
-	err := terminusdAction.Execute()
-
-	if p.convert() >= PhaseDownload {
-		if err == nil {
-			p.modules = append(p.modules, &daemon.UninstallTerminusdModule{})
-		}
 	}
 	return p
 }
@@ -178,8 +167,7 @@ func UninstallTerminus(phase string, runtime *common.KubeRuntime) pipeline.Pipel
 		builder.
 			phaseInstall().
 			phaseStorage().
-			phasePrepare().
-			phaseDownload()
+			phasePrepare()
 	}
 
 	return pipeline.Pipeline{


### PR DESCRIPTION
* **Background**
When olaresd is uninstalled during operating some operations, the state file may be left unable to be uncleared, causing wrong stats reported after reinstallation, these files should be removed by olares-cli during uninstallation.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none