### PR TITLE
feat: Chinese uses both single-character segmentation and word segmen…

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.53
+        image: beclab/search3:v0.0.55
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.53
+        image: beclab/search3monitor:v0.0.55
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: both single-character segmentation and word segmentation for chinese
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
 Chinese uses both single-character segmentation and word segmentation. Word segmentation for easy sorting
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
* https://github.com/Above-Os/search3/pull/85


