### PR TITLE
bfl: change unmount-api of file-server

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -325,7 +325,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.10
+        image: beclab/bfl-ingress:v0.3.11
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION
* **Background**
Change unmount-api route path of `file server` from /api/unmount to /api/unmount/external

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/112


* **Other information**:
