### PR TITLE
fix(headscale): Make the Affinity Rule Strict

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -87,16 +87,15 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
               - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux
               - key: node-role.kubernetes.io/master
                 operator: Exists
-            weight: 10
       serviceAccountName: tailscale
       securityContext:
         runAsUser: 1000

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -94,7 +94,7 @@ spec:
                 operator: In
                 values:
                 - linux
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
       serviceAccountName: tailscale
       securityContext:


### PR DESCRIPTION

* **Background**
When k8s has multiple nodes, l4-bfl-proxy and headscale/tailscale may be scheduled to different nodes

* **Target Version for Merge**
1.12.0

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
