### PR TITLE
bfl: change ingress default domain

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -327,7 +327,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.12
+        image: beclab/bfl-ingress:v0.3.13
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION
* **Background**
Change `ingress` default domain to www.olares.com

* **Target Version for Merge**
v1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/114


* **Other information**:
