### PR TITLE
fix(cli): make sure hostname resolvable before running olaresd

### DIFF
--- a/cli/pkg/daemon/module.go
+++ b/cli/pkg/daemon/module.go
@@ -92,6 +92,12 @@ func (i *InstallTerminusdBinaryModule) Init() {
 	i.Name = "InstallOlaresdBinaryModule"
 	i.Desc = "Install olaresd"
 
+	updateHost := &task.LocalTask{
+		Name:    "UpdateHosts",
+		Action:  new(terminus.UpdateKubeKeyHosts),
+		Prepare: new(HostnameNotResolvable),
+	}
+
 	install := &task.RemoteTask{
 		Name:  "InstallOlaresdBinary",
 		Desc:  "Install olaresd using binary",
@@ -134,6 +140,7 @@ func (i *InstallTerminusdBinaryModule) Init() {
 	}
 
 	i.Tasks = []task.Interface{
+		updateHost,
 		install,
 		generateEnv,
 		generateService,

--- a/cli/pkg/daemon/prepares.go
+++ b/cli/pkg/daemon/prepares.go
@@ -1,0 +1,21 @@
+package daemon
+
+import (
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"net"
+)
+
+type HostnameNotResolvable struct {
+	common.KubePrepare
+}
+
+func (p *HostnameNotResolvable) PreCheck(runtime connector.Runtime) (bool, error) {
+	ips, _ := net.LookupIP(runtime.GetSystemInfo().GetHostname())
+	for _, ip := range ips {
+		if ip.To4() != nil && ip.To4().String() == runtime.GetSystemInfo().GetLocalIp() {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
* **Background**
When olaresd is installed in the prepare phase but the `/etc/hosts` is not properly configured for the local hostname, a changeip will be triggered and may influence the normal installing process, in that case, the `/etc/hosts` is updated before installing olaresd

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none