### PR TITLE
fix: invalid path clean watch error

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.55
+        image: beclab/search3:v0.0.56
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.55
+        image: beclab/search3monitor:v0.0.56
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: invalid path watch clean error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
* https://github.com/Above-Os/search3/pull/87


