### PR TITLE
fix(cli): check emptiness of user and domain before write release file

### DIFF
--- a/cli/pkg/common/kube_runtime.go
+++ b/cli/pkg/common/kube_runtime.go
@@ -327,7 +327,7 @@ func (a *Argument) SaveReleaseInfo() error {
 		ENV_OLARES_VERSION:  a.OlaresVersion,
 	}
 
-	if a.User != nil {
+	if a.User != nil && a.User.UserName != "" && a.User.DomainName != "" {
 		releaseInfoMap["OLARES_NAME"] = fmt.Sprintf("%s@%s", a.User.UserName, a.User.DomainName)
 	} else {
 		if util.IsExist(OlaresReleaseFile) {


### PR DESCRIPTION
* **Background**
`arg.User` is initialized in `NewArgument` so the pointer is always non-nil, correct non-emptiness check should be further extended to the specific fields.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none