### PR TITLE
feat(cli): adjust release line constraint and output order of upgrade path command

### DIFF
--- a/cli/cmd/ctl/os/upgrade.go
+++ b/cli/cmd/ctl/os/upgrade.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"log"
 	"os"
+	"slices"
 )
 
 type UpgradeOsOptions struct {
@@ -43,6 +44,7 @@ func NewCmdUpgradeOs() *cobra.Command {
 
 func NewCmdGetUpgradePath() *cobra.Command {
 	var baseVersionStr string
+	var latestFirst bool
 	cmd := &cobra.Command{
 		Use:   "path",
 		Short: "Get the upgrade path (required intermediate versions) from base version to the latest upgradable version (as known to this release of olares-cli)",
@@ -65,6 +67,11 @@ func NewCmdGetUpgradePath() *cobra.Command {
 				fmt.Println(err)
 				os.Exit(1)
 			}
+
+			if latestFirst {
+				slices.Reverse(path)
+			}
+
 			encoder := json.NewEncoder(cmd.OutOrStdout())
 			encoder.SetIndent("", "  ")
 			return encoder.Encode(path)
@@ -72,6 +79,7 @@ func NewCmdGetUpgradePath() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&baseVersionStr, "base-version", "b", baseVersionStr, "base version to be upgraded, defaults to the current Olares version if inside Olares cluster")
+	cmd.Flags().BoolVar(&latestFirst, "latest-first", true, "sort versions to put recent ones in the front")
 
 	return cmd
 }

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -22,8 +22,14 @@ var (
 
 func getReleaseLineOfVersion(v *semver.Version) releaseLine {
 	preRelease := v.Prerelease()
-	if preRelease == "" || strings.HasPrefix(preRelease, "rc") {
+	mainLinePrereleasePrefixes := []string{"alpha", "beta", "rc"}
+	if preRelease == "" {
 		return mainLine
+	}
+	for _, prefix := range mainLinePrereleasePrefixes {
+		if strings.HasPrefix(preRelease, prefix) {
+			return mainLine
+		}
 	}
 	return dailyLine
 }

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -38,10 +38,15 @@ func check(base *semver.Version, target *semver.Version) error {
 	if base == nil {
 		return fmt.Errorf("base version is nil")
 	}
+	baseReleaseLine := getReleaseLineOfVersion(base)
 
 	cliVersion, err := utils.ParseOlaresVersionString(version.VERSION)
 	if err != nil {
 		return fmt.Errorf("invalid olares-cli version :\"%s\"", version.VERSION)
+	}
+	cliReleaseLine := getReleaseLineOfVersion(cliVersion)
+	if baseReleaseLine != cliReleaseLine {
+		return fmt.Errorf("incompatible base release line: %s and olares-cli release line: %s", baseReleaseLine, cliReleaseLine)
 	}
 
 	if target != nil {
@@ -50,11 +55,10 @@ func check(base *semver.Version, target *semver.Version) error {
 		}
 
 		targetReleaseLine := getReleaseLineOfVersion(target)
-		baseReleaseLine := getReleaseLineOfVersion(base)
 		if targetReleaseLine != baseReleaseLine {
 			return fmt.Errorf("unable to upgrade to %s on %s release line from %s on %s release line", target, targetReleaseLine, base, baseReleaseLine)
 		}
-		switch baseReleaseLine {
+		switch targetReleaseLine {
 		case mainLine:
 			if !sameMajorLevelVersion(base, target) {
 				return fmt.Errorf("upgrade on %s rlease line can only be performed across same major level version", baseReleaseLine)


### PR DESCRIPTION
* **Background**
when getting upgrade path or doing upgrade, all three of: base/target/olares-cli version must be on the same release line
the output order of upgrade path can be optionally reversed and defaults to the latest version in the first

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none