### PR TITLE
perf(ci): use skopeo to upload image archive to cdn

### DIFF
--- a/build/upload-images.sh
+++ b/build/upload-images.sh
@@ -17,8 +17,7 @@ cat $1|while read image; do
         code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$name.tar.gz)
         if [ $code -eq 403 ]; then
             set -ex
-            docker pull $image
-            docker save $image -o $name.tar
+            skopeo copy --insecure-policy docker://$image oci-archive:$name.tar
             gzip $name.tar
 
             md5sum $name.tar.gz > $checksum
@@ -51,8 +50,7 @@ cat $1|while read image; do
         code=$(curl -o /dev/null -fsSLI -w "%{http_code}" https://dc3p1870nn3cj.cloudfront.net/$path$checksum)
         if [ $code -eq 403 ]; then
             set -ex
-            docker pull $image
-            docker save $image -o $name.tar
+            skopeo copy --insecure-policy docker://$image oci-archive:$name.tar
             gzip $name.tar
 
             md5sum $name.tar.gz > $checksum


### PR DESCRIPTION
* **Background**

Image layers are not compressed when generating archives by `docker save`, take the image `beclab/hami:v2.5.4` as an example:
```
➜  ~ sudo docker save mirrors.joinolares.cn/beclab/hami:v2.5.4 > docker-hami.tar
➜  ~ mkdir docker-hami
➜  ~ tar xf docker-hami.tar -C docker-hami
➜  ~ file docker-hami/blobs/sha256/*
docker-hami/blobs/sha256/096e1df4f7d9bdf9dba4a48975218030baae0f559d8e1c8481ba43dd7e3797cf: JSON data
docker-hami/blobs/sha256/0df26ec8d5656f0db50c6b71bc74210997320bc3bb6f3e316cef32511513dce1: JSON data
docker-hami/blobs/sha256/14b6e58bdddd8a008a31e21f23c87708544af7ed1929a194bf1af7ed3cd5488b: POSIX tar archive
docker-hami/blobs/sha256/1954c94787cadb0888f5c98b32d139fdddbeef342aecd199b7504a168ce3ab4c: POSIX tar archive
docker-hami/blobs/sha256/2170eed0689e972fd28928c91c9cc8f3239dcdca2e7c20da58c8ab588d8ab125: JSON data
docker-hami/blobs/sha256/22a6b24d317a6fdc34ef42e62fd96b08c0923034a705be3b4dd2836686b5ed7d: JSON data
docker-hami/blobs/sha256/2573e0d8158209ed54ab25c87bcdcb00bd3d2539246960a3d592a1c599d70465: POSIX tar archive
docker-hami/blobs/sha256/273999ef88232d1b8bf3bb33b978eb350a929848fdba169ef2d800a6dca81d79: JSON data
docker-hami/blobs/sha256/349d00c5c6918368dfa002075b41ed628db8cce2b6ee8a70f27709689c093e8b: JSON data
docker-hami/blobs/sha256/3d83729a65e04eae7b2d75c3aa4e0a9addcbc330201d6e0b08aa7c3735e76cca: JSON data
docker-hami/blobs/sha256/474751953810344f96bd0b45ee9f1af08c7f792836acae924fa8434c89e83457: POSIX tar archive
docker-hami/blobs/sha256/515242ca94ceae7e81cb216b6281269d44d1372ef3b15cbafbdf7db4a1d4098e: JSON data
docker-hami/blobs/sha256/782979f338e98d1e0241d3cb112e75d90e3484563e23090673d97e9b82c71c11: POSIX tar archive
docker-hami/blobs/sha256/7845bf0256350d17f43cd6041cc36c32e4e91490a64f6bf924148dea33c6cc3b: POSIX tar archive
docker-hami/blobs/sha256/7869b14558c6e01471827abf0032b65c9e43c19b393149778bba22bca468386c: JSON data
docker-hami/blobs/sha256/8de6d4a7d976a745639d43cda0c53adc97960c6b07988b1e23fa731b62819316: POSIX tar archive
docker-hami/blobs/sha256/948bc803bcddca8a8dbf787d96a518eeb4eee767dd6a9c680aa59c23d3a1b5f0: JSON data
docker-hami/blobs/sha256/98cf23d171c6f991b498ef073854d6f5b842489ef1eb14c4fe9256e371c51695: JSON data
docker-hami/blobs/sha256/ab206d49a42df26e6a45c71ee6e61b2aa93736f06f5ae1bc0cdce91675266c01: JSON data
docker-hami/blobs/sha256/b17b491a633768e68cb4340d84a568c60d71073d237a7081f649e2eed464cf1d: POSIX tar archive
docker-hami/blobs/sha256/cc9ee102691b0001ef58aac6dd110a06ec89469ff13c11e526dfaadb39eba791: POSIX tar archive
docker-hami/blobs/sha256/f0caebf6d8861a8dfb8630799ed7adae3d6e4885b0d8eb186e252c35e87a4ce4: POSIX tar archive
docker-hami/blobs/sha256/f72f00af3d1173f2896261009fdf165589496b3d8d3db4f15f93034a3aadf38d: POSIX tar archive
docker-hami/blobs/sha256/f892bdd1a8be67c8e55922a0da11dde67eab1174d4018b92e8309472f961e0ea: JSON data
``` 

We can switch to `skopeo copy` to make the archive file smaller by compressing all the image layers:
```
➜  ~ sudo skopeo copy --insecure-policy docker://mirrors.joinolares.cn/beclab/hami:v2.5.4 oci-archive:skopeo-hami.tar
Getting image source signatures
Copying blob 6414378b6477 done   |
Copying blob df2824ac310a done   |
Copying blob 16e8a5a726fd done   |
Copying blob af813042aa5b done   |
Copying blob 150ae9de14cf done   |
Copying blob 8ad852d6ec03 done   |
Copying blob 36440dd5e1d2 done   |
Copying blob 3bd217f35350 done   |
Copying blob a244ccef2cbc done   |
Copying blob bdc0815a77a5 done   |
Copying blob 7f7c487d7d5c done   |
Copying config f892bdd1a8 done   |
Writing manifest to image destination
➜  ~ mkdir skopeo-hami
➜  ~ tar xf skopeo-hami.tar -C skopeo-hami
➜  ~ file skopeo-hami/blobs/sha256/*
skopeo-hami/blobs/sha256/150ae9de14cf67d192ab855eb94172865ba70f5b4b2e832ffed3e8f1df6307f5: gzip compressed data, original size modulo 2^32 18944
skopeo-hami/blobs/sha256/16e8a5a726fd0b9296e2ffce9d0b05e2640937b7cb4b97cecbae4c6792e5d6b8: gzip compressed data, original size modulo 2^32 161908736
skopeo-hami/blobs/sha256/36440dd5e1d25ee714db748cc18751c6e88125e97cec466bf0d52846032eb182: gzip compressed data, original size modulo 2^32 166236160
skopeo-hami/blobs/sha256/3bd217f35350876218cb3663bf10ac2925358101f3450c3c63eee0d06ac222d5: gzip compressed data, original size modulo 2^32 11558912
skopeo-hami/blobs/sha256/6414378b647780fee8fd903ddb9541d134a1947ce092d08bdeb23a54cb3684ac: gzip compressed data, was "1e9ef6fb41d9a178d5cb59e82c12944410cd55426e16d2da1b04c31607ace752.tar", last modified: Wed Sep 11 16:25:18 2024, max compression, original size modulo 2^32 80413184
skopeo-hami/blobs/sha256/7f7c487d7d5c28140fe11f95c27bf564293b807a2628ae7b436173a41f06a2e2: gzip compressed data, original size modulo 2^32 4096
skopeo-hami/blobs/sha256/8ad852d6ec03806a38c5b8b52403e6d7a1a60a82f8f363584cd15fd41fda6dd9: gzip compressed data, original size modulo 2^32 13824
skopeo-hami/blobs/sha256/96ac5c6b47341b8b39e470a6ffa4bee517f0e085cdd2e5d4e2256f15de41013d: JSON data
skopeo-hami/blobs/sha256/a244ccef2cbc3149339eaa45b2584e1daec555cf840b362eecc03c3d573ab83f: gzip compressed data, original size modulo 2^32 3584
skopeo-hami/blobs/sha256/af813042aa5b3f88f04ca55f2bdba48846781439e69541120f5f3d81dfa77d4f: gzip compressed data, original size modulo 2^32 3072
skopeo-hami/blobs/sha256/bdc0815a77a58ef2934dafe1c1f46803ae9e54553730a7dee56aa91830d9a6b7: gzip compressed data, original size modulo 2^32 866304
skopeo-hami/blobs/sha256/df2824ac310a017894dc4f4c26c50ff01525f48c0d1eda8738822ed4d09550b8: gzip compressed data, original size modulo 2^32 11112960
skopeo-hami/blobs/sha256/f892bdd1a8be67c8e55922a0da11dde67eab1174d4018b92e8309472f961e0ea: JSON data
```

Plus, the current way of `docker pull` & `docker save` introduces unnecessary time consumptions, we can switch to `skopeo copy` to make this operation faster

The archived image size is reduced by >50%:
```
➜  ~ ls -lh | grep hami.tar
-rw-rw-r--  1 keven    keven    413M Jul 18 20:15 docker-hami.tar
-rw-rw-r--  1 keven    keven    138M Jul 18 20:21 skopeo-hami.tar
```

We should also consider convert other base images to optimize the download time and disk space of users gradually in the future.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none