### PR TITLE
fix(ci): increase timeout when retrieving layer size from dockerhub

### DIFF
--- a/build/build-manifest.py
+++ b/build/build-manifest.py
@@ -137,7 +137,7 @@ def get_layer_uncompressed_size_from_registry(registry, repository, layer_digest
         # Request only the last 4 bytes of the gzipped blob
         headers['Range'] = f'bytes={compressed_size - 4}-{compressed_size - 1}'
 
-        response = requests.get(blob_url, headers=headers, timeout=10)
+        response = requests.get(blob_url, headers=headers, timeout=20)
         response.raise_for_status()
 
         # The last 4 bytes of a gzip file contain the uncompressed size (mod 2^32)


### PR DESCRIPTION
* **Background**
In https://github.com/beclab/Olares/pull/1570, uncompressed layer size is retrieved from docker hub for all Images, but it seems rate limit is occasionally reached, causing a timeout, we temporarily lift the timeout to workaround it, in the long run, we might consider cache uncompressed size of every layer in the cdn to speed up this process.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none