### PR TITLE
feat(docs): Remove knowledge, rsshub and argowoflow infomation from Readme

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -9,7 +9,6 @@ The application framework layer provides common functionality and interfaces for
 | Component | Description |
 | --- | --- |
 | [app-service](app-service) | Handles application lifecycle management and resource allocation. |
-| [argo-workflow](argo-workflow) | A Kubernetes-native workflow engine for orchestrating parallel jobs. |
 | [authelia](authelia) | An open-source authentication and authorization server that provides multi-factor authentication and single sign-on (SSO). |
 | [backup-server](backup-server) | Supports backups for directories, applications, and clusters. |
 | [bfl](bfl) | The Backend For Launcher service that aggregates backend interfaces and proxies requests for all system services. |
@@ -17,7 +16,6 @@ The application framework layer provides common functionality and interfaces for
 | [files](files) | Provides essential file management services. |
 | [headscale](headscale) | A self-hosted implementation of the Tailscale control server. |
 | [infisical](infisical) | A tool for managing sensitive information and preventing secret leaks in Olares development. |
-| [knowledge](knowledge) | Stores content such as web pages, videos, audio files, PDFs, and EPUBs that users collect. |
 | [kube-state-metrics](kube-state-metrics) | A service that listens to the Kubernetes API server and generates metrics about the state of the objects. |
 | [l4-bfl-proxy](l4-bfl-proxy) | A Layer 4 network proxy for BFL (Backend For Launcher). |
 | [market](market) | A decentralized and permissionless app store for installing, uninstalling, and updating applications and recommendation algorithms. |
@@ -25,7 +23,6 @@ The application framework layer provides common functionality and interfaces for
 | [notifications](notifications) | Delivers system-wide notifications. |
 | [osnode-init](osnode-init) | Initializes the Olares node. |
 | [reverse-proxy](reverse-proxy) | Options include Cloudflare Tunnel, Olares Tunnel, and self-built FRP. |
-| [rsshub](rsshub) | Generates RSS feeds for easier content subscription. |
 | [seahub](seahub) | The web frontend for the Seafile file hosting platform. |
 | [search3](search3) | Provides full-text search for stored content in Knowledge and Files. |
 | [system-server](system-server) | Manages permissions for inter-application API calls and handles network routing between applications and database middlewares. |


### PR DESCRIPTION
Background
Since the release cycle of applications such as knowledge and wise is inconsistent with the main Olares project, we moved them to independent repositories and released them through the app market.

Target Version for Merge
1.12.0

Related Issues
none

PRs Involving Sub-Systems
none

Other information:
none