### PR TITLE
app-service: add workflow label to the namespace of workeflow

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -163,7 +163,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.56
+        image: beclab/app-service:0.3.57
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
Add cluster app ref label to the namespace of the workflow to make the knowledge backend accessible for the workflow tasks

* **Target Version for Merge**
v1.12.0

* **Related Issues**
The tasks of the workflow cannot access the knowledge backend service.

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/commit/6b1164e816e8070b9428c4aa2e6a3f0df6754adb


* **Other information**:
