### PR TITLE
fix(daemon): do not clear upgrade state file when upgrading is in progress

### DIFF
--- a/daemon/internel/watcher/upgrade/upgrade_watcher.go
+++ b/daemon/internel/watcher/upgrade/upgrade_watcher.go
@@ -86,7 +86,7 @@ func (w *upgradeWatcher) Watch(ctx context.Context) {
 	currentVersion, err := semver.NewVersion(*currentVersionStr)
 	if err != nil || currentVersion.LessThan(&w.target.Version) {
 		state.CurrentState.UpgradingTarget = w.target.Version.Original()
-	} else {
+	} else if !w.isUpgrading() {
 		w.target = nil
 		_, err = upgrade.NewRemoveUpgradeTarget().Execute(ctx, nil)
 		if err != nil {


### PR DESCRIPTION
* **Background**
Currently, the upgrade watcher has a clear logic in case of left-out upgrade state files, and this can interrupt the final check for all pods' readiness, i.e., when the upgrade has finished, but services are being recreated and still initializing, a upgrade-in-progress check should be added to wait until the check completes and then do the clean up.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none