### PR TITLE
fix: fix inotify race

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.59 
+        image: beclab/search3:v0.0.60
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.59
+        image: beclab/search3monitor:v0.0.60
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: inotify error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
Directory **a** is under watch. When a subdirectory **b** is created inside **a**, monitoring is then attached to **b**. If another directory **c** is created under **b** almost immediately, the creation event for **c** may be missed. This happens because the interval between creating **b** and **c** is so short that **c** is already created before the monitoring is successfully added to **b**. Note that the process creating the directories and the process adding the watches are different, which leads to this race condition.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/93


