### PR TITLE
fix(daemon): do not set download state again after completion

### DIFF
--- a/daemon/internel/watcher/upgrade/upgrade_watcher.go
+++ b/daemon/internel/watcher/upgrade/upgrade_watcher.go
@@ -227,9 +227,6 @@ func (w *upgradeWatcher) doUpgrade(ctx context.Context) (err error) {
 	}
 
 	klog.Info("download already completed, skipping download phases")
-	state.CurrentState.UpgradingDownloadState = state.Completed
-	state.CurrentState.UpgradingDownloadProgress = "100%"
-	state.CurrentState.UpgradingDownloadProgressNum = 100
 
 	if target.DownloadOnly {
 		state.CurrentState.UpgradingState = "WaitingForUserConfirm"
@@ -253,6 +250,8 @@ func doDownloadPhases(ctx context.Context, target state.UpgradeTarget) (err erro
 			klog.Errorf("download phases failed: %v", err)
 		} else {
 			state.CurrentState.UpgradingDownloadState = state.Completed
+			state.CurrentState.UpgradingDownloadProgress = "100%"
+			state.CurrentState.UpgradingDownloadProgressNum = 100
 			state.CurrentState.UpgradingDownloadError = ""
 			klog.Info("download phases completed successfully")
 		}


### PR DESCRIPTION
* **Background**
Currently, the download state and progress is tracked and set across the whole period of upgrading, even when olaresd is restarted, causing a state glitch on frontend's display during olaresd's restart, it's now changed to only be set when first download action is finished, and not getting set again after olaresd's restart, until next redownload.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none