### PR TITLE
feat: add vendor type to olares-cli/olaresd

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -27,6 +27,10 @@ builds:
       - -s
       - -w
       - -X github.com/beclab/Olares/cli/version.VERSION={{ .Version }}
+      - >-
+        {{- if index .Env "OLARES_VENDOR_TYPE" }}
+        -X github.com/beclab/Olares/cli/version.VENDOR={{ .Env.OLARES_VENDOR_TYPE }}
+        {{- end }}
 dist: ./output
 archives:
   - id: olares-cli

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -10,12 +10,22 @@ import (
 )
 
 func NewDefaultCommand() *cobra.Command {
+	var showVendor bool
 	cmds := &cobra.Command{
 		Use:               "olares-cli",
 		Short:             "Olares Installer",
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 		Version:           version.VERSION,
+		Run: func(cmd *cobra.Command, args []string) {
+			if showVendor {
+				println(version.VENDOR)
+			} else {
+				cmd.Usage()
+			}
+			return
+		},
 	}
+	cmds.Flags().BoolVar(&showVendor, "vendor", false, "show the vendor type of olares-cli")
 
 	cmds.AddCommand(osinfo.NewCmdInfo())
 	cmds.AddCommand(os.NewOSCommands()...)

--- a/cli/version/vendor.go
+++ b/cli/version/vendor.go
@@ -1,0 +1,3 @@
+package version
+
+var VENDOR = "community"

--- a/daemon/.goreleaser.yml
+++ b/daemon/.goreleaser.yml
@@ -32,6 +32,10 @@ builds:
     - -w
     - -s
     - -X 'github.com/beclab/Olares/daemon/cmd/terminusd/version.version=v{{ .Version }}'
+    - >-
+      {{- if index .Env "OLARES_VENDOR_TYPE" }}
+      -X github.com/beclab/Olares/daemon/cmd/terminusd/version.VENDOR={{ .Env.OLARES_VENDOR_TYPE }}
+      {{- end }}
 dist: output
 archives:
 - name_template: "olaresd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -33,15 +33,22 @@ func main() {
 
 	port := 18088
 	var showVersion bool
+	var showVendor bool
 
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.BoolVar(&showVersion, "version", false, "show olaresd version")
+	pflag.CommandLine.BoolVar(&showVendor, "vendor", false, "show the vendor type of olaresd")
 
 	pflag.Parse()
 
 	if showVersion {
 		fmt.Println(version.Version())
+		return
+	}
+
+	if showVendor {
+		fmt.Println(version.VENDOR)
 		return
 	}
 

--- a/daemon/cmd/terminusd/version/vendor.go
+++ b/daemon/cmd/terminusd/version/vendor.go
@@ -1,0 +1,3 @@
+package version
+
+var VENDOR = "community"


### PR DESCRIPTION
* **Background**
If the env `OLARES_VENDOR_TYPE` is detected when building olares-cli and olaresd in CI, it will be injected to the built binary, and can be retrieved respectively by: `olares-cli --vendor` and `olaresd --vendor`, which defaults to `community`

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none