### PR TITLE
feat: upgrade containerd to v2.1.3

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/containerd/containerd v1.7.27
 	github.com/decentralized-identity/web5-go v0.25.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
+	github.com/distribution/reference v0.6.0
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/uuid v1.6.0
@@ -93,7 +94,6 @@ require (
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect

--- a/cli/pkg/container/containerd.go
+++ b/cli/pkg/container/containerd.go
@@ -404,3 +404,14 @@ func (t *KillContainerdProcess) Execute(runtime connector.Runtime) error {
 
 	return nil
 }
+
+type RestartContainerd struct {
+	common.KubeAction
+}
+
+func (t *RestartContainerd) Execute(runtime connector.Runtime) error {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl restart containerd", false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to restart containerd")
+	}
+	return nil
+}

--- a/cli/pkg/container/templates/containerd_config.go
+++ b/cli/pkg/container/templates/containerd_config.go
@@ -29,151 +29,27 @@ root = {{ .DataRoot }}
 {{ else }}
 root = "/var/lib/containerd"
 {{- end }}
-state = "/run/containerd"
-
-[cgroup]
-  path = ""
-
-[debug]
-  address = ""
-  format = ""
-  gid = 0
-  level = ""
-  uid = 0
-
-[grpc]
-  address = "/run/containerd/containerd.sock"
-  gid = 0
-  max_recv_message_size = 16777216
-  max_send_message_size = 16777216
-	tcp_address = ""
-  tcp_tls_ca = ""
-  tcp_tls_cert = ""
-  tcp_tls_key = ""
-  uid = 0
-
-[metrics]
-  address = ""
-  grpc_histogram = false
-
-[ttrpc]
-  address = ""
-  uid = 0
-  gid = 0
-
-[timeouts]
-  "io.containerd.timeout.shim.cleanup" = "5s"
-  "io.containerd.timeout.shim.load" = "5s"
-  "io.containerd.timeout.shim.shutdown" = "3s"
-  "io.containerd.timeout.task.state" = "2s"
 
 [plugins]
-	[plugins."io.containerd.gc.v1.scheduler"]
-    deletion_threshold = 0
-    mutation_threshold = 100
-    pause_threshold = 0.02
-    schedule_delay = "0s"
-    startup_delay = "100ms"
 
   [plugins."io.containerd.grpc.v1.cri"]
-		device_ownership_from_security_context = false
-    disable_apparmor = false
-    disable_cgroup = false
-    disable_hugetlb_controller = true
-    disable_proc_mount = false
-    disable_tcp_service = true
-    enable_selinux = false
-    enable_tls_streaming = false
-    enable_unprivileged_icmp = false
-    enable_unprivileged_ports = false
-    ignore_image_defined_volumes = false
-    max_concurrent_downloads = 3
-    max_container_log_line_size = 16384
-    netns_mounts_under_state_dir = false
-    restrict_oom_score_adj = false
-    selinux_category_range = 1024
-    stats_collect_period = 10
-    stream_idle_timeout = "4h0m0s"
-    stream_server_address = "127.0.0.1"
-    stream_server_port = "10010"
-    systemd_cgroup = false
-    tolerate_missing_hugetlb_controller = true
-    unset_seccomp_profile = ""
     sandbox_image = "{{ .SandBoxImage }}"
 
-    [plugins."io.containerd.grpc.v1.cri".cni]
-      bin_dir = "/opt/cni/bin"
-      conf_dir = "/etc/cni/net.d"
-      max_conf_num = 1
-      conf_template = ""
-
-		[plugins."io.containerd.grpc.v1.cri".containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "runc"
-      disable_snapshot_annotations = true
-      discard_unpacked_layers = false
-      ignore_rdt_not_enabled_errors = false
-      no_pivot = false
-      snapshotter = "{{ .FsType }}"
-
-      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
-        base_runtime_spec = ""
-        cni_conf_dir = ""
-        cni_max_conf_num = 0
-        container_annotations = []
-        pod_annotations = []
-        privileged_without_host_devices = false
-        runtime_engine = ""
-        runtime_path = ""
-        runtime_root = ""
-        runtime_type = ""
-
-        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-          base_runtime_spec = ""
-          cni_conf_dir = ""
-          cni_max_conf_num = 0
-          container_annotations = []
-          pod_annotations = []
-          privileged_without_host_devices = false
-          runtime_engine = ""
-          runtime_path = ""
-          runtime_root = ""
-          runtime_type = "io.containerd.runc.v2"
+          runtime_type = 'io.containerd.runc.v2'
+          sandboxer = 'podsandbox'
+          snapshotter = "{{ .FsType }}"
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-            BinaryName = ""
-            CriuImagePath = ""
-            CriuPath = ""
-            CriuWorkPath = ""
-            IoGid = 0
-            IoUid = 0
-            NoNewKeyring = false
-            NoPivotRoot = false
-            Root = ""
-            ShimCgroup = ""
             SystemdCgroup = true
 
-      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
-        base_runtime_spec = ""
-        cni_conf_dir = ""
-        cni_max_conf_num = 0
-        container_annotations = []
-        pod_annotations = []
-        privileged_without_host_devices = false
-        runtime_engine = ""
-        runtime_path = ""
-        runtime_root = ""
-        runtime_type = ""
-
-        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
-
-    [plugins."io.containerd.grpc.v1.cri".image_decryption]
-      key_model = "node"
-
     [plugins."io.containerd.grpc.v1.cri".registry]
+
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         {{- if .Mirrors }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
@@ -201,84 +77,6 @@ state = "/run/containerd"
           {{- end}}
         {{- end}}
 
-	[plugins."io.containerd.internal.v1.opt"]
-    path = "/opt/containerd"
-
-  [plugins."io.containerd.internal.v1.restart"]
-    interval = "10s"
-
-  [plugins."io.containerd.internal.v1.tracing"]
-    sampling_ratio = 1.0
-    service_name = "containerd"
-
-  [plugins."io.containerd.metadata.v1.bolt"]
-    content_sharing_policy = "shared"
-
-  [plugins."io.containerd.monitor.v1.cgroups"]
-    no_prometheus = false
-
-  [plugins."io.containerd.runtime.v1.linux"]
-    no_shim = false
-    runtime = "runc"
-    runtime_root = ""
-    shim = "containerd-shim"
-    shim_debug = false
-
-  [plugins."io.containerd.runtime.v2.task"]
-    platforms = ["linux/amd64"]
-    sched_core = false
-
-  [plugins."io.containerd.service.v1.diff-service"]
-    default = ["walking"]
-
-  [plugins."io.containerd.service.v1.tasks-service"]
-    rdt_config_file = ""
-
-  [plugins."io.containerd.snapshotter.v1.aufs"]
-    root_path = ""
-
-  [plugins."io.containerd.snapshotter.v1.btrfs"]
-    root_path = ""
-
-  [plugins."io.containerd.snapshotter.v1.devmapper"]
-    async_remove = false
-    base_image_size = ""
-    discard_blocks = false
-    fs_options = ""
-    fs_type = ""
-    pool_name = ""
-    root_path = ""
-
-  [plugins."io.containerd.snapshotter.v1.native"]
-    root_path = ""
-
-  [plugins."io.containerd.snapshotter.v1.overlayfs"]
-    root_path = ""
-    upperdir_label = false
-
   [plugins."io.containerd.snapshotter.v1.zfs"]
     root_path = "{{ .ZfsRootPath }}"
-
-  [plugins."io.containerd.tracing.processor.v1.otlp"]
-    endpoint = ""
-    insecure = false
-    protocol = ""
-
-[proxy_plugins]
-
-[stream_processors]
-
-  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
-    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
-    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
-    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
-    path = "ctd-decoder"
-    returns = "application/vnd.oci.image.layer.v1.tar"
-
-  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
-    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
-    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
-    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
-    path = "ctd-decoder"
-    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
 `)))

--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -1,6 +1,7 @@
 package gpu
 
 import (
+	"github.com/beclab/Olares/cli/pkg/container"
 	"time"
 
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -174,7 +175,7 @@ func (m *RestartContainerdModule) Init() {
 		Prepare: &prepare.PrepareCollection{
 			new(ContainerdInstalled),
 		},
-		Action:   new(RestartContainerd),
+		Action:   new(container.RestartContainerd),
 		Parallel: false,
 		Retry:    1,
 	}

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -290,21 +290,10 @@ type ConfigureContainerdRuntime struct {
 }
 
 func (t *ConfigureContainerdRuntime) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd("nvidia-ctk runtime configure --runtime=containerd --set-as-default --config-source=command", false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("nvidia-ctk runtime configure --runtime=containerd --set-as-default --config-source=file", false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to nvidia-ctk runtime configure")
 	}
 
-	return nil
-}
-
-type RestartContainerd struct {
-	common.KubeAction
-}
-
-func (t *RestartContainerd) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd("systemctl restart containerd", false, true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "Failed to restart containerd")
-	}
 	return nil
 }
 

--- a/cli/pkg/upgrade/1_12_0_20250723.go
+++ b/cli/pkg/upgrade/1_12_0_20250723.go
@@ -1,0 +1,50 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/container"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+)
+
+type upgrader_1_12_0_20250723 struct {
+	upgraderBase
+}
+
+func (u upgrader_1_12_0_20250723) Version() *semver.Version {
+	return semver.MustParse("1.12.0-20250723")
+}
+
+func (u upgrader_1_12_0_20250723) PrepareForUpgrade() []task.Interface {
+	preTasks := []task.Interface{
+		&task.LocalTask{
+			Name:   "UpgradeContainerd",
+			Action: new(upgradeContainerd),
+		},
+		&task.LocalTask{
+			Name:   "RestartContainerd",
+			Action: new(container.RestartContainerd),
+		},
+	}
+	return append(preTasks, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+type upgradeContainerd struct {
+	common.KubeAction
+}
+
+func (u *upgradeContainerd) Execute(runtime connector.Runtime) error {
+	m, err := manifest.ReadAll(u.KubeConf.Arg.Manifest)
+	if err != nil {
+		return err
+	}
+	action := &container.SyncContainerd{
+		ManifestAction: manifest.ManifestAction{
+			Manifest: m,
+			BaseDir:  runtime.GetBaseDir(),
+		},
+	}
+	return action.Execute(runtime)
+}

--- a/cli/pkg/upgrade/modules.go
+++ b/cli/pkg/upgrade/modules.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"github.com/beclab/Olares/cli/pkg/bootstrap/precheck"
+	"github.com/beclab/Olares/cli/pkg/manifest"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -10,6 +11,7 @@ import (
 
 type Module struct {
 	common.KubeModule
+	manifest.ManifestModule
 	TargetVersion *semver.Version
 }
 

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -16,6 +16,7 @@ var (
 
 	dailyUpgraders = []breakingUpgrader{
 		upgrader_1_12_0_20250702{},
+		upgrader_1_12_0_20250723{},
 	}
 	mainUpgraders = []breakingUpgrader{}
 )

--- a/daemon/internel/watcher/upgrade/upgrade_watcher.go
+++ b/daemon/internel/watcher/upgrade/upgrade_watcher.go
@@ -202,8 +202,8 @@ var upgradePhases = []upgradePhase{
 	{upgrade.NewVersionCompatibilityCheck, 0, 5},
 	{upgrade.NewHealthCheck, 5, 5},
 	{upgrade.NewInstallCLI, 10, 10},
-	{upgrade.NewImportImages, 20, 30},
-	{upgrade.NewInstallOlaresd, 50, 10},
+	{upgrade.NewInstallOlaresd, 20, 10},
+	{upgrade.NewImportImages, 30, 30},
 	{upgrade.NewUpgrade, 60, 35},
 	{upgrade.NewRemoveTarget, 95, 5},
 }

--- a/infrastructure/containerd/.olares/Olares.yaml
+++ b/infrastructure/containerd/.olares/Olares.yaml
@@ -4,6 +4,6 @@ output:
   binaries:
     - 
       id: containerd
-      name: containerd-1.6.36.tar.gz
-      amd64: https://github.com/containerd/containerd/releases/download/v1.6.36/containerd-1.6.36-linux-amd64.tar.gz
-      arm64: https://github.com/containerd/containerd/releases/download/v1.6.36/containerd-1.6.36-linux-arm64.tar.gz
+      name: containerd-2.1.3.tar.gz
+      amd64: https://github.com/containerd/containerd/releases/download/v2.1.3/containerd-2.1.3-linux-amd64.tar.gz
+      arm64: https://github.com/containerd/containerd/releases/download/v2.1.3/containerd-2.1.3-linux-arm64.tar.gz


### PR DESCRIPTION
* **Background**
Upgrade Containerd to `v2.1.3`
Deprecated and unnecessary default configs in the current config template are removed, according to [Deprecated config properties](https://containerd.io/releases/#deprecated-config-properties), except the `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]` that multiple services rely on
When configuring Nvidia runtime for Containerd using `nvidia-ctk`, the config source is changed from command to file, to avoid a config migration to version 3
An upgrade version for the incoming daily build `1.12.0-20250723` is also added, to upgrade Containerd

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none