### PR TITLE
fix(monitoring-server): update monitoring server role management

### DIFF
--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.2
+        image: beclab/monitoring-server-v1:v0.3.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**
User metadata has reconstructed the label data, and the monitoring server needs to perform some compatibility processing.

* **Target Version for Merge**
1.12

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/ks-apiserver-proxy/pull/2


* **Other information**:
none