### PR TITLE
bfl, authelia: fix internal mode and get real ip

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -43,6 +43,18 @@ else
     VERSION="debug"
 fi
 
+# vendor replace
+if [[ "${REPO_PATH}" != "" && "$REPO_PATH" != "/" ]]; then
+    path="vendor${REPO_PATH}"
+    echo "replace vendor path: ${path}"
+    find ${BASE_DIR}/$path -type f | while read l; 
+    do 
+        file=$(awk -F "$path" '{print $1$2}' <<< "$l")  
+        if [[ "$file" != ".gitkeep" ]]; then
+            cp -f "$l" "$file"
+        fi
+    done
+fi
 
 $TAR --exclude=wizard/tools --exclude=.git -zcvf ${BASE_DIR}/../install-wizard-${VERSION}.tar.gz .
 

--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -367,7 +367,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.17
+        image: beclab/auth:0.2.18
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -310,7 +310,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.1
+          value: v0.3.2
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE


### PR DESCRIPTION
* **Background**
1. Change the internal mode rule that only requests via Larepass VPN will match the rule
2. Fix admin user resets the password of another user bug
3. Get the real client IP from the proxy protocol header sent by frp
4. OnFirstFactor message data fix

* **Target Version for Merge**
v1.12.0

* **Related Issues**
The user's password, which has been reset, is still a valid password

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/26
https://github.com/beclab/l4-bfl-proxy/commit/c2d6a93ac9c7c1b258f45c4a06ac357831537ad1

* **Other information**:
