### PR TITLE
feat(cli): download wizard from different vendor path

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -31,6 +31,10 @@ builds:
         {{- if index .Env "OLARES_VENDOR_TYPE" }}
         -X github.com/beclab/Olares/cli/version.VENDOR={{ .Env.OLARES_VENDOR_TYPE }}
         {{- end }}
+      - >-
+        {{- if index .Env "OLARES_VENDOR_REPO_PATH" }}
+        -X github.com/beclab/Olares/cli/version.VENDOR_REPO_PATH={{ .Env.OLARES_VENDOR_REPO_PATH }}
+        {{- end }}
 dist: ./output
 archives:
   - id: olares-cli

--- a/cli/pkg/files/file.go
+++ b/cli/pkg/files/file.go
@@ -21,9 +21,11 @@ import (
 	_ "compress/bzip2"
 	"context"
 	"fmt"
+	cliversion "github.com/beclab/Olares/cli/version"
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -330,7 +332,7 @@ func NewKubeBinary(name, arch, osType, osVersion, osPlatformFamily, version, pre
 	case installwizard:
 		component.Type = WIZARD
 		component.FileName = fmt.Sprintf("install-wizard-v%s.tar.gz", version)
-		component.Url = fmt.Sprintf("%s/install-wizard-v%s.tar.gz", component.getDownloadMirrors(downloadMirrors), version)
+		component.Url, _ = url.JoinPath(component.getDownloadMirrors(downloadMirrors), cliversion.VENDOR_REPO_PATH, fmt.Sprintf("install-wizard-v%s.tar.gz", version))
 		component.CheckSum = false
 		component.BaseDir = filepath.Join(prePath, fmt.Sprintf("v%s", version))
 	case cudakeyring: // + gpu

--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -5,10 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/beclab/Olares/cli/version"
 	"io/fs"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -171,7 +173,8 @@ func (t *Download) Execute(runtime connector.Runtime) error {
 	var wizard = files.NewKubeBinary("install-wizard", osArch, osType, osVersion, osPlatformFamily, t.Version, prePath, t.DownloadCdnUrl)
 
 	if t.UrlOverride == "" {
-		var fetchMd5 = fmt.Sprintf("curl -sSfL %s/install-wizard-v%s.md5sum.txt |awk '{print $1}'", t.DownloadCdnUrl, t.Version)
+		md5URL, _ := url.JoinPath(t.DownloadCdnUrl, version.VENDOR_REPO_PATH, fmt.Sprintf("install-wizard-v%s.md5sum.txt", t.Version))
+		var fetchMd5 = fmt.Sprintf("curl -sSfL %s |awk '{print $1}'", md5URL)
 		md5sum, err := runtime.GetRunner().Cmd(fetchMd5, false, false)
 		if err != nil {
 			return errors.New("get md5sum failed")

--- a/cli/version/vendor.go
+++ b/cli/version/vendor.go
@@ -1,3 +1,4 @@
 package version
 
-var VENDOR = "community"
+var VENDOR = "main"
+var VENDOR_REPO_PATH = ""

--- a/daemon/cmd/terminusd/version/vendor.go
+++ b/daemon/cmd/terminusd/version/vendor.go
@@ -1,3 +1,3 @@
 package version
 
-var VENDOR = "community"
+var VENDOR = "main"


### PR DESCRIPTION
* **Background**
Inject `VENDOR_REPO_PATH` from the env`OLARES_VENDOR_REPO_PATH` when building olares-cli, and download wizard from the specific vendor path

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none