### PR TITLE
fix(cli): make the timer for renewing K8s certs persistent

### DIFF
--- a/cli/pkg/certs/templates/certs_renew_service.go
+++ b/cli/pkg/certs/templates/certs_renew_service.go
@@ -40,6 +40,7 @@ Description=Timer to renew K8S control plane certificates
 [Timer]
 OnCalendar=Mon *-*-* 03:00:00
 Unit=k8s-certs-renew.service
+Persistent=true
 [Install]
 WantedBy=multi-user.target
     `)))


### PR DESCRIPTION
* **Background**
If the official Kubernetes distro is selected when installing Olares, all the components' certs are signed by kubeadm, with a 1-year validity that's not configurable, the auto-renew of these certs is handled by a system timer which is triggered once a week.
So if the machine is powered off during the scheduled certs renewal, another week is waited before renewing again, and this is unacceptable.
Setting the [`Persistent=true`](https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html#Persistent=) option ensures that the renewal will be always executed upon machine power on, even if there was a misfire.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none