### PR TITLE
feat(daemon): add API to confirm upgrade after download

### DIFF
--- a/daemon/internel/apiserver/handlers/command_group.go
+++ b/daemon/internel/apiserver/handlers/command_group.go
@@ -37,6 +37,9 @@ func init() {
 		handlers.RequireOwner(
 			handlers.RunCommand(handlers.CancelOlaresUpgrade, upgrade.NewRemoveUpgradeTarget))))
 
+	cmd.Post("/upgrade/confirm", handlers.RequireSignature(
+		handlers.RequireOwner(handlers.ConfirmOlaresUpgrade)))
+
 	cmd.Post("/reboot", handlers.RequireSignature(
 		handlers.RequireOwner(
 			handlers.WaitServerRunning(


### PR DESCRIPTION
* **Background**
Currently, the whole upgrade progress is split into download and upgrade phase, and when requesting upgrade, whether do upgrade immediately after download can be specified and modified, with all other options, for easier implementation of the client, a separate API is also added to confirm only the upgrade operation after the download, without other options.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none