### PR TITLE
feat(gpu): force out app exclusively bound to GPU

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.5.5"
+version: "v2.5.6"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.5.5
+      name: beclab/hami:v2.5.6
     - 
       name: beclab/hami-webui-fe-oss:v1.0.7
     - 


### PR DESCRIPTION
* **Background**
Currently, requests to bind an app to a GPU which is exclusively bound to another app is rejected, this is now changed to forcing out the old app and binding the new one

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none