### PR TITLE
feat(cli): inject rootfs type to global envs

### DIFF
--- a/cli/pkg/storage/juicefs.go
+++ b/cli/pkg/storage/juicefs.go
@@ -269,3 +269,14 @@ func getManagedMinIOAccessFlags(localIp string) (string, error) {
 	return fmt.Sprintf(" --storage minio --bucket http://%s:9000/%s --access-key %s --secret-key %s",
 		localIp, cc.OlaresDir, MinioRootUser, minioPassword), nil
 }
+
+func GetRootFSType() string {
+	if util.IsExist(JuiceFsServiceFile) {
+		return "jfs"
+	}
+	return "fs"
+}
+
+func init() {
+	common.TerminusGlobalEnvs["OLARES_FS_TYPE"] = GetRootFSType()
+}

--- a/cli/pkg/terminus/apps.go
+++ b/cli/pkg/terminus/apps.go
@@ -96,7 +96,7 @@ func (u *PrepareAppValues) Execute(runtime connector.Runtime) error {
 	if err != nil {
 		return err
 	}
-	fsType := getRootFSType()
+	fsType := storage.GetRootFSType()
 	gpuType := getGpuType(u.KubeConf.Arg.GPU.Enable)
 	appValues := getAppSecrets(getAppPatches())
 

--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -70,7 +70,7 @@ func (t *InstallOsSystem) Execute(runtime connector.Runtime) error {
 		},
 		"gpu":                                  getGpuType(t.KubeConf.Arg.GPU.Enable),
 		"s3_bucket":                            t.KubeConf.Arg.Storage.StorageBucket,
-		"fs_type":                              getRootFSType(),
+		"fs_type":                              storage.GetRootFSType(),
 		common.HelmValuesKeyTerminusGlobalEnvs: common.TerminusGlobalEnvs,
 		common.HelmValuesKeyOlaresRootFSPath:   storage.OlaresRootDir,
 	}
@@ -294,13 +294,6 @@ func cloudValue(cloudInstance bool) string {
 	}
 
 	return ""
-}
-
-func getRootFSType() string {
-	if util.IsExist(storage.JuiceFsServiceFile) {
-		return "jfs"
-	}
-	return "fs"
 }
 
 func getRedisPassword(client clientset.Client, runtime connector.Runtime) (string, error) {


### PR DESCRIPTION
* **Background**
Inject Olares' rootfs type as `OLARES_FS_TYPE` into global envs when initializing storage module, which will be passed to and used by system service when creating new users

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none