### PR TITLE
fix(ci): specify arch variant in goreleaser override config

### DIFF
--- a/daemon/.goreleaser.yml
+++ b/daemon/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
   overrides:
     - goarch: amd64
       goos: linux
+      goamd64: v1
       env:
         - CGO_ENABLED=1
   tags:


### PR DESCRIPTION
* **Background**
The arch variant`goamd64: v1` needs to be specified explicitly in goreleaser.yaml to make the env override actually take effect

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none