### PR TITLE
feat: add producer, consumer watch

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.60
+        image: beclab/search3:v0.0.61
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: os-internal
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.60
+        image: beclab/search3monitor:v0.0.61
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_IP


### PR DESCRIPTION
Title: aboveos/search3: add consumer,producer watcher
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
A new watcher has been implemented using a producer–consumer pattern. The producer continuously retrieves monitoring events from inotify, buffers them, and places them into a channel. The consumer then takes events from the channel and processes them.
In the original approach, each event was fetched from inotify and acted upon immediately. Because these actions could take a long time, events queued in the kernel’s buffer risked being lost. By buffering the events and letting separate threads consume them, the new design prevents event loss.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/101