### PR TITLE
fix(upgrade): wait for user to finish activation before upgrading

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -245,7 +245,7 @@ func (u *upgradeUserComponents) Execute(runtime connector.Runtime) error {
 		}
 
 		var wizardNeedUpgrade bool
-		if wizardStatus, ok := user.Annotations["bytetrade.io/wizard-status"]; ok && wizardStatus == "completed" {
+		if wizardStatus, ok := user.Annotations["bytetrade.io/wizard-status"]; !ok || wizardStatus != "completed" {
 			wizardNeedUpgrade = true
 		}
 

--- a/daemon/internel/watcher/upgrade/upgrade_watcher.go
+++ b/daemon/internel/watcher/upgrade/upgrade_watcher.go
@@ -200,7 +200,7 @@ var downloadPhases = []upgradePhase{
 
 var upgradePhases = []upgradePhase{
 	{upgrade.NewVersionCompatibilityCheck, 0, 5},
-	{upgrade.NewHealthCheck, 5, 5},
+	{upgrade.NewPreCheck, 5, 5},
 	{upgrade.NewInstallCLI, 10, 10},
 	{upgrade.NewInstallOlaresd, 20, 10},
 	{upgrade.NewImportImages, 30, 30},

--- a/daemon/pkg/commands/operations.go
+++ b/daemon/pkg/commands/operations.go
@@ -22,7 +22,7 @@ const (
 	DownloadCLI               Operations = "downloadCLI"
 	DownloadWizard            Operations = "downloadWizard"
 	VersionCompatibilityCheck Operations = "versionCompatibilityCheck"
-	UpgradeHealthCheck        Operations = "upgradeHealthCheck"
+	UpgradePreCheck           Operations = "PreCheck"
 	DownloadSpaceCheck        Operations = "downloadSpaceCheck"
 	DownloadComponent         Operations = "downloadComponent"
 	ImportImages              Operations = "importImages"


### PR DESCRIPTION
* **Background**
In upgrade's precheck, if any user is in the progress of activation, wait for it to complete
Already activated user's wizard should be skipped when upgrading

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none