### PR TITLE
fix(cli): trucate file before untar

### DIFF
--- a/cli/pkg/core/util/file.go
+++ b/cli/pkg/core/util/file.go
@@ -344,7 +344,7 @@ func Untar(src, dst string) error {
 				}
 			}
 
-			file, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
+			file, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(hdr.Mode))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
* **Background**
add `os.O_TRUNC` option when open file for untar, to avoid messing up with existing content

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none