### PR TITLE
feat(cli): fallback target to current cli version for both release line

### DIFF
--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -90,7 +90,17 @@ func GetUpgradePathFor(base *semver.Version, target *semver.Version) ([]*semver.
 	var path []*semver.Version
 	var releaseLineUpgraders []breakingUpgrader
 	var versionFilter func(v *semver.Version) bool
-	switch getReleaseLineOfVersion(base) {
+	line := getReleaseLineOfVersion(base)
+	if target == nil {
+		cliVersion, err := utils.ParseOlaresVersionString(version.VERSION)
+		if err != nil {
+			return path, fmt.Errorf("invalid olares-cli version :\"%s\"", version.VERSION)
+		}
+		if getReleaseLineOfVersion(cliVersion) == line && cliVersion.GreaterThan(base) {
+			target = cliVersion
+		}
+	}
+	switch line {
 	case mainLine:
 		releaseLineUpgraders = mainUpgraders
 		versionFilter = func(v *semver.Version) bool {
@@ -106,15 +116,6 @@ func GetUpgradePathFor(base *semver.Version, target *semver.Version) ([]*semver.
 			return true
 		}
 	case dailyLine:
-		if target == nil {
-			cliVersion, err := utils.ParseOlaresVersionString(version.VERSION)
-			if err != nil {
-				return path, fmt.Errorf("invalid olares-cli version :\"%s\"", version.VERSION)
-			}
-			if getReleaseLineOfVersion(cliVersion) == dailyLine && samePatchLevelVersion(cliVersion, base) && cliVersion.GreaterThan(base) {
-				target = cliVersion
-			}
-		}
 		releaseLineUpgraders = dailyUpgraders
 		versionFilter = func(v *semver.Version) bool {
 			if !v.GreaterThan(base) {


### PR DESCRIPTION
* **Background**
Currently, the target version falls back to current olares-cli version for dailybuild release line, regardless of whether it's related to breaking changes, this should be the behavior for both dailybuild and main release lines.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none