### PR TITLE
fix(ci): correct path to release joincluster script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
             build/base-package/publicInstaller.latest.ps1
             build/base-package/install.ps1
             build/base-package/publicAddnode.sh
-            build/instbase-packagealler/joincluster.sh
+            build/base-package/joincluster.sh
             build/base-package/version.hint
             build/base-package/publicRestoreInstaller.sh
           prerelease: true


### PR DESCRIPTION
* **Background**
The current path in the workflow is messed up

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none