### PR TITLE
fix(cli): installation on MacOS using minikube

### DIFF
--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -333,8 +333,10 @@ var TerminusGlobalEnvs = map[string]interface{}{
 	"FRP_LIST_URL":               "https://terminus-frp.snowinning.com",
 	"TAILSCALE_CONTROLPLANE_URL": "https://controlplane.snowinning.com",
 	"OLARES_ROOT_DIR":            "/olares",
-	ENV_DOWNLOAD_CDN_URL:         cc.DownloadUrl,
-	ENV_MARKET_PROVIDER:          "appstore-server-prod.bttcdn.com",
+	// the default value used by kubeadm
+	"COREDNS_SVC":        "10.96.0.10",
+	ENV_DOWNLOAD_CDN_URL: cc.DownloadUrl,
+	ENV_MARKET_PROVIDER:  "appstore-server-prod.bttcdn.com",
 }
 
 const (

--- a/cli/pkg/kubesphere/minikube.go
+++ b/cli/pkg/kubesphere/minikube.go
@@ -50,7 +50,7 @@ func (t *CreateMiniKubeCluster) Execute(runtime connector.Runtime) error {
 		}
 	}
 	logger.Infof("creating minikube cluster %s ...", t.KubeConf.Arg.MinikubeProfile)
-	cmd = fmt.Sprintf("%s start -p '%s' --kubernetes-version=v1.22.10 --container-runtime=containerd --network-plugin=cni --cni=calico --cpus='4' --memory='8g' --ports=30180:30180,443:443,80:80", minikube, t.KubeConf.Arg.MinikubeProfile)
+	cmd = fmt.Sprintf("%s start -p '%s' --kubernetes-version=v1.33.3 --container-runtime=containerd --network-plugin=cni --cni=calico --cpus='4' --memory='8g' --ports=30180:30180,443:443,80:80", minikube, t.KubeConf.Arg.MinikubeProfile)
 	if _, err := runtime.GetRunner().Cmd(cmd, false, true); err != nil {
 		return errors.Wrap(err, "failed to create minikube cluster")
 	}

--- a/infrastructure/kubernetes/.olares/Olares.yaml
+++ b/infrastructure/kubernetes/.olares/Olares.yaml
@@ -25,8 +25,6 @@ output:
     - 
       name: alpine:3.14
     -
-      name: mirrorgooglecontainers/defaultbackend-amd64:1.4
-    - 
       name: bitnami/kube-rbac-proxy:0.19.0
     - 
       name: registry.k8s.io/kube-apiserver:v1.33.3


### PR DESCRIPTION
* **Background**
Fixes some errors that fail the installation on MacOS using Minikube:
Upgrade K8s to v1.33.3 when starting cluster using Minikube
Import images into containerd using native ctr command
Removed unused image with a fixed amd64 architecture  

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none