### PR TITLE
authelia: ignore error when app policies reloading

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.20
+        image: beclab/auth:0.2.21
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
When reloading app policies, ignore errors for one user to ensure that the policies for other users are successfully reloaded.

* **Target Version for Merge**
v1.12.0 v1.12.1

* **Related Issues**
When a new user creating, app policies cannot be reloaded.

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/29

* **Other information**:
