### PR TITLE
feat(testing‑mode): allow installation on unsupported OS + ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docs/.vitepress/dist/
 docs/.vitepress/cache/
 node_modules
 .idea/
+cli/olares-cli*

--- a/cli/pkg/bootstrap/precheck/tasks.go
+++ b/cli/pkg/bootstrap/precheck/tasks.go
@@ -75,7 +75,22 @@ func (t *SystemSupportCheck) Name() string {
 }
 
 func (t *SystemSupportCheck) Check(runtime connector.Runtime) error {
-	return runtime.GetSystemInfo().IsSupport()
+	err := runtime.GetSystemInfo().IsSupport()
+	if err == nil {
+		return nil
+	}
+	// Interactive warning instead of outright failure
+	fmt.Printf("%v Use at your own risk, would you like to continue? (Y/N): ", err)
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return fmt.Errorf("could not read terminal input: %v", err)
+	}
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(input)
+	if !strings.HasPrefix("yes", strings.ToLower(input)) {
+		return err
+	}
+	return nil
 }
 
 type RequiredPortsCheck struct{}


### PR DESCRIPTION
# What this PR does
This PR modifies the cli to alow a user to bypass the failer on an unsupported os to allow for better testing.
It also modifies the .gitignore to prevent unwanted build files and output binaries from being commited.

# ai code use
This PR did use ai code but I did verify all code worked and was accurate.
 
# testing 
I testes the binary on both an previously working os and ubuntu devel branch. It appered to work on both.

# Affected Issues
Issues that should be closed because of this PR
#1645 

old issues that have since been recitfied
#723
#890

