### PR TITLE
daemon: fix checking if ip changed bug

### DIFF
--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -191,9 +191,8 @@ func IsIpChanged(ctx context.Context, installed bool) (bool, error) {
 
 				}
 
-				if nodeRole == "master" && nodeIp != ip.IP {
-					klog.Info("node is master and node ip is not the same as internal ip of interface, ", nodeIp, ", ", hostIp, ", ", ip.IP)
-					return true, nil
+				if nodeRole == "master" && nodeIp == ip.IP {
+					return false, nil
 				}
 
 				// FIXME:(BUG) worker node will not work with this check
@@ -201,8 +200,8 @@ func IsIpChanged(ctx context.Context, installed bool) (bool, error) {
 					return false, nil
 				}
 
-				klog.Info("get node ip, ", nodeIp, ", ", hostIp, ", ", ip.IP)
-
+				klog.Info("node is master and node ip is not the same as internal ip of interface, ", nodeIp, ", ", hostIp, ", ", ip.IP)
+				return true, nil
 			}
 		} // end for host ips
 	} // end for interface ips


### PR DESCRIPTION
* **Background**
When the server is restarted and its IP address has changed, the check to determine if the node is the master will fail, and the mechanism to detect IP changes will also fail.

* **Target Version for Merge**
v1.12.0 v1.12.1

* **Related Issues**
IP changing was not performed

* **PRs Involving Sub-Systems** 
none

* **Other information**:
