### PR TITLE
fix: entrance url matching error in market

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -99,7 +99,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.4.17
+        image: beclab/market-backend:v0.4.18
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION

* **Background**
In the case of missing URL, the market will try to find the URL from the secp information. This action ignores the username matching, resulting in the wrong information being found.

* **Target Version for Merge**
1.12.0

* **Related Issues**


* **PRs Involving Sub-Systems** 
https://github.com/beclab/market/commit/8678eee7cfb003bc6ca33835697f31b3ee0a7630


* **Other information**:
