### PR TITLE
fix(cli): create symlink to sysconf if none exists

### DIFF
--- a/cli/pkg/bootstrap/os/module.go
+++ b/cli/pkg/bootstrap/os/module.go
@@ -166,6 +166,15 @@ func (c *ConfigureOSModule) Init() {
 		Parallel: true,
 	}
 
+	symlinkSysconf := &task.RemoteTask{
+		Name:     "SymlinkSysconf",
+		Desc:     "Create symbolic link to sysconf if non-existing",
+		Hosts:    c.Runtime.GetAllHosts(),
+		Prepare:  &kubernetes.NodeInCluster{Not: true},
+		Action:   new(SymLinkSysconf),
+		Parallel: true,
+	}
+
 	ConfigureNtpServer := &task.RemoteTask{
 		Name:  "ConfigureNtpServer",
 		Desc:  "configure the ntp server for each node",
@@ -191,6 +200,7 @@ func (c *ConfigureOSModule) Init() {
 		initOS,
 		GenerateScript,
 		ExecScript,
+		symlinkSysconf,
 		ConfigureNtpServer,
 		configureSwap,
 	}


### PR DESCRIPTION
* **Background**
In some systems, the default config file for sysctl `/etc/sysctl.conf` is not read after reboot, due to a missing `/etc/sysctl.d/99-sysctl.conf` that symbolically links to it, in such cases, we create the missing symlink.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
see also https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2084376