### PR TITLE
chore(cli): remove any call to ulimit that has no effect

### DIFF
--- a/cli/cmd/ctl/os/root.go
+++ b/cli/cmd/ctl/os/root.go
@@ -1,15 +1,10 @@
 package os
 
 import (
-	"os/exec"
-
 	"github.com/spf13/cobra"
 )
 
 func NewOSCommands() []*cobra.Command {
-	_ = exec.Command("/bin/bash", "-c", "ulimit -u 65535").Run()
-	_ = exec.Command("/bin/bash", "-c", "ulimit -n 65535").Run()
-
 	return []*cobra.Command{
 		NewCmdPrecheck(),
 		NewCmdRootDownload(),

--- a/cli/cmd/main.go
+++ b/cli/cmd/main.go
@@ -1,16 +1,12 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-
 	"github.com/beclab/Olares/cli/cmd/ctl"
+	"os"
 )
 
 func main() {
 	cmd := ctl.NewDefaultCommand()
-	_ = exec.Command("/bin/bash", "-c", "ulimit -u 65535").Run()
-	_ = exec.Command("/bin/bash", "-c", "ulimit -n 65535").Run()
 
 	if err := cmd.Execute(); err != nil {
 		// fmt.Println(err)

--- a/cli/pkg/bootstrap/os/templates/init_script.go
+++ b/cli/pkg/bootstrap/os/templates/init_script.go
@@ -152,9 +152,6 @@ update-alternatives --set arptables /usr/sbin/arptables-legacy >/dev/null 2>&1 |
 update-alternatives --set ebtables /usr/sbin/ebtables-legacy >/dev/null 2>&1 || true
 
 for i in $(systemctl list-unit-files --no-legend --no-pager -l | grep --color=never -o .*.slice | grep kubepod); do sudo systemctl stop $i; done
-
-ulimit -u 65535
-ulimit -n 65535
 `)))
 
 func GenerateHosts(runtime connector.ModuleRuntime, kubeConf *common.KubeConf) []string {


### PR DESCRIPTION
* **Background**
`ulimit`, as a shell builtin function, set the hard/soft limit to the CURRENT shell and any processes spawned, which means the current way to spawn a bash process and call `ulimit` does not have any real effect, and should be removed.

* **Target Version for Merge**
1.12.0

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none