### PR TITLE
authelia: send the cookie of an ephemeral user to subdomain

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.21
+        image: beclab/auth:0.2.22
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
When the ephemeral user is initializing, send the cookie to the wizard subdomain instead of the parent domain.

* **Target Version for Merge**
v1.12.1

* **Related Issues**
Initializing the new user in the same browser will make the admin user's access forbidden.

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/30


* **Other information**:
