### PR TITLE
chore: get rid of unused values & ops related to ks redis

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/values.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/values.yaml
@@ -44,5 +44,3 @@ os:
   dashboard:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/apps/.olares/config/user/helm-charts/wizard/values.yaml
+++ b/apps/.olares/config/user/helm-charts/wizard/values.yaml
@@ -34,5 +34,3 @@ os:
   appstore:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/build/base-package/wizard/config/os-chart-template/values.yaml
+++ b/build/base-package/wizard/config/os-chart-template/values.yaml
@@ -1,5 +1,3 @@
-kubesphere:
-  redis_password: ""
 backup:
   bucket: "${BACKUP_CLUSTER_BUCKET}"
   key_prefix: "${BACKUP_KEY_PREFIX}"

--- a/cli/pkg/kubesphere/plugins/files/build/ks-core-config/values.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/ks-core-config/values.yaml
@@ -59,14 +59,7 @@ securityContext: {}
 # Kubernetes Version shows in KubeSphere console
 # kube_version: "v1.19.4" # ! 这里要替换下
 
-env:
-- name: KUBESPHERE_REDIS_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: redis-secret
-      key: auth
-
-tolerations: 
+tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
   - key: CriticalAddonsOnly

--- a/cli/pkg/kubesphere/plugins/files/build/ks-core/values.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/ks-core/values.yaml
@@ -58,14 +58,7 @@ securityContext: {}
 # Kubernetes Version shows in KubeSphere console
 # kube_version: "v1.19.4" # ! 这里要替换下
 
-env:
-- name: KUBESPHERE_REDIS_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: redis-secret
-      key: auth
-
-tolerations: 
+tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
   - key: CriticalAddonsOnly

--- a/framework/authelia/.olares/config/user/helm-charts/auth/values.yaml
+++ b/framework/authelia/.olares/config/user/helm-charts/auth/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/values.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/framework/infisical/.olares/config/user/helm-charts/infisical/values.yaml
+++ b/framework/infisical/.olares/config/user/helm-charts/infisical/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/values.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/values.yaml
+++ b/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/platform/tapr/.olares/config/user/helm-charts/citus/values.yaml
+++ b/platform/tapr/.olares/config/user/helm-charts/citus/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/platform/tapr/.olares/config/user/helm-charts/mongo/values.yaml
+++ b/platform/tapr/.olares/config/user/helm-charts/mongo/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/platform/tapr/.olares/config/user/helm-charts/redis/values.yaml
+++ b/platform/tapr/.olares/config/user/helm-charts/redis/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""

--- a/platform/tapr/.olares/config/user/helm-charts/tapr/values.yaml
+++ b/platform/tapr/.olares/config/user/helm-charts/tapr/values.yaml
@@ -38,5 +38,3 @@ os:
   search2:
     appKey: '${ks[0]}'
     appSecret: test
-kubesphere:
-  redis_password: ""


### PR DESCRIPTION
* **Background**
The Redis component of KubeSphere was removed in https://github.com/beclab/Olares/pull/1690, so various helm charts and operations with reference to it should also be cleaned up.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none