### PR TITLE
fix(manifest): add missing condition for sharedlib vol in files

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -161,9 +161,11 @@ spec:
               name: userspace-dir
             - mountPath: /appcache/
               name: upload-appdata
+{{ if .Values.sharedlib }}
             - mountPath: /data/External
               mountPropagation: Bidirectional
               name: shared-lib
+{{ end }}
 
         - name: files
           image: beclab/files-server:v0.2.90


### PR DESCRIPTION
* **Background**
A new container `rclone` was added to the files server in https://github.com/beclab/Olares/pull/1683, along with its volumes, including the `sharedlib`, which might not be declared and should be rendered by a helm conditional template.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none