### PR TITLE
feat(ci): differentiate multiple releases of the same version

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -10,6 +10,8 @@ on:
         type: string
       repository:
         type: string
+      release-id:
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -18,6 +20,8 @@ on:
       ref:
         type: string
       repository:
+        type: string
+      release-id:
         type: string
 jobs:
   goreleaser:
@@ -53,6 +57,7 @@ jobs:
           version: v1.18.2
           args: release --clean
         env:
+          OLARES_RELEASE_ID: ${{ inputs.release-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to S3
@@ -61,6 +66,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
         run: |
-          cd cli/output && for file in *.tar.gz; do
+          cd cli/output && for file in $(ls *.tar.gz | grep -v no-release-id); do
             aws s3 cp "$file" s3://terminus-os-install${{ secrets.REPO_PATH }}${file} --acl=public-read
           done

--- a/.github/workflows/release-daemon.yaml
+++ b/.github/workflows/release-daemon.yaml
@@ -10,6 +10,8 @@ on:
         type: string
       repository:
         type: string
+      release-id:
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -18,6 +20,8 @@ on:
       ref:
         type: string
       repository:
+        type: string
+      release-id:
         type: string
 
 jobs:
@@ -52,6 +56,8 @@ jobs:
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0
+        env:
+          OLARES_RELEASE_ID: ${{ inputs.release-id }}
         with:
           distribution: goreleaser
           workdir: './daemon'
@@ -64,6 +70,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-east-1'
         run: |
-          cd daemon/output && for file in *.tar.gz; do
+          cd daemon/output && for file in $(ls *.tar.gz | grep -v no-release-id); do
             aws s3 cp "$file" s3://terminus-os-install${{ secrets.REPO_PATH }}${file} --acl=public-read
           done

--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -20,19 +20,33 @@ jobs:
           v=1.12.1-$(date +"%Y%m%d")
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
+  release-id:
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.generate.outputs.id }}
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+      - id: generate
+        run: |
+          hash=$(git rev-parse --short HEAD)
+          echo "id=$hash" >> "$GITHUB_OUTPUT"
+
   release-cli:
-    needs: daily-version
+    needs: [daily-version, release-id]
     uses: ./.github/workflows/release-cli.yaml
     secrets: inherit
     with:
       version: ${{ needs.daily-version.outputs.version }}
+      release-id: ${{ needs.release-id.outputs.id }}
 
   release-daemon:
-    needs: daily-version
+    needs: [daily-version, release-id]
     uses: ./.github/workflows/release-daemon.yaml
     secrets: inherit
     with:
       version: ${{ needs.daily-version.outputs.version }}
+      release-id: ${{ needs.release-id.outputs.id }}
 
   push-images:
     runs-on: ubuntu-22.04
@@ -64,7 +78,7 @@ jobs:
           bash build/image-manifest.sh && bash build/upload-images.sh .manifest/images.mf linux/arm64
 
   push-deps:
-    needs: [daily-version, release-daemon]
+    needs: [daily-version, release-id, release-daemon]
     runs-on: ubuntu-latest
 
     steps:
@@ -77,12 +91,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION: ${{ needs.daily-version.outputs.version }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
           REPO_PATH: '${{ secrets.REPO_PATH }}'
         run: |
           bash build/deps-manifest.sh && bash build/upload-deps.sh
 
   push-deps-arm64:
-    needs: [daily-version, release-daemon]
+    needs: [daily-version, release-id, release-daemon]
     runs-on: [self-hosted, linux, ARM64]
 
     steps:
@@ -95,6 +110,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION: ${{ needs.daily-version.outputs.version }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
           REPO_PATH: '${{ secrets.REPO_PATH }}'
         run: |
           export PATH=$PATH:/usr/local/bin:/home/ubuntu/.local/bin
@@ -102,7 +118,7 @@ jobs:
 
 
   upload-package:
-    needs: [daily-version, push-images, push-images-arm64, push-deps, push-deps-arm64]
+    needs: [daily-version, release-id, push-images, push-images-arm64, push-deps, push-deps-arm64]
     runs-on: ubuntu-latest
     outputs:
       md5sum: ${{ steps.upload.outputs.md5sum }}
@@ -127,9 +143,12 @@ jobs:
           aws s3 cp install-wizard-v${{ needs.daily-version.outputs.version }}.tar.gz s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ needs.daily-version.outputs.version }}.tar.gz --acl=public-read && \
           echo "md5sum=$(awk '{print $1}' install-wizard-v${{ needs.daily-version.outputs.version }}.md5sum.txt)" >> "$GITHUB_OUTPUT"
 
+          aws s3 cp install-wizard-v${{ needs.daily-version.outputs.version }}.md5sum.txt s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ needs.daily-version.outputs.version }}.${{ needs.release-id.outputs.id }}.md5sum.txt --acl=public-read && \
+          aws s3 cp install-wizard-v${{ needs.daily-version.outputs.version }}.tar.gz s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ needs.daily-version.outputs.version }}.${{ needs.release-id.outputs.id }}.tar.gz --acl=public-read && \
+
 
   release:
-    needs: [daily-version, upload-package, release-cli]
+    needs: [daily-version, upload-package, release-cli, release-id]
     runs-on: ubuntu-latest
 
     steps:
@@ -145,7 +164,7 @@ jobs:
       
       - name: Package installer
         run: |
-          bash build/build.sh ${{ needs.daily-version.outputs.version }}
+          bash build/build.sh ${{ needs.daily-version.outputs.version }} ${{ needs.release-id.outputs.id }}
 
       - name: 'Archives'
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,18 +10,36 @@ on:
 
 jobs:
 
+  release-id:
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.generate.outputs.id }}
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tags }}
+      - id: generate
+        run: |
+          hash=$(git rev-parse --short HEAD)
+          echo "id=$hash" >> "$GITHUB_OUTPUT"
+
   release-cli:
+    needs: [release-id]
     uses: ./.github/workflows/release-cli.yaml
     secrets: inherit
     with:
       version: ${{ github.event.inputs.tags }}
+      release-id: ${{ needs.release-id.outputs.id }}
       ref: ${{ github.event.inputs.tags }}
 
   release-daemon:
+    needs: [release-id]
     uses: ./.github/workflows/release-daemon.yaml
     secrets: inherit
     with:
       version: ${{ github.event.inputs.tags }}
+      release-id: ${{ needs.release-id.outputs.id }}
       ref: ${{ github.event.inputs.tags }}
 
   push:
@@ -60,7 +78,7 @@ jobs:
           bash build/image-manifest.sh && bash build/upload-images.sh .manifest/images.mf linux/arm64
 
   push-deps:
-    needs: [release-daemon]
+    needs: [release-daemon, release-id]
     runs-on: ubuntu-latest
 
     steps:
@@ -73,12 +91,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION: ${{ github.event.inputs.tags }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
           REPO_PATH: '${{ secrets.REPO_PATH }}'
         run: |
           bash build/deps-manifest.sh && bash build/upload-deps.sh
 
   push-deps-arm64:
-    needs: [release-daemon]
+    needs: [release-daemon, release-id]
     runs-on: [self-hosted, linux, ARM64]
 
     steps:
@@ -91,6 +110,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION: ${{ github.event.inputs.tags }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
           REPO_PATH: '${{ secrets.REPO_PATH }}'
         run: |
           export PATH=$PATH:/usr/local/bin:/home/ubuntu/.local/bin
@@ -98,7 +118,7 @@ jobs:
 
 
   upload-package:
-    needs: [push, push-arm64, push-deps, push-deps-arm64, release-daemon]
+    needs: [push, push-arm64, push-deps, push-deps-arm64, release-daemon, release-id]
     runs-on: ubuntu-latest
 
     steps:
@@ -121,9 +141,12 @@ jobs:
           aws s3 cp install-wizard-v${{ github.event.inputs.tags }}.md5sum.txt s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ github.event.inputs.tags }}.md5sum.txt --acl=public-read && \
           aws s3 cp install-wizard-v${{ github.event.inputs.tags }}.tar.gz s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ github.event.inputs.tags }}.tar.gz --acl=public-read
 
+          aws s3 cp install-wizard-v${{ needs.daily-version.outputs.version }}.md5sum.txt s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ needs.daily-version.outputs.version }}.${{ needs.release-id.outputs.id }}.md5sum.txt --acl=public-read && \
+          aws s3 cp install-wizard-v${{ needs.daily-version.outputs.version }}.tar.gz s3://terminus-os-install${{ secrets.REPO_PATH }}install-wizard-v${{ needs.daily-version.outputs.version }}.${{ needs.release-id.outputs.id }}.tar.gz --acl=public-read && \
+
   release:
     runs-on: ubuntu-latest
-    needs: [upload-package, release-cli]
+    needs: [upload-package, release-cli, release-id]
 
     steps:
       - name: 'Checkout source code'
@@ -139,7 +162,7 @@ jobs:
       - name: Get checksum
         id: vars
         run: |
-          echo "version_md5sum=$(curl -sSfL https://dc3p1870nn3cj.cloudfront.net${{ secrets.REPO_PATH }}install-wizard-v${{ github.event.inputs.tags }}.md5sum.txt|awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "version_md5sum=$(curl -sSfL https://dc3p1870nn3cj.cloudfront.net${{ secrets.REPO_PATH }}install-wizard-v${{ github.event.inputs.tags }}.${{ needs.release-id.outputs.id }}.md5sum.txt|awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Update checksum
         uses: eball/write-tag-to-version-file@latest
@@ -150,7 +173,7 @@ jobs:
 
       - name: Package installer
         run: |
-          bash build/build.sh ${{ github.event.inputs.tags }}
+          bash build/build.sh ${{ github.event.inputs.tags }} ${{ needs.release-id.outputs.id }}
           
       - name: 'Archives'
         run: |

--- a/build/base-package/install.ps1
+++ b/build/base-package/install.ps1
@@ -2,6 +2,7 @@ $currentPath = Get-Location
 $architecture = $env:PROCESSOR_ARCHITECTURE
 $downloadCdnUrlFromEnv = $env:DOWNLOAD_CDN_URL
 $version = "#__VERSION__"
+$releaseID = "#__RELEASE_ID__"
 $downloadUrl = "https://dc3p1870nn3cj.cloudfront.net"
 
 function Test-Wait {
@@ -49,7 +50,11 @@ if (-Not (Test-Path $CLI_PROGRAM_PATH)) {
 }
 
 $CLI_VERSION = "$version"
-$CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
+if (-not [string]::IsNullOrEmpty($releaseID) -and $releaseID.Substring(0,3) -ne "#__") {
+  $CLI_FILE = "olares-cli-v{0}_windows_{1}.{2}.tar.gz" -f $CLI_VERSION, $arch, $releaseID
+} else {
+  $CLI_FILE = "olares-cli-v{0}_windows_{1}.tar.gz" -f $CLI_VERSION, $arch
+}
 $CLI_URL = "{0}/{1}" -f $downloadUrl, $CLI_FILE
 $CLI_PATH = "{0}{1}" -f $CLI_PROGRAM_PATH, $CLI_FILE
 

--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -74,9 +74,15 @@ if [ -z ${cdn_url} ]; then
     cdn_url="https://dc3p1870nn3cj.cloudfront.net"
 fi
 
-CLI_FILE="olares-cli-v${VERSION}_linux_${ARCH}.tar.gz"
+RELEASE_ID="#__RELEASE_ID__"
+if [[ $RELEASE_ID == "" || "${RELEASE_ID:3}" == "RELEASE_ID__" ]]; then
+  RELEASE_ID_SUFFIX=""
+else
+  RELEASE_ID_SUFFIX=".$RELEASE_ID"
+fi
+CLI_FILE="olares-cli-v${VERSION}_linux_${ARCH}${RELEASE_ID_SUFFIX}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
-    CLI_FILE="olares-cli-v${VERSION}_darwin_${ARCH}.tar.gz"
+    CLI_FILE="olares-cli-v${VERSION}_darwin_${ARCH}${RELEASE_ID_SUFFIX}.tar.gz"
 fi
 
 if [[ "$LOCAL_RELEASE" == "1" ]]; then
@@ -159,7 +165,10 @@ else
         fi
         echo "downloading installation wizard..."
         echo ""
-        $sh_c "$INSTALL_OLARES_CLI download wizard $PARAMS $KUBE_PARAM $CDN"
+        if [[ ! -z "$RELEASE_ID_SUFFIX" ]]; then
+            DOWNLOAD_WIZARD_RELEASE_ID_PARAM="--release-id $RELEASE_ID"
+        fi
+        $sh_c "$INSTALL_OLARES_CLI download wizard $PARAMS $KUBE_PARAM $CDN $DOWNLOAD_WIZARD_RELEASE_ID_PARAM"
         if [[ $? -ne 0 ]]; then
             echo "error: failed to download installation wizard"
             exit 1

--- a/build/base-package/joincluster.sh
+++ b/build/base-package/joincluster.sh
@@ -165,7 +165,13 @@ fi
 
 set_master_host_ssh_options
 
-CLI_FILE="olares-cli-v${VERSION}_linux_${ARCH}.tar.gz"
+RELEASE_ID="#__RELEASE_ID__"
+if [[ $RELEASE_ID == "" || "${RELEASE_ID:3}" == "RELEASE_ID__" ]]; then
+  RELEASE_ID_SUFFIX=""
+else
+  RELEASE_ID_SUFFIX=".$RELEASE_ID"
+fi
+CLI_FILE="olares-cli-v${VERSION}_linux_${ARCH}${RELEASE_ID_SUFFIX}.tar.gz"
 
 if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]]; then
     INSTALL_OLARES_CLI=$(which olares-cli)
@@ -225,7 +231,10 @@ else
 
     echo "downloading installation wizard..."
     echo ""
-    $sh_c "$INSTALL_OLARES_CLI download wizard $PARAMS $CDN"
+    if [[ ! -z "$RELEASE_ID_SUFFIX" ]]; then
+        DOWNLOAD_WIZARD_RELEASE_ID_PARAM="--release-id $RELEASE_ID"
+    fi
+    $sh_c "$INSTALL_OLARES_CLI download wizard $PARAMS $KUBE_PARAM $CDN $DOWNLOAD_WIZARD_RELEASE_ID_PARAM"
     if [[ $? -ne 0 ]]; then
         echo "error: failed to download installation wizard"
         exit 1

--- a/build/build-manifest.py
+++ b/build/build-manifest.py
@@ -54,6 +54,7 @@ def main():
 
     manifest_file = args.manifest_file
     version = os.environ.get("VERSION", "")
+    release_id = os.environ.get("RELEASE_ID", "")
     repo_path = os.environ.get("REPO_PATH", "/")
     manifest_amd64_data = {}
     manifest_arm64_data = {}
@@ -69,6 +70,9 @@ def main():
                 # Replace version
                 if version:
                     line = line.replace("#__VERSION__", version)
+
+                if release_id:
+                    line = line.replace("#__RELEASE_ID_SUFFIX__", "."+release_id)
 
                 # Replace repo path
                 if repo_path:

--- a/build/build-manifest.sh
+++ b/build/build-manifest.sh
@@ -46,6 +46,13 @@ while read line; do
 done < components
 sed -i "s/#__VERSION__/${VERSION}/g" $manifest_file
 
+if [[ ! -z "$RELEASE_ID" ]]; then
+    RELEASE_ID_SUFFIX=".$RELEASE_ID"
+else
+    RELEASE_ID_SUFFIX=""
+fi
+sed -i "s/#__RELEASE_ID_SUFFIX__/${RELEASE_ID_SUFFIX}/g" $manifest_file
+
 path="${REPO_PATH:-/}"
 sed -i "s|#__REPO_PATH__|${path}|g" $manifest_file
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,6 +4,7 @@ BASE_DIR=$(dirname $(realpath -s $0))
 rm -rf ${BASE_DIR}/../.dist
 DIST_PATH="${BASE_DIR}/../.dist/install-wizard" 
 export VERSION=$1
+export RELEASE_ID=$2
 
 
 # vendor replace
@@ -57,6 +58,12 @@ if [ ! -z $VERSION ]; then
     VERSION="v${VERSION}"
 else
     VERSION="debug"
+fi
+
+if [ ! -z $RELEASE_ID ]; then
+    sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' install.sh"
+    sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' install.ps1"
+    sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' joincluster.sh"
 fi
 
 $TAR --exclude=wizard/tools --exclude=.git -zcvf ${BASE_DIR}/../install-wizard-${VERSION}.tar.gz .

--- a/build/deps-manifest.sh
+++ b/build/deps-manifest.sh
@@ -92,5 +92,13 @@ find $BASE_DIR/../ -type f -name Olares.yaml | while read f; do
 done
 
 sed -i "s/#__VERSION__/${VERSION}/g" ${manifest}
+
+if [[ ! -z "$RELEASE_ID" ]]; then
+    RELEASE_ID_SUFFIX=".$RELEASE_ID"
+else
+    RELEASE_ID_SUFFIX=""
+fi
+sed -i "s/#__RELEASE_ID_SUFFIX__/${RELEASE_ID_SUFFIX}/g" ${manifest}
+
 path="${REPO_PATH:-/}"
 sed -i "s|#__REPO_PATH__|${path}|g" ${manifest}

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -37,8 +37,15 @@ builds:
         {{- end }}
 dist: ./output
 archives:
-  - id: olares-cli
+  - id: without-release-id
     name_template: "{{ .ProjectName }}-v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: with-release-id
+    name_template: >-
+                   {{- if index .Env "OLARES_RELEASE_ID" }}
+                   {{- .ProjectName }}-v{{ .Version }}_{{ .Os }}_{{ .Arch }}.{{ .Env.OLARES_RELEASE_ID }}
+                   {{- else }}
+                   {{- .ProjectName }}-v{{ .Version }}_{{ .Os }}_{{ .Arch }}.no-release-id
+                   {{- end }}
 checksum:
   name_template: "checksums.txt"
 release:

--- a/cli/cmd/ctl/options/download_options.go
+++ b/cli/cmd/ctl/options/download_options.go
@@ -10,6 +10,7 @@ type CliDownloadWizardOptions struct {
 	KubeType       string
 	BaseDir        string
 	DownloadCdnUrl string
+	ReleaseID      string
 	UrlOverride    string
 }
 
@@ -23,6 +24,7 @@ func (o *CliDownloadWizardOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.KubeType, "kube", "k3s", "Set kube type, e.g., k3s or k8s")
 	cmd.Flags().StringVar(&o.DownloadCdnUrl, "download-cdn-url", "", "Set the CDN accelerated download address in the format https://example.cdn.com. If not set, the default download address will be used")
 	cmd.Flags().StringVar(&o.UrlOverride, "url-override", "", "Set another URL for wizard download explicitly")
+	cmd.Flags().StringVar(&o.ReleaseID, "release-id", "", "Set the specific release id of the release version")
 }
 
 type CliDownloadOptions struct {

--- a/cli/pkg/files/file.go
+++ b/cli/pkg/files/file.go
@@ -21,11 +21,9 @@ import (
 	_ "compress/bzip2"
 	"context"
 	"fmt"
-	cliversion "github.com/beclab/Olares/cli/version"
 	"io"
 	"math"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -329,12 +327,6 @@ func NewKubeBinary(name, arch, osType, osVersion, osPlatformFamily, version, pre
 		component.Url = fmt.Sprintf("https://github.com/fqrouter/conntrack-tools/archive/refs/tags/conntrack-tools-%s.tar.gz", version)
 		component.CheckSum = false
 		component.BaseDir = filepath.Join(prePath, component.Type)
-	case installwizard:
-		component.Type = WIZARD
-		component.FileName = fmt.Sprintf("install-wizard-v%s.tar.gz", version)
-		component.Url, _ = url.JoinPath(component.getDownloadMirrors(downloadMirrors), cliversion.VENDOR_REPO_PATH, fmt.Sprintf("install-wizard-v%s.tar.gz", version))
-		component.CheckSum = false
-		component.BaseDir = filepath.Join(prePath, fmt.Sprintf("v%s", version))
 	case cudakeyring: // + gpu
 		if strings.Contains(osVersion, "24.") {
 			version = "1.1"
@@ -387,7 +379,7 @@ func NewKubeBinary(name, arch, osType, osVersion, osPlatformFamily, version, pre
 	return component
 }
 
-func (b *KubeBinary) getDownloadMirrors(downloadMirrors string) string {
+func (b *KubeBinary) GetDownloadMirrors(downloadMirrors string) string {
 	if downloadMirrors == "" {
 		return common.DownloadUrl
 	}

--- a/cli/pkg/phase/download/download_wizard.go
+++ b/cli/pkg/phase/download/download_wizard.go
@@ -8,11 +8,11 @@ import (
 	"github.com/beclab/Olares/cli/pkg/terminus"
 )
 
-func NewDownloadWizard(runtime *common.KubeRuntime, urlOverride string) *pipeline.Pipeline {
+func NewDownloadWizard(runtime *common.KubeRuntime, urlOverride, releaseID string) *pipeline.Pipeline {
 
 	m := []module.Module{
 		&precheck.GreetingsModule{},
-		&terminus.InstallWizardDownloadModule{Version: runtime.Arg.OlaresVersion, DownloadCdnUrl: runtime.Arg.DownloadCdnUrl, UrlOverride: urlOverride},
+		&terminus.InstallWizardDownloadModule{Version: runtime.Arg.OlaresVersion, DownloadCdnUrl: runtime.Arg.DownloadCdnUrl, UrlOverride: urlOverride, ReleaseID: releaseID},
 	}
 
 	return &pipeline.Pipeline{

--- a/cli/pkg/pipelines/download_wizard.go
+++ b/cli/pkg/pipelines/download_wizard.go
@@ -26,7 +26,7 @@ func DownloadInstallationWizard(opts *options.CliDownloadWizardOptions) error {
 		return fmt.Errorf("--download-cdn-url invalid")
 	}
 
-	p := download.NewDownloadWizard(runtime, opts.UrlOverride)
+	p := download.NewDownloadWizard(runtime, opts.UrlOverride, opts.ReleaseID)
 	if err := p.Start(); err != nil {
 		logger.Errorf("download wizard failed %v", err)
 		return err

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -34,6 +34,7 @@ type InstallWizardDownloadModule struct {
 	Version        string
 	DownloadCdnUrl string
 	UrlOverride    string
+	ReleaseID      string
 }
 
 func (m *InstallWizardDownloadModule) Init() {
@@ -44,6 +45,7 @@ func (m *InstallWizardDownloadModule) Init() {
 			Version:        m.Version,
 			DownloadCdnUrl: m.DownloadCdnUrl,
 			UrlOverride:    m.UrlOverride,
+			ReleaseID:      m.ReleaseID,
 		},
 		Retry: 1,
 	}

--- a/daemon/.goreleaser.yml
+++ b/daemon/.goreleaser.yml
@@ -29,7 +29,15 @@ builds:
       {{- end }}
 dist: output
 archives:
-- name_template: "olaresd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+- id: without-release-id
+  name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+- id: with-release-id
+  name_template: >-
+                 {{- if index .Env "OLARES_RELEASE_ID" }}
+                 {{- .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}.{{ .Env.OLARES_RELEASE_ID }}
+                 {{- else }}
+                 {{- .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}.no-release-id
+                 {{- end }}
   files:
     - none*
 checksum:

--- a/daemon/.olares/Olares.yaml
+++ b/daemon/.olares/Olares.yaml
@@ -4,6 +4,6 @@ output:
   binaries:
     - 
       id: olaresd
-      name: olaresd-v#__VERSION__.tar.gz
-      amd64: https://dc3p1870nn3cj.cloudfront.net#__REPO_PATH__olaresd-v#__VERSION__-linux-amd64.tar.gz
-      arm64: https://dc3p1870nn3cj.cloudfront.net#__REPO_PATH__olaresd-v#__VERSION__-linux-arm64.tar.gz
+      name: olaresd-v#__VERSION__#__RELEASE_ID_SUFFIX__.tar.gz
+      amd64: https://dc3p1870nn3cj.cloudfront.net#__REPO_PATH__olaresd-v#__VERSION__-linux-amd64#__RELEASE_ID_SUFFIX__.tar.gz
+      arm64: https://dc3p1870nn3cj.cloudfront.net#__REPO_PATH__olaresd-v#__VERSION__-linux-arm64#__RELEASE_ID_SUFFIX__.tar.gz


### PR DESCRIPTION
* **Background**

To address the issue that a released version may need to be overridden by a new release action, and thus need a manual refresh to the CDN. We differentiate multiple releases of the same version by suffixing their commit hashes to the released artifacts stored in the CDN.

All archived components that are unified with the main release version or scripts that need to download these archives, specifically:

install-wizard(including its contained manifests)
olares-cli
olaresd
install/join scripts

when  released on the main/daily line, will be suffixed with the release id(commit hash)

The auto-installation CI for pull request check is not changed.

All modifications are backwards compatible, i.e., if release id is not specified, the old archive format is used.


* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none