### PR TITLE
fix(ci): add missing param for release_id when uploading package

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Package installer
         run: |
-          bash build/build.sh ${{ needs.daily-version.outputs.version }}
+          bash build/build.sh ${{ needs.daily-version.outputs.version }} ${{ needs.release-id.outputs.id }}
 
       - name: Upload to S3
         id: upload

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Package installer
         run: |
-          bash build/build.sh ${{ github.event.inputs.tags }}
+          bash build/build.sh ${{ github.event.inputs.tags }} ${{ needs.release-id.outputs.id }}
 
       - name: Upload to S3
         env: 


### PR DESCRIPTION
* **Background**
In https://github.com/beclab/Olares/pull/1727, a new param called release id has been added for `build/bash.sh` but was missed in some steps of the workflow.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none