### PR TITLE
feat(cli): adjust local release command for release id

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
       - id: generate
         run: |
-          hash=$(git rev-parse --short HEAD)
+          hash=$(git rev-parse --short=7 HEAD)
           echo "id=$hash" >> "$GITHUB_OUTPUT"
 
   release-cli:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.inputs.tags }}
       - id: generate
         run: |
-          hash=$(git rev-parse --short HEAD)
+          hash=$(git rev-parse --short=7 HEAD)
           echo "id=$hash" >> "$GITHUB_OUTPUT"
 
   release-cli:


### PR DESCRIPTION
* **Background**
Adjust the local release command `olares-cli release` to align with the new changes introduced in https://github.com/beclab/Olares/pull/1724, specifically, in addition to get the latest daily build tag, its commit hash is also retrieved to generate the final manifest. The commit hash in release CI is set to a fixed length for the local release command.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none