### PR TITLE
refactor(upgrade): remove path cmd & add spec/viable cmd for upgrade

### DIFF
--- a/cli/pkg/upgrade/1_12_0_20250702.go
+++ b/cli/pkg/upgrade/1_12_0_20250702.go
@@ -12,7 +12,7 @@ import (
 )
 
 type upgrader_1_12_0_20250702 struct {
-	upgraderBase
+	breakingUpgraderBase
 }
 
 func (u upgrader_1_12_0_20250702) Version() *semver.Version {

--- a/cli/pkg/upgrade/1_12_0_20250723.go
+++ b/cli/pkg/upgrade/1_12_0_20250723.go
@@ -10,7 +10,7 @@ import (
 )
 
 type upgrader_1_12_0_20250723 struct {
-	upgraderBase
+	breakingUpgraderBase
 }
 
 func (u upgrader_1_12_0_20250723) Version() *semver.Version {

--- a/cli/pkg/upgrade/1_12_0_20250730.go
+++ b/cli/pkg/upgrade/1_12_0_20250730.go
@@ -19,7 +19,7 @@ import (
 )
 
 type upgrader_1_12_0_20250730 struct {
-	upgraderBase
+	breakingUpgraderBase
 }
 
 func (u upgrader_1_12_0_20250730) Version() *semver.Version {

--- a/cli/pkg/upgrade/1_12_1.go
+++ b/cli/pkg/upgrade/1_12_1.go
@@ -1,0 +1,37 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/version"
+)
+
+var version_12_1_1 = semver.MustParse("1.12.1")
+
+type upgrader_1_12_1 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_1) Version() *semver.Version {
+	cliVersion, err := semver.NewVersion(version.VERSION)
+	// tolerate local dev version
+	if err != nil {
+		return version_12_1_1
+	}
+	if samePatchLevelVersion(version_12_1_1, cliVersion) && getReleaseLineOfVersion(cliVersion) == mainLine {
+		return cliVersion
+	}
+	return version_12_1_1
+}
+
+func (u upgrader_1_12_1) AddedBreakingChange() bool {
+	if u.Version().Equal(version_12_1_1) {
+		// if this version introduced breaking change
+		return true
+	}
+	if u.Version().Equal(semver.MustParse("1.12.1-alpha.2")) {
+		// if this alpha version introduced more breaking change
+		// halfway through release
+		return true
+	}
+	return false
+}

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -21,12 +21,24 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+type breakingUpgraderBase struct {
+	upgraderBase
+}
+
+func (u breakingUpgraderBase) AddedBreakingChange() bool {
+	return true
+}
+
 // upgraderBase is the general-purpose upgrader implementation
 // for upgrading across versions without any breaking changes.
 // Other implementations of breakingUpgrader,
 // targeted for versions with breaking changes,
 // should use this as a base for injecting and/or rewriting specific tasks as needed
 type upgraderBase struct{}
+
+func (u upgraderBase) AddedBreakingChange() bool {
+	return false
+}
 
 func (u upgraderBase) PrepareForUpgrade() []task.Interface {
 	return []task.Interface{

--- a/cli/pkg/upgrade/interfaces.go
+++ b/cli/pkg/upgrade/interfaces.go
@@ -15,6 +15,7 @@ type upgrader interface {
 	UpgradeSystemComponents() []task.Interface
 	UpdateOlaresVersion() []task.Interface
 	PostUpgrade() []task.Interface
+	AddedBreakingChange() bool
 }
 
 type breakingUpgrader interface {

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -5,8 +5,43 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/utils"
 	"github.com/beclab/Olares/cli/version"
+	"sort"
+	"strconv"
 	"strings"
 )
+
+type VersionSpec struct {
+	Version                   string                    `json:"version"`
+	Major                     uint64                    `json:"major"`
+	Minor                     uint64                    `json:"minor"`
+	Patch                     uint64                    `json:"patch"`
+	ReleaseType               string                    `json:"releaseType"`
+	ReleaseNum                int                       `json:"releaseNum"`
+	PreRelease                bool                      `json:"prerelease"`
+	AddedBreakingChange       bool                      `json:"addedBreakingChange"`
+	MinimumUpgradableVersions MinimumVersionConstraints `json:"minimumUpgradableVersions"`
+}
+
+type VersionConstraints map[string]*semver.Version
+type MinimumVersionConstraints VersionConstraints
+
+func (c MinimumVersionConstraints) SatisfiedBy(base *semver.Version) (bool, error) {
+	if base == nil {
+		return false, nil
+	}
+	var minVersion *semver.Version
+	prerelease := base.Prerelease()
+	if prerelease == "" {
+		minVersion = c[releaseTypeStable]
+	} else {
+		prereleaseType, _, err := parsePrereleaseVersion(prerelease)
+		if err != nil {
+			return false, fmt.Errorf("invalid version '%s': %v", base, err)
+		}
+		minVersion = c[prereleaseType]
+	}
+	return minVersion != nil && minVersion.LessThanEqual(base), nil
+}
 
 type releaseLine string
 
@@ -14,17 +49,30 @@ var (
 	mainLine  = releaseLine("main")
 	dailyLine = releaseLine("daily")
 
+	// the versions when current upgrade framework is introduced
+	minUpgradableStableVersion = semver.MustParse("1.12.0")
+	minUpgradableDailyVersion  = semver.MustParse("1.12.0-0")
+
+	releaseTypeStable = "stable"
+	releaseTypeDaily  = "daily"
+	releaseTypeRC     = "rc"
+	releaseTypeBeta   = "beta"
+	releaseTypeAlpha  = "alpha"
+	prereleaseSep     = "."
+
 	dailyUpgraders = []breakingUpgrader{
 		upgrader_1_12_0_20250702{},
 		upgrader_1_12_0_20250723{},
 		upgrader_1_12_0_20250730{},
 	}
-	mainUpgraders = []breakingUpgrader{}
+	mainUpgraders = []breakingUpgrader{
+		upgrader_1_12_1{},
+	}
 )
 
 func getReleaseLineOfVersion(v *semver.Version) releaseLine {
 	preRelease := v.Prerelease()
-	mainLinePrereleasePrefixes := []string{"alpha", "beta", "rc"}
+	mainLinePrereleasePrefixes := []string{releaseTypeRC, releaseTypeBeta, releaseTypeAlpha}
 	if preRelease == "" {
 		return mainLine
 	}
@@ -36,107 +84,40 @@ func getReleaseLineOfVersion(v *semver.Version) releaseLine {
 	return dailyLine
 }
 
-func check(base *semver.Version, target *semver.Version) error {
+func Check(base *semver.Version, target *semver.Version) error {
 	if base == nil {
 		return fmt.Errorf("base version is nil")
 	}
-	baseReleaseLine := getReleaseLineOfVersion(base)
 
 	cliVersion, err := utils.ParseOlaresVersionString(version.VERSION)
 	if err != nil {
 		return fmt.Errorf("invalid olares-cli version :\"%s\"", version.VERSION)
-	}
-	cliReleaseLine := getReleaseLineOfVersion(cliVersion)
-	if baseReleaseLine != cliReleaseLine {
-		return fmt.Errorf("incompatible base release line: %s and olares-cli release line: %s", baseReleaseLine, cliReleaseLine)
 	}
 
 	if target != nil {
 		if !target.GreaterThan(base) {
 			return fmt.Errorf("base version: %s, target version: %s, no need to upgrade", base, target)
 		}
-
-		targetReleaseLine := getReleaseLineOfVersion(target)
-		if targetReleaseLine != baseReleaseLine {
-			return fmt.Errorf("unable to upgrade to %s on %s release line from %s on %s release line", target, targetReleaseLine, base, baseReleaseLine)
-		}
-		switch targetReleaseLine {
-		case mainLine:
-			if !sameMajorLevelVersion(base, target) {
-				return fmt.Errorf("upgrade on %s rlease line can only be performed across same major level version", baseReleaseLine)
-			}
-		case dailyLine:
-			if !sameMinorLevelVersion(base, target) {
-				return fmt.Errorf("upgrade on %s rlease line can only be performed across same patch version", baseReleaseLine)
-			}
-		}
-
-		if target.GreaterThan(cliVersion) {
-			return fmt.Errorf("target version: %s, cli version: %s, please upgrade olares-cli first!", target, cliVersion)
+		if !target.Equal(cliVersion) {
+			return fmt.Errorf("target version: %s is not the same with cli version: %s", target, cliVersion)
 		}
 	}
 
-	if base.GreaterThan(cliVersion) {
-		return fmt.Errorf("base version: %s, cli version: %s, please upgrade olares-cli first!", base, cliVersion)
+	currentVersionSpec, err := CurrentVersionSpec()
+	if err != nil {
+		return fmt.Errorf("failed to get current version's upgrade spec: %v", err)
+	}
+
+	satisfied, err := currentVersionSpec.MinimumUpgradableVersions.SatisfiedBy(base)
+	if err != nil {
+		return err
+	}
+
+	if !satisfied {
+		return fmt.Errorf("cannot upgrade to version '%s' from '%s': version constraints not satified: %v", target, base, currentVersionSpec.MinimumUpgradableVersions)
 	}
 
 	return nil
-}
-
-func GetUpgradePathFor(base *semver.Version, target *semver.Version) ([]*semver.Version, error) {
-	if err := check(base, target); err != nil {
-		return nil, err
-	}
-	var path []*semver.Version
-	var releaseLineUpgraders []breakingUpgrader
-	var versionFilter func(v *semver.Version) bool
-	line := getReleaseLineOfVersion(base)
-	if target == nil {
-		cliVersion, err := utils.ParseOlaresVersionString(version.VERSION)
-		if err != nil {
-			return path, fmt.Errorf("invalid olares-cli version :\"%s\"", version.VERSION)
-		}
-		if getReleaseLineOfVersion(cliVersion) == line && cliVersion.GreaterThan(base) {
-			target = cliVersion
-		}
-	}
-	switch line {
-	case mainLine:
-		releaseLineUpgraders = mainUpgraders
-		versionFilter = func(v *semver.Version) bool {
-			if !v.GreaterThan(base) {
-				return false
-			}
-			if target != nil && !v.LessThan(target) {
-				return false
-			}
-			return true
-		}
-	case dailyLine:
-		releaseLineUpgraders = dailyUpgraders
-		versionFilter = func(v *semver.Version) bool {
-			if !v.GreaterThan(base) {
-				return false
-			}
-			if target != nil && !v.LessThan(target) {
-				return false
-			}
-			return true
-		}
-	}
-
-	for _, u := range releaseLineUpgraders {
-		v := u.Version()
-		if versionFilter(v) {
-			path = append(path, v)
-		}
-	}
-
-	if target != nil {
-		path = append(path, target)
-	}
-
-	return path, nil
 }
 
 func getUpgraderByVersion(target *semver.Version) upgrader {
@@ -152,6 +133,102 @@ func getUpgraderByVersion(target *semver.Version) upgrader {
 		}
 	}
 	return upgraderBase{}
+}
+
+func parsePrereleaseVersion(prereleaseVersion string) (string, int, error) {
+	if !strings.Contains(prereleaseVersion, prereleaseSep) {
+		n, err := strconv.Atoi(prereleaseVersion)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid prereleaseVersion: %s", prereleaseVersion)
+		}
+		return releaseTypeDaily, n, nil
+	}
+	parts := strings.Split(prereleaseVersion, prereleaseSep)
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("invalid prereleaseVersion: %s", prereleaseVersion)
+	}
+	tStr, nStr := parts[0], parts[1]
+	if tStr != releaseTypeRC && tStr != releaseTypeBeta && tStr != releaseTypeAlpha {
+		return "", 0, fmt.Errorf("invalid prereleaseVersion: %s", prereleaseVersion)
+	}
+	n, err := strconv.Atoi(nStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid prereleaseVersion: %s", prereleaseVersion)
+	}
+	return tStr, n, nil
+}
+
+func formatPrereleaseVersion(releaseType string, releaseNum int) string {
+	if releaseType == releaseTypeDaily {
+		return strconv.Itoa(releaseNum)
+	}
+	return fmt.Sprintf("%s%s%s", releaseType, prereleaseSep, strconv.Itoa(releaseNum))
+}
+
+func CurrentVersionSpec() (spec *VersionSpec, err error) {
+	v, err := semver.NewVersion(version.VERSION)
+	if err != nil {
+		return nil, fmt.Errorf("current version '%s' is invalid: %v", version.VERSION, err)
+	}
+	spec = &VersionSpec{}
+	spec.Version, spec.Major, spec.Minor, spec.Patch = v.Original(), v.Major(), v.Minor(), v.Patch()
+	if v.Prerelease() != "" {
+		spec.PreRelease = true
+		spec.ReleaseType, spec.ReleaseNum, err = parsePrereleaseVersion(v.Prerelease())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		spec.ReleaseType = releaseTypeStable
+	}
+	u := getUpgraderByVersion(v)
+	spec.AddedBreakingChange = u.AddedBreakingChange()
+	if spec.ReleaseType == releaseTypeDaily {
+		lastBreakingVersion := getLastBreakingVersion(dailyUpgraders, v)
+		if lastBreakingVersion == nil {
+			lastBreakingVersion = minUpgradableDailyVersion
+		}
+		spec.MinimumUpgradableVersions = MinimumVersionConstraints{releaseTypeDaily: lastBreakingVersion}
+	} else {
+		lastBreakingVersion := getLastBreakingVersion(mainUpgraders, v)
+		if lastBreakingVersion == nil {
+			lastBreakingVersion = minUpgradableStableVersion
+		}
+		// all mainline release types support upgrade from stable release
+		spec.MinimumUpgradableVersions = MinimumVersionConstraints{
+			releaseTypeStable: semver.New(lastBreakingVersion.Major(), lastBreakingVersion.Minor(), lastBreakingVersion.Patch(), "", ""),
+		}
+		switch spec.ReleaseType {
+		// both stable and rc release types support upgrade from stable/rc release
+		case releaseTypeStable, releaseTypeRC:
+			spec.MinimumUpgradableVersions[releaseTypeRC] = semver.New(lastBreakingVersion.Major(), lastBreakingVersion.Minor(), lastBreakingVersion.Patch(), formatPrereleaseVersion(releaseTypeRC, 0), "")
+		case releaseTypeAlpha:
+			// alpha release type supports upgrade from the last alpha release
+			// if it exists
+			// and no breaking change is added to the current version
+			if !spec.AddedBreakingChange && spec.ReleaseNum > 0 {
+				spec.MinimumUpgradableVersions[releaseTypeAlpha] = semver.New(spec.Major, spec.Minor, spec.Patch, formatPrereleaseVersion(releaseTypeAlpha, spec.ReleaseNum-1), "")
+			}
+		}
+	}
+
+	return spec, nil
+}
+
+func getLastBreakingVersion(upgraders []breakingUpgrader, current *semver.Version) *semver.Version {
+	sort.Slice(upgraders, func(i, j int) bool {
+		return upgraders[i].Version().LessThan(upgraders[j].Version())
+	})
+	for i := len(upgraders) - 1; i >= 0; i-- {
+		if !upgraders[i].AddedBreakingChange() {
+			continue
+		}
+		if upgraders[i].Version().GreaterThanEqual(current) {
+			continue
+		}
+		return upgraders[i].Version()
+	}
+	return nil
 }
 
 func samePatchLevelVersion(a, b *semver.Version) bool {


### PR DESCRIPTION
* **Background**
Switch the current single-flow path-based upgrade mechanism, to a multi-dimension matrix-based one.
Two new subcommands of `upgrade` is added to the `olares-cli`:
`spec`: returns the upgrade spec of the current version, in JSON format, including its version numbers, release type(`stable`/`daily`/`rc`/`beta`/`alpha`), whether breaking change is introduced, and what versions are supported to upgrade to it, distinguished by different release types.
`viable`: whether a base-version can upgrade to the current version.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none