### PR TITLE
ci(files): upload files to cloud

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -136,6 +136,9 @@ spec:
           - --log-level
           - DEBUG
           - --no-check-certificate
+          - --s3-directory-markers
+          - --fs-cache-expire-duration
+          - "0"
           - --s3-list-version
           - "2"
           - --config
@@ -169,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.95
+          image: beclab/files-server:v0.2.97
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
1. The process for uploading files to the cloud has been modified: files will first pass through Olares, and then be synchronized to the cloud. 
2. Use rclone's internal function to create empty directories.



* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12.1

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/files/pull/68


* **Other information**:
