### PR TITLE
authelia: support default subdomains of system frontend

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.25
+        image: beclab/auth:0.2.26
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION

* **Background**
Support setting policies for default subdomains of system-frontend

* **Target Version for Merge**
v1.12.1

* **Related Issues**
vault server policy not working

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/34

* **Other information**:
