### PR TITLE
Fixed url for multinode in the docs.

### DIFF
--- a/docs/manual/best-practices/install-olares-multi-node.md
+++ b/docs/manual/best-practices/install-olares-multi-node.md
@@ -54,7 +54,7 @@ If you already have your own MinIO cluster or an S3 (or S3-compatible) bucket, y
 
 ## Step 2: Add a worker node to the cluster
 
-1. On the worker node, download `joincluster.sh` from https://joincluster.com.
+1. On the worker node, download `joincluster.sh` from https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh. You can use `curl -fsSL https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh -o joincluster.sh` to download from the cli if you have curl or ```wget https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh``` if you have wget. 
 2. Run the `joincluster.sh` script with the necessary environment variables. These variables tell the worker node how to connect to the master node. At a minimum, you must set the MASTER_HOST variable, which specifies the IP address of the master node:
    ```bash
    export MASTER_HOST=192.168.1.15


### PR DESCRIPTION
## Docs fixed
I have update the url in the docs for multi node olares from https://joincluster.com to the github raw url for the joincluster.sh file in the repo.