### PR TITLE
fix(cli): explicitly set locale in etcd backup service

### DIFF
--- a/cli/pkg/etcd/templates/backup_service.go
+++ b/cli/pkg/etcd/templates/backup_service.go
@@ -30,6 +30,7 @@ var (
 		dedent.Dedent(`[Unit]
 Description=Backup ETCD
 [Service]
+Environment=LANG=C
 Type=oneshot
 ExecStart={{ .ScriptPath }}
     `)))

--- a/cli/pkg/upgrade/1_12_1_20250826.go
+++ b/cli/pkg/upgrade/1_12_1_20250826.go
@@ -1,0 +1,43 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/apis/kubekey/v1alpha2"
+	"github.com/beclab/Olares/cli/pkg/core/action"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/core/util"
+	"github.com/beclab/Olares/cli/pkg/etcd/templates"
+	"github.com/beclab/Olares/cli/pkg/terminus"
+	"path/filepath"
+)
+
+type upgrader_1_12_1_20250826 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_1_20250826) Version() *semver.Version {
+	return semver.MustParse("1.12.1-20250826")
+}
+
+func (u upgrader_1_12_1_20250826) PrepareForUpgrade() []task.Interface {
+	preTasks := []task.Interface{
+		&task.LocalTask{
+			Name: "UpdateBackupETCDService",
+			Action: &action.Template{
+				Name:     "GenerateBackupETCDService",
+				Template: templates.BackupETCDService,
+				Dst:      filepath.Join("/etc/systemd/system/", templates.BackupETCDService.Name()),
+				Data: util.Data{
+					"ScriptPath": filepath.Join(v1alpha2.DefaultEtcdBackupScriptDir, templates.EtcdBackupScript.Name()),
+				},
+			},
+		},
+		&task.LocalTask{
+			Name: "ReloadBackupETCDService",
+			Action: &terminus.SystemctlCommand{
+				DaemonReloadPreExec: true,
+			},
+		},
+	}
+	return append(preTasks, u.upgraderBase.PrepareForUpgrade()...)
+}

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -64,6 +64,7 @@ var (
 		upgrader_1_12_0_20250702{},
 		upgrader_1_12_0_20250723{},
 		upgrader_1_12_0_20250730{},
+		upgrader_1_12_1_20250826{},
 	}
 	mainUpgraders = []breakingUpgrader{
 		upgrader_1_12_1{},


### PR DESCRIPTION
* **Background**
The script that `backup-etcd.service` executes clears history data by parsing the filenames using awk, but for different locales, the output of `ls -lt` is inconsistent, this can be avoided by explicitly setting the locale in the systemd service config.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none