### PR TITLE
fix(cli): return original error after prompt

### DIFF
--- a/cli/pkg/bootstrap/precheck/tasks.go
+++ b/cli/pkg/bootstrap/precheck/tasks.go
@@ -81,9 +81,9 @@ func (t *SystemSupportCheck) Check(runtime connector.Runtime) error {
 	}
 	// Interactive warning instead of outright failure
 	fmt.Printf("%v Use at your own risk, would you like to continue? (Y/N): ", err)
-	reader, err := utils.GetBufIOReaderOfTerminalInput()
-	if err != nil {
-		return fmt.Errorf("could not read terminal input: %v", err)
+	reader, rerr := utils.GetBufIOReaderOfTerminalInput()
+	if rerr != nil {
+		return fmt.Errorf("could not read terminal input: %v", rerr)
 	}
 	input, _ := reader.ReadString('\n')
 	input = strings.TrimSpace(input)


### PR DESCRIPTION
* **Background**
When doing prechecks, user is prompted to whether tolerate an unsupported OS and continue installation, the original precheck error should be returned rather than the prompt reader error.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none