### PR TITLE
systemserver: change user-backend service account namespace and privilege

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.45" }}
+{{ $backupVersion := "0.3.46" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -321,7 +321,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.17
+        image: beclab/bfl-ingress:v0.3.18
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.101
+          image: beclab/files-server:v0.2.102
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/permission.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/permission.yaml
@@ -2,7 +2,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: user-system-{{ .Values.bfl.username }}
   name: user-backend
 
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend:{{ .Values.bfl.username }}:user-backend:settings-provider-svc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.bfl.username }}:settings-provider-svc
+subjects:
+- kind: ServiceAccount
+  name: user-backend
+  namespace: user-system-{{ .Values.bfl.username }}


### PR DESCRIPTION
* **Background**
1. Change the namespace of the user-backend service account
2. Add privileges to user-backend service account

* **Target Version for Merge**
v1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
