### PR TITLE
authelia: expired token not deleted

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.26
+        image: beclab/auth:0.2.27
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Change the ttl token cache disable-touch-on-hit option from default false to true, let the token can be deleted when it expires

* **Target Version for Merge**
v1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/35

* **Other information**:
