### PR TITLE
fix(bfl): migrate from deprecated form3tech-oss/jwt-go to golang-jwt

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -266,7 +266,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.24
+        image: beclab/bfl:v0.4.26
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
As stated in https://github.com/beclab/bfl/security/dependabot/20, the current jwt library we depend on has a high-level vulnerability, and also this project has already been archived 3 years ago, this PR migrates the jwt dependency to the https://github.com/golang-jwt/jwt

* **Target Version for Merge**
1.12.1

* **Related Issues**
https://github.com/beclab/bfl/security/dependabot/20
https://github.com/beclab/bfl/security/dependabot/25

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/130
https://github.com/beclab/bfl/pull/131
https://github.com/beclab/bfl/pull/132

* **Other information**:
none