### PR TITLE
systemserver: create non-resource-url role privileges

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/monitoring-provider.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/monitoring-provider.yaml
@@ -20,7 +20,7 @@ metadata:
 rules:
 - nonResourceURLs: 
   - "/kapis/*"
-  - "/api/*"
+  - "/api*"
   - "/capi/*"
   - "/apis/apps/*"
   verbs: ["*"]

--- a/build/base-package/wizard/config/settings/templates/system-serviceaccount.yaml
+++ b/build/base-package/wizard/config/settings/templates/system-serviceaccount.yaml
@@ -105,6 +105,7 @@ rules:
   resources:
   - 'clusterroles'
   - 'clusterrolebindings'
+  - 'services'
   verbs:
   - create
   - delete
@@ -286,3 +287,12 @@ rules:
   - get
   - list
   - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nonresourceurl-admin
+rules:
+- nonResourceURLs: ["*"]
+  verbs: ["*"]

--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
@@ -10,6 +10,21 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: user-system-{{ .Values.bfl.username }}:bytetrade-sys-ops:nonresourceurl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nonresourceurl-admin
+subjects:
+- kind: ServiceAccount
+  name: bytetrade-sys-ops
+  namespace: user-system-{{ .Values.bfl.username }}
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: user-system-{{ .Values.bfl.username }}:bytetrade-sys-ops
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
* **Background**
1. Add the creating non-resource-url clusterrole privileges to system-server
2. Fix control-hub /apis routing bug

* **Target Version for Merge**
v1.12.1

* **Related Issues**
Cannot create non-resource-url clusterrole
Control-hub can not list the CRD resources in CRD page

* **PRs Involving Sub-Systems** 
none

* **Other information**:
