### PR TITLE
fix: files /api/resources empty response bug

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.103
+          image: beclab/files-server:v0.2.104
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
- Background
   POST/PATCH/DELETE /api/resources will 400 when response is empty. This PR fixed this bug.

- Target Version for Merge
   1.12.1

- Related Issues
   none

- PRs Involving Sub-Systems
   https://github.com/beclab/files/pull/84

- Other information:
   none