### PR TITLE
fix(bfl): add hs512 as a valid signing method

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -266,7 +266,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.26
+        image: beclab/bfl:v0.4.27
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
Currently only HS256 is considered a valid signing method when parsing JWT token in bfl, HS512 should also be added.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/133

* **Other information**:
none