### PR TITLE
chore(app-service/image-service): update outdated dependencies to latest

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.3.85
+        image: beclab/app-service:0.4.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -405,7 +405,7 @@ spec:
       hostNetwork: true
       containers:
         - name: image-service
-          image: beclab/image-service:0.3.78
+          image: beclab/image-service:0.4.0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
* **Background**
The current dependencies, mostly K8s-related ones, in app-service/image-service are outdated and can block other module's dependency on it, they're updated to the latest version, with some necessary code and API migrations.
The lldap-client is also updated, with an empty creator when creating lldap group in the background controller.

* **Target Version for Merge**
1.12.1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/302
https://github.com/beclab/app-service/pull/303

* **Other information**:
none