### PR TITLE
fix: files change some upload chunks req field from required to normal for compatible with LarePass

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.104
+          image: beclab/files-server:v0.2.105
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
- Background
   Some of upload chunks request fields are not transferred when uploading in LarePass, because they are added for web frontend use and none of backend's business. To be compatible for all scenes, this PR changed them from required to normal.

- Target Version for Merge
   1.12.1

- Related Issues
   none

- PRs Involving Sub-Systems
   https://github.com/beclab/files/pull/85

- Other information:
   none