### PR TITLE
feat(cli): create and set values of sharedlib path in MacOS

### DIFF
--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -57,10 +57,7 @@ func (t *InstallOsSystem) Execute(runtime connector.Runtime) error {
 		"fs_type":                              storage.GetRootFSType(),
 		common.HelmValuesKeyTerminusGlobalEnvs: common.TerminusGlobalEnvs,
 		common.HelmValuesKeyOlaresRootFSPath:   storage.OlaresRootDir,
-	}
-
-	if !runtime.GetSystemInfo().IsDarwin() {
-		vals["sharedlib"] = storage.OlaresSharedLibDir
+		"sharedlib":                            storage.OlaresSharedLibDir,
 	}
 
 	var platformPath = path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-platform")


### PR DESCRIPTION
* **Background**
Currently, the shared lib path of Olares is not created when installing on MacOS, and the `sharedlib` value is not set when creating system components. This PR add a task to create that directory in Minikube container and remove this special treatment of MacOS when creating system components.

* **Target Version for Merge**
1.12..1

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none