### PR TITLE
authelia: do not save anonymous session

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.27
+        image: beclab/auth:0.2.28
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Do not save an anonymous session to the cache.

* **Target Version for Merge**
v1.12.1

* **Related Issues**
Wrong to save an anonymous session in the cache when the backend api responds with an error 

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/36

* **Other information**:
