### PR TITLE
fix: disable suspend app feature when system high load

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -198,13 +198,13 @@ spec:
         - name: SHARED_LIB_PATH
           value: {{ .Values.sharedlib }}
         - name: CLUSTER_CPU_THRESHOLD
-          value: "90"
+          value: "0"
         - name: CLUSTER_MEMORY_THRESHOLD
-          value: "90"
+          value: "0"
         - name: USER_CPU_THRESHOLD
-          value: "90"
+          value: "0"
         - name: USER_MEMORY_THRESHOLD
-          value: "90"
+          value: "0"
         - name: NATS_HOST
           value: nats.os-platform
         - name: NATS_PORT


### PR DESCRIPTION
* **Background**
- third party app may be suspend due to system high load, that may cause some bad case.
* **Target Version for Merge**
1.12
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
