### PR TITLE
fix: files image and pdf preview, and /api/mount response for choosing path

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.112
+          image: beclab/files-server:v0.2.113
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.113
+          image: beclab/files-server:v0.2.114
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -172,7 +172,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.111
+          image: beclab/files-server:v0.2.112
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
- Background
   fix a bug of drive pdf preview leads to downloading
   fix svg preview
   fix /api/mount response without data field for choosing path
   add avif and heic support in sync

- Target Version for Merge
   1.12.1

- Related Issues
   none

- PRs Involving Sub-Systems
   https://github.com/beclab/files/pull/94
   https://github.com/beclab/files/pull/95
   https://github.com/beclab/files/pull/96
   https://github.com/beclab/files/pull/97
   https://github.com/beclab/files/pull/98

- Other information:
   none
