### PR TITLE
lldap: invalidate refresh token after reset password

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -201,7 +201,7 @@ spec:
             - name: NATS_SUBJECT_SYSTEM_GROUPS
               value: "os.groups"
 
-          image: beclab/lldap:0.0.12
+          image: beclab/lldap:0.0.13
           imagePullPolicy: IfNotPresent
           name: lldap
           ports:


### PR DESCRIPTION
* **Background**
- user can also refresh token after reset password, that's bad
* **Target Version for Merge**
1.12.1
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/lldap/pull/23

* **Other information**:
