### PR TITLE
fix(cli): distinguish exit code when checking status of terminated containers

### DIFF
--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -103,8 +103,11 @@ func (t *CheckKeyPodsRunning) Execute(runtime connector.Runtime) error {
 			return fmt.Errorf("pod %s/%s has not started all containers yet", pod.Namespace, pod.Name)
 		}
 		for _, cStatus := range pod.Status.ContainerStatuses {
-			if cStatus.State.Terminated != nil && cStatus.State.Terminated.ExitCode != 0 {
-				return fmt.Errorf("container %s in pod %s/%s is terminated", cStatus.Name, pod.Namespace, pod.Name)
+			if cStatus.State.Terminated != nil {
+				if cStatus.State.Terminated.ExitCode != 0 {
+					return fmt.Errorf("container %s in pod %s/%s is terminated", cStatus.Name, pod.Namespace, pod.Name)
+				}
+				continue
 			}
 			if cStatus.State.Running == nil {
 				return fmt.Errorf("container %s in pod %s/%s is not running", cStatus.Name, pod.Namespace, pod.Name)


### PR DESCRIPTION
* **Background**
The `CheckKeyPodsRunning` task is executed in the end of: ip-changing/installation/upgrade/start, to ensure key pods' successfully initiated and running, in the case of terminated containers, an exit code of 0 should be considered normal, instead of continuing checking the `Ready` status, as a terminated container always have a `Ready` status set to false.

* **Target Version for Merge**
v1.12.1 v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none