### PR TITLE
app-serivce: fix v2 uninstall all wait ns be deleted

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -178,7 +178,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.4
+        image: beclab/app-service:0.4.5
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
- v2 uninstall all does not wait ns to be deleted that's may cause second install failed 
- helm uninstall launcher to delete pv

* **Target Version for Merge**
v1.12.1
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/313
https://github.com/beclab/app-service/pull/312

* **Other information**:
