### PR TITLE
fix: market initialization skipped

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -88,6 +88,8 @@ metadata:
     applications.app.bytetrade.io/author: bytetrade.io
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: chartrepo
@@ -119,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.1.15
+        image: beclab/dynamic-chart-repository:v0.1.16
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81
@@ -166,6 +168,8 @@ spec:
             value: prod
           - name: IMAGE_ANALYZER_WORKERS
             value: '5'
+          - name: APP_VERSION
+            value: 0.2.0
         volumeMounts:
           - name: opt-data
             mountPath: /opt/app/data

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -62,6 +62,8 @@ metadata:
     applications.app.bytetrade.io/author: bytetrade.io
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: appstore
@@ -99,7 +101,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.4.30
+        image: beclab/market-backend:v0.4.31
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION

* **Background**
Due to rolling updates, the new version of the market accesses the old version of the chart repo after it is launched, resulting in the failure of the initialization task execution.

* **Target Version for Merge**
1.12.1

* **Related Issues**


* **PRs Involving Sub-Systems** 
https://github.com/beclab/market/commit/dd14913681c6d326b394192f0c736fe23d04cc46
https://github.com/beclab/dynamic-chart-repository/commit/df4885754be7b44fb0bc4a793968dafed7150140
