### PR TITLE
bfl: set auth upstream header to files proxy

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -321,7 +321,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.21
+        image: beclab/bfl-ingress:v0.3.22
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION
* **Background**
Get the header from the response of the auth request upstream, and add it to the files proxy to pass through the RBAC proxy.

* **Target Version for Merge**
v1.12.1 v1.12.2

* **Related Issues**
The playing video requests failed in Files

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/139

* **Other information**:
