### PR TITLE
feat: support installation on Ubuntu 25.04

### DIFF
--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -54,6 +54,7 @@ const (
 	Ubuntu20 UbuntuVersion = "20."
 	Ubuntu22 UbuntuVersion = "22."
 	Ubuntu24 UbuntuVersion = "24."
+	Ubuntu25 UbuntuVersion = "25."
 
 	Debian9  DebianVersion = "9"
 	Debian10 DebianVersion = "10"
@@ -134,7 +135,7 @@ func (s *SystemInfo) IsSupport() error {
 	//}
 
 	if s.IsUbuntu() {
-		if !s.IsUbuntuVersionEqual(Ubuntu22) && !s.IsUbuntuVersionEqual(Ubuntu24) {
+		if !s.IsUbuntuVersionEqual(Ubuntu22) && !s.IsUbuntuVersionEqual(Ubuntu24) && !s.IsUbuntuVersionEqual(Ubuntu25) {
 			return fmt.Errorf("unsupported ubuntu os version '%s'", s.GetOsVersion())
 		}
 	}


### PR DESCRIPTION
* **Background**
Support installing Olares on Ubuntu 25.04
The deprecated [apt-key(8)](https://manpages.debian.org/testing/apt/apt-key.8.en.html) utility has been removed in Ubuntu 25.04 and the import of libnvidia-container's gpgkey is changed to the new method and path as suggested in [Installing the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none