### PR TITLE
feat(gpu): support many to many GPU bindings based on App policy

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.5.11"
+version: "v2.6.0"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.5.11
+      name: beclab/hami:v2.6.0
     - 
       name: beclab/hami-webui-fe-oss:v1.0.7
     - 


### PR DESCRIPTION
* **Background**
Currently, the binding relations between GPU(s) and App(s) are strictly on a one-to-one basis, with the `/gpus/:id/assign` API clearing out any existing bindings for the same App upon GPU assignment requests. Also, the replicas of an GPU-consuming App should always be 1.
This is now changed to a many-to-many relationship, and allowing an GPU-consuming app to have multiple replicas, each sharing a distinct GPU, or one replica to consume multiple GPUs, by specifying the gpu-consumption policy label `"hami.io/app-gpu-consume"` on the workload template.
A new API `/gpus/:id/unassign` is added to unassign a GPU from an App, as they cannot be cleared in the old implementation.
The old API `/gpus/:id/assign` now has a new restriction that prevents an App with existing GPU bindings to be assigned a new GPU from another node.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/b918e824dc3167616b98e0d7cd96018f90eb1d1e

* **Other information**:
none