### PR TITLE
image-serivce: fix avoid panic with invalid image ref

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -178,7 +178,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.6
+        image: beclab/app-service:0.4.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -416,7 +416,7 @@ spec:
       hostNetwork: true
       containers:
         - name: image-service
-          image: beclab/image-service:0.4.0
+          image: beclab/image-service:0.4.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
* **Background**
image was panic with invalid image ref
* **Target Version for Merge**
1.12.2
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/314

* **Other information**:
