### PR TITLE
feat(app-service): support declaration of GPU consume policy in app manifest

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.11
+        image: beclab/app-service:0.4.12
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.0"
+version: "v2.6.1"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.0
+      name: beclab/hami:v2.6.1
     - 
       name: beclab/hami-webui-fe-oss:v1.0.7
     - 


### PR DESCRIPTION
* **Background**
A new field `podGpuConsumePolicy` is added into application's OlaresManifest.yaml, and if declared, the corresponding label gpu.bytetrade.io/app-pod-consume-policy will be injected to the app pod's labels, enabling a single pod of the app to consume all GPUs bound to it, or multiple replicas of the app to each consume a seperate bound GPU.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/320

* **Other information**:
none