### PR TITLE
fix(cli): add retry with delay before applying CR of new kind

### DIFF
--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -435,6 +435,8 @@ func (m *InstallOsSystemModule) Init() {
 	applySystemEnv := &task.LocalTask{
 		Name:   "ApplySystemEnv",
 		Action: new(ApplySystemEnv),
+		Retry:  5,
+		Delay:  15 * time.Second,
 	}
 
 	createUserEnvConfigMap := &task.LocalTask{

--- a/daemon/pkg/commands/upgrade/check.go
+++ b/daemon/pkg/commands/upgrade/check.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	"github.com/beclab/Olares/daemon/pkg/containerd"
 	"github.com/dustin/go-humanize"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/utils/strings/slices"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
@@ -152,7 +153,7 @@ func (i *preCheck) Execute(ctx context.Context, p any) (res any, err error) {
 
 		podStatus := utils.GetPodStatus(&pod)
 
-		if podStatus != "Running" && podStatus != "Completed" {
+		if podStatus != "Running" && podStatus != "Completed" && podStatus != "Succeeded" {
 			klog.Errorf("Pod %s/%s is not healthy: %s", pod.Namespace, pod.Name, podStatus)
 			return nil, fmt.Errorf("pod %s/%s is not healthy: %s", pod.Namespace, pod.Name, podStatus)
 		}


### PR DESCRIPTION
* **Background**
Olares is shipped with dozens of CRDs, and they are applied to the kube-apiserver in a batch request, along with other components. Although the request may succeed immediately, but the actual registration and serving of the new CRD kinds is asynchronous from the API handler, typically this only takes a short period of time, less than a second, but when programmatically applying CRs right after applying CRDs, combined with a relatively slow machine, a race condition can occur and cause the CRs to be rejected by the kube-apiserver.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none