### PR TITLE
authelia: mark request from cluster pods as internal

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -429,7 +429,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.33
+        image: beclab/auth:0.2.34
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
If the entrance policy is set to internal, the requests from the cluster pods should get the bypass policy as an internal requests

* **Target Version for Merge**
v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/42

* **Other information**:
