### PR TITLE
cli: change did-gate-url to a variable

### DIFF
--- a/cli/pkg/web5/jws/checkjws.go
+++ b/cli/pkg/web5/jws/checkjws.go
@@ -17,7 +17,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-const (
+var (
 	DIDGateURL     = "https://did-gate-v3.bttcdn.com/1.0/name/"
 	DIDGateTimeout = 10 * time.Second
 )


### PR DESCRIPTION
* **Background**
Change the did-gate-url from a constant to a variable, so it can be reset by the environment

* **Target Version for Merge**
v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none


* **Other information**:
