### PR TITLE
olares: change kube-rbac-proxy image repo

### DIFF
--- a/cli/pkg/kubesphere/plugins/files/build/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8081/
-        image: bitnami/kube-rbac-proxy:0.19.0
+        image: beclab/kube-rbac-proxy:0.19.0
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy-main
         ports:
@@ -86,7 +86,7 @@ spec:
         - --secure-listen-address=:9443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8082/
-        image: bitnami/kube-rbac-proxy:0.19.0
+        image: beclab/kube-rbac-proxy:0.19.0
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy-self
         ports:

--- a/cli/pkg/kubesphere/plugins/files/build/prometheus/node-exporter/node-exporter-daemonset.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/prometheus/node-exporter/node-exporter-daemonset.yaml
@@ -75,7 +75,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: bitnami/kube-rbac-proxy:0.19.0
+        image: beclab/kube-rbac-proxy:0.19.0
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/cli/pkg/kubesphere/plugins/files/build/prometheus/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/prometheus/prometheus-operator/prometheus-operator-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8080/
-        image: bitnami/kube-rbac-proxy:0.19.0
+        image: beclab/kube-rbac-proxy:0.19.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/infrastructure/kubernetes/.olares/Olares.yaml
+++ b/infrastructure/kubernetes/.olares/Olares.yaml
@@ -25,7 +25,7 @@ output:
     - 
       name: alpine:3.14
     -
-      name: bitnami/kube-rbac-proxy:0.19.0
+      name: beclab/kube-rbac-proxy:0.19.0
     - 
       name: registry.k8s.io/kube-apiserver:v1.33.3
     - 


### PR DESCRIPTION
* **Background**
Change kube-rbac-proxy image repo to beclab

* **Target Version for Merge**
v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
