### PR TITLE
refactor(cli): move upgrader registration of different versions to seperate files

### DIFF
--- a/cli/pkg/upgrade/1_12_0_20250702.go
+++ b/cli/pkg/upgrade/1_12_0_20250702.go
@@ -2,13 +2,14 @@ package upgrade
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/task"
-	"os"
-	"strings"
 )
 
 type upgrader_1_12_0_20250702 struct {
@@ -91,4 +92,8 @@ func (u *updateSysctlReservedPorts) Execute(runtime connector.Runtime) error {
 	}
 
 	return nil
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_0_20250702{})
 }

--- a/cli/pkg/upgrade/1_12_0_20250723.go
+++ b/cli/pkg/upgrade/1_12_0_20250723.go
@@ -18,3 +18,7 @@ func (u upgrader_1_12_0_20250723) PrepareForUpgrade() []task.Interface {
 	preTasks = append(preTasks, upgradeContainerd()...)
 	return append(preTasks, u.upgraderBase.PrepareForUpgrade()...)
 }
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_0_20250723{})
+}

--- a/cli/pkg/upgrade/1_12_0_20250730.go
+++ b/cli/pkg/upgrade/1_12_0_20250730.go
@@ -2,6 +2,10 @@ package upgrade
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/bootstrap/precheck"
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -13,9 +17,6 @@ import (
 	"github.com/beclab/Olares/cli/pkg/manifest"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 	"github.com/pkg/errors"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type upgrader_1_12_0_20250730 struct {
@@ -109,4 +110,8 @@ func (u *injectK3sCertExpireTime) Execute(runtime connector.Runtime) error {
 	newContent := string(content) + fmt.Sprintf("\n%s=36500\n", expireTimeEnv)
 	err = os.WriteFile(envFile, []byte(newContent), 0644)
 	return err
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_0_20250730{})
 }

--- a/cli/pkg/upgrade/1_12_1.go
+++ b/cli/pkg/upgrade/1_12_1.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
@@ -61,4 +62,8 @@ func (c *removeLegacySystemFrontendManifest) Execute(runtime connector.Runtime) 
 	}
 
 	return nil
+}
+
+func init() {
+	registerMainUpgrader(upgrader_1_12_1{})
 }

--- a/cli/pkg/upgrade/1_12_1_20250826.go
+++ b/cli/pkg/upgrade/1_12_1_20250826.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"path/filepath"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/apis/kubekey/v1alpha2"
 	"github.com/beclab/Olares/cli/pkg/core/action"
@@ -8,7 +10,6 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/util"
 	"github.com/beclab/Olares/cli/pkg/etcd/templates"
 	"github.com/beclab/Olares/cli/pkg/terminus"
-	"path/filepath"
 )
 
 type upgrader_1_12_1_20250826 struct {
@@ -44,4 +45,8 @@ func (u upgrader_1_12_1_20250826) preToPrepareForUpgrade() []task.Interface {
 func (u upgrader_1_12_1_20250826) PrepareForUpgrade() []task.Interface {
 	preTasks := u.preToPrepareForUpgrade()
 	return append(preTasks, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_1_20250826{})
 }

--- a/cli/pkg/upgrade/1_12_2_20250929.go
+++ b/cli/pkg/upgrade/1_12_2_20250929.go
@@ -96,3 +96,7 @@ func (c *takeOverKbCRDByHelm) Execute(runtime connector.Runtime) error {
 
 	return nil
 }
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_2_20250929{})
+}

--- a/cli/pkg/upgrade/version.go
+++ b/cli/pkg/upgrade/version.go
@@ -2,12 +2,13 @@ package upgrade
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"github.com/beclab/Olares/cli/pkg/utils"
-	"github.com/beclab/Olares/cli/version"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	"github.com/beclab/Olares/cli/version"
 )
 
 type VersionSpec struct {
@@ -60,16 +61,8 @@ var (
 	releaseTypeAlpha  = "alpha"
 	prereleaseSep     = "."
 
-	dailyUpgraders = []breakingUpgrader{
-		upgrader_1_12_0_20250702{},
-		upgrader_1_12_0_20250723{},
-		upgrader_1_12_0_20250730{},
-		upgrader_1_12_1_20250826{},
-		upgrader_1_12_2_20250929{},
-	}
-	mainUpgraders = []breakingUpgrader{
-		upgrader_1_12_1{},
-	}
+	dailyUpgraders []breakingUpgrader
+	mainUpgraders  []breakingUpgrader
 )
 
 func getReleaseLineOfVersion(v *semver.Version) releaseLine {
@@ -243,4 +236,18 @@ func sameMinorLevelVersion(a, b *semver.Version) bool {
 
 func sameMajorLevelVersion(a, b *semver.Version) bool {
 	return a.Major() == b.Major()
+}
+
+func registerDailyUpgrader(upgrader breakingUpgrader) {
+	dailyUpgraders = append(dailyUpgraders, upgrader)
+	sort.Slice(dailyUpgraders, func(i, j int) bool {
+		return dailyUpgraders[i].Version().LessThan(dailyUpgraders[j].Version())
+	})
+}
+
+func registerMainUpgrader(upgrader breakingUpgrader) {
+	mainUpgraders = append(mainUpgraders, upgrader)
+	sort.Slice(mainUpgraders, func(i, j int) bool {
+		return mainUpgraders[i].Version().LessThan(mainUpgraders[j].Version())
+	})
 }


### PR DESCRIPTION
* **Background**
The current registration method of upgraders is based on a simple array assignment in a single central file, with the order managed by developer, and makes commit conflicts more likely. We move the registration to each upgrader file individually, and sort them programmatically.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none