### PR TITLE
fix(daemon): log warnings upon system error in upgrade precheck

### DIFF
--- a/daemon/pkg/commands/upgrade/check.go
+++ b/daemon/pkg/commands/upgrade/check.go
@@ -154,13 +154,13 @@ func (i *preCheck) Execute(ctx context.Context, p any) (res any, err error) {
 		podStatus := utils.GetPodStatus(&pod)
 
 		if podStatus != "Running" && podStatus != "Completed" && podStatus != "Succeeded" {
-			klog.Errorf("Pod %s/%s is not healthy: %s", pod.Namespace, pod.Name, podStatus)
-			return nil, fmt.Errorf("pod %s/%s is not healthy: %s", pod.Namespace, pod.Name, podStatus)
+			klog.Warningf("Pod %s/%s is not healthy before upgrade: %s", pod.Namespace, pod.Name, podStatus)
+			continue
 		}
 
 		if !utils.IsPodReady(&pod) && pod.Status.Phase == corev1.PodRunning {
-			klog.Warningf("Pod %s/%s is running but not ready", pod.Namespace, pod.Name)
-			return nil, fmt.Errorf("pod %s/%s is running but not ready", pod.Namespace, pod.Name)
+			klog.Warningf("Pod %s/%s is running but not ready before upgrade", pod.Namespace, pod.Name)
+			continue
 		}
 	}
 


### PR DESCRIPTION
* **Background**
Currently, if any system workloads is not running normally, the precheck blocks the upgrade to start, to avoid a chaos status, however, some components themselves may need to be upgraded to recover to a normal state, this behaviour is now changed to log warnings instead of directly error out.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none