### PR TITLE
refactor(app-service): watch sysenvs as svc addrs; migrate sysenv based on sys domain

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,15 +170,11 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.17
+        image: beclab/app-service:0.4.18
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: KS_APISERVER_SERVICE_HOST
           value: 'ks-apiserver.kubesphere-system'
         - name: KS_APISERVER_SERVICE_PORT


### PR DESCRIPTION
* **Background**
Get rid of the old way of statically injected envs in helm rendered manifest, watch for SystemEnvs and update configs in real-time.
Migrate old injected envs from legacy versions to new configs
Migrate new SystemEnvs containing service URLs to appropriate mirrors based on system domain

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/331
https://github.com/beclab/app-service/pull/332


* **Other information**:
none