### PR TITLE
refactor(nodeinit): watch systemenvs as service addresses

### DIFF
--- a/framework/osnode-init/.olares/config/cluster/deploy/nodeinit_daemonset.yaml
+++ b/framework/osnode-init/.olares/config/cluster/deploy/nodeinit_daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: daemon
-        image: beclab/osnode-init:v0.0.10
+        image: beclab/osnode-init:v0.0.11
         imagePullPolicy: IfNotPresent
         args:
         - --metrics-bind-address
@@ -31,10 +31,6 @@ spec:
         - --health-probe-bind-address
         - :18881
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: NODE_IP
           valueFrom:
             fieldRef:


### PR DESCRIPTION
* **Background**
Get rid of the old way of statically injected envs in helm rendered manifest, watch for SystemEnvs and update configs in real-time.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/osnode-init/pull/5

* **Other information**:
none