### PR TITLE
feat(gpu): export and serve GPU power limit metrics

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/metrics-configmap.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/metrics-configmap.yaml
@@ -28,8 +28,9 @@ data:
       DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
       
       # Power
-      DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
-      DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+      DCGM_FI_DEV_POWER_USAGE,               gauge,   Power draw (in W).
+      DCGM_FI_DEV_ENFORCED_POWER_LIMIT,      gauge,   Power enforced limit (in W).
+      DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION,  counter, Total energy consumption since boot (in mJ).
       
       # PCIE
       # DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -290,7 +290,8 @@ dcgmExporter:
   podLabels: {}
 
   # Annotations to be added to dcgm-exporter pods
-  podAnnotations: {}
+  podAnnotations:
+    gpu.bytetrade.io/restart-for-metric: "DCGM_FI_DEV_ENFORCED_POWER_LIMIT"
     # Using this annotation which is required for prometheus scraping
     # prometheus.io/scrape: "true"
   # prometheus.io/port: "9400"
@@ -432,11 +433,11 @@ webui:
       repository: beclab/hami-webui-fe-oss
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: "v1.0.7"
+      tag: "v1.0.8"
     backend:
       repository: beclab/hami-webui-be-oss
       pullPolicy: IfNotPresent
-      tag: "v1.0.7"
+      tag: "v1.0.8"
 
   imagePullSecrets: []
   nameOverride: "webui"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -5,9 +5,9 @@ output:
     - 
       name: beclab/hami:v2.6.1
     - 
-      name: beclab/hami-webui-fe-oss:v1.0.7
+      name: beclab/hami-webui-fe-oss:v1.0.8
     - 
-      name: beclab/hami-webui-be-oss:v1.0.7
+      name: beclab/hami-webui-be-oss:v1.0.8
     - 
       name: beclab/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04
       


### PR DESCRIPTION
* **Background**
Configure DCGM to export the metric [DCGM_FI_DEV_ENFORCED_POWER_LIMIT](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_DEV_ENFORCED_POWER_LIMIT).
Export the power limit metrics gathered from DCGM in HAMI-webUI, and serve it as `powerLimit` in the GPUs API.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi-WebUI/pull/1

* **Other information**:
none