### PR TITLE
feat(app-service): also sync type from referred envs

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.20
+        image: beclab/app-service:0.4.21
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
Currently, AppEnvs that references User/System Envs only get the effetive values synced, however, the referenced upper-level Envs' type is also useful for frontend display, thus helpful to be also synced

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/338

* **Other information**:
none