### PR TITLE
system-server: fix websocket rbac proxy tls bug

### DIFF
--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
@@ -82,7 +82,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: system-server
-        image: beclab/system-server:0.1.30
+        image: beclab/system-server:0.1.31
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80


### PR DESCRIPTION
* **Background**
When adding TLSClientConfig to RBAC proxy transport configuration, the websocket RBAC proxy will connect with TLS by default. So we need to set two different transport configurations for HTTP proxy and WebSocket proxy.

* **Target Version for Merge**
v1.12.2

* **Related Issues**
RBAC proxy for WebSocket not working

* **PRs Involving Sub-Systems** 
https://github.com/beclab/system-server/pull/15

* **Other information**:
