### PR TITLE
cli: refactor error handling for jws cache directory checks

### DIFF
--- a/cli/pkg/web5/jws/checkjws.go
+++ b/cli/pkg/web5/jws/checkjws.go
@@ -44,7 +44,7 @@ func init() {
 		}
 	}
 
-	if !info.IsDir() {
+	if info == nil || !info.IsDir() {
 		err = os.RemoveAll(DIDCachePath)
 		if err != nil {
 			panic(fmt.Sprintf("failed to remove file: %v", err))


### PR DESCRIPTION
* **Background**
Refactor error handling for JWS cache directory checks

* **Target Version for Merge**
v1.12.2

* **Related Issues**
Olaresd panics when jws cache directory does not exist

* **PRs Involving Sub-Systems** 
none

* **Other information**:
