### PR TITLE
gpu(optimize): lower metrics collect interval to reduce lag

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -330,7 +330,7 @@ dcgmExporter:
   serviceMonitor:
     apiVersion: "monitoring.coreos.com/v1"
     enabled: true
-    interval: 15s
+    interval: 3s
     honorLabels: false
     additionalLabels: {}
     # monitoring: prometheus
@@ -522,7 +522,7 @@ webui:
 
   serviceMonitor:
     enabled: true
-    interval: 15s
+    interval: 3s
     honorLabels: false
     additionalLabels:
       jobRelease: hami-webui-prometheus
@@ -530,7 +530,7 @@ webui:
 
   hamiServiceMonitor:
     enabled: true
-    interval: 15s
+    interval: 3s
     honorLabels: false
     additionalLabels:
       jobRelease: hami-webui-prometheus


### PR DESCRIPTION
* **Background**
The GPU monitoring metrics are queried from Prometheus, which periodically scrapes DCGM & HAMi-webUI. The current intervals are 15s, resulting in a latency for dashboard display, they're reset to 3s to enable a more real-time data.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none