### PR TITLE
fix(manifest): change user env smtp server's type to domain

### DIFF
--- a/build/user-env.yaml
+++ b/build/user-env.yaml
@@ -13,7 +13,7 @@ userEnvs:
     type: bool
     editable: true
   - envName: OLARES_USER_SMTP_SERVER
-    type: url
+    type: domain
     editable: true
   - envName: OLARES_USER_SMTP_PORT
     type: number


### PR DESCRIPTION
* **Background**
the env `SMTP_SERVER` typically does not need a URL scheme prefix

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none