### PR TITLE
chore: get rid of legacy env injection for tailscale

### DIFF
--- a/build/system-env.yaml
+++ b/build/system-env.yaml
@@ -35,9 +35,3 @@ systemEnvs:
   - envName: OLARES_SYSTEM_CUDA_VERSION
     editable: false
     required: false
-  # the legacy COREDNS_SVC
-  - envName: OLARES_SYSTEM_CLUSTER_DNS_SERVICE
-    default: "10.233.0.3"
-    editable: false
-    type: ip
-    required: true

--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -328,17 +328,14 @@ var TerminusGlobalEnvs = map[string]interface{}{
 	"FRP_LIST_URL":               "https://terminus-frp.snowinning.com",
 	"TAILSCALE_CONTROLPLANE_URL": "https://controlplane.snowinning.com",
 	"OLARES_ROOT_DIR":            "/olares",
-	// the default value used by kubeadm
-	"COREDNS_SVC":        "10.96.0.10",
-	ENV_DOWNLOAD_CDN_URL: cc.DownloadUrl,
-	ENV_MARKET_PROVIDER:  "https://appstore-server-prod.bttcdn.com",
+	ENV_DOWNLOAD_CDN_URL:         cc.DownloadUrl,
+	ENV_MARKET_PROVIDER:          "https://appstore-server-prod.bttcdn.com",
 }
 
 // LegacyToNewSystemEnv maps legacy env keys to new SystemEnv EnvName
 var LegacyToNewSystemEnv = map[string]string{
 	"DOWNLOAD_CDN_URL": "OLARES_SYSTEM_CDN_SERVICE",
 	"OLARES_ROOT_DIR":  "OLARES_SYSTEM_ROOT_PATH",
-	"COREDNS_SVC":      "OLARES_SYSTEM_CLUSTER_DNS_SERVICE",
 	"CUDA_VERSION":     "OLARES_SYSTEM_CUDA_VERSION",
 	"OLARES_FS_TYPE":   "OLARES_SYSTEM_ROOTFS_TYPE",
 }

--- a/cli/pkg/plugins/dns/module.go
+++ b/cli/pkg/plugins/dns/module.go
@@ -43,9 +43,6 @@ type ClusterDNSModule struct {
 func (c *ClusterDNSModule) Init() {
 	c.Name = "ClusterDNSModule"
 
-	// inject coredns svc ip to the global envs before other relative components are created
-	common.SetTerminusGlobalEnv("COREDNS_SVC", c.KubeConf.Cluster.CorednsClusterIP(), true)
-
 	generateCoreDNDService := &task.RemoteTask{
 		Name:  "GenerateCoreDNSService",
 		Hosts: c.Runtime.GetHostsByRole(common.Master),

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.23
+        image: beclab/app-service:0.4.24
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -14,6 +14,12 @@
 {{ $role = (index $user "metadata" "annotations" "bytetrade.io/owner-role") }}
 {{- end -}}
 
+{{- $corednsIP := "10.233.0.3" -}}
+{{ $corednsService := (lookup "v1" "Service" "kube-system" "coredns") }}
+{{- if $corednsService -}}
+{{ $corednsIP = (index $corednsService "spec" "clusterIP") }}
+{{- end -}}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -127,10 +133,8 @@ spec:
         securityContext:
           privileged: true
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
+        - name: COREDNS_SVC
+          value: {{ $corednsIP }}
         - name: NAMESPACE
           value: bfl.user-space-{{ .Values.bfl.username }}
         - name: PG_HOST
@@ -175,11 +179,6 @@ spec:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
-        env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-        {{- end }}
         command:
         - headscale
         - serve
@@ -291,10 +290,8 @@ spec:
         - name: tailscale-data
           mountPath: /var/lib/tailscale
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
+        - name: COREDNS_SVC
+          value: {{ $corednsIP }}
         - name: TS_DISABLE_TAILDROP
           value: "true"
         - name: NODE_IP


### PR DESCRIPTION
* **Background**
Clean up the explicit legacy env injection logic for tailscale in app-service, the SystemEnv for that is no longer needed and removed as well, it shouldn't have existed in the first place since there is already a single source of truth from the `coredns` Service and can be easily looked-up and injected during helm chart rendering.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/340

* **Other information**:
none