### PR TITLE
chore(manifests): clean up legacy env rendering in all files

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -429,10 +429,6 @@ spec:
           ports:
             - containerPort: 3000
           env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-            - name: {{ $key }}
-              value: {{ $val | quote }}
-        {{- end }}
             - name: DEV_MODE
               value: ''
             - name: MY_NAME

--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -91,10 +91,6 @@ spec:
             cpu: 500m
             memory: 512Mi
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: TERMINUS_IS_CLOUD_VERSION
           value: {{ default "false" .Values.backup.is_cloud_version | quote }}
         - name: ENABLE_MIDDLEWARE_BACKUP
@@ -144,10 +140,6 @@ spec:
             cpu: 2
             memory: 1500Mi
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: NATS_HOST
           value: nats.os-platform
         - name: NATS_PORT

--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -126,10 +126,6 @@ spec:
         ports:
           - containerPort: 81
         env:
-          {{- range $key, $val := .Values.terminusGlobalEnvs }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-          {{- end }}                               
           - name: APP_SERVICE_SERVICE_HOST                                         
             value: app-service
           - name: APP_SERVICE_SERVICE_PORT                                         

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -106,10 +106,6 @@ spec:
         ports:
           - containerPort: 81
         env:
-          {{- range $key, $val := .Values.terminusGlobalEnvs }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-          {{- end }}
           - name: APP_SOTRE_SERVICE_SERVICE_PORT                                   
             value: "443"                                                           
           - name: APP_SERVICE_SERVICE_HOST                                         

--- a/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
+++ b/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
@@ -106,10 +106,6 @@ spec:
         ports:
         - containerPort: 3000
         env:
-        {{- range $key, $val := .Values.terminusGlobalEnvs }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: AUTH_URL
           value: http://authelia-backend:9091
         - name: PL_DATA_BACKEND


### PR DESCRIPTION
* **Background**
Now that all relevant components have migrated from relying on statically injected legacy envs, the manifests can be cleaned up.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none