### PR TITLE
fix(app-service): retain legacy env rendering for migration

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -175,6 +175,10 @@ spec:
         securityContext:
           runAsUser: 0
         env:
+        {{- range $key, $val := .Values.terminusGlobalEnvs }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end }}
         - name: KS_APISERVER_SERVICE_HOST
           value: 'ks-apiserver.kubesphere-system'
         - name: KS_APISERVER_SERVICE_PORT


### PR DESCRIPTION
* **Background**
Although the legacy envs have been removed, for users upgrading from a previous version, some statically injected values during installation are needed for migrating to corresponding SystemEnvs, removing the rendering part in the chart results them to be lost, and should be retained. This only applies to app-service.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none