### PR TITLE
tapr: fix minio policy was override when set multi bucket

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.19
+        image: beclab/middleware-operator:0.2.20
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
* **Background**
minio policy was override when set multi bucket
* **Target Version for Merge**
1.12.2
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/79
https://github.com/beclab/tapr/pull/78

* **Other information**:
