### PR TITLE
feat: update L4 proxy image version to v0.3.6 in deployment configurations

### DIFF
--- a/cli/pkg/upgrade/1_12_2_20251020.go
+++ b/cli/pkg/upgrade/1_12_2_20251020.go
@@ -153,7 +153,7 @@ type upgradeL4 struct {
 
 func (u *upgradeL4) Execute(runtime connector.Runtime) error {
 	if _, err := runtime.GetRunner().SudoCmd(
-		"/usr/local/bin/kubectl set image deployment/l4-bfl-proxy proxy=beclab/l4-bfl-proxy:v0.3.5 -n os-network", false, true); err != nil {
+		"/usr/local/bin/kubectl set image deployment/l4-bfl-proxy proxy=beclab/l4-bfl-proxy:v0.3.6 -n os-network", false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "failed to upgrade L4 network proxy")
 	}
 

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -304,7 +304,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.5
+          value: v0.3.6
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.4
+      name: beclab/l4-bfl-proxy:v0.3.6
 # must have blank new line            


### PR DESCRIPTION
* **Background**
Change the L4 proxy default listening port from 80 to 10080 on the first startup

* **Target Version for Merge**
v1.12.2

* **Related Issues**
L4 proxy cannot starup

* **PRs Involving Sub-Systems** 
https://github.com/beclab/l4-bfl-proxy/commit/3ef0f0d24c90a570037d931a211b7e8a658adc9e

* **Other information**:
