### PR TITLE
daemon: run proxy server in a goroutine

### DIFF
--- a/daemon/internel/intranet/proxy.go
+++ b/daemon/internel/intranet/proxy.go
@@ -52,7 +52,14 @@ func (p *proxyServer) Start() error {
 	)
 	p.proxy.Use(middleware.ProxyWithConfig(config))
 
-	return p.proxy.Start(":80")
+	go func(){
+		err := p.proxy.Start(":80")
+		if err != nil {
+			klog.Error(err)
+		}
+	}()
+
+	return nil
 }
 
 func (p *proxyServer) Close() error {


### PR DESCRIPTION
* **Background**
Start the proxy server in a goroutine to avoid blocking.


* **Target Version for Merge**
v1.12.2

* **Related Issues**
Olaresd watchers are blocked

* **PRs Involving Sub-Systems** 
none

* **Other information**:
