### PR TITLE
fix(cli): install a stable version of nvidia container tool

### DIFF
--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -234,7 +234,7 @@ type InstallNvidiaContainerToolkit struct {
 
 func (t *InstallNvidiaContainerToolkit) Execute(runtime connector.Runtime) error {
 	logger.Debugf("install nvidia-container-toolkit")
-	if _, err := runtime.GetRunner().SudoCmd("apt-get update && sudo apt-get install -y nvidia-container-toolkit jq", false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("apt-get update && sudo apt-get install -y nvidia-container-toolkit=1.17.9-1 nvidia-container-toolkit-base=1.17.9-1 jq", false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to apt-get install nvidia-container-toolkit")
 	}
 	return nil


### PR DESCRIPTION
* **Background**
Starting in `1.18.0`, the `nvidia-container-toolkit` refactors some of the config modification patterns, and some of them are incompatible with Olares, we install a stable `1.17.9` version by explicitly specifying it during installation.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none