### PR TITLE
feat(app-service): auto-suspend app upon evicted or long-pending pod

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.25
+        image: beclab/app-service:0.4.26
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
For any app, if its pod gets evicted or is unschedulable and stucks in pending, it's automatically suspended if the operation is eligible.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/344

* **Other information**:
none