### PR TITLE
fix(image-service): watch whole config dir to tolerate file removal

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -393,7 +393,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
         - name: image-service
-          image: beclab/image-service:0.4.7
+          image: beclab/image-service:0.4.29
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -409,12 +409,12 @@ spec:
             - mountPath: /var/run/containerd
               mountPropagation: Bidirectional
               name: containerd-socket
-            - mountPath: /etc/containerd/config.toml
-              name: configtoml
+            - mountPath: /etc/containerd
+              name: containerd-config
       volumes:
-        - name: configtoml
+        - name: containerd-config
           hostPath:
-            path: /etc/containerd/config.toml
+            path: /etc/containerd
         - name: containerd-socket
           hostPath:
             path: /var/run/containerd


### PR DESCRIPTION
* **Background**
Currently, the watcher for Containerd config file change is designed to exit upon the file's removal, as Olares never deletes the file, and once deleted, the fsnotify will lose the watch handle. This is now changed to watch the whole config directory and continue to watch for new file's creation even when it's deleted, in case the user pass around Olares and recreate the config file.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/345

* **Other information**:
none