### PR TITLE
fix: chartrepo support oci type in image manifest

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.2.3
+        image: beclab/dynamic-chart-repository:v0.2.4
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION

* **Background**
When processing images in the chart package, the oci type file omits the arch information.

* **Target Version for Merge**
1.12.2

* **Related Issues**


* **PRs Involving Sub-Systems** 
https://github.com/beclab/dynamic-chart-repository/commit/2672c632f491276b7c3576586e0cd657db535885
