### PR TITLE
app-sevice: fix upgrade chart context in setupdomain cause release failed

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.26
+        image: beclab/app-service:0.4.28
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION


* **Background**
fix upgrade chart context in setupdomain cause release failed

* **Target Version for Merge**
1.12.2
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/346

* **Other information**:
