### PR TITLE
app-service: fix helm upgrade set recreate to false

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.28
+        image: beclab/app-service:0.4.30
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION


* **Background**
setup domain, then upgrade chart cause system-server pod restart, 
because wise have svc refrence system-server pod

* **Target Version for Merge**
1.12.2
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/348

* **Other information**:
