### PR TITLE
refactor: change the backend of JuiceFS notify daemon  to inotify

### DIFF
--- a/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_daemon.yaml
+++ b/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_daemon.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: daemon
-        image: beclab/fsnotify-daemon:0.1.3
+        image: beclab/fsnotify-daemon:0.1.4
         imagePullPolicy: IfNotPresent
         env:
         - name: REDIS_PASSWORD

--- a/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
+++ b/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: os-internal
       containers:
         - name: proxy
-          image: beclab/fsnotify-proxy:0.1.10
+          image: beclab/fsnotify-proxy:0.1.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5079

--- a/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
+++ b/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccount: bytetrade-sys-ops
       containers:
       - name: proxy
-        image: beclab/fsnotify-proxy:0.1.10
+        image: beclab/fsnotify-proxy:0.1.11
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5079


### PR DESCRIPTION
* **Background**
Change the backend of JuiceFS notify daemon  to inotify

* **Target Version for Merge**
v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/fs-lib/pull/4

* **Other information**:
