### PR TITLE
fix(bfl): use dynamical variable endpoint in cert manager

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -266,7 +266,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.31
+        image: beclab/bfl:v0.4.32
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
Starting from https://github.com/beclab/bfl/pull/140, bfl watches the SystemEnv `OLARES_SYSTEM_REMOTE_SERVICE` and updates corresponding services' endpoints in realtime, however, the `CertManager` that many components use is initiated with a static endpoints set, making the dynamic update useless, it should be changed to directly use the updated variables to reflect realtime SystemEnv change.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/144

* **Other information**:
none