### PR TITLE
juicefs: bump version to v1.3.0 in Olares.yaml

### DIFF
--- a/platform/juicefs/.olares/Olares.yaml
+++ b/platform/juicefs/.olares/Olares.yaml
@@ -4,9 +4,9 @@ output:
   binaries:
     - 
       id: juicefs
-      name:  juicefs-v11.1.1.tar.gz
-      amd64: https://github.com/beclab/juicefs-ext/releases/download/v11.1.1/juicefs-v11.1.1-linux-amd64.tar.gz
-      arm64: https://github.com/beclab/juicefs-ext/releases/download/v11.1.1/juicefs-v11.1.1-linux-arm64.tar.gz
+      name:  juicefs-v1.3.0.tar.gz
+      amd64: https://github.com/juicedata/juicefs/releases/download/v1.3.0/juicefs-1.3.0-linux-amd64.tar.gz
+      arm64: https://github.com/juicedata/juicefs/releases/download/v1.3.0/juicefs-1.3.0-linux-arm64.tar.gz
     
 
 


### PR DESCRIPTION
* **Background**
Bump JuiceFS version to v1.3.0

* **Target Version for Merge**
v1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
