### PR TITLE
feat(daemon): handle sysenv for dockerhub mirror endpoint

### DIFF
--- a/build/system-env.yaml
+++ b/build/system-env.yaml
@@ -21,6 +21,11 @@ systemEnvs:
     type: url
     editable: true
     required: true
+  # docker hub mirror endpoint for docker.io registry
+  - envName: OLARES_SYSTEM_DOCKERHUB_SERVICE
+    type: url
+    editable: true
+    required: false
   # the legacy OLARES_ROOT_DIR
   - envName: OLARES_SYSTEM_ROOT_PATH
     default: /olares

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.31
+        image: beclab/app-service:0.4.32
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
Add a new SystemEnv `OLARES_SYSTEM_DOCKERHUB_SERVICE` pointing to a registry mirror endpoint for `docker.io`, whose value is automatically configured with regard to Olares's domain region, and being watched and applied to Containerd's config file by Olaresd.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/350

* **Other information**:
none