### PR TITLE
feat(daemon): unified node disk size between olaresd and dashboard

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -139,7 +139,7 @@ func CheckCurrentStatus(ctx context.Context) error {
 		return err
 	}
 
-	diskSize, err := utils.GetDiskSize()
+	diskSize, err := utils.GetNodeFilesystemTotalSize()
 	if err != nil {
 		return err
 	}

--- a/daemon/pkg/utils/filesystem.go
+++ b/daemon/pkg/utils/filesystem.go
@@ -1,0 +1,156 @@
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	unix "golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+// FilesystemStat represents capacity and inode stats for a mounted filesystem.
+type FilesystemStat struct {
+	Device     string
+	MountPoint string
+	FSType     string
+	SizeBytes  uint64
+	FreeBytes  uint64
+	AvailBytes uint64
+	Files      uint64
+	FilesFree  uint64
+	ReadOnly   bool
+}
+
+const (
+	ignoredMountPointsPattern = "^/(dev|proc|sys|var/lib/docker/.+|var/lib/containerd/.+|var/lib/kubelet/.+)($|/)"
+	ignoredFSTypesPattern     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+)
+
+func GetNodeFilesystemTotalSize() (uint64, error) {
+	stats, err := GetFilesystemStats()
+	if err != nil {
+		return 0, fmt.Errorf("unable to get filesystem stats: %w", err)
+	}
+
+	var totalSize uint64
+	filteredStats := make(map[string]FilesystemStat)
+	for _, stat := range stats {
+		if !strings.HasPrefix(stat.Device, "/dev") || strings.HasPrefix(stat.Device, "/dev/loop") {
+			continue
+		}
+		if _, ok := filteredStats[stat.Device]; ok {
+			continue
+		}
+		filteredStats[stat.Device] = stat
+	}
+
+	for _, stat := range filteredStats {
+		totalSize += stat.SizeBytes
+	}
+
+	return totalSize, nil
+}
+
+// GetFilesystemStats returns filesystem stats for all mounts, filtered by built-in regex patterns.
+func GetFilesystemStats() ([]FilesystemStat, error) {
+	mounts, err := readMountInfo()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read mount info: %w", err)
+	}
+
+	mpFilter, err := regexp.Compile(ignoredMountPointsPattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid built-in mount points regex: %w", err)
+	}
+	fsFilter, err := regexp.Compile(ignoredFSTypesPattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid built-in fs types regex: %w", err)
+	}
+
+	var out []FilesystemStat
+	for _, m := range mounts {
+		if mpFilter.MatchString(m.mountPoint) {
+			continue
+		}
+		if fsFilter.MatchString(m.fsType) {
+			continue
+		}
+
+		var readOnly bool
+		for _, opt := range strings.Split(m.options, ",") {
+			if opt == "ro" {
+				readOnly = true
+				break
+			}
+		}
+
+		buf := new(unix.Statfs_t)
+		if err := unix.Statfs(m.mountPoint, buf); err != nil {
+			klog.Warningf("unable to statfs mount point %q: %v", m.mountPoint, err)
+			continue
+		}
+
+		bsize := uint64(buf.Bsize)
+		out = append(out, FilesystemStat{
+			Device:     m.device,
+			MountPoint: m.mountPoint,
+			FSType:     m.fsType,
+			SizeBytes:  uint64(buf.Blocks) * bsize,
+			FreeBytes:  uint64(buf.Bfree) * bsize,
+			AvailBytes: uint64(buf.Bavail) * bsize,
+			Files:      uint64(buf.Files),
+			FilesFree:  uint64(buf.Ffree),
+			ReadOnly:   readOnly,
+		})
+	}
+	return out, nil
+}
+
+type mountInfo struct {
+	device     string
+	mountPoint string
+	fsType     string
+	options    string
+}
+
+// readMountInfo parses /proc/1/mountinfo (or falls back to self) and returns essential fields.
+func readMountInfo() ([]mountInfo, error) {
+	file, err := os.Open("/proc/1/mountinfo")
+	if errors.Is(err, os.ErrNotExist) {
+		file, err = os.Open("/proc/self/mountinfo")
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var mounts []mountInfo
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) < 10 {
+			return nil, fmt.Errorf("malformed mount point information: %q", scanner.Text())
+		}
+
+		m := 5
+		for parts[m+1] != "-" {
+			m++
+		}
+
+		// Unescape as per fstab: \040 (space), \011 (tab).
+		mountPoint := strings.ReplaceAll(parts[4], "\\040", " ")
+		mountPoint = strings.ReplaceAll(mountPoint, "\\011", "\t")
+
+		mounts = append(mounts, mountInfo{
+			device:     parts[m+3],
+			mountPoint: mountPoint,
+			fsType:     parts[m+2],
+			options:    parts[5],
+		})
+	}
+	return mounts, scanner.Err()
+}


### PR DESCRIPTION
* **Background**
Currently, the `DiskSize` served by Olaresd's system status API fetches the size of the block volume mounted at the root directory `/`, which might be a physical disk, a physical disk partition, or a LVM LV in a VG consisting of PVs backed by multiple physical disks/partitions.
In the meantime, the `Disk` (total size) data in the Olares dashboard are aggregated from metrics of NodeExporter agent, at the filesystem level, refer to: [NodeExporter's data collection logic](https://github.com/prometheus/node_exporter/blob/654f19dee6a0c41de78a8d6d870e8c742cdb43b9/collector/filesystem_linux.go#L53), [PrometheusRule to aggregate node-level data](https://github.com/beclab/Olares/blob/ac482bceae776151e07f12d26f2aec469bd67691/cli/pkg/kubesphere/plugins/files/build/prometheus/kubernetes/kubernetes-prometheusRule.yaml#L949-L951), [KS apiserver's PromQL to aggregate cluster-level data](https://github.com/beclab/kubesphere-ext/blob/eb77935e74f22d54cfbf9c86fe67d4f606bf2c37/pkg/simple/client/monitoring/prometheus/promql.go#L49)
Olaresd's data computation is now changed to the same as NodeExporter, providing unified stats.

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
Olaresd only collects node-level stats, but dashboard displays cluster-level data, so in multi-node environment, there'll still be differences.