### PR TITLE
daemon: improve error handling in CheckCurrentStatus function

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -136,22 +136,21 @@ func CheckCurrentStatus(ctx context.Context) error {
 	osType, osInfo, osArch, osVersion, _, err := GetMachineInfo(ctx)
 	if err != nil {
 		klog.Error("get machine info from terminus cli error, ", err)
-		return err
 	}
 
 	diskSize, err := utils.GetNodeFilesystemTotalSize()
 	if err != nil {
-		return err
+		klog.Error("get node filesystem total size error, ", err)
 	}
 
 	gpu, err := utils.GetGpuInfo()
 	if err != nil {
-		return err
+		klog.Error("get gpu info error, ", err)
 	}
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		return err
+		klog.Error("get hostname error, ", err)
 	}
 
 	CurrentState.OsArch = osArch


### PR DESCRIPTION
* **Background**
Ignore non-critical errors in Olaresd status checking function

* **Target Version for Merge**
v1.12.3 v1.12.2

* **Related Issues**
Status checking is blocked by a non-critical error

* **PRs Involving Sub-Systems** 
none

* **Other information**:
