### PR TITLE
refactor(app-service): change Env CRD schema for future i18n

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 toolchain go1.24.6
 
 replace (
-	bytetrade.io/web3os/app-service => github.com/beclab/app-service v0.4.10
+	bytetrade.io/web3os/app-service => github.com/beclab/app-service v0.4.33
 	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.17
 	github.com/containers/image/v5 => github.com/containers/image/v5 v5.21.1
 	github.com/containers/storage => github.com/containers/storage v1.40.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -45,8 +45,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/api v0.0.2 h1:aD5RcMie2uqa/FZI7aQBa1F4yVEib8/x3IIZSLiHkBM=
 github.com/beclab/api v0.0.2/go.mod h1:ESZLe8cf4934QFkU6cqbskKfiTyNk67i1qbv/ctS6js=
-github.com/beclab/app-service v0.4.10 h1:0CT8sl5K+qwQsrKO6FYxbUFNXcRJVkkErw3sB7V7OQw=
-github.com/beclab/app-service v0.4.10/go.mod h1:0vEg3rv/DbR7dYznvTlXNXyYNn+TXNMaxz03GQYRWUQ=
+github.com/beclab/app-service v0.4.33 h1:H3fAeH6hHeGNxJGrf4V5zq+2Ztu+S+tOmuMqjNRnFsU=
+github.com/beclab/app-service v0.4.33/go.mod h1:0vEg3rv/DbR7dYznvTlXNXyYNn+TXNMaxz03GQYRWUQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 toolchain go1.24.4
 
 replace (
-	bytetrade.io/web3os/app-service => github.com/beclab/app-service v0.4.23
+	bytetrade.io/web3os/app-service => github.com/beclab/app-service v0.4.33
 	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.17
 	bytetrade.io/web3os/bfl => github.com/beclab/bfl v0.3.36
 	github.com/labstack/echo/v4 => github.com/eball/echo/v4 v4.13.4-patch

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -26,8 +26,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/Olares/cli v0.0.0-20251016092744-6241cceceb89 h1:5s9hXV8K3faToQtE9DbiM7O6jt5kIiEsLAaKn6F0UfA=
 github.com/beclab/Olares/cli v0.0.0-20251016092744-6241cceceb89/go.mod h1:iEvZxM6PnFxFRppneTzV3hgr2tIxDnsI3dhp4pi7pFg=
-github.com/beclab/app-service v0.4.23 h1:6kjpq7rie62FafQRBGXtM9MQD3CEMGmrOC7aGPbvLJY=
-github.com/beclab/app-service v0.4.23/go.mod h1:0vEg3rv/DbR7dYznvTlXNXyYNn+TXNMaxz03GQYRWUQ=
+github.com/beclab/app-service v0.4.33 h1:H3fAeH6hHeGNxJGrf4V5zq+2Ztu+S+tOmuMqjNRnFsU=
+github.com/beclab/app-service v0.4.33/go.mod h1:0vEg3rv/DbR7dYznvTlXNXyYNn+TXNMaxz03GQYRWUQ=
 github.com/beclab/bfl v0.3.36 h1:PgeSPGc+XoONiwFsKq9xX8rqcL4kVM1G/ut0lYYj/js=
 github.com/beclab/bfl v0.3.36/go.mod h1:A82u38MxYk1C3Lqnm4iUUK4hBeY9HHIs+xU4V93OnJk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_appenvs.yaml
+++ b/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_appenvs.yaml
@@ -9,92 +9,98 @@ spec:
   group: sys.bytetrade.io
   names:
     categories:
-      - all
+    - all
     kind: AppEnv
     listKind: AppEnvList
     plural: appenvs
     shortNames:
-      - appenv
+    - appenv
     singular: appenv
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .appName
-          name: app name
-          type: string
-        - jsonPath: .appOwner
-          name: owner
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: AppEnv is the Schema for the application environment variables
-            API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            appName:
-              type: string
-            appOwner:
-              type: string
-            envs:
-              items:
-                properties:
-                  applyOnChange:
-                    type: boolean
-                  default:
+  - additionalPrinterColumns:
+    - jsonPath: .appName
+      name: app name
+      type: string
+    - jsonPath: .appOwner
+      name: owner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AppEnv is the Schema for the application environment variables
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          appName:
+            type: string
+          appOwner:
+            type: string
+          envs:
+            items:
+              properties:
+                applyOnChange:
+                  type: boolean
+                default:
+                  type: string
+                description:
+                  additionalProperties:
                     type: string
-                  description:
-                    type: string
-                  editable:
-                    type: boolean
-                  envName:
-                    type: string
-                  required:
-                    type: boolean
-                  type:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    description: ValueFrom defines a reference to an environment variable
-                      (UserEnv or SystemEnv)
-                    properties:
-                      envName:
-                        type: string
-                      status:
-                        type: string
-                    required:
-                      - envName
-                    type: object
+                  type: object
+                editable:
+                  type: boolean
+                envName:
+                  type: string
                 required:
+                  type: boolean
+                title:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type:
+                  type: string
+                value:
+                  type: string
+                valueFrom:
+                  description: ValueFrom defines a reference to an environment variable
+                    (UserEnv or SystemEnv)
+                  properties:
+                    envName:
+                      type: string
+                    status:
+                      type: string
+                  required:
                   - envName
-                type: object
-              type: array
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
+                  type: object
+              required:
+              - envName
               type: object
-            needApply:
-              type: boolean
-          required:
-            - appName
-            - appOwner
-          type: object
-      served: true
-      storage: true
-      subresources: {}
+            type: array
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          needApply:
+            type: boolean
+        required:
+        - appName
+        - appOwner
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_systemenvs.yaml
+++ b/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_systemenvs.yaml
@@ -9,71 +9,77 @@ spec:
   group: sys.bytetrade.io
   names:
     categories:
-      - all
+    - all
     kind: SystemEnv
     listKind: SystemEnvList
     plural: systemenvs
     shortNames:
-      - sysenv
+    - sysenv
     singular: systemenv
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .envName
-          name: env name
-          type: string
-        - jsonPath: .value
-          name: value
-          type: string
-        - jsonPath: .editable
-          name: editable
-          type: boolean
-        - jsonPath: .required
-          name: required
-          type: boolean
-        - jsonPath: .metadata.creationTimestamp
-          name: age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SystemEnv is the Schema for the system environment variables
-            API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  - additionalPrinterColumns:
+    - jsonPath: .envName
+      name: env name
+      type: string
+    - jsonPath: .value
+      name: value
+      type: string
+    - jsonPath: .editable
+      name: editable
+      type: boolean
+    - jsonPath: .required
+      name: required
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SystemEnv is the Schema for the system environment variables
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          default:
+            type: string
+          description:
+            additionalProperties:
               type: string
-            default:
-              type: string
-            description:
-              type: string
-            editable:
-              type: boolean
-            envName:
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            required:
-              type: boolean
-            type:
-              type: string
-            value:
-              type: string
+            type: object
+          editable:
+            type: boolean
+          envName:
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
           required:
-            - envName
-          type: object
-      served: true
-      storage: true
-      subresources: {}
+            type: boolean
+          title:
+            additionalProperties:
+              type: string
+            type: object
+          type:
+            type: string
+          value:
+            type: string
+        required:
+        - envName
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_userenvs.yaml
+++ b/framework/app-service/.olares/config/cluster/crds/sys.bytetrade.io_userenvs.yaml
@@ -49,7 +49,9 @@ spec:
           default:
             type: string
           description:
-            type: string
+            additionalProperties:
+              type: string
+            type: object
           editable:
             type: boolean
           envName:
@@ -66,6 +68,10 @@ spec:
             type: object
           required:
             type: boolean
+          title:
+            additionalProperties:
+              type: string
+            type: object
           type:
             type: string
           value:

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.32
+        image: beclab/app-service:0.4.33
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
Add `title` and `description` field of type `map[string]string` to Env CRD definition
Use correct token when creating HelmOps instance to apply App Env

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/351

* **Other information**:
none