### PR TITLE
feat(app-service): independent op & API for apply env

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.34
+        image: beclab/app-service:0.4.36
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
* **Background**
Add an API to allow the user to manually request to apply AppEnv
Add a HelmOps method `ApplyEnv`, to only upgrade deployed chart's values, instead of relying on the `Upgrade` method, which does many other unnecessary tasks.
Do not auto-retry on failed ApplyEnv operation in controller

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/app-service/pull/353
https://github.com/beclab/app-service/pull/354

* **Other information**:
none