### PR TITLE
bfl: Update AUTHELIA_AUTH_URL in bfl_deploy.yaml

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -321,7 +321,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: AUTHELIA_AUTH_URL
-          value: 'http://authelia-backend-provider.user-system-{{ .Values.bfl.username }}:28080/api/authz/auth-request'
+          value: 'http://authelia-backend.user-system-{{ .Values.bfl.username }}:9091/api/authz/auth-request'
         volumeMounts:
         - name: ngxlog
           mountPath: /var/log/nginx


### PR DESCRIPTION
* **Background**
Since the OPTIONS request does not have any token, change the Authelia requests from the provider to proxy in BFL ingress.

* **Target Version for Merge**
v1.12.2 v1.12.3

* **Related Issues**
OPTIONS requests of `Files` got response code 401.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
