### PR TITLE
fix(daemon): avoid concurrent execution of uninstall and change-ip

### DIFF
--- a/daemon/pkg/cluster/state/terminus.go
+++ b/daemon/pkg/cluster/state/terminus.go
@@ -258,7 +258,7 @@ type IpChangingValidator struct{}
 
 func (i IpChangingValidator) ValidateOp(op commands.Interface) error {
 	switch op.OperationName() {
-	case commands.Reboot, commands.Shutdown, commands.Uninstall, commands.SetSSHPassword:
+	case commands.Reboot, commands.Shutdown, commands.SetSSHPassword:
 		return nil
 	}
 


### PR DESCRIPTION
* **Background**
Do not allow uninstall operation if there's a running task of change-ip, to avoid race conditions

* **Target Version for Merge**
1.12.2

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none