### PR TITLE
chore(cli): remove any left vgpu lock file

### DIFF
--- a/cli/pkg/bootstrap/os/tasks.go
+++ b/cli/pkg/bootstrap/os/tasks.go
@@ -447,6 +447,7 @@ var (
 		"/etc/kubekey",
 		"/etc/kke/version",
 		"/etc/systemd/system/olares-swap.service",
+		"/tmp/vgpulock",
 	}
 
 	networkResetCmds = []string{


### PR DESCRIPTION
* **Background**
The lock file `/tmp/vgpulock/lock` created by HAMi-core may be left uncleaned in rare cases, this should be removed during uninstallation.

* **Target Version for Merge**
1.12.2, 1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none