### PR TITLE
fix: wait drive, cache root directory create successfully

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -241,7 +241,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.70
+        image: beclab/search3:v0.0.71
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -292,7 +292,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.70
+        image: beclab/search3monitor:v0.0.71
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081


### PR DESCRIPTION
Title: search3monitor service
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
When monitor start, wait user's cache,drive root directory to be created successfully
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   1.12.2, dailybuild
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/123/files
