### PR TITLE
fix: wsl shutdown command not working on newer WSL versions

### DIFF
--- a/cli/pkg/windows/tasks.go
+++ b/cli/pkg/windows/tasks.go
@@ -314,7 +314,7 @@ func (c *ConfigWslConf) Execute(runtime connector.Runtime) error {
 	}
 
 	cmd = &utils.DefaultCommandExecutor{
-		Commands: []string{"--shutdown", distro},
+		Commands: []string{"-t", distro},
 	}
 	if _, err := cmd.RunCmd("wsl", utils.DEFAULT); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("shutdown wsl %s failed", distro))


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
WSL 2.6 does not support shutting down a specific distro using `wsl --shutdown <Distro>`, switch to `wsl -t <Distro>`.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12.2

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/commit/3d1d53a27b5ef7dde3e919b9d034e4d8f6c4bf26


* **Other information**:
