### PR TITLE
chore(manifest): lift GPU split count limit in timeslicing mode

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -147,7 +147,7 @@ devicePlugin:
   monitorimage: "beclab/hami"
   monitorctrPath: /usr/local/vgpu/containers
   imagePullPolicy: IfNotPresent
-  deviceSplitCount: 10
+  deviceSplitCount: 30
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
   # The runtime class name to be used by the device plugin, and added to the pod.spec.runtimeClassName of applications utilizing NVIDIA GPUs


### PR DESCRIPTION
* **Background**
For a single GPU card in timeslicing mode, the max number of pod concurrently consuming it is 10, this is now lifted to 30

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none