### PR TITLE
chore(cli): use preferred nvidia driver meta pkg name

### DIFF
--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -131,8 +131,8 @@ func (t *InstallCudaDriver) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(err, "failed to apt-get install nvidia-open")
 	}
 
-	if _, err := runtime.GetRunner().SudoCmd("apt-get -y install nvidia-kernel-open-575", false, true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "Failed to apt-get install nvidia-kernel-open-575")
+	if _, err := runtime.GetRunner().SudoCmd("apt-get -y install nvidia-open-575", false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to apt-get install nvidia-open-575")
 	}
 
 	if t.SkipNVMLCheckAfterInstall {


### PR DESCRIPTION
* **Background**
Switch from `nvidia-kernel-open-<branch>` to `nvidia-open-<branch>` when installing meta APT package for Nvidia driver.
This is a temporary trivial change, and we'll later migrate to Nvidia's new installation method by  [Version locking packages for Ubuntu / Debian](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/recent-updates.html#version-locking-packages-for-ubuntu-debian)

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none