### PR TITLE
feat(cli): expand NodePort range to allow sharing SMB service

### DIFF
--- a/cli/pkg/k3s/tasks.go
+++ b/cli/pkg/k3s/tasks.go
@@ -207,7 +207,11 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 		"proxy-mode": "ipvs",
 	}
 
-	kubeApiserverArgs, _ := util.GetArgs(map[string]string{}, g.KubeConf.Cluster.Kubernetes.ApiServerArgs)
+	defaultKubeApiServerArgs := map[string]string{
+		"service-node-port-range": "445-32767",
+	}
+
+	kubeApiserverArgs, _ := util.GetArgs(defaultKubeApiServerArgs, g.KubeConf.Cluster.Kubernetes.ApiServerArgs)
 	kubeControllerManager, _ := util.GetArgs(map[string]string{
 		"terminated-pod-gc-threshold": "1",
 	}, g.KubeConf.Cluster.Kubernetes.ControllerManagerArgs)

--- a/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -162,17 +162,19 @@ var (
 	}
 
 	ApiServerArgs = map[string]string{
-		"bind-address":        "0.0.0.0",
-		"audit-log-maxage":    "30",
-		"audit-log-maxbackup": "10",
-		"audit-log-maxsize":   "100",
+		"bind-address":            "0.0.0.0",
+		"audit-log-maxage":        "30",
+		"audit-log-maxbackup":     "10",
+		"audit-log-maxsize":       "100",
+		"service-node-port-range": "445-32767",
 	}
 	ApiServerSecurityArgs = map[string]string{
-		"bind-address":        "0.0.0.0",
-		"audit-log-maxage":    "30",
-		"audit-log-maxbackup": "10",
-		"audit-log-maxsize":   "100",
-		"authorization-mode":  "Node,RBAC",
+		"bind-address":            "0.0.0.0",
+		"audit-log-maxage":        "30",
+		"audit-log-maxbackup":     "10",
+		"audit-log-maxsize":       "100",
+		"service-node-port-range": "445-32767",
+		"authorization-mode":      "Node,RBAC",
 		// --enable-admission-plugins=EventRateLimit must have a configuration file
 		"enable-admission-plugins": "AlwaysPullImages,ServiceAccount,NamespaceLifecycle,NodeRestriction,LimitRanger,ResourceQuota,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodNodeSelector,PodSecurity",
 		// "audit-log-path":      "/var/log/apiserver/audit.log", // need audit policy

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -675,7 +675,7 @@ func (m *ChangeIPModule) addKubernetesTasks() {
 			},
 			&task.LocalTask{
 				Name:   "RegenerateK8sFilesWithKubeadm",
-				Action: new(RegenerateFilesForK8sIPChange),
+				Action: new(RegenerateFilesForK8s),
 			},
 			&task.LocalTask{
 				Name:   "CopyNewKubeConfig",

--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -447,11 +447,11 @@ func (a *PrepareFilesForK8sIPChange) Execute(runtime connector.Runtime) error {
 	})
 }
 
-type RegenerateFilesForK8sIPChange struct {
+type RegenerateFilesForK8s struct {
 	common.KubeAction
 }
 
-func (a *RegenerateFilesForK8sIPChange) Execute(runtime connector.Runtime) error {
+func (a *RegenerateFilesForK8s) Execute(runtime connector.Runtime) error {
 	initCmd := "/usr/local/bin/kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --skip-phases=preflight,mark-control-plane,bootstrap-token,addon,show-join-command"
 
 	if _, err := runtime.GetRunner().SudoCmd(initCmd, false, false); err != nil {

--- a/cli/pkg/upgrade/1_12_3_20251112.go
+++ b/cli/pkg/upgrade/1_12_3_20251112.go
@@ -1,0 +1,22 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_3_20251112 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_3_20251112) Version() *semver.Version {
+	return semver.MustParse("1.12.3-20251112")
+}
+
+func (u upgrader_1_12_3_20251112) PrepareForUpgrade() []task.Interface {
+	return append(regenerateKubeFiles(), u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_3_20251112{})
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -1,14 +1,21 @@
 package upgrade
 
 import (
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/bootstrap/precheck"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/container"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/k3s"
+	k3stemplates "github.com/beclab/Olares/cli/pkg/k3s/templates"
+	"github.com/beclab/Olares/cli/pkg/kubernetes"
 	"github.com/beclab/Olares/cli/pkg/kubesphere"
 	"github.com/beclab/Olares/cli/pkg/kubesphere/plugins"
 	"github.com/beclab/Olares/cli/pkg/manifest"
-	"time"
+	"github.com/beclab/Olares/cli/pkg/phase"
+	"github.com/beclab/Olares/cli/pkg/terminus"
 )
 
 type upgradeContainerdAction struct {
@@ -62,4 +69,48 @@ func upgradeKSCore() []task.Interface {
 			Delay:  10 * time.Second,
 		},
 	}
+}
+
+func regenerateKubeFiles() []task.Interface {
+	var tasks []task.Interface
+	kubeType := phase.GetKubeType()
+	if kubeType == common.K3s {
+		tasks = append(tasks,
+			&task.LocalTask{
+				Name:   "RegenerateK3sService",
+				Action: new(k3s.GenerateK3sService),
+			},
+			&task.LocalTask{
+				Name: "RestartK3sService",
+				Action: &terminus.SystemctlCommand{
+					Command:             "restart",
+					UnitNames:           []string{k3stemplates.K3sService.Name()},
+					DaemonReloadPreExec: true,
+				},
+			},
+		)
+	} else {
+		tasks = append(tasks,
+			&task.LocalTask{
+				Name: "RegenerateKubeadmConfig",
+				Action: &kubernetes.GenerateKubeadmConfig{
+					IsInitConfiguration: true,
+				},
+			},
+			&task.LocalTask{
+				Name:   "RegenerateK8sFilesWithKubeadm",
+				Action: new(terminus.RegenerateFilesForK8s),
+			},
+		)
+	}
+
+	tasks = append(tasks,
+		&task.LocalTask{
+			Name:   "WaitForKubeAPIServerUp",
+			Action: new(precheck.GetKubernetesNodesStatus),
+			Retry:  10,
+			Delay:  10,
+		},
+	)
+	return tasks
 }


### PR DESCRIPTION
* **Background**
Expand NodePort service range in K3s/Kubernetes configuration to allow sharing SMB service exposed at `445`.
A daily upgrader is also added to update and restart already installed K3s/Kubernetes service.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none