### PR TITLE
cli: add disk management commands for extending and listing unmounted disks

### DIFF
--- a/cli/cmd/ctl/disk/extend.go
+++ b/cli/cmd/ctl/disk/extend.go
@@ -1,0 +1,445 @@
+package disk
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/beclab/Olares/cli/pkg/utils"
+	"github.com/beclab/Olares/cli/pkg/utils/lvm"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const defaultOlaresVGName = "olares-vg"
+
+func NewExtendDiskCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extend",
+		Short: "extend disk operations",
+		Run: func(cmd *cobra.Command, args []string) {
+			// early return if no unmounted disks found
+			unmountedDevices, err := lvm.FindUnmountedDevices()
+			if err != nil {
+				log.Fatalf("Error finding unmounted devices: %v\n", err)
+			}
+
+			if len(unmountedDevices) == 0 {
+				log.Println("No unmounted disks found to extend.")
+				return
+			}
+
+			// select volume group to extend
+			currentVgs, err := lvm.FindCurrentLVM()
+			if err != nil {
+				log.Fatalf("Error finding current LVM: %v\n", err)
+			}
+
+			if len(currentVgs) == 0 {
+				log.Println("No valid volume groups found to extend.")
+				return
+			}
+
+			selectedVg, err := selectExtendingVG(currentVgs)
+			if err != nil {
+				log.Fatalf("Error selecting volume group: %v\n", err)
+			}
+			log.Printf("Selected volume group to extend: %s\n", selectedVg)
+
+			// select logical volume to extend
+			lvInVg, err := lvm.FindLvByVgName(selectedVg)
+			if err != nil {
+				log.Fatalf("Error finding logical volumes in volume group %s: %v\n", selectedVg, err)
+			}
+
+			if len(lvInVg) == 0 {
+				log.Printf("No logical volumes found in volume group %s to extend.\n", selectedVg)
+				return
+			}
+
+			selectedLv, err := selectExtendingLV(selectedVg, lvInVg)
+			if err != nil {
+				log.Fatalf("Error selecting logical volume: %v\n", err)
+			}
+			log.Printf("Selected logical volume to extend: %s\n", selectedLv)
+
+			// select unmounted devices to create physical volume
+			selectedDevice, err := selectExtendingDevices(unmountedDevices)
+			if err != nil {
+				log.Fatalf("Error selecting unmounted device: %v\n", err)
+			}
+			log.Printf("Selected unmounted device to use: %s\n", selectedDevice)
+
+			options := &LvmExtendOptions{
+				VgName:     selectedVg,
+				DevicePath: selectedDevice,
+				LvName:     selectedLv,
+				DeviceBlk:  unmountedDevices[selectedDevice],
+			}
+
+			log.Printf("Extending logical volume %s in volume group %s using device %s\n", options.LvName, options.VgName, options.DevicePath)
+			cleanupNeeded, err := options.cleanupDiskParts()
+			if err != nil {
+				log.Fatalf("Error during disk partition cleanup check: %v\n", err)
+			}
+
+			if cleanupNeeded {
+				do, err := options.destroyWarning()
+				if err != nil {
+					log.Fatalf("Error during partition cleanup confirmation: %v\n", err)
+				}
+				if !do {
+					log.Println("Operation aborted by user.")
+					return
+				}
+
+				err = options.deleteDevicePartitions()
+				if err != nil {
+					log.Fatalf("Error deleting device partitions: %v\n", err)
+				}
+
+			} else {
+				do, err := options.makeDecision()
+				if err != nil {
+					log.Fatalf("Error during extension confirmation: %v\n", err)
+				}
+				if !do {
+					log.Println("Operation aborted by user.")
+					return
+				}
+			}
+
+			err = options.extendLVM()
+			if err != nil {
+				log.Fatalf("Error extending LVM: %v\n", err)
+			}
+
+			log.Println("Disk extension completed successfully.")
+
+			// end of command run, and show result
+			// show the result of the extension
+			lvInVg, err = lvm.FindLvByVgName(selectedVg)
+			if err != nil {
+				log.Fatalf("Error finding logical volumes in volume group %s: %v\n", selectedVg, err)
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+			fmt.Fprint(w, "id\tLV\tVG\tLSize\tMountpoints\n")
+			for idx, lv := range lvInVg {
+				fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n", idx+1, lv.LvName, lv.VgName, lv.LvSize, strings.Join(lv.Mountpoints, ","))
+			}
+			w.Flush()
+
+		},
+	}
+
+	return cmd
+}
+
+type LvmExtendOptions struct {
+	VgName     string
+	DevicePath string
+	LvName     string
+	DeviceBlk  *lvm.BlkPart
+}
+
+func selectExtendingVG(vgs []*lvm.VgItem) (string, error) {
+	// if only one vg, return it directly
+	if len(vgs) == 1 {
+		return vgs[0].VgName, nil
+	}
+
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get terminal input reader")
+	}
+
+	fmt.Println("Multiple volume groups found. Please select one to extend:")
+	fmt.Println("")
+	// print header
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+	fmt.Fprint(w, "id\tVG\tVSize\tVFree\n")
+	for idx, vg := range vgs {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n", idx+1, vg.VgName, vg.VgSize, vg.VgFree)
+	}
+	w.Flush()
+
+LOOP:
+	fmt.Printf("\nEnter the volume group id to extend: ")
+	var input string
+	input, err = reader.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return "", errors.Wrap(errors.WithStack(err), "read volume group id failed")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		fmt.Printf("\ninvalid volume group id, please try again")
+		goto LOOP
+	}
+
+	selectedIdx, err := strconv.Atoi(input)
+	if err != nil || selectedIdx < 1 || selectedIdx > len(vgs) {
+		fmt.Printf("\ninvalid volume group id, please try again")
+		goto LOOP
+	}
+
+	return vgs[selectedIdx-1].VgName, nil
+}
+
+func selectExtendingLV(vgName string, lvs []*lvm.LvItem) (string, error) {
+	if len(lvs) == 1 {
+		return lvs[0].LvName, nil
+	}
+
+	if vgName == defaultOlaresVGName {
+		selectedLv := ""
+		for _, lv := range lvs {
+			if lv.LvName == "root" {
+				selectedLv = lv.LvName
+				continue
+			}
+
+			if lv.LvName == "data" {
+				selectedLv = lv.LvName
+				break
+			}
+		}
+
+		if selectedLv != "" {
+			return selectedLv, nil
+		}
+	}
+
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get terminal input reader")
+	}
+
+	fmt.Println("Multiple logical volumes found. Please select one to extend:")
+	fmt.Println("")
+	// print header
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+	fmt.Fprint(w, "id\tLV\tVG\tLSize\tMountpoints\n")
+	for idx, lv := range lvs {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n", idx+1, lv.LvName, lv.VgName, lv.LvSize, strings.Join(lv.Mountpoints, ","))
+	}
+	w.Flush()
+
+LOOP:
+	fmt.Printf("\nEnter the logical volume id to extend: ")
+	var input string
+	input, err = reader.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return "", errors.Wrap(errors.WithStack(err), "read logical volume id failed")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		fmt.Printf("\ninvalid logical volume id, please try again")
+		goto LOOP
+	}
+
+	selectedIdx, err := strconv.Atoi(input)
+	if err != nil || selectedIdx < 1 || selectedIdx > len(lvs) {
+		fmt.Printf("\ninvalid logical volume id, please try again")
+		goto LOOP
+	}
+
+	return lvs[selectedIdx-1].LvName, nil
+}
+
+func selectExtendingDevices(unmountedDevices map[string]*lvm.BlkPart) (string, error) {
+	if len(unmountedDevices) == 0 {
+		return "", errors.New("no unmounted devices available for selection")
+	}
+
+	if len(unmountedDevices) == 1 {
+		for path := range unmountedDevices {
+			return path, nil
+		}
+	}
+
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get terminal input reader")
+	}
+
+	fmt.Println("Multiple unmounted devices found. Please select one to use:")
+	fmt.Println("")
+	// print header
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+	fmt.Fprint(w, "id\tDevice\tSize\n")
+	idx := 1
+	devicePaths := make([]string, 0, len(unmountedDevices))
+	for path, device := range unmountedDevices {
+		fmt.Fprintf(w, "%d\t%s\t%s\n", idx, path, device.Size)
+		devicePaths = append(devicePaths, path)
+		idx++
+	}
+	w.Flush()
+
+LOOP:
+	fmt.Printf("\nEnter the device id to use: ")
+	var input string
+	input, err = reader.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return "", errors.Wrap(errors.WithStack(err), "read device id failed")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		fmt.Printf("\ninvalid device id, please try again")
+		goto LOOP
+	}
+	selectedIdx, err := strconv.Atoi(input)
+	if err != nil || selectedIdx < 1 || selectedIdx > len(devicePaths) {
+		fmt.Printf("\ninvalid device id, please try again")
+		goto LOOP
+	}
+
+	return devicePaths[selectedIdx-1], nil
+}
+
+func (o LvmExtendOptions) destroyWarning() (bool, error) {
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get terminal input reader")
+	}
+
+	fmt.Printf("WARNING: This will DESTROY all data on %s\n", o.DevicePath)
+LOOP:
+	fmt.Printf("Type 'YES' to continue, CTRL+C to abort: ")
+	var input string
+	input, err = reader.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return false, errors.Wrap(errors.WithStack(err), "read confirmation input failed")
+	}
+	input = strings.ToUpper(strings.TrimSpace(input))
+	if input != "YES" {
+		goto LOOP
+	}
+	return true, nil
+}
+
+func (o LvmExtendOptions) makeDecision() (bool, error) {
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get terminal input reader")
+	}
+
+	fmt.Printf("NOTICE: Extending LVM will begin on device %s\n", o.DevicePath)
+LOOP:
+	fmt.Printf("Type 'YES' to continue, CTRL+C to abort: ")
+	var input string
+	input, err = reader.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return false, errors.Wrap(errors.WithStack(err), "read confirmation input failed")
+	}
+	input = strings.ToUpper(strings.TrimSpace(input))
+	if input != "YES" {
+		goto LOOP
+	}
+	return true, nil
+}
+
+func (o LvmExtendOptions) cleanupDiskParts() (bool, error) {
+	if o.DeviceBlk == nil {
+		return false, errors.New("device block is nil")
+	}
+
+	if len(o.DeviceBlk.Children) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (o LvmExtendOptions) deleteDevicePartitions() error {
+	log.Printf("Selected device %s has existing partitions. Cleaning up...\n", o.DevicePath)
+	if o.DeviceBlk == nil {
+		return errors.New("device block is nil")
+	}
+
+	if len(o.DeviceBlk.Children) == 0 {
+		return nil
+	}
+
+	log.Printf("Deleting existing partitions on device %s...\n", o.DevicePath)
+	var partitions []string
+	for _, part := range o.DeviceBlk.Children {
+		partitions = append(partitions, "/dev/"+part.Name)
+	}
+
+	vgs, err := lvm.FindVgsOnDevice(partitions)
+	if err != nil {
+		return errors.Wrap(err, "failed to find volume groups on device partitions")
+	}
+
+	if len(vgs) > 0 {
+		log.Println("existing volume group on device, delete it first")
+		for _, vg := range vgs {
+			lvs, err := lvm.FindLvByVgName(vg.VgName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to find logical volumes in volume group %s", vg.VgName)
+			}
+
+			err = lvm.DeactivateLv(vg.VgName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to deactivate volume group %s", vg.VgName)
+			}
+
+			for _, lv := range lvs {
+				err = lvm.RemoveLv(lv.LvPath)
+				if err != nil {
+					return errors.Wrapf(err, "failed to remove logical volume %s", lv.LvPath)
+				}
+			}
+
+			err = lvm.RemoveVg(vg.VgName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to remove volume group %s", vg)
+			}
+
+			err = lvm.RemovePv(vg.PvName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to remove physical volume %s", vg.PvName)
+			}
+		}
+
+	}
+
+	log.Printf("Deleting partitions on device %s...\n", o.DevicePath)
+	err = lvm.DeleteDevicePartitions(o.DevicePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete partitions on device %s", o.DevicePath)
+	}
+
+	return nil
+}
+
+func (o LvmExtendOptions) extendLVM() error {
+	log.Printf("Creating partition on device %s...\n", o.DevicePath)
+	err := lvm.MakePartOnDevice(o.DevicePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create partition on device %s", o.DevicePath)
+	}
+
+	log.Printf("Creating physical volume on device %s...\n", o.DevicePath)
+	err = lvm.AddNewPV(o.DevicePath, o.VgName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create physical volume on device %s", o.DevicePath)
+	}
+
+	log.Printf("Extending volume group %s with logic volume %s on  device %s...\n", o.VgName, o.LvName, o.DevicePath)
+	err = lvm.ExtendLv(o.VgName, o.LvName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to extend logical volume %s in volume group %s", o.LvName, o.VgName)
+	}
+
+	return nil
+}

--- a/cli/cmd/ctl/disk/listumounted.go
+++ b/cli/cmd/ctl/disk/listumounted.go
@@ -1,0 +1,34 @@
+package disk
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/beclab/Olares/cli/pkg/utils/lvm"
+	"github.com/spf13/cobra"
+)
+
+func NewListUnmountedDisksCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-unmounted",
+		Short: "List unmounted disks",
+		Run: func(cmd *cobra.Command, args []string) {
+			unmountedDevices, err := lvm.FindUnmountedDevices()
+			if err != nil {
+				log.Fatalf("Error finding unmounted devices: %v\n", err)
+			}
+
+			// print header
+			w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+			fmt.Fprint(w, "Device\tSize\n")
+			for path, device := range unmountedDevices {
+				fmt.Fprintf(w, "%s\t%s\n", path, device.Size)
+			}
+			w.Flush()
+		},
+	}
+	return cmd
+}

--- a/cli/cmd/ctl/disk/root.go
+++ b/cli/cmd/ctl/disk/root.go
@@ -1,0 +1,15 @@
+package disk
+
+import "github.com/spf13/cobra"
+
+func NewDiskCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disk",
+		Short: "disk management operations",
+	}
+
+	cmd.AddCommand(NewListUnmountedDisksCommand())
+	cmd.AddCommand(NewExtendDiskCommand())
+
+	return cmd
+}

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -1,6 +1,7 @@
 package ctl
 
 import (
+	"github.com/beclab/Olares/cli/cmd/ctl/disk"
 	"github.com/beclab/Olares/cli/cmd/ctl/gpu"
 	"github.com/beclab/Olares/cli/cmd/ctl/node"
 	"github.com/beclab/Olares/cli/cmd/ctl/os"
@@ -33,6 +34,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmds.AddCommand(node.NewNodeCommand())
 	cmds.AddCommand(gpu.NewCmdGpu())
 	cmds.AddCommand(user.NewUserCommand())
+	cmds.AddCommand(disk.NewDiskCommand())
 
 	return cmds
 }

--- a/cli/pkg/utils/lvm/command.go
+++ b/cli/pkg/utils/lvm/command.go
@@ -3,9 +3,8 @@ package lvm
 import (
 	"bytes"
 	"errors"
+	"log"
 	"os/exec"
-
-	"k8s.io/klog/v2"
 )
 
 type command[T any] struct {
@@ -22,13 +21,11 @@ func (c *command[T]) Run(args ...string) (*T, string, error) {
 	allArgs := append(c.defaultArgs, args...)
 	o, e, err := runCommandSplit(c.cmd, allArgs...)
 	if err != nil {
-		klog.Errorf("command %s failed: %s", c.cmd, string(e))
 		return nil, string(e), err
 	}
 
 	result, err := c.format(o)
 	if err != nil {
-		klog.Errorf("command %s format failed: %v", c.cmd, err)
 		return nil, "", err
 	}
 
@@ -51,10 +48,10 @@ func runCommandSplit(command string, args ...string) ([]byte, []byte, error) {
 }
 
 func findCmd(cmd string) string {
-	c := exec.Command("command", "-v", cmd)
-	path, err := c.Output()
+	path, err := exec.LookPath(cmd)
 	if err != nil {
+		log.Printf("failed to find command %s: %v\n", cmd, err)
 		return ""
 	}
-	return string(bytes.TrimSpace(path))
+	return path
 }

--- a/cli/pkg/utils/lvm/disk.go
+++ b/cli/pkg/utils/lvm/disk.go
@@ -1,26 +1,179 @@
 package lvm
 
-/*
-wipefs -a /dev/nvme0n1
-sgdisk --zap-all /dev/nvme0n1
+import (
+	"bytes"
+	"encoding/json"
+)
 
-findmnt -n -J --target /olares
-{
-   "filesystems": [
-      {
-         "target": "/olares",
-         "source": "/dev/mapper/olares--vg-data[/olares]",
-         "fstype": "ext4",
-         "options": "rw,relatime"
-      }
-   ]
+/*
+lsblk -J
+
+	{
+	   "blockdevices": [
+	      {
+	         "name": "nvme0n1",
+	         "maj:min": "259:0",
+	         "rm": false,
+	         "size": "1.9T",
+	         "ro": false,
+	         "type": "disk",
+	         "mountpoints": [
+	             null
+	         ],
+	         "children": [
+	            {
+	               "name": "nvme0n1p1",
+	               "maj:min": "259:1",
+	               "rm": false,
+	               "size": "512M",
+	               "ro": false,
+	               "type": "part",
+	               "mountpoints": [
+	                   "/boot/efi"
+	               ]
+	            },{
+	               "name": "nvme0n1p2",
+	               "maj:min": "259:2",
+	               "rm": false,
+	               "size": "1.9T",
+	               "ro": false,
+	               "type": "part",
+	               "mountpoints": [
+	                   null
+	               ],
+	               "children": [
+	                  {
+	                     "name": "olares--vg-swap",
+	                     "maj:min": "252:0",
+	                     "rm": false,
+	                     "size": "1G",
+	                     "ro": false,
+	                     "type": "lvm",
+	                     "mountpoints": [
+	                         "[SWAP]"
+	                     ]
+	                  },{
+	                     "name": "olares--vg-root",
+	                     "maj:min": "252:1",
+	                     "rm": false,
+	                     "size": "100G",
+	                     "ro": false,
+	                     "type": "lvm",
+	                     "mountpoints": [
+	                         "/"
+	                     ]
+	                  },{
+	                     "name": "olares--vg-data",
+	                     "maj:min": "252:2",
+	                     "rm": false,
+	                     "size": "1.8T",
+	                     "ro": false,
+	                     "type": "lvm",
+	                     "mountpoints": [
+	                         "/olares", "/var"
+	                     ]
+	                  }
+	               ]
+	            }
+	         ]
+	      }
+	   ]
+	}
+*/
+const LBLK = "lsblk"
+
+type BlkPart struct {
+	Name        string           `json:"name"`
+	MajMin      string           `json:"maj:min"`
+	Rm          bool             `json:"rm"`
+	Size        string           `json:"size"`
+	Ro          bool             `json:"ro"`
+	Type        string           `json:"type"`
+	Mountpoints BlkList[string]  `json:"mountpoints"`
+	Children    BlkList[BlkPart] `json:"children,omitempty"`
 }
 
-lvs --reportformat json /dev/mapper/olares--vg-data
+type BlkList[T any] []T
 
+type BlkResult struct {
+	Blockdevices BlkList[BlkPart] `json:"blockdevices"`
+}
 
-sudo parted -a optimal /dev/sdX mkpart primary 1MiB 100%
-sudo pvcreate /dev/sdX1
-sudo vgextend target_vg /dev/sdX1
+func CommandLBLK() *command[BlkResult] {
+	cmd := findCmd(LBLK)
+	return &command[BlkResult]{
+		cmd:         cmd,
+		defaultArgs: []string{"-J"},
 
+		format: func(data []byte) (BlkResult, error) {
+			var res BlkResult
+			err := json.Unmarshal(data, &res)
+			return res, err
+		},
+	}
+}
+
+func (s *BlkList[T]) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if bytes.Equal(b, []byte("null")) {
+		*s = nil
+		return nil
+	}
+	var raws []json.RawMessage
+	if err := json.Unmarshal(b, &raws); err != nil {
+		return err
+	}
+	var out []T
+	for _, r := range raws {
+		if bytes.Equal(bytes.TrimSpace(r), []byte("null")) {
+			continue
+		}
+		var v T
+		if err := json.Unmarshal(r, &v); err != nil {
+			return err
+		}
+		out = append(out, v)
+	}
+	*s = out
+	return nil
+}
+
+/*
+findmnt -n -J --target /olares
+
+	{
+	   "filesystems": [
+	      {
+	         "target": "/olares",
+	         "source": "/dev/mapper/olares--vg-data[/olares]",
+	         "fstype": "ext4",
+	         "options": "rw,relatime"
+	      }
+	   ]
+	}
 */
+type Filesystem struct {
+	Target  string `json:"target"`
+	Source  string `json:"source"`
+	Fstype  string `json:"fstype"`
+	Options string `json:"options"`
+}
+
+type FindMntResult struct {
+	Filesystems []Filesystem `json:"filesystems"`
+}
+
+const FINDMNT = "findmnt"
+
+func CommandFindMnt() *command[FindMntResult] {
+	cmd := findCmd(FINDMNT)
+	return &command[FindMntResult]{
+		cmd:         cmd,
+		defaultArgs: []string{"-J"},
+		format: func(data []byte) (FindMntResult, error) {
+			var res FindMntResult
+			err := json.Unmarshal(data, &res)
+			return res, err
+		},
+	}
+}

--- a/cli/pkg/utils/lvm/lvm.go
+++ b/cli/pkg/utils/lvm/lvm.go
@@ -24,18 +24,21 @@ const (
 	}
 */
 type LvItem struct {
-	LvName          string `json:"lv_name"`
-	VgName          string `json:"vg_name"`
-	LvAttr          string `json:"lv_attr"`
-	LvSize          string `json:"lv_size"`
-	PoolLv          string `json:"pool_lv"`
-	Origin          string `json:"origin"`
-	DataPercent     string `json:"data_percent"`
-	MetadataPercent string `json:"metadata_percent"`
-	MovePv          string `json:"move_pv"`
-	MirrorLog       string `json:"mirror_log"`
-	CopyPercent     string `json:"copy_percent"`
-	ConvertLv       string `json:"convert_lv"`
+	LvName          string   `json:"lv_name"`
+	VgName          string   `json:"vg_name"`
+	LvAttr          string   `json:"lv_attr"`
+	LvSize          string   `json:"lv_size"`
+	PoolLv          string   `json:"pool_lv"`
+	Origin          string   `json:"origin"`
+	DataPercent     string   `json:"data_percent"`
+	MetadataPercent string   `json:"metadata_percent"`
+	MovePv          string   `json:"move_pv"`
+	MirrorLog       string   `json:"mirror_log"`
+	CopyPercent     string   `json:"copy_percent"`
+	ConvertLv       string   `json:"convert_lv"`
+	LvPath          string   `json:"lv_path"`
+	LvDmPath        string   `json:"lv_dm_path"`
+	Mountpoints     []string `json:"mountpoints"`
 }
 
 type LvsResult struct {
@@ -78,6 +81,7 @@ type VgItem struct {
 	VgAttr    string `json:"vg_attr"`
 	VgSize    string `json:"vg_size"`
 	VgFree    string `json:"vg_free"`
+	PvName    string `json:"pv_name"`
 }
 
 type VgsResult struct {

--- a/cli/pkg/utils/lvm/tools.go
+++ b/cli/pkg/utils/lvm/tools.go
@@ -1,0 +1,272 @@
+package lvm
+
+import (
+	"errors"
+	"log"
+	"os"
+	"os/exec"
+	"slices"
+)
+
+func FindCurrentLVM() ([]*VgItem, error) {
+	VG := CommandVGS()
+	result, errmsg, err := VG.Run()
+	if err != nil {
+		log.Printf("failed to run vgs command: %s \n%s\n", err, errmsg)
+		return nil, err
+	}
+
+	if len(result.Report) == 0 || len(result.Report[0].Vg) == 0 {
+		err = errors.New("no volume groups found")
+		return nil, err
+	}
+
+	var vgs []*VgItem
+	for _, vg := range result.Report[0].Vg {
+		if vg.PvCount == "0" || vg.LvCount == "0" {
+			continue
+		}
+		vgs = append(vgs, &vg)
+	}
+
+	if len(vgs) == 0 {
+		err = errors.New("no valid volume groups found")
+		return nil, err
+	}
+
+	return vgs, nil
+}
+
+func FindUnmountedDevices() (map[string]*BlkPart, error) {
+	lblkCmd := CommandLBLK()
+	result, errmsg, err := lblkCmd.Run()
+	if err != nil {
+		log.Printf("failed to run lsblk command: %s \n%s\n", err, errmsg)
+		return nil, err
+	}
+
+	var unmountedDevices map[string]*BlkPart = make(map[string]*BlkPart)
+	var unmountedPart func(part BlkPart) bool
+	unmountedPart = func(part BlkPart) bool {
+		if len(part.Mountpoints) > 0 {
+			return false
+		}
+
+		if len(part.Mountpoints) == 0 && len(part.Children) == 0 {
+			return true
+		}
+
+		for _, child := range part.Children {
+			if !unmountedPart(child) {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, dev := range result.Blockdevices {
+		if dev.Type != "disk" {
+			continue
+		}
+
+		if unmountedPart(dev) {
+			unmountedDevices["/dev/"+dev.Name] = &dev
+		}
+	}
+
+	return unmountedDevices, nil
+}
+
+func FindLvByVgName(vgName string) ([]*LvItem, error) {
+	LV := CommandLVS()
+	result, errmsg, err := LV.Run("-o", "+lv_dm_path,lv_path")
+	if err != nil {
+		log.Printf("failed to run lvs command: %s \n%s\n", err, errmsg)
+		return nil, err
+	}
+
+	if len(result.Report) == 0 || len(result.Report[0].Lv) == 0 {
+		return nil, nil
+	}
+
+	var lvs []*LvItem
+	for _, lv := range result.Report[0].Lv {
+		if lv.VgName == vgName {
+			mountpoints, err := FindMountpointsByLvDmPath(lv.LvDmPath)
+			if err == nil {
+				lv.Mountpoints = mountpoints
+			}
+			lvs = append(lvs, &lv)
+		}
+	}
+
+	return lvs, nil
+}
+
+func FindMountpointsByLvDmPath(lvDmPath string) ([]string, error) {
+	FINDMNT := CommandFindMnt()
+	result, errmsg, err := FINDMNT.Run(lvDmPath)
+	if err != nil && errmsg != "" {
+		log.Printf("failed to run findmnt command: %s \n%s\n", err, errmsg)
+		return nil, err
+	}
+
+	if len(result.Filesystems) == 0 {
+		return nil, nil
+	}
+
+	var mountpoints []string
+	for _, fs := range result.Filesystems {
+		mountpoints = append(mountpoints, fs.Target)
+	}
+
+	return mountpoints, nil
+}
+
+/*
+wipefs -a /dev/nvme0n1
+sgdisk --zap-all /dev/nvme0n1
+*/
+func DeleteDevicePartitions(devicePath string) error {
+	c, err := exec.Command("wipefs", "-a", devicePath).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to wipe device %s: %s\n", devicePath, c)
+		return err
+	}
+
+	// c, err = exec.Command("sgdisk", "--zap-all", devicePath).CombinedOutput()
+	// if err != nil {
+	// 	log.Printf("failed to zap device %s: %s\n", devicePath, c)
+	// 	return err
+	// }
+
+	return nil
+}
+
+/*
+sudo parted /dev/sdX mklabel gpt
+sudo parted -a optimal /dev/sdX mkpart primary 1MiB 100%
+*/
+func MakePartOnDevice(devicePath string) error {
+	c, err := exec.Command("parted", devicePath, "mklabel", "gpt").CombinedOutput()
+	if err != nil {
+		log.Printf("failed to make partition table on device %s: %s\n", devicePath, c)
+		return err
+	}
+
+	c, err = exec.Command("parted", "-a", "optimal", devicePath, "mkpart", "primary", "1MiB", "100%").CombinedOutput()
+	if err != nil {
+		log.Printf("failed to make partition on device %s: %s\n", devicePath, c)
+		return err
+	}
+
+	return nil
+}
+
+/*
+sudo pvcreate /dev/sdX1
+sudo vgextend target_vg /dev/sdX1
+*/
+func AddNewPV(devicePath string, vg string) error {
+	partition := devicePath + "p1"
+	c, err := exec.Command("pvcreate", partition).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to create physical volume on device %s: %s\n", partition, c)
+		return err
+	}
+
+	c, err = exec.Command("vgextend", vg, partition).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to extend volume group %s with device %s: %s\n", vg, partition, c)
+		return err
+	}
+
+	return nil
+}
+
+/*
+lvextend -l +100%FREE "/dev/$VG_NAME/$LV_ROOT_NAME"
+resize2fs "/dev/$VG_NAME/$LV_ROOT_NAME"
+*/
+func ExtendLv(vg, lv string) error {
+	c, err := exec.Command("lvextend", "-l", "+100%FREE", "/dev/"+vg+"/"+lv).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to extend logical volume %s in volume group %s: %s\n", lv, vg, c)
+		return err
+	}
+
+	c, err = exec.Command("resize2fs", "/dev/"+vg+"/"+lv).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to resize filesystem on logical volume %s in volume group %s: %s\n", lv, vg, c)
+		return err
+	}
+
+	return nil
+}
+
+func DeactivateLv(vg string) error {
+	c, err := exec.Command("lvchange", "-an", vg).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to deactivate logical volume in volume group %s: %s\n", vg, c)
+		return err
+	}
+
+	return nil
+}
+
+func RemoveLv(lvpath string) error {
+	_, err := os.Stat(lvpath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		log.Printf("failed to stat logical volume %s: %s\n", lvpath, err)
+		return err
+	}
+
+	c, err := exec.Command("lvremove", "-f", lvpath).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to remove logical volume %s: %s\n", lvpath, c)
+		return err
+	}
+
+	return nil
+}
+
+func RemoveVg(vg string) error {
+	c, err := exec.Command("vgremove", "-f", vg).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to remove volume group %s: %s\n", vg, c)
+		return err
+	}
+
+	return nil
+}
+
+func RemovePv(pv string) error {
+	c, err := exec.Command("pvremove", "-f", pv).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to remove physical volume %s: %s\n", pv, c)
+		return err
+	}
+
+	return nil
+}
+
+func FindVgsOnDevice(devicePaths []string) ([]*VgItem, error) {
+	VG := CommandVGS()
+	result, errmsg, err := VG.Run("-o", "+pv_name")
+	if err != nil {
+		log.Printf("failed to run vgs command: %s \n%s\n", err, errmsg)
+		return nil, err
+	}
+
+	var vgs []*VgItem
+	for _, vg := range result.Report[0].Vg {
+		if slices.Contains(devicePaths, vg.PvName) {
+			vgs = append(vgs, &vg)
+		}
+	}
+
+	return vgs, nil
+}

--- a/daemon/internel/intranet/dsr_linux.go
+++ b/daemon/internel/intranet/dsr_linux.go
@@ -477,7 +477,7 @@ func (d *DSRProxy) regonfigure() error {
 	klog.Infof("Calico interface: %s", d.calicoInterface.Name)
 
 	var err error
-	d.pcapHandle, err = pcap.OpenLive(d.vipInterface.Name, 65536, true, pcap.BlockForever)
+	d.pcapHandle, err = pcap.OpenLive(d.vipInterface.Name, 65536, false, pcap.BlockForever)
 	if err != nil {
 		klog.Error("pcap openlive failed:", err)
 		return err

--- a/daemon/internel/watcher/intranet/watchers.go
+++ b/daemon/internel/watcher/intranet/watchers.go
@@ -3,6 +3,7 @@ package intranet
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/beclab/Olares/daemon/internel/intranet"
@@ -248,7 +249,15 @@ func getPodNeighborInfo(podIp string) (mac, iface string, err error) {
 		}
 	}
 
-	// try to
+	// try to refresh neighbor table
+	go func() {
+		cmd := exec.Command("ping", "-c", "3", podIp)
+		err := cmd.Run()
+		if err != nil {
+			klog.Error("ping pod ip to refresh neighbor table error, ", err)
+			return
+		}
+	}()
 
 	return "", "", fmt.Errorf("not found pod neighbor info for ip %s", podIp)
 }


### PR DESCRIPTION
* **Background**
Add some disk management to olares-cli.
If the Olares is installed on LVM, the olares-cli can be used to manage the LVM. Using the `disk extend` command to add the new disk to the Olares volume.
 
```bash
disk management operations

Usage:
  olares-cli disk [command]

Available Commands:
  extend         Extend disk operations
  list-unmounted List unmounted disks

Flags:
  -h, --help   help for disk
```

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
