### PR TITLE
docs: add Getlood native apps documentation and manifests

### DIFF
--- a/getlood-native-apps/ARCHITECTURE.md
+++ b/getlood-native-apps/ARCHITECTURE.md
@@ -1,0 +1,439 @@
+# Architecture Native Olares : Intégration AIOS & SmythOS via YAML
+
+**Auteur** : Manus AI
+**Date** : 17 novembre 2025
+**Version** : 3.0.0
+
+---
+
+## 🎯 Vision Simplifiée
+
+Au lieu de créer des couches MCP complexes, nous utilisons directement **l'infrastructure native d'Olares** :
+
+- **Kubernetes d'Olares** pour l'orchestration
+- **Docker d'Olares** pour les conteneurs
+- **Réseau Olares** pour la communication
+- **BFL Gateway** pour le routing
+
+AIOS et SmythOS deviennent de **simples applications Olares rebrandées**, orchestrées uniquement par des **manifestes YAML**.
+
+---
+
+## 🏗️ Architecture Globale
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  OLARES DESKTOP (Interface Utilisateur)                     │
+│  - Files, Settings, Market, Desktop                         │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         ↓ BFL Gateway (Routing HTTP/gRPC)
+┌────────────────────────┼─────────────────────────────────────┐
+│  APPLICATIONS OLARES (Rebrandées)                           │
+│                        │                                     │
+│  ┌──────────────────────────────────────────┐               │
+│  │  Getlood Brain (AIOS Rebrandé)           │               │
+│  │  - Namespace: getloodbrain-{user}        │               │
+│  │  - URL: api.getloodbrain.{user}.local    │               │
+│  │  - Services: Scheduler, Context, Memory  │               │
+│  └──────────────────────────────────────────┘               │
+│                                                              │
+│  ┌──────────────────────────────────────────┐               │
+│  │  Getlood Agents (SmythOS Rebrandé)       │               │
+│  │  - Namespace: getloodagents-{user}       │               │
+│  │  - URL: api.getloodagents.{user}.local   │               │
+│  │  - Services: Agent Runtime, LLM Manager  │               │
+│  └──────────────────────────────────────────┘               │
+│                                                              │
+│  ┌──────────────────────────────────────────┐               │
+│  │  Getlood LLM (Ollama Rebrandé)           │               │
+│  │  - Namespace: getloodllm-{user}          │               │
+│  │  - URL: api.getloodllm.{user}.local      │               │
+│  │  - Services: Ollama, vLLM                │               │
+│  └──────────────────────────────────────────┘               │
+└────────────────────────┼─────────────────────────────────────┘
+                         │
+                         ↓ Kubernetes Services
+┌────────────────────────┼─────────────────────────────────────┐
+│  OLARES KUBERNETES CLUSTER                                   │
+│  - Namespaces par utilisateur                               │
+│  - Services avec DNS interne                                │
+│  - PersistentVolumes pour données                           │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🔑 Principes Clés
+
+### 1. **Zéro Code Custom**
+
+Tout est orchestré par des **manifestes YAML** :
+- OlaresManifest.yaml (métadonnées app)
+- Deployment.yaml (Kubernetes)
+- Service.yaml (réseau)
+- PVC.yaml (stockage)
+
+### 2. **BFL Gateway comme Routeur**
+
+Le BFL Gateway d'Olares route automatiquement le trafic vers les applications via des **annotations** :
+
+```yaml
+metadata:
+  annotations:
+    applications.app.bytetrade.io/entrances: |
+      - name: api
+        host: api.getloodbrain.{username}.{olares.local}
+        port: 8080
+        title: Getlood Brain API
+```
+
+### 3. **Réseau Olares Natif**
+
+Chaque application obtient automatiquement :
+- Un **namespace Kubernetes** : `getloodbrain-{username}`
+- Un **service DNS** : `getloodbrain-svc.getloodbrain-{username}.svc.cluster.local`
+- Une **URL publique** : `https://api.getloodbrain.{username}.olares.local`
+
+### 4. **Authentification via Authelia**
+
+Toutes les requêtes passent par **Authelia** (SSO d'Olares) :
+- Pas besoin de gérer des tokens
+- Authentification unique
+- RBAC intégré
+
+---
+
+## 📦 Applications Olares Rebrandées
+
+### 1. Getlood Brain (AIOS Rebrandé)
+
+**Rôle** : Kernel AI pour orchestration intelligente.
+
+**Composants** :
+- AIOS Scheduler
+- AIOS Context Manager
+- AIOS Memory Manager
+- AIOS LLM Core
+- AIOS Storage Manager
+
+**Architecture de Communication** :
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Getlood Brain Architecture                        │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  API Gateway (Port 8080)                     │  │
+│  │  - Entrée principale                         │  │
+│  │  - Routing des requêtes                      │  │
+│  └──────────────┬───────────────────────────────┘  │
+│                 │                                   │
+│     ┌───────────┼───────────┬───────────┐          │
+│     ↓           ↓           ↓           ↓          │
+│  ┌──────┐  ┌────────┐  ┌────────┐  ┌─────────┐   │
+│  │Sched │  │Context │  │Memory  │  │LLM Core │   │
+│  │:8001 │  │:8002   │  │:8003   │  │:8004    │   │
+│  └──┬───┘  └────────┘  └───┬────┘  └────┬────┘   │
+│     │                       │            │         │
+│     └───────────────────────┼────────────┘         │
+│                             ↓                      │
+│                    ┌─────────────────┐             │
+│                    │ Storage Manager │             │
+│                    │      :8005      │             │
+│                    └─────────────────┘             │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+### 2. Getlood Agents (SmythOS Rebrandé)
+
+**Rôle** : Runtime pour agents AI autonomes.
+
+**Composants** :
+- SmythOS Agent Runtime
+- SmythOS LLM Manager
+- SmythOS Workflow Engine
+- SmythOS Tool Manager
+
+**Architecture de Communication** :
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Getlood Agents Architecture                       │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  Agent Runtime (Port 8080)                   │  │
+│  │  - Exécution des agents                      │  │
+│  │  - Communication inter-agents                │  │
+│  └──────────────┬───────────────────────────────┘  │
+│                 │                                   │
+│     ┌───────────┼───────────┬───────────┐          │
+│     ↓           ↓           ↓           ↓          │
+│  ┌──────┐  ┌────────┐  ┌────────┐  ┌──────────┐  │
+│  │LLM   │  │Workflow│  │Tool    │  │UI        │  │
+│  │Mgr   │  │Engine  │  │Manager │  │:3000     │  │
+│  │:8081 │  │:8082   │  │:8083   │  │          │  │
+│  └──┬───┘  └───┬────┘  └────────┘  └──────────┘  │
+│     │          │                                   │
+│     │          │   Calls Brain API                │
+│     │          └──────────────────────────────────►│
+│     │                                               │
+│     │   Calls Getlood LLM                          │
+│     └──────────────────────────────────────────────►│
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+### 3. Getlood LLM (Ollama Rebrandé)
+
+**Rôle** : Runtime LLM local avec support GPU.
+
+**Composants** :
+- Ollama (LLM inference)
+- Model Manager (téléchargement/gestion modèles)
+
+**Architecture** :
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Getlood LLM Architecture                          │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  Ollama Runtime (Port 11434)                 │  │
+│  │  - Inférence LLM                             │  │
+│  │  - Gestion des modèles                       │  │
+│  │  - Support GPU (optionnel)                   │  │
+│  └──────────────────────────────────────────────┘  │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  Model Manager (Port 8080)                   │  │
+│  │  - Téléchargement modèles                    │  │
+│  │  - Mise à jour modèles                       │  │
+│  └──────────────────────────────────────────────┘  │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  UI (Port 3000)                              │  │
+│  │  - Interface de gestion                      │  │
+│  └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+### 4. Getlood VectorDB (Qdrant Rebrandé)
+
+**Rôle** : Base de données vectorielle pour embeddings.
+
+**Architecture** :
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Getlood VectorDB Architecture                     │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  Qdrant (Port 6333 HTTP, 6334 gRPC)         │  │
+│  │  - Stockage vectoriel                        │  │
+│  │  - Recherche sémantique                      │  │
+│  │  - Snapshots                                 │  │
+│  └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🔄 Communication entre Applications
+
+### Via Services Kubernetes
+
+Les applications communiquent via des **services Kubernetes** :
+
+```yaml
+# Getlood Agents appelle Getlood Brain
+GET http://getloodbrain-svc.getloodbrain-{username}.svc:8080/api/scheduler/submit
+
+# Getlood Brain appelle Getlood LLM
+POST http://getloodllm-svc.getloodllm-{username}.svc:11434/api/generate
+
+# Getlood Brain appelle Getlood VectorDB
+POST http://getloodvectordb-svc.getloodvectordb-{username}.svc:6333/collections/search
+```
+
+### Via BFL Gateway (Externe)
+
+Les utilisateurs accèdent via le **BFL Gateway** :
+
+```bash
+# Depuis le navigateur ou CLI
+curl https://api.getloodbrain.alice.olares.local/api/scheduler/status
+curl https://api.getloodagents.alice.olares.local/api/agents/list
+curl https://api.getloodllm.alice.olares.local/api/tags
+```
+
+---
+
+## 🚀 Déploiement
+
+### Étape 1 : Créer les Namespaces
+
+Olares crée automatiquement les namespaces lors de l'installation :
+
+```bash
+# Exemple pour utilisateur "alice"
+getloodbrain-alice
+getloodagents-alice
+getloodllm-alice
+getloodvectordb-alice
+```
+
+### Étape 2 : Déployer les Services
+
+Chaque application déploie ses services :
+
+```yaml
+# Exemple pour Getlood Brain
+apiVersion: v1
+kind: Service
+metadata:
+  name: getloodbrain-svc
+  namespace: getloodbrain-alice
+spec:
+  selector:
+    app: getloodbrain
+  ports:
+    - name: api
+      port: 8080
+      targetPort: 8080
+```
+
+### Étape 3 : Configurer le BFL Gateway
+
+Le BFL Gateway route automatiquement :
+
+```yaml
+# Route créée automatiquement
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: getloodbrain-ingress
+  namespace: getloodbrain-alice
+spec:
+  rules:
+    - host: api.getloodbrain.alice.olares.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: getloodbrain-svc
+                port:
+                  number: 8080
+```
+
+---
+
+## 🔐 Sécurité
+
+### Authentification
+
+Toutes les requêtes passent par **Authelia** :
+
+```
+User Request
+    ↓
+BFL Gateway
+    ↓
+Authelia (SSO)
+    ↓ (if authenticated)
+Application
+```
+
+### Isolation
+
+Chaque utilisateur a ses propres namespaces :
+
+```bash
+# Utilisateur Alice
+getloodbrain-alice
+getloodagents-alice
+
+# Utilisateur Bob
+getloodbrain-bob
+getloodagents-bob
+```
+
+### Permissions
+
+Les applications définissent leurs permissions via `sysData` :
+
+```yaml
+permission:
+  sysData:
+    - dataType: legacy_api
+      appName: getloodbrain
+      port: 8080
+      group: api.getloodbrain
+      version: v1
+      ops:
+        - POST
+        - GET
+        - PUT
+        - DELETE
+```
+
+---
+
+## 📊 Monitoring
+
+### Via Kubernetes
+
+```bash
+# Voir tous les pods
+kubectl get pods -A | grep getlood
+
+# Voir les logs
+kubectl logs -f {pod-name} -n {namespace}
+
+# Voir les ressources
+kubectl top pods -n {namespace}
+```
+
+### Via Olares Dashboard
+
+```
+Control Hub > Applications > Getlood *
+- Status
+- CPU/Memory usage
+- Logs
+- Metrics
+```
+
+---
+
+## ✅ Avantages de cette Architecture
+
+| Aspect | Avantage |
+|---|---|
+| **Simplicité** | Zéro code custom, uniquement YAML |
+| **Native** | Utilise 100% l'infrastructure Olares |
+| **Isolation** | Chaque app dans son namespace |
+| **Sécurité** | Authelia SSO intégré |
+| **Scalabilité** | Kubernetes natif |
+| **Maintenance** | Sync avec upstream via Git |
+| **UX** | Interface Olares familière |
+
+---
+
+## 🎯 Conclusion
+
+Cette architecture **native Olares** est la plus simple et la plus élégante :
+
+1. **Pas de MCP Gateway** : Le BFL Gateway d'Olares suffit
+2. **Pas de code custom** : Uniquement des manifestes YAML
+3. **Pas de modification d'Olares** : Respect de la contrainte
+4. **Intégration parfaite** : AIOS et SmythOS deviennent des citoyens de première classe d'Olares
+
+**Getlood OS** devient un **ensemble d'applications Olares** qui transforment la plateforme en un système d'exploitation AI complet.

--- a/getlood-native-apps/README.md
+++ b/getlood-native-apps/README.md
@@ -1,0 +1,391 @@
+# Getlood Native Apps : Applications Olares Rebrandées
+
+Ce répertoire contient les **4 applications Olares** qui transforment Olares en **Getlood OS**, une plateforme AI agentique complète.
+
+## 🎯 Vue d'Ensemble
+
+Les applications sont des **versions rebrandées** d'AIOS et SmythOS, intégrées nativement dans Olares via des manifestes YAML. Aucun code custom n'est nécessaire : tout est orchestré par Kubernetes, Docker et le BFL Gateway d'Olares.
+
+## 📦 Applications
+
+### 1. Getlood Brain (AIOS Rebrandé)
+
+**Rôle** : Kernel AI pour orchestration intelligente des ressources.
+
+**Composants** :
+- AIOS Scheduler : Ordonnancement des tâches AI
+- AIOS Context Manager : Gestion du contexte conversationnel
+- AIOS Memory Manager : Mémoire à long terme avec RAG
+- AIOS LLM Core : Adaptateur multi-modèles LLM
+- AIOS Storage Manager : Système de fichiers sémantique
+
+**URLs** :
+- API : `https://api.getloodbrain.{username}.olares.local`
+- UI : `https://ui.getloodbrain.{username}.olares.local`
+
+**Dépendances** :
+- Getlood LLM (pour l'inférence LLM)
+- Getlood VectorDB (pour les embeddings)
+
+---
+
+### 2. Getlood Agents (SmythOS Rebrandé)
+
+**Rôle** : Runtime pour agents AI autonomes.
+
+**Composants** :
+- SmythOS Agent Runtime : Exécution des agents
+- SmythOS LLM Manager : Gestion des modèles LLM
+- SmythOS Workflow Engine : Orchestration de workflows
+- SmythOS Tool Manager : Gestion des outils et APIs
+
+**URLs** :
+- API : `https://api.getloodagents.{username}.olares.local`
+- UI : `https://ui.getloodagents.{username}.olares.local`
+
+**Dépendances** :
+- Getlood Brain (pour l'orchestration)
+- Getlood LLM (pour l'inférence LLM)
+
+---
+
+### 3. Getlood LLM (Ollama Rebrandé)
+
+**Rôle** : Runtime LLM local avec support GPU.
+
+**Composants** :
+- Ollama : Inférence LLM locale
+- Model Manager : Téléchargement et gestion des modèles
+
+**URLs** :
+- API : `https://api.getloodllm.{username}.olares.local`
+- UI : `https://ui.getloodllm.{username}.olares.local`
+
+**Modèles Recommandés** :
+- Llama 3.1 8B (4.7GB) : Généraliste excellent
+- Mistral 7B (4.1GB) : Rapide et efficace
+- Phi-3 Mini (2.3GB) : Léger pour tâches simples
+- DeepSeek Coder 6.7B (3.8GB) : Spécialisé code
+
+**Dépendances** : Aucune
+
+---
+
+### 4. Getlood VectorDB (Qdrant Rebrandé)
+
+**Rôle** : Base de données vectorielle pour embeddings.
+
+**Composants** :
+- Qdrant : Stockage et recherche vectorielle haute performance
+
+**URLs** :
+- API : `https://api.getloodvectordb.{username}.olares.local`
+- Dashboard : `https://dashboard.getloodvectordb.{username}.olares.local`
+
+**Dépendances** : Aucune
+
+---
+
+## 🚀 Installation
+
+### Prérequis
+
+- Une instance Olares fonctionnelle (v1.0.0+)
+- Accès au Olares Market
+- Au minimum 8GB RAM, 200GB disque
+
+### Ordre d'Installation
+
+1. **Getlood VectorDB** (infrastructure)
+2. **Getlood LLM** (infrastructure)
+3. **Getlood Brain** (kernel)
+4. **Getlood Agents** (applications)
+
+### Méthode 1 : Via Olares Market (Recommandée)
+
+```bash
+# 1. Ouvrir Olares Market
+Market > Search "Getlood"
+
+# 2. Installer dans l'ordre
+Install "Getlood VectorDB" → Wait for "Running"
+Install "Getlood LLM" → Wait for "Running"
+Install "Getlood Brain" → Wait for "Running"
+Install "Getlood Agents" → Wait for "Running"
+
+# 3. Télécharger un modèle LLM
+Open "Getlood LLM UI" → Download Model → "Llama 3.1 8B"
+```
+
+### Méthode 2 : Via CLI (Avancée)
+
+```bash
+# 1. Cloner ce dépôt
+git clone https://github.com/Getlood/getlood-native-apps.git
+cd getlood-native-apps
+
+# 2. Installer les applications
+kubectl apply -f getlood-vectordb/OlaresManifest.yaml
+kubectl apply -f getlood-llm/OlaresManifest.yaml
+kubectl apply -f getlood-brain/OlaresManifest.yaml
+kubectl apply -f getlood-agents/OlaresManifest.yaml
+
+# 3. Vérifier le statut
+kubectl get applications -n user-space-{username}
+```
+
+---
+
+## 🔧 Configuration
+
+### GPU (Optionnel mais Recommandé)
+
+Pour activer le GPU sur Getlood LLM :
+
+```yaml
+# Éditer getlood-llm/OlaresManifest.yaml
+resources:
+  limits:
+    nvidia.com/gpu: 1  # Ajouter cette ligne
+```
+
+### Modèles LLM
+
+Télécharger des modèles via l'UI ou CLI :
+
+```bash
+# Via CLI
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull llama3.1:8b
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull mistral:7b
+```
+
+### Mémoire et CPU
+
+Ajuster les ressources selon votre hardware :
+
+```yaml
+# Dans chaque OlaresManifest.yaml
+resources:
+  requests:
+    cpu: 1000m      # Minimum
+    memory: 2Gi     # Minimum
+  limits:
+    cpu: 4000m      # Maximum
+    memory: 8Gi     # Maximum
+```
+
+---
+
+## 🧪 Tests
+
+### Test 1 : Getlood VectorDB
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/collections
+# Attendu : {"result": {"collections": []}, "status": "ok", "time": 0.001}
+```
+
+### Test 2 : Getlood LLM
+
+```bash
+curl https://api.getloodllm.{username}.olares.local/api/tags
+# Attendu : Liste des modèles installés
+```
+
+### Test 3 : Getlood Brain
+
+```bash
+curl https://api.getloodbrain.{username}.olares.local/health
+# Attendu : {"status": "healthy", "components": {...}}
+```
+
+### Test 4 : Getlood Agents
+
+```bash
+curl https://api.getloodagents.{username}.olares.local/agents
+# Attendu : {"agents": [], "total": 0}
+```
+
+### Test End-to-End
+
+```bash
+# Créer un agent simple
+curl -X POST https://api.getloodagents.{username}.olares.local/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Test Agent",
+    "description": "A simple test agent",
+    "model": "llama3.1:8b",
+    "system_prompt": "You are a helpful assistant."
+  }'
+
+# Exécuter l'agent
+curl -X POST https://api.getloodagents.{username}.olares.local/agents/{agent_id}/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Hello, who are you?"
+  }'
+```
+
+---
+
+## 📊 Monitoring
+
+### Via Olares Control Hub
+
+```
+Control Hub > Applications > Getlood *
+- Status : Running / Stopped / Error
+- CPU : Usage en temps réel
+- Memory : Usage en temps réel
+- Logs : Derniers 1000 lignes
+```
+
+### Via Kubernetes
+
+```bash
+# Pods
+kubectl get pods -n getloodbrain-{username}
+kubectl get pods -n getloodagents-{username}
+kubectl get pods -n getloodllm-{username}
+kubectl get pods -n getloodvectordb-{username}
+
+# Logs
+kubectl logs -f getloodbrain-scheduler-0 -n getloodbrain-{username}
+kubectl logs -f getloodagents-runtime-0 -n getloodagents-{username}
+
+# Services
+kubectl get svc -n getloodbrain-{username}
+```
+
+---
+
+## 🐛 Dépannage
+
+### Problème : Application ne démarre pas
+
+```bash
+# Vérifier les événements
+kubectl describe pod {pod-name} -n {namespace}
+
+# Vérifier les logs
+kubectl logs {pod-name} -n {namespace}
+
+# Vérifier les ressources
+kubectl top pod {pod-name} -n {namespace}
+```
+
+### Problème : Erreur 502 Bad Gateway
+
+```bash
+# Vérifier le service
+kubectl get svc -n {namespace}
+
+# Vérifier les endpoints
+kubectl get endpoints -n {namespace}
+
+# Redémarrer le pod
+kubectl delete pod {pod-name} -n {namespace}
+```
+
+### Problème : Modèle LLM non trouvé
+
+```bash
+# Lister les modèles
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama list
+
+# Télécharger un modèle
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull llama3.1:8b
+```
+
+### Problème : Manque de mémoire
+
+```bash
+# Augmenter les limites dans OlaresManifest.yaml
+resources:
+  limits:
+    memory: 16Gi  # Au lieu de 8Gi
+
+# Redéployer
+kubectl apply -f {app}/OlaresManifest.yaml
+```
+
+---
+
+## 🔄 Mise à Jour
+
+### Via Olares Market
+
+```
+Market > My Apps > Getlood * > Update
+```
+
+### Via CLI
+
+```bash
+# Pull latest
+git pull origin main
+
+# Redéployer
+kubectl apply -f getlood-vectordb/OlaresManifest.yaml
+kubectl apply -f getlood-llm/OlaresManifest.yaml
+kubectl apply -f getlood-brain/OlaresManifest.yaml
+kubectl apply -f getlood-agents/OlaresManifest.yaml
+```
+
+---
+
+## 🗑️ Désinstallation
+
+### Via Olares Market
+
+```
+Market > My Apps > Getlood * > Uninstall
+```
+
+### Via CLI
+
+```bash
+# Supprimer les applications (dans l'ordre inverse)
+kubectl delete application getloodagents -n user-space-{username}
+kubectl delete application getloodbrain -n user-space-{username}
+kubectl delete application getloodllm -n user-space-{username}
+kubectl delete application getloodvectordb -n user-space-{username}
+
+# Supprimer les namespaces
+kubectl delete namespace getloodagents-{username}
+kubectl delete namespace getloodbrain-{username}
+kubectl delete namespace getloodllm-{username}
+kubectl delete namespace getloodvectordb-{username}
+```
+
+---
+
+## 📖 Documentation
+
+- [Architecture Native Olares](./ARCHITECTURE.md)
+- [Documentation AIOS](https://github.com/Getlood/AIOS)
+- [Documentation SmythOS](https://smythos.com/docs)
+- [Documentation Olares](https://docs.olares.com)
+
+---
+
+## 🤝 Contribution
+
+Les contributions sont les bienvenues ! Voir [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+---
+
+## 📄 Licence
+
+Apache 2.0 - Voir [LICENSE](../LICENSE).
+
+---
+
+## 🙏 Remerciements
+
+- [Olares](https://olares.com) pour la plateforme
+- [AIOS](https://github.com/agiresearch/AIOS) pour le kernel AI
+- [SmythOS](https://smythos.com) pour le runtime agents
+- [Ollama](https://ollama.com) pour le runtime LLM
+- [Qdrant](https://qdrant.tech) pour la base vectorielle

--- a/getlood-native-apps/getlood-agents/OlaresManifest.yaml
+++ b/getlood-native-apps/getlood-agents/OlaresManifest.yaml
@@ -1,0 +1,228 @@
+apiVersion: app.bytetrade.io/v1alpha1
+kind: Application
+metadata:
+  name: getloodagents
+  namespace: "{{ .Values.userspace }}"
+spec:
+  metadata:
+    title: Getlood Agents
+    description: Autonomous AI agents runtime powered by SmythOS
+    icon: https://file.bttcdn.com/appstore/getlood/getloodagents.webp
+    appid: getloodagents
+    version: 1.0.0
+    categories:
+      - AI
+      - Automation
+      - Productivity
+    author: Getlood
+    website: https://getlood.com
+    sourceCode: https://github.com/Getlood/getlood-smythos
+    submitter: Getlood
+    language:
+      - en
+    requiredMemory: 2Gi
+    requiredDisk: 20Gi
+    requiredCpu: 1000m
+    supportClient:
+      edge: "N/A"
+
+  entrances:
+    - name: api
+      host: api
+      port: 8080
+      title: Getlood Agents API
+      authLevel: private
+      invisible: false
+    - name: ui
+      host: ui
+      port: 3000
+      title: Getlood Agents Studio
+      authLevel: private
+      invisible: false
+
+  permission:
+    appData: true
+    appCache: true
+    userData:
+      - Home/Documents
+      - Home/Downloads
+    sysData:
+      - dataType: legacy_api
+        appName: getloodagents
+        port: 8080
+        group: api.getloodagents
+        version: v1
+        ops:
+          - POST
+          - GET
+          - PUT
+          - DELETE
+
+  middleware:
+    postgres:
+      username: getloodagents
+      password: "{{ randAlphaNum 16 }}"
+      databases:
+        - name: getloodagents
+          distributed: false
+    redis:
+      password: "{{ randAlphaNum 16 }}"
+      namespace: getloodagents
+
+  options:
+    dependencies:
+      - name: getloodbrain
+        type: application
+        version: ">=1.0.0"
+      - name: getloodllm
+        type: application
+        version: ">=1.0.0"
+
+  deployment:
+    - name: getloodagents-runtime
+      image: getlood/smythos-runtime:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /app/agents
+      env:
+        - name: BRAIN_API_URL
+          value: "http://getloodbrain-api.{{ .Values.userspace }}:8080"
+        - name: LLM_API_URL
+          value: "http://getloodllm-svc.{{ .Values.userspace }}:11434"
+        - name: LLM_MANAGER_URL
+          value: "http://getloodagents-llm-manager:8081"
+        - name: WORKFLOW_ENGINE_URL
+          value: "http://getloodagents-workflow:8082"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodagents"
+        - name: REDIS_HOST
+          value: "{{ .Values.redis.host }}"
+        - name: REDIS_PORT
+          value: "{{ .Values.redis.port }}"
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis.password }}"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+
+    - name: getloodagents-llm-manager
+      image: getlood/smythos-llm-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8081
+          protocol: TCP
+      env:
+        - name: OLLAMA_URL
+          value: "http://getloodllm-svc.{{ .Values.userspace }}:11434"
+        - name: BRAIN_LLM_URL
+          value: "http://getloodbrain-llm.{{ .Values.userspace }}:8004"
+        - name: REDIS_HOST
+          value: "{{ .Values.redis.host }}"
+        - name: REDIS_PORT
+          value: "{{ .Values.redis.port }}"
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis.password }}"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+
+    - name: getloodagents-workflow
+      image: getlood/smythos-workflow:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8082
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /app/workflows
+      env:
+        - name: RUNTIME_URL
+          value: "http://getloodagents-runtime:8080"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodagents"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+
+    - name: getloodagents-tool-manager
+      image: getlood/smythos-tool-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8083
+          protocol: TCP
+      env:
+        - name: RUNTIME_URL
+          value: "http://getloodagents-runtime:8080"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodagents"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+
+    - name: getloodagents-ui
+      image: getlood/smythos-ui:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+      env:
+        - name: API_URL
+          value: "http://getloodagents-runtime:8080"
+        - name: WORKFLOW_URL
+          value: "http://getloodagents-workflow:8082"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi

--- a/getlood-native-apps/getlood-agents/README.md
+++ b/getlood-native-apps/getlood-agents/README.md
@@ -1,0 +1,183 @@
+# Getlood Agents
+
+**Autonomous AI agents runtime powered by SmythOS**
+
+Getlood Agents est le runtime pour agents AI autonomes, basé sur SmythOS. Il permet de créer, déployer et orchestrer des agents AI.
+
+## Composants
+
+### SmythOS Agent Runtime
+Environnement d'exécution pour agents AI avec support multi-agents et communication inter-agents.
+
+### SmythOS LLM Manager
+Gestionnaire de modèles LLM pour distribuer les charges et optimiser les ressources.
+
+### SmythOS Workflow Engine
+Moteur d'orchestration de workflows pour créer des pipelines AI complexes.
+
+### SmythOS Tool Manager
+Gestionnaire d'outils et APIs pour étendre les capacités des agents.
+
+## Installation
+
+```bash
+# Via Olares Market
+Market > Search "Getlood Agents" > Install
+
+# Via CLI
+kubectl apply -f OlaresManifest.yaml
+```
+
+## Configuration
+
+### Ressources Minimales
+
+- CPU: 1000m (1 core)
+- Memory: 2Gi
+- Disk: 20Gi
+
+### Variables d'Environnement
+
+```yaml
+BRAIN_API_URL: "http://getloodbrain-api:8080"
+LLM_API_URL: "http://getloodllm-svc:11434"
+LLM_MANAGER_URL: "http://getloodagents-llm-manager:8081"
+WORKFLOW_ENGINE_URL: "http://getloodagents-workflow:8082"
+```
+
+## Dépendances
+
+- **Getlood Brain** : Pour l'orchestration intelligente
+- **Getlood LLM** : Pour l'inférence LLM
+
+## URLs
+
+- API: `https://api.getloodagents.{username}.olares.local`
+- UI: `https://ui.getloodagents.{username}.olares.local`
+
+## API Endpoints
+
+### List Agents
+
+```bash
+curl https://api.getloodagents.{username}.olares.local/agents
+```
+
+### Create Agent
+
+```bash
+curl -X POST https://api.getloodagents.{username}.olares.local/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Research Agent",
+    "description": "Agent for research tasks",
+    "model": "llama3.1:8b",
+    "system_prompt": "You are a research assistant.",
+    "tools": ["web_search", "summarize"]
+  }'
+```
+
+### Execute Agent
+
+```bash
+curl -X POST https://api.getloodagents.{username}.olares.local/agents/{agent_id}/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Research the latest AI trends",
+    "context": {}
+  }'
+```
+
+### Create Workflow
+
+```bash
+curl -X POST https://api.getloodagents.{username}.olares.local/workflows \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Research & Summarize",
+    "steps": [
+      {"agent": "research_agent", "action": "search"},
+      {"agent": "summary_agent", "action": "summarize"}
+    ]
+  }'
+```
+
+## Monitoring
+
+```bash
+# Vérifier les pods
+kubectl get pods -n getloodagents-{username}
+
+# Voir les logs
+kubectl logs -f getloodagents-runtime-0 -n getloodagents-{username}
+
+# Vérifier les ressources
+kubectl top pod -n getloodagents-{username}
+```
+
+## Exemples d'Agents
+
+### Agent de Recherche
+
+```json
+{
+  "name": "Web Researcher",
+  "model": "llama3.1:8b",
+  "system_prompt": "You are a web researcher. Search and analyze information.",
+  "tools": ["web_search", "extract_text", "summarize"]
+}
+```
+
+### Agent de Code
+
+```json
+{
+  "name": "Code Assistant",
+  "model": "deepseek-coder:6.7b",
+  "system_prompt": "You are a coding assistant. Write clean, efficient code.",
+  "tools": ["code_analyzer", "linter", "test_generator"]
+}
+```
+
+### Agent de Traduction
+
+```json
+{
+  "name": "Translator",
+  "model": "mistral:7b",
+  "system_prompt": "You are a professional translator.",
+  "tools": ["detect_language", "translate"]
+}
+```
+
+## Dépannage
+
+### Problème: Agent ne répond pas
+
+```bash
+# Vérifier LLM
+curl https://api.getloodllm.{username}.olares.local/api/tags
+
+# Vérifier les logs
+kubectl logs getloodagents-runtime-0 -n getloodagents-{username}
+```
+
+### Problème: Workflow échoue
+
+```bash
+# Vérifier Workflow Engine
+kubectl logs getloodagents-workflow-0 -n getloodagents-{username}
+
+# Redémarrer le workflow
+kubectl delete pod getloodagents-workflow-0 -n getloodagents-{username}
+```
+
+## Documentation
+
+- [SmythOS Documentation](https://smythos.com/docs)
+- [Architecture Globale](../README.md)
+- [Olares Documentation](https://docs.olares.com)
+
+## Licence
+
+Apache 2.0

--- a/getlood-native-apps/getlood-brain/OlaresManifest.yaml
+++ b/getlood-native-apps/getlood-brain/OlaresManifest.yaml
@@ -1,0 +1,277 @@
+apiVersion: app.bytetrade.io/v1alpha1
+kind: Application
+metadata:
+  name: getloodbrain
+  namespace: "{{ .Values.userspace }}"
+spec:
+  metadata:
+    title: Getlood Brain
+    description: AI Kernel for intelligent orchestration and resource management
+    icon: https://file.bttcdn.com/appstore/getlood/getloodbrain.webp
+    appid: getloodbrain
+    version: 1.0.0
+    categories:
+      - AI
+      - Productivity
+      - Utilities
+    author: Getlood
+    website: https://getlood.com
+    sourceCode: https://github.com/Getlood/getlood-aios
+    submitter: Getlood
+    language:
+      - en
+    requiredMemory: 2Gi
+    requiredDisk: 10Gi
+    requiredCpu: 1000m
+    supportClient:
+      edge: "N/A"
+
+  entrances:
+    - name: api
+      host: api
+      port: 8080
+      title: Getlood Brain API
+      authLevel: private
+      invisible: false
+    - name: ui
+      host: ui
+      port: 3000
+      title: Getlood Brain Dashboard
+      authLevel: private
+      invisible: false
+
+  permission:
+    appData: true
+    appCache: true
+    userData:
+      - Home/Documents
+      - Home/Downloads
+    sysData:
+      - dataType: legacy_api
+        appName: getloodbrain
+        port: 8080
+        group: api.getloodbrain
+        version: v1
+        ops:
+          - POST
+          - GET
+          - PUT
+          - DELETE
+
+  middleware:
+    postgres:
+      username: getloodbrain
+      password: "{{ randAlphaNum 16 }}"
+      databases:
+        - name: getloodbrain
+          distributed: false
+    redis:
+      password: "{{ randAlphaNum 16 }}"
+      namespace: getloodbrain
+
+  options:
+    dependencies:
+      - name: getloodllm
+        type: application
+        version: ">=1.0.0"
+      - name: getloodvectordb
+        type: application
+        version: ">=1.0.0"
+
+  deployment:
+    - name: getloodbrain-scheduler
+      image: getlood/aios-scheduler:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8001
+          protocol: TCP
+      env:
+        - name: AIOS_MODE
+          value: "scheduler"
+        - name: CONTEXT_MANAGER_URL
+          value: "http://getloodbrain-context:8002"
+        - name: MEMORY_MANAGER_URL
+          value: "http://getloodbrain-memory:8003"
+        - name: LLM_CORE_URL
+          value: "http://getloodbrain-llm:8004"
+        - name: STORAGE_MANAGER_URL
+          value: "http://getloodbrain-storage:8005"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodbrain"
+        - name: REDIS_HOST
+          value: "{{ .Values.redis.host }}"
+        - name: REDIS_PORT
+          value: "{{ .Values.redis.port }}"
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis.password }}"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+
+    - name: getloodbrain-context
+      image: getlood/aios-context-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8002
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /data/context
+      env:
+        - name: REDIS_HOST
+          value: "{{ .Values.redis.host }}"
+        - name: REDIS_PORT
+          value: "{{ .Values.redis.port }}"
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis.password }}"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+
+    - name: getloodbrain-memory
+      image: getlood/aios-memory-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8003
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /data/memory
+      env:
+        - name: QDRANT_URL
+          value: "http://getloodvectordb-svc.{{ .Values.userspace }}:6333"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodbrain"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+
+    - name: getloodbrain-llm
+      image: getlood/aios-llm-core:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8004
+          protocol: TCP
+      env:
+        - name: OLLAMA_URL
+          value: "http://getloodllm-svc.{{ .Values.userspace }}:11434"
+        - name: REDIS_HOST
+          value: "{{ .Values.redis.host }}"
+        - name: REDIS_PORT
+          value: "{{ .Values.redis.port }}"
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis.password }}"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+
+    - name: getloodbrain-storage
+      image: getlood/aios-storage-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8005
+          protocol: TCP
+      volumeMounts:
+        - name: userdata
+          mountPath: /userdata
+        - name: appdata
+          mountPath: /appdata
+      env:
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodbrain"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+
+    - name: getloodbrain-api
+      image: getlood/aios-api-gateway:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      env:
+        - name: SCHEDULER_URL
+          value: "http://getloodbrain-scheduler:8001"
+        - name: CONTEXT_MANAGER_URL
+          value: "http://getloodbrain-context:8002"
+        - name: MEMORY_MANAGER_URL
+          value: "http://getloodbrain-memory:8003"
+        - name: LLM_CORE_URL
+          value: "http://getloodbrain-llm:8004"
+        - name: STORAGE_MANAGER_URL
+          value: "http://getloodbrain-storage:8005"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    - name: getloodbrain-ui
+      image: getlood/aios-ui:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+      env:
+        - name: API_URL
+          value: "http://getloodbrain-api:8080"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi

--- a/getlood-native-apps/getlood-brain/README.md
+++ b/getlood-native-apps/getlood-brain/README.md
@@ -1,0 +1,132 @@
+# Getlood Brain
+
+**AI Kernel for intelligent orchestration and resource management**
+
+Getlood Brain est le kernel AI d'Olares, basé sur AIOS (AI Operating System). Il orchestre intelligemment les ressources et les tâches AI.
+
+## Composants
+
+### AIOS Scheduler
+Ordonnancement intelligent des tâches AI avec gestion des priorités et des ressources.
+
+### AIOS Context Manager
+Gestion du contexte conversationnel pour maintenir la cohérence entre les interactions.
+
+### AIOS Memory Manager
+Système de mémoire à long terme avec RAG (Retrieval-Augmented Generation) pour stocker et récupérer les connaissances.
+
+### AIOS LLM Core
+Adaptateur multi-modèles LLM pour supporter différents modèles (Ollama, vLLM, etc.).
+
+### AIOS Storage Manager
+Système de fichiers sémantique pour organiser et rechercher les données par leur signification.
+
+## Installation
+
+```bash
+# Via Olares Market
+Market > Search "Getlood Brain" > Install
+
+# Via CLI
+kubectl apply -f OlaresManifest.yaml
+```
+
+## Configuration
+
+### Ressources Minimales
+
+- CPU: 1000m (1 core)
+- Memory: 2Gi
+- Disk: 10Gi
+
+### Variables d'Environnement
+
+```yaml
+AIOS_MODE: "scheduler"
+CONTEXT_MANAGER_URL: "http://getloodbrain-context:8002"
+MEMORY_MANAGER_URL: "http://getloodbrain-memory:8003"
+LLM_CORE_URL: "http://getloodbrain-llm:8004"
+STORAGE_MANAGER_URL: "http://getloodbrain-storage:8005"
+```
+
+## Dépendances
+
+- **Getlood LLM** : Pour l'inférence LLM
+- **Getlood VectorDB** : Pour le stockage des embeddings
+
+## URLs
+
+- API: `https://api.getloodbrain.{username}.olares.local`
+- UI: `https://ui.getloodbrain.{username}.olares.local`
+
+## API Endpoints
+
+### Health Check
+
+```bash
+curl https://api.getloodbrain.{username}.olares.local/health
+```
+
+### Submit Task
+
+```bash
+curl -X POST https://api.getloodbrain.{username}.olares.local/api/scheduler/submit \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "generate_summary",
+    "input": "Long text to summarize...",
+    "priority": "high"
+  }'
+```
+
+### Get Task Status
+
+```bash
+curl https://api.getloodbrain.{username}.olares.local/api/scheduler/status/{task_id}
+```
+
+## Monitoring
+
+```bash
+# Vérifier les pods
+kubectl get pods -n getloodbrain-{username}
+
+# Voir les logs
+kubectl logs -f getloodbrain-scheduler-0 -n getloodbrain-{username}
+
+# Vérifier les ressources
+kubectl top pod -n getloodbrain-{username}
+```
+
+## Dépannage
+
+### Problème: Scheduler ne démarre pas
+
+```bash
+# Vérifier les dépendances
+kubectl get svc -n getloodllm-{username}
+kubectl get svc -n getloodvectordb-{username}
+
+# Vérifier les logs
+kubectl logs getloodbrain-scheduler-0 -n getloodbrain-{username}
+```
+
+### Problème: Memory Manager erreur de connexion
+
+```bash
+# Vérifier Qdrant
+curl https://api.getloodvectordb.{username}.olares.local/collections
+
+# Redémarrer Memory Manager
+kubectl delete pod getloodbrain-memory-0 -n getloodbrain-{username}
+```
+
+## Documentation
+
+- [AIOS GitHub](https://github.com/agiresearch/AIOS)
+- [Architecture Globale](../README.md)
+- [Olares Documentation](https://docs.olares.com)
+
+## Licence
+
+Apache 2.0

--- a/getlood-native-apps/getlood-llm/OlaresManifest.yaml
+++ b/getlood-native-apps/getlood-llm/OlaresManifest.yaml
@@ -1,0 +1,154 @@
+apiVersion: app.bytetrade.io/v1alpha1
+kind: Application
+metadata:
+  name: getloodllm
+  namespace: "{{ .Values.userspace }}"
+spec:
+  metadata:
+    title: Getlood LLM
+    description: Local LLM runtime powered by Ollama with GPU acceleration
+    icon: https://file.bttcdn.com/appstore/getlood/getloodllm.webp
+    appid: getloodllm
+    version: 1.0.0
+    categories:
+      - AI
+      - Infrastructure
+      - Utilities
+    author: Getlood
+    website: https://getlood.com
+    sourceCode: https://github.com/ollama/ollama
+    submitter: Getlood
+    language:
+      - en
+    requiredMemory: 4Gi
+    requiredDisk: 100Gi
+    requiredCpu: 2000m
+    supportClient:
+      edge: "N/A"
+
+  entrances:
+    - name: api
+      host: api
+      port: 11434
+      title: Getlood LLM API
+      authLevel: private
+      invisible: false
+    - name: ui
+      host: ui
+      port: 3000
+      title: Getlood LLM Manager
+      authLevel: private
+      invisible: false
+
+  permission:
+    appData: true
+    appCache: true
+    gpu: true  # Demander accès GPU si disponible
+    sysData:
+      - dataType: legacy_api
+        appName: getloodllm
+        port: 11434
+        group: api.getloodllm
+        version: v1
+        ops:
+          - POST
+          - GET
+
+  middleware:
+    postgres:
+      username: getloodllm
+      password: "{{ randAlphaNum 16 }}"
+      databases:
+        - name: getloodllm
+          distributed: false
+
+  deployment:
+    - name: getloodllm-ollama
+      image: ollama/ollama:latest
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 11434
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /root/.ollama
+      env:
+        - name: OLLAMA_HOST
+          value: "0.0.0.0:11434"
+        - name: OLLAMA_MODELS
+          value: "/root/.ollama/models"
+        - name: OLLAMA_KEEP_ALIVE
+          value: "24h"
+        - name: OLLAMA_NUM_PARALLEL
+          value: "4"
+        - name: OLLAMA_MAX_LOADED_MODELS
+          value: "3"
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+        limits:
+          cpu: 4000m
+          memory: 8Gi
+          # GPU sera ajouté dynamiquement si disponible
+          # nvidia.com/gpu: 1
+
+    - name: getloodllm-ui
+      image: getlood/ollama-ui:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+      env:
+        - name: OLLAMA_URL
+          value: "http://getloodllm-ollama:11434"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodllm"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+
+    - name: getloodllm-model-manager
+      image: getlood/ollama-model-manager:1.0.0
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /data
+      env:
+        - name: OLLAMA_URL
+          value: "http://getloodllm-ollama:11434"
+        - name: POSTGRES_HOST
+          value: "{{ .Values.postgres.host }}"
+        - name: POSTGRES_PORT
+          value: "{{ .Values.postgres.port }}"
+        - name: POSTGRES_USER
+          value: "{{ .Values.postgres.username }}"
+        - name: POSTGRES_PASSWORD
+          value: "{{ .Values.postgres.password }}"
+        - name: POSTGRES_DB
+          value: "getloodllm"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi

--- a/getlood-native-apps/getlood-llm/README.md
+++ b/getlood-native-apps/getlood-llm/README.md
@@ -1,0 +1,224 @@
+# Getlood LLM
+
+**Local LLM runtime powered by Ollama with GPU acceleration**
+
+Getlood LLM est le runtime LLM local pour Olares, basé sur Ollama. Il permet d'exécuter des modèles de langage localement avec support GPU.
+
+## Composants
+
+### Ollama
+Runtime LLM haute performance pour l'inférence locale de modèles.
+
+### Model Manager
+Gestionnaire de modèles pour télécharger, mettre à jour et gérer les modèles LLM.
+
+## Installation
+
+```bash
+# Via Olares Market
+Market > Search "Getlood LLM" > Install
+
+# Via CLI
+kubectl apply -f OlaresManifest.yaml
+```
+
+## Configuration
+
+### Ressources Minimales
+
+- CPU: 2000m (2 cores)
+- Memory: 4Gi
+- Disk: 100Gi (pour stocker les modèles)
+- GPU: Optionnel mais recommandé
+
+### Support GPU
+
+Pour activer le GPU :
+
+```yaml
+# Éditer OlaresManifest.yaml
+resources:
+  limits:
+    nvidia.com/gpu: 1
+```
+
+### Variables d'Environnement
+
+```yaml
+OLLAMA_HOST: "0.0.0.0:11434"
+OLLAMA_MODELS: "/root/.ollama/models"
+OLLAMA_KEEP_ALIVE: "24h"
+OLLAMA_NUM_PARALLEL: "4"
+OLLAMA_MAX_LOADED_MODELS: "3"
+```
+
+## URLs
+
+- API: `https://api.getloodllm.{username}.olares.local`
+- UI: `https://ui.getloodllm.{username}.olares.local`
+
+## Modèles Recommandés
+
+### Llama 3.1 8B (4.7GB)
+Excellent modèle généraliste, bon équilibre performance/qualité.
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull llama3.1:8b
+```
+
+### Mistral 7B (4.1GB)
+Rapide et efficace, excellent pour les tâches générales.
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull mistral:7b
+```
+
+### Phi-3 Mini (2.3GB)
+Léger et rapide, parfait pour les tâches simples.
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull phi3:mini
+```
+
+### DeepSeek Coder 6.7B (3.8GB)
+Spécialisé pour le code, excellent pour la programmation.
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull deepseek-coder:6.7b
+```
+
+## API Endpoints
+
+### List Models
+
+```bash
+curl https://api.getloodllm.{username}.olares.local/api/tags
+```
+
+### Generate Text
+
+```bash
+curl -X POST https://api.getloodllm.{username}.olares.local/api/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.1:8b",
+    "prompt": "Explain quantum computing in simple terms.",
+    "stream": false
+  }'
+```
+
+### Chat Completion
+
+```bash
+curl -X POST https://api.getloodllm.{username}.olares.local/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.1:8b",
+    "messages": [
+      {"role": "user", "content": "Hello, who are you?"}
+    ]
+  }'
+```
+
+### Pull Model
+
+```bash
+curl -X POST https://api.getloodllm.{username}.olares.local/api/pull \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "llama3.1:8b"
+  }'
+```
+
+### Delete Model
+
+```bash
+curl -X DELETE https://api.getloodllm.{username}.olares.local/api/delete \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "llama3.1:8b"
+  }'
+```
+
+## Monitoring
+
+```bash
+# Vérifier les pods
+kubectl get pods -n getloodllm-{username}
+
+# Voir les logs
+kubectl logs -f getloodllm-ollama-0 -n getloodllm-{username}
+
+# Vérifier les ressources (incluant GPU)
+kubectl top pod -n getloodllm-{username}
+```
+
+## Gestion des Modèles
+
+### Lister les modèles installés
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama list
+```
+
+### Télécharger un modèle
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama pull llama3.1:8b
+```
+
+### Supprimer un modèle
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- ollama rm llama3.1:8b
+```
+
+### Vérifier l'espace disque
+
+```bash
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- df -h /root/.ollama
+```
+
+## Dépannage
+
+### Problème: Modèle ne charge pas
+
+```bash
+# Vérifier l'espace disque
+kubectl exec -it getloodllm-ollama-0 -n getloodllm-{username} -- df -h
+
+# Vérifier les logs
+kubectl logs getloodllm-ollama-0 -n getloodllm-{username}
+```
+
+### Problème: Inférence lente
+
+```bash
+# Vérifier si GPU est utilisé
+kubectl describe pod getloodllm-ollama-0 -n getloodllm-{username} | grep -A 5 "Limits"
+
+# Augmenter les ressources CPU/Memory si nécessaire
+```
+
+### Problème: Out of Memory
+
+```bash
+# Réduire le nombre de modèles chargés
+OLLAMA_MAX_LOADED_MODELS=1
+
+# Augmenter la limite mémoire dans OlaresManifest.yaml
+resources:
+  limits:
+    memory: 16Gi
+```
+
+## Documentation
+
+- [Ollama Documentation](https://ollama.com)
+- [Ollama GitHub](https://github.com/ollama/ollama)
+- [Architecture Globale](../README.md)
+- [Olares Documentation](https://docs.olares.com)
+
+## Licence
+
+Apache 2.0

--- a/getlood-native-apps/getlood-vectordb/OlaresManifest.yaml
+++ b/getlood-native-apps/getlood-vectordb/OlaresManifest.yaml
@@ -1,0 +1,91 @@
+apiVersion: app.bytetrade.io/v1alpha1
+kind: Application
+metadata:
+  name: getloodvectordb
+  namespace: "{{ .Values.userspace }}"
+spec:
+  metadata:
+    title: Getlood VectorDB
+    description: High-performance vector database for AI embeddings powered by Qdrant
+    icon: https://file.bttcdn.com/appstore/getlood/getloodvectordb.webp
+    appid: getloodvectordb
+    version: 1.0.0
+    categories:
+      - AI
+      - Database
+      - Infrastructure
+    author: Getlood
+    website: https://getlood.com
+    sourceCode: https://github.com/qdrant/qdrant
+    submitter: Getlood
+    language:
+      - en
+    requiredMemory: 2Gi
+    requiredDisk: 50Gi
+    requiredCpu: 1000m
+    supportClient:
+      edge: "N/A"
+
+  entrances:
+    - name: api
+      host: api
+      port: 6333
+      title: Getlood VectorDB API
+      authLevel: private
+      invisible: false
+    - name: dashboard
+      host: dashboard
+      port: 6333
+      title: Getlood VectorDB Dashboard
+      authLevel: private
+      invisible: false
+
+  permission:
+    appData: true
+    appCache: true
+    sysData:
+      - dataType: legacy_api
+        appName: getloodvectordb
+        port: 6333
+        group: api.getloodvectordb
+        version: v1
+        ops:
+          - POST
+          - GET
+          - PUT
+          - DELETE
+
+  deployment:
+    - name: getloodvectordb-qdrant
+      image: qdrant/qdrant:latest
+      replicas: 1
+      ports:
+        - name: http
+          containerPort: 6333
+          protocol: TCP
+        - name: grpc
+          containerPort: 6334
+          protocol: TCP
+      volumeMounts:
+        - name: appdata
+          mountPath: /qdrant/storage
+      env:
+        - name: QDRANT__SERVICE__HTTP_PORT
+          value: "6333"
+        - name: QDRANT__SERVICE__GRPC_PORT
+          value: "6334"
+        - name: QDRANT__STORAGE__STORAGE_PATH
+          value: "/qdrant/storage"
+        - name: QDRANT__STORAGE__SNAPSHOTS_PATH
+          value: "/qdrant/storage/snapshots"
+        - name: QDRANT__STORAGE__OPTIMIZERS__DEFAULT_SEGMENT_NUMBER
+          value: "4"
+        - name: QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS
+          value: "4"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi

--- a/getlood-native-apps/getlood-vectordb/README.md
+++ b/getlood-native-apps/getlood-vectordb/README.md
@@ -1,0 +1,273 @@
+# Getlood VectorDB
+
+**High-performance vector database for AI embeddings powered by Qdrant**
+
+Getlood VectorDB est la base de données vectorielle pour Olares, basée sur Qdrant. Elle stocke et recherche des embeddings pour RAG et autres applications AI.
+
+## Composants
+
+### Qdrant
+Base de données vectorielle haute performance avec support de recherche sémantique.
+
+## Installation
+
+```bash
+# Via Olares Market
+Market > Search "Getlood VectorDB" > Install
+
+# Via CLI
+kubectl apply -f OlaresManifest.yaml
+```
+
+## Configuration
+
+### Ressources Minimales
+
+- CPU: 1000m (1 core)
+- Memory: 2Gi
+- Disk: 50Gi
+
+### Variables d'Environnement
+
+```yaml
+QDRANT__SERVICE__HTTP_PORT: "6333"
+QDRANT__SERVICE__GRPC_PORT: "6334"
+QDRANT__STORAGE__STORAGE_PATH: "/qdrant/storage"
+QDRANT__STORAGE__SNAPSHOTS_PATH: "/qdrant/storage/snapshots"
+QDRANT__STORAGE__OPTIMIZERS__DEFAULT_SEGMENT_NUMBER: "4"
+QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS: "4"
+```
+
+## URLs
+
+- API: `https://api.getloodvectordb.{username}.olares.local`
+- Dashboard: `https://dashboard.getloodvectordb.{username}.olares.local`
+
+## API Endpoints
+
+### Health Check
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/
+```
+
+### List Collections
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/collections
+```
+
+### Create Collection
+
+```bash
+curl -X PUT https://api.getloodvectordb.{username}.olares.local/collections/my_collection \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vectors": {
+      "size": 384,
+      "distance": "Cosine"
+    }
+  }'
+```
+
+### Insert Vectors
+
+```bash
+curl -X PUT https://api.getloodvectordb.{username}.olares.local/collections/my_collection/points \
+  -H "Content-Type: application/json" \
+  -d '{
+    "points": [
+      {
+        "id": 1,
+        "vector": [0.1, 0.2, 0.3, ...],
+        "payload": {"text": "Hello world"}
+      }
+    ]
+  }'
+```
+
+### Search Vectors
+
+```bash
+curl -X POST https://api.getloodvectordb.{username}.olares.local/collections/my_collection/points/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector": [0.1, 0.2, 0.3, ...],
+    "limit": 10
+  }'
+```
+
+### Delete Collection
+
+```bash
+curl -X DELETE https://api.getloodvectordb.{username}.olares.local/collections/my_collection
+```
+
+## Exemples d'Utilisation
+
+### RAG (Retrieval-Augmented Generation)
+
+```python
+import requests
+import numpy as np
+
+# 1. Créer une collection
+requests.put(
+    "https://api.getloodvectordb.{username}.olares.local/collections/knowledge_base",
+    json={
+        "vectors": {
+            "size": 384,  # Dimension des embeddings
+            "distance": "Cosine"
+        }
+    }
+)
+
+# 2. Insérer des documents (avec embeddings)
+requests.put(
+    "https://api.getloodvectordb.{username}.olares.local/collections/knowledge_base/points",
+    json={
+        "points": [
+            {
+                "id": 1,
+                "vector": embedding_model.encode("Document 1 text"),
+                "payload": {"text": "Document 1 text", "source": "doc1.pdf"}
+            },
+            # ... plus de documents
+        ]
+    }
+)
+
+# 3. Rechercher des documents pertinents
+query_embedding = embedding_model.encode("User question")
+results = requests.post(
+    "https://api.getloodvectordb.{username}.olares.local/collections/knowledge_base/points/search",
+    json={
+        "vector": query_embedding.tolist(),
+        "limit": 5
+    }
+).json()
+```
+
+### Recherche Sémantique
+
+```bash
+# 1. Créer collection pour articles
+curl -X PUT https://api.getloodvectordb.{username}.olares.local/collections/articles \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vectors": {"size": 768, "distance": "Cosine"}
+  }'
+
+# 2. Insérer articles
+# (générer embeddings avec un modèle comme sentence-transformers)
+
+# 3. Rechercher articles similaires
+curl -X POST https://api.getloodvectordb.{username}.olares.local/collections/articles/points/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector": [...],  # embedding de la requête
+    "limit": 10,
+    "with_payload": true
+  }'
+```
+
+## Monitoring
+
+```bash
+# Vérifier les pods
+kubectl get pods -n getloodvectordb-{username}
+
+# Voir les logs
+kubectl logs -f getloodvectordb-qdrant-0 -n getloodvectordb-{username}
+
+# Vérifier les ressources
+kubectl top pod -n getloodvectordb-{username}
+```
+
+## Gestion des Collections
+
+### Lister toutes les collections
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/collections
+```
+
+### Obtenir les infos d'une collection
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/collections/my_collection
+```
+
+### Créer un snapshot
+
+```bash
+curl -X POST https://api.getloodvectordb.{username}.olares.local/collections/my_collection/snapshots
+```
+
+### Lister les snapshots
+
+```bash
+curl https://api.getloodvectordb.{username}.olares.local/collections/my_collection/snapshots
+```
+
+## Dépannage
+
+### Problème: Collection ne crée pas
+
+```bash
+# Vérifier l'espace disque
+kubectl exec -it getloodvectordb-qdrant-0 -n getloodvectordb-{username} -- df -h
+
+# Vérifier les logs
+kubectl logs getloodvectordb-qdrant-0 -n getloodvectordb-{username}
+```
+
+### Problème: Recherche lente
+
+```bash
+# Vérifier le nombre de points dans la collection
+curl https://api.getloodvectordb.{username}.olares.local/collections/my_collection
+
+# Augmenter les ressources CPU
+# Éditer OlaresManifest.yaml et augmenter les limites CPU
+```
+
+### Problème: Out of Memory
+
+```bash
+# Augmenter la limite mémoire
+resources:
+  limits:
+    memory: 8Gi
+
+# Redéployer
+kubectl apply -f OlaresManifest.yaml
+```
+
+## Optimisation des Performances
+
+### Indexation
+
+```bash
+# Optimiser les segments pour de meilleures performances
+curl -X POST https://api.getloodvectordb.{username}.olares.local/collections/my_collection/index
+```
+
+### Nombre de Threads
+
+Ajuster `MAX_SEARCH_THREADS` selon le nombre de CPU :
+
+```yaml
+QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS: "8"
+```
+
+## Documentation
+
+- [Qdrant Documentation](https://qdrant.tech/documentation/)
+- [Qdrant GitHub](https://github.com/qdrant/qdrant)
+- [Architecture Globale](../README.md)
+- [Olares Documentation](https://docs.olares.com)
+
+## Licence
+
+Apache 2.0


### PR DESCRIPTION
Add comprehensive documentation and Kubernetes manifests for 4 Getlood applications:
- Getlood Brain (AIOS rebrand): AI kernel for intelligent orchestration
- Getlood Agents (SmythOS rebrand): Autonomous AI agents runtime
- Getlood LLM (Ollama rebrand): Local LLM runtime with GPU support
- Getlood VectorDB (Qdrant rebrand): Vector database for AI embeddings

Each application includes:
- OlaresManifest.yaml: Complete Kubernetes deployment manifest
- README.md: Detailed usage documentation and examples
- Architecture documentation explaining native Olares integration

These applications transform Olares into Getlood OS, a complete AI agentic platform using only YAML manifests with zero custom code.

Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:
