### PR TITLE
coredns,bfl,l4: resolving domain to cluster ip in pods

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -304,7 +304,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.8
+          value: v0.3.9
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE
@@ -317,7 +317,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.25
+        image: beclab/bfl-ingress:v0.3.26
         imagePullPolicy: IfNotPresent
         env:
         - name: AUTHELIA_AUTH_URL
@@ -384,6 +384,10 @@ spec:
   - name: ingress-https
     port: 443
     targetPort: 443
+    protocol: TCP
+  - name: ingress-https-proxy
+    port: 444
+    targetPort: 444
     protocol: TCP
   selector:
     tier: bfl

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.8
+      name: beclab/l4-bfl-proxy:v0.3.9
 # must have blank new line            

--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -78,7 +78,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.12
+        image: beclab/sys-event:0.2.13
         imagePullPolicy: IfNotPresent
 
 ---


### PR DESCRIPTION
* **Background**
Resolving the domains of Olares apps to BFL Ingress pod IP in pods, let the requests from pods of the cluster access the ingress directly.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/bfl/pull/146
https://github.com/beclab/l4-bfl-proxy/commit/f3a0bc2ea8e6dff92ea8cfad93063b998a0a6ac3
https://github.com/beclab/tapr/commit/ef2c8ae3e4d392d56947cbc1508ff7fed1495d89

* **Other information**:
