### PR TITLE
fix(manifest): handle the case of present secret with missing key

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -19,17 +19,15 @@
 {{- $pg_password = (index $auth_secret "data" "pg_password") -}}
 {{- $nats_password = (index $auth_secret "data" "nats_password") -}}
 {{- $probe_secret = (index $auth_secret "data" "probe_secret") -}}
-
-{{ else -}}
-{{ $jwt_secret = randAlphaNum 16 | b64enc }}
-{{ $session_secret = randAlphaNum 16 | b64enc }}
-{{ $hmac_secret = randAlphaNum 16 | b64enc }}
-{{ $encryption_key = randAlphaNum 32 | b64enc }}
-{{ $redis_password = randAlphaNum 16 | b64enc }}
-{{ $pg_password = randAlphaNum 16 | b64enc }}
-{{ $nats_password = randAlphaNum 16 | b64enc }}
-{{ $probe_secret = randAlphaNum 16 | b64enc }}
 {{- end -}}
+{{- $jwt_secret = (default (randAlphaNum 16 | b64enc) $jwt_secret) -}}
+{{- $session_secret = (default (randAlphaNum 16 | b64enc) $session_secret) -}}
+{{- $hmac_secret = (default (randAlphaNum 16 | b64enc) $hmac_secret) -}}
+{{- $encryption_key = (default (randAlphaNum 32 | b64enc) $encryption_key) -}}
+{{- $redis_password = (default (randAlphaNum 16 | b64enc) $redis_password) -}}
+{{- $pg_password = (default (randAlphaNum 16 | b64enc) $pg_password) -}}
+{{- $nats_password = (default (randAlphaNum 16 | b64enc) $nats_password) -}}
+{{- $probe_secret = (default (randAlphaNum 16 | b64enc) $probe_secret) -}}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
* **Background**
A new key `probe_secret` was added to the `authelia-secrets`, which is only generated when the secret is missing, this should work as expected in new installation, but in upgrade scenario, it's not because the secret is present, this is now changed to generate every key in the secret if it's empty, regardless of the presence of the secret itself.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none