### PR TITLE
backup: fix bufio.Scanner token too long

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.56" }}
+{{ $backupVersion := "0.3.57" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix bufio.Scanner token too long when app restoring

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
1.12.3

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/backup-server/commit/a2d06ba77c5be08677427d317832f5ef380db975


* **Other information**:
