### PR TITLE
fix: process history data resource url without protocol

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.73
+        image: beclab/search3:v0.0.77
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.73
+        image: beclab/search3monitor:v0.0.77
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -37,7 +37,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.0.73
+        image: beclab/search3validation:v0.0.77
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3monitor,search3 service
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->
* **Background**
file_name_documents history data, parents and resource_uri missing protocol prefix
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   dailybuild
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
https://github.com/Above-Os/search3/pull/129
