### PR TITLE
fix: multiple node monitor setting webhook call fail

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -35,6 +35,13 @@ spec:
     spec:
       serviceAccountName: os-internal
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       containers:
       - name: search3-validation
         image: beclab/search3validation:v0.0.77


### PR DESCRIPTION
Title: search3monitor,search3 service
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->
* **Background**
When Olares is deployed in a multi-node configuration, the k8s API server cannot invoke the monitor setting validation server's validation interface if they are not on the same physical node. This modification ensures that the monitor setting validation server is deployed on control plane nodes, thereby colocating it with the k8s API server on the same physical node.
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
   dailybuild
* **Related Issues**
<!-- Reference any related issues here, if applicable -->
* **PRs Involving Sub-Systems** 
