### PR TITLE
jfsnotify: update jfsnotify daemon volume configurations

### DIFF
--- a/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_daemon.yaml
+++ b/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_daemon.yaml
@@ -73,12 +73,12 @@ spec:
             cpu: 20m
             memory: 200Mi
         volumeMounts:
-        - name: jfs-sock
-          mountPath: /tmp
+        - name: node-data
+          mountPath: /olares
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: jfs-sock
-        hostPath:
-          path: /tmp
+      - name: node-data
+        hostPath: /olares
+          
 
 {{- end }}  # End of fs type condition    


### PR DESCRIPTION
* **Background**
Mount the Olares data host path of the node to the jfsnotify-daemon to watch the events of the JuiceFS file system on the node.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
jfsnotify-daemon got 'no such file or directory' error when adding watching

* **PRs Involving Sub-Systems** 
none

* **Other information**:
