### PR TITLE
fix(gpu): add precheck and disable op for nouveau kernel module

### DIFF
--- a/cli/cmd/ctl/gpu/disable_nouveau.go
+++ b/cli/cmd/ctl/gpu/disable_nouveau.go
@@ -1,0 +1,23 @@
+package gpu
+
+import (
+	"log"
+
+	"github.com/beclab/Olares/cli/pkg/pipelines"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdDisableNouveau() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable-nouveau",
+		Short: "Blacklist and disable the nouveau kernel module",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.DisableNouveau(); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+	return cmd
+}
+
+

--- a/cli/cmd/ctl/gpu/root.go
+++ b/cli/cmd/ctl/gpu/root.go
@@ -15,5 +15,6 @@ func NewCmdGpu() *cobra.Command {
 	rootGpuCmd.AddCommand(NewCmdEnableGpu())
 	rootGpuCmd.AddCommand(NewCmdDisableGpu())
 	rootGpuCmd.AddCommand(NewCmdGpuStatus())
+	rootGpuCmd.AddCommand(NewCmdDisableNouveau())
 	return rootGpuCmd
 }

--- a/cli/pkg/bootstrap/precheck/module.go
+++ b/cli/pkg/bootstrap/precheck/module.go
@@ -79,6 +79,7 @@ func (m *RunPrechecksModule) Init() {
 		new(RequiredPortsCheck),
 		new(ConflictingContainerdCheck),
 		new(NvidiaCardArchChecker),
+		new(NouveauChecker),
 		new(CudaChecker),
 	}
 	runPreChecks := &task.LocalTask{

--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -346,3 +346,21 @@ func (l *UninstallCudaModule) Init() {
 	}
 
 }
+
+type DisableNouveauModule struct {
+	common.KubeModule
+}
+
+func (m *DisableNouveauModule) Init() {
+	m.Name = "DisableNouveau"
+
+	writeBlacklist := &task.LocalTask{
+		Name:   "WriteNouveauBlacklist",
+		Action: new(WriteNouveauBlacklist),
+		Retry:  1,
+	}
+
+	m.Tasks = []task.Interface{
+		writeBlacklist,
+	}
+}

--- a/cli/pkg/pipelines/gpu_disable_nouveau.go
+++ b/cli/pkg/pipelines/gpu_disable_nouveau.go
@@ -1,0 +1,30 @@
+package pipelines
+
+import (
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/module"
+	"github.com/beclab/Olares/cli/pkg/core/pipeline"
+	"github.com/beclab/Olares/cli/pkg/gpu"
+)
+
+func DisableNouveau() error {
+	arg := common.NewArgument()
+	arg.SetConsoleLog("gpudisable-nouveau.log", true)
+
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return err
+	}
+
+	p := &pipeline.Pipeline{
+		Name: "DisableNouveau",
+		Modules: []module.Module{
+			&gpu.DisableNouveauModule{},
+		},
+		Runtime: runtime,
+	}
+
+	return p.Start()
+}
+
+


### PR DESCRIPTION
* **Background**
A Linux system with `nouveau` module loaded in kernel conflicts with the NVIDIA driver that will be installed by Olares for machines with NVIDIA GPU card, we add a detection for it in the precheck list, and a command `olares-cli gpu disable-nouveau` to disable it.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none