### PR TITLE
feat(ci): distinguish different vendor in build & install script

### DIFF
--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -7,6 +7,14 @@ function command_exists() {
 	  command -v "$@" > /dev/null 2>&1
 }
 
+if [[ x"$REPO_PATH" == x"" ]]; then
+    export REPO_PATH="#__REPO_PATH__"
+fi
+
+if [[ "x${REPO_PATH:3}" == "xREPO_PATH__" ]]; then
+    export REPO_PATH="/"
+fi
+
 if [[ x"$VERSION" == x"" ]]; then
     if [[ "$LOCAL_RELEASE" == "1" ]]; then
         ts=$(date +%Y%m%d%H%M%S)
@@ -92,13 +100,17 @@ if [[ "$LOCAL_RELEASE" == "1" ]]; then
     fi
     INSTALL_OLARES_CLI=$(which olares-cli)
 else
-    if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]]; then
+    expected_vendor="main"
+    if [[ "$(basename "$REPO_PATH")" == "olares-one" ]]; then
+        expected_vendor="OlaresOne"
+    fi
+    if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
         INSTALL_OLARES_CLI=$(which olares-cli)
         echo "olares-cli already installed and is the expected version"
         echo ""
     else
         if [[ ! -f ${CLI_FILE} ]]; then
-            CLI_URL="${cdn_url}/${CLI_FILE}"
+            CLI_URL="${cdn_url}${REPO_PATH}${CLI_FILE}"
 
             echo "downloading Olares installer from ${CLI_URL} ..."
             echo ""

--- a/build/base-package/joincluster.sh
+++ b/build/base-package/joincluster.sh
@@ -7,6 +7,15 @@ function command_exists() {
 	  command -v "$@" > /dev/null 2>&1
 }
 
+if [[ x"$REPO_PATH" == x"" ]]; then
+    export REPO_PATH="#__REPO_PATH__"
+fi
+
+
+if [[ "x${REPO_PATH:3}" == "xREPO_PATH__" ]]; then
+    export REPO_PATH="/"
+fi
+
 function read_tty() {
     echo -n $1
     read $2 < /dev/tty
@@ -172,15 +181,17 @@ else
   RELEASE_ID_SUFFIX=".$RELEASE_ID"
 fi
 CLI_FILE="olares-cli-v${VERSION}_linux_${ARCH}${RELEASE_ID_SUFFIX}.tar.gz"
-
-if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]]; then
+expected_vendor="main"
+if [[ "$(basename "$REPO_PATH")" == "olares-one" ]]; then
+    expected_vendor="OlaresOne"
+fi
+if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
     INSTALL_OLARES_CLI=$(which olares-cli)
     echo "olares-cli already installed and is the expected version"
     echo ""
 else
     if [[ ! -f ${CLI_FILE} ]]; then
-        CLI_URL="${cdn_url}/${CLI_FILE}"
-
+        CLI_URL="${cdn_url}${REPO_PATH}${CLI_FILE}"
         echo "downloading Olares installer from ${CLI_URL} ..."
         echo ""
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -66,6 +66,12 @@ if [ ! -z $RELEASE_ID ]; then
     sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' joincluster.sh"
 fi
 
+# replace repo path placeholder in scripts if provided
+if [ ! -z "$REPO_PATH" ]; then
+    sh -c "$SED 's/#__REPO_PATH__/${REPO_PATH}/' install.sh"
+    sh -c "$SED 's/#__REPO_PATH__/${REPO_PATH}/' joincluster.sh"
+fi
+
 $TAR --exclude=wizard/tools --exclude=.git -zcvf ${BASE_DIR}/../install-wizard-${VERSION}.tar.gz .
 
 popd


### PR DESCRIPTION
* **Background**
Currently, different vendor types of Olares can be installed on a fresh machine(by different release ids), but can not be installed multiple times across  them for a same version, as the install script only checks for the version rather than the vendor type, this check is now added, and also works when the release id is missing.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none