### PR TITLE
fix(ci): use non-slash separator in sed fo repo path

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -68,8 +68,8 @@ fi
 
 # replace repo path placeholder in scripts if provided
 if [ ! -z "$REPO_PATH" ]; then
-    sh -c "$SED 's/#__REPO_PATH__/${REPO_PATH}/' install.sh"
-    sh -c "$SED 's/#__REPO_PATH__/${REPO_PATH}/' joincluster.sh"
+    sh -c "$SED 's|#__REPO_PATH__|${REPO_PATH}|g' install.sh"
+    sh -c "$SED 's|#__REPO_PATH__|${REPO_PATH}|g' joincluster.sh"
 fi
 
 $TAR --exclude=wizard/tools --exclude=.git -zcvf ${BASE_DIR}/../install-wizard-${VERSION}.tar.gz .


### PR DESCRIPTION
* **Background**
The existence of `/` in `REPO_PATH` messes with the slash separator we use for `sed`, it is replaced with `|`

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none