### PR TITLE
opa: enhance validating webhook with namespace selectors

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -109,7 +109,22 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     namespaceSelector: 
       matchExpressions:
-        - {key: openpolicyagent.org/webhook, operator: NotIn, values: [ignore]}
+        - key: kubernetes.io/metadata.name 
+          operator: NotIn
+          values: 
+          - kube-system
+          - kubesphere-monitoring-system
+          - kubesphere-system
+          - os-framework
+          - os-gpu
+          - os-network
+          - os-platform
+          - os-protected
+        - key: bytetrade.io/ns-type
+          operator: NotIn
+          values:
+          - user-space
+          - user-internal
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]


### PR DESCRIPTION

* **Background**
Added namespace selectors to validating webhook configuration to exclude specific namespaces.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
