### PR TITLE
fix(app-service): check for nil annotations before assignment

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -347,6 +347,9 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 
 	appCopy.Spec.Config = config
 	appCopy.Spec.OpType = appv1alpha1.UpgradeOp
+	if appCopy.Annotations == nil {
+		appCopy.Annotations = make(map[string]string)
+	}
 	appCopy.Annotations[api.AppRepoURLKey] = request.RepoURL
 	appCopy.Annotations[api.AppVersionKey] = request.Version
 	appCopy.Annotations[api.AppTokenKey] = token


### PR DESCRIPTION
* **Background**
During handling of some requests, object's annotations is directly assigned to, instead, a nil check should be performed and a map is allocated in case of missing field.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none