### PR TITLE
opa: update image restriction to include docker.io prefix for beclab

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -217,6 +217,7 @@ data:
         some container
         input_containers[container]
         not startswith(container.image, "beclab/")
+        not startswith(container.image, "docker.io/beclab/")
 
         is_root_user(input.request.object.spec.securityContext)
     


### PR DESCRIPTION
* **Background**
Update image restriction to include docker.io registry server for beclab

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
