### PR TITLE
opa: add check for docker.io image registry in container policy

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -208,6 +208,7 @@ data:
         some container
         input_containers[container]
         not startswith(container.image, "beclab/")
+        not startswith(container.image, "docker.io/beclab/")
 
         is_root_user(container.securityContext)
     


### PR DESCRIPTION
* **Background**
Add check for docker.io image registry in container policy

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
