### PR TITLE
tapr: fix reconciling kvrocks creating event bug

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.27
+        image: beclab/middleware-operator:0.2.28
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
* **Background**
When reconciling the kvrocks creating event if the kvrocks instance exists, there is a panic error in the tapr-middleware.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
Tapr-middleware is panic when it restarts

* **PRs Involving Sub-Systems** 
https://github.com/beclab/tapr/pull/88

* **Other information**:
