### PR TITLE
daemon: reset local domain when ip changing

### DIFF
--- a/daemon/internel/watcher/intranet/watchers.go
+++ b/daemon/internel/watcher/intranet/watchers.go
@@ -29,7 +29,7 @@ func NewApplicationWatcher() *applicationWatcher {
 
 func (w *applicationWatcher) Watch(ctx context.Context) {
 	switch state.CurrentState.TerminusState {
-	case state.NotInstalled, state.Uninitialized, state.InitializeFailed:
+	case state.NotInstalled, state.Uninitialized, state.InitializeFailed, state.IPChanging:
 		// Stop the intranet server if it's running
 		if w.intranetServer != nil {
 			w.intranetServer.Close()


### PR DESCRIPTION
* **Background**
Close the intranet server and the local domain resolver when IP changing, and when changing IP success, reset the local domain address to the new IP.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
After IP changing, resolve the local domain to the wrong IP

* **PRs Involving Sub-Systems** 
none

* **Other information**:
