### PR TITLE
fix(ci): specify working directory in github action for tapr

### DIFF
--- a/.github/workflows/module_tapr_build_main.yaml
+++ b/.github/workflows/module_tapr_build_main.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '1.23.3'
-    - run: |
+    - working-directory: platform/tapr
+      run: |
         make build-uploader build-vault build-middleware
-        working-directory: platform/tapr
 


### PR DESCRIPTION
* **Background**
The `working-directory` option should be at the same level with the `run` option in the job of GitHub action

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none