### PR TITLE
app-service: update owner field to use app owner from app manager

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_service.go
+++ b/framework/app-service/pkg/apiserver/handler_service.go
@@ -212,7 +212,7 @@ func (h *Handler) listBackend(req *restful.Request, resp *restful.Response) {
 				Appid:           appv1alpha1.AppName(am.Spec.AppName).GetAppID(),
 				IsSysApp:        appv1alpha1.AppName(am.Spec.AppName).IsSysApp(),
 				Namespace:       am.Spec.AppNamespace,
-				Owner:           owner,
+				Owner:           am.Spec.AppOwner,
 				Entrances:       appconfig.Entrances,
 				SharedEntrances: appconfig.SharedEntrances,
 				Icon:            appconfig.Icon,


### PR DESCRIPTION
* **Background**
Set the wrong owner to the shared entrance app

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
