### PR TITLE
fix(ci): filter out dummy image names when scanning

### DIFF
--- a/build/image-manifest.sh
+++ b/build/image-manifest.sh
@@ -32,8 +32,7 @@ for mod in "${PACKAGE_MODULE[@]}";do
         fi
     done
 done
-
-awk '{print $3}' ${TMP_MANIFEST} | sort | uniq | grep -v nitro | grep -v orion >> ${IMAGE_MANIFEST}
+awk '{print $3}' ${TMP_MANIFEST} | sort | uniq | grep -v nitro | grep -v orion | grep -v '^nonexisting$' >> ${IMAGE_MANIFEST}
 
 # patch
 # fix backup server version

--- a/cli/pkg/release/manifest/manifest.go
+++ b/cli/pkg/release/manifest/manifest.go
@@ -4,17 +4,18 @@ import (
 	"bufio"
 	"crypto/md5"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	dockerref "github.com/containerd/containerd/reference/docker"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sort"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	dockerref "github.com/containerd/containerd/reference/docker"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 type OlaresManifest struct {
@@ -232,6 +233,10 @@ func (m *Manager) scan() error {
 				image := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "image:"))
 				image = strings.Trim(image, "'")
 				image = strings.Trim(image, "\"")
+				// filter out dummy placeholder image names
+				if strings.EqualFold(strings.TrimSpace(image), "nonexisting") {
+					continue
+				}
 				images = append(images, image)
 			}
 		}


### PR DESCRIPTION
* **Background**
filter out image name `nonexisting` when scanning images for manifest

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none