### PR TITLE
chore(ci): only scan for image manifest under .olares

### DIFF
--- a/build/image-manifest.sh
+++ b/build/image-manifest.sh
@@ -17,7 +17,7 @@ for mod in "${PACKAGE_MODULE[@]}";do
         chart_path="${mod}/${app}"
 
         if [ -d $chart_path ]; then
-            find $chart_path -type f -name *.yaml | while read p; do
+            find $chart_path -type f -path '*/.olares/*.yaml' | while read p; do
                 bash ${BASE_DIR}/yaml2prop.sh -f $p | while read l;do 
                     if [[ "$l" == *".image = "* || "$l" == "output.containers."*".name"* ]]; then 
                         echo "$l"


### PR DESCRIPTION
* **Background**
Currently, all yaml files are scanned to generate the image manifest, as many sub projects are merged into the main repo, some example manifests which contain images are also scanned, producing unnecessary images, we limit the scanning scope to only the files under `.olares` path.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none