### PR TITLE
feat: upgrade v0.0.93

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_provider.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_provider.yaml
@@ -25,10 +25,7 @@ metadata:
     provider-service-ref: search3-provider-svc.{{ .Release.Namespace }}:28080
 rules:
   - nonResourceURLs: 
-      - "/document/get_by_resource_uri"
-      - "/document/add"
-      - "/document/delete/*"
-      - "/document/update/*"
+      - "/document/*"
     verbs: ["*"]
 
 ---

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.92
+        image: beclab/search3:v0.0.93
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.92
+        image: beclab/search3monitor:v0.0.93
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081


### PR DESCRIPTION
Title: search3:  search3 result by converagre order
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
The original search result structure, when the search type was 'aggregate', placed all filename matches at the front and full-text search results at the back, with internal ordering maintained within each group. This has now been changed to re-rank all results based on keyword coverage.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/147
* **Other information**:
