### PR TITLE
daemon: improve handling of broken mounts with detailed error reporting

### DIFF
--- a/daemon/internel/watcher/usb/watchers.go
+++ b/daemon/internel/watcher/usb/watchers.go
@@ -74,7 +74,7 @@ func NewUmountWatcher() *umountWatcher {
 }
 
 func (w *umountWatcher) Watch(ctx context.Context) {
-	if err := utils.UmountBrokenUsbMount(ctx, commands.MOUNT_BASE_DIR); err != nil {
+	if err := utils.UmountBrokenMount(ctx, commands.MOUNT_BASE_DIR); err != nil {
 		klog.Error("umount broken mount point error, ", err)
 	}
 }

--- a/daemon/pkg/utils/drivers_macos.go
+++ b/daemon/pkg/utils/drivers_macos.go
@@ -44,7 +44,7 @@ func UmountUsbDevice(ctx context.Context, path string) error {
 	return nil
 }
 
-func UmountBrokenUsbMount(ctx context.Context, baseDir string) error {
+func UmountBrokenMount(ctx context.Context, baseDir string) error {
 	klog.Warning("not implement")
 	return nil
 }


### PR DESCRIPTION
* **Background**
Modified the checking of broken mount points to try to access the mount points, to avoid unmounting some specific mount type devices.

* **Target Version for Merge**
v1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
