### PR TITLE
fix(cli): adjust internal DNS when cloud VM is detected

### DIFF
--- a/cli/pkg/bootstrap/os/module.go
+++ b/cli/pkg/bootstrap/os/module.go
@@ -100,18 +100,9 @@ func (c *ConfigSystemModule) Init() {
 		Retry:    0,
 	}
 
-	configProxyTask := &task.RemoteTask{
-		Name:     "ConfigProxy",
-		Hosts:    c.Runtime.GetAllHosts(),
-		Action:   new(ConfigProxyTask),
-		Parallel: false,
-		Retry:    0,
-	}
-
 	c.Tasks = []task.Interface{
 		updateNtpDateTask,
 		timeSyncTask,
-		configProxyTask,
 	}
 }
 

--- a/cli/pkg/bootstrap/os/tasks.go
+++ b/cli/pkg/bootstrap/os/tasks.go
@@ -204,24 +204,6 @@ exit 0`, setNTPCommand, hwclockCmd)
 	return nil
 }
 
-type ConfigProxyTask struct {
-	common.KubeAction
-}
-
-func (t *ConfigProxyTask) Execute(runtime connector.Runtime) error {
-	if common.ResolvProxy == "" {
-		return nil
-	}
-
-	var cmd = fmt.Sprintf("echo nameserver %s > /etc/resolv.conf", common.ResolvProxy)
-	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
-		logger.Errorf("failed to execute %s: %v", cmd, err)
-		return err
-	}
-
-	return nil
-}
-
 type NodeConfigureOS struct {
 	common.KubeAction
 }

--- a/cli/pkg/bootstrap/patch/tasks.go
+++ b/cli/pkg/bootstrap/patch/tasks.go
@@ -275,9 +275,17 @@ func (t *DisableLocalDNSTask) configResolvConf(runtime connector.Runtime) error 
 	overrideOp := ">"
 	appendOp := ">>"
 
-	if common.CloudVendor == common.CloudVendorAliYun {
+	var internalDNS string
+	if util.IsOnAliyunECS() {
+		internalDNS = "100.100.10.12"
+	} else if util.IsOnAWSEC2() {
+		internalDNS = "169.254.169.253"
+	} else if util.IsOnTencentCVM() {
+		internalDNS = "183.60.83.19"
+	}
+	if internalDNS != "" {
 		secondNameserverOp = appendOp
-		cmd = `echo 'nameserver 100.100.2.136' > /etc/resolv.conf`
+		cmd = fmt.Sprintf("echo 'nameserver %s' > /etc/resolv.conf", internalDNS)
 		if _, err = runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("exec %s error %v", cmd, err)
 			return err

--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -169,19 +169,9 @@ const (
 	ManagedMinIO = "managed-minio"
 )
 
-var (
-	CloudVendor = os.Getenv("CLOUD_VENDOR")
-	ResolvProxy = os.Getenv("PROXY")
-)
-
 const (
 	OlaresRegistryMirrorHost       = "mirrors.joinolares.cn"
 	OlaresRegistryMirrorHostLegacy = "mirrors.jointerminus.cn"
-)
-
-const (
-	CloudVendorAliYun = "aliyun"
-	CloudVendorAWS    = "aws"
 )
 
 const (

--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -738,6 +738,19 @@ func (p *DetectPublicIPAddress) Execute(runtime connector.Runtime) error {
 		}
 	}
 
+	if util.IsOnAliyunECS() {
+		logger.Info("on Aliyun ECS instance, will try to check if a public IP address is bound")
+		aliyunPublicIP, err := util.GetPublicIPFromAliyunIMDS()
+		if err != nil {
+			return errors.Wrap(err, "failed to get public IP from Aliyun")
+		}
+		if aliyunPublicIP != nil {
+			logger.Info("retrieved public IP addresses from IMDS")
+			p.KubeConf.Arg.NetworkSettings.CloudProviderPublicIP = aliyunPublicIP
+			return nil
+		}
+	}
+
 	osPublicIPs, err := util.GetPublicIPsFromOS()
 	if err != nil {
 		return errors.Wrap(err, "failed to get public IPs from OS")


### PR DESCRIPTION
* **Background**
Currently, some supported cloud vendors are actively detected by Olares, and whether the machine has a bound public IP address is queried, which sometimes relies on the internal DNS server.
When configuring DNS server on such environments, we reserve one primary DNS server as the cloud vendor's internal DNS server to avoid misfunction.
Support for AliYun is added.
Also, the legacy environment variables `CLOUD_VENDOR` and `PROXY` used by Olares space to configure DNS server is removed in favor of the new programmatic way.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none