### PR TITLE
fix(cli): only (un)label current node in multi-node cluster

### DIFF
--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -251,7 +251,7 @@ func (l *NodeLabelingModule) Init() {
 		Name: "UpdateNode",
 		Prepare: &prepare.PrepareCollection{
 			new(CudaInstalled),
-			new(K8sNodeInstalled),
+			new(CurrentNodeInK8s),
 		},
 		Action: new(UpdateNodeLabels),
 		Retry:  1,
@@ -262,7 +262,7 @@ func (l *NodeLabelingModule) Init() {
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
 			new(CudaInstalled),
-			new(K8sNodeInstalled),
+			new(CurrentNodeInK8s),
 		},
 		Action: new(RestartPlugin),
 		Retry:  1,
@@ -286,7 +286,7 @@ func (l *NodeUnlabelingModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			new(K8sNodeInstalled),
+			new(CurrentNodeInK8s),
 		},
 		Action:   new(RemoveNodeLabels),
 		Parallel: false,
@@ -298,7 +298,7 @@ func (l *NodeUnlabelingModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			new(K8sNodeInstalled),
+			new(CurrentNodeInK8s),
 			new(GpuDevicePluginInstalled),
 		},
 		Action:   new(RestartPlugin),

--- a/cli/pkg/gpu/prepares.go
+++ b/cli/pkg/gpu/prepares.go
@@ -63,11 +63,11 @@ func (p *CudaNotInstalled) PreCheck(runtime connector.Runtime) (bool, error) {
 	return false, nil
 }
 
-type K8sNodeInstalled struct {
+type CurrentNodeInK8s struct {
 	common.KubePrepare
 }
 
-func (p *K8sNodeInstalled) PreCheck(runtime connector.Runtime) (bool, error) {
+func (p *CurrentNodeInK8s) PreCheck(runtime connector.Runtime) (bool, error) {
 	client, err := clientset.NewKubeClient()
 	if err != nil {
 		logger.Debug(errors.Wrap(errors.WithStack(err), "kubeclient create error"))
@@ -84,11 +84,13 @@ func (p *K8sNodeInstalled) PreCheck(runtime connector.Runtime) (bool, error) {
 		return false, nil
 	}
 
-	if len(node.Items) == 0 {
-		return false, nil
+	for _, node := range node.Items {
+		if node.Name == runtime.GetSystemInfo().GetHostname() {
+			return true, nil
+		}
 	}
 
-	return true, nil
+	return false, nil
 }
 
 type NvidiaGraphicsCard struct {


### PR DESCRIPTION
* **Background**
Currently, when doing install/uninstall/enable/disable operation for GPU driver/plugin, whether to label the K8s Node is determined solely by the existence of the K8s node(s) itself, in a multi-node environment, this check does not apply, and should be changed to check the existence of current node we're operating on.

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none