### PR TITLE
fix(ci): specify working dir in github action for backup module

### DIFF
--- a/.github/workflows/module_backup_build_main.yaml
+++ b/.github/workflows/module_backup_build_main.yaml
@@ -26,6 +26,6 @@ jobs:
       with:
         go-version: '1.21.10'
     - name: Run Build
+      working-directory: framework/backup-server
       run: |
         make all
-        working-directory: framework/backup-server


### PR DESCRIPTION
* **Background**
The `working-directory` option should be at the same level with the `run` option in the job of GitHub action

* **Target Version for Merge**
1.12.3

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none