### PR TITLE
kubeblock-addons: fix image repo transfer due to opa

### DIFF
--- a/platform/kubeblocks/.olares/Olares.yaml
+++ b/platform/kubeblocks/.olares/Olares.yaml
@@ -7,4 +7,4 @@ output:
     -
       name: beclab/apecloud-kubeblocks:1.0.1
     -
-      name: beclab/kubeblock-addon-charts:v1.0.1
+      name: beclab/kubeblock-addon-charts:v1.0.1-ext

--- a/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks-addon.yaml
+++ b/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks-addon.yaml
@@ -11,7 +11,7 @@ spec:
     or cluster of machines.
   helm:
     chartLocationURL: file:///minio-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
     chartsPathInImage: /charts
     installValues: {}
     valuesMapping:
@@ -44,7 +44,7 @@ spec:
     and scaling.
   helm:
     chartLocationURL: file:///mongodb-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
   installable:
     autoInstall: true
   type: Helm
@@ -68,7 +68,7 @@ spec:
     speed and relevance on production-scale workloads.
   helm:
     chartLocationURL: file:///elasticsearch-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
   installable:
     autoInstall: true
   type: Helm
@@ -90,7 +90,7 @@ spec:
   description: RabbitMQ is a reliable and mature messaging and streaming broker.
   helm:
     chartLocationURL: file:///rabbitmq-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
   installable:
     autoInstall: true
   type: Helm
@@ -113,7 +113,7 @@ spec:
     system that is widely used for web and application servers
   helm:
     chartLocationURL: file:///mariadb-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
   installable:
     autoInstall: true
   type: Helm
@@ -136,7 +136,7 @@ spec:
     system (RDBMS)
   helm:
     chartLocationURL: file:///mysql-1.0.1.tgz
-    chartsImage: beclab/kubeblock-addon-charts:v1.0.1
+    chartsImage: beclab/kubeblock-addon-charts:v1.0.1-ext
   installable:
     autoInstall: true
   type: Helm


### PR DESCRIPTION
* **Background**
some middleware need privilege permission, image repo transfer due to opa


* **Target Version for Merge**
v1.12.3
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/kubeblocks-addons/pull/1

* **Other information**:
