### PR TITLE
fix: sync add support video of 3gp, mpg and vob

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.139
+          image: beclab/files-server:v0.2.140
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- files-server: fix: sync add support video of 3gp, mpg and vob

Target Version for Merge
- v1.12.3

Related Issues
- None

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/174

Other information: