### PR TITLE
opa: enhance untrusted image checks in deployment configuration

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -251,6 +251,7 @@ data:
         not startswith(container.image, "redis:")
         not startswith(container.image, "ghcr.io/coder/coder:v2.19.0")
         not startswith(container.image, "apecloud/")
+        not startswith(container.image, "docker.io/apecloud/")
     }
         
     is_root_user(ctx) if {


### PR DESCRIPTION
* **Background**
Add some image repos to OPA policy as the trusted image list

* **Target Version for Merge**
v1.12.3 v1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
