### PR TITLE
fix(cli): unify node GPU info update logic

### DIFF
--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -187,7 +187,7 @@ func (m *InstallPluginModule) Init() {
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
 		},
-		Action:   new(UpdateNodeLabels),
+		Action:   new(UpdateNodeGPUInfo),
 		Parallel: false,
 		Retry:    1,
 	}
@@ -223,23 +223,6 @@ func (m *InstallPluginModule) Init() {
 	}
 }
 
-type GetCudaVersionModule struct {
-	common.KubeModule
-}
-
-func (g *GetCudaVersionModule) Init() {
-	g.Name = "GetCudaVersion"
-
-	getCudaVersion := &task.LocalTask{
-		Name:   "GetCudaVersion",
-		Action: new(GetCudaVersion),
-	}
-
-	g.Tasks = []task.Interface{
-		getCudaVersion,
-	}
-}
-
 type NodeLabelingModule struct {
 	common.KubeModule
 }
@@ -253,7 +236,7 @@ func (l *NodeLabelingModule) Init() {
 			new(CudaInstalled),
 			new(CurrentNodeInK8s),
 		},
-		Action: new(UpdateNodeLabels),
+		Action: new(UpdateNodeGPUInfo),
 		Retry:  1,
 	}
 

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -58,7 +58,6 @@ func (l *linuxInstallPhaseBuilder) installGpuPlugin() phase {
 	return []module.Module{
 		&gpu.RestartK3sServiceModule{Skip: !(l.runtime.Arg.Kubetype == common.K3s)},
 		&gpu.InstallPluginModule{Skip: skipGpuPlugin},
-		&gpu.GetCudaVersionModule{},
 	}
 }
 


### PR DESCRIPTION
* **Background**
Unify the update logic of GPU info on node both in the installation and in the upgrade process, which is currently separated and only partially updated after upgrade of GPU driver.

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none