### PR TITLE
feat(bfl): reuse owner's proxy config when activating sub-accounts

### DIFF
--- a/framework/bfl/pkg/apis/settings/v1alpha1/reverseproxyconf.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/reverseproxyconf.go
@@ -549,7 +549,11 @@ func (conf *ReverseProxyConfig) generateReverseProxyConfigMapData() map[string]s
 }
 
 func GetReverseProxyConfig(ctx context.Context) (*ReverseProxyConfig, error) {
-	configData, err := k8sutil.GetConfigMapData(ctx, constants.Namespace, constants.ReverseProxyConfigMapName)
+	return GetReverseProxyConfigFromNamespace(ctx, constants.Namespace)
+}
+
+func GetReverseProxyConfigFromNamespace(ctx context.Context, namespace string) (*ReverseProxyConfig, error) {
+	configData, err := k8sutil.GetConfigMapData(ctx, namespace, constants.ReverseProxyConfigMapName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting configmap")
 	}


### PR DESCRIPTION
* **Background**
Currently, all users of an Olares instance can choose reverse proxy settings on activation, if enabled. This is now changed to only eligible for owner account, and all sub-accounts will use the owner's settings. 

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none