### PR TITLE
feat(wizard): remove the option to select an FRP node when activating a sub-account.

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -317,7 +317,7 @@ spec:
             chown -R 1000:1000 /uploadstemp && \
             chown -R 1000:1000 /appdata 
         - name: olares-app-init
-          image: beclab/system-frontend:v1.6.29
+          image: beclab/system-frontend:v1.6.30
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
+++ b/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
@@ -29,7 +29,7 @@ spec:
 
       containers:
       - name: wizard
-        image: beclab/wizard:v1.6.5
+        image: beclab/wizard:v1.6.30
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/framework/authelia/.olares/config/user/helm-charts/auth/templates/auth_deploy.yaml
+++ b/framework/authelia/.olares/config/user/helm-charts/auth/templates/auth_deploy.yaml
@@ -29,7 +29,7 @@ spec:
         name: check-auth
       containers:
       - name: auth-front
-        image: beclab/login:v1.6.26
+        image: beclab/login:v1.6.30
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.140
+          image: beclab/files-server:v0.2.141
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -140,7 +140,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.11
+        image: beclab/market-backend:v0.6.12
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
wizard: remove the option to select an FRP node when activating a sub-account.
files: supports editing XML, JSON, YAML, and configuration files.
market & files: fix some bugs

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/859

* **Other information**:
None
