### PR TITLE
feat： use poppler-utils and catdoc

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.0.97
+        image: beclab/search3:v0.0.98
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.0.97
+        image: beclab/search3monitor:v0.0.98
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.0.97
+        image: beclab/search3validation:v0.0.98
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3:  use poppler-utils and catdoc
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**

1. Extract PDF content using `poppler-utils` and `.doc` content using `catdoc`.  
2. Fix sorting-related issues.  
3. Fix search the contents of the `external` directory that are **not** on an HDD.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build,1.12.3
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/153
* **Other information**:
