### PR TITLE
fix: files sync reconnection

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.141
+          image: beclab/files-server:v0.2.142
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -226,7 +226,7 @@ spec:
     spec:
       initContainers:
       - name: seahub-init
-        image: beclab/seahub-init:v0.0.4
+        image: beclab/seahub-init:v0.0.5
         env:
           - name: DB_HOST
             value: citus-headless.os-platform


### PR DESCRIPTION
Background
- files-server: fix: add sync reconnection, seahub patch.sql and patch user creation for some border conditions; change usb watcher interval from 0.3s to 1s

Target Version for Merge
- v1.12.3

Related Issues
- None

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/176
- https://github.com/beclab/files/pull/177

Other information: