### PR TITLE
opa: update image validation to exclude alpine and mariadb images

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -251,6 +251,8 @@ data:
         not startswith(image, "ghcr.io/coder/coder:v2.19.0")
         not startswith(image, "apecloud/")
         not startswith(image, "kldtks/")
+        not startswith(image, "alpine:")
+        not startswith(image, "mariadb:")
     }
         
     is_root_user(ctx) if {


### PR DESCRIPTION
* **Background**
Update image validation to exclude alpine and mariadb images

* **Target Version for Merge**
v1.12.3 v1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
