### PR TITLE
fix: helm upgrade do not use atomic param and allow upgrade failed release

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.71
+        image: beclab/app-service:0.4.72
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
@@ -2,7 +2,6 @@ package appinstaller
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	appv1alpha1 "github.com/beclab/Olares/framework/app-service/api/app.bytetrade.io/v1alpha1"
@@ -12,7 +11,6 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/helm"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
-	helmrelease "helm.sh/helm/v3/pkg/release"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,15 +21,7 @@ import (
 
 // Upgrade do a upgrade operation for release.
 func (h *HelmOps) Upgrade() error {
-	status, err := h.status()
-	if err != nil {
-		klog.Errorf("get release status failed %v", err)
-		return err
-	}
-	if status.Info.Status == helmrelease.StatusDeployed {
-		return h.upgrade()
-	}
-	return fmt.Errorf("cannot upgrade release %s/%s, current state is %s", h.app.Namespace, h.app.AppName, status.Info.Status)
+	return h.upgrade()
 }
 
 func (h *HelmOps) upgrade() error {

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -85,9 +85,10 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	ctrl.Log.Info("helm action config", "reachable", actionConfig.KubeClient.IsReachable())
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = namespace
-	client.Timeout = 2400 * time.Second
+	client.Timeout = 300 * time.Second
 	client.Recreate = false
-	client.Atomic = true
+	// Do not use Atomic, this could cause helm wait all resource ready.
+	//client.Atomic = true
 	if reuseValue {
 		client.ReuseValues = true
 	}


### PR DESCRIPTION




* **Background**
fix: helm upgrade do not use atomic param and allow upgrade failed release
* **Target Version for Merge**
v1.12.3,v1.12.4
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
