### PR TITLE
olares app: update settings create sub-accounts to block domain

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -317,7 +317,7 @@ spec:
             chown -R 1000:1000 /uploadstemp && \
             chown -R 1000:1000 /appdata 
         - name: olares-app-init
-          image: beclab/system-frontend:v1.6.36
+          image: beclab/system-frontend:v1.6.37
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
settings: When creating a sub-account, the system will block any Olares ID that does not belong to the same domain.

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/868

* **Other information**:
None