### PR TITLE
fix(cli): remove olares name when uninstalling to prepare

### DIFF
--- a/cli/pkg/common/kube_runtime.go
+++ b/cli/pkg/common/kube_runtime.go
@@ -287,7 +287,7 @@ func (a *Argument) LoadReleaseInfo() error {
 	return nil
 }
 
-func (a *Argument) SaveReleaseInfo() error {
+func (a *Argument) SaveReleaseInfo(withoutName bool) error {
 	if a.BaseDir == "" {
 		return errors.New("invalid: empty base directory")
 	}
@@ -300,15 +300,17 @@ func (a *Argument) SaveReleaseInfo() error {
 		ENV_OLARES_VERSION:  a.OlaresVersion,
 	}
 
-	if a.User != nil && a.User.UserName != "" && a.User.DomainName != "" {
-		releaseInfoMap["OLARES_NAME"] = fmt.Sprintf("%s@%s", a.User.UserName, a.User.DomainName)
-	} else {
-		if util.IsExist(OlaresReleaseFile) {
-			// if the user is not set, try to load the user name from the release file
-			envs, err := godotenv.Read(OlaresReleaseFile)
-			if err == nil {
-				if userName, ok := envs["OLARES_NAME"]; ok {
-					releaseInfoMap["OLARES_NAME"] = userName
+	if !withoutName {
+		if a.User != nil && a.User.UserName != "" && a.User.DomainName != "" {
+			releaseInfoMap["OLARES_NAME"] = fmt.Sprintf("%s@%s", a.User.UserName, a.User.DomainName)
+		} else {
+			if util.IsExist(OlaresReleaseFile) {
+				// if the user is not set, try to load the user name from the release file
+				envs, err := godotenv.Read(OlaresReleaseFile)
+				if err == nil {
+					if userName, ok := envs["OLARES_NAME"]; ok {
+						releaseInfoMap["OLARES_NAME"] = userName
+					}
 				}
 			}
 		}

--- a/cli/pkg/phase/cluster/delete_cluster.go
+++ b/cli/pkg/phase/cluster/delete_cluster.go
@@ -111,6 +111,7 @@ func (p *phaseBuilder) phaseInstall() *phaseBuilder {
 				PhaseFile: common.TerminusStateFileInstalled,
 				BaseDir:   p.runtime.GetBaseDir(),
 			},
+			&terminus.WriteReleaseFileModule{WithoutName: true},
 		)
 	}
 	return p

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -74,6 +74,7 @@ func (m *PreparedModule) Init() {
 
 type WriteReleaseFileModule struct {
 	common.KubeModule
+	WithoutName bool
 }
 
 func (m *WriteReleaseFileModule) Init() {
@@ -82,7 +83,7 @@ func (m *WriteReleaseFileModule) Init() {
 	m.Tasks = []task.Interface{
 		&task.LocalTask{
 			Name:   "WriteReleaseFile",
-			Action: new(WriteReleaseFile),
+			Action: &WriteReleaseFile{WithoutName: m.WithoutName},
 		},
 	}
 }

--- a/cli/pkg/terminus/tasks.go
+++ b/cli/pkg/terminus/tasks.go
@@ -250,13 +250,14 @@ func (t *PrepareFinished) Execute(runtime connector.Runtime) error {
 
 type WriteReleaseFile struct {
 	common.KubeAction
+	WithoutName bool
 }
 
 func (t *WriteReleaseFile) Execute(runtime connector.Runtime) error {
 	if util.IsExist(common.OlaresReleaseFile) {
 		logger.Debugf("found existing release file: %s, overriding ...", common.OlaresReleaseFile)
 	}
-	return t.KubeConf.Arg.SaveReleaseInfo()
+	return t.KubeConf.Arg.SaveReleaseInfo(t.WithoutName)
 }
 
 type RemoveReleaseFile struct {


### PR DESCRIPTION
* **Background**
Remove the `OLARES_NAME` field from olares release file when uninstalling to the prepare phase.

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none