### PR TITLE
fix(gpu): handle scheduler inconsistency and device stuck in unhealthy

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.6"
+version: "v2.6.7"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.6
+      name: beclab/hami:v2.6.7
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Fixed some issues causing errors in pod schedule & device allocation phase:
missing connection to the kube-apiserver for some time might cause state inconsistency in scheduler
currently, if a device becomes unhealthy, even from a glitch of NVML library call, it can not recover unless restart device plugin

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/8
https://github.com/beclab/HAMi/pull/9

* **Other information**:
none