### PR TITLE
fix: files sync reconnection at pipe client when sending has met broken pipe

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.144
+          image: beclab/files-server:v0.2.145
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -226,7 +226,7 @@ spec:
     spec:
       initContainers:
       - name: seahub-init
-        image: beclab/seahub-init:v0.0.5
+        image: beclab/seahub-init:v0.0.6
         env:
           - name: DB_HOST
             value: citus-headless.os-platform
@@ -248,7 +248,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.17
+        image: beclab/pg_seafile_server:v0.0.18
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- files-server: sync reconnection at pipe client when sending has met broken pipe

Target Version for Merge
- v1.12.3

Related Issues
- None

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/182
- https://github.com/beclab/seafile-server/pull/2

Other information: