### PR TITLE
daemon: bump zeroconf dependency to v0.2.4 

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/containerd/containerd v1.7.29
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/eball/zeroconf v0.2.2
+	github.com/eball/zeroconf v0.2.4
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/gopacket v1.1.19

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -87,8 +87,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eball/echo/v4 v4.13.4-patch h1:5w83KQrEqrxhc1BO0BpRBHssC37vFrWualUM27Rt2sg=
 github.com/eball/echo/v4 v4.13.4-patch/go.mod h1:ORgy8LWTq8knpwgaz538rAJMri7WgpoAD6H3zYccn84=
-github.com/eball/zeroconf v0.2.2 h1:y23X67tLFlU+b35LyM9THXGsdC88IUz803G+mzfeSeE=
-github.com/eball/zeroconf v0.2.2/go.mod h1:eIbIjGYo9sSMaKWLcveHEPRWdyblz7q9ih2R1HnNw5M=
+github.com/eball/zeroconf v0.2.4 h1:S5nUHLu2zhpA8YuR/Ue/vXPiY6ynPECkpDXjYV+Ckj4=
+github.com/eball/zeroconf v0.2.4/go.mod h1:eIbIjGYo9sSMaKWLcveHEPRWdyblz7q9ih2R1HnNw5M=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=

--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -81,7 +81,7 @@ func (s *mDNSServer) StartAll() error {
 			host:        &DNSConfig{Domain: domain},
 		}
 	}
-	klog.Info("Intranet mDNS server started")
+	klog.V(8).Info("Intranet mDNS server started")
 	return nil
 }
 

--- a/daemon/internel/intranet/server.go
+++ b/daemon/internel/intranet/server.go
@@ -147,6 +147,6 @@ func (s *Server) Reload(o *ServerOptions) error {
 		return fmt.Errorf("reload intranet server with %d errors", len(errs))
 	}
 
-	klog.Info("Intranet server reloaded")
+	klog.V(8).Info("Intranet server reloaded")
 	return nil
 }

--- a/daemon/internel/watcher/intranet/watchers.go
+++ b/daemon/internel/watcher/intranet/watchers.go
@@ -79,7 +79,7 @@ func (w *applicationWatcher) Watch(ctx context.Context) {
 				klog.Error("reload intranet server config error, ", err)
 				return
 			}
-			klog.Info("Intranet server config reloaded")
+			klog.V(8).Info("Intranet server config reloaded")
 		} else {
 			// Start the intranet server
 			err = w.intranetServer.Start(o)


### PR DESCRIPTION

* **Background**
Bump zeroconf dependency to v0.2.4 to support mDNS query from Android
Remove some useless logs

* **Target Version for Merge**
v1.12.3 v1.12.4

* **Related Issues**
Android client cannot access the local domain

* **PRs Involving Sub-Systems** 
none

* **Other information**:
