### PR TITLE
fix(bfl): add backend cluster API handler for stats report

### DIFF
--- a/framework/bfl/pkg/apis/backend/v1/register.go
+++ b/framework/bfl/pkg/apis/backend/v1/register.go
@@ -52,6 +52,12 @@ func AddContainer(c *restful.Container) error {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))
 
+	ws.Route(ws.GET("/cluster").
+		To(handler.getClusterMetric).
+		Doc("get the cluster current metrics ( cpu, memory, disk ).").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
 	ws.Route(ws.GET("/config-system").
 		To(handler.HandleGetSysConfig).
 		Doc("get user locale.").


### PR DESCRIPTION
* **Background**
Once an user has bound OlaresID to the Olares Space in integration, the API `/backend/v1/cluster` is needed to report cluster status so that the user can view system data in the Space dashboard.

* **Target Version for Merge**
1.12.3, 1.12.4

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none