### PR TITLE
fix: files sync reconnection error msg and upload chuck access token

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.145
+          image: beclab/files-server:v0.2.146
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- files-server: formal sync reconnection error msg
- files-server: fix upload chuck access token lost problem
- files-server: fix sync folder share upload permission bug

Target Version for Merge
- v1.12.3

Related Issues
- None

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/183
- https://github.com/beclab/files/pull/184

Other information:
