### PR TITLE
fix: files check disk space for upload link and copy

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.146
+          image: beclab/files-server:v0.2.148
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -314,8 +314,8 @@ spec:
               value: os.users
             - name: NATS_SUBJECT_SYSTEM_GROUPS
               value: os.groups
-            - name: RESERVED_SPACE
-              value: '1000'
+            - name: RESERVED_SPACE_PERCENT
+              value: '1.00'
             - name: OLARES_VERSION
               value: '1.12'
             - name: FILE_CACHE_DIR


### PR DESCRIPTION
Background
- files-server: fix: check disk space for upload link and copy
- files-server: fix: rsync change to --no-o and --no-g with chown to support inner root folder copying with no 'w' permission given to other users
- files-server: fix: formal searpc err when returning int value in float64 at some border conditions

Target Version for Merge
- v1.12.4

Related Issues
- None

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/185
- https://github.com/beclab/files/pull/186
- https://github.com/beclab/files/pull/187

Other information:
