### PR TITLE
feat(gpu): update gpu plugin version to v2.6.8

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.7"
+version: "v2.6.8"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.7
+      name: beclab/hami:v2.6.8
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Allow GPU devices marked unhealthy by Xid critical error events to recover
Mount node level vgpu lock to tmpfs for auto clean up across machine reboots
Clean up orphaned pods assigned to GPU devices that are gone

* **Target Version for Merge**
1.12.5

* **Related Issues**
1.12.5

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/10
https://github.com/beclab/HAMi/pull/11
https://github.com/beclab/HAMi/pull/12

* **Other information**:
none