### PR TITLE
fix: fix english highight missing

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.1.2
+        image: beclab/search3:v0.1.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.1.2
+        image: beclab/search3monitor:v0.1.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.1.2
+        image: beclab/search3validation:v0.1.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: fix missing highlight
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
 For space-delimited languages, such as "the appleWatch," if "appleWatch" is treated as a single token, then when the keyword is "apple," "appleWatch" should not be highlighted. This issue affects not only highlighting but also ranking, causing the correct passage to be pushed down.
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build,1.12.4
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/160

* **Other information**:
