### PR TITLE
kubeblocks: skip check pod spec,status image

### DIFF
--- a/platform/kubeblocks/.olares/Olares.yaml
+++ b/platform/kubeblocks/.olares/Olares.yaml
@@ -5,6 +5,6 @@ output:
     - 
       name: beclab/apecloud-kubeblocks-tools:1.0.1
     -
-      name: beclab/apecloud-kubeblocks:1.0.1
+      name: beclab/kubeblocks:1.0.1-ext1
     -
       name: beclab/kubeblock-addon-charts:v1.0.1-ext2

--- a/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks.yaml
+++ b/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks.yaml
@@ -98,7 +98,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: beclab/apecloud-kubeblocks:1.0.1
+          image: beclab/kubeblocks:1.0.1-ext1
           imagePullPolicy: IfNotPresent
           ports:
             - name: webhook-server


### PR DESCRIPTION
* **Background**
We upgraded the kubeblocks-addon, but found that this upgrade did not update the corresponding CRD (componetDefinition) image. However, the new image was upgraded in olaresManifest.yaml, which causes a mismatch between the image in spec and the image ref in status, resulting in the KubeBlocks cluster being stuck in the Creating state.
* **Target Version for Merge**
v1.12.4
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/kubeblocks/commit/569c3dbe9741af2add1334daa8f3abc7027b40df

* **Other information**:
