### PR TITLE
fix: fix meaningless word highlight

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.1.3
+        image: beclab/search3:v0.1.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.1.3
+        image: beclab/search3monitor:v0.1.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.1.3
+        image: beclab/search3validation:v0.1.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: fix meaningless word  highlight
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**

For humans, “97b6e65fbd516bdedec2efee8478c0a094bfbaaccf046889b7c805bf9dc90437” is a meaningless string. However, when it is enclosed in double quotes in the text, it is considered a token. When performing highlighting, the string “97b6e65fbd516bdedec2efee8478c0a094bfbaaccf046889b7c805bf9dc90437” will be split into an array of keywords using a predefined keyword segmentation function. This is done to match partial keywords because sometimes only partial matches are possible. For this long string, it would be split into the keyword array ["97", "b6e", "65", "fbd", "516", "bdedec2efee", "8478", "c0a", "094", "bfbaaccf", "046889", "b7c", "805", "bf9dc", "90437"]. Although the segmentation function is correct, it is not suitable for highlighting. This kind of segmentation may result in a large number of partial matches, which can drown out the correct matches. The array of segmented keywords should include the original string, and the highlighted terms should also include the original string.
In normal cases, the segmentation function works like this: “Python编程，Rust语言！Go开发。” is transformed into ["python", "编程", "rust", "语言", "go", "开发"]. Highlighting in this case works fine.
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build,1.12.4
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/161

* **Other information**:
