### PR TITLE
feat: optimize highlight segment order

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -240,7 +240,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.1.4
+        image: beclab/search3:v0.1.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -301,7 +301,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.1.4
+        image: beclab/search3monitor:v0.1.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.1.4
+        image: beclab/search3validation:v0.1.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: optimize segment highlight order
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
For a text like
“der Mann die Männer die Frau die Frauen der Lehrer die Lehrer die Lehrerin die Lehrerinnen
die Arbeiter der Schauspieler die Sängerin der Verkäufer die Physikerin die Chemikerinnen
die Informatiker der Designer der Ingenieur die Ingenieure die Ingenieurin die Ingenieurinnen
der Arzt die Ärzte die Ärztin die Ärztinnen die Köche die Rechtsanwältinnen”
if the highlight keyword is “der arzt” and only two segments are allowed, the system currently returns
“der Mann die Männer die Frau die Frauen der Lehrer” and
“die Informatiker der Designer der Ingenieur”.
The third segment “Ingenieurinnen der Arzt die Ärzte die Ärztin die Ärztinnen die Köche” is skipped, yet it contains the best match “der Arzt”.
When the number of segments is limited, the segment with the best-matching hit should be returned.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build,1.12.4
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/162

* **Other information**:
