### PR TITLE
feat(gpu): supports dynamic detection of hot plugged-in GPUs

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/daemonset.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/dcgm-exporter/daemonset.yaml
@@ -67,6 +67,9 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
+      - name: hostdev
+        hostPath:
+          path: /dev
       - name: "pod-gpu-resources"
         hostPath:
           path: '{{ .Values.dcgmExporter.kubeletPath }}'
@@ -124,6 +127,8 @@ spec:
         - name: "metrics"
           containerPort: {{ .Values.dcgmExporter.service.port }}
         volumeMounts:
+        - name: hostdev
+          mountPath: /dev
         - name: "pod-gpu-resources"
           readOnly: true
           mountPath: "/var/lib/kubelet/pod-resources"

--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -80,6 +80,8 @@ spec:
           resources:
           {{- toYaml .Values.devicePlugin.resources | nindent 12 }}
           volumeMounts:
+            - name: hostdev
+              mountPath: /dev
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
             - name: lib
@@ -120,6 +122,8 @@ spec:
           resources:
           {{- toYaml .Values.devicePlugin.vgpuMonitor.resources | nindent 12 }}
           volumeMounts:
+            - name: hostdev
+              mountPath: /dev
             - name: ctrs
               mountPath: {{ .Values.devicePlugin.monitorctrPath }}
             - name: dockers
@@ -133,6 +137,9 @@ spec:
             - name: hosttmp
               mountPath: /tmp
       volumes:
+        - name: hostdev
+          hostPath:
+            path: /dev
         - name: ctrs
           hostPath:
             path: {{ .Values.devicePlugin.monitorctrPath }}

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.9"
+version: "v2.6.10"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.9
+      name: beclab/hami:v2.6.10
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Supports dynamic detection of hot plugged-in GPUs
Note that cold plugged in eGPUs through thunderbolt sometimes may also be seen as hot plugged-in ones from the perspective of device plugin, as it takes some time for the thunderbolt module and Nvidia driver to initiate eGPU after the system boot.
The host `/dev` is needed to be bind mount as containers only get allocated the already initialized GPUs as of time the containers are started.

* **Target Version for Merge**
1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/13

* **Other information**:
none