### PR TITLE
daemon: change pcap open timeout to 1 millisecond to prevent close hang

### DIFF
--- a/daemon/internel/intranet/dsr_linux.go
+++ b/daemon/internel/intranet/dsr_linux.go
@@ -477,7 +477,7 @@ func (d *DSRProxy) regonfigure() error {
 	klog.Infof("Calico interface: %s", d.calicoInterface.Name)
 
 	var err error
-	d.pcapHandle, err = pcap.OpenLive(d.vipInterface.Name, 65536, false, pcap.BlockForever)
+	d.pcapHandle, err = pcap.OpenLive(d.vipInterface.Name, 65536, false, time.Millisecond)
 	if err != nil {
 		klog.Error("pcap openlive failed:", err)
 		return err


### PR DESCRIPTION
* **Background**
Opening the PCAP handler in blocking mode will hang when closing if the network interface is invalid.  Add a short timeout to it to work around.

* **Target Version for Merge**
v1.12.5

* **Related Issues**
When the device loses the ethernet cable and changes the cluster node IP to WIFI, the local domain cannot be resolved.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
