### PR TITLE
authelia: add user regulation for TOTP authentication attempts

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.45
+        image: beclab/auth:0.2.46
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Add user regulation for TOTP authentication attempts.
If the user failed to sign TOTP and retried 3 times within 2 minutes, they will be banned for 5 minutes.

* **Target Version for Merge**
v1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/52

* **Other information**:
