### PR TITLE
docs: fix a link issue

### DIFF
--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -429,7 +429,7 @@ const side = {
         },
         {
           text: "本地访问 Olares",
-          link: "/manual/best-practices/local-access",
+          link: "/zh/manual/best-practices/local-access",
         },
       ],
     },


### PR DESCRIPTION
Title: fix the link that directs to the wrong location in ZH doc set.

* **Background**
See title.

* **Target Version for Merge**
1.12 
* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None