### PR TITLE
feat: support more scheme update to env crs

### DIFF
--- a/build/user-env.yaml
+++ b/build/user-env.yaml
@@ -43,6 +43,15 @@ userEnvs:
   - envName: OLARES_USER_SMTP_SECURITY_PROTOCOLS
     type: string
     editable: true        
+    options:
+    - title: "TLS"
+      value: "tls"
+    - title: "SSL"
+      value: "ssl"
+    - title: "StartTLS"
+      value: "starttls"
+    - title: "None"
+      value: "none"
   - envName: OLARES_USER_OPENAI_APIKEY
     type: password
     editable: true

--- a/cli/pkg/release/app/app.go
+++ b/cli/pkg/release/app/app.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/util"
 )
 
@@ -54,6 +55,10 @@ func (m *Manager) Package() error {
 	}
 
 	if err := m.packageGPU(); err != nil {
+		return err
+	}
+
+	if err := m.packageEnvConfig(); err != nil {
 		return err
 	}
 
@@ -120,4 +125,20 @@ func (m *Manager) packageGPU() error {
 		filepath.Join(m.olaresRepoRoot, "infrastructure/gpu/.olares/config/gpu"),
 		filepath.Join(m.distPath, "wizard/config/gpu"),
 	)
+}
+
+func (m *Manager) packageEnvConfig() error {
+	fmt.Println("packaging env config ...")
+
+	systemEnvSrc := filepath.Join(m.olaresRepoRoot, "build", common.OLARES_SYSTEM_ENV_FILENAME)
+	userEnvSrc := filepath.Join(m.olaresRepoRoot, "build", common.OLARES_USER_ENV_FILENAME)
+
+	if err := util.CopyFile(systemEnvSrc, filepath.Join(m.distPath, common.OLARES_SYSTEM_ENV_FILENAME)); err != nil {
+		return err
+	}
+	if err := util.CopyFile(userEnvSrc, filepath.Join(m.distPath, common.OLARES_USER_ENV_FILENAME)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.4.78
+        image: beclab/app-service:0.4.79
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755


### PR DESCRIPTION
* **Background**
Add encryption options to the user env `OLARES_USER_SMTP_SECURITY_PROTOCOLS`
Package user and sys env template files in local release
Update user env template during upgrade to trigger scheme change
Allow certain fields in the userenv to be updated by the new template of system, given that no old data will be overridden
Allow user to change or set a `valueFrom` reference to an already applied appenv

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/Olares/pull/2472

* **Other information**:
none