### PR TITLE
fix(cli): bind config item to the effective command

### DIFF
--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/beclab/Olares/cli/cmd/ctl/user"
 	"github.com/beclab/Olares/cli/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewDefaultCommand() *cobra.Command {
@@ -25,6 +26,11 @@ func NewDefaultCommand() *cobra.Command {
 		Short:             "Olares Installer",
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 		Version:           version.VERSION,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.InheritedFlags())
+			viper.BindPFlags(cmd.PersistentFlags())
+			viper.BindPFlags(cmd.Flags())
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if showVendor {
 				fmt.Println(version.VENDOR)

--- a/cli/pkg/common/kube_runtime.go
+++ b/cli/pkg/common/kube_runtime.go
@@ -211,6 +211,9 @@ func NewArgument() *Argument {
 	arg.IsOlaresInContainer = os.Getenv(ENV_CONTAINER_MODE) == "oic"
 	si.IsOIC = arg.IsOlaresInContainer
 
+	// Ensure BaseDir is initialized before loading master.conf
+	// so master host config can be loaded from ${base-dir}/master.conf reliably.
+	arg.SetBaseDir(viper.GetString(FlagBaseDir))
 	arg.loadMasterHostConfig()
 	return arg
 }

--- a/cli/pkg/pipelines/add_node.go
+++ b/cli/pkg/pipelines/add_node.go
@@ -18,7 +18,6 @@ func AddNodePipeline() error {
 	}
 
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("addnode.log", true)
 
 	if err := arg.MasterHostConfig.Validate(); err != nil {

--- a/cli/pkg/pipelines/changeip.go
+++ b/cli/pkg/pipelines/changeip.go
@@ -19,7 +19,6 @@ func ChangeIPPipeline() error {
 
 	var arg = common.NewArgument()
 	arg.SetOlaresVersion(terminusVersion)
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("changeip.log", true)
 	arg.SetKubeVersion(kubeType)
 	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))

--- a/cli/pkg/pipelines/check_download.go
+++ b/cli/pkg/pipelines/check_download.go
@@ -12,7 +12,6 @@ import (
 func CheckDownloadInstallationPackage() error {
 	arg := common.NewArgument()
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 
 	runtime, err := common.NewKubeRuntime(*arg)
 	if err != nil {

--- a/cli/pkg/pipelines/download_package.go
+++ b/cli/pkg/pipelines/download_package.go
@@ -13,7 +13,6 @@ import (
 
 func DownloadInstallationPackage() error {
 	arg := common.NewArgument()
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
 	arg.SetOlaresCDNService(viper.GetString(common.FlagCDNService))
 

--- a/cli/pkg/pipelines/download_wizard.go
+++ b/cli/pkg/pipelines/download_wizard.go
@@ -13,7 +13,6 @@ import (
 func DownloadInstallationWizard() error {
 	arg := common.NewArgument()
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetOlaresCDNService(viper.GetString(common.FlagCDNService))
 
 	runtime, err := common.NewKubeRuntime(*arg)

--- a/cli/pkg/pipelines/gpu_install.go
+++ b/cli/pkg/pipelines/gpu_install.go
@@ -15,7 +15,6 @@ import (
 func InstallGpuDrivers() error {
 	arg := common.NewArgument()
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("gpuinstall.log", true)
 	runtime, err := common.NewKubeRuntime(*arg)
 	if err != nil {

--- a/cli/pkg/pipelines/install_terminus.go
+++ b/cli/pkg/pipelines/install_terminus.go
@@ -20,7 +20,6 @@ func CliInstallTerminusPipeline() error {
 	}
 
 	arg := common.NewArgument()
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetKubeVersion(viper.GetString(common.FlagKubeType))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
 	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))

--- a/cli/pkg/pipelines/masterinfo.go
+++ b/cli/pkg/pipelines/masterinfo.go
@@ -8,7 +8,6 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/core/pipeline"
 	"github.com/beclab/Olares/cli/pkg/terminus"
-	"github.com/spf13/viper"
 )
 
 func MasterInfoPipeline() error {
@@ -17,7 +16,6 @@ func MasterInfoPipeline() error {
 		fmt.Println("error: Only Linux nodes can be added to an Olares cluster!")
 		os.Exit(1)
 	}
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("masterinfo.log", true)
 
 	if err := arg.MasterHostConfig.Validate(); err != nil {

--- a/cli/pkg/pipelines/precheck.go
+++ b/cli/pkg/pipelines/precheck.go
@@ -11,7 +11,6 @@ import (
 func StartPreCheckPipeline() error {
 	var arg = common.NewArgument()
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("precheck.log", true)
 
 	runtime, err := common.NewKubeRuntime(*arg)

--- a/cli/pkg/pipelines/prepare_system.go
+++ b/cli/pkg/pipelines/prepare_system.go
@@ -28,7 +28,6 @@ func PrepareSystemPipeline(components []string) error {
 	}
 
 	var arg = common.NewArgument()
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetKubeVersion(viper.GetString(common.FlagKubeType))
 	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))

--- a/cli/pkg/pipelines/storage.go
+++ b/cli/pkg/pipelines/storage.go
@@ -18,7 +18,6 @@ func CliInstallStoragePipeline() error {
 	}
 
 	arg := common.NewArgument()
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
 	arg.SetStorage(getStorageConfig())
 

--- a/cli/pkg/pipelines/uninstall_terminus.go
+++ b/cli/pkg/pipelines/uninstall_terminus.go
@@ -20,7 +20,6 @@ func UninstallTerminusPipeline() error {
 
 	var arg = common.NewArgument()
 	arg.SetOlaresVersion(version)
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetConsoleLog("uninstall.log", true)
 	arg.SetKubeVersion(kubeType)
 	arg.SetStorage(getStorageConfig())

--- a/cli/pkg/pipelines/upgrade.go
+++ b/cli/pkg/pipelines/upgrade.go
@@ -46,7 +46,6 @@ func UpgradeOlaresPipeline() error {
 	}
 
 	arg := common.NewArgument()
-	arg.SetBaseDir(viper.GetString(common.FlagBaseDir))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
 	arg.SetConsoleLog("upgrade.log", true)
 	arg.SetKubeVersion(phase.GetKubeType())


### PR DESCRIPTION
* **Background**
For some commands with exact same options, the viper config item may be bound to another command instead of the effective command, a `PersistentPreRun` is added before execution to make sure the correct command is bound to.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none