### PR TITLE
fix(cli): do not override upgrade target version by config file

### DIFF
--- a/cli/pkg/pipelines/upgrade.go
+++ b/cli/pkg/pipelines/upgrade.go
@@ -30,13 +30,7 @@ func UpgradeOlaresPipeline() error {
 		return fmt.Errorf("error parsing current Olares version: %v", err)
 	}
 
-	// should only be and defaults to the current cli version
-	// this argument is for backwards-compatibility with older olaresd
-	targetVersionStr := viper.GetString(common.FlagVersion)
-	if targetVersionStr == "" {
-		targetVersionStr = version.VERSION
-	}
-	targetVersion, err := utils.ParseOlaresVersionString(targetVersionStr)
+	targetVersion, err := utils.ParseOlaresVersionString(version.VERSION)
 	if err != nil {
 		return fmt.Errorf("error parsing target Olares version: %v", err)
 	}

--- a/cli/pkg/upgrade/1_12_5_20260122.go
+++ b/cli/pkg/upgrade/1_12_5_20260122.go
@@ -7,15 +7,15 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/task"
 )
 
-type upgrader_1_12_6_20260122 struct {
+type upgrader_1_12_5_20260122 struct {
 	breakingUpgraderBase
 }
 
-func (u upgrader_1_12_6_20260122) Version() *semver.Version {
-	return semver.MustParse("1.12.6-20260122")
+func (u upgrader_1_12_5_20260122) Version() *semver.Version {
+	return semver.MustParse("1.12.5-20260122")
 }
 
-func (u upgrader_1_12_6_20260122) UpgradeSystemComponents() []task.Interface {
+func (u upgrader_1_12_5_20260122) UpgradeSystemComponents() []task.Interface {
 	pre := []task.Interface{
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
@@ -28,5 +28,5 @@ func (u upgrader_1_12_6_20260122) UpgradeSystemComponents() []task.Interface {
 }
 
 func init() {
-	registerDailyUpgrader(upgrader_1_12_6_20260122{})
+	registerDailyUpgrader(upgrader_1_12_5_20260122{})
 }


### PR DESCRIPTION
* **Background**
Now that the config scheme for olares-cli is unified by env/option/file, the upgrade target version can be overridden by the config file, we explicitly set the target version to the build version.
The wrongly modified upgrader for 1.12.5 to 1.12.6 is reverted

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none