### PR TITLE
fix(cli): clear master host config when uninstalling

### DIFF
--- a/cli/pkg/common/kube_runtime.go
+++ b/cli/pkg/common/kube_runtime.go
@@ -385,6 +385,10 @@ func (a *Argument) loadMasterHostConfig() {
 	}
 }
 
+func (a *Argument) ClearMasterHostConfig() {
+	a.MasterHostConfig = &MasterHostConfig{}
+}
+
 func (a *Argument) SetManifest(manifest string) {
 	a.Manifest = manifest
 }

--- a/cli/pkg/pipelines/uninstall_terminus.go
+++ b/cli/pkg/pipelines/uninstall_terminus.go
@@ -23,6 +23,7 @@ func UninstallTerminusPipeline() error {
 	arg.SetConsoleLog("uninstall.log", true)
 	arg.SetKubeVersion(kubeType)
 	arg.SetStorage(getStorageConfig())
+	arg.ClearMasterHostConfig()
 
 	phase := viper.GetString(common.FlagUninstallPhase)
 	all := viper.GetBool(common.FlagUninstallAll)


### PR DESCRIPTION
* **Background**
Now that the master host config is automatically loaded, it must be explicitly cleared before executing the uninstallation pipeline to avoid master being uninstalled.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none