### PR TITLE
fix: seafile trim commit_id for syncing and change psql ccnet init

### DIFF
--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -166,6 +166,7 @@ data:
     user = seafile_os_framework
     password = {{ $pg_password | b64dec }}
     db_name = os_framework_seafile
+    ccnet_db_name = os_framework_ccnet
     connection_charset = utf8
     create_tables = true
   ccnet.conf: |-
@@ -248,7 +249,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.18
+        image: beclab/pg_seafile_server:v0.0.19
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- fix: seafile trim commit_id for syncing and change psql ccnet init

Target Version for Merge
- 1.12.5

Related Issues

PRs Involving Sub-Systems
- https://github.com/beclab/seafile-server/pull/3

Other information:
