### PR TITLE
fix(cli): seperate dmesg args for dmesg logs

### DIFF
--- a/cli/cmd/ctl/os/logs.go
+++ b/cli/cmd/ctl/os/logs.go
@@ -281,7 +281,7 @@ func collectSystemdLogs(tw *tar.Writer, options *LogCollectOptions) error {
 }
 
 func collectDmesgLogs(tw *tar.Writer, options *LogCollectOptions) error {
-	cmd := exec.Command("dmesg -T")
+	cmd := exec.Command("dmesg", "-T")
 	output, err := cmd.Output()
 	if err != nil {
 		return err


### PR DESCRIPTION
* **Background**
currently the cmd and args are concatenated

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none