### PR TITLE
feat(cli): add more lines to default journalctl limit

### DIFF
--- a/cli/cmd/ctl/os/logs.go
+++ b/cli/cmd/ctl/os/logs.go
@@ -648,7 +648,7 @@ func checkServiceExists(service string) bool {
 func NewCmdLogs() *cobra.Command {
 	options := &LogCollectOptions{
 		Since:            "7d",
-		MaxLines:         3000,
+		MaxLines:         20000,
 		OutputDir:        "./olares-logs",
 		IgnoreKubeErrors: false,
 	}


### PR DESCRIPTION
* **Background**
currently the default max lines limit is 3000, we lift this to 20000

* **Target Version for Merge**
1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none