### PR TITLE
feat(bfl): supports switch on/off access from external network

### DIFF
--- a/framework/bfl/cmd/apiserver/app/watch_entrance_ip.go
+++ b/framework/bfl/cmd/apiserver/app/watch_entrance_ip.go
@@ -72,7 +72,9 @@ func reconcile(ctx context.Context, terminusName constants.TerminusName, zone st
 	case "":
 		log.Warnf("user %q's network is not set up yet", user.Name)
 		return nil
-	case constants.ReverseProxyTypeNone:
+	case constants.ReverseProxyTypeExternalNetworkOff:
+		return nil
+	case constants.ReverseProxyTypePublic, constants.ReverseProxyTypeNone:
 		isPublicIP = true
 	case constants.ReverseProxyTypeCloudflare:
 		isCloudFlareTunnel = true

--- a/framework/bfl/pkg/apis/settings/v1alpha1/external_network/switch.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/external_network/switch.go
@@ -1,0 +1,444 @@
+package external_network
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
+	"bytetrade.io/web3os/bfl/pkg/constants"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/pkg/errors"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	PhaseProcessing = "PROCESSING"
+	PhaseCompleted  = "COMPLETED"
+	PhaseFailed     = "FAILED"
+)
+
+type SwitchConfig struct {
+	Spec   SwitchSpec   `json:"spec"`
+	Status SwitchStatus `json:"status"`
+}
+
+type SwitchSpec struct {
+	Disabled bool `json:"disabled"`
+}
+
+type SwitchStatus struct {
+	Phase     string `json:"phase,omitempty"`
+	StartedAt string `json:"startedAt,omitempty"`
+	TaskID    string `json:"taskId,omitempty"`
+	Message   string `json:"message,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+func DefaultConfig() *SwitchConfig {
+	return &SwitchConfig{
+		Spec: SwitchSpec{Disabled: false},
+		Status: SwitchStatus{
+			Phase: PhaseCompleted,
+		},
+	}
+}
+
+func (c *SwitchConfig) PrettyJSON() (string, error) {
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func ParseConfigMap(cm *corev1.ConfigMap) (*SwitchConfig, error) {
+	if cm == nil || cm.Data == nil {
+		return DefaultConfig(), nil
+	}
+	raw := cm.Data[constants.ExternalNetworkSwitchConfigKey]
+	if raw == "" {
+		return DefaultConfig(), nil
+	}
+	cfg := &SwitchConfig{}
+	if err := json.Unmarshal([]byte(raw), cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal external network switch config")
+	}
+	// tolerate missing fields
+	if cfg.Status.Phase == "" {
+		cfg.Status.Phase = PhaseCompleted
+	}
+	return cfg, nil
+}
+
+func Load(ctx context.Context) (*SwitchConfig, *corev1.ConfigMap, error) {
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		return nil, nil, err
+	}
+	cm, err := kc.Kubernetes().CoreV1().ConfigMaps(constants.OSSystemNamespace).Get(ctx, constants.ExternalNetworkSwitchConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return DefaultConfig(), nil, nil
+		}
+		return nil, nil, err
+	}
+	cfg, err := ParseConfigMap(cm)
+	return cfg, cm, err
+}
+
+func Upsert(ctx context.Context, mutate func(*SwitchConfig) error) (*SwitchConfig, error) {
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		cm, err := kc.Kubernetes().CoreV1().ConfigMaps(constants.OSSystemNamespace).Get(ctx, constants.ExternalNetworkSwitchConfigMapName, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		var cfg *SwitchConfig
+		if apierrors.IsNotFound(err) {
+			cfg = DefaultConfig()
+			cm = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.ExternalNetworkSwitchConfigMapName,
+					Namespace: constants.OSSystemNamespace,
+				},
+				Data: map[string]string{},
+			}
+		} else {
+			cfg, err = ParseConfigMap(cm)
+			if err != nil {
+				return nil, err
+			}
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+		}
+
+		if mutate != nil {
+			if err := mutate(cfg); err != nil {
+				return nil, err
+			}
+		}
+		cfg.Status.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		raw, err := cfg.PrettyJSON()
+		if err != nil {
+			return nil, err
+		}
+		cm.Data[constants.ExternalNetworkSwitchConfigKey] = raw
+
+		if cm.ResourceVersion == "" {
+			_, err = kc.Kubernetes().CoreV1().ConfigMaps(constants.OSSystemNamespace).Create(ctx, cm, metav1.CreateOptions{})
+			if err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					continue
+				}
+				return nil, err
+			}
+			return cfg, nil
+		}
+
+		_, err = kc.Kubernetes().CoreV1().ConfigMaps(constants.OSSystemNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return nil, err
+		}
+		return cfg, nil
+	}
+}
+
+type IntegrationAccount struct {
+	AccessToken string
+	UserID      string
+	RawData     any
+}
+
+type settingsRetrieveAccountResponse struct {
+	Code    int `json:"code"`
+	Message any `json:"message"`
+	Data    *struct {
+		Name    string `json:"name"`
+		Type    string `json:"type"`
+		RawData struct {
+			RefreshToken string `json:"refresh_token"`
+			AccessToken  string `json:"access_token"`
+			ExpiresIn    int64  `json:"expires_in"`
+			ExpiresAt    int64  `json:"expires_at"`
+			UserID       string `json:"userid"`
+			Available    bool   `json:"available"`
+			CreateAt     int64  `json:"create_at"`
+		} `json:"raw_data"`
+	} `json:"data"`
+}
+
+func getUserBackendServiceAccountToken(ctx context.Context, ownerUsername string) (string, error) {
+	if ownerUsername == "" {
+		return "", errors.New("empty owner username")
+	}
+	ns := fmt.Sprintf("user-system-%s", ownerUsername)
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		return "", err
+	}
+	// Use TokenRequest API to mint a token for serviceaccount "user-backend" in the user's system namespace.
+	tr := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			// leave audiences default; just request a short-lived token
+			ExpirationSeconds: pointer.Int64(3600),
+		},
+	}
+	resp, err := kc.Kubernetes().CoreV1().ServiceAccounts(ns).CreateToken(ctx, "user-backend", tr, metav1.CreateOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "create serviceaccount token failed")
+	}
+	if resp == nil || resp.Status.Token == "" {
+		return "", errors.New("empty serviceaccount token")
+	}
+	return resp.Status.Token, nil
+}
+
+// GetIntegrationAccount fetches integration account token/userid from settings backend:
+// POST http://settings.user-system-{owner}:28080/api/account/retrieve
+// body: {"name":"integration-account:space:{terminusName}"}
+// auth: serviceaccount token of user-backend in namespace user-system-{owner}.
+func GetIntegrationAccount(ctx context.Context, ownerUsername, terminusName string) (*IntegrationAccount, error) {
+	if ownerUsername == "" {
+		return nil, errors.New("empty owner username")
+	}
+	if terminusName == "" {
+		return nil, errors.New("empty terminus name")
+	}
+	saToken, err := getUserBackendServiceAccountToken(ctx, ownerUsername)
+	if err != nil {
+		return nil, err
+	}
+
+	ns := fmt.Sprintf("user-system-%s", ownerUsername)
+	reqURL := fmt.Sprintf("http://settings.%s:28080/api/account/retrieve", ns)
+	payload := map[string]string{
+		"name": fmt.Sprintf("integration-account:space:%s", terminusName),
+	}
+	var out settingsRetrieveAccountResponse
+	r, err := resty.New().SetTimeout(30*time.Second).R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Authorization", fmt.Sprintf("Bearer %s", saToken)).
+		SetBody(payload).
+		SetResult(&out).
+		Post(reqURL)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("settings retrieve account: status=%d body=%s", r.StatusCode(), string(r.Body()))
+	}
+	if out.Code != 0 || out.Data == nil {
+		return nil, fmt.Errorf("settings retrieve account: code=%d message=%v", out.Code, out.Message)
+	}
+	if out.Data.RawData.AccessToken == "" || out.Data.RawData.UserID == "" {
+		return nil, fmt.Errorf("settings retrieve account: missing access_token/userid")
+	}
+	return &IntegrationAccount{
+		AccessToken: out.Data.RawData.AccessToken,
+		UserID:      out.Data.RawData.UserID,
+		RawData:     out.Data.RawData,
+	}, nil
+}
+
+type PublicDNSDeleteResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    *struct {
+		TaskID string `json:"taskId"`
+		Status string `json:"status"`
+	} `json:"data"`
+}
+
+type PublicDNSInfoResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    *struct {
+		DNSType  string `json:"dnsType"`
+		DNSValue string `json:"dnsValue"`
+		DNSName  string `json:"dnsName"`
+	} `json:"data"`
+}
+
+type PublicDNSTaskResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    *struct {
+		TaskID     string `json:"taskId"`
+		TerminusID string `json:"terminusId"`
+		Tasks      []struct {
+			UserID string `json:"userid"`
+			Status string `json:"status"`
+			Msg    string `json:"message"`
+		} `json:"tasks"`
+	} `json:"data"`
+}
+
+func publicDNSBase() (string, error) {
+	u, err := url.JoinPath(constants.OlaresRemoteService, "/space/v1/resource/public-dns")
+	if err != nil {
+		return "", err
+	}
+	return u, nil
+}
+
+type PublicDNSRecoverResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
+type PublicDNSAuthPayload struct {
+	Token  string `json:"token"`
+	UserID string `json:"userid"`
+}
+
+func RecoverPublicDNS(ctx context.Context, auth PublicDNSAuthPayload) error {
+	base, err := publicDNSBase()
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/recover", base)
+	var out PublicDNSRecoverResponse
+	r, err := resty.New().SetTimeout(30*time.Second).R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(auth).
+		SetResult(&out).
+		Post(endpoint)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return fmt.Errorf("public dns recover: status=%d body=%s", r.StatusCode(), string(r.Body()))
+	}
+	if out.Code != 200 {
+		return fmt.Errorf("public dns recover: unexpected response: code=%d message=%s", out.Code, out.Message)
+	}
+	return nil
+}
+
+func CreatePublicDNSDeleteTask(ctx context.Context, auth PublicDNSAuthPayload) (string, error) {
+	base, err := publicDNSBase()
+	if err != nil {
+		return "", err
+	}
+	endpoint := fmt.Sprintf("%s/delete", base)
+	var out PublicDNSDeleteResponse
+	r, err := resty.New().SetTimeout(30*time.Second).R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(auth).
+		SetResult(&out).
+		Post(endpoint)
+	if err != nil {
+		return "", err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("public dns delete: status=%d body=%s", r.StatusCode(), string(r.Body()))
+	}
+	if out.Code != 200 || out.Data == nil || out.Data.TaskID == "" {
+		return "", fmt.Errorf("public dns delete: unexpected response: code=%d message=%s", out.Code, out.Message)
+	}
+	return out.Data.TaskID, nil
+}
+
+func GetPublicDNSInfo(ctx context.Context, auth PublicDNSAuthPayload) (bool, error) {
+	base, err := publicDNSBase()
+	if err != nil {
+		return false, err
+	}
+	endpoint := fmt.Sprintf("%s/info", base)
+	var out PublicDNSInfoResponse
+	r, err := resty.New().SetTimeout(30*time.Second).R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(auth).
+		SetResult(&out).
+		Post(endpoint)
+	if err != nil {
+		return false, err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("public dns info: status=%d body=%s", r.StatusCode(), string(r.Body()))
+	}
+	switch out.Code {
+	case 200:
+		if out.Data == nil {
+			return false, fmt.Errorf("public dns info: missing data")
+		}
+		return true, nil
+	case 501:
+		return false, nil
+	default:
+		return false, fmt.Errorf("public dns info: unexpected response: code=%d message=%s", out.Code, out.Message)
+	}
+}
+
+func GetPublicDNSTask(ctx context.Context, auth PublicDNSAuthPayload, taskID string) (*PublicDNSTaskResponse, error) {
+	base, err := publicDNSBase()
+	if err != nil {
+		return nil, err
+	}
+	endpoint := fmt.Sprintf("%s/task/%s", base, url.PathEscape(taskID))
+	var out PublicDNSTaskResponse
+	r, err := resty.New().SetTimeout(30*time.Second).R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(auth).
+		SetResult(&out).
+		Post(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("public dns task: status=%d body=%s", r.StatusCode(), string(r.Body()))
+	}
+	if out.Code != 200 || out.Data == nil {
+		return nil, fmt.Errorf("public dns task: unexpected response: code=%d message=%s", out.Code, out.Message)
+	}
+	return &out, nil
+}
+
+func (r *PublicDNSTaskResponse) AllTasksCompleted() (bool, string) {
+	if r == nil || r.Data == nil {
+		return false, "empty response"
+	}
+	if len(r.Data.Tasks) == 0 {
+		return false, "no tasks"
+	}
+	var failed []string
+	for _, t := range r.Data.Tasks {
+		switch t.Status {
+		case "COMPLETED":
+			continue
+		case "FAILED":
+			failed = append(failed, fmt.Sprintf("%s:%s", t.UserID, t.Msg))
+		default:
+			// PENDING/PROCESSING
+			return false, ""
+		}
+	}
+	if len(failed) > 0 {
+		return false, fmt.Sprintf("failed tasks: %v", failed)
+	}
+	return true, ""
+}

--- a/framework/bfl/pkg/apis/settings/v1alpha1/model.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/model.go
@@ -92,6 +92,25 @@ type PublicDomainAccessPolicy struct {
 	// AllowedDomains []string `json:"allowed_domains"`
 }
 
+type ExternalNetworkSwitchUpdateRequest struct {
+	Disabled bool `json:"disabled"`
+}
+
+type ExternalNetworkSwitchView struct {
+	Spec   ExternalNetworkSwitchSpecView   `json:"spec"`
+	Status ExternalNetworkSwitchStatusView `json:"status"`
+}
+
+type ExternalNetworkSwitchSpecView struct {
+	Disabled bool `json:"disabled"`
+}
+
+type ExternalNetworkSwitchStatusView struct {
+	Phase     string `json:"phase,omitempty"`
+	Message   string `json:"message,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
 type ActivateRequest struct {
 	Language string `json:"language"`
 	Location string `json:"location"`

--- a/framework/bfl/pkg/apis/settings/v1alpha1/register.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/register.go
@@ -65,6 +65,19 @@ func AddContainer(c *restful.Container) error {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))
 
+	ws.Route(ws.GET("/external-network").
+		To(handler.handleGetExternalNetworkSwitch).
+		Doc("Get external network switch status.").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
+	ws.Route(ws.POST("/external-network").
+		To(handler.handleUpdateExternalNetworkSwitch).
+		Doc("Enable/Disable external network access (owner only).").
+		Reads(ExternalNetworkSwitchUpdateRequest{}).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
 	ws.Route(ws.GET("/launcher-acc-policy").
 		To(handler.handleGetLauncherAccessPolicy).
 		Doc("Get launcher access policy.").

--- a/framework/bfl/pkg/constants/constants.go
+++ b/framework/bfl/pkg/constants/constants.go
@@ -188,10 +188,17 @@ var (
 
 	UserAnnotationLocalDomainDNSRecord = fmt.Sprintf("%s/local-domain-dns-record", AnnotationGroup)
 
-	UserAnnotationReverseProxyType = fmt.Sprintf("%s/reverse-proxy-type", AnnotationGroup)
-	ReverseProxyTypeFRP            = "frp"
-	ReverseProxyTypeCloudflare     = "cloudflare"
-	ReverseProxyTypeNone           = "none"
+	UserAnnotationReverseProxyType     = fmt.Sprintf("%s/reverse-proxy-type", AnnotationGroup)
+	ReverseProxyTypeFRP                = "frp"
+	ReverseProxyTypeCloudflare         = "cloudflare"
+	ReverseProxyTypePublic             = "public"
+	ReverseProxyTypeNone               = "none"
+	ReverseProxyTypeExternalNetworkOff = "external_network_off"
+)
+
+var (
+	ExternalNetworkSwitchConfigMapName = "external-network-switch"
+	ExternalNetworkSwitchConfigKey     = "config.json"
 )
 
 var (

--- a/framework/bfl/pkg/watchers/external_network_switch/external_network_switch.go
+++ b/framework/bfl/pkg/watchers/external_network_switch/external_network_switch.go
@@ -1,0 +1,327 @@
+package external_network_switch
+
+import (
+	"context"
+	"fmt"
+	"errors"
+	"time"
+
+	"bytetrade.io/web3os/bfl/pkg/apis/iam/v1alpha1/operator"
+	settingsv1alpha1 "bytetrade.io/web3os/bfl/pkg/apis/settings/v1alpha1"
+	external_network "bytetrade.io/web3os/bfl/pkg/apis/settings/v1alpha1/external_network"
+	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
+	"bytetrade.io/web3os/bfl/pkg/constants"
+	"bytetrade.io/web3os/bfl/pkg/watchers"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+var GVR = schema.GroupVersionResource{
+	Group: "", Version: "v1", Resource: "configmaps",
+}
+
+type Subscriber struct {
+	*watchers.Watchers
+}
+
+func NewSubscriber(w *watchers.Watchers) *Subscriber {
+	return &Subscriber{Watchers: w}
+}
+
+func (s *Subscriber) Handler() cache.ResourceEventHandler {
+	handleFunc := func(obj interface{}) {
+		s.Watchers.Enqueue(
+			watchers.EnqueueObj{
+				Subscribe: s,
+				Obj:       obj,
+				Action:    watchers.UPDATE,
+			},
+		)
+	}
+	return cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				klog.Error("not configmap resource, invalid obj")
+				return false
+			}
+			return cm.Namespace == constants.OSSystemNamespace && cm.Name == constants.ExternalNetworkSwitchConfigMapName
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: handleFunc,
+			UpdateFunc: func(_, new interface{}) {
+				handleFunc(new)
+			},
+			DeleteFunc: func(_ interface{}) {},
+		},
+	}
+}
+
+func (s *Subscriber) Do(ctx context.Context, obj interface{}, _ watchers.Action) error {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok || cm == nil {
+		klog.Error("external network switch: invalid object type")
+		return fmt.Errorf("invalid object type")
+	}
+	cfg, err := external_network.ParseConfigMap(cm)
+	if err != nil {
+		klog.Errorf("external network switch: parse configmap error: %v", err)
+		return err
+	}
+	return s.reconcile(ctx, cfg)
+}
+
+func (s *Subscriber) reconcile(ctx context.Context, cfg *external_network.SwitchConfig) (retErr error) {
+	if cfg == nil {
+		return nil
+	}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		var rq *requeueError
+		if errors.As(retErr, &rq) {
+			return
+		}
+		_, _ = external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+			sw.Status.Message = retErr.Error()
+			return nil
+		})
+	}()
+	klog.Infof("external network switch reconcile: spec.disabled=%v phase=%s startedAt=%s taskId=%s",
+		cfg.Spec.Disabled, cfg.Status.Phase, cfg.Status.StartedAt, cfg.Status.TaskID)
+	// do not retry automatically once marked failed; wait for a new request to change spec/phase
+	if cfg.Status.Phase == external_network.PhaseFailed {
+		klog.Infof("external network switch: phase=FAILED, stop retrying")
+		return nil
+	}
+	if cfg.Status.Phase == external_network.PhaseCompleted {
+		klog.Infof("external network switch: phase=COMPLETED, already converged to spec.disabled=%v", cfg.Spec.Disabled)
+		return nil
+	}
+	start := cfg.Status.StartedAt
+	if start != "" {
+		if t, err := time.Parse(time.RFC3339, start); err == nil {
+			if time.Since(t) > 15*time.Minute {
+				klog.Errorf("external network switch: operation timeout (>10m), marking failed. spec.disabled=%v startedAt=%s",
+					cfg.Spec.Disabled, start)
+				_, _ = external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+					sw.Spec.Disabled = cfg.Spec.Disabled
+					sw.Status.Phase = external_network.PhaseFailed
+					sw.Status.Message = "operation timed out"
+					return nil
+				})
+				return nil
+			}
+		} else {
+			klog.Warningf("external network switch: invalid startedAt %q: %v", start, err)
+		}
+	}
+
+	userOp, err := operator.NewUserOperatorWithContext(ctx)
+	if err != nil {
+		klog.Errorf("external network switch: new user operator error: %v", err)
+		return err
+	}
+	// fetch integration account token/userid on-demand for external public-dns APIs
+	ownerUser, err := userOp.GetUser("")
+	if err != nil {
+		klog.Errorf("external network switch: get owner user error: %v", err)
+		return err
+	}
+	terminusName := userOp.GetUserAnnotation(ownerUser, constants.UserAnnotationTerminusNameKey)
+	acc, err := external_network.GetIntegrationAccount(ctx, ownerUser.Name, terminusName)
+	if err != nil {
+		klog.Errorf("external network switch: get integration account error: %v", err)
+		return err
+	}
+	auth := external_network.PublicDNSAuthPayload{Token: acc.AccessToken, UserID: acc.UserID}
+
+	if !cfg.Spec.Disabled {
+		if err := external_network.RecoverPublicDNS(ctx, auth); err != nil {
+			klog.Errorf("external network switch: public dns recover error: %v", err)
+			return err
+		}
+		klog.Infof("external network switch: public dns recover completed")
+		if err := applyReverseProxyExternalOff(ctx, userOp, cfg.Spec.Disabled); err != nil {
+			return err
+		}
+		_, err := external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+			sw.Spec.Disabled = false
+			sw.Status.Phase = external_network.PhaseCompleted
+			sw.Status.Message = ""
+			sw.Status.TaskID = ""
+			return nil
+		})
+		if err == nil {
+			klog.Infof("external network switch: enable completed")
+		}
+		return err
+	}
+
+	if cfg.Status.TaskID == "" {
+		hasRecord, err := external_network.GetPublicDNSInfo(ctx, auth)
+		if err != nil {
+			klog.Errorf("external network switch: get public dns info error: %v", err)
+			return err
+		}
+		if !hasRecord {
+			klog.Infof("external network switch: no public dns record, skipping delete task")
+			if err := applyReverseProxyExternalOff(ctx, userOp, cfg.Spec.Disabled); err != nil {
+				return err
+			}
+			_, err := external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+				sw.Spec.Disabled = true
+				sw.Status.Phase = external_network.PhaseCompleted
+				sw.Status.Message = ""
+				sw.Status.TaskID = ""
+				return nil
+			})
+			if err == nil {
+				klog.Infof("external network switch: disable completed (no public dns record)")
+			}
+			return err
+		}
+		klog.Infof("external network switch: disabling flow, creating public dns delete task")
+		taskID, err := external_network.CreatePublicDNSDeleteTask(ctx, auth)
+		if err != nil {
+			// todo: parse specific error and determine if retry is possible
+			klog.Errorf("external network switch: create public dns delete task error: %v", err)
+			return err
+		}
+		klog.Infof("external network switch: public dns delete task created: taskId=%s", taskID)
+		_, err = external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+			sw.Spec.Disabled = true
+			sw.Status.TaskID = taskID
+			sw.Status.Phase = external_network.PhaseProcessing
+			sw.Status.Message = "delete task created"
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		return newRequeueError(fmt.Errorf("delete task created, waiting"))
+	}
+
+	taskResp, err := external_network.GetPublicDNSTask(ctx, auth, cfg.Status.TaskID)
+	if err != nil {
+		// todo: parse specific error and determine if retry is possible (if task not exists, it needs to be created again)
+		klog.Errorf("external network switch: get public dns task error: taskId=%s err=%v", cfg.Status.TaskID, err)
+		return err
+	}
+	done, msg := taskResp.AllTasksCompleted()
+	if done {
+		if err := applyReverseProxyExternalOff(ctx, userOp, cfg.Spec.Disabled); err != nil {
+			return err
+		}
+		_, err := external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+			sw.Spec.Disabled = true
+			sw.Status.Phase = external_network.PhaseCompleted
+			sw.Status.Message = ""
+			return nil
+		})
+		if err == nil {
+			klog.Infof("external network switch: disable completed. taskId=%s", cfg.Status.TaskID)
+		}
+		return err
+	}
+	if msg != "" {
+		// task response contains failed tasks -> mark failed and stop retrying
+		klog.Errorf("external network switch: public dns delete tasks failed: taskId=%s msg=%s", cfg.Status.TaskID, msg)
+		_, err := external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+			sw.Spec.Disabled = true
+			sw.Status.Phase = external_network.PhaseFailed
+			sw.Status.Message = msg
+			return nil
+		})
+		return err
+	}
+	_, _ = external_network.Upsert(ctx, func(sw *external_network.SwitchConfig) error {
+		sw.Spec.Disabled = true
+		sw.Status.Phase = external_network.PhaseProcessing
+		sw.Status.Message = "waiting public dns delete tasks"
+		return nil
+	})
+	klog.Infof("external network switch: waiting public dns delete tasks. taskId=%s", cfg.Status.TaskID)
+	return newRequeueError(fmt.Errorf("waiting public dns delete tasks"))
+}
+
+type requeueError struct {
+	err error
+}
+
+func (e *requeueError) Error() string {
+	return e.err.Error()
+}
+
+func newRequeueError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &requeueError{err: err}
+}
+
+func upsertReverseProxyConfigExternalOff(ctx context.Context, client kubernetes.Interface, namespace string, off bool) error {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, constants.ReverseProxyConfigMapName, metav1.GetOptions{})
+	isNew := false
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		isNew = true
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.ReverseProxyConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{},
+		}
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	want := ""
+	if off {
+		want = settingsv1alpha1.ReverseProxyConfigValueTrue
+	}
+	if cm.Data[settingsv1alpha1.ReverseProxyConfigKeyExternalNetworkOff] == want {
+		return nil
+	}
+	cm.Data[settingsv1alpha1.ReverseProxyConfigKeyExternalNetworkOff] = want
+	if isNew {
+		_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+	_, err = client.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+func applyReverseProxyExternalOff(ctx context.Context, userOp *operator.UserOperator, off bool) error {
+	users, err := userOp.ListUsers()
+	if err != nil {
+		klog.Errorf("external network switch: list users error: %v", err)
+		return err
+	}
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		klog.Errorf("external network switch: new kube client error: %v", err)
+		return err
+	}
+	kube := kc.Kubernetes()
+
+	for _, u := range users {
+		ns := fmt.Sprintf(constants.UserspaceNameFormat, u.Name)
+		if err := upsertReverseProxyConfigExternalOff(ctx, kube, ns, off); err != nil {
+			klog.Errorf("external network switch: update reverse-proxy-config off=%v in ns=%s error: %v",
+				off, ns, err)
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
* **Background**
Add a new API route `/bfl/settings/v1alpha1/external-network` to query & update the current settings of access from external network, preserved in configmap
Only accounts with Olares Space integration can operate on this setting
A new watcher is added to reconcile the configmap, propagating settings for all sub accounts, and invoking public DNS APIs
A new flag `external_network_off` is added to the reverse proxy config to override and disable any existing reverse proxy config

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none