### PR TITLE
fix: set amd apu/gpu limit key to amd.com/gpu

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -338,7 +338,10 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 	case utils.GB10ChipType:
 		return constants.NvidiaGB10GPU
 	case utils.AmdApuCardType:
-		return constants.AMDAPU
+		return constants.AMDGPU
+	case utils.AmdGpuCardType:
+		return constants.AMDGPU
+
 	default:
 		return ""
 	}

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -87,6 +87,7 @@ const (
 	NvidiaGPU     = "nvidia.com/gpu"
 	NvidiaGB10GPU = "nvidia.com/gb10"
 	AMDAPU        = "amd.com/apu"
+	AMDGPU        = "amd.com/gpu"
 
 	AuthorizationLevelOfPublic  = "public"
 	AuthorizationLevelOfPrivate = "private"


### PR DESCRIPTION
* **Background**
set amd apu/gpu limit key to amd.com/gpu
* **Target Version for Merge**
v1.12.6
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
