### PR TITLE
authelia: add auth type param to user regulation

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.46
+        image: beclab/auth:0.2.47
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Add the Authorization type parameter to the user regulation when loading authorization logs. Allow to regulate the user's TOTP attempt

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
User regulation failed in the TOTP attempt

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/fb89d2b0a0dd0b2232bb66b96432829dfcd15b57

* **Other information**:
