### PR TITLE
fix(cli): ignore finished pods in readiness check

### DIFF
--- a/cli/pkg/utils/pod.go
+++ b/cli/pkg/utils/pod.go
@@ -11,6 +11,13 @@ func AssertPodReady(pod *corev1.Pod) error {
 		return fmt.Errorf("pod is nil")
 	}
 
+	// simply ignore finished pod
+	// it can be seen as just an execution record, not a running pod
+	// and the deployment will create a new replica
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return nil
+	}
+
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	if pod.DeletionTimestamp != nil {
 		return fmt.Errorf("pod %s is terminating", podKey)


### PR DESCRIPTION
* **Background**
Currently, for many tasks that triggers components' restart, a readiness check for all key pods is done at the end, for this case, any finished pods, either succeeded or failed, should be filtered out as it's just an execution record and does not affect the system's functionning.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none