### PR TITLE
fix: bfl add sync urls to master node

### DIFF
--- a/framework/bfl/internal/ingress/controllers/patches.go
+++ b/framework/bfl/internal/ingress/controllers/patches.go
@@ -138,6 +138,13 @@ func filesNodeApiPatch(ctx context.Context, r *NginxController, s *config.Server
 		"/api/preview/share/",
 		"/api/tree/share/",
 		"/api/raw/share/",
+		"/api/resources/sync/",
+		"/api/preview/sync/",
+		"/api/tree/sync/",
+		"/api/raw/sync/",
+		"/api/md5/sync/",
+		"/api/sync/account/info/",
+		"/api/search/sync_search/",
 	}
 
 	for node := range podMap {


### PR DESCRIPTION
Background
- bfl add sync urls to master node

Target Version for Merge
- v1.12.5

Related Issues
- None

PRs Involving Sub-Systems
- None

Other information: