### PR TITLE
fix: update bfl-ingress image to v0.3.30

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -317,7 +317,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.29
+        image: beclab/bfl-ingress:v0.3.30
         imagePullPolicy: IfNotPresent
         env:
         - name: AUTHELIA_AUTH_URL


### PR DESCRIPTION
Background
- bfl add sync urls to master node

Target Version for Merge
- v1.12.5, v1.12.6

Related Issues
- None

PRs Involving Sub-Systems
- None

Other information:
