### PR TITLE
fix: upgrade bfl-ingress image version to v0.3.29-125

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -317,7 +317,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: ingress
-        image: beclab/bfl-ingress:v0.3.28
+        image: beclab/bfl-ingress:v0.3.29-125
         imagePullPolicy: IfNotPresent
         env:
         - name: AUTHELIA_AUTH_URL

--- a/framework/bfl/internal/ingress/controllers/patches.go
+++ b/framework/bfl/internal/ingress/controllers/patches.go
@@ -138,6 +138,13 @@ func filesNodeApiPatch(ctx context.Context, r *NginxController, s *config.Server
 		"/api/preview/share/",
 		"/api/tree/share/",
 		"/api/raw/share/",
+		"/api/resources/sync/",
+		"/api/preview/sync/",
+		"/api/tree/sync/",
+		"/api/raw/sync/",
+		"/api/md5/sync/",
+		"/api/sync/account/info/",
+		"/api/search/sync_search/",
 	}
 
 	for node := range podMap {


### PR DESCRIPTION
Background
- add sync urls to master node

Target Version for Merge
- v1.12.5

Related Issues
- none

PRs Involving Sub-Systems
- none

Other information:
