### PR TITLE
olares app: Use the Roboto font to match the theme of the rest of the applications

### DIFF
--- a/apps/packages/app/src/apps/Desktop/components/BasicWindow.vue
+++ b/apps/packages/app/src/apps/Desktop/components/BasicWindow.vue
@@ -415,7 +415,7 @@ export default defineComponent({
 		background-color: $background-1;
 
 		.app_title {
-			font-family: 'Inter';
+			font-family: 'Roboto' !important;
 			font-style: normal;
 			font-weight: 600;
 			font-size: 16px;

--- a/apps/packages/app/src/apps/Desktop/mobile/BasicWindow.vue
+++ b/apps/packages/app/src/apps/Desktop/mobile/BasicWindow.vue
@@ -358,7 +358,7 @@ export default defineComponent({
 		left: 0;
 
 		.app_title {
-			font-family: 'Source Han Sans CN';
+			font-family: 'Roboto' !important;
 			font-style: normal;
 			font-weight: 500;
 			font-size: 16px;


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
Updated the app_title class to use the 'Roboto' font style. Right now the app title font looks like "Times new roman" and does not match the rest of the application themes. 

* **Target Version for Merge**
1.12.5

* **Related Issues**
N/A

* **PRs Involving Sub-Systems** 
N/A

* **Other information**:
N/A - The font style was bugging me and thought it could be an easy fix