### PR TITLE
fix: skip nginx reload if configuration has not changed

### DIFF
--- a/framework/l4-bfl-proxy/main.go
+++ b/framework/l4-bfl-proxy/main.go
@@ -146,6 +146,8 @@ type Server struct {
 	ngxCmd *nginx.Command
 
 	ngxTmpl *template.Template
+
+	prevNgxConf []byte
 }
 
 func (s *Server) init() error {
@@ -932,6 +934,13 @@ func (s *Server) renderAndReload() error {
 		return err
 	}
 	nginxConfig := buf.Bytes()
+
+	if bytes.Equal(nginxConfig, s.prevNgxConf) {
+		klog.Infof("nginx config not changed, skip reload")
+		return nil
+	}
+	s.prevNgxConf = nginxConfig
+
 	err = s.testTemplate(nginxConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Skip nginx reload if configuration has not changed