### PR TITLE
fix: conditionally install storage for juicefs

### DIFF
--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -202,11 +202,15 @@ if [ "$PREINSTALL" == "1" ]; then
 fi
 
 
-echo "configuring storage ..."
-$sh_c "$INSTALL_OLARES_CLI install storage"
-if [[ $? -ne 0 ]]; then
-    echo "error: failed to configure storage"
-    exit 1
+if [[ "$JUICEFS" == "1" ]]; then
+    echo "configuring storage for juicefs ..."
+    $sh_c "$INSTALL_OLARES_CLI install storage"
+    if [[ $? -ne 0 ]]; then
+        echo "error: failed to configure storage"
+        exit 1
+    fi
+else
+    echo "juicefs is not enabled, skip configuring storage"
 fi
 
 


### PR DESCRIPTION
* **Background**
When unifying environment variables with cli options and config items, all conditions in build scripts were removed, but the command to configure storage should only be executed when juicefs is enabled.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small installer-script guard that only affects whether `install storage` runs, with no impact to the main install path when `JUICEFS=1`. Risk is limited to mis-set environment variables causing storage setup to be skipped or unexpectedly run.
> 
> **Overview**
> The installer now **conditionally configures storage**: `install.sh` runs `olares install storage` only when `JUICEFS=1`, otherwise it skips storage setup with a log message.
> 
> This restores a missing guard so non-JuiceFS installs no longer attempt storage configuration before running the main `olares install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e49fa96663921a78ebe804f4e037e2f07b7e0e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->