### PR TITLE
feat(cli): add mainline upgrader for 1.12.5

### DIFF
--- a/cli/pkg/upgrade/1_12_5.go
+++ b/cli/pkg/upgrade/1_12_5.go
@@ -1,0 +1,57 @@
+package upgrade
+
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/gpu"
+	"github.com/beclab/Olares/cli/version"
+)
+
+var version_1_12_5 = semver.MustParse("1.12.5")
+
+type upgrader_1_12_5 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_5) Version() *semver.Version {
+	cliVersion, err := semver.NewVersion(version.VERSION)
+	// tolerate local dev version
+	if err != nil {
+		return version_1_12_5
+	}
+	if samePatchLevelVersion(version_1_12_5, cliVersion) && getReleaseLineOfVersion(cliVersion) == mainLine {
+		return cliVersion
+	}
+	return version_1_12_5
+}
+
+func (u upgrader_1_12_5) AddedBreakingChange() bool {
+	if u.Version().Equal(version_1_12_5) {
+		return true
+	}
+	return false
+}
+
+func (u upgrader_1_12_5) UpgradeSystemComponents() []task.Interface {
+	pre := []task.Interface{
+		&task.LocalTask{
+			Name:   "UpgradeL4BFLProxy",
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.11"},
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+		&task.LocalTask{
+			Name:   "UpdateNodeGPUInfo",
+			Action: new(gpu.UpdateNodeGPUInfo),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	}
+	return append(pre, u.upgraderBase.UpgradeSystemComponents()...)
+}
+
+func init() {
+	registerMainUpgrader(upgrader_1_12_5{})
+}


### PR DESCRIPTION
* **Background**
Add upgrader for stable version 1.12.5 to upgrade L4 proxy and node GPU infos

* **Target Version for Merge**
1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the mainline upgrade path by introducing new pre-upgrade tasks that modify system components (L4 proxy) and update node GPU metadata; failures could impact cluster networking or GPU scheduling during upgrades.
> 
> **Overview**
> Adds a new mainline upgrader `upgrader_1_12_5` (version-resolved against `version.VERSION`) and registers it for the `1.12.5` stable release.
> 
> During `UpgradeSystemComponents`, it now **prepends** two retryable tasks: upgrading `upgradeL4BFLProxy` to tag `v0.3.11` and running `gpu.UpdateNodeGPUInfo`, before continuing with the existing base upgrade sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86ab19aa32fccf4a283ec9452847977d4aeac4fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->