### PR TITLE
fix(cli): dynamic creation of nvidia runtimeclass

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/device-plugin/runtime-class.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/device-plugin/runtime-class.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.devicePlugin.createRuntimeClass .Values.devicePlugin.runtimeClassName }}
+{{- $existingRuntimeClass := lookup "node.k8s.io/v1" "RuntimeClass" "" .Values.devicePlugin.runtimeClassName }}
+{{- if not $existingRuntimeClass }}
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
@@ -6,4 +8,5 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
 handler: nvidia
+{{- end }}
 {{- end }}

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -151,9 +151,9 @@ devicePlugin:
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
   # The runtime class name to be used by the device plugin, and added to the pod.spec.runtimeClassName of applications utilizing NVIDIA GPUs
-  runtimeClassName: ""
+  runtimeClassName: "nvidia"
   # Whether to create runtime class, name comes from runtimeClassName when it is set
-  createRuntimeClass: false
+  createRuntimeClass: true
   migStrategy: "none"
   disablecorelimit: "false"
   passDeviceSpecsEnabled: false


### PR DESCRIPTION
* **Background**
Currently, on devices with Nvidia GPU card(s) detected, the GPU device plugin is deployed upon Olares installation, along with the creation of the necessary RuntimeClass `nvidia`, however, this behavior relies on the additional helper in K3s, not in the official Kubernetes, the GPU device plugin chart is changed to dynamically create RuntimeClass on Kubernetes and not conflict it with K3s.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Helm install/upgrade behavior for the GPU device plugin by conditionally creating a cluster-scoped `RuntimeClass` and enabling it by default; misconfiguration or unexpected existing `RuntimeClass` state could affect GPU workload scheduling.
> 
> **Overview**
> Ensures the GPU device-plugin chart **does not conflict with pre-existing `RuntimeClass` resources** by adding a Helm `lookup` guard so `RuntimeClass` creation only happens when the named class is absent.
> 
> Updates defaults to use `runtimeClassName: "nvidia"` and enables `createRuntimeClass` by default, shifting installs/upgrades to automatically manage the `nvidia` runtime class when missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e45229c823058447a1a31a515567ca4cd1210d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->