### PR TITLE
fix(appservice): avoid race condition between upgrade & applyenv

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -342,6 +342,19 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
+	// hold env batch lease during upgrade kickoff
+	// to avoid AppEnv controller racing and switching app manager op/state to ApplyEnv in this window
+	userNamespace := utils.UserspaceName(owner)
+	releaseLease, err := h.acquireUserEnvBatchLease(req.Request.Context(), userNamespace)
+	if err != nil {
+		klog.Errorf("Failed to acquire user env batch lease err=%v", err)
+		api.HandleError(resp, req, err)
+		return
+	}
+	if releaseLease != nil {
+		defer releaseLease()
+	}
+
 	err = helper.applyAppEnv(req.Request.Context())
 	if err != nil {
 		klog.Errorf("Failed to apply app env err=%v", err)


### PR DESCRIPTION
* **Background**
As the current way to trigger AppManager state transition of check & patch & retry update is prune to race conditions where two threads check & transition at the same time, especially when the upgrade handler applies new AppEnv and instantly transition the AppManager to upgrading, while simultaneously triggering the appenv controller to transition to applyingenv.
It's now changed to hold the lease when kicking off upgrade transition, blocking the appenv controller from transitioning.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the app upgrade execution path and introduces coordination via a Kubernetes Lease; incorrect acquisition/release could stall upgrades or delay env updates under contention.
> 
> **Overview**
> Prevents a race between app upgrades and AppEnv-driven state transitions by acquiring the per-user `env-batch-lock` Lease before calling `applyAppEnv` in `appUpgrade`.
> 
> If the lease cannot be acquired, the upgrade request now fails early; otherwise the lease is released via `defer` after the upgrade kickoff window.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 583ea88ecb85c9822ea9c108ed21cae96d536793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->