### PR TITLE
authelia: fix bug of sub-policy failed if set it to two-factor

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.47
+        image: beclab/auth:0.2.48
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
1. Setting a sub-resource's policy to `Two-Factor` is not working
2. When an app's policy is `Internal`, login on first-factor gets the wrong policy

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
App's subpolicy is not working

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/32c6c34c6bb46fc11b756b4cf114bdd0665a93cb
https://github.com/beclab/authelia/commit/325efe0bace0efe9fdde2c87df31b19868eb3c37

* **Other information**:
