### PR TITLE
cli: update etcd service template to use network-online.target

### DIFF
--- a/cli/pkg/etcd/templates/etcd_service.go
+++ b/cli/pkg/etcd/templates/etcd_service.go
@@ -27,7 +27,7 @@ var (
 	ETCDService = template.Must(template.New("etcd.service").Parse(
 		dedent.Dedent(`[Unit]
 Description=etcd
-After=network.target
+After=network-online.target
 StartLimitIntervalSec=0
 
 [Service]


### PR DESCRIPTION
* **Background**
Update etcd service template to use network-online.target to avoid failing to start etcd service when the system reboots.

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
etcd service failed to start on the system reboot

* **PRs Involving Sub-Systems** 


* **Other information**:
