### PR TITLE
feat(cli): add upgrade task to regenerate new etcd service

### DIFF
--- a/cli/pkg/upgrade/1_12_5.go
+++ b/cli/pkg/upgrade/1_12_5.go
@@ -4,8 +4,11 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/action"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/etcd/templates"
 	"github.com/beclab/Olares/cli/pkg/gpu"
+	"github.com/beclab/Olares/cli/pkg/terminus"
 	"github.com/beclab/Olares/cli/version"
 )
 
@@ -32,6 +35,27 @@ func (u upgrader_1_12_5) AddedBreakingChange() bool {
 		return true
 	}
 	return false
+}
+
+func (u upgrader_1_12_5) PrepareForUpgrade() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name: "GenerateETCDService",
+			Desc: "Generate etcd service",
+			Action: &action.Template{
+				Name:     "GenerateETCDService",
+				Template: templates.ETCDService,
+				Dst:      "/etc/systemd/system/etcd.service",
+			},
+		},
+		&task.LocalTask{
+			Name: "ReloadSystemd",
+			Desc: "Reload systemd",
+			Action: &terminus.SystemctlCommand{
+				DaemonReloadPreExec: true,
+			},
+		},
+	}
 }
 
 func (u upgrader_1_12_5) UpgradeSystemComponents() []task.Interface {


### PR DESCRIPTION
* **Background**
In https://github.com/beclab/Olares/pull/2603, the install target of etcd systemd unit is changed, a corresponding task is added in the upgrader for 1.12.5 to reflect that change to existing systems when upgrading.

* **Target Version for Merge**
1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upgrade orchestration and rewrites `/etc/systemd/system/etcd.service`, which can impact etcd startup/boot behavior if the template or reload sequence is incorrect; otherwise the change is small and localized.
> 
> **Overview**
> Adds a new `PrepareForUpgrade` step to the `1.12.5` upgrader that **regenerates the `etcd` systemd unit** using `templates.ETCDService` and writes it to `/etc/systemd/system/etcd.service`.
> 
> After writing the unit, the upgrade now **runs a systemd daemon reload** via `terminus.SystemctlCommand` so the updated unit is picked up before continuing with the rest of the upgrade tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54ce1584268b81f2cf72a486a468d038ac4781a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->