### PR TITLE
feat(bfl): use unified remote api env to query external ip

### DIFF
--- a/framework/bfl/pkg/constants/constants.go
+++ b/framework/bfl/pkg/constants/constants.go
@@ -97,6 +97,8 @@ var (
 
 	APIDNSSetCloudFlareTunnel string
 
+	APIMyExternalIP string
+
 	NameSSLConfigMapName = "zone-ssl-config"
 
 	nameParamters = "name=%s"
@@ -315,6 +317,11 @@ func ReloadEnvDependantVars() error {
 		return err
 	}
 	APIPrefixDNSOPService, err := url.JoinPath(OlaresRemoteService, "/dns/op")
+	if err != nil {
+		return err
+	}
+
+	APIMyExternalIP, err = url.JoinPath(OlaresRemoteService, "/myip/ip")
 	if err != nil {
 		return err
 	}

--- a/framework/bfl/pkg/utils/iputils.go
+++ b/framework/bfl/pkg/utils/iputils.go
@@ -3,14 +3,14 @@ package utils
 import (
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"bytetrade.io/web3os/bfl/internal/log"
+	"bytetrade.io/web3os/bfl/pkg/constants"
 )
 
 const (
@@ -40,13 +40,6 @@ func RemoteIp(req *http.Request) string {
 
 // GetMyExternalIPAddr get my network outgoing ip address
 func GetMyExternalIPAddr() string {
-	sites := map[string]string{
-		"httpbin":    "https://httpbin.org/ip",
-		"ifconfigme": "https://ifconfig.me/all.json",
-		"externalip": "https://myexternalip.com/json",
-		"joinolares": "https://myip.joinolares.cn/ip",
-	}
-
 	type httpBin struct {
 		Origin string `json:"origin"`
 	}
@@ -66,96 +59,74 @@ func GetMyExternalIPAddr() string {
 		IP string `json:"ip"`
 	}
 
-	var unmarshalFuncs = map[string]func(v []byte) string{
-		"httpbin": func(v []byte) string {
-			var hb httpBin
-			if err := json.Unmarshal(v, &hb); err == nil && hb.Origin != "" {
-				return hb.Origin
-			}
-			return ""
-		},
-		"ifconfigme": func(v []byte) string {
-			var ifMe ifconfigMe
-			if err := json.Unmarshal(v, &ifMe); err == nil && ifMe.IPAddr != "" {
-				return ifMe.IPAddr
-			}
-			return ""
-		},
-		"externalip": func(v []byte) string {
-			var extip externalIP
-			if err := json.Unmarshal(v, &extip); err == nil && extip.IP != "" {
-				return extip.IP
-			}
-			return ""
-		},
-		"joinolares": func(v []byte) string {
-			return strings.TrimSpace(string(v))
-		},
+	type siteConfig struct {
+		url           string
+		unmarshalFunc func(v []byte) string
 	}
 
-	var mu sync.Mutex
-	ch := make(chan any, len(sites))
-	chSyncOp := func(f func()) {
-		mu.Lock()
-		defer mu.Unlock()
-		if ch != nil {
-			f()
-		}
-	}
-
-	for site := range sites {
-		go func(name string) {
-			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			c := http.Client{Timeout: 5 * time.Second}
-			resp, err := c.Get(sites[name])
-			if err != nil {
-				chSyncOp(func() { ch <- err })
-				return
-			}
-			defer resp.Body.Close()
-			respBytes, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				chSyncOp(func() { ch <- err })
-				return
-			}
-
-			ip := unmarshalFuncs[name](respBytes)
-			//println(name, site, ip)
-			chSyncOp(func() { ch <- ip })
-
-		}(site)
-	}
-
-	tr := time.NewTimer(time.Duration(5*len(sites)+3) * time.Second)
-	defer func() {
-		tr.Stop()
-		chSyncOp(func() {
-			close(ch)
-			ch = nil
-		})
-	}()
-
-LOOP:
-	for i := 0; i < len(sites); i++ {
-		select {
-		case r, ok := <-ch:
-			if !ok {
-				continue
-			}
-
-			switch v := r.(type) {
-			case string:
-				ip := net.ParseIP(v)
-				if ip != nil && ip.To4() != nil && !ip.IsLoopback() && !ip.IsMulticast() {
-					return v
+	sites := []siteConfig{
+		{
+			url: constants.APIMyExternalIP,
+			unmarshalFunc: func(v []byte) string {
+				return strings.TrimSpace(string(v))
+			},
+		},
+		{
+			url: "https://httpbin.org/ip",
+			unmarshalFunc: func(v []byte) string {
+				var hb httpBin
+				if err := json.Unmarshal(v, &hb); err == nil && hb.Origin != "" {
+					return hb.Origin
 				}
-			case error:
-				log.Warnf("got an error, %v", v)
-			}
-		case <-tr.C:
-			tr.Stop()
-			log.Warnf("timed out")
-			break LOOP
+				return ""
+			},
+		},
+		{
+			url: "https://ifconfig.me/all.json",
+			unmarshalFunc: func(v []byte) string {
+				var ifMe ifconfigMe
+				if err := json.Unmarshal(v, &ifMe); err == nil && ifMe.IPAddr != "" {
+					return ifMe.IPAddr
+				}
+				return ""
+			},
+		},
+		{
+			url: "https://myexternalip.com/json",
+			unmarshalFunc: func(v []byte) string {
+				var extip externalIP
+				if err := json.Unmarshal(v, &extip); err == nil && extip.IP != "" {
+					return extip.IP
+				}
+				return ""
+			},
+		},
+	}
+
+	client := http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	for _, site := range sites {
+		resp, err := client.Get(site.url)
+		if err != nil {
+			log.Warnf("failed to get external ip from %s, %v", site.url, err)
+			continue
+		}
+
+		respBytes, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			log.Warnf("failed to read response from %s, %v", site.url, readErr)
+			continue
+		}
+
+		ipStr := site.unmarshalFunc(respBytes)
+		ip := net.ParseIP(ipStr)
+		if ip != nil && ip.To4() != nil && !ip.IsLoopback() && !ip.IsMulticast() {
+			return ipStr
 		}
 	}
 


### PR DESCRIPTION
* **Background**
Use unified system env `OLARES_SYSTEM_REMOTE_SERVICE` to query for external IP of current device.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none