### PR TITLE
docs: add manual restart instructions and refine discord channel config

### DIFF
--- a/docs/use-cases/openclaw.md
+++ b/docs/use-cases/openclaw.md
@@ -529,7 +529,7 @@ To manage skills and plugins, install ClawHub. It is the package manager for Ope
 
 If you attempt to manually start, stop, or restart OpenClaw using commands like `openclaw gateway` or `openclaw gateway stop` in the OpenClaw CLI, you receive the following error messages:
 - `Gateway failed to start: gateway already running (pid 1); lock timeout after 5000ms`
-- `Gateway service check failed: Error: systemctl --user unavailable: spawn systemctl EACCES`
+- `Gateway service check failed: Error: systemctl --user unavailable: spawn systemctl ENOENT`
 
 #### Cause
 


### PR DESCRIPTION
Title: Add manual restart instructions and refine discord channel config section

* **Background**
- Added manual restart and troubleshooting instructions
- Updated the Discord channel configuration instructions to clarify that users must manually add the `channels` JSON block, and added a note for basic setup expectation as well as linking to the official openclaw documentation.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None