### PR TITLE
fix(daemon): increase retry count for USB device detection

### DIFF
--- a/daemon/internel/watcher/usb/watchers.go
+++ b/daemon/internel/watcher/usb/watchers.go
@@ -27,7 +27,7 @@ func WithSerial(ctx context.Context, serial string) context.Context {
 }
 
 func (w *usbWatcher) Watch(ctx context.Context) {
-	retry := 1
+	retry := 3
 	devs, err := utils.DetectdUsbDevices(ctx)
 	for {
 		if err != nil {

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -131,7 +131,8 @@ func CheckCurrentStatus(ctx context.Context) error {
 		klog.Info("current state: ", CurrentState.TerminusState)
 	}()
 
-	utils.ForceMountHdd(ctx)
+	// Deprecated, only for Olares Zero
+	// utils.ForceMountHdd(ctx)
 
 	// set default value
 	if CurrentState.TerminusVersion == nil {


### PR DESCRIPTION
* **Background**
Increase the retry count for USB device detection to wait for the system to recognize the device partition info.

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
Some kinds of USB disks cannot be mounted
 
* **PRs Involving Sub-Systems** 
none

* **Other information**:
