### PR TITLE
fix(manifest): add password reset path for cli in auth provider

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_provider.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_provider.yaml
@@ -26,6 +26,7 @@ metadata:
 rules:
   - nonResourceURLs: 
       - "/api/reset/*"
+      - "/cli/api/reset/*"
     verbs: ["*"]
 
 ---


### PR DESCRIPTION
* **Background**
The non-resource URL `/cli/api/reset/*` should be added in the auth provider cluster role to allow olares-cli to access the password reset API.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none