### PR TITLE
fix(cli): remove error logging for GB10 chip check

### DIFF
--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -512,7 +512,6 @@ func getCpu() *CpuInfo {
 	if err == nil && strings.TrimSpace(string(output)) != "" {
 		isGB10Chip = true
 	} else {
-		fmt.Printf("Error checking GB10 chip: %v\n", err)
 		gb10env := os.Getenv(common.ENV_GB10_CHIP)
 		if gb10env == "1" || strings.EqualFold(gb10env, "true") {
 			isGB10Chip = true


### PR DESCRIPTION
* **Background**
Remove confusing GB10 checking error log

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
