### PR TITLE
fix(daemon): improve host IP validation and error handling in CheckCurrentStatus

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -239,11 +239,18 @@ func CheckCurrentStatus(ctx context.Context) error {
 		return nil
 	}
 
-	if !slices.ContainsFunc(ips, func(i *nets.NetInterface) bool { return i.IP == hostIp }) {
-		// wrong host ip
-		klog.Warningf("host ip %s not in internal ips, try to fix it", hostIp)
-		if err = fix(); err != nil {
-			return err
+	if hostIp != "" {
+		if !slices.ContainsFunc(ips, func(i *nets.NetInterface) bool { return i.IP == hostIp }) {
+			// wrong host ip
+			klog.Warningf("host ip %s not in internal ips, try to fix it", hostIp)
+			if err = fix(); err != nil {
+				klog.Warning("fix host ip failed,", err)
+			}
+		} else if hostIpInFile, err := nets.GetHostIpFromHostsFile(hostname); err == nil && hostIpInFile != "" && hostIpInFile != hostIp {
+			klog.Warningf("host ip %s in hosts file is different from current host ip %s, try to fix it", hostIpInFile, hostIp)
+			if err = fix(); err != nil {
+				klog.Warning("fix host ip failed,", err)
+			}
 		}
 	}
 
@@ -252,7 +259,7 @@ func CheckCurrentStatus(ctx context.Context) error {
 	} else if conflict {
 		klog.Warningf("domain %s conflict with internal ip, try to fix it", hostname)
 		if err = fix(); err != nil {
-			return err
+			klog.Warning("fix host ip failed,", err)
 		}
 	}
 


### PR DESCRIPTION
* **Background**
If looking up the ip of the hostname returns an ip different from the ip in the hosts file, force fix the host ip in the hosts file.

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
Cannot access the Olares via the local domain when ip is changed

* **PRs Involving Sub-Systems** 
none

* **Other information**:
