### PR TITLE
fix(cli): clear master host config when preparing

### DIFF
--- a/cli/pkg/pipelines/prepare_system.go
+++ b/cli/pkg/pipelines/prepare_system.go
@@ -32,6 +32,7 @@ func PrepareSystemPipeline(components []string) error {
 	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))
 	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
 	arg.SetStorage(getStorageConfig())
+	arg.ClearMasterHostConfig()
 
 	runtime, err := common.NewKubeRuntime(*arg)
 	if err != nil {


### PR DESCRIPTION
* **Background**
When doing prepare phase for a worker node that's about to join an existing cluster, the master host config need to be cleared to avoid executing incorrect tasks on both node.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none