### PR TITLE
fix(cli): correct PrepareForUpgrade method to append tasks properly

### DIFF
--- a/cli/pkg/upgrade/1_12_5.go
+++ b/cli/pkg/upgrade/1_12_5.go
@@ -38,7 +38,7 @@ func (u upgrader_1_12_5) AddedBreakingChange() bool {
 }
 
 func (u upgrader_1_12_5) PrepareForUpgrade() []task.Interface {
-	return []task.Interface{
+	return append([]task.Interface{
 		&task.LocalTask{
 			Name: "GenerateETCDService",
 			Desc: "Generate etcd service",
@@ -55,7 +55,7 @@ func (u upgrader_1_12_5) PrepareForUpgrade() []task.Interface {
 				DaemonReloadPreExec: true,
 			},
 		},
-	}
+	}, u.upgraderBase.PrepareForUpgrade()...)
 }
 
 func (u upgrader_1_12_5) UpgradeSystemComponents() []task.Interface {


### PR DESCRIPTION

* **Background**
Append base PrepareForUpgrade to breaking change upgrade

* **Target Version for Merge**
v1.12.5

* **Related Issues**
cannot upgrade to 1.12.5

* **PRs Involving Sub-Systems** 


* **Other information**:
