### PR TITLE
olares: update init-check host values to use full domain in deployment configurations

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -408,7 +408,7 @@ spec:
             echo -e " >> $PGDB exists";
         env:
           - name: PGHOST
-            value: citus-headless.os-platform
+            value: citus-headless.os-platform.svc.cluster.local
           - name: PGPORT
             value: "5432"
           - name: PGUSER

--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -142,7 +142,7 @@ spec:
       initContainers:
         - args:
           - -it
-          - nats.os-platform:4222
+          - nats.os-platform.svc.cluster.local:4222
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-nats

--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -109,13 +109,13 @@ spec:
       initContainers:
         - args:
           - -it
-          - authelia-backend.os-framework:9091
+          - authelia-backend.os-framework.svc.cluster.local:9091
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-auth
         - args:
           - -it
-          - app-service.os-framework:6755
+          - app-service.os-framework.svc.cluster.local:6755
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-appservice

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -88,7 +88,7 @@ spec:
               PostgreSQL DB Server has started";
           env:
             - name: PGHOST
-              value: citus-headless.os-platform
+              value: citus-headless.os-platform.svc.cluster.local
             - name: PGPORT
               value: '5432'
             - name: PGUSER

--- a/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
+++ b/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
@@ -145,7 +145,7 @@ spec:
             echo -e "Checking for the availability of PostgreSQL Server deployment"; until psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDB -c "SELECT 1"; do sleep 1; printf "-"; done; sleep 5; echo -e " >> PostgreSQL DB Server has started";
         env:
           - name: PGHOST
-            value: citus-0.citus-headless.os-platform
+            value: citus-0.citus-headless.os-platform.svc.cluster.local
           - name: PGPORT
             value: "5432"
           - name: PGUSER

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -130,19 +130,19 @@ spec:
       initContainers:
         - args:
           - -it
-          - authelia-backend.os-framework:9091
+          - authelia-backend.os-framework.svc.cluster.local:9091
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-auth
         - args:
           - -it
-          - app-service.os-framework:6755
+          - app-service.os-framework.svc.cluster.local:6755
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-appservice
         - args:
           - -it
-          - chart-repo-service.os-framework:82
+          - chart-repo-service.os-framework.svc.cluster.local:82
           image: owncloudci/wait-for:latest
           imagePullPolicy: IfNotPresent
           name: check-chart-repo

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -230,7 +230,7 @@ spec:
         image: beclab/seahub-init:v0.0.6
         env:
           - name: DB_HOST
-            value: citus-headless.os-platform
+            value: citus-headless.os-platform.svc.cluster.local
           - name: DB_PORT
             value: '5432'
           - name: DB_USER

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -229,7 +229,7 @@ spec:
             echo -e "Checking for the availability of PostgreSQL Server deployment"; until psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDB1 -c "SELECT 1"; do sleep 1; printf "-"; done; sleep 5; echo -e " >> PostgreSQL DB Server has started";
         env:
           - name: PGHOST
-            value: citus-0.citus-headless.os-platform
+            value: citus-0.citus-headless.os-platform.svc.cluster.local
           - name: PGPORT
             value: "5432"
           - name: PGUSER

--- a/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
+++ b/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
@@ -90,7 +90,7 @@ spec:
             echo -e "Checking for the availability of PostgreSQL Server deployment"; until psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDB1 -c "SELECT 1"; do sleep 1; printf "-"; done; sleep 5; echo -e " >> PostgreSQL DB Server has started";
         env:
           - name: PGHOST
-            value: citus-0.citus-headless.os-platform
+            value: citus-0.citus-headless.os-platform.svc.cluster.local
           - name: PGPORT
             value: "5432"
           - name: PGUSER

--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -136,7 +136,7 @@ spec:
               PostgreSQL DB Server has started";
           env:
             - name: PGHOST
-              value: citus-headless.os-platform
+              value: citus-headless.os-platform.svc.cluster.local
             - name: PGPORT
               value: '5432'
             - name: PGUSER


### PR DESCRIPTION
* **Background**
Use a full domain in deployment init-container configurations to avoid coredns forwarding the domain name lookup to upstream. 

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
Lookup the domain in the cluster got a wrong IP.

* **PRs Involving Sub-Systems** 
none

* **Other information**:
