### PR TITLE
daemon: replace CPU info retrieval with a new utility function

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
-	cpu "github.com/klauspost/cpuid/v2"
 	"github.com/pbnjay/memory"
 )
 
@@ -171,7 +170,7 @@ func CheckCurrentStatus(ctx context.Context) error {
 	CurrentState.OsVersion = osVersion
 	CurrentState.OsType = osType
 	CurrentState.DeviceName = utils.GetDeviceName()
-	CurrentState.CpuInfo = cpu.CPU.BrandName
+	CurrentState.CpuInfo = utils.GetCPUName()
 	CurrentState.Memory = bToGb(memory.TotalMemory())
 	CurrentState.Disk = bToGb(diskSize)
 	CurrentState.GpuInfo = gpu

--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
+	cpu "github.com/klauspost/cpuid/v2"
 	"github.com/mackerelio/go-osstat/uptime"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -141,4 +143,19 @@ func GetBaseDirFromReleaseFile() (string, error) {
 
 	baseDir := data["OLARES_BASE_DIR"]
 	return baseDir, nil
+}
+
+func GetCPUName() string {
+	brandName := cpu.CPU.BrandName
+	if brandName == "" {
+		// cannot read info from /proc/cpuinfo, try to get from lscpu command
+		cmd := exec.Command("sh", "-c", "lscpu | awk -F: '/BIOS Model name/ {print $2}' | head -1 | sed 's/^[ \t]*//'")
+		output, err := cmd.Output()
+		if err != nil {
+			klog.Error("get CPU name error, ", err)
+			return ""
+		}
+		brandName = strings.TrimSpace(string(output))
+	}
+	return brandName
 }


### PR DESCRIPTION
* **Background**
Cannot read CPU info from /proc/cpuinfo on DGX Spark, try to get from lscpu command.

* **Target Version for Merge**
v1.12.5 v1.12.6

* **Related Issues**
CPU Name not found on DGX Spark

* **PRs Involving Sub-Systems** 
none

* **Other information**:
