### PR TITLE
fix(gpu): consider other node constraints when scheduling pod

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.11"
+version: "v2.6.12"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.11
+      name: beclab/hami:v2.6.12
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Currently, the scheduling process does not take into consideration of some node constraints specified by the pod such as node affinity, these are now considered at the cost of ignoring potential GPUBindings.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/15

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates configuration to pull `beclab/hami` v2.6.12 (from v2.6.11) with no code or behavior changes in this repo beyond the deployed image version.
> 
> **Overview**
> Updates the HAMi deployment/config to use **v2.6.12** instead of **v2.6.11** by bumping the chart `version` in `values.yaml` and the prebuilt container reference in `Olares.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc542abdc950f7c2f66569e51ce5e9af7ce706e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->