### PR TITLE
fix: occasional invalid format because of assert column type failed

### DIFF
--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -227,7 +227,7 @@ spec:
     spec:
       initContainers:
       - name: seahub-init
-        image: beclab/seahub-init:v0.0.6
+        image: beclab/seahub-init:v0.0.7
         env:
           - name: DB_HOST
             value: citus-headless.os-platform.svc.cluster.local
@@ -249,7 +249,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.19
+        image: beclab/pg_seafile_server:v0.0.20
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- sync occasional invalid format because of assert column type failed

Target Version for Merge
- 1.12.5, 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/188
- https://github.com/beclab/seafile-server/pull/4

Other information:
- none
