### PR TITLE
download-server: fix download progress issue

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -180,7 +180,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v0.1.21"
+        image: "beclab/download-server:v0.1.22"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
Background
fix missing nats messages when Aria2 download tasks for pause, continue, and remove actions

Target Version for Merge
1.12.6

PRs Involving Sub-Systems
none

Other information: