### PR TITLE
fix: include selected GPU type in app configuration during upgrade

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -97,6 +97,7 @@ func (h *upgradeHandlerHelper) getAppConfig(prevCfg *appcfg.ApplicationConfig, a
 		Admin:        admin,
 		MarketSource: marketSource,
 		IsAdmin:      prevCfg.AppScope.ClusterScoped,
+		SelectedGpu:  prevCfg.SelectedGpuType,
 	})
 	if err != nil {
 		api.HandleError(h.resp, h.req, err)


### PR DESCRIPTION
Keep the gpu type in app configuration during app upgrade