### PR TITLE
fix(cli): do not provide version option for upgrade commands

### DIFF
--- a/cli/cmd/ctl/os/upgrade.go
+++ b/cli/cmd/ctl/os/upgrade.go
@@ -27,8 +27,8 @@ func NewCmdUpgradeOs() *cobra.Command {
 	}
 
 	flagSetter := config.NewFlagSetterFor(cmd)
-	config.AddVersionFlagBy(flagSetter)
 	config.AddBaseDirFlagBy(flagSetter)
+	config.AddVersionFlagBy(flagSetter)
 
 	cmd.AddCommand(NewCmdCurrentVersionUpgradeSpec())
 	cmd.AddCommand(NewCmdUpgradeViable())

--- a/cli/pkg/pipelines/upgrade.go
+++ b/cli/pkg/pipelines/upgrade.go
@@ -7,7 +7,6 @@ import (
 	"github.com/beclab/Olares/cli/pkg/upgrade"
 	"github.com/beclab/Olares/cli/pkg/utils"
 	"github.com/beclab/Olares/cli/version"
-	"github.com/spf13/viper"
 
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
@@ -40,7 +39,7 @@ func UpgradeOlaresPipeline() error {
 	}
 
 	arg := common.NewArgument()
-	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
+	arg.SetOlaresVersion(version.VERSION)
 	arg.SetConsoleLog("upgrade.log", true)
 	arg.SetKubeVersion(phase.GetKubeType())
 

--- a/daemon/pkg/commands/upgrade/upgrade.go
+++ b/daemon/pkg/commands/upgrade/upgrade.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 
 	"github.com/beclab/Olares/daemon/pkg/cli"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -69,7 +70,6 @@ func (i *upgrade) Execute(ctx context.Context, p any) (res any, err error) {
 
 	params := []string{
 		"upgrade",
-		"--version", target.Version.Original(),
 		"--base-dir", commands.TERMINUS_BASE_DIR,
 	}
 	if err = cmd.RunAsync_(ctx, cli.TERMINUS_CLI, params...); err != nil {


### PR DESCRIPTION
* **Background**
olares-cli should only be used to upgrade Olares to the version of itself, no `--version` option should be provided to be overridden. for now it's reserved to maintain backwards compatibility with older versions of olaresd and should be removed in the next release.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none