### PR TITLE
cli(fix): override non-empty GPU requirement during upgrade

### DIFF
--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -692,12 +692,18 @@ func (a *backfillAppGPUConfig) Execute(_ connector.Runtime) error {
 
 		modified := false
 
-		if appCfg.Requirement.GPU == nil {
-			gpuMem, ok := gpuMemoryByRawAppName[am.Spec.RawAppName]
-			if !ok {
-				gpuMem = defaultGPUMemory
-			}
-			q := resource.MustParse(gpuMem)
+		gpuMem, ok := gpuMemoryByRawAppName[am.Spec.RawAppName]
+		if !ok {
+			gpuMem = defaultGPUMemory
+		}
+		q := resource.MustParse(gpuMem)
+
+		if appCfg.RequiredGPU != q.String() {
+			appCfg.RequiredGPU = q.String()
+			modified = true
+		}
+
+		if appCfg.Requirement.GPU == nil || !appCfg.Requirement.GPU.Equal(q) {
 			appCfg.Requirement.GPU = &q
 			modified = true
 		}


### PR DESCRIPTION
* **Background**
Handle the case of non-empty `RequiredGPU` and `Requirement.GPU` of legacy applications' configuration during upgrade, overriding them if necessary.

* **Target Version for Merge**
1.12.5

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none