### PR TITLE
fix(gpu): do not abort plugin start in case no device is found

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.12"
+version: "v2.6.13"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.12
+      name: beclab/hami:v2.6.13
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
In https://github.com/beclab/HAMi/pull/13, support for hot plug/unplug is added to GPU device-plugin. 
In rare cases, the nvidia driver loses control (e.g. PCI timeout) of the only GPU and reinitiates it shortly after. If this happens during the device plugin is starting, and before the reinitialization is finished, NVML may report no devices are found, causing device plugin to abort start, thus when the reinitialization finishes, the GPU still will not be reported by the device plugin. We make the case of no devices also eligible to restart device plugin after a delay.

* **Target Version for Merge**
1.12.5, 1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/16

* **Other information**:
none