### PR TITLE
fix: remove sync upload flooded logs and correct a sync upload log in files

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.148
+          image: beclab/files-server:v0.2.149
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -249,7 +249,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.20
+        image: beclab/pg_seafile_server:v0.0.21
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- flooded upload logs make sync unstable when lots of tiny files uploading, remove them to make it more stable

Target Version for Merge
- 1.12.5, 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/189
- https://github.com/beclab/seafile-server/pull/5

Other information:
- none