### PR TITLE
fix: files rpc connection pool, and limit sync previews to 10

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.149
+          image: beclab/files-server:v0.2.151
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- files edit rpc connection pool, and limit sync previews to 10

Target Version for Merge
- 1.12.5, 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/191

Other information:
- none