### PR TITLE
fix: files sync unstable by scale pool size from 5 to 45, add additional retry for upload, and fix a retry bug in upload chunk

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.151
+          image: beclab/files-server:v0.2.152
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: files sync unstable by scale pool size from 5 to 45, add additional retry for upload, and fix a retry bug in upload chunk

Target Version for Merge
- 1.12.5, 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/192

Other information:
-none
