### PR TITLE
chore: bump version to 1.12.7 in workflows and scripts

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - id: generate
         run: |
-          v=1.12.6-$(echo $RANDOM$RANDOM)
+          v=1.12.7-$(echo $RANDOM$RANDOM)
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
   upload-cli:

--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: generate
         run: |
-          v=1.12.6-$(date +"%Y%m%d")
+          v=1.12.7-$(date +"%Y%m%d")
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
   release-id:

--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -18,7 +18,7 @@ fi
 if [[ x"$VERSION" == x"" ]]; then
     if [[ "$LOCAL_RELEASE" == "1" ]]; then
         ts=$(date +%Y%m%d%H%M%S)
-        export VERSION="1.12.6-$ts"
+        export VERSION="1.12.7-$ts"
         echo "will build and use a local release of Olares with version: $VERSION"
         echo ""
     else
@@ -28,7 +28,7 @@ fi
 
 if [[ "x${VERSION}" == "x" || "x${VERSION:3}" == "xVERSION__" ]]; then
     echo "error: Olares version is unspecified, please set the VERSION env var and rerun this script."
-    echo "for example: VERSION=1.12.6-20241124 bash $0"
+    echo "for example: VERSION=1.12.7-20241124 bash $0"
     exit 1
 fi
 

--- a/build/base-package/joincluster.sh
+++ b/build/base-package/joincluster.sh
@@ -158,7 +158,7 @@ export VERSION="#__VERSION__"
 
 if [[ "x${VERSION}" == "x" || "x${VERSION:3}" == "xVERSION__" ]]; then
     echo "error: Olares version is unspecified, please set the VERSION env var and rerun this script."
-    echo "for example: VERSION=1.12.6-20241124 bash $0"
+    echo "for example: VERSION=1.12.7-20241124 bash $0"
     exit 1
 fi
 

--- a/cli/cmd/ctl/os/release.go
+++ b/cli/cmd/ctl/os/release.go
@@ -50,7 +50,7 @@ func NewCmdRelease() *cobra.Command {
 			}
 
 			if version == "" {
-				version = fmt.Sprintf("1.12.6-%s", time.Now().Format("20060102150405"))
+				version = fmt.Sprintf("1.12.7-%s", time.Now().Format("20060102150405"))
 				fmt.Printf("--version unspecified, using: %s\n", version)
 				time.Sleep(1 * time.Second)
 			}


### PR DESCRIPTION
* **Background**
Bump the main development version to 1.12.7

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
