### PR TITLE
fix(cli): correct upgrader line for daily version

### DIFF
--- a/cli/pkg/upgrade/1_12_6_20260408.go
+++ b/cli/pkg/upgrade/1_12_6_20260408.go
@@ -43,5 +43,5 @@ func (u upgrader_1_12_6_20260408) UpgradeSystemComponents() []task.Interface {
 }
 
 func init() {
-	registerMainUpgrader(upgrader_1_12_6_20260408{})
+	registerDailyUpgrader(upgrader_1_12_6_20260408{})
 }


### PR DESCRIPTION
* **Background**
The previous upgrader for daily version `1.12.6-20260408` is incorrectly registered to the main line.

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none