### PR TITLE
daemon: remove closed state management and simplify Close logic

### DIFF
--- a/daemon/internel/intranet/dsr_linux.go
+++ b/daemon/internel/intranet/dsr_linux.go
@@ -34,7 +34,6 @@ type DSRProxy struct {
 	responseConn *raw.Conn
 	backendConn  *raw.Conn
 
-	closed bool
 	mu     sync.Mutex
 	stopCh chan struct{}
 
@@ -121,15 +120,12 @@ func (d *DSRProxy) Close() {
 		d.backendConn = nil
 	}
 
-	d.closed = true
 }
 
 func (d *DSRProxy) Stop() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if !d.closed {
-		d.Close()
-	}
+	d.Close()
 
 	close(d.stopCh)
 	return nil
@@ -467,9 +463,7 @@ func (d *DSRProxy) regonfigure() error {
 		return nil
 	}
 
-	if !d.closed {
-		d.Close()
-	}
+	d.Close()
 
 	klog.Info("reconfigure DSR proxy")
 	klog.Infof("VIP: %s on interface %s", d.vip.String(), d.vipInterface.Name)
@@ -502,7 +496,6 @@ func (d *DSRProxy) regonfigure() error {
 		return err
 	}
 
-	d.closed = false
 	d.configChanged = false
 
 	return nil

--- a/daemon/internel/watcher/intranet/watchers.go
+++ b/daemon/internel/watcher/intranet/watchers.go
@@ -263,7 +263,7 @@ func getPodNeighborInfo(podIp string) (mac, iface string, err error) {
 	}
 
 	for _, n := range neighs {
-		if n.IP.String() == podIp {
+		if n.IP.String() == podIp && n.State == netlink.NUD_REACHABLE {
 			mac = n.HardwareAddr.String()
 			if mac == "<nil>" {
 				mac = ""


### PR DESCRIPTION
* **Background**
1. Force close DSR proxy handlers to avoid resource leak 
2. Only get the  DNS pod reachable state interface 

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
* 