### PR TITLE
fix(tapr): change preferred scheduling constraint to required

### DIFF
--- a/platform/tapr/pkg/workload/citus/templates.go
+++ b/platform/tapr/pkg/workload/citus/templates.go
@@ -77,9 +77,9 @@ var (
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-								{
-									Preference: corev1.NodeSelectorTerm{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
 												Key:      "kubernetes.io/os",
@@ -92,7 +92,6 @@ var (
 											},
 										},
 									},
-									Weight: 10,
 								},
 							},
 						},

--- a/platform/tapr/pkg/workload/kvrocks/templates.go
+++ b/platform/tapr/pkg/workload/kvrocks/templates.go
@@ -53,9 +53,9 @@ var (
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-								{
-									Preference: corev1.NodeSelectorTerm{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
 												Key:      "kubernetes.io/os",
@@ -68,7 +68,6 @@ var (
 											},
 										},
 									},
-									Weight: 10,
 								},
 							},
 						},


### PR DESCRIPTION
* **Background**
The database middlewares need to be running on the master node and the current `PreferredDuringSchedulingIgnoredDuringExecution` is not enough to make sure of that.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none