### PR TITLE
fix(bfl): change preferred scheduling constraint to required

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -211,16 +211,15 @@ spec:
 {{ if .Values.bfl.admin_user }}
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
               - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux
               - key: node-role.kubernetes.io/master
                 operator: Exists
-            weight: 10
 {{ end }}            
       serviceAccountName: bytetrade-controller
       priorityClassName: "system-cluster-critical"

--- a/framework/bfl/pkg/apis/settings/v1alpha1/model.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/model.go
@@ -185,10 +185,9 @@ func NewL4ProxyDeploymentApplyConfiguration(namespace, serviceAccountName string
 					}(),
 					Affinity: &applyCorev1.AffinityApplyConfiguration{
 						NodeAffinity: &applyCorev1.NodeAffinityApplyConfiguration{
-							PreferredDuringSchedulingIgnoredDuringExecution: []applyCorev1.PreferredSchedulingTermApplyConfiguration{
-								{
-									Weight: pointer.Int32(10),
-									Preference: &applyCorev1.NodeSelectorTermApplyConfiguration{
+							RequiredDuringSchedulingIgnoredDuringExecution: &applyCorev1.NodeSelectorApplyConfiguration{
+								NodeSelectorTerms: []applyCorev1.NodeSelectorTermApplyConfiguration{
+									{
 										MatchExpressions: []applyCorev1.NodeSelectorRequirementApplyConfiguration{
 											{
 												Key:      pointer.String("kubernetes.io/os"),


### PR DESCRIPTION
* **Background**
The admin user's bfl instance needs to be scheduled to the master node to perform necessary initialization tasks and the L4 proxy instance needs to be scheduled to the master node to properly expose services by the local IP.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none