### PR TITLE
fix(tapr): change preferred scheduling constraint to required

### DIFF
--- a/.github/workflows/module_tapr_build_main.yaml
+++ b/.github/workflows/module_tapr_build_main.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.23.3'
+        go-version: '1.25.9'
     - working-directory: platform/tapr
       run: |
         make build-uploader build-vault build-middleware

--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.32
+        image: beclab/middleware-operator:0.2.33
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.33
+        image: beclab/middleware-operator:0.2.34
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/platform/tapr/Makefile
+++ b/platform/tapr/Makefile
@@ -6,7 +6,7 @@ $(LOCALBIN):
 
 ## Tool Binaries
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.16.5
 
 
 .PHONY: build-uploader run-uploader build-vault run-vault fmt vet

--- a/platform/tapr/docker/middleware/Dockerfile
+++ b/platform/tapr/docker/middleware/Dockerfile
@@ -1,6 +1,6 @@
 
 # Build the manager binary
-FROM golang:1.24.0 as builder
+FROM golang:1.25.9 as builder
 WORKDIR /workspace
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     apt-get update && \

--- a/platform/tapr/docker/sys-event/Dockerfile
+++ b/platform/tapr/docker/sys-event/Dockerfile
@@ -1,7 +1,7 @@
 
 
 # Build the manager binary
-FROM golang:1.24.6 as builder
+FROM golang:1.25.9 as builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/platform/tapr/docker/uploader/Dockerfile
+++ b/platform/tapr/docker/uploader/Dockerfile
@@ -1,7 +1,7 @@
 
 
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.25.9 as builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/platform/tapr/docker/vault/Dockerfile
+++ b/platform/tapr/docker/vault/Dockerfile
@@ -1,7 +1,7 @@
 
 
 # Build the manager binary
-FROM golang:1.23.5 as builder
+FROM golang:1.25.9 as builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/platform/tapr/docker/ws-gateway/Dockerfile
+++ b/platform/tapr/docker/ws-gateway/Dockerfile
@@ -1,7 +1,7 @@
 
 
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.25.9 as builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/platform/tapr/pkg/workload/citus/templates.go
+++ b/platform/tapr/pkg/workload/citus/templates.go
@@ -77,9 +77,9 @@ var (
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-								{
-									Preference: corev1.NodeSelectorTerm{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
 												Key:      "kubernetes.io/os",
@@ -92,7 +92,6 @@ var (
 											},
 										},
 									},
-									Weight: 10,
 								},
 							},
 						},

--- a/platform/tapr/pkg/workload/citus/templates.go
+++ b/platform/tapr/pkg/workload/citus/templates.go
@@ -87,7 +87,7 @@ var (
 												Values:   []string{"linux"},
 											},
 											{
-												Key:      "node-role.kubernetes.io/master",
+												Key:      "node-role.kubernetes.io/control-plane",
 												Operator: "Exists",
 											},
 										},

--- a/platform/tapr/pkg/workload/kvrocks/templates.go
+++ b/platform/tapr/pkg/workload/kvrocks/templates.go
@@ -53,9 +53,9 @@ var (
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-								{
-									Preference: corev1.NodeSelectorTerm{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
 												Key:      "kubernetes.io/os",
@@ -68,7 +68,6 @@ var (
 											},
 										},
 									},
-									Weight: 10,
 								},
 							},
 						},

--- a/platform/tapr/pkg/workload/kvrocks/templates.go
+++ b/platform/tapr/pkg/workload/kvrocks/templates.go
@@ -63,7 +63,7 @@ var (
 												Values:   []string{"linux"},
 											},
 											{
-												Key:      "node-role.kubernetes.io/master",
+												Key:      "node-role.kubernetes.io/control-plane",
 												Operator: "Exists",
 											},
 										},


### PR DESCRIPTION
* **Background**
The database middlewares need to be running on the master node and the current `PreferredDuringSchedulingIgnoredDuringExecution` is not enough to make sure of that.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none