### PR TITLE
fix(tapr): use control-plane instead of master as node selector

### DIFF
--- a/platform/tapr/pkg/workload/citus/templates.go
+++ b/platform/tapr/pkg/workload/citus/templates.go
@@ -87,7 +87,7 @@ var (
 												Values:   []string{"linux"},
 											},
 											{
-												Key:      "node-role.kubernetes.io/master",
+												Key:      "node-role.kubernetes.io/control-plane",
 												Operator: "Exists",
 											},
 										},

--- a/platform/tapr/pkg/workload/kvrocks/templates.go
+++ b/platform/tapr/pkg/workload/kvrocks/templates.go
@@ -63,7 +63,7 @@ var (
 												Values:   []string{"linux"},
 											},
 											{
-												Key:      "node-role.kubernetes.io/master",
+												Key:      "node-role.kubernetes.io/control-plane",
 												Operator: "Exists",
 											},
 										},


### PR DESCRIPTION
* **Background**
The `node-role.kubernetes.io/master` label is deprecated and `node-role.kubernetes.io/control-plane` should be used instead.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none