### PR TITLE
fix(nodeinit): use control-plane instead of master as node selector

### DIFF
--- a/framework/osnode-init/.olares/config/cluster/deploy/nodeinit_daemonset.yaml
+++ b/framework/osnode-init/.olares/config/cluster/deploy/nodeinit_daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: daemon
-        image: beclab/osnode-init:v0.0.11
+        image: beclab/osnode-init:v0.0.12
         imagePullPolicy: IfNotPresent
         args:
         - --metrics-bind-address

--- a/framework/osnode-init/pkg/controller/controller.go
+++ b/framework/osnode-init/pkg/controller/controller.go
@@ -236,7 +236,7 @@ func (r *NodeInitController) isMasterNode(config *rest.Config) (bool, string, er
 	}
 
 	var nodeLists *corev1.NodeList
-	labels := client.HasLabels{"node-role.kubernetes.io/master"}
+	labels := client.HasLabels{"node-role.kubernetes.io/control-plane"}
 	var opts client.ListOptions
 	labels.ApplyToList(&opts)
 


### PR DESCRIPTION
* **Background**
The `node-role.kubernetes.io/master` label is deprecated and `node-role.kubernetes.io/control-plane` should be used instead.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none