### PR TITLE
feat(cli): enable gpu plugin on worker node if eligible

### DIFF
--- a/cli/pkg/amdgpu/module.go
+++ b/cli/pkg/amdgpu/module.go
@@ -78,39 +78,26 @@ func (m *InstallAmdPluginModule) Init() {
 	m.Name = "InstallAmdPlugin"
 
 	// update node with AMD GPU labels
-	updateNode := &task.RemoteTask{
-		Name:  "UpdateNodeAmdGPUInfo",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(UpdateNodeAmdGPUInfo),
-		Parallel: false,
-		Retry:    1,
+	updateNode := &task.LocalTask{
+		Name:   "UpdateNodeAmdGPUInfo",
+		Action: new(UpdateNodeAmdGPUInfo),
+		Retry:  1,
 	}
 
-	installPlugin := &task.RemoteTask{
-		Name:  "InstallAmdPlugin",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(InstallAmdPlugin),
-		Parallel: false,
-		Retry:    1,
+	installPlugin := &task.LocalTask{
+		Name:   "InstallAmdPlugin",
+		Action: new(InstallAmdPlugin),
+		Retry:  1,
 	}
 
-	checkGpuState := &task.RemoteTask{
-		Name:  "CheckAmdGPUState",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
+	checkGpuState := &task.LocalTask{
+		Name: "CheckAmdGPUState",
 		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
 			new(RocmInstalled),
 		},
-		Action:   new(CheckAmdGpuStatus),
-		Parallel: false,
-		Retry:    50,
-		Delay:    10 * time.Second,
+		Action: new(CheckAmdGpuStatus),
+		Retry:  50,
+		Delay:  10 * time.Second,
 	}
 
 	m.Tasks = []task.Interface{

--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -181,39 +181,26 @@ func (m *InstallPluginModule) Init() {
 	m.Name = "InstallPlugin"
 
 	// update node with gpu labels, to make plugins enabled
-	updateNode := &task.RemoteTask{
-		Name:  "UpdateNode",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(UpdateNodeGPUInfo),
-		Parallel: false,
-		Retry:    1,
+	updateNode := &task.LocalTask{
+		Name:   "UpdateNodeGPUInfo",
+		Action: new(UpdateNodeGPUInfo),
+		Retry:  1,
 	}
 
-	installPlugin := &task.RemoteTask{
-		Name:  "InstallPlugin",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(InstallPlugin),
-		Parallel: false,
-		Retry:    1,
+	installPlugin := &task.LocalTask{
+		Name:   "InstallGPUPlugin",
+		Action: new(InstallPlugin),
+		Retry:  1,
 	}
 
-	checkGpuState := &task.RemoteTask{
-		Name:  "CheckGPUState",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
+	checkGpuState := &task.LocalTask{
+		Name: "CheckGPUState",
 		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
 			new(CudaInstalled),
 		},
-		Action:   new(CheckGpuStatus),
-		Parallel: false,
-		Retry:    50,
-		Delay:    10 * time.Second,
+		Action: new(CheckGpuStatus),
+		Retry:  50,
+		Delay:  10 * time.Second,
 	}
 
 	m.Tasks = []task.Interface{

--- a/cli/pkg/phase/cluster/add_node.go
+++ b/cli/pkg/phase/cluster/add_node.go
@@ -1,11 +1,13 @@
 package cluster
 
 import (
+	"github.com/beclab/Olares/cli/pkg/amdgpu"
 	"github.com/beclab/Olares/cli/pkg/bootstrap/os"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/core/pipeline"
+	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/gpu"
 	"github.com/beclab/Olares/cli/pkg/k3s"
 	"github.com/beclab/Olares/cli/pkg/kubernetes"
@@ -40,6 +42,7 @@ func AddNodePhase(runtime *common.KubeRuntime) *pipeline.Pipeline {
 		},
 	)
 
+	m = append(m, (&linuxInstallPhaseBuilder{runtime: runtime, manifestMap: manifestMap}).installGpuPlugin()...)
 	m = append(m, &terminus.SaveMasterHostConfigModule{}, &terminus.InstalledModule{})
 
 	return &pipeline.Pipeline{
@@ -83,4 +86,16 @@ func (m *AddNodeModule) Init() {
 		underlyingModule.Init()
 		m.Tasks = append(m.Tasks, underlyingModule.GetTasks()...)
 	}
+	m.Tasks = append(m.Tasks,
+		&task.RemoteTask{
+			Name:   "UpdateNodeGPUInfo",
+			Action: new(gpu.UpdateNodeGPUInfo),
+			Retry:  1,
+		},
+		&task.LocalTask{
+			Name:   "UpdateNodeAmdGPUInfo",
+			Action: new(amdgpu.UpdateNodeAmdGPUInfo),
+			Retry:  1,
+		},
+	)
 }


### PR DESCRIPTION
* **Background**
Currently, when a worker node with GPU loaded joins a cluster, the GPU plugin is not automatically loaded, we add the necessary tasks to auto enable the GPU plugin(s) when a worker node joins. 

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none