### PR TITLE
feat: support new format olaresmanifest multi chip resources

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -39,9 +39,11 @@ type depRequest struct {
 type installHelperIntf interface {
 	getAdminUsers() (admin []string, isAdmin bool, err error)
 	getInstalledApps() (installed bool, app []*v1alpha1.Application, err error)
-	getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (err error)
+	getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error)
 	setAppConfig(req *api.InstallRequest, appName string)
-	validate(bool, []*v1alpha1.Application) error
+	validate(isAdmin bool, installedApps []*v1alpha1.Application) error
+	resolveInstallType(appConfig *appcfg.ApplicationConfig) (string, error)
+	overlayAppConfig(installType string) (*appcfg.ApplicationConfig, error)
 	setAppEnv(overrides []sysv1alpha1.AppEnvVar) error
 	applyAppEnv(ctx context.Context) error
 	applyApplicationManager(marketSource string) (opID string, err error)
@@ -137,7 +139,7 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		}
 	}
 
-	apiVersion, appCfg, err := apputils.GetApiVersionFromAppConfig(req.Request.Context(), &apputils.ConfigOptions{
+	apiVersion, err := apputils.GetAppConfigVersion(req.Request.Context(), &apputils.ConfigOptions{
 		App:          app,
 		RawAppName:   rawAppName,
 		Owner:        owner,
@@ -147,14 +149,11 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		SelectedGpu:  insReq.SelectedGpuType,
 	})
 	klog.Infof("chartVersion: %s", chartVersion)
+	klog.Infof("apiVersion: %s", apiVersion)
+
 	if err != nil {
 		klog.Errorf("Failed to get api version err=%v", err)
 		api.HandleBadRequest(resp, req, err)
-		return
-	}
-	if !appCfg.AllowMultipleInstall && insReq.RawAppName != "" {
-		klog.Errorf("app %s can not be clone", app)
-		api.HandleBadRequest(resp, req, fmt.Errorf("app %s can not be clone", app))
 		return
 	}
 
@@ -221,11 +220,31 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	err = helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, insReq.SelectedGpuType)
+	appCfg, err := helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, insReq.SelectedGpuType)
 	if err != nil {
 		klog.Errorf("Failed to get app config err=%v", err)
 		return
 	}
+	if !appCfg.AllowMultipleInstall && insReq.RawAppName != "" {
+		klog.Errorf("app %s can not be clone", app)
+		api.HandleBadRequest(resp, req, fmt.Errorf("app %s can not be clone", app))
+		return
+	}
+
+	installType, err := helper.resolveInstallType(appCfg)
+	if err != nil {
+		klog.Errorf("Failed to resolve install type err=%v", err)
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	appCfg, err = helper.overlayAppConfig(installType)
+	if err != nil {
+		klog.Errorf("Failed to overlay app config err=%v", err)
+		api.HandleError(resp, req, err)
+		return
+	}
+
 	err = helper.setAppEnv(insReq.Envs)
 	if err != nil {
 		klog.Errorf("Failed to set app env err=%v", err)
@@ -274,6 +293,29 @@ func (h *Handler) getOriginChartVersion(rawAppName, owner string) (string, error
 	return "", fmt.Errorf("rawApp %s not found", rawAppName)
 }
 
+func (h *installHandlerHelper) sharedNamespaceExists(appConfig *appcfg.ApplicationConfig) (bool, error) {
+	sharedNamespace := ""
+	for _, s := range appConfig.SubCharts {
+		if s.Shared {
+			sharedNamespace = s.Namespace(appConfig.OwnerName, s.Name)
+			break
+		}
+	}
+	if sharedNamespace == "" {
+		return false, errors.New("v2 app has no shared namespace")
+	}
+
+	var ns corev1.Namespace
+	err := h.h.ctrlClient.Get(context.TODO(), types.NamespacedName{Name: sharedNamespace}, &ns)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (h *installHandlerHelper) getAdminUsers() (admin []string, isAdmin bool, err error) {
 	adminList, err := kubesphere.GetAdminUserList(h.req.Request.Context(), h.h.kubeConfig)
 	if err != nil {
@@ -289,6 +331,20 @@ func (h *installHandlerHelper) getAdminUsers() (admin []string, isAdmin bool, er
 	}
 
 	return
+}
+
+func (h *installHandlerHelper) resolveInstallType(appConfig *appcfg.ApplicationConfig) (string, error) {
+	if appConfig.APIVersion == appcfg.V1 || appConfig.APIVersion == "" {
+		return appcfg.InstallV1, nil
+	}
+	exists, err := h.sharedNamespaceExists(appConfig)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return appcfg.InstallServerAndClient, nil
+	}
+	return appcfg.InstallClientOnly, nil
 }
 
 func (h *installHandlerHelper) validate(isAdmin bool, installedApps []*v1alpha1.Application) (err error) {
@@ -374,7 +430,6 @@ func (h *installHandlerHelper) validate(isAdmin bool, installedApps []*v1alpha1.
 		return
 	}
 
-	//resourceType, err := CheckAppRequirement(h.h.kubeConfig, h.token, h.appConfig)
 	resourceType, resourceConditionType, err := apputils.CheckAppRequirement(h.token, h.appConfig, v1alpha1.InstallOp)
 	if err != nil {
 		klog.Errorf("Failed to check app requirement err=%v", err)
@@ -456,7 +511,7 @@ func (h *installHandlerHelper) getInstalledApps() (installed bool, app []*v1alph
 	return
 }
 
-func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (err error) {
+func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error) {
 	var (
 		admin                   string
 		installAsAdmin          bool
@@ -496,7 +551,7 @@ func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource st
 		installAsAdmin = true
 	}
 
-	appConfig, _, err := apputils.GetAppConfig(h.req.Request.Context(), &apputils.ConfigOptions{
+	appConfig, _, err = apputils.GetAppConfig(h.req.Request.Context(), &apputils.ConfigOptions{
 		App:          h.app,
 		RawAppName:   h.rawAppName,
 		Owner:        h.owner,
@@ -516,6 +571,25 @@ func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource st
 	h.appConfig = appConfig
 
 	return
+}
+
+func (h *installHandlerHelper) overlayAppConfig(installType string) (*appcfg.ApplicationConfig, error) {
+	if h.appConfig == nil {
+		return nil, fmt.Errorf("app config is nil")
+	}
+	if !config.IsNewManifestVersion(h.appConfig.CfgFileVersion) {
+		return h.appConfig, nil
+	}
+
+	h.appConfig.ApplyOverlay(installType)
+
+	appRequirement, err := h.appConfig.ResolveRequirement(h.appConfig.SelectedGpuType, installType)
+	if err != nil {
+		return nil, fmt.Errorf("resolve requirement: %w", err)
+	}
+	h.appConfig.Requirement = *appRequirement
+
+	return h.appConfig, nil
 }
 
 func (h *installHandlerHelper) setAppConfig(req *api.InstallRequest, appName string) {
@@ -716,7 +790,7 @@ func (h *installHandlerHelperV2) _validateClusterScope(isAdmin bool, installedAp
 	return nil
 }
 
-func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (err error) {
+func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error) {
 	klog.Info("get app config for install handler v2")
 
 	var (
@@ -733,8 +807,7 @@ func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource 
 		}
 		admin = adminUsers[0]
 	}
-
-	appConfig, _, err := apputils.GetAppConfig(h.req.Request.Context(), &apputils.ConfigOptions{
+	appConfig, _, err = apputils.GetAppConfig(h.req.Request.Context(), &apputils.ConfigOptions{
 		App:          h.app,
 		RawAppName:   h.rawAppName,
 		Owner:        h.owner,

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -335,16 +335,16 @@ func (h *installHandlerHelper) getAdminUsers() (admin []string, isAdmin bool, er
 
 func (h *installHandlerHelper) resolveInstallType(appConfig *appcfg.ApplicationConfig) (string, error) {
 	if appConfig.APIVersion == appcfg.V1 || appConfig.APIVersion == "" {
-		return appcfg.InstallV1, nil
+		return appcfg.InstallOrUpgradeV1, nil
 	}
 	exists, err := h.sharedNamespaceExists(appConfig)
 	if err != nil {
 		return "", err
 	}
 	if !exists {
-		return appcfg.InstallServerAndClient, nil
+		return appcfg.InstallOrUpgradeServerAndClient, nil
 	}
-	return appcfg.InstallClientOnly, nil
+	return appcfg.InstallOrUpgradeClientOnly, nil
 }
 
 func (h *installHandlerHelper) validate(isAdmin bool, installedApps []*v1alpha1.Application) (err error) {
@@ -541,7 +541,8 @@ func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource st
 	case !isAdmin:
 		if len(adminUsers) == 0 {
 			klog.Errorf("No admin user found")
-			api.HandleBadRequest(h.resp, h.req, fmt.Errorf("no admin user found"))
+			err = fmt.Errorf("no admin user found")
+			api.HandleBadRequest(h.resp, h.req, err)
 			return
 		}
 		admin = adminUsers[0]
@@ -802,7 +803,8 @@ func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource 
 	} else {
 		if len(adminUsers) == 0 {
 			klog.Errorf("No admin user found")
-			api.HandleBadRequest(h.resp, h.req, fmt.Errorf("no admin user found"))
+			err = fmt.Errorf("no admin user found")
+			api.HandleBadRequest(h.resp, h.req, err)
 			return
 		}
 		admin = adminUsers[0]

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -27,10 +27,12 @@ import (
 
 type upgradeHelperIntf interface {
 	getAdminUsers() (admin []string, isAdmin bool, err error)
-	getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, isAdmin bool) (err error)
+	getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, isAdmin bool) (appConfig *appcfg.ApplicationConfig, err error)
 	validate() error
 	applyAppEnv(ctx context.Context) error
 	setAndEncodingAppCofnig(prevCfg *appcfg.ApplicationConfig) (string, error)
+	resolveUpgradeType(appConfig *appcfg.ApplicationConfig, isAdmin bool) string
+	overlayAppConfig(upgradeType string) (*appcfg.ApplicationConfig, error)
 }
 
 var _ upgradeHelperIntf = (upgradeHelperIntf)(nil)
@@ -70,7 +72,7 @@ func (h *upgradeHandlerHelper) getAdminUsers() (admins []string, isAdmin bool, e
 	return
 }
 
-func (h *upgradeHandlerHelper) getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, _ bool) (err error) {
+func (h *upgradeHandlerHelper) getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, _ bool) (*appcfg.ApplicationConfig, error) {
 	var admin string
 	if !prevCfg.AppScope.ClusterScoped {
 		// installed as non-admin
@@ -101,11 +103,11 @@ func (h *upgradeHandlerHelper) getAppConfig(prevCfg *appcfg.ApplicationConfig, a
 	})
 	if err != nil {
 		api.HandleError(h.resp, h.req, err)
-		return
+		return nil, err
 	}
 
 	h.appConfig = appConfig
-	return nil
+	return appConfig, nil
 }
 
 func (h *upgradeHandlerHelper) validate() error {
@@ -174,13 +176,13 @@ func (h *upgradeHandlerHelper) applyAppEnv(ctx context.Context) (err error) {
 	return
 }
 
-func (h *upgradeHandlerHelperV2) getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, isAdmin bool) (err error) {
+func (h *upgradeHandlerHelperV2) getAppConfig(prevCfg *appcfg.ApplicationConfig, adminUsers []string, marketSource string, isAdmin bool) (*appcfg.ApplicationConfig, error) {
 	klog.Info("Getting app config for V2")
 	if len(adminUsers) == 0 {
 		err := fmt.Errorf("no admin users found")
 		klog.Error(err)
 		api.HandleError(h.resp, h.req, err)
-		return err
+		return nil, err
 	}
 
 	var admin string
@@ -204,12 +206,40 @@ func (h *upgradeHandlerHelperV2) getAppConfig(prevCfg *appcfg.ApplicationConfig,
 	})
 	if err != nil {
 		api.HandleError(h.resp, h.req, err)
-		return
+		return nil, err
 	}
 
 	h.appConfig = appConfig
 
-	return nil
+	return appConfig, nil
+}
+
+func (h *upgradeHandlerHelper) resolveUpgradeType(appConfig *appcfg.ApplicationConfig, isAdmin bool) string {
+	if appConfig.APIVersion == appcfg.V1 || appConfig.APIVersion == "" {
+		return appcfg.InstallOrUpgradeV1
+	}
+	if isAdmin {
+		return appcfg.InstallOrUpgradeServerAndClient
+	}
+	return appcfg.InstallOrUpgradeClientOnly
+}
+
+func (h *upgradeHandlerHelper) overlayAppConfig(upgradeType string) (*appcfg.ApplicationConfig, error) {
+	if h.appConfig == nil {
+		return nil, fmt.Errorf("app config is nil")
+	}
+	if !config.IsNewManifestVersion(h.appConfig.CfgFileVersion) {
+		return h.appConfig, nil
+	}
+	h.appConfig.ApplyOverlay(upgradeType)
+
+	appRequirement, err := h.appConfig.ResolveRequirement(h.appConfig.SelectedGpuType, upgradeType)
+	if err != nil {
+		return nil, fmt.Errorf("resolve requirement: %w", err)
+	}
+	h.appConfig.Requirement = *appRequirement
+
+	return h.appConfig, nil
 }
 
 func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
@@ -332,9 +362,16 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	err = helper.getAppConfig(&prevCfg, adminUsers, marketSource, isAdmin)
+	appConfig, err := helper.getAppConfig(&prevCfg, adminUsers, marketSource, isAdmin)
 	if err != nil {
 		klog.Errorf("Failed to get app config err=%v", err)
+		return
+	}
+	upgradeType := helper.resolveUpgradeType(appConfig, isAdmin)
+
+	appConfig, err = helper.overlayAppConfig(upgradeType)
+	if err != nil {
+		klog.Errorf("Failed to get overlay config err=%v", err)
 		return
 	}
 

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -267,7 +267,7 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 	if appMgr.Spec.RawAppName != "" {
 		rawAppName = appMgr.Spec.RawAppName
 	}
-	apiVersion, _, err := apputils.GetApiVersionFromAppConfig(req.Request.Context(), &apputils.ConfigOptions{
+	apiVersion, err := apputils.GetAppConfigVersion(req.Request.Context(), &apputils.ConfigOptions{
 		App:          app,
 		RawAppName:   rawAppName,
 		Owner:        owner,

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -372,6 +372,8 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 		return constants.AMDGPU
 	case utils.StrixHaloChipType:
 		return constants.AMDGPU
+	case utils.MthreadsM100ChipType:
+		return ""
 	case utils.CPUType:
 		klog.Info("CPU type is selected, no GPU resource will be injected")
 		return ""

--- a/framework/app-service/pkg/appcfg/appcfg_types.go
+++ b/framework/app-service/pkg/appcfg/appcfg_types.go
@@ -63,8 +63,8 @@ type AppSpec struct {
 	RequiredCPU         string         `yaml:"requiredCpu" json:"requiredCpu"`
 	LimitedMemory       string         `yaml:"limitedMemory" json:"limitedMemory"`
 	LimitedDisk         string         `yaml:"limitedDisk" json:"limitedDisk"`
-	LimitedGPU          string         `yaml:"limitedGPU" json:"limitedGPU"`
-	LimitedCPU          string         `yaml:"limitedCPU" json:"limitedCPU"`
+	LimitedGPU          string         `yaml:"limitedGpu" json:"limitedGpu"`
+	LimitedCPU          string         `yaml:"limitedCpu" json:"limitedCpu"`
 	SupportClient       SupportClient  `yaml:"supportClient" json:"supportClient"`
 	RunAsUser           bool           `yaml:"runAsUser" json:"runAsUser"`
 	RunAsInternal       bool           `yaml:"runAsInternal" json:"runAsInternal"`

--- a/framework/app-service/pkg/appcfg/appcfg_types.go
+++ b/framework/app-service/pkg/appcfg/appcfg_types.go
@@ -209,9 +209,9 @@ type SpecialResource struct {
 }
 
 const (
-	InstallClientOnly      string = "clientOnly"
-	InstallServerAndClient string = "clientAndServer"
-	InstallV1              string = "v1"
+	InstallOrUpgradeClientOnly      string = "clientOnly"
+	InstallOrUpgradeServerAndClient string = "clientAndServer"
+	InstallOrUpgradeV1              string = "v1"
 )
 
 type ResourceRequirement struct {

--- a/framework/app-service/pkg/appcfg/appcfg_types.go
+++ b/framework/app-service/pkg/appcfg/appcfg_types.go
@@ -42,33 +42,37 @@ type AppConfiguration struct {
 
 	// Only for v2 c/s apps to share the api to other cluster scope apps
 	SharedEntrances []v1alpha1.Entrance `yaml:"sharedEntrances,omitempty" json:"sharedEntrances,omitempty"`
+
+	Server *ConfigOverlay `yaml:"server,omitempty" json:"server,omitempty"`
+	Client *ConfigOverlay `yaml:"client,omitempty" json:"client,omitempty"`
 }
 
 type AppSpec struct {
-	Namespace           string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	OnlyAdmin           bool          `yaml:"onlyAdmin,omitempty" json:"onlyAdmin,omitempty"`
-	VersionName         string        `yaml:"versionName" json:"versionName"`
-	FullDescription     string        `yaml:"fullDescription" json:"fullDescription"`
-	UpgradeDescription  string        `yaml:"upgradeDescription" json:"upgradeDescription"`
-	PromoteImage        []string      `yaml:"promoteImage" json:"promoteImage"`
-	PromoteVideo        string        `yaml:"promoteVideo" json:"promoteVideo"`
-	SubCategory         string        `yaml:"subCategory" json:"subCategory"`
-	Developer           string        `yaml:"developer" json:"developer"`
-	RequiredMemory      string        `yaml:"requiredMemory" json:"requiredMemory"`
-	RequiredDisk        string        `yaml:"requiredDisk" json:"requiredDisk"`
-	RequiredGPU         string        `yaml:"requiredGpu" json:"requiredGpu"`
-	RequiredCPU         string        `yaml:"requiredCpu" json:"requiredCpu"`
-	LimitedMemory       string        `yaml:"limitedMemory" json:"limitedMemory"`
-	LimitedDisk         string        `yaml:"limitedDisk" json:"limitedDisk"`
-	LimitedGPU          string        `yaml:"limitedGPU" json:"limitedGPU"`
-	LimitedCPU          string        `yaml:"limitedCPU" json:"limitedCPU"`
-	SupportClient       SupportClient `yaml:"supportClient" json:"supportClient"`
-	RunAsUser           bool          `yaml:"runAsUser" json:"runAsUser"`
-	RunAsInternal       bool          `yaml:"runAsInternal" json:"runAsInternal"`
-	PodGPUConsumePolicy string        `yaml:"podGpuConsumePolicy" json:"podGpuConsumePolicy"`
-	SubCharts           []Chart       `yaml:"subCharts" json:"subCharts"`
-	Hardware            Hardware      `yaml:"hardware" json:"hardware"`
-	SupportedGpu        []any         `yaml:"supportedGpu,omitempty" json:"supportedGpu,omitempty"`
+	Namespace           string         `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	OnlyAdmin           bool           `yaml:"onlyAdmin,omitempty" json:"onlyAdmin,omitempty"`
+	VersionName         string         `yaml:"versionName" json:"versionName"`
+	FullDescription     string         `yaml:"fullDescription" json:"fullDescription"`
+	UpgradeDescription  string         `yaml:"upgradeDescription" json:"upgradeDescription"`
+	PromoteImage        []string       `yaml:"promoteImage" json:"promoteImage"`
+	PromoteVideo        string         `yaml:"promoteVideo" json:"promoteVideo"`
+	SubCategory         string         `yaml:"subCategory" json:"subCategory"`
+	Developer           string         `yaml:"developer" json:"developer"`
+	RequiredMemory      string         `yaml:"requiredMemory" json:"requiredMemory"`
+	RequiredDisk        string         `yaml:"requiredDisk" json:"requiredDisk"`
+	RequiredGPU         string         `yaml:"requiredGpu" json:"requiredGpu"`
+	RequiredCPU         string         `yaml:"requiredCpu" json:"requiredCpu"`
+	LimitedMemory       string         `yaml:"limitedMemory" json:"limitedMemory"`
+	LimitedDisk         string         `yaml:"limitedDisk" json:"limitedDisk"`
+	LimitedGPU          string         `yaml:"limitedGPU" json:"limitedGPU"`
+	LimitedCPU          string         `yaml:"limitedCPU" json:"limitedCPU"`
+	SupportClient       SupportClient  `yaml:"supportClient" json:"supportClient"`
+	RunAsUser           bool           `yaml:"runAsUser" json:"runAsUser"`
+	RunAsInternal       bool           `yaml:"runAsInternal" json:"runAsInternal"`
+	PodGPUConsumePolicy string         `yaml:"podGpuConsumePolicy" json:"podGpuConsumePolicy"`
+	SubCharts           []Chart        `yaml:"subCharts" json:"subCharts"`
+	Hardware            Hardware       `yaml:"hardware" json:"hardware"`
+	SupportedGpu        []any          `yaml:"supportedGpu,omitempty" json:"supportedGpu,omitempty"`
+	Resources           []ResourceMode `yaml:"resources,omitempty" json:"resources,omitempty"`
 }
 
 type Hardware struct {
@@ -202,6 +206,39 @@ type SpecialResource struct {
 	LimitedDisk    *string `yaml:"limitedDisk,omitempty" json:"limitedDisk,omitempty"`
 	LimitedGPU     *string `yaml:"limitedGPU,omitempty" json:"limitedGPU,omitempty"`
 	LimitedCPU     *string `yaml:"limitedCPU,omitempty" json:"limitedCPU,omitempty"`
+}
+
+const (
+	InstallClientOnly      string = "clientOnly"
+	InstallServerAndClient string = "clientAndServer"
+	InstallV1              string = "v1"
+)
+
+type ResourceRequirement struct {
+	RequiredCPU    string `yaml:"requiredCpu,omitempty" json:"requiredCpu,omitempty"`
+	LimitedCPU     string `yaml:"limitedCpu,omitempty" json:"limitedCpu,omitempty"`
+	RequiredMemory string `yaml:"requiredMemory,omitempty" json:"requiredMemory,omitempty"`
+	LimitedMemory  string `yaml:"limitedMemory,omitempty" json:"limitedMemory,omitempty"`
+	RequiredDisk   string `yaml:"requiredDisk,omitempty" json:"requiredDisk,omitempty"`
+	LimitedDisk    string `yaml:"limitedDisk,omitempty" json:"limitedDisk,omitempty"`
+	RequiredGPU    string `yaml:"requiredGpu,omitempty" json:"requiredGpu,omitempty"`
+	LimitedGPU     string `yaml:"limitedGpu,omitempty" json:"limitedGpu,omitempty"`
+}
+
+type ResourceMode struct {
+	Mode                string `yaml:"mode" json:"mode"`
+	ResourceRequirement `yaml:",inline"`
+	Server              *ResourceRequirement `yaml:"server,omitempty" json:"server,omitempty"`
+	Client              *ResourceRequirement `yaml:"client,omitempty" json:"client,omitempty"`
+}
+
+type ConfigOverlay struct {
+	Entrances  []v1alpha1.Entrance     `yaml:"entrances,omitempty" json:"entrances,omitempty"`
+	Middleware *tapr.Middleware        `yaml:"middleware,omitempty" json:"middleware,omitempty"`
+	Permission *Permission             `yaml:"permission,omitempty" json:"permission,omitempty"`
+	Options    *Options                `yaml:"options,omitempty" json:"options,omitempty"`
+	Provider   []Provider              `yaml:"provider,omitempty" json:"provider,omitempty"`
+	Envs       []sysv1alpha1.AppEnvVar `yaml:"envs,omitempty" json:"envs,omitempty"`
 }
 
 func (c *Chart) Namespace(owner string, chartName string) string {

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -201,9 +201,9 @@ func (c *ApplicationConfig) applyConfigOverlay(installType string) {
 	var overlay *ConfigOverlay
 	klog.Infof("applyConfigOverlay: installType: %v", installType)
 	switch installType {
-	case InstallServerAndClient:
+	case InstallOrUpgradeServerAndClient:
 		overlay = c.Server
-	case InstallClientOnly:
+	case InstallOrUpgradeClientOnly:
 		overlay = c.Client
 	}
 	if overlay == nil {
@@ -213,37 +213,41 @@ func (c *ApplicationConfig) applyConfigOverlay(installType string) {
 	c.Entrances = overlay.Entrances
 	c.Middleware = overlay.Middleware
 
-	var permission []AppPermission
-	if overlay.Permission.AppData {
-		permission = append(permission, AppDataRW)
-	}
-	if overlay.Permission.AppCache {
-		permission = append(permission, AppCacheRW)
-	}
-	if len(overlay.Permission.UserData) > 0 {
-		permission = append(permission, UserDataRW)
-	}
-	if len(overlay.Permission.Provider) > 0 {
-		var perm []ProviderPermission
-		for _, s := range overlay.Permission.Provider {
-			perm = append(perm, ProviderPermission(s))
+	if overlay.Permission != nil {
+		var permission []AppPermission
+		if overlay.Permission.AppData {
+			permission = append(permission, AppDataRW)
 		}
-		permission = append(permission, perm)
+		if overlay.Permission.AppCache {
+			permission = append(permission, AppCacheRW)
+		}
+		if len(overlay.Permission.UserData) > 0 {
+			permission = append(permission, UserDataRW)
+		}
+		if len(overlay.Permission.Provider) > 0 {
+			var perm []ProviderPermission
+			for _, s := range overlay.Permission.Provider {
+				perm = append(perm, ProviderPermission(s))
+			}
+			permission = append(permission, perm)
+		}
+		c.Permission = permission
 	}
-	c.Permission = permission
 
-	c.ResetCookieEnabled = overlay.Options.ResetCookie.Enabled
-	c.Dependencies = overlay.Options.Dependencies
-	c.Conflicts = overlay.Options.Conflicts
-	c.AppScope = overlay.Options.AppScope
-	c.WsConfig = overlay.Options.WsConfig
-	c.Upload = overlay.Options.Upload
-	c.MobileSupported = overlay.Options.MobileSupported
-	c.OIDC = overlay.Options.OIDC
-	c.ApiTimeout = overlay.Options.ApiTimeout
-	c.AllowedOutboundPorts = overlay.Options.AllowedOutboundPorts
-	c.Images = overlay.Options.Images
-	c.AllowMultipleInstall = overlay.Options.AllowMultipleInstall
+	if overlay.Options != nil {
+		c.ResetCookieEnabled = overlay.Options.ResetCookie.Enabled
+		c.Dependencies = overlay.Options.Dependencies
+		c.Conflicts = overlay.Options.Conflicts
+		c.AppScope = overlay.Options.AppScope
+		c.WsConfig = overlay.Options.WsConfig
+		c.Upload = overlay.Options.Upload
+		c.MobileSupported = overlay.Options.MobileSupported
+		c.OIDC = overlay.Options.OIDC
+		c.ApiTimeout = overlay.Options.ApiTimeout
+		c.AllowedOutboundPorts = overlay.Options.AllowedOutboundPorts
+		c.Images = overlay.Options.Images
+		c.AllowMultipleInstall = overlay.Options.AllowMultipleInstall
+	}
 	c.Provider = overlay.Provider
 	c.Envs = overlay.Envs
 }
@@ -271,13 +275,13 @@ func (c *ApplicationConfig) ResolveRequirement(selectedGpu, installType string) 
 	}
 
 	switch installType {
-	case InstallClientOnly:
+	case InstallOrUpgradeClientOnly:
 		if mode.Client == nil {
 			return nil, fmt.Errorf("client resource requirement can not be empty")
 		}
 		req := parseResourceRequirement(mode.Client)
 		return &req, nil
-	case InstallServerAndClient:
+	case InstallOrUpgradeServerAndClient:
 		req := sumResourceRequirements(mode.Server, mode.Client)
 		return &req, nil
 	}

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -2,6 +2,7 @@ package appcfg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -101,6 +102,10 @@ type ApplicationConfig struct {
 	HardwareRequirement  Hardware
 	SharedEntrances      []v1alpha1.Entrance
 	SelectedGpuType      string
+	Resources            []ResourceMode
+	InstallType          string
+	Client               *ConfigOverlay
+	Server               *ConfigOverlay
 }
 
 func (c *ApplicationConfig) IsMiddleware() bool {
@@ -165,6 +170,189 @@ func (c *ApplicationConfig) GetSelectedGpuTypeValue() string {
 		return "none"
 	}
 	return c.SelectedGpuType
+}
+
+func (c *ApplicationConfig) DeepCopy() *ApplicationConfig {
+	data, err := json.Marshal(c)
+	if err != nil {
+		klog.Errorf("failed to marshal ApplicationConfig for deep copy: %v", err)
+		return nil
+	}
+	out := &ApplicationConfig{}
+	if err := json.Unmarshal(data, out); err != nil {
+		klog.Errorf("failed to unmarshal ApplicationConfig for deep copy: %v", err)
+		return nil
+	}
+	return out
+}
+
+// ApplyOverlay mutates c in place, merging fields from the Server/Client
+// overlay (selected by installType) into the top-level config. It's a no-op
+// when c is nil or no overlay is defined for the given installType.
+func (c *ApplicationConfig) ApplyOverlay(installType string) {
+	if c == nil {
+		return
+	}
+	c.InstallType = installType
+	c.applyConfigOverlay(installType)
+}
+
+func (c *ApplicationConfig) applyConfigOverlay(installType string) {
+	var overlay *ConfigOverlay
+	klog.Infof("applyConfigOverlay: installType: %v", installType)
+	switch installType {
+	case InstallServerAndClient:
+		overlay = c.Server
+	case InstallClientOnly:
+		overlay = c.Client
+	}
+	if overlay == nil {
+		return
+	}
+
+	c.Entrances = overlay.Entrances
+	c.Middleware = overlay.Middleware
+
+	var permission []AppPermission
+	if overlay.Permission.AppData {
+		permission = append(permission, AppDataRW)
+	}
+	if overlay.Permission.AppCache {
+		permission = append(permission, AppCacheRW)
+	}
+	if len(overlay.Permission.UserData) > 0 {
+		permission = append(permission, UserDataRW)
+	}
+	if len(overlay.Permission.Provider) > 0 {
+		var perm []ProviderPermission
+		for _, s := range overlay.Permission.Provider {
+			perm = append(perm, ProviderPermission(s))
+		}
+		permission = append(permission, perm)
+	}
+	c.Permission = permission
+
+	c.ResetCookieEnabled = overlay.Options.ResetCookie.Enabled
+	c.Dependencies = overlay.Options.Dependencies
+	c.Conflicts = overlay.Options.Conflicts
+	c.AppScope = overlay.Options.AppScope
+	c.WsConfig = overlay.Options.WsConfig
+	c.Upload = overlay.Options.Upload
+	c.MobileSupported = overlay.Options.MobileSupported
+	c.OIDC = overlay.Options.OIDC
+	c.ApiTimeout = overlay.Options.ApiTimeout
+	c.AllowedOutboundPorts = overlay.Options.AllowedOutboundPorts
+	c.Images = overlay.Options.Images
+	c.AllowMultipleInstall = overlay.Options.AllowMultipleInstall
+	c.Provider = overlay.Provider
+	c.Envs = overlay.Envs
+}
+
+func (c *ApplicationConfig) ResolveRequirement(selectedGpu, installType string) (*AppRequirement, error) {
+	if len(c.Resources) == 0 {
+		return nil, fmt.Errorf("empty spec resources")
+	}
+
+	mode := resolveResourceMode(c.Resources, selectedGpu)
+	if mode == nil {
+		return nil, fmt.Errorf("mode %s not found in spec resources", selectedGpu)
+	}
+	if c.APIVersion == V1 {
+		req := parseResourceRequirement(&mode.ResourceRequirement)
+		return &req, nil
+	}
+
+	if mode.Client == nil && mode.Server == nil {
+		if mode.ResourceRequirement == (ResourceRequirement{}) {
+			return nil, fmt.Errorf("empty resource requirement")
+		}
+		req := parseResourceRequirement(&mode.ResourceRequirement)
+		return &req, nil
+	}
+
+	switch installType {
+	case InstallClientOnly:
+		if mode.Client == nil {
+			return nil, fmt.Errorf("client resource requirement can not be empty")
+		}
+		req := parseResourceRequirement(mode.Client)
+		return &req, nil
+	case InstallServerAndClient:
+		req := sumResourceRequirements(mode.Server, mode.Client)
+		return &req, nil
+	}
+	return nil, fmt.Errorf("no resource requirement found")
+}
+
+func resolveResourceMode(modes []ResourceMode, selectedGpu string) *ResourceMode {
+	targetMode := selectedGpu
+	if targetMode == "" || targetMode == "none" {
+		targetMode = utils.CPUType
+	}
+
+	for i := range modes {
+		if modes[i].Mode == targetMode {
+			return &modes[i]
+		}
+	}
+
+	// no target mode found fallback to cpu mode
+	for i := range modes {
+		if modes[i].Mode == utils.CPUType {
+			return &modes[i]
+		}
+	}
+
+	return nil
+}
+
+func parseResourceRequirement(req *ResourceRequirement) AppRequirement {
+	parseQty := func(s string) *resource.Quantity {
+		if s == "" {
+			return nil
+		}
+		q, err := resource.ParseQuantity(s)
+		if err != nil {
+			return nil
+		}
+		return &q
+	}
+
+	return AppRequirement{
+		CPU:    parseQty(req.RequiredCPU),
+		Memory: parseQty(req.RequiredMemory),
+		Disk:   parseQty(req.RequiredDisk),
+		GPU:    parseQty(req.RequiredGPU),
+	}
+}
+
+func sumResourceRequirements(parts ...*ResourceRequirement) AppRequirement {
+	parseAndAdd := func(existing *resource.Quantity, s string) *resource.Quantity {
+		if s == "" {
+			return existing
+		}
+		q, err := resource.ParseQuantity(s)
+		if err != nil {
+			return existing
+		}
+		if existing == nil {
+			return &q
+		}
+		existing.Add(q)
+		return existing
+	}
+
+	var cpu, mem, disk, gpu *resource.Quantity
+	for _, p := range parts {
+		if p == nil {
+			continue
+		}
+		cpu = parseAndAdd(cpu, p.RequiredCPU)
+		mem = parseAndAdd(mem, p.RequiredMemory)
+		disk = parseAndAdd(disk, p.RequiredDisk)
+		gpu = parseAndAdd(gpu, p.RequiredGPU)
+	}
+	return AppRequirement{CPU: cpu, Memory: mem, Disk: disk, GPU: gpu}
 }
 
 func (p *ProviderPermission) GetNamespace(ownerName string) string {

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -837,7 +837,7 @@ func ParseAppPermission(data []appcfg.AppPermission) []appcfg.AppPermission {
 
 func (h *HelmOps) Install() error {
 	var err error
-	values, err := h.SetValues()
+	values, err := h.SetValues(false)
 	if err != nil {
 		klog.Errorf("set values err %v", err)
 		return err

--- a/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
@@ -25,7 +25,7 @@ func (h *HelmOps) Upgrade() error {
 }
 
 func (h *HelmOps) upgrade() error {
-	values, err := h.SetValues()
+	values, err := h.SetValues(true)
 	if err != nil {
 		return err
 	}

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -32,7 +32,7 @@ import (
 // cluster-scoped deps, middleware, etc.) so that a Helm template dry-run still
 // produces a complete manifest. When dryRun is false those keys are left unset
 // and the caller (SetValues) is expected to fill them with real data.
-func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig *appcfg.ApplicationConfig, ownerName string, dryRun bool) (values map[string]interface{}, err error) {
+func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig *appcfg.ApplicationConfig, ownerName string, dryRun bool, isUpgrade bool) (values map[string]interface{}, err error) {
 	values = make(map[string]interface{})
 
 	values["bfl"] = map[string]interface{}{
@@ -148,14 +148,20 @@ func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig
 			"refs":     map[string]interface{}{},
 		}
 	}
-
+	values["client"] = true
+	if appConfig.InstallType == appcfg.InstallServerAndClient {
+		values["server"] = true
+	}
+	if isUpgrade {
+		values["server"] = true
+	}
 	return values, nil
 }
 
-func (h *HelmOps) SetValues() (values map[string]interface{}, err error) {
+func (h *HelmOps) SetValues(isUpgrade bool) (values map[string]interface{}, err error) {
 	ctx := context.TODO()
 
-	values, err = BuildBaseHelmValues(ctx, h.kubeConfig, h.app, h.app.OwnerName, false)
+	values, err = BuildBaseHelmValues(ctx, h.kubeConfig, h.app, h.app.OwnerName, false, isUpgrade)
 	if err != nil {
 		return values, err
 	}

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -148,11 +148,13 @@ func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig
 			"refs":     map[string]interface{}{},
 		}
 	}
+
 	values["client"] = true
-	if appConfig.InstallType == appcfg.InstallServerAndClient {
+	if appConfig.InstallType == appcfg.InstallOrUpgradeServerAndClient {
 		values["server"] = true
 	}
-	if isUpgrade {
+
+	if isUpgrade && isAdmin {
 		values["server"] = true
 	}
 	return values, nil

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_install.go
@@ -54,14 +54,10 @@ func (h *HelmOpsV2) Install() error {
 	}
 
 	var err error
-	values, err := h.SetValues()
+	values, err := h.SetValues(false)
 	if err != nil {
 		klog.Errorf("set values err %v", err)
 		return err
-	}
-	if values["isAdmin"].(bool) {
-		// force set the admin is owner
-		values["admin"] = h.App().OwnerName
 	}
 
 	// in v2, if app is multi-charts and has a cluster shared chart,

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_upgrade.go
@@ -34,7 +34,7 @@ func (h *HelmOpsV2) Upgrade() error {
 		return err
 	}
 	if status.Info.Status == helmrelease.StatusDeployed {
-		values, err := h.SetValues()
+		values, err := h.SetValues(true)
 		if err != nil {
 			klog.Errorf("set values err %v", err)
 			return err

--- a/framework/app-service/pkg/appstate/downloading_app.go
+++ b/framework/app-service/pkg/appstate/downloading_app.go
@@ -154,7 +154,7 @@ func (p *DownloadingApp) exec(ctx context.Context) error {
 		return err
 	}
 
-	values, err := appinstaller.BuildBaseHelmValues(ctx, kubeConfig, appConfig, p.manager.Spec.AppOwner, true)
+	values, err := appinstaller.BuildBaseHelmValues(ctx, kubeConfig, appConfig, p.manager.Spec.AppOwner, true, false)
 	if err != nil {
 		klog.Errorf("build base helm values failed %v", err)
 		return err

--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -234,7 +234,7 @@ func (p *UpgradingApp) exec(ctx context.Context) error {
 		return err
 	}
 
-	values, err := appinstaller.BuildBaseHelmValues(ctx, kubeConfig, appConfig, p.manager.Spec.AppOwner, true)
+	values, err := appinstaller.BuildBaseHelmValues(ctx, kubeConfig, appConfig, p.manager.Spec.AppOwner, true, true)
 	if err != nil {
 		klog.Errorf("build base helm values failed %v", err)
 		return err

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -792,6 +792,9 @@ func GetAppConfigVersion(ctx context.Context, options *ConfigOptions) (appcfg.AP
 	}
 
 	apiVersion := GetTopLevelValue(raw, "apiVersion")
+	if apiVersion == "" {
+		apiVersion = "v1"
+	}
 	return appcfg.APIVersion(apiVersion), nil
 }
 
@@ -990,10 +993,6 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		Client:               cfg.Client,
 		Server:               cfg.Server,
 	}, chart, nil
-}
-
-func ResolveRequirementByCfg(cfg *appcfg.ApplicationConfig, opt *ConfigOptions) (*appcfg.AppRequirement, error) {
-	return cfg.ResolveRequirement(opt.SelectedGpu, opt.InstallType)
 }
 
 func getAppConfigFromConfigurationFile(opt *ConfigOptions, chartPath string) (*appcfg.ApplicationConfig, string, error) {
@@ -1380,5 +1379,5 @@ func GetTopLevelValue(content []byte, key string) string {
 			return value
 		}
 	}
-	return "v1"
+	return ""
 }

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -843,54 +843,56 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		return nil, chart, err
 	}
 
-	// set suppertedGpu to ["nvidia","nvidia-gb10"] by default
-	if len(cfg.Spec.SupportedGpu) == 0 {
-		cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType}
-	}
+	if !config.IsNewManifestVersion(cfg.ConfigVersion) {
+		// set suppertedGpu to ["nvidia","nvidia-gb10"] by default
+		if len(cfg.Spec.SupportedGpu) == 0 {
+			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType}
+		}
 
-	// try to get selected GPU type special resource requirement
-	if opt.SelectedGpu != "" {
-		found := false
-		for _, supportedGpu := range cfg.Spec.SupportedGpu {
-			if str, ok := supportedGpu.(string); ok && str == opt.SelectedGpu {
-				found = true
-				break
-			}
-
-			if supportedGpuResourceMap, ok := supportedGpu.(map[string]interface{}); ok {
-				if resourceRequirement, ok := supportedGpuResourceMap[opt.SelectedGpu].(map[string]interface{}); ok {
+		// try to get selected GPU type special resource requirement
+		if opt.SelectedGpu != "" {
+			found := false
+			for _, supportedGpu := range cfg.Spec.SupportedGpu {
+				if str, ok := supportedGpu.(string); ok && str == opt.SelectedGpu {
 					found = true
-					var specialResource appcfg.SpecialResource
-					err := mapstructure.Decode(resourceRequirement, &specialResource)
-					if err != nil {
-						return nil, chart, fmt.Errorf("failed to decode special resource for selected GPU type %s: %v", opt.SelectedGpu, err)
-					}
+					break
+				}
 
-					for _, resSetter := range []struct {
-						v **resource.Quantity
-						s *string
-					}{
-						{v: &mem, s: specialResource.RequiredMemory},
-						{v: &disk, s: specialResource.RequiredDisk},
-						{v: &cpu, s: specialResource.RequiredCPU},
-						{v: &gpu, s: specialResource.RequiredGPU},
-					} {
+				if supportedGpuResourceMap, ok := supportedGpu.(map[string]interface{}); ok {
+					if resourceRequirement, ok := supportedGpuResourceMap[opt.SelectedGpu].(map[string]interface{}); ok {
+						found = true
+						var specialResource appcfg.SpecialResource
+						err := mapstructure.Decode(resourceRequirement, &specialResource)
+						if err != nil {
+							return nil, chart, fmt.Errorf("failed to decode special resource for selected GPU type %s: %v", opt.SelectedGpu, err)
+						}
 
-						if resSetter.s != nil && *resSetter.s != "" {
-							*resSetter.v, err = valuePtr(resource.ParseQuantity(*resSetter.s))
-							if err != nil {
-								return nil, chart, fmt.Errorf("failed to parse special resource quantity %s: %v", *resSetter.s, err)
+						for _, resSetter := range []struct {
+							v **resource.Quantity
+							s *string
+						}{
+							{v: &mem, s: specialResource.RequiredMemory},
+							{v: &disk, s: specialResource.RequiredDisk},
+							{v: &cpu, s: specialResource.RequiredCPU},
+							{v: &gpu, s: specialResource.RequiredGPU},
+						} {
+
+							if resSetter.s != nil && *resSetter.s != "" {
+								*resSetter.v, err = valuePtr(resource.ParseQuantity(*resSetter.s))
+								if err != nil {
+									return nil, chart, fmt.Errorf("failed to parse special resource quantity %s: %v", *resSetter.s, err)
+								}
 							}
 						}
-					}
 
-					break
-				} // end if selected gpu's resource requirement found
-			} // end if supportedGpu is map
-		} // end for supportedGpu
+						break
+					} // end if selected gpu's resource requirement found
+				} // end if supportedGpu is map
+			} // end for supportedGpu
 
-		if !found {
-			return nil, chart, fmt.Errorf("selected GPU type %s is not supported", opt.SelectedGpu)
+			if !found {
+				return nil, chart, fmt.Errorf("selected GPU type %s is not supported", opt.SelectedGpu)
+			}
 		}
 	}
 

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -714,7 +714,6 @@ type ConfigOptions struct {
 	IsAdmin      bool
 	RawAppName   string
 	SelectedGpu  string
-	InstallType  string
 }
 
 // GetAppConfig get app installation configuration from app store
@@ -755,21 +754,6 @@ func GetAppConfig(ctx context.Context, options *ConfigOptions) (*appcfg.Applicat
 	appcfg.OwnerName = options.Owner
 	appcfg.RepoURL = options.RepoURL
 	return appcfg, chartPath, nil
-}
-
-func GetApiVersionFromAppConfig(ctx context.Context, options *ConfigOptions) (appcfg.APIVersion, *appcfg.ApplicationConfig, error) {
-
-	cfg, _, err := GetAppConfig(ctx, options)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to get app config: %w", err)
-	}
-
-	// default version is v1
-	if cfg.APIVersion == "" {
-		return appcfg.V1, cfg, nil
-	}
-
-	return cfg.APIVersion, cfg, nil
 }
 
 func getAppConfigFromRepo(ctx context.Context, options *ConfigOptions) (*appcfg.ApplicationConfig, string, error) {

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils/config"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils/files"
 
 	"github.com/Masterminds/semver/v3"
@@ -712,6 +714,7 @@ type ConfigOptions struct {
 	IsAdmin      bool
 	RawAppName   string
 	SelectedGpu  string
+	InstallType  string
 }
 
 // GetAppConfig get app installation configuration from app store
@@ -778,7 +781,21 @@ func getAppConfigFromRepo(ctx context.Context, options *ConfigOptions) (*appcfg.
 	return getAppConfigFromConfigurationFile(options, chartPath)
 }
 
-func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg.AppConfiguration) (*appcfg.ApplicationConfig, string, error) {
+func GetAppConfigVersion(ctx context.Context, options *ConfigOptions) (appcfg.APIVersion, error) {
+	chartPath, err := GetIndexAndDownloadChart(ctx, options)
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(filepath.Join(chartPath, AppCfgFileName))
+	if err != nil {
+		return "", err
+	}
+
+	apiVersion := GetTopLevelValue(raw, "apiVersion")
+	return appcfg.APIVersion(apiVersion), nil
+}
+
+func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfiguration) (*appcfg.ApplicationConfig, string, error) {
 	var permission []appcfg.AppPermission
 	if cfg.Permission.AppData {
 		permission = append(permission, appcfg.AppDataRW)
@@ -832,21 +849,21 @@ func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg
 	}
 
 	// try to get selected GPU type special resource requirement
-	if selectedGpu != "" {
+	if opt.SelectedGpu != "" {
 		found := false
 		for _, supportedGpu := range cfg.Spec.SupportedGpu {
-			if str, ok := supportedGpu.(string); ok && str == selectedGpu {
+			if str, ok := supportedGpu.(string); ok && str == opt.SelectedGpu {
 				found = true
 				break
 			}
 
 			if supportedGpuResourceMap, ok := supportedGpu.(map[string]interface{}); ok {
-				if resourceRequirement, ok := supportedGpuResourceMap[selectedGpu].(map[string]interface{}); ok {
+				if resourceRequirement, ok := supportedGpuResourceMap[opt.SelectedGpu].(map[string]interface{}); ok {
 					found = true
 					var specialResource appcfg.SpecialResource
 					err := mapstructure.Decode(resourceRequirement, &specialResource)
 					if err != nil {
-						return nil, chart, fmt.Errorf("failed to decode special resource for selected GPU type %s: %v", selectedGpu, err)
+						return nil, chart, fmt.Errorf("failed to decode special resource for selected GPU type %s: %v", opt.SelectedGpu, err)
 					}
 
 					for _, resSetter := range []struct {
@@ -873,7 +890,7 @@ func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg
 		} // end for supportedGpu
 
 		if !found {
-			return nil, chart, fmt.Errorf("selected GPU type %s is not supported", selectedGpu)
+			return nil, chart, fmt.Errorf("selected GPU type %s is not supported", opt.SelectedGpu)
 		}
 	}
 
@@ -903,10 +920,10 @@ func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg
 		}
 	}
 	var appid string
-	if userspace.IsSysApp(app) {
-		appid = app
+	if userspace.IsSysApp(opt.App) {
+		appid = opt.App
 	} else {
-		appid = utils.Md5String(app)[:8]
+		appid = utils.Md5String(opt.App)[:8]
 	}
 
 	if appcfg.APIVersion(cfg.APIVersion) == appcfg.V2 {
@@ -921,8 +938,8 @@ func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg
 		AppID:          appid,
 		APIVersion:     appcfg.APIVersion(cfg.APIVersion),
 		CfgFileVersion: cfg.ConfigVersion,
-		AppName:        app,
-		RawAppName:     rawAppName,
+		AppName:        opt.App,
+		RawAppName:     opt.RawAppName,
 		Title:          cfg.Metadata.Title,
 		Version:        cfg.Metadata.Version,
 		Target:         cfg.Metadata.Target,
@@ -966,11 +983,28 @@ func toApplicationConfig(app, chart, rawAppName, selectedGpu string, cfg *appcfg
 		PodsSelectors:        podSelectors,
 		HardwareRequirement:  cfg.Spec.Hardware,
 		SharedEntrances:      cfg.SharedEntrances,
-		SelectedGpuType:      selectedGpu,
+		SelectedGpuType:      opt.SelectedGpu,
+		Resources:            cfg.Spec.Resources,
+		Client:               cfg.Client,
+		Server:               cfg.Server,
 	}, chart, nil
 }
 
+func ResolveRequirementByCfg(cfg *appcfg.ApplicationConfig, opt *ConfigOptions) (*appcfg.AppRequirement, error) {
+	return cfg.ResolveRequirement(opt.SelectedGpu, opt.InstallType)
+}
+
 func getAppConfigFromConfigurationFile(opt *ConfigOptions, chartPath string) (*appcfg.ApplicationConfig, string, error) {
+	raw, err := os.ReadFile(filepath.Join(chartPath, AppCfgFileName))
+	if err != nil {
+		return nil, chartPath, err
+	}
+
+	configVersion := GetTopLevelValue(raw, "olaresManifest.version")
+	if config.IsNewManifestVersion(configVersion) {
+		return parseNewManifest(opt, chartPath, raw)
+	}
+
 	data, err := utils.RenderManifest(filepath.Join(chartPath, AppCfgFileName), opt.Owner, opt.Admin, opt.IsAdmin)
 	if err != nil {
 		return nil, chartPath, err
@@ -980,7 +1014,21 @@ func getAppConfigFromConfigurationFile(opt *ConfigOptions, chartPath string) (*a
 		return nil, chartPath, err
 	}
 
-	return toApplicationConfig(opt.App, chartPath, opt.RawAppName, opt.SelectedGpu, &cfg)
+	return toApplicationConfig(opt, chartPath, &cfg)
+}
+
+func parseNewManifest(opt *ConfigOptions, chartPath string, raw []byte) (*appcfg.ApplicationConfig, string, error) {
+	var cfg appcfg.AppConfiguration
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, chartPath, fmt.Errorf("failed to unmarshal new manifest: %w", err)
+	}
+
+	appConfig, chart, err := toApplicationConfig(opt, chartPath, &cfg)
+	if err != nil {
+		return nil, chart, err
+	}
+
+	return appConfig, chart, nil
 }
 
 func checkVersionFormat(constraint string) error {
@@ -1314,4 +1362,21 @@ func BuildPrevPortsMap(prevConfig *appcfg.ApplicationConfig) map[string]int32 {
 		}
 	}
 	return m
+}
+
+func GetTopLevelValue(content []byte, key string) string {
+	lines := strings.Split(string(content), "\n")
+	prefix := key + ":"
+
+	for _, line := range lines {
+		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' || line[0] == '#' {
+			continue
+		}
+		if strings.HasPrefix(line, prefix) {
+			value := strings.TrimSpace(line[len(prefix):])
+			value = strings.Trim(value, `'"`)
+			return value
+		}
+	}
+	return "v1"
 }

--- a/framework/app-service/pkg/utils/app/validate.go
+++ b/framework/app-service/pkg/utils/app/validate.go
@@ -994,8 +994,6 @@ func CheckAppK8sRequestResource(appConfig *appcfg.ApplicationConfig, op v1alpha1
 	}
 	klog.Infof("availableResources: cpu: %#v", availableResources.cpu.allocatable.String())
 	klog.Infof("availableResources: memory: %#v", availableResources.memory.allocatable.String())
-	klog.Infof("required memory: %#v", appConfig.Requirement.Memory.String())
-	klog.Infof("required cpu: %#v", appConfig.Requirement.CPU.String())
 
 	sufficientCPU, sufficientMemory := false, false
 

--- a/framework/app-service/pkg/utils/app/validate.go
+++ b/framework/app-service/pkg/utils/app/validate.go
@@ -994,6 +994,8 @@ func CheckAppK8sRequestResource(appConfig *appcfg.ApplicationConfig, op v1alpha1
 	}
 	klog.Infof("availableResources: cpu: %#v", availableResources.cpu.allocatable.String())
 	klog.Infof("availableResources: memory: %#v", availableResources.memory.allocatable.String())
+	klog.Infof("required memory: %#v", appConfig.Requirement.Memory.String())
+	klog.Infof("required cpu: %#v", appConfig.Requirement.CPU.String())
 
 	sufficientCPU, sufficientMemory := false, false
 

--- a/framework/app-service/pkg/utils/config/app.go
+++ b/framework/app-service/pkg/utils/config/app.go
@@ -1,8 +1,31 @@
 package config
 
+import (
+	"github.com/Masterminds/semver/v3"
+	"k8s.io/klog/v2"
+)
+
 const (
 	// AppCfgFileName config file name for application.
 	AppCfgFileName = "OlaresManifest.yaml"
 
-	MinCfgFileVersion = ">= 0.7.2"
+	MinCfgFileVersion  = ">= 0.7.2"
+	NewManifestVersion = "0.12.0"
 )
+
+func IsNewManifestVersion(version string) bool {
+	if version == "" {
+		return false
+	}
+	c, err := semver.NewConstraint(">= " + NewManifestVersion)
+	if err != nil {
+		klog.Errorf("invalid new manifest version constraint: %v", err)
+		return false
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		klog.Errorf("invalid manifest version %s: %v", version, err)
+		return false
+	}
+	return c.Check(v)
+}

--- a/framework/app-service/pkg/utils/gpu_types.go
+++ b/framework/app-service/pkg/utils/gpu_types.go
@@ -5,10 +5,11 @@ const (
 )
 
 const (
-	CPUType           = "cpu"         // force to use CPU, no GPU
-	NvidiaCardType    = "nvidia"      // handling by HAMi
-	AmdGpuCardType    = "amd-gpu"     //
-	AmdApuCardType    = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
-	GB10ChipType      = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
-	StrixHaloChipType = "strix-halo"  // AMD Strix Halo GPU & unified system memory
+	CPUType              = "cpu"         // force to use CPU, no GPU
+	NvidiaCardType       = "nvidia"      // handling by HAMi
+	AmdGpuCardType       = "amd-gpu"     //
+	AmdApuCardType       = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
+	GB10ChipType         = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
+	StrixHaloChipType    = "strix-halo"  // AMD Strix Halo GPU & unified system memory
+	MthreadsM100ChipType = "mthreads-m1000"
 )


### PR DESCRIPTION

* **Background**
feat: support new format olaresmanifest multi chip resources
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core install/upgrade and Helm value generation paths and changes how resource requirements and permissions/entrances can be derived from manifests, which could affect rollout behavior for new-format apps.
> 
> **Overview**
> Updates app install/upgrade to support a *new manifest format* (version = `0.12.0`) that can define per-GPU/CPU `spec.resources` and server/client overlays.
> 
> Install/upgrade now detect app config API version via `GetAppConfigVersion`, resolve an install/upgrade type (`v1`, `clientOnly`, `clientAndServer`) based on admin role and shared-namespace presence, then apply overlayed config + recomputed resource requirements before validation and Helm execution. Helm values generation is updated to accept an `isUpgrade` flag and to set `client`/`server` flags accordingly. Also adds a new GPU type constant (`mthreads-m1000`) and prevents GPU resource injection for it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77eee3bfd1a055d9fd950808663983cf85acc23b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->