### PR TITLE
fix(tapr): filter search domain that conflicts with cluster local

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -79,7 +79,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.18
+        image: beclab/sys-event:0.2.19
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -583,7 +583,7 @@ func getNonClusterLocalSearchDomains() ([]string, error) {
 			continue
 		}
 		for _, d := range strings.Fields(line)[1:] {
-			if !strings.HasSuffix(d, "cluster.local") {
+			if !strings.HasSuffix(d, "cluster.local") && d != "local" {
 				domains = append(domains, d)
 			}
 		}


### PR DESCRIPTION
* **Background**
When the local search domains in node's `/etc/resolv.conf` conflicts with the cluster's local domain suffix, such as `local`, `cluster.local`, `svc.cluster.local`, it should be filtered out to avoid resolve errors inside the cluster.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none