### PR TITLE
authelia: fix reloading sub-resource authorization missing

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.49
+        image: beclab/auth:0.2.50
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Authelia reloads the access tokens when the server is restarted, but the sub-resource authorizations cannot be reloaded

* **Target Version for Merge**
v1.12.6, v.12.7

* **Related Issues**
Some desktop APIs get invalid when Authelia is restarted

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/55be55322fc63b94adb9abe4359c15e7e4be36f1

* **Other information**:
