### PR TITLE
feat(cli/wizard): activate v2 with persisted state, vault crypto, and platform rename

### DIFF
--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/beclab/Olares/cli/cmd/ctl/os"
 	"github.com/beclab/Olares/cli/cmd/ctl/osinfo"
 	"github.com/beclab/Olares/cli/cmd/ctl/user"
+	"github.com/beclab/Olares/cli/cmd/ctl/wizard"
 	"github.com/beclab/Olares/cli/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -49,6 +50,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmds.AddCommand(gpu.NewCmdGpu())
 	cmds.AddCommand(amdgpu.NewCmdAmdGpu())
 	cmds.AddCommand(user.NewUserCommand())
+	cmds.AddCommand(wizard.NewWizardCommand())
 	cmds.AddCommand(disk.NewDiskCommand())
 	cmds.AddCommand(app.NewAppCommand())
 

--- a/cli/cmd/ctl/user/activate.go
+++ b/cli/cmd/ctl/user/activate.go
@@ -13,6 +13,7 @@ type activateUserOptions struct {
 	Mnemonic      string
 	BflUrl        string
 	VaultUrl      string
+	AuthUrl       string
 	Password      string
 	OlaresId      string
 	ResetPassword string
@@ -48,6 +49,7 @@ func (o *activateUserOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Mnemonic, "mnemonic", "", "12-word mnemonic phrase, required for activation")
 	cmd.Flags().StringVar(&o.BflUrl, "bfl", "http://127.0.0.1:30180", "Bfl URL (e.g., https://example.com, default: http://127.0.0.1:30180)")
 	cmd.Flags().StringVar(&o.VaultUrl, "vault", "http://127.0.0.1:30180", "Vault URL (e.g., https://example.com, default: http://127.0.0.1:30181)")
+	cmd.Flags().StringVar(&o.AuthUrl, "authurl", "", "Auth URL (e.g., https://auth.example.com, default: empty -> auto-derived)")
 	cmd.Flags().StringVarP(&o.Password, "password", "p", "", "OS password for authentication, required for activation")
 	cmd.Flags().StringVar(&o.Location, "location", "Asia/Shanghai", "Timezone location (default: Asia/Shanghai)")
 	cmd.Flags().StringVar(&o.Language, "language", "en-US", "System language (default: en-US)")
@@ -84,6 +86,7 @@ func (c *activateUserOptions) Run() error {
 	log.Printf("Parameters:")
 	log.Printf("  BflUrl: %s", c.BflUrl)
 	log.Printf("  VaultUrl: %s", c.VaultUrl)
+	log.Printf("  AuthUrl: %s", c.AuthUrl)
 	log.Printf("  Terminus Name: %s", c.OlaresId)
 	log.Printf("  Local Name: %s", localName)
 
@@ -93,7 +96,7 @@ func (c *activateUserOptions) Run() error {
 		return fmt.Errorf("failed to initialize global stores: %v", err)
 	}
 
-	accessToken, err := wizard.UserBindTerminus(c.Mnemonic, c.BflUrl, c.VaultUrl, c.Password, c.OlaresId, localName)
+	accessToken, err := wizard.UserBindTerminus(c.Mnemonic, c.BflUrl, c.VaultUrl, c.AuthUrl, c.Password, c.OlaresId, localName)
 	if err != nil {
 		return fmt.Errorf("user bind failed: %v", err)
 	}

--- a/cli/cmd/ctl/user/root.go
+++ b/cli/cmd/ctl/user/root.go
@@ -11,7 +11,6 @@ func NewUserCommand() *cobra.Command {
 	cmd.AddCommand(NewCmdDeleteUser())
 	cmd.AddCommand(NewCmdListUsers())
 	cmd.AddCommand(NewCmdGetUser())
-	cmd.AddCommand(NewCmdActivateUser())
 	cmd.AddCommand(NewCmdResetPassword())
 	// cmd.AddCommand(NewCmdUpdateUserLimits())
 	return cmd

--- a/cli/cmd/ctl/wizard/activate.go
+++ b/cli/cmd/ctl/wizard/activate.go
@@ -1,15 +1,15 @@
-package user
+package wizard
 
 import (
 	"fmt"
 	"log"
 	"strings"
 
-	"github.com/beclab/Olares/cli/pkg/wizard"
+	wizardpkg "github.com/beclab/Olares/cli/pkg/wizard"
 	"github.com/spf13/cobra"
 )
 
-type activateUserOptions struct {
+type activateOptions struct {
 	Mnemonic      string
 	BflUrl        string
 	VaultUrl      string
@@ -25,11 +25,11 @@ type activateUserOptions struct {
 	Jws          string
 }
 
-func NewCmdActivateUser() *cobra.Command {
-	o := &activateUserOptions{}
+func NewCmdActivate() *cobra.Command {
+	o := &activateOptions{}
 	cmd := &cobra.Command{
 		Use:   "activate {Olares ID (e.g., user@example.com)}",
-		Short: "activate a new user",
+		Short: "run the activation wizard end-to-end",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			o.OlaresId = args[0]
@@ -45,7 +45,7 @@ func NewCmdActivateUser() *cobra.Command {
 	return cmd
 }
 
-func (o *activateUserOptions) AddFlags(cmd *cobra.Command) {
+func (o *activateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Mnemonic, "mnemonic", "", "12-word mnemonic phrase, required for activation")
 	cmd.Flags().StringVar(&o.BflUrl, "bfl", "http://127.0.0.1:30180", "Bfl URL (e.g., https://example.com, default: http://127.0.0.1:30180)")
 	cmd.Flags().StringVar(&o.VaultUrl, "vault", "http://127.0.0.1:30180", "Vault URL (e.g., https://example.com, default: http://127.0.0.1:30181)")
@@ -59,7 +59,7 @@ func (o *activateUserOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.ResetPassword, "reset-password", "", "New password for resetting (required for password reset)")
 }
 
-func (o *activateUserOptions) Validate() error {
+func (o *activateOptions) Validate() error {
 	if o.OlaresId == "" {
 		return fmt.Errorf("Olares ID is required")
 	}
@@ -75,7 +75,7 @@ func (o *activateUserOptions) Validate() error {
 	return nil
 }
 
-func (c *activateUserOptions) Run() error {
+func (c *activateOptions) Run() error {
 	log.Println("=== TermiPass CLI - User Bind Terminus ===")
 
 	localName := c.OlaresId
@@ -91,12 +91,12 @@ func (c *activateUserOptions) Run() error {
 	log.Printf("  Local Name: %s", localName)
 
 	log.Printf("Initializing global stores with mnemonic...")
-	err := wizard.InitializeGlobalStores(c.Mnemonic, c.OlaresId)
+	err := wizardpkg.InitializeGlobalStores(c.Mnemonic, c.OlaresId)
 	if err != nil {
 		return fmt.Errorf("failed to initialize global stores: %v", err)
 	}
 
-	accessToken, err := wizard.UserBindTerminus(c.Mnemonic, c.BflUrl, c.VaultUrl, c.AuthUrl, c.Password, c.OlaresId, localName)
+	accessToken, err := wizardpkg.UserBindTerminus(c.Mnemonic, c.BflUrl, c.VaultUrl, c.AuthUrl, c.Password, c.OlaresId, localName)
 	if err != nil {
 		return fmt.Errorf("user bind failed: %v", err)
 	}
@@ -104,7 +104,7 @@ func (c *activateUserOptions) Run() error {
 	log.Printf("✅ Vault activation completed successfully!")
 	log.Printf("🚀 Starting system activation wizard...")
 
-	wizardConfig := wizard.CustomWizardConfig(c.Location, c.Language, c.EnableTunnel, c.Host, c.Jws, c.Password, c.ResetPassword)
+	wizardConfig := wizardpkg.CustomWizardConfig(c.Location, c.Language, c.EnableTunnel, c.Host, c.Jws, c.Password, c.ResetPassword)
 
 	log.Printf("Wizard configuration:")
 	log.Printf("  Location: %s", wizardConfig.System.Location)
@@ -115,7 +115,7 @@ func (c *activateUserOptions) Run() error {
 		log.Printf("  FRP JWS: %s", wizardConfig.System.FRP.Jws)
 	}
 
-	err = wizard.RunActivationWizard(c.BflUrl, accessToken, wizardConfig)
+	err = wizardpkg.RunActivationWizard(c.BflUrl, accessToken, wizardConfig)
 	if err != nil {
 		return fmt.Errorf("activation wizard failed: %v", err)
 	}

--- a/cli/cmd/ctl/wizard/root.go
+++ b/cli/cmd/ctl/wizard/root.go
@@ -1,0 +1,12 @@
+package wizard
+
+import "github.com/spf13/cobra"
+
+func NewWizardCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wizard",
+		Short: "activation wizard operations",
+	}
+	cmd.AddCommand(NewCmdActivate())
+	return cmd
+}

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -692,8 +692,14 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 		Version:        "3.0.14",
 	}
 
-	// 6. Create account secrets (private key + signing key)
-	privateKeyDER := x509.MarshalPKCS1PrivateKey(privateKey)
+	// 6. Create account secrets (private key + signing key).
+	//    Use PKCS#8 PrivateKeyInfo DER so the encrypted blob is
+	//    interoperable with the TS web client, whose WebCrypto
+	//    importKey('pkcs8', ...) only accepts this format.
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to marshal private key as PKCS#8: %w", err)
+	}
 	signingKey := generateRandomBytes(32) // HMAC key
 
 	// Combine private key and signing key into account secrets

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -274,7 +274,13 @@ func (a *App) Login(params LoginParams) error {
 					log.Printf("Login: failed to unlock new mainVault for merge: %v", err)
 				}
 			}
-			if mv.items != nil && localvault.items != nil {
+			// Only drop the legacy localvault once we are sure every item
+			// has been safely migrated into the new mainVault. If any
+			// unlock or CreateItem call failed we keep the localvault
+			// around so the next Login attempt can retry the merge.
+			mergeReady := mv.items != nil && localvault.items != nil
+			migrationFailed := false
+			if mergeReady {
 				for id, item := range localvault.items.Items {
 					if _, exists := mv.items.Items[id]; exists {
 						continue
@@ -296,12 +302,18 @@ func (a *App) Login(params LoginParams) error {
 						Type:   itemType,
 					}); err != nil {
 						log.Printf("Login: failed to migrate localvault item %s: %v", id, err)
+						migrationFailed = true
 					}
 				}
+			} else {
+				log.Printf("Login: skipping localvault merge (mv.items=%v, localvault.items=%v); keeping localvault for retry",
+					mv.items != nil, localvault.items != nil)
 			}
-			a.State.RemoveVault(localvault.ID)
-			if err := a.State.Save(); err != nil {
-				log.Printf("Login: failed to persist app state after merge: %v", err)
+			if mergeReady && !migrationFailed {
+				a.State.RemoveVault(localvault.ID)
+				if err := a.State.Save(); err != nil {
+					log.Printf("Login: failed to persist app state after merge: %v", err)
+				}
 			}
 		}
 	}

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -1,8 +1,6 @@
 package wizard
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -16,66 +14,43 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// App class - simplified version for backend CLI use
+// App class - mirrors the TS App in apps/packages/sdk/src/core/app.ts.
+//
+// Holds a single AppState which is both the in-memory client state used
+// by the RPC Client and the persistable representation of the
+// account / vaults / orgs known to this client.
 type App struct {
-	Version string  `json:"version"`
-	API     *Client `json:"-"` // Uses Client from client.go
+	Version string     `json:"version"`
+	API     *Client    `json:"-"`
+	State   *AppState  `json:"-"`
 }
 
-// NewApp constructor - initializes with Client (corresponds to original TypeScript constructor)
-func NewApp(sender Sender) *App {
-	// Create simplified client state (backend CLI doesn't need complex state management)
-	state := &SimpleClientState{}
-
-	// Initialize Client (corresponds to original TypeScript's new Client(this.state, sender, hook))
+// NewApp constructs an App using the given sender and AppState.
+// If state is nil, an in-memory only state is created.
+func NewApp(sender Sender, state *AppState) *App {
+	if state == nil {
+		state = NewAppState(nil, "")
+	}
 	client := NewClient(state, sender)
-
 	return &App{
 		Version: "3.0",
 		API:     client,
+		State:   state,
 	}
 }
 
-// NewAppWithBaseURL creates App with base URL (convenience function)
+// NewAppWithBaseURL creates App with base URL (convenience function).
+// Uses an in-memory state. Prefer NewAppWithState when you need persistence.
 func NewAppWithBaseURL(baseURL string) *App {
-	// Create HTTP Sender
 	sender := NewHTTPSender(baseURL)
-
-	// Create App with HTTP Sender
-	return NewApp(sender)
+	return NewApp(sender, nil)
 }
 
-// SimpleClientState - simplified client state for backend CLI
-type SimpleClientState struct {
-	session *Session
-	account *Account
-	device  *DeviceInfo
-}
-
-func (s *SimpleClientState) GetSession() *Session {
-	return s.session
-}
-
-func (s *SimpleClientState) SetSession(session *Session) {
-	s.session = session
-}
-
-func (s *SimpleClientState) GetAccount() *Account {
-	return s.account
-}
-
-func (s *SimpleClientState) SetAccount(account *Account) {
-	s.account = account
-}
-
-func (s *SimpleClientState) GetDevice() *DeviceInfo {
-	if s.device == nil {
-		s.device = &DeviceInfo{
-			ID:       "cli-device-" + generateUUID(),
-			Platform: "go-cli",
-		}
-	}
-	return s.device
+// NewAppWithState creates App with an explicit AppState (typically backed
+// by a DirKVStorage rooted at ~/.olares/<did>/).
+func NewAppWithState(baseURL string, state *AppState) *App {
+	sender := NewHTTPSender(baseURL)
+	return NewApp(sender, state)
 }
 
 // Signup function - based on original TypeScript signup method (ref: app.ts)
@@ -155,14 +130,28 @@ func (a *App) Signup(params SignupParams) (*CreateAccountResponse, error) {
 
 	log.Printf("Login after signup successful")
 
-	// 5. Initialize main vault and create TOTP item (ref: app.ts line 1003-1038)
-	// err = a.initializeMainVaultWithTOTP(response.MFA)
-	// if err != nil {
-	// 	log.Printf("Warning: Failed to initialize main vault with TOTP: %v", err)
-	// 	// Don't return error as account creation was successful
-	// } else {
-	// 	log.Printf("Main vault initialized with TOTP item successfully")
-	// }
+	// 5. Inject MFA TOTP item into the freshly synchronized main vault
+	//    (ref: apps/packages/sdk/src/core/app.ts:1003-1038).
+	if mv := a.MainVault(); mv != nil && response.MFA != "" {
+		tpl := GetAuthenticatorTemplate()
+		if tpl != nil && len(tpl.Fields) > 0 {
+			tpl.Fields[0].Value = response.MFA
+			if _, err := a.CreateItem(CreateItemParams{
+				Name:   account.Name,
+				Vault:  mv,
+				Fields: tpl.Fields,
+				Tags:   []string{},
+				Icon:   tpl.Icon,
+				Type:   VaultTypeTerminusTotp,
+			}); err != nil {
+				log.Printf("Warning: failed to write TOTP item to main vault: %v", err)
+			} else {
+				log.Printf("Main vault updated with TOTP item")
+			}
+		}
+	} else if response.MFA != "" {
+		log.Printf("Warning: skipped TOTP injection (no main vault available yet)")
+	}
 
 	// 6. Activate account (ref: app.ts line 1039-1046)
 	activeParams := ActiveAccountParams{
@@ -184,25 +173,29 @@ func (a *App) Signup(params SignupParams) (*CreateAccountResponse, error) {
 	return response, nil
 }
 
-// Login function - simplified version
+// Login mirrors apps/packages/sdk/src/core/app.ts App.login.
+//
+// Flow:
+//  1. SRP negotiate session
+//  2. GetAccount → Account.Unlock(password) → AppState.SetUnlocked
+//  3. Persist app state to disk (Save)
+//  4. Synchronize (AuthInfo + Account + Orgs + Vaults)
+//  5. If a localvault existed before login (from a prior session), merge
+//     its items into the (possibly new) main vault.
 func (a *App) Login(params LoginParams) error {
 	log.Printf("Starting login process for DID: %s", params.DID)
 
-	// 1. Start creating session
-	startParams := StartCreateSessionParams{
+	// 1. SRP — start session
+	startResponse, err := a.API.StartCreateSession(StartCreateSessionParams{
 		DID:       params.DID,
 		AuthToken: params.AuthToken,
 		AsAdmin:   params.AsAdmin,
-	}
-
-	startResponse, err := a.API.StartCreateSession(startParams)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to start create session: %v", err)
 	}
-
 	log.Printf("Session creation started for Account ID: %s", startResponse.AccountID)
 
-	// 2. Use SRP for authentication
 	authKey, err := deriveKeyPBKDF2(
 		[]byte(params.Password),
 		startResponse.KeyParams.Salt.Bytes(),
@@ -212,61 +205,100 @@ func (a *App) Login(params LoginParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to derive auth key: %v", err)
 	}
-
-	// 3. SRP client negotiation
 	srpClient := NewSRPClient(SRPGroup4096)
-	err = srpClient.Initialize(authKey)
-	if err != nil {
+	if err := srpClient.Initialize(authKey); err != nil {
 		return fmt.Errorf("failed to initialize SRP client: %v", err)
 	}
-
-	err = srpClient.SetB(startResponse.B.Bytes())
-	if err != nil {
+	if err := srpClient.SetB(startResponse.B.Bytes()); err != nil {
 		return fmt.Errorf("failed to set B value: %v", err)
 	}
 
-	log.Printf("SRP negotiation completed")
-
-	// 4. Complete session creation
-	completeParams := CompleteCreateSessionParams{
+	session, err := a.API.CompleteCreateSession(CompleteCreateSessionParams{
 		SRPId:            startResponse.SRPId,
 		AccountID:        startResponse.AccountID,
 		A:                Base64Bytes(srpClient.GetA()),
 		M:                Base64Bytes(srpClient.GetM1()),
-		AddTrustedDevice: false,   // Don't add trusted device by default
-		Kind:             "oe",    // Based on server logs, kind should be "oe"
-		Version:          "4.0.0", // Based on server logs, version should be "4.0.0"
-	}
-
-	session, err := a.API.CompleteCreateSession(completeParams)
+		AddTrustedDevice: false,
+		Kind:             "oe",
+		Version:          "4.0.0",
+	})
 	if err != nil {
 		return fmt.Errorf("failed to complete create session: %v", err)
 	}
-
-	// 5. Set session key
-	sessionKey := srpClient.GetK()
-	session.Key = sessionKey
+	session.Key = srpClient.GetK()
 	a.API.State.SetSession(session)
-
 	log.Printf("Session created: %s", session.ID)
-	log.Printf("Session key length: %d bytes", len(sessionKey))
-	log.Printf("Session key (hex): %x", sessionKey)
 
-	// Create a simplified account object for subsequent operations
-	// account, err := a.API.GetAccount()
-	// if err != nil {
-	// 	return fmt.Errorf("failed to get account: %v", err)
-	// }
-
-	account := &Account{
-		ID:   startResponse.AccountID,
-		DID:  params.DID,
-		Name: params.DID,
+	// 2. Fetch & unlock the server account.
+	account, err := a.API.GetAccount()
+	if err != nil {
+		return fmt.Errorf("failed to fetch account after login: %v", err)
+	}
+	unlocked, err := account.Unlock(params.Password)
+	if err != nil {
+		return fmt.Errorf("failed to unlock account: %v", err)
+	}
+	a.API.State.SetAccount(account)
+	if a.State != nil {
+		a.State.SetUnlocked(unlocked)
 	}
 
-	a.API.State.SetAccount(account)
+	// 3. Snapshot any pre-existing local main vault so we can merge stale
+	//    items in step 5.
+	var localvault *Vault
+	if a.State != nil && len(a.State.Vaults) > 0 {
+		v := a.State.Vaults[0]
+		localvault = &v
+	}
 
-	log.Printf("Login completed successfully for DID: %s (skipped GetAccount due to signature issue)", params.DID)
+	// 4. Persist what we have so far, then synchronize.
+	if a.State != nil {
+		if err := a.State.Save(); err != nil {
+			log.Printf("Login: failed to persist app state: %v", err)
+		}
+	}
+	if err := a.Synchronize(); err != nil {
+		log.Printf("Login: synchronize failed: %v", err)
+		// Synchronize errors are non-fatal — the user can still operate
+		// against the local cache.
+	}
+
+	// 5. Merge the legacy localvault into the (possibly new) main vault
+	//    by re-creating any items that no longer exist remotely.
+	if localvault != nil && a.State != nil {
+		if mv := a.MainVault(); mv != nil && mv.ID != localvault.ID {
+			if err := localvault.Unlock(unlocked); err != nil {
+				log.Printf("Login: failed to unlock localvault for merge: %v", err)
+			} else if mv.aesKey == nil {
+				if err := mv.Unlock(unlocked); err != nil {
+					log.Printf("Login: failed to unlock new mainVault for merge: %v", err)
+				}
+			}
+			if mv.items != nil && localvault.items != nil {
+				for id, item := range localvault.items.Items {
+					if _, exists := mv.items.Items[id]; exists {
+						continue
+					}
+					if _, err := a.CreateItem(CreateItemParams{
+						Name:   item.Name,
+						Vault:  mv,
+						Fields: item.Fields,
+						Tags:   item.Tags,
+						Icon:   item.Icon,
+						Type:   item.Type,
+					}); err != nil {
+						log.Printf("Login: failed to migrate localvault item %s: %v", id, err)
+					}
+				}
+			}
+			a.State.RemoveVault(localvault.ID)
+			if err := a.State.Save(); err != nil {
+				log.Printf("Login: failed to persist app state after merge: %v", err)
+			}
+		}
+	}
+
+	log.Printf("Login completed successfully for DID: %s", params.DID)
 	return nil
 }
 
@@ -373,6 +405,46 @@ func (c *Client) UpdateVault(vault Vault) (*Vault, error) {
 		return nil, fmt.Errorf("failed to parse UpdateVault response: %v", err)
 	}
 
+	return &result, nil
+}
+
+// GetVault fetches a vault by id (mirrors api.getVault in TS).
+func (c *Client) GetVault(id string) (*Vault, error) {
+	response, err := c.call("getVault", []interface{}{id})
+	if err != nil {
+		return nil, err
+	}
+	var result Vault
+	if err := c.parseResponse(response.Result, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse GetVault response: %v", err)
+	}
+	return &result, nil
+}
+
+// GetOrg fetches an org by id (mirrors api.getOrg in TS).
+func (c *Client) GetOrg(id string) (*Org, error) {
+	response, err := c.call("getOrg", []interface{}{id})
+	if err != nil {
+		return nil, err
+	}
+	var result Org
+	if err := c.parseResponse(response.Result, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse GetOrg response: %v", err)
+	}
+	return &result, nil
+}
+
+// GetAuthInfo fetches the AuthInfo for the current session (mirrors
+// api.getAuthInfo in TS).
+func (c *Client) GetAuthInfo() (*AuthInfo, error) {
+	response, err := c.call("getAuthInfo", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	var result AuthInfo
+	if err := c.parseResponse(response.Result, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse GetAuthInfo response: %v", err)
+	}
 	return &result, nil
 }
 
@@ -492,135 +564,15 @@ func getCurrentTimeISO() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
-// initializeMainVaultWithTOTP initializes main vault and creates TOTP item (ref: app.ts line 1003-1038)
-func (a *App) initializeMainVaultWithTOTP(mfaToken string) error {
-	account := a.API.State.GetAccount()
-	if account == nil {
-		return fmt.Errorf("account is null")
-	}
-
-	// 1. Initialize main vault (ref: server.ts line 1573-1579)
-	vault := &Vault{
-		Kind:    "vault", // Serializable.kind getter (ref: vault.ts line 18-20)
-		ID:      generateUUID(),
-		Name:    "My Vault",
-		Owner:   account.ID,
-		Created: getCurrentTimeISO(),
-		Updated: getCurrentTimeISO(),
-		Items:   []VaultItem{}, // Initialize empty items array
-		Version: "4.0.0",       // Serialization version (ref: encoding.ts toRaw)
-	}
-
-	// 2. Initialize parent class fields (SharedContainer extends BaseContainer)
-	// BaseContainer has: encryptionParams: AESEncryptionParams = new AESEncryptionParams()
-	vault.EncryptionParams = EncryptionParams{
-		Algorithm:      "AES-GCM",
-		TagSize:        128,
-		KeySize:        256,
-		IV:             "", // Empty, will be set when data is encrypted
-		AdditionalData: "", // Empty, will be set when data is encrypted
-		Version:        "4.0.0",
-	}
-
-	// SharedContainer has: keyParams: RSAEncryptionParams = new RSAEncryptionParams()
-	vault.KeyParams = map[string]any{
-		"algorithm": "RSA-OAEP",
-		"hash":      "SHA-256",
-		"kind":      "c",
-		"version":   "4.0.0",
-	}
-
-	// SharedContainer has: accessors: Accessor[] = []
-	vault.Accessors = []map[string]any{} // Empty array, will be populated via updateAccessors()
-
-	log.Printf("Main vault initialized: ID=%s, Name=%s, Owner=%s", vault.ID, vault.Name, vault.Owner)
-
-	// 2. Get authenticator template (ref: app.ts line 1008-1014)
-	template := GetAuthenticatorTemplate()
-	if template == nil {
-		return fmt.Errorf("authenticator template is null")
-	}
-
-	// 3. Set MFA token value (ref: app.ts line 1015)
-	template.Fields[0].Value = mfaToken
-	log.Printf("TOTP template prepared with MFA token: %s...", mfaToken[:min(8, len(mfaToken))])
-
-	// 4. Create vault item (ref: app.ts line 1024-1033)
-	item, err := a.createVaultItem(CreateVaultItemParams{
-		Name:   account.Name,
-		Vault:  vault,
-		Fields: template.Fields,
-		Tags:   []string{},
-		Icon:   template.Icon,
-		Type:   VaultTypeTerminusTotp,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create vault item: %v", err)
-	}
-
-	log.Printf("TOTP vault item created: ID=%s, Name=%s", item.ID, item.Name)
-	log.Printf("TOTP field value: %s", item.Fields[0].Value)
-
-	// 5. Add item to vault
-	vault.Items = append(vault.Items, *item)
-
-	// 6. Update vault on server (ref: app.ts line 2138: await this.addItems([item], vault))
-	// Note: The vault is created empty without encryption. Items will be encrypted when
-	// the user unlocks the vault for the first time via vault.unlock() -> vault.updateAccessors()
-	err = a.updateVault(vault)
-	if err != nil {
-		return fmt.Errorf("failed to update vault on server: %v", err)
-	}
-
-	log.Printf("Vault updated on server successfully")
-	return nil
-}
-
-// CreateVaultItemParams parameters for creating a vault item
-type CreateVaultItemParams struct {
-	Name   string
-	Vault  *Vault
-	Fields []Field
-	Tags   []string
-	Icon   string
-	Type   VaultType
-}
-
-// createVaultItem creates a new vault item (ref: app.ts line 2096-2141)
-func (a *App) createVaultItem(params CreateVaultItemParams) (*VaultItem, error) {
-	account := a.API.State.GetAccount()
-	if account == nil {
-		return nil, fmt.Errorf("account is null")
-	}
-
-	// Create vault item (ref: item.ts line 451-475)
-	item := &VaultItem{
-		ID:        generateUUID(),
-		Name:      params.Name,
-		Type:      params.Type,
-		Icon:      params.Icon,
-		Fields:    params.Fields,
-		Tags:      params.Tags,
-		Updated:   getCurrentTimeISO(),
-		UpdatedBy: account.ID,
-	}
-
-	log.Printf("Vault item created: ID=%s, Name=%s, Type=%d", item.ID, item.Name, item.Type)
-	return item, nil
-}
-
-// updateVault updates vault on server (ref: app.ts line 1855-2037)
+// updateVault is a thin wrapper that bumps revision/updated and pushes to
+// the server. The Vault must already be Commit()-ed by the caller.
 func (a *App) updateVault(vault *Vault) error {
-	// Update vault revision
 	vault.Revision = generateUUID()
 	vault.Updated = getCurrentTimeISO()
-
-	// Call server API to update vault
 	updatedVault, err := a.API.UpdateVault(*vault)
 	if err != nil {
 		return fmt.Errorf("failed to update vault on server: %v", err)
 	}
-
 	log.Printf("Vault updated on server: ID=%s, Revision=%s", updatedVault.ID, updatedVault.Revision)
 	return nil
 }
@@ -706,21 +658,8 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 	return nil
 }
 
-// encryptAESGCM encrypts data using AES-GCM
+// encryptAESGCM is kept for callers that already have a *App receiver; it
+// just delegates to the package-level aesGCMEncrypt helper.
 func (a *App) encryptAESGCM(key, plaintext, iv, additionalData []byte) ([]byte, error) {
-	// Import crypto/aes and crypto/cipher packages are needed at the top of the file
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cipher: %v", err)
-	}
-
-	gcm, err := cipher.NewGCMWithNonceSize(block, 16)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM: %v", err)
-	}
-
-	// Encrypt the plaintext using AES-GCM
-	ciphertext := gcm.Seal(nil, iv, plaintext, additionalData)
-
-	return ciphertext, nil
+	return aesGCMEncrypt(key, plaintext, iv, additionalData)
 }

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -584,19 +584,6 @@ func getCurrentTimeISO() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
-// updateVault is a thin wrapper that bumps revision/updated and pushes to
-// the server. The Vault must already be Commit()-ed by the caller.
-func (a *App) updateVault(vault *Vault) error {
-	vault.Revision = generateUUID()
-	vault.Updated = getCurrentTimeISO()
-	updatedVault, err := a.API.UpdateVault(*vault)
-	if err != nil {
-		return fmt.Errorf("failed to update vault on server: %v", err)
-	}
-	log.Printf("Vault updated on server: ID=%s, Revision=%s", updatedVault.ID, updatedVault.Revision)
-	return nil
-}
-
 // min returns the minimum of two integers
 func min(a, b int) int {
 	if a < b {

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -20,9 +20,9 @@ import (
 // by the RPC Client and the persistable representation of the
 // account / vaults / orgs known to this client.
 type App struct {
-	Version string     `json:"version"`
-	API     *Client    `json:"-"`
-	State   *AppState  `json:"-"`
+	Version string    `json:"version"`
+	API     *Client   `json:"-"`
+	State   *AppState `json:"-"`
 }
 
 // NewApp constructs an App using the given sender and AppState.
@@ -297,6 +297,7 @@ func (a *App) Login(params LoginParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to unlock account: %v", err)
 	}
+
 	a.API.State.SetAccount(account)
 	if a.State != nil {
 		a.State.SetUnlocked(unlocked)
@@ -473,6 +474,22 @@ func (c *Client) GetAccount() (*Account, error) {
 }
 
 func (c *Client) UpdateVault(vault Vault) (*Vault, error) {
+	if vault.Revision == "" {
+		if acc := c.State.GetAccount(); acc != nil && vault.ID != "" &&
+			acc.MainVault.ID == vault.ID && acc.MainVault.Revision != "" {
+			vault.Revision = acc.MainVault.Revision
+		}
+	}
+	if vault.Revision == "" && vault.ID != "" {
+		current, err := c.GetVault(vault.ID)
+		if err != nil {
+			return nil, fmt.Errorf("updateVault: resolve revision: %w", err)
+		}
+		vault.Revision = current.Revision
+		if acc := c.State.GetAccount(); acc != nil && acc.MainVault.ID == vault.ID && current.Revision != "" {
+			acc.MainVault.Revision = current.Revision
+		}
+	}
 	requestParams := []interface{}{vault}
 	response, err := c.call("updateVault", requestParams)
 	if err != nil {
@@ -664,7 +681,7 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal public key: %v", err)
 	}
-	account.PublicKey = base64.StdEncoding.EncodeToString(publicKeyDER)
+	account.PublicKey = base64.RawURLEncoding.EncodeToString(publicKeyDER)
 
 	// 3. Set up key derivation parameters (ref: container.ts line 125-133)
 	salt := generateRandomBytes(16)
@@ -673,8 +690,8 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 		Hash:       "SHA-256",
 		KeySize:    256,
 		Iterations: 100000,
-		Salt:       base64.StdEncoding.EncodeToString(salt),
-		Version:    "3.0.14",
+		Salt:       base64.RawURLEncoding.EncodeToString(salt),
+		Version:    "4.0.0",
 	}
 
 	// 4. Derive encryption key from master password
@@ -687,22 +704,29 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 		Algorithm:      "AES-GCM",
 		TagSize:        128,
 		KeySize:        256,
-		IV:             base64.StdEncoding.EncodeToString(iv),
-		AdditionalData: base64.StdEncoding.EncodeToString(additionalData),
-		Version:        "3.0.14",
+		IV:             base64.RawURLEncoding.EncodeToString(iv),
+		AdditionalData: base64.RawURLEncoding.EncodeToString(additionalData),
+		Kind:           "r",
+		Version:        "4.0.0",
 	}
 
 	// 6. Create account secrets (private key + signing key)
-	privateKeyDER := x509.MarshalPKCS1PrivateKey(privateKey)
+	// PKCS#8 matches browser TS WebCryptoProvider in apps/packages/sdk/src/crypto.ts:
+	// generateKey(RSA) → subtle.exportKey('pkcs8', ...), and _decryptRSA → importKey('pkcs8', ...).
+	// PKCS#1 (MarshalPKCS1PrivateKey) breaks that import and vault accessor unwrap on the client.
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to marshal PKCS8 private key: %w", err)
+	}
 	signingKey := generateRandomBytes(32) // HMAC key
 
-	// Combine private key and signing key into account secrets
+	// Combine private key and signing key into account secrets (TS AccountSecrets uses @AsBytes → url-safe unpadded).
 	accountSecrets := struct {
-		SigningKey []byte `json:"signingKey"`
-		PrivateKey []byte `json:"privateKey"`
+		SigningKey Base64Bytes `json:"signingKey"`
+		PrivateKey Base64Bytes `json:"privateKey"`
 	}{
-		SigningKey: signingKey,
-		PrivateKey: privateKeyDER,
+		SigningKey: Base64Bytes(signingKey),
+		PrivateKey: Base64Bytes(privateKeyDER),
 	}
 
 	accountSecretsBytes, err := json.Marshal(accountSecrets)
@@ -715,7 +739,7 @@ func (a *App) initializeAccount(account *Account, masterPassword string) error {
 	if err != nil {
 		return fmt.Errorf("failed to encrypt account secrets: %v", err)
 	}
-	account.EncryptedData = base64.StdEncoding.EncodeToString(encryptedData)
+	account.EncryptedData = base64.RawURLEncoding.EncodeToString(encryptedData)
 
 	log.Printf("Account initialized with RSA key pair and encryption parameters")
 	log.Printf("Public key length: %d bytes", len(publicKeyDER))

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -279,13 +279,21 @@ func (a *App) Login(params LoginParams) error {
 					if _, exists := mv.items.Items[id]; exists {
 						continue
 					}
+					if item.Name == "" {
+						continue
+					}
+					itemType := item.Type
+					if itemType == VaultTypeTerminusTotp {
+						itemType = VaultTypeDefault
+					}
 					if _, err := a.CreateItem(CreateItemParams{
+						ID:     id,
 						Name:   item.Name,
 						Vault:  mv,
 						Fields: item.Fields,
 						Tags:   item.Tags,
 						Icon:   item.Icon,
-						Type:   item.Type,
+						Type:   itemType,
 					}); err != nil {
 						log.Printf("Login: failed to migrate localvault item %s: %v", id, err)
 					}

--- a/cli/pkg/wizard/app.go
+++ b/cli/pkg/wizard/app.go
@@ -133,6 +133,10 @@ func (a *App) Signup(params SignupParams) (*CreateAccountResponse, error) {
 	// 5. Inject MFA TOTP item into the freshly synchronized main vault
 	//    (ref: apps/packages/sdk/src/core/app.ts:1003-1038).
 	if mv := a.MainVault(); mv != nil && response.MFA != "" {
+		log.Printf("Signup: TOTP injection target mv id=%s revision=%s accessors=%d encryptedData=%d aesKey?=%t items?=%t itemCount=%d",
+			mv.ID, mv.Revision, len(mv.Accessors), len(mv.EncryptedData),
+			mv.aesKey != nil, mv.items != nil, vaultItemCount(mv))
+
 		tpl := GetAuthenticatorTemplate()
 		if tpl != nil && len(tpl.Fields) > 0 {
 			tpl.Fields[0].Value = response.MFA
@@ -145,8 +149,63 @@ func (a *App) Signup(params SignupParams) (*CreateAccountResponse, error) {
 				Type:   VaultTypeTerminusTotp,
 			}); err != nil {
 				log.Printf("Warning: failed to write TOTP item to main vault: %v", err)
+				log.Printf("CRITICAL: TOTP item not stored in vault, web second-factor will fail: %v", err)
 			} else {
 				log.Printf("Main vault updated with TOTP item")
+
+				// Round-trip verification: refetch the vault from server,
+				// unlock with the same account, and list the items the
+				// server now persists. Diagnostic-only — useful for
+				// distinguishing "push succeeded" from "push succeeded
+				// but server did not actually persist TOTP".
+				if unlocked := a.State.Unlocked(); unlocked != nil {
+					verify, gerr := a.API.GetVault(mv.ID)
+					if gerr != nil {
+						log.Printf("verify: GetVault after TOTP push failed: %v", gerr)
+					} else {
+						if uerr := verify.Unlock(unlocked); uerr != nil {
+							log.Printf("verify: Unlock of refetched vault failed: %v", uerr)
+						}
+						count := vaultItemCount(verify)
+						log.Printf("verify: server vault id=%s revision=%s items=%d accessors=%d encryptedData=%d",
+							verify.ID, verify.Revision, count,
+							len(verify.Accessors), len(verify.EncryptedData))
+						if verify.items != nil {
+							for _, it := range verify.items.Items {
+								firstFieldType := ""
+								if len(it.Fields) > 0 {
+									firstFieldType = string(it.Fields[0].Type)
+								}
+								log.Printf("verify item: id=%s type=%d name=%s fields=%d firstFieldType=%s",
+									it.ID, it.Type, it.Name, len(it.Fields), firstFieldType)
+							}
+						}
+
+						// Vault id alignment: compare the vault id we just
+						// wrote into with the one the server records as
+						// account.mainVault.id. If they diverge, the web
+						// client (which reads account.mainVault.id from
+						// server) will fetch a different vault and never
+						// see the TOTP item.
+						srvAcc, aerr := a.API.GetAccount()
+						if aerr != nil {
+							log.Printf("post-signup: GetAccount failed: %v", aerr)
+						} else if srvAcc == nil {
+							log.Printf("post-signup: GetAccount returned nil account")
+						} else {
+							match := srvAcc.MainVault.ID == mv.ID
+							log.Printf("post-signup: account.id=%s account.did=%s account.mainVault.id=%s vs CLI mv.id=%s match=%t",
+								srvAcc.ID, srvAcc.DID, srvAcc.MainVault.ID, mv.ID, match)
+							for i, ac := range verify.Accessors {
+								accMatch := ac.ID == srvAcc.ID
+								log.Printf("post-signup: verify.accessors[%d].id=%s vs account.id=%s match=%t",
+									i, ac.ID, srvAcc.ID, accMatch)
+							}
+						}
+					}
+				} else {
+					log.Printf("verify: skipped (no unlocked account in state)")
+				}
 			}
 		}
 	} else if response.MFA != "" {

--- a/cli/pkg/wizard/app_state.go
+++ b/cli/pkg/wizard/app_state.go
@@ -71,22 +71,16 @@ func LoadAppState(storage Storage, did string) (*AppState, error) {
 	return state, nil
 }
 
-// Save persists the AppState (and any associated vaults) to the storage.
+// Save persists the AppState to the storage. Vaults are serialized inline
+// as part of the AppState (see the `Vaults` field above and TS
+// AppState.vaults / App.saveState in apps/packages/sdk/src/core/app.ts),
+// so we do NOT write per-vault files separately.
 func (s *AppState) Save() error {
 	if s.storage == nil {
 		return nil
 	}
 	if err := s.storage.Put(AppStateKind, s.ID, s); err != nil {
 		return fmt.Errorf("failed to save app state %s: %w", s.ID, err)
-	}
-	for i := range s.Vaults {
-		v := &s.Vaults[i]
-		if v.ID == "" {
-			continue
-		}
-		if err := s.storage.Put("vault", v.ID, v); err != nil {
-			return fmt.Errorf("failed to save vault %s: %w", v.ID, err)
-		}
 	}
 	return nil
 }
@@ -165,7 +159,9 @@ func (s *AppState) PutVault(v Vault) {
 	s.Vaults = append(s.Vaults, v)
 }
 
-// RemoveVault deletes the vault with the given id from state and storage.
+// RemoveVault deletes the vault with the given id from in-memory state.
+// The change is persisted next time Save() is called (vaults live inline
+// inside the AppState record, so there is no separate file to delete).
 func (s *AppState) RemoveVault(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -176,7 +172,4 @@ func (s *AppState) RemoveVault(id string) {
 		}
 	}
 	s.Vaults = out
-	if s.storage != nil {
-		_ = s.storage.Delete("vault", id)
-	}
 }

--- a/cli/pkg/wizard/app_state.go
+++ b/cli/pkg/wizard/app_state.go
@@ -1,0 +1,182 @@
+package wizard
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// AppState mirrors the relevant subset of the TS AppState
+// (apps/packages/sdk/src/core/app.ts: class AppState). Persisted to
+// the local Storage as kind="appstate", id="app-state-<did>".
+//
+// Only fields that we currently need on the CLI are tracked. Runtime-only
+// state (storage handle, unlocked secrets) is annotated with json:"-".
+type AppState struct {
+	ID       string      `json:"id"` // "app-state-<did>"
+	Device   *DeviceInfo `json:"device,omitempty"`
+	Account  *Account    `json:"account,omitempty"`
+	AuthInfo *AuthInfo   `json:"authInfo,omitempty"`
+	Orgs     []Org       `json:"orgs,omitempty"`
+	Vaults   []Vault     `json:"vaults,omitempty"`
+	LastSync string      `json:"lastSync,omitempty"`
+
+	// Session and unlocked secrets are intentionally NOT persisted.
+	// A Session is bound to a specific server-side record (with its
+	// HMAC key) and becomes invalid as soon as the process exits or
+	// the server restarts. Persisting it would cause subsequent runs
+	// to sign requests with a dead session id, which the server
+	// rejects with [invalid_session]. They live in memory only and
+	// must be re-established by Login() on every process start.
+	Session  *Session         `json:"-"`
+	storage  Storage          `json:"-"`
+	unlocked *UnlockedAccount `json:"-"`
+	mu       sync.Mutex       `json:"-"`
+}
+
+// AppStateKind is the kind used by the local Storage layer.
+const AppStateKind = "appstate"
+
+// NewAppState returns a fresh AppState bound to the given storage and DID.
+// It does NOT load anything from disk — use LoadAppState for that.
+func NewAppState(storage Storage, did string) *AppState {
+	id := "app-state"
+	if did != "" {
+		id = "app-state-" + did
+	}
+	return &AppState{
+		ID:      id,
+		Device:  &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"},
+		storage: storage,
+	}
+}
+
+// LoadAppState attempts to load an existing state from storage; if none
+// exists, returns a freshly-initialized AppState.
+func LoadAppState(storage Storage, did string) (*AppState, error) {
+	state := NewAppState(storage, did)
+	if storage == nil {
+		return state, nil
+	}
+	if err := storage.Get(AppStateKind, state.ID, state); err != nil {
+		log.Printf("AppState %s not found in storage (creating new): %v", state.ID, err)
+		// Reattach storage since Unmarshal does not touch unexported fields.
+		state.storage = storage
+		return state, nil
+	}
+	state.storage = storage
+	if state.Device == nil {
+		state.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"}
+	}
+	return state, nil
+}
+
+// Save persists the AppState (and any associated vaults) to the storage.
+func (s *AppState) Save() error {
+	if s.storage == nil {
+		return nil
+	}
+	if err := s.storage.Put(AppStateKind, s.ID, s); err != nil {
+		return fmt.Errorf("failed to save app state %s: %w", s.ID, err)
+	}
+	for i := range s.Vaults {
+		v := &s.Vaults[i]
+		if v.ID == "" {
+			continue
+		}
+		if err := s.storage.Put("vault", v.ID, v); err != nil {
+			return fmt.Errorf("failed to save vault %s: %w", v.ID, err)
+		}
+	}
+	return nil
+}
+
+// ClientState interface implementation.
+
+func (s *AppState) GetSession() *Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Session
+}
+
+func (s *AppState) SetSession(session *Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Session = session
+}
+
+func (s *AppState) GetAccount() *Account {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Account
+}
+
+func (s *AppState) SetAccount(account *Account) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Account = account
+}
+
+func (s *AppState) GetDevice() *DeviceInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Device == nil {
+		s.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"}
+	}
+	return s.Device
+}
+
+// Unlocked returns the currently in-memory UnlockedAccount (or nil).
+func (s *AppState) Unlocked() *UnlockedAccount {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unlocked
+}
+
+// SetUnlocked stores the unlocked account in memory only.
+func (s *AppState) SetUnlocked(u *UnlockedAccount) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unlocked = u
+}
+
+// GetVault returns a pointer to the vault with the given id, or nil.
+func (s *AppState) GetVault(id string) *Vault {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.Vaults {
+		if s.Vaults[i].ID == id {
+			return &s.Vaults[i]
+		}
+	}
+	return nil
+}
+
+// PutVault inserts or replaces the vault with the same id.
+func (s *AppState) PutVault(v Vault) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.Vaults {
+		if s.Vaults[i].ID == v.ID {
+			s.Vaults[i] = v
+			return
+		}
+	}
+	s.Vaults = append(s.Vaults, v)
+}
+
+// RemoveVault deletes the vault with the given id from state and storage.
+func (s *AppState) RemoveVault(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.Vaults[:0]
+	for _, v := range s.Vaults {
+		if v.ID != id {
+			out = append(out, v)
+		}
+	}
+	s.Vaults = out
+	if s.storage != nil {
+		_ = s.storage.Delete("vault", id)
+	}
+}

--- a/cli/pkg/wizard/app_state.go
+++ b/cli/pkg/wizard/app_state.go
@@ -46,7 +46,7 @@ func NewAppState(storage Storage, did string) *AppState {
 	}
 	return &AppState{
 		ID:      id,
-		Device:  &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"},
+		Device:  &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "olares-cli"},
 		storage: storage,
 	}
 }
@@ -66,7 +66,10 @@ func LoadAppState(storage Storage, did string) (*AppState, error) {
 	}
 	state.storage = storage
 	if state.Device == nil {
-		state.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"}
+		state.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "olares-cli"}
+	} else if state.Device.Platform == "go-cli" {
+		// Migrate legacy platform identifier from previous CLI versions.
+		state.Device.Platform = "olares-cli"
 	}
 	return state, nil
 }
@@ -115,7 +118,7 @@ func (s *AppState) GetDevice() *DeviceInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.Device == nil {
-		s.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "go-cli"}
+		s.Device = &DeviceInfo{ID: "cli-device-" + generateUUID(), Platform: "olares-cli"}
 	}
 	return s.Device
 }

--- a/cli/pkg/wizard/auth.go
+++ b/cli/pkg/wizard/auth.go
@@ -190,20 +190,18 @@ func UserBindTerminus(mnemonic, bflUrl, vaultUrl, authUrl, osPwd, terminusName, 
 
 	// 2. Initialize platform and App (if not already initialized)
 	var app *App
+	state, err := LoadAppState(globalStorage, globalUserStore.GetDid())
+	if err != nil {
+		return "", fmt.Errorf("failed to load app state: %w", err)
+	}
 	if platform == nil {
 		log.Printf("Initializing platform...")
-
-		// Create App using vaultUrl as base URL
-		app = NewAppWithBaseURL(vaultUrl)
-
-		// Create and set WebPlatform (no need to pass mnemonic, uses global storage)
+		app = NewAppWithState(vaultUrl, state)
 		webPlatform := NewWebPlatform(app.API)
 		SetPlatform(webPlatform)
-
 		log.Printf("Platform initialized successfully with base URL: %s", vaultUrl)
 	} else {
-		// If platform already initialized, create new App instance for signup
-		app = NewAppWithBaseURL(vaultUrl)
+		app = NewAppWithState(vaultUrl, state)
 	}
 
 	log.Printf("Using bflUrl: %s", bflUrl)

--- a/cli/pkg/wizard/auth.go
+++ b/cli/pkg/wizard/auth.go
@@ -38,8 +38,13 @@ type FirstFactorResponse struct {
 	Data   Token  `json:"data"`
 }
 
-// OnFirstFactor implements first factor authentication (ref: BindTerminusBusiness.ts)
-func OnFirstFactor(baseURL, terminusName, osUser, osPwd string, acceptCookie, needTwoFactor bool) (*Token, error) {
+// OnFirstFactor implements first factor authentication (ref: BindTerminusBusiness.ts).
+//
+// If client is nil, a fresh http.Client is created internally. Pass a shared
+// client (e.g. from newAuthHTTPClient) when the caller intends to follow up
+// with /api/secondfactor/totp so that Authelia session cookies set by this
+// request are reused on the next one.
+func OnFirstFactor(client *http.Client, baseURL, terminusName, osUser, osPwd string, acceptCookie, needTwoFactor bool) (*Token, error) {
 	log.Printf("Starting onFirstFactor for user: %s", osUser)
 
 	// Process password (salted MD5)
@@ -60,9 +65,10 @@ func OnFirstFactor(baseURL, terminusName, osUser, osPwd string, acceptCookie, ne
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	// Send HTTP request
-	client := &http.Client{
-		Timeout: 10 * time.Second,
+	if client == nil {
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
 	}
 
 	reqURL := fmt.Sprintf("%s/api/firstfactor?hideCookie=true", baseURL)
@@ -206,8 +212,10 @@ func UserBindTerminus(mnemonic, bflUrl, vaultUrl, authUrl, osPwd, terminusName, 
 
 	log.Printf("Using bflUrl: %s", bflUrl)
 
-	// 3. Call onFirstFactor to get token (ref: TypeScript implementation)
-	token, err := OnFirstFactor(bflUrl, terminusName, localName, osPwd, false, false)
+	// 3. Call onFirstFactor to get token (ref: TypeScript implementation).
+	// Use a cookie-jar-backed client for consistency with LoginTerminus,
+	// even though no second factor follows in this flow.
+	token, err := OnFirstFactor(newAuthHTTPClient(), bflUrl, terminusName, localName, osPwd, false, false)
 	if err != nil {
 		return "", fmt.Errorf("onFirstFactor failed: %v", err)
 	}

--- a/cli/pkg/wizard/auth.go
+++ b/cli/pkg/wizard/auth.go
@@ -170,7 +170,7 @@ func Authenticate(req AuthenticateRequest) (*AuthenticateResponse, error) {
 }
 
 // UserBindTerminus main user binding function (ref: TypeScript version)
-func UserBindTerminus(mnemonic, bflUrl, vaultUrl, osPwd, terminusName, localName string) (string, error) {
+func UserBindTerminus(mnemonic, bflUrl, vaultUrl, authUrl, osPwd, terminusName, localName string) (string, error) {
 	log.Printf("Starting userBindTerminus for user: %s", terminusName)
 
 	// 1. Initialize global storage
@@ -181,6 +181,11 @@ func UserBindTerminus(mnemonic, bflUrl, vaultUrl, osPwd, terminusName, localName
 			return "", fmt.Errorf("failed to initialize global stores: %w", err)
 		}
 		log.Printf("Global stores initialized successfully")
+	}
+
+	if authUrl != "" {
+		globalUserStore.SetAuthURL(authUrl)
+		log.Printf("Custom auth URL applied: %s", authUrl)
 	}
 
 	// 2. Initialize platform and App (if not already initialized)

--- a/cli/pkg/wizard/crypto_helpers.go
+++ b/cli/pkg/wizard/crypto_helpers.go
@@ -58,7 +58,9 @@ func rsaOAEPEncrypt(publicKeyDER []byte, payload []byte) ([]byte, error) {
 }
 
 // rsaOAEPDecrypt decrypts an RSA-OAEP/SHA-256 payload using the provided
-// PKCS1 DER-encoded private key (matching how Account.initialize stores it).
+// PKCS#8 PrivateKeyInfo DER-encoded private key (matching how
+// Account.initialize stores it and what the TS WebCrypto importKey('pkcs8')
+// expects).
 func rsaOAEPDecrypt(privateKeyDER []byte, ciphertext []byte) ([]byte, error) {
 	priv, err := parseRSAPrivateKeyDER(privateKeyDER)
 	if err != nil {
@@ -67,19 +69,18 @@ func rsaOAEPDecrypt(privateKeyDER []byte, ciphertext []byte) ([]byte, error) {
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, ciphertext, nil)
 }
 
-// parseRSAPrivateKeyDER accepts both PKCS1 and PKCS8 encoded RSA private
-// keys; falls back to PKCS8 if PKCS1 parsing fails.
+// parseRSAPrivateKeyDER decodes a PKCS#8 PrivateKeyInfo DER blob into a
+// *rsa.PrivateKey. Only PKCS#8 is accepted so any future regression that
+// writes PKCS#1 will fail loudly instead of silently working against
+// itself but breaking the TS web client.
 func parseRSAPrivateKeyDER(privateKeyDER []byte) (*rsa.PrivateKey, error) {
-	if priv, err := x509.ParsePKCS1PrivateKey(privateKeyDER); err == nil {
-		return priv, nil
-	}
 	keyAny, err := x509.ParsePKCS8PrivateKey(privateKeyDER)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse RSA private key (tried PKCS1 and PKCS8): %w", err)
+		return nil, fmt.Errorf("failed to parse RSA private key as PKCS#8: %w", err)
 	}
 	priv, ok := keyAny.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("PKCS8 key is not an RSA key")
+		return nil, fmt.Errorf("PKCS#8 key is not an RSA key")
 	}
 	return priv, nil
 }

--- a/cli/pkg/wizard/crypto_helpers.go
+++ b/cli/pkg/wizard/crypto_helpers.go
@@ -1,0 +1,90 @@
+package wizard
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+)
+
+// aesGCMEncrypt encrypts data using AES-GCM with a 16-byte nonce, matching
+// the TS provider in apps/packages/sdk/src/core/container.ts which uses
+// `additionalData` as AAD (and never appends it to the ciphertext).
+func aesGCMEncrypt(key, plaintext, iv, additionalData []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, len(iv))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	return gcm.Seal(nil, iv, plaintext, additionalData), nil
+}
+
+// aesGCMDecrypt is the inverse of aesGCMEncrypt; iv length must match the
+// length used at encryption time (TS uses 16 bytes).
+func aesGCMDecrypt(key, ciphertext, iv, additionalData []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, len(iv))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, iv, ciphertext, additionalData)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decrypt failed: %w", err)
+	}
+	return plaintext, nil
+}
+
+// rsaOAEPEncrypt encrypts payload with the given DER-encoded RSA public key
+// using RSA-OAEP/SHA-256, matching `RSAEncryptionParams` in TS.
+func rsaOAEPEncrypt(publicKeyDER []byte, payload []byte) ([]byte, error) {
+	pubAny, err := x509.ParsePKIXPublicKey(publicKeyDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA public key: %w", err)
+	}
+	pub, ok := pubAny.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA public key")
+	}
+	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, payload, nil)
+}
+
+// rsaOAEPDecrypt decrypts an RSA-OAEP/SHA-256 payload using the provided
+// PKCS1 DER-encoded private key (matching how Account.initialize stores it).
+func rsaOAEPDecrypt(privateKeyDER []byte, ciphertext []byte) ([]byte, error) {
+	priv, err := parseRSAPrivateKeyDER(privateKeyDER)
+	if err != nil {
+		return nil, err
+	}
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, ciphertext, nil)
+}
+
+// parseRSAPrivateKeyDER accepts both PKCS1 and PKCS8 encoded RSA private
+// keys; falls back to PKCS8 if PKCS1 parsing fails.
+func parseRSAPrivateKeyDER(privateKeyDER []byte) (*rsa.PrivateKey, error) {
+	if priv, err := x509.ParsePKCS1PrivateKey(privateKeyDER); err == nil {
+		return priv, nil
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(privateKeyDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA private key (tried PKCS1 and PKCS8): %w", err)
+	}
+	priv, ok := keyAny.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("PKCS8 key is not an RSA key")
+	}
+	return priv, nil
+}
+
+// generateAESKey returns a fresh random 32-byte AES key (256 bits).
+func generateAESKey() []byte {
+	return generateRandomBytes(32)
+}

--- a/cli/pkg/wizard/crypto_helpers.go
+++ b/cli/pkg/wizard/crypto_helpers.go
@@ -57,8 +57,8 @@ func rsaOAEPEncrypt(publicKeyDER []byte, payload []byte) ([]byte, error) {
 	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, payload, nil)
 }
 
-// rsaOAEPDecrypt decrypts an RSA-OAEP/SHA-256 payload using the provided
-// PKCS1 DER-encoded private key (matching how Account.initialize stores it).
+// rsaOAEPDecrypt decrypts an RSA-OAEP/SHA-256 payload using PKCS#8 DER
+// (same as apps/packages/sdk/src/crypto.ts subtle.importKey('pkcs8', ...)).
 func rsaOAEPDecrypt(privateKeyDER []byte, ciphertext []byte) ([]byte, error) {
 	priv, err := parseRSAPrivateKeyDER(privateKeyDER)
 	if err != nil {
@@ -67,19 +67,15 @@ func rsaOAEPDecrypt(privateKeyDER []byte, ciphertext []byte) ([]byte, error) {
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, ciphertext, nil)
 }
 
-// parseRSAPrivateKeyDER accepts both PKCS1 and PKCS8 encoded RSA private
-// keys; falls back to PKCS8 if PKCS1 parsing fails.
+// parseRSAPrivateKeyDER parses PKCS#8 DER into an RSA private key.
 func parseRSAPrivateKeyDER(privateKeyDER []byte) (*rsa.PrivateKey, error) {
-	if priv, err := x509.ParsePKCS1PrivateKey(privateKeyDER); err == nil {
-		return priv, nil
-	}
 	keyAny, err := x509.ParsePKCS8PrivateKey(privateKeyDER)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse RSA private key (tried PKCS1 and PKCS8): %w", err)
+		return nil, fmt.Errorf("failed to parse PKCS#8 RSA private key: %w", err)
 	}
 	priv, ok := keyAny.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("PKCS8 key is not an RSA key")
+		return nil, fmt.Errorf("PKCS#8 key is not an RSA key")
 	}
 	return priv, nil
 }

--- a/cli/pkg/wizard/http_sender.go
+++ b/cli/pkg/wizard/http_sender.go
@@ -25,52 +25,50 @@ func NewHTTPSender(baseURL string) *HTTPSender {
 	}
 }
 
-// Send implements Sender interface, sends HTTP request
+// Send implements Sender interface, sends HTTP request.
+//
+// Mirrors the TS AjaxSender behavior: the caller passes the full endpoint
+// URL, and the sender POSTs to it directly without appending any path.
 func (h *HTTPSender) Send(req *Request) (*Response, error) {
-	// Build request URL
-	url := fmt.Sprintf("%s/api/rpc", h.BaseURL)
-	
-	// Serialize request
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
-	
-	// Create HTTP request
-	httpReq, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
+
+	httpReq, err := http.NewRequest("POST", h.BaseURL, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
-	
+
 	// Set request headers
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
-	
+
 	// Authentication info already included in JSON request body's auth field, no extra HTTP headers needed
-	
+
 	// Send request
 	httpResp, err := h.Client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
 	defer httpResp.Body.Close()
-	
+
 	// Read response
 	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	
+
 	// Check HTTP status code
 	if httpResp.StatusCode != 200 {
 		return nil, fmt.Errorf("HTTP error %d: %s", httpResp.StatusCode, string(respBody))
 	}
-	
+
 	// Parse response
 	var response Response
 	if err := json.Unmarshal(respBody, &response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
-	
+
 	return &response, nil
 }

--- a/cli/pkg/wizard/login_terminus.go
+++ b/cli/pkg/wizard/login_terminus.go
@@ -10,16 +10,36 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"net/http/cookiejar"
 	"strings"
 	"time"
 )
 
+// newAuthHTTPClient creates an HTTP client with a cookie jar so that
+// Set-Cookie headers from /api/firstfactor are automatically attached to
+// subsequent requests like /api/secondfactor/totp. This mirrors the
+// `withCredentials: true` behavior of the TS axios instance used in
+// loginTerminus (BindTerminusBusiness.ts).
+func newAuthHTTPClient() *http.Client {
+	jar, _ := cookiejar.New(nil)
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Jar:     jar,
+	}
+}
+
 // LoginTerminus implements Terminus login functionality (ref: BindTerminusBusiness.ts loginTerminus)
 func LoginTerminus(bflUrl, terminusName, localName, password string, needTwoFactor bool) (*Token, error) {
 	log.Printf("Starting loginTerminus for user: %s", terminusName)
-	
+
+	// Share a single http.Client (with cookie jar) across both factors so that
+	// the Authelia session cookie set by /api/firstfactor is automatically
+	// attached to /api/secondfactor/totp, mirroring the TS axios
+	// `withCredentials: true` behavior in loginTerminus.
+	client := newAuthHTTPClient()
+
 	// 1. Call onFirstFactor to get initial token (ref: loginTerminus line 364-372)
-	token, err := OnFirstFactor(bflUrl, terminusName, localName, password, true, needTwoFactor)
+	token, err := OnFirstFactor(client, bflUrl, terminusName, localName, password, true, needTwoFactor)
 	if err != nil {
 		return nil, fmt.Errorf("first factor authentication failed: %v", err)
 	}
@@ -39,7 +59,7 @@ func LoginTerminus(bflUrl, terminusName, localName, password string, needTwoFact
 		log.Printf("Generated TOTP: %s", totpValue)
 		
 		// Perform second factor authentication
-		secondToken, err := performSecondFactor(bflUrl, terminusName, totpValue)
+		secondToken, err := performSecondFactor(client, bflUrl, terminusName, totpValue)
 		if err != nil {
 			return nil, fmt.Errorf("second factor authentication failed: %v", err)
 		}
@@ -121,29 +141,35 @@ func generateHOTP(secret string, counter int64) (string, error) {
 	return fmt.Sprintf("%06d", otp), nil
 }
 
-// performSecondFactor performs second factor authentication (ref: loginTerminus line 419-446)
-func performSecondFactor(baseURL, terminusName, totpValue string) (*Token, error) {
+// performSecondFactor performs second factor authentication (ref: loginTerminus line 419-446).
+//
+// Pass the same *http.Client that was used for the first factor so that the
+// Authelia session cookie set on /api/firstfactor is automatically attached
+// here. If client is nil, a fresh client is created (cookies will not be
+// shared, which the server typically rejects).
+func performSecondFactor(client *http.Client, baseURL, terminusName, totpValue string) (*Token, error) {
 	log.Printf("Performing second factor authentication")
-	
+
 	// Build target URL
 	targetURL := fmt.Sprintf("https://desktop.%s/", strings.ReplaceAll(terminusName, "@", "."))
-	
+
 	// Build request data
 	reqData := map[string]interface{}{
 		"targetUrl": targetURL,
 		"token":     totpValue,
 	}
-	
+
 	jsonData, err := json.Marshal(reqData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
-	
-	// Send HTTP request
-	client := &http.Client{
-		Timeout: 10 * time.Second,
+
+	if client == nil {
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
 	}
-	
+
 	url := fmt.Sprintf("%s/api/secondfactor/totp", baseURL)
 	req, err := http.NewRequest("POST", url, strings.NewReader(string(jsonData)))
 	if err != nil {

--- a/cli/pkg/wizard/login_terminus.go
+++ b/cli/pkg/wizard/login_terminus.go
@@ -43,35 +43,35 @@ func LoginTerminus(bflUrl, terminusName, localName, password string, needTwoFact
 	if err != nil {
 		return nil, fmt.Errorf("first factor authentication failed: %v", err)
 	}
-	
+
 	log.Printf("First factor completed, session_id: %s, FA2 required: %t", token.SessionID, token.FA2 || needTwoFactor)
-	
+
 	// 2. If second factor authentication is required (ref: loginTerminus line 379-446)
 	if token.FA2 || needTwoFactor {
 		log.Printf("Second factor authentication required")
-		
+
 		// Get TOTP value
 		totpValue, err := getTOTPFromMFA()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TOTP: %v", err)
 		}
-		
+
 		log.Printf("Generated TOTP: %s", totpValue)
-		
+
 		// Perform second factor authentication
-		secondToken, err := performSecondFactor(client, bflUrl, terminusName, totpValue)
+		secondToken, err := performSecondFactor(client, bflUrl, terminusName, totpValue, token.AccessToken)
 		if err != nil {
 			return nil, fmt.Errorf("second factor authentication failed: %v", err)
 		}
-		
+
 		// Update token information
 		token.AccessToken = secondToken.AccessToken
 		token.RefreshToken = secondToken.RefreshToken
 		token.SessionID = secondToken.SessionID
-		
+
 		log.Printf("Second factor completed, updated session_id: %s", token.SessionID)
 	}
-	
+
 	log.Printf("LoginTerminus completed successfully")
 	return token, nil
 }
@@ -83,19 +83,19 @@ func getTOTPFromMFA() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("MFA token not found: %v", err)
 	}
-	
+
 	log.Printf("Using MFA token for TOTP generation: %s", mfa)
-	
+
 	// Generate TOTP (ref: TypeScript hotp function)
 	currentTime := time.Now().Unix()
 	interval := int64(30) // 30 second interval
 	counter := currentTime / interval
-	
+
 	totp, err := generateHOTP(mfa, counter)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate TOTP: %v", err)
 	}
-	
+
 	return totp, nil
 }
 
@@ -103,41 +103,41 @@ func getTOTPFromMFA() (string, error) {
 func generateHOTP(secret string, counter int64) (string, error) {
 	// Process base32 string: remove spaces, convert to uppercase, handle padding
 	cleanSecret := strings.ToUpper(strings.ReplaceAll(secret, " ", ""))
-	
+
 	// Add padding characters if needed
 	padding := len(cleanSecret) % 8
 	if padding != 0 {
 		cleanSecret += strings.Repeat("=", 8-padding)
 	}
-	
+
 	// Decode base32 encoded secret to bytes
 	secretBytes, err := base32.StdEncoding.DecodeString(cleanSecret)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode base32 secret: %v", err)
 	}
-	
+
 	// Convert counter to 8-byte big-endian
 	counterBytes := make([]byte, 8)
 	for i := 7; i >= 0; i-- {
 		counterBytes[i] = byte(counter & 0xff)
 		counter >>= 8
 	}
-	
+
 	// Use HMAC-SHA1 to calculate hash (consistent with TypeScript version)
 	h := hmac.New(sha1.New, secretBytes)
 	h.Write(counterBytes)
 	hash := h.Sum(nil)
-	
+
 	// Dynamic truncation (consistent with TypeScript getToken function)
 	offset := hash[len(hash)-1] & 0xf
 	code := ((int(hash[offset]) & 0x7f) << 24) |
 		((int(hash[offset+1]) & 0xff) << 16) |
 		((int(hash[offset+2]) & 0xff) << 8) |
 		(int(hash[offset+3]) & 0xff)
-	
+
 	// Generate 6-digit number
 	otp := code % int(math.Pow10(6))
-	
+
 	return fmt.Sprintf("%06d", otp), nil
 }
 
@@ -147,7 +147,7 @@ func generateHOTP(secret string, counter int64) (string, error) {
 // Authelia session cookie set on /api/firstfactor is automatically attached
 // here. If client is nil, a fresh client is created (cookies will not be
 // shared, which the server typically rejects).
-func performSecondFactor(client *http.Client, baseURL, terminusName, totpValue string) (*Token, error) {
+func performSecondFactor(client *http.Client, baseURL, terminusName, totpValue string, accessToken string) (*Token, error) {
 	log.Printf("Performing second factor authentication")
 
 	// Build target URL
@@ -175,41 +175,42 @@ func performSecondFactor(client *http.Client, baseURL, terminusName, totpValue s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
-	
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Access-Control-Allow-Origin", "*")
 	req.Header.Set("X-Unauth-Error", "Non-Redirect")
-	
+	req.Header.Set("X-Authorization", accessToken)
+
 	log.Printf("Sending second factor request to: %s", url)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %v", err)
 	}
-	
+
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(body))
 	}
-	
+
 	var response struct {
 		Status string `json:"status"`
 		Data   Token  `json:"data"`
 	}
-	
+
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
 	}
-	
+
 	if response.Status != "OK" {
 		return nil, fmt.Errorf("second factor authentication failed: %s", response.Status)
 	}
-	
+
 	log.Printf("Second factor authentication successful")
 	return &response.Data, nil
 }
@@ -217,65 +218,65 @@ func performSecondFactor(client *http.Client, baseURL, terminusName, totpValue s
 // ResetPassword implements password reset functionality (ref: account.ts reset_password)
 func ResetPassword(baseURL, localName, currentPassword, newPassword, accessToken string) error {
 	log.Printf("Starting reset password for user: %s", localName)
-	
+
 	// Process passwords (salted MD5)
 	processedCurrentPassword := passwordAddSort(currentPassword)
 	processedNewPassword := passwordAddSort(newPassword)
-	
+
 	// Build request data (ref: account.ts line 138-141)
 	reqData := map[string]interface{}{
 		"current_password": processedCurrentPassword,
 		"password":         processedNewPassword,
 	}
-	
+
 	jsonData, err := json.Marshal(reqData)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %v", err)
 	}
-	
+
 	// Create HTTP client (ref: account.ts line 128-135)
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
-	
+
 	// Build request URL (ref: account.ts line 136-137)
 	url := fmt.Sprintf("%s/bfl/iam/v1alpha1/users/%s/password", baseURL, localName)
 	req, err := http.NewRequest("PUT", url, strings.NewReader(string(jsonData)))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}
-	
+
 	// Set request headers (ref: account.ts line 131-134)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Authorization", accessToken)
-	
+
 	log.Printf("Sending reset password request to: %s", url)
-	
+
 	// Send request
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	
+
 	// Read response
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response: %v", err)
 	}
-	
+
 	// Check HTTP status code (ref: account.ts line 144-146)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(body))
 	}
-	
+
 	// Parse response
 	var response struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
+		Code    int         `json:"code"`
+		Message string      `json:"message"`
 		Data    interface{} `json:"data"`
 	}
-	
+
 	if err := json.Unmarshal(body, &response); err != nil {
 		return fmt.Errorf("failed to unmarshal response: %v", err)
 	}
@@ -287,7 +288,7 @@ func ResetPassword(baseURL, localName, currentPassword, newPassword, accessToken
 		}
 		return fmt.Errorf("password reset failed: network error")
 	}
-	
+
 	log.Printf("Password reset completed successfully")
 	return nil
 }

--- a/cli/pkg/wizard/platform.go
+++ b/cli/pkg/wizard/platform.go
@@ -117,22 +117,39 @@ func (p *WebPlatform) CompleteAuthRequest(req *StartAuthRequestResponse) (*Authe
 // Global variables
 var platform Platform
 var globalUserStore *UserStore
+var globalStorage Storage
 // globalJWSSigner removed as UserStore.SignJWS() is actually used
 
 func SetPlatform(p Platform) {
 	platform = p
 }
 
-// InitializeGlobalStores initializes global storage
+// GetGlobalStorage returns the process-wide DirKVStorage initialized via
+// InitializeGlobalStores. May be nil if init has not yet been called.
+func GetGlobalStorage() Storage {
+	return globalStorage
+}
+
+// InitializeGlobalStores initializes the global UserStore and the local
+// DirKVStorage rooted at ~/.olares/<did>/. The DID is derived from the
+// mnemonic via the UserStore.
 func InitializeGlobalStores(mnemonic, terminusName string) error {
 	// Create UserStore (contains all necessary JWS signing functionality)
 	userStore, err := NewUserStore(mnemonic, terminusName)
 	if err != nil {
 		return fmt.Errorf("failed to create UserStore: %w", err)
 	}
-	
-	// Set global variables
+
 	globalUserStore = userStore
-	
+
+	root, err := DefaultStorageRoot(userStore.GetDid())
+	if err != nil {
+		return fmt.Errorf("failed to resolve storage root: %w", err)
+	}
+	storage, err := NewDirKVStorage(root)
+	if err != nil {
+		return fmt.Errorf("failed to initialize storage: %w", err)
+	}
+	globalStorage = storage
 	return nil
 }

--- a/cli/pkg/wizard/storage.go
+++ b/cli/pkg/wizard/storage.go
@@ -1,0 +1,116 @@
+package wizard
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Storage abstracts a small key/value store keyed by (kind, id).
+// CLI uses DirKVStorage to persist AppState/Vault objects under
+// ~/.olares/<did>/{kind}-{id}.json.
+type Storage interface {
+	Get(kind, id string, out any) error
+	Put(kind, id string, in any) error
+	Delete(kind, id string) error
+	List(kind string) ([]string, error)
+}
+
+// DirKVStorage is a filesystem-backed Storage implementation that
+// stores each (kind, id) entry as a JSON file under Root.
+type DirKVStorage struct {
+	Root string
+	mu   sync.Mutex
+}
+
+// NewDirKVStorage creates a new DirKVStorage at the given root.
+// Creates the root directory if it does not exist.
+func NewDirKVStorage(root string) (*DirKVStorage, error) {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create storage root %s: %w", root, err)
+	}
+	return &DirKVStorage{Root: root}, nil
+}
+
+func (s *DirKVStorage) path(kind, id string) string {
+	safeKind := sanitize(kind)
+	safeID := sanitize(id)
+	return filepath.Join(s.Root, fmt.Sprintf("%s-%s.json", safeKind, safeID))
+}
+
+func (s *DirKVStorage) Get(kind, id string, out any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := os.ReadFile(s.path(kind, id))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, out)
+}
+
+func (s *DirKVStorage) Put(kind, id string, in any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := json.MarshalIndent(in, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s/%s: %w", kind, id, err)
+	}
+	target := s.path(kind, id)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", tmp, err)
+	}
+	return os.Rename(tmp, target)
+}
+
+func (s *DirKVStorage) Delete(kind, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := os.Remove(s.path(kind, id))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *DirKVStorage) List(kind string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entries, err := os.ReadDir(s.Root)
+	if err != nil {
+		return nil, err
+	}
+	prefix := sanitize(kind) + "-"
+	var ids []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".json")
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// sanitize replaces characters that are unsafe in filenames.
+func sanitize(s string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", ":", "_", " ", "_")
+	return r.Replace(s)
+}
+
+// DefaultStorageRoot returns ~/.olares/<did>; falls back to current dir
+// if the user home cannot be resolved.
+func DefaultStorageRoot(did string) (string, error) {
+	if did == "" {
+		return "", fmt.Errorf("did is required to determine storage root")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve user home dir: %w", err)
+	}
+	return filepath.Join(home, ".olares", sanitize(did)), nil
+}

--- a/cli/pkg/wizard/synchronize.go
+++ b/cli/pkg/wizard/synchronize.go
@@ -163,20 +163,48 @@ func (a *App) CreateItem(params CreateItemParams) (*VaultItem, error) {
 	}
 
 	vault := params.Vault
+	log.Printf("CreateItem: enter id=%s revision=%s accessors=%d encryptedData=%d aesKey?=%t items?=%t itemCount=%d hasChanges=%t",
+		vault.ID, vault.Revision, len(vault.Accessors), len(vault.EncryptedData),
+		vault.aesKey != nil, vault.items != nil, vaultItemCount(vault), vaultHasChanges(vault))
+
 	if vault.aesKey == nil {
+		log.Printf("CreateItem: vault aesKey nil, calling Unlock to bootstrap")
 		if err := vault.Unlock(unlocked); err != nil {
 			return nil, fmt.Errorf("unlock vault: %w", err)
 		}
+		log.Printf("CreateItem: post-Unlock accessors=%d encryptedData=%d aesKey?=%t",
+			len(vault.Accessors), len(vault.EncryptedData), vault.aesKey != nil)
 	}
 
 	vault.AddItems(item)
+	{
+		fieldType := ""
+		fieldValueLen := 0
+		if len(item.Fields) > 0 {
+			fieldType = string(item.Fields[0].Type)
+			fieldValueLen = len(item.Fields[0].Value)
+		}
+		log.Printf("CreateItem: post-AddItems itemCount=%d added id=%s type=%d fields=%d firstFieldType=%s firstFieldValueLen=%d",
+			vaultItemCount(vault), item.ID, item.Type, len(item.Fields), fieldType, fieldValueLen)
+	}
+
 	if err := vault.Commit(); err != nil {
 		return nil, fmt.Errorf("commit vault: %w", err)
 	}
+	log.Printf("CreateItem: post-Commit encryptedData=%d iv?=%t aad?=%t",
+		len(vault.EncryptedData),
+		vault.EncryptionParams.IV != "", vault.EncryptionParams.AdditionalData != "")
+
+	log.Printf("CreateItem: pre-UpdateVault id=%s revision=%s encryptedData=%d accessors=%d",
+		vault.ID, vault.Revision, len(vault.EncryptedData), len(vault.Accessors))
 	pushed, err := a.API.UpdateVault(*vault)
 	if err != nil {
+		log.Printf("CreateItem: API.UpdateVault failed: %+v", err)
 		return nil, fmt.Errorf("updateVault: %w", err)
 	}
+	log.Printf("CreateItem: post-UpdateVault id=%s revision=%s encryptedData=%d accessors=%d",
+		pushed.ID, pushed.Revision, len(pushed.EncryptedData), len(pushed.Accessors))
+
 	pushed.aesKey = vault.aesKey
 	pushed.items = vault.items
 	if err := pushed.Unlock(unlocked); err != nil {
@@ -199,6 +227,24 @@ type CreateItemParams struct {
 	Tags   []string
 	Icon   string
 	Type   VaultType
+}
+
+// vaultItemCount returns the number of items currently held in the
+// vault's in-memory collection (0 if not yet unlocked).
+func vaultItemCount(v *Vault) int {
+	if v == nil || v.items == nil {
+		return 0
+	}
+	return len(v.items.Items)
+}
+
+// vaultHasChanges reports whether the vault's in-memory items collection
+// has any pending local changes.
+func vaultHasChanges(v *Vault) bool {
+	if v == nil || v.items == nil {
+		return false
+	}
+	return v.items.HasChanges()
 }
 
 // MainVault returns the (possibly nil) Vault stored locally that

--- a/cli/pkg/wizard/synchronize.go
+++ b/cli/pkg/wizard/synchronize.go
@@ -147,8 +147,12 @@ func (a *App) CreateItem(params CreateItemParams) (*VaultItem, error) {
 	account := unlocked.Account
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+	itemID := params.ID
+	if itemID == "" {
+		itemID = generateUUID()
+	}
 	item := VaultItem{
-		ID:        generateUUID(),
+		ID:        itemID,
 		Name:      params.Name,
 		Type:      params.Type,
 		Icon:      params.Icon,
@@ -188,6 +192,7 @@ func (a *App) CreateItem(params CreateItemParams) (*VaultItem, error) {
 
 // CreateItemParams is the Go counterpart of TS CreateItemParams.
 type CreateItemParams struct {
+	ID     string // optional; if empty, a new UUID is generated
 	Name   string
 	Vault  *Vault
 	Fields []Field

--- a/cli/pkg/wizard/synchronize.go
+++ b/cli/pkg/wizard/synchronize.go
@@ -1,0 +1,210 @@
+package wizard
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+// Synchronize fetches AuthInfo, Account, Orgs and Vaults from the server,
+// merges any local changes back in, and persists everything to the local
+// Storage. Mirrors App.synchronize in apps/packages/sdk/src/core/app.ts.
+//
+// Requires the AppState to already have an unlocked account (call
+// Account.Unlock before invoking this).
+func (a *App) Synchronize() error {
+	if a.State == nil {
+		return fmt.Errorf("app has no AppState")
+	}
+	unlocked := a.State.Unlocked()
+	if unlocked == nil {
+		return fmt.Errorf("synchronize requires an unlocked account")
+	}
+
+	// 1. AuthInfo
+	if info, err := a.API.GetAuthInfo(); err != nil {
+		log.Printf("synchronize: getAuthInfo failed: %v", err)
+	} else {
+		a.State.AuthInfo = info
+	}
+
+	// 2. Refresh Account
+	freshAccount, err := a.API.GetAccount()
+	if err != nil {
+		return fmt.Errorf("synchronize: getAccount failed: %w", err)
+	}
+	unlocked.Account = freshAccount
+	a.State.SetAccount(freshAccount)
+
+	// 3. Orgs
+	a.State.Orgs = a.State.Orgs[:0]
+	for _, info := range freshAccount.Orgs {
+		org, err := a.API.GetOrg(info.ID)
+		if err != nil {
+			log.Printf("synchronize: getOrg %s failed: %v", info.ID, err)
+			continue
+		}
+		a.State.Orgs = append(a.State.Orgs, *org)
+	}
+
+	// 4. Vaults
+	if err := a.syncVaults(unlocked); err != nil {
+		return fmt.Errorf("synchronize: syncVaults failed: %w", err)
+	}
+
+	a.State.LastSync = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := a.State.Save(); err != nil {
+		log.Printf("synchronize: failed to persist app state: %v", err)
+	}
+	return nil
+}
+
+// syncVaults pulls the main vault and every shared vault available
+// through the user's orgs, merges in any local changes, and pushes
+// changes back. Errors on individual vaults are logged but do not stop
+// the overall sync.
+func (a *App) syncVaults(unlocked *UnlockedAccount) error {
+	// Build the ordered list of (vaultID, isMain) tuples to sync.
+	type vaultSpec struct {
+		ID     string
+		IsMain bool
+	}
+	var specs []vaultSpec
+	if id := unlocked.Account.MainVault.ID; id != "" {
+		specs = append(specs, vaultSpec{ID: id, IsMain: true})
+	}
+	for _, org := range a.State.Orgs {
+		for _, v := range org.Vaults {
+			specs = append(specs, vaultSpec{ID: v.ID})
+		}
+	}
+
+	for _, spec := range specs {
+		if err := a.syncVault(unlocked, spec.ID); err != nil {
+			log.Printf("synchronize: vault %s failed: %v", spec.ID, err)
+		}
+	}
+	return nil
+}
+
+// syncVault is the per-vault flow: fetch → unlock → merge with local →
+// commit + push if there were local changes → store.
+func (a *App) syncVault(unlocked *UnlockedAccount, id string) error {
+	remote, err := a.API.GetVault(id)
+	if err != nil {
+		return fmt.Errorf("getVault: %w", err)
+	}
+	if err := remote.Unlock(unlocked); err != nil {
+		return fmt.Errorf("unlock remote vault: %w", err)
+	}
+
+	local := a.State.GetVault(id)
+	if local != nil && local.items != nil && local.items.HasChanges() {
+		// Local has unsynced edits — unlock the local copy too so we can
+		// merge then push back.
+		if local.aesKey == nil {
+			if err := local.Unlock(unlocked); err != nil {
+				log.Printf("syncVault: failed to unlock local %s, dropping local: %v", id, err)
+				local = nil
+			}
+		}
+		if local != nil {
+			local.Merge(remote)
+			if err := local.Commit(); err != nil {
+				return fmt.Errorf("commit merged vault: %w", err)
+			}
+			pushed, err := a.API.UpdateVault(*local)
+			if err != nil {
+				return fmt.Errorf("updateVault: %w", err)
+			}
+			pushed.aesKey = local.aesKey
+			pushed.items = local.items
+			if err := pushed.Unlock(unlocked); err != nil {
+				return fmt.Errorf("re-unlock pushed vault: %w", err)
+			}
+			pushed.MarkSynced(time.Now())
+			a.State.PutVault(*pushed)
+			return nil
+		}
+	}
+
+	a.State.PutVault(*remote)
+	return nil
+}
+
+// CreateItem builds a fresh VaultItem, adds it to the given vault,
+// commits, pushes to the server, and re-unlocks (so the vault is left
+// in a usable state). Mirrors App.createItem → addItems → saveVault →
+// syncVault in TS.
+func (a *App) CreateItem(params CreateItemParams) (*VaultItem, error) {
+	if a.State == nil || a.State.Unlocked() == nil {
+		return nil, fmt.Errorf("CreateItem requires an unlocked account")
+	}
+	if params.Vault == nil {
+		return nil, fmt.Errorf("CreateItem requires a vault")
+	}
+	unlocked := a.State.Unlocked()
+	account := unlocked.Account
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	item := VaultItem{
+		ID:        generateUUID(),
+		Name:      params.Name,
+		Type:      params.Type,
+		Icon:      params.Icon,
+		Fields:    params.Fields,
+		Tags:      append([]string{}, params.Tags...),
+		Updated:   now,
+		UpdatedBy: account.ID,
+	}
+
+	vault := params.Vault
+	if vault.aesKey == nil {
+		if err := vault.Unlock(unlocked); err != nil {
+			return nil, fmt.Errorf("unlock vault: %w", err)
+		}
+	}
+
+	vault.AddItems(item)
+	if err := vault.Commit(); err != nil {
+		return nil, fmt.Errorf("commit vault: %w", err)
+	}
+	pushed, err := a.API.UpdateVault(*vault)
+	if err != nil {
+		return nil, fmt.Errorf("updateVault: %w", err)
+	}
+	pushed.aesKey = vault.aesKey
+	pushed.items = vault.items
+	if err := pushed.Unlock(unlocked); err != nil {
+		return nil, fmt.Errorf("re-unlock pushed vault: %w", err)
+	}
+	pushed.MarkSynced(time.Now())
+	a.State.PutVault(*pushed)
+	if err := a.State.Save(); err != nil {
+		log.Printf("CreateItem: persist app state failed: %v", err)
+	}
+	return &item, nil
+}
+
+// CreateItemParams is the Go counterpart of TS CreateItemParams.
+type CreateItemParams struct {
+	Name   string
+	Vault  *Vault
+	Fields []Field
+	Tags   []string
+	Icon   string
+	Type   VaultType
+}
+
+// MainVault returns the (possibly nil) Vault stored locally that
+// corresponds to account.mainVault.id.
+func (a *App) MainVault() *Vault {
+	if a.State == nil {
+		return nil
+	}
+	acc := a.State.GetAccount()
+	if acc == nil || acc.MainVault.ID == "" {
+		return nil
+	}
+	return a.State.GetVault(acc.MainVault.ID)
+}

--- a/cli/pkg/wizard/types.go
+++ b/cli/pkg/wizard/types.go
@@ -221,7 +221,8 @@ type EncryptionParams struct {
 	KeySize        int    `json:"keySize"`        // 256
 	IV             string `json:"iv"`             // Base64 encoded initialization vector
 	AdditionalData string `json:"additionalData"` // Base64 encoded additional data
-	Version        string `json:"version"`        // "3.0.14"
+	Kind           string `json:"kind,omitempty"`    // TS Serializable short kind, e.g. "r"
+	Version        string `json:"version,omitempty"` // e.g. "4.0.0"
 }
 
 // KeyParams represents PBKDF2 key derivation parameters
@@ -231,7 +232,7 @@ type KeyParams struct {
 	KeySize    int    `json:"keySize"`    // 256
 	Iterations int    `json:"iterations"` // 100000
 	Salt       string `json:"salt"`       // Base64 encoded salt
-	Version    string `json:"version"`    // "3.0.14"
+	Version    string `json:"version,omitempty"`
 }
 
 type Account struct {
@@ -341,24 +342,26 @@ func (b *Base64Bytes) UnmarshalJSON(data []byte) error {
 	// Try base64url decoding first
 	decoded, err := base64.URLEncoding.DecodeString(str)
 	if err != nil {
-		// If base64url fails, try raw base64url decoding
 		decoded, err = base64.RawURLEncoding.DecodeString(str)
-		if err != nil {
-			// Finally try standard base64 decoding
-			decoded, err = base64.StdEncoding.DecodeString(str)
-			if err != nil {
-				return fmt.Errorf("failed to decode base64url/base64: %v", err)
-			}
-		}
+	}
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(str)
+	}
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(str)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to decode base64url/base64: %w", err)
 	}
 
 	*b = Base64Bytes(decoded)
 	return nil
 }
 
-// MarshalJSON implements JSON serialization, automatically encoding to base64 string
+// MarshalJSON encodes like TS bytesToBase64 (url-safe, no padding);
+// see apps/packages/sdk/src/core/base64.ts fromByteArray(..., urlSafe=true).
 func (b Base64Bytes) MarshalJSON() ([]byte, error) {
-	encoded := base64.StdEncoding.EncodeToString([]byte(b))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(b))
 	return json.Marshal(encoded)
 }
 
@@ -426,18 +429,60 @@ type Accessor struct {
 	ID           string      `json:"id"`
 	EncryptedKey Base64Bytes `json:"encryptedKey"`
 	PublicKey    Base64Bytes `json:"publicKey,omitempty"`
+	Kind         string      `json:"kind,omitempty"`
+	Version      string      `json:"version,omitempty"`
 }
 
 // RSAEncryptionParams mirrors the same-named TS class. Only RSA-OAEP /
 // SHA-256 is supported (matching the server defaults).
+//
+// Do not put Serializable "kind"/"version" on the wire: WebCryptoProvider in
+// apps/packages/sdk/src/crypto.ts passes keyParams into subtle.importKey/decrypt
+// via Object.assign; extra keys (e.g. kind, version) can cause DataError on decrypt.
 type RSAEncryptionParams struct {
 	Algorithm string `json:"algorithm"` // "RSA-OAEP"
 	Hash      string `json:"hash"`      // "SHA-256"
-	Kind      string `json:"kind,omitempty"`
-	Version   string `json:"version,omitempty"`
 }
 
-// NewRSAEncryptionParams constructs the canonical params used by TS.
+// MarshalJSON emits only algorithm+hash so WebCryptoProvider (crypto.ts) never
+// sees Serializable extras (kind/version) on keyParams after Object.assign.
+func (p RSAEncryptionParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		Algorithm string `json:"algorithm"`
+		Hash      string `json:"hash"`
+	}
+	alg, h := p.Algorithm, p.Hash
+	if alg == "" {
+		alg = "RSA-OAEP"
+	}
+	if h == "" {
+		h = "SHA-256"
+	}
+	return json.Marshal(wire{Algorithm: alg, Hash: h})
+}
+
+// UnmarshalJSON ignores unknown fields (e.g. legacy kind/version from server).
+func (p *RSAEncryptionParams) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		Algorithm string `json:"algorithm"`
+		Hash      string `json:"hash"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	p.Algorithm = w.Algorithm
+	p.Hash = w.Hash
+	if p.Algorithm == "" {
+		p.Algorithm = "RSA-OAEP"
+	}
+	if p.Hash == "" {
+		p.Hash = "SHA-256"
+	}
+	return nil
+}
+
+// NewRSAEncryptionParams constructs the canonical params used by TS/WebCrypto.
 func NewRSAEncryptionParams() RSAEncryptionParams {
 	return RSAEncryptionParams{Algorithm: "RSA-OAEP", Hash: "SHA-256"}
 }
@@ -454,7 +499,7 @@ type Vault struct {
 	Org              *OrgInfo            `json:"org,omitempty"`
 	Created          string              `json:"created"`
 	Updated          string              `json:"updated"`
-	Revision         string              `json:"revision,omitempty"`
+	Revision         string              `json:"revision"` // required on updateVault (server revision check)
 	KeyParams        RSAEncryptionParams `json:"keyParams"`
 	EncryptionParams EncryptionParams    `json:"encryptionParams"`
 	Accessors        []Accessor          `json:"accessors"`
@@ -633,7 +678,7 @@ type AuthInfo struct {
 type UnlockedAccount struct {
 	Account    *Account
 	MasterKey  []byte
-	PrivateKey []byte // PKCS1 DER
+	PrivateKey []byte // PKCS#8 DER (matches apps/packages/sdk/src/crypto.ts subtle.exportKey('pkcs8', ...))
 	SigningKey []byte // HMAC key
 }
 

--- a/cli/pkg/wizard/types.go
+++ b/cli/pkg/wizard/types.go
@@ -103,7 +103,29 @@ type AccountProvisioning struct {
 	BillingPage   any            `json:"billingPage,omitempty"`
 	Quota         map[string]any `json:"quota"`
 	Features      map[string]any `json:"features"`
-	Orgs          []string       `json:"orgs"`
+	Orgs          []string       `json:"orgs,omitempty"`
+}
+
+// OrgProvisioning mirrors the subset of TS OrgProvisioning that can appear
+// inside AuthInfo.provisioning.orgs.
+type OrgProvisioning struct {
+	OrgID         string         `json:"orgId"`
+	OrgName       string         `json:"orgName,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	StatusLabel   string         `json:"statusLabel,omitempty"`
+	StatusMessage any            `json:"statusMessage,omitempty"`
+	ActionURL     *string        `json:"actionUrl,omitempty"`
+	ActionLabel   *string        `json:"actionLabel,omitempty"`
+	MetaData      map[string]any `json:"metaData,omitempty"`
+	AutoCreate    bool           `json:"autoCreate,omitempty"`
+	Quota         map[string]any `json:"quota,omitempty"`
+	Features      map[string]any `json:"features,omitempty"`
+}
+
+// Provisioning mirrors apps/packages/sdk/src/core/provisioning.ts Provisioning.
+type Provisioning struct {
+	Account *AccountProvisioning `json:"account,omitempty"`
+	Orgs    []OrgProvisioning    `json:"orgs,omitempty"`
 }
 
 type StartAuthRequestResponse struct {
@@ -237,10 +259,18 @@ type DeviceInfo struct {
 	// Other device-related fields...
 }
 
-// Request represents an RPC request
+// Request represents an RPC request.
+//
+// IMPORTANT: do NOT add `omitempty` to Params. The TS client always
+// sends `params: []` on the wire (see apps/packages/sdk/src/core/client.ts
+// line 41-52: `typeof input === 'undefined' ? [] : [...]`), and the server
+// signs against `JSON.stringify(req.params)` (where `[]` -> "[]" but
+// `undefined` -> "undefined"). With `omitempty` Go would drop the field
+// for empty param calls (e.g. `getAccount`), causing a signature mismatch:
+// client signs `..._[]` while server signs `..._undefined`.
 type Request struct {
 	Method string        `json:"method"`
-	Params []interface{} `json:"params,omitempty"`
+	Params []interface{} `json:"params"`
 	Device *DeviceInfo   `json:"device,omitempty"`
 	Auth   *RequestAuth  `json:"auth,omitempty"`
 }
@@ -391,21 +421,236 @@ type VaultItem struct {
 	UpdatedBy string    `json:"updatedBy"`
 }
 
-// Vault represents a vault containing items
-type Vault struct {
-	Kind         string      `json:"kind"`                    // Always "vault" for Vault objects
+// Accessor mirrors apps/packages/sdk/src/core/container.ts Accessor.
+type Accessor struct {
 	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Owner        string      `json:"owner"`
-	Created      string      `json:"created"`                 // ISO 8601 format
-	Updated      string      `json:"updated"`                 // ISO 8601 format
-	Revision     string      `json:"revision,omitempty"`
-	Items        []VaultItem `json:"items,omitempty"`
-	KeyParams    interface{} `json:"keyParams,omitempty"`
-	EncryptionParams interface{} `json:"encryptionParams,omitempty"`
-	Accessors    interface{} `json:"accessors,omitempty"`
-	EncryptedData interface{} `json:"encryptedData,omitempty"`
-	Version      string      `json:"version,omitempty"`       // Serialization version
+	EncryptedKey Base64Bytes `json:"encryptedKey"`
+	PublicKey    Base64Bytes `json:"publicKey,omitempty"`
+}
+
+// RSAEncryptionParams mirrors the same-named TS class. Only RSA-OAEP /
+// SHA-256 is supported (matching the server defaults).
+type RSAEncryptionParams struct {
+	Algorithm string `json:"algorithm"` // "RSA-OAEP"
+	Hash      string `json:"hash"`      // "SHA-256"
+	Kind      string `json:"kind,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+// NewRSAEncryptionParams constructs the canonical params used by TS.
+func NewRSAEncryptionParams() RSAEncryptionParams {
+	return RSAEncryptionParams{Algorithm: "RSA-OAEP", Hash: "SHA-256"}
+}
+
+// Vault is the Go counterpart of apps/packages/sdk/src/core/vault.ts.
+//
+// `items` and the cleartext shared key live only in memory after a
+// successful Unlock call; they are not serialized to JSON.
+type Vault struct {
+	Kind             string              `json:"kind"`
+	ID               string              `json:"id"`
+	Name             string              `json:"name"`
+	Owner            string              `json:"owner"`
+	Org              *OrgInfo            `json:"org,omitempty"`
+	Created          string              `json:"created"`
+	Updated          string              `json:"updated"`
+	Revision         string              `json:"revision,omitempty"`
+	KeyParams        RSAEncryptionParams `json:"keyParams"`
+	EncryptionParams EncryptionParams    `json:"encryptionParams"`
+	Accessors        []Accessor          `json:"accessors"`
+	EncryptedData    Base64Bytes         `json:"encryptedData,omitempty"`
+	Version          string              `json:"version,omitempty"`
+
+	// Runtime-only state populated by Unlock() / UpdateAccessors() / Commit().
+	items  *VaultItemCollection `json:"-"`
+	aesKey []byte               `json:"-"`
+}
+
+// VaultItemCollection mirrors apps/packages/sdk/src/core/collection.ts.
+// Items keyed by id; Changes records the last time an item was modified
+// locally so that merge() knows which side wins.
+type VaultItemCollection struct {
+	Items   map[string]VaultItem `json:"-"`
+	Changes map[string]ISOTime   `json:"-"`
+}
+
+// NewVaultItemCollection returns an empty collection.
+func NewVaultItemCollection() *VaultItemCollection {
+	return &VaultItemCollection{
+		Items:   map[string]VaultItem{},
+		Changes: map[string]ISOTime{},
+	}
+}
+
+// vaultItemCollectionRaw is the on-disk shape produced by TS
+// VaultItemCollection._toRaw: { items: VaultItem[], changes: [string,string][] }.
+type vaultItemCollectionRaw struct {
+	Items   []VaultItem `json:"items"`
+	Changes [][2]string `json:"changes"`
+}
+
+// ToBytes serializes the collection in a way compatible with the TS
+// implementation (items: array, changes: [[id, iso-time], ...]).
+func (c *VaultItemCollection) ToBytes() ([]byte, error) {
+	if c == nil {
+		c = NewVaultItemCollection()
+	}
+	raw := vaultItemCollectionRaw{
+		Items:   make([]VaultItem, 0, len(c.Items)),
+		Changes: make([][2]string, 0, len(c.Changes)),
+	}
+	for _, item := range c.Items {
+		raw.Items = append(raw.Items, item)
+	}
+	for id, t := range c.Changes {
+		raw.Changes = append(raw.Changes, [2]string{id, time.Time(t).UTC().Format(time.RFC3339Nano)})
+	}
+	return json.Marshal(raw)
+}
+
+// FromBytes deserializes a TS-compatible payload back into the collection.
+func (c *VaultItemCollection) FromBytes(data []byte) error {
+	var raw vaultItemCollectionRaw
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("failed to parse VaultItemCollection: %w", err)
+	}
+	c.Items = make(map[string]VaultItem, len(raw.Items))
+	for _, item := range raw.Items {
+		c.Items[item.ID] = item
+	}
+	c.Changes = make(map[string]ISOTime, len(raw.Changes))
+	for _, ch := range raw.Changes {
+		t, err := time.Parse(time.RFC3339Nano, ch[1])
+		if err != nil {
+			t, _ = time.Parse(time.RFC3339, ch[1])
+		}
+		c.Changes[ch[0]] = ISOTime(t)
+	}
+	return nil
+}
+
+// Update inserts or replaces the given items, marking each as changed.
+func (c *VaultItemCollection) Update(items ...VaultItem) {
+	now := time.Now().UTC()
+	for _, item := range items {
+		item.Updated = now.Format(time.RFC3339Nano)
+		c.Items[item.ID] = item
+		c.Changes[item.ID] = ISOTime(now)
+	}
+}
+
+// Remove deletes items by id and records the deletion as a change.
+func (c *VaultItemCollection) Remove(items ...VaultItem) {
+	now := time.Now().UTC()
+	for _, item := range items {
+		delete(c.Items, item.ID)
+		c.Changes[item.ID] = ISOTime(now)
+	}
+}
+
+// HasChanges reports whether any local changes are still pending sync.
+func (c *VaultItemCollection) HasChanges() bool {
+	return c != nil && len(c.Changes) > 0
+}
+
+// ClearChanges drops change records older than `before` (zero means all).
+func (c *VaultItemCollection) ClearChanges(before time.Time) {
+	if c == nil {
+		return
+	}
+	for id, t := range c.Changes {
+		if before.IsZero() || !time.Time(t).After(before) {
+			delete(c.Changes, id)
+		}
+	}
+}
+
+// Merge mirrors VaultItemCollection.merge in TS: locally-changed items
+// always win, otherwise the other side's items overwrite.
+func (c *VaultItemCollection) Merge(other *VaultItemCollection) {
+	if other == nil {
+		return
+	}
+	for id := range c.Items {
+		if _, changed := c.Changes[id]; !changed {
+			if _, ok := other.Items[id]; !ok {
+				delete(c.Items, id)
+			}
+		}
+	}
+	for id, item := range other.Items {
+		if _, changed := c.Changes[id]; !changed {
+			c.Items[id] = item
+		}
+	}
+}
+
+// Items returns the in-memory collection (allocating if needed).
+func (v *Vault) ItemsCollection() *VaultItemCollection {
+	if v.items == nil {
+		v.items = NewVaultItemCollection()
+	}
+	return v.items
+}
+
+// Org is the minimal subset of apps/packages/sdk/src/core/org.ts that
+// the CLI needs in order to fetch / iterate vaults shared via an org.
+type Org struct {
+	ID        string      `json:"id"`
+	Name      string      `json:"name,omitempty"`
+	Revision  string      `json:"revision,omitempty"`
+	PublicKey Base64Bytes `json:"publicKey,omitempty"`
+	Vaults    []OrgVault  `json:"vaults,omitempty"`
+	Members   []OrgMember `json:"members,omitempty"`
+}
+
+type OrgVault struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+}
+
+type OrgMember struct {
+	ID        string      `json:"id,omitempty"`
+	AccountID string      `json:"accountId,omitempty"`
+	DID       string      `json:"did"`
+	Name      string      `json:"name,omitempty"`
+	PublicKey Base64Bytes `json:"publicKey,omitempty"`
+	Role      int         `json:"role,omitempty"`
+	Status    string      `json:"status,omitempty"`
+	Vaults    []OrgVault  `json:"vaults,omitempty"`
+}
+
+// AuthInfo is the minimal subset of apps/packages/sdk/src/core/api.ts
+// AuthInfo persisted by the CLI.
+type AuthInfo struct {
+	Provisioning *Provisioning `json:"provisioning,omitempty"`
+}
+
+// UnlockedAccount holds the in-memory secrets derived from a successful
+// Account.Unlock call (PBKDF2 → AES-GCM decrypt of EncryptedData).
+type UnlockedAccount struct {
+	Account    *Account
+	MasterKey  []byte
+	PrivateKey []byte // PKCS1 DER
+	SigningKey []byte // HMAC key
+}
+
+// AccountSecrets is the JSON shape that lives inside the account's
+// AES-GCM encryptedData blob.
+type AccountSecrets struct {
+	SigningKey Base64Bytes `json:"signingKey"`
+	PrivateKey Base64Bytes `json:"privateKey"`
+	Favorites  []string    `json:"favorites,omitempty"`
+	Tags       []TagInfo   `json:"tags,omitempty"`
+}
+
+// TagInfo mirrors apps/packages/sdk/src/core/item.ts TagInfo.
+type TagInfo struct {
+	Name     string  `json:"name"`
+	Unlisted *bool   `json:"unlisted,omitempty"`
+	Color    *string `json:"color,omitempty"`
 }
 
 // ItemTemplate represents a template for creating vault items

--- a/cli/pkg/wizard/user_store.go
+++ b/cli/pkg/wizard/user_store.go
@@ -17,11 +17,18 @@ import (
 
 // UserStore implementation using actual DID keys
 type UserStore struct {
-	terminusName string
-	mnemonic     string
-	did          string
-	privateJWK   *jwk.JWK // Direct use of Web5 JWK structure
-	mfa          string   // Store MFA token
+	terminusName  string
+	mnemonic      string
+	did           string
+	privateJWK    *jwk.JWK // Direct use of Web5 JWK structure
+	mfa           string   // Store MFA token
+	customAuthURL string   // Optional override for the auth URL
+}
+
+// SetAuthURL sets a custom auth URL that takes precedence over the
+// auto-derived value returned by GetAuthURL.
+func (u *UserStore) SetAuthURL(url string) {
+	u.customAuthURL = url
 }
 
 func (u *UserStore) GetTerminusName() string {
@@ -190,6 +197,10 @@ func (u *UserStore) SignJWS(payload map[string]any) (string, error) {
 const TerminusDefaultDomain = "olares.cn"
 
 func (u *UserStore) GetAuthURL() string {
+	if u.customAuthURL != "" {
+		return u.customAuthURL
+	}
+
 	array := strings.Split(u.terminusName, "@")
 	localURL := u.getLocalURL()
 

--- a/cli/pkg/wizard/user_store.go
+++ b/cli/pkg/wizard/user_store.go
@@ -194,7 +194,7 @@ func (u *UserStore) SignJWS(payload map[string]any) (string, error) {
 	return signedJWT, nil
 }
 
-const TerminusDefaultDomain = "olares.cn"
+const TerminusDefaultDomain = "olares.com"
 
 func (u *UserStore) GetAuthURL() string {
 	if u.customAuthURL != "" {

--- a/cli/pkg/wizard/vault_crypto.go
+++ b/cli/pkg/wizard/vault_crypto.go
@@ -95,19 +95,6 @@ func (acc *Account) Unlock(password string) (*UnlockedAccount, error) {
 	}, nil
 }
 
-// CopySecrets transfers in-memory secrets and master key from `other` so
-// that a freshly-fetched Account can be re-used without re-deriving them
-// (mirrors Account.copySecrets in TS).
-func (acc *Account) CopySecrets(unlocked *UnlockedAccount) {
-	if unlocked == nil {
-		return
-	}
-	// no-op for the dehydrated server account; the unlocked struct already
-	// carries the secrets out of band, so callers should keep the
-	// UnlockedAccount around in AppState.
-	_ = acc
-}
-
 // =============================================================================
 // Vault crypto
 // =============================================================================

--- a/cli/pkg/wizard/vault_crypto.go
+++ b/cli/pkg/wizard/vault_crypto.go
@@ -1,0 +1,318 @@
+package wizard
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// hashFromAlgo returns a hash.Hash factory for the given SDK algo name.
+// Only SHA-256 is supported (matches the TS SDK defaults).
+func hashFromAlgo(name string) (func() hash.Hash, error) {
+	if name == "" || name == "SHA-256" {
+		return sha256.New, nil
+	}
+	return nil, fmt.Errorf("unsupported hash: %s", name)
+}
+
+// decodeBase64Loose accepts both standard and URL-safe base64
+// (with or without padding); matches the lenient parsing in the TS server.
+func decodeBase64Loose(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	if b, err := base64.URLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	if b, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	return base64.RawStdEncoding.DecodeString(s)
+}
+
+// Unlock derives the master key from `password` using PBKDF2 (account.KeyParams),
+// AES-GCM-decrypts the account secrets blob, and returns a non-nil
+// UnlockedAccount carrying the cleartext private/signing keys.
+//
+// Mirrors apps/packages/sdk/src/core/account.ts Account.unlock.
+func (acc *Account) Unlock(password string) (*UnlockedAccount, error) {
+	if acc == nil {
+		return nil, fmt.Errorf("account is nil")
+	}
+	if acc.EncryptedData == "" {
+		return nil, fmt.Errorf("account has no encrypted data — cannot unlock")
+	}
+	hashFn, err := hashFromAlgo(acc.KeyParams.Hash)
+	if err != nil {
+		return nil, err
+	}
+
+	salt, err := decodeBase64Loose(acc.KeyParams.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid keyParams.salt: %w", err)
+	}
+	iv, err := decodeBase64Loose(acc.EncryptionParams.IV)
+	if err != nil {
+		return nil, fmt.Errorf("invalid encryptionParams.iv: %w", err)
+	}
+	aad, err := decodeBase64Loose(acc.EncryptionParams.AdditionalData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid encryptionParams.additionalData: %w", err)
+	}
+	ciphertext, err := decodeBase64Loose(acc.EncryptedData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid encryptedData: %w", err)
+	}
+
+	keyLen := acc.KeyParams.KeySize / 8
+	if keyLen == 0 {
+		keyLen = 32
+	}
+	masterKey := pbkdf2.Key([]byte(password), salt, acc.KeyParams.Iterations, keyLen, hashFn)
+	plaintext, err := aesGCMDecrypt(masterKey, ciphertext, iv, aad)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt account secrets (wrong password?): %w", err)
+	}
+
+	var secrets AccountSecrets
+	if err := json.Unmarshal(plaintext, &secrets); err != nil {
+		return nil, fmt.Errorf("failed to parse account secrets: %w", err)
+	}
+
+	return &UnlockedAccount{
+		Account:    acc,
+		MasterKey:  masterKey,
+		PrivateKey: []byte(secrets.PrivateKey),
+		SigningKey: []byte(secrets.SigningKey),
+	}, nil
+}
+
+// CopySecrets transfers in-memory secrets and master key from `other` so
+// that a freshly-fetched Account can be re-used without re-deriving them
+// (mirrors Account.copySecrets in TS).
+func (acc *Account) CopySecrets(unlocked *UnlockedAccount) {
+	if unlocked == nil {
+		return
+	}
+	// no-op for the dehydrated server account; the unlocked struct already
+	// carries the secrets out of band, so callers should keep the
+	// UnlockedAccount around in AppState.
+	_ = acc
+}
+
+// =============================================================================
+// Vault crypto
+// =============================================================================
+
+// Unlock decrypts the vault's shared key using the unlocked account's RSA
+// private key, then AES-GCM-decrypts the items blob. Mirrors
+// apps/packages/sdk/src/core/vault.ts Vault.unlock.
+func (v *Vault) Unlock(unlocked *UnlockedAccount) error {
+	if unlocked == nil || unlocked.Account == nil {
+		return fmt.Errorf("vault.Unlock requires an unlocked account")
+	}
+	if v.aesKey != nil {
+		return nil // already unlocked
+	}
+
+	if len(v.Accessors) == 0 {
+		// Fresh vault: bootstrap with this account as the sole accessor.
+		if err := v.UpdateAccessors([]*UnlockedAccount{unlocked}); err != nil {
+			return err
+		}
+		return v.Commit()
+	}
+
+	var accessor *Accessor
+	for i := range v.Accessors {
+		if v.Accessors[i].ID == unlocked.Account.ID {
+			accessor = &v.Accessors[i]
+			break
+		}
+	}
+	if accessor == nil || len(accessor.EncryptedKey) == 0 {
+		return fmt.Errorf("no accessor entry for account %s", unlocked.Account.ID)
+	}
+
+	sharedKey, err := rsaOAEPDecrypt(unlocked.PrivateKey, []byte(accessor.EncryptedKey))
+	if err != nil {
+		return fmt.Errorf("failed to unwrap shared key: %w", err)
+	}
+	v.aesKey = sharedKey
+
+	if len(v.EncryptedData) > 0 {
+		iv, err := decodeBase64Loose(v.EncryptionParams.IV)
+		if err != nil {
+			return fmt.Errorf("invalid vault.encryptionParams.iv: %w", err)
+		}
+		aad, err := decodeBase64Loose(v.EncryptionParams.AdditionalData)
+		if err != nil {
+			return fmt.Errorf("invalid vault.encryptionParams.additionalData: %w", err)
+		}
+		plain, err := aesGCMDecrypt(sharedKey, []byte(v.EncryptedData), iv, aad)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt vault data: %w", err)
+		}
+		coll := NewVaultItemCollection()
+		if err := coll.FromBytes(plain); err != nil {
+			return fmt.Errorf("failed to parse vault items: %w", err)
+		}
+		v.items = coll
+	} else {
+		v.items = NewVaultItemCollection()
+	}
+	return nil
+}
+
+// UpdateAccessors generates a fresh shared AES key, re-encrypts any
+// existing data with it, and wraps the new key with each subject's RSA
+// public key. Mirrors SharedContainer.updateAccessors in TS.
+func (v *Vault) UpdateAccessors(subjects []*UnlockedAccount) error {
+	var existing []byte
+	if len(v.EncryptedData) > 0 {
+		if v.aesKey == nil {
+			return fmt.Errorf("non-empty vault must be unlocked before updating accessors")
+		}
+		iv, err := decodeBase64Loose(v.EncryptionParams.IV)
+		if err != nil {
+			return fmt.Errorf("invalid vault.encryptionParams.iv: %w", err)
+		}
+		aad, err := decodeBase64Loose(v.EncryptionParams.AdditionalData)
+		if err != nil {
+			return fmt.Errorf("invalid vault.encryptionParams.additionalData: %w", err)
+		}
+		existing, err = aesGCMDecrypt(v.aesKey, []byte(v.EncryptedData), iv, aad)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt existing vault data: %w", err)
+		}
+	}
+
+	v.aesKey = generateAESKey()
+
+	if v.KeyParams.Algorithm == "" {
+		v.KeyParams = NewRSAEncryptionParams()
+	}
+	if v.EncryptionParams.Algorithm == "" {
+		v.EncryptionParams = EncryptionParams{
+			Algorithm: "AES-GCM",
+			TagSize:   128,
+			KeySize:   256,
+		}
+	}
+
+	if existing != nil {
+		if err := v.setEncryptedData(existing); err != nil {
+			return err
+		}
+	}
+
+	v.Accessors = make([]Accessor, 0, len(subjects))
+	for _, subj := range subjects {
+		if subj == nil || subj.Account == nil {
+			continue
+		}
+		pubDER, err := decodeBase64Loose(subj.Account.PublicKey)
+		if err != nil {
+			return fmt.Errorf("invalid public key for %s: %w", subj.Account.ID, err)
+		}
+		wrapped, err := rsaOAEPEncrypt(pubDER, v.aesKey)
+		if err != nil {
+			return fmt.Errorf("failed to wrap shared key for %s: %w", subj.Account.ID, err)
+		}
+		v.Accessors = append(v.Accessors, Accessor{
+			ID:           subj.Account.ID,
+			PublicKey:    Base64Bytes(pubDER),
+			EncryptedKey: Base64Bytes(wrapped),
+		})
+	}
+	return nil
+}
+
+// Commit re-encrypts the in-memory item collection into EncryptedData.
+// Mirrors Vault.commit in TS.
+func (v *Vault) Commit() error {
+	if v.aesKey == nil {
+		return fmt.Errorf("vault must be unlocked before commit")
+	}
+	if v.items == nil {
+		v.items = NewVaultItemCollection()
+	}
+	plain, err := v.items.ToBytes()
+	if err != nil {
+		return err
+	}
+	return v.setEncryptedData(plain)
+}
+
+// setEncryptedData generates a fresh IV and AAD, then AES-GCM-encrypts.
+func (v *Vault) setEncryptedData(plaintext []byte) error {
+	iv := generateRandomBytes(16)
+	aad := generateRandomBytes(16)
+	ciphertext, err := aesGCMEncrypt(v.aesKey, plaintext, iv, aad)
+	if err != nil {
+		return err
+	}
+	v.EncryptionParams.IV = base64.URLEncoding.EncodeToString(iv)
+	v.EncryptionParams.AdditionalData = base64.URLEncoding.EncodeToString(aad)
+	v.EncryptionParams.Algorithm = "AES-GCM"
+	if v.EncryptionParams.TagSize == 0 {
+		v.EncryptionParams.TagSize = 128
+	}
+	if v.EncryptionParams.KeySize == 0 {
+		v.EncryptionParams.KeySize = 256
+	}
+	v.EncryptedData = Base64Bytes(ciphertext)
+	return nil
+}
+
+// Merge takes the items, name, accessors, etc from `other` while
+// preserving locally-changed items. Mirrors Vault.merge in TS.
+func (v *Vault) Merge(other *Vault) {
+	if other == nil {
+		return
+	}
+	if v.items == nil {
+		v.items = NewVaultItemCollection()
+	}
+	v.items.Merge(other.items)
+	if other.Name != "" {
+		v.Name = other.Name
+	}
+	v.Revision = other.Revision
+	v.Org = other.Org
+	v.Accessors = other.Accessors
+	if other.aesKey != nil {
+		v.aesKey = other.aesKey
+	}
+	v.EncryptedData = other.EncryptedData
+	v.EncryptionParams = other.EncryptionParams
+	v.KeyParams = other.KeyParams
+	if other.Updated != "" {
+		v.Updated = other.Updated
+	}
+}
+
+// AddItems inserts items into the vault's in-memory collection (the
+// caller must subsequently Commit + push to the server).
+func (v *Vault) AddItems(items ...VaultItem) {
+	if v.items == nil {
+		v.items = NewVaultItemCollection()
+	}
+	v.items.Update(items...)
+}
+
+// MarkSynced clears all change records up to `cutoff` (or all of them if
+// the zero time is passed).
+func (v *Vault) MarkSynced(cutoff time.Time) {
+	if v.items != nil {
+		v.items.ClearChanges(cutoff)
+	}
+}

--- a/cli/pkg/wizard/vault_crypto.go
+++ b/cli/pkg/wizard/vault_crypto.go
@@ -118,20 +118,33 @@ func (v *Vault) Unlock(unlocked *UnlockedAccount) error {
 		return v.Commit()
 	}
 
-	var accessor *Accessor
+	var sharedKey []byte
 	for i := range v.Accessors {
-		if v.Accessors[i].ID == unlocked.Account.ID {
-			accessor = &v.Accessors[i]
-			break
+		if v.Accessors[i].ID != unlocked.Account.ID || len(v.Accessors[i].EncryptedKey) == 0 {
+			continue
+		}
+		sk, err := rsaOAEPDecrypt(unlocked.PrivateKey, []byte(v.Accessors[i].EncryptedKey))
+		if err != nil {
+			return fmt.Errorf("failed to unwrap shared key: %w", err)
+		}
+		sharedKey = sk
+		break
+	}
+	if sharedKey == nil {
+		// Accessor id may still be a pre-server client UUID while account.id is canonical.
+		for i := range v.Accessors {
+			if len(v.Accessors[i].EncryptedKey) == 0 {
+				continue
+			}
+			sk, err := rsaOAEPDecrypt(unlocked.PrivateKey, []byte(v.Accessors[i].EncryptedKey))
+			if err == nil {
+				sharedKey = sk
+				break
+			}
 		}
 	}
-	if accessor == nil || len(accessor.EncryptedKey) == 0 {
+	if sharedKey == nil {
 		return fmt.Errorf("no accessor entry for account %s", unlocked.Account.ID)
-	}
-
-	sharedKey, err := rsaOAEPDecrypt(unlocked.PrivateKey, []byte(accessor.EncryptedKey))
-	if err != nil {
-		return fmt.Errorf("failed to unwrap shared key: %w", err)
 	}
 	v.aesKey = sharedKey
 
@@ -192,6 +205,8 @@ func (v *Vault) UpdateAccessors(subjects []*UnlockedAccount) error {
 			Algorithm: "AES-GCM",
 			TagSize:   128,
 			KeySize:   256,
+			Kind:      "r",
+			Version:   "4.0.0",
 		}
 	}
 
@@ -218,6 +233,8 @@ func (v *Vault) UpdateAccessors(subjects []*UnlockedAccount) error {
 			ID:           subj.Account.ID,
 			PublicKey:    Base64Bytes(pubDER),
 			EncryptedKey: Base64Bytes(wrapped),
+			Kind:         "d",
+			Version:      "4.0.0",
 		})
 	}
 	return nil
@@ -247,14 +264,19 @@ func (v *Vault) setEncryptedData(plaintext []byte) error {
 	if err != nil {
 		return err
 	}
-	v.EncryptionParams.IV = base64.URLEncoding.EncodeToString(iv)
-	v.EncryptionParams.AdditionalData = base64.URLEncoding.EncodeToString(aad)
+	v.EncryptionParams.IV = base64.RawURLEncoding.EncodeToString(iv)
+	v.EncryptionParams.AdditionalData = base64.RawURLEncoding.EncodeToString(aad)
 	v.EncryptionParams.Algorithm = "AES-GCM"
+	v.EncryptionParams.Kind = "r"
+	v.EncryptionParams.Version = "4.0.0"
 	if v.EncryptionParams.TagSize == 0 {
 		v.EncryptionParams.TagSize = 128
 	}
 	if v.EncryptionParams.KeySize == 0 {
 		v.EncryptionParams.KeySize = 256
+	}
+	if v.Version == "" {
+		v.Version = "4.0.0"
 	}
 	v.EncryptedData = Base64Bytes(ciphertext)
 	return nil

--- a/cli/pkg/wizard/vault_crypto_test.go
+++ b/cli/pkg/wizard/vault_crypto_test.go
@@ -1,0 +1,216 @@
+package wizard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// buildTestAccount mints a brand-new RSA-backed account whose secrets
+// are sealed with the given password — exactly the shape Account.Unlock
+// expects on the wire.
+func buildTestAccount(t *testing.T, password string) *Account {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal pub: %v", err)
+	}
+	privDER := x509.MarshalPKCS1PrivateKey(priv)
+	signingKey := generateRandomBytes(32)
+
+	salt := generateRandomBytes(16)
+	iter := 1000 // smaller for tests
+	masterKey := pbkdf2.Key([]byte(password), salt, iter, 32, sha256.New)
+
+	secrets := AccountSecrets{
+		PrivateKey: Base64Bytes(privDER),
+		SigningKey: Base64Bytes(signingKey),
+	}
+	plain, err := json.Marshal(secrets)
+	if err != nil {
+		t.Fatalf("marshal secrets: %v", err)
+	}
+
+	iv := generateRandomBytes(16)
+	aad := generateRandomBytes(16)
+	ciphertext, err := aesGCMEncrypt(masterKey, plain, iv, aad)
+	if err != nil {
+		t.Fatalf("encrypt secrets: %v", err)
+	}
+
+	return &Account{
+		ID:        "acc-1",
+		DID:       "did:test:1",
+		Name:      "tester",
+		PublicKey: base64.URLEncoding.EncodeToString(pubDER),
+		KeyParams: KeyParams{
+			Algorithm:  "PBKDF2",
+			Hash:       "SHA-256",
+			KeySize:    256,
+			Iterations: iter,
+			Salt:       base64.URLEncoding.EncodeToString(salt),
+		},
+		EncryptionParams: EncryptionParams{
+			Algorithm:      "AES-GCM",
+			TagSize:        128,
+			KeySize:        256,
+			IV:             base64.URLEncoding.EncodeToString(iv),
+			AdditionalData: base64.URLEncoding.EncodeToString(aad),
+		},
+		EncryptedData: base64.URLEncoding.EncodeToString(ciphertext),
+	}
+}
+
+func TestAccountUnlock_RoundTrip(t *testing.T) {
+	const password = "correct horse battery staple"
+	acc := buildTestAccount(t, password)
+
+	unlocked, err := acc.Unlock(password)
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if len(unlocked.PrivateKey) == 0 || len(unlocked.SigningKey) == 0 {
+		t.Fatalf("expected non-empty secrets, got %d/%d", len(unlocked.PrivateKey), len(unlocked.SigningKey))
+	}
+	if _, err := parseRSAPrivateKeyDER(unlocked.PrivateKey); err != nil {
+		t.Fatalf("private key did not round-trip: %v", err)
+	}
+}
+
+func TestAccountUnlock_WrongPassword(t *testing.T) {
+	acc := buildTestAccount(t, "right")
+	if _, err := acc.Unlock("wrong"); err == nil {
+		t.Fatalf("expected unlock with wrong password to fail")
+	}
+}
+
+func TestVault_RoundTrip_UpdateAccessors_Commit_Unlock(t *testing.T) {
+	acc := buildTestAccount(t, "pw")
+	unlocked, err := acc.Unlock("pw")
+	if err != nil {
+		t.Fatalf("unlock account: %v", err)
+	}
+
+	v := &Vault{
+		Kind:  "vault",
+		ID:    "v-1",
+		Name:  "main",
+		Owner: acc.ID,
+	}
+	if err := v.UpdateAccessors([]*UnlockedAccount{unlocked}); err != nil {
+		t.Fatalf("UpdateAccessors: %v", err)
+	}
+	if len(v.Accessors) != 1 || v.Accessors[0].ID != acc.ID {
+		t.Fatalf("expected single accessor for %s, got %+v", acc.ID, v.Accessors)
+	}
+
+	v.AddItems(VaultItem{ID: "item-1", Name: "TOTP", Type: VaultTypeTerminusTotp, Fields: []Field{{Name: "code", Type: FieldTypeTotp, Value: "JBSWY3DPEHPK3PXP"}}})
+	if err := v.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if len(v.EncryptedData) == 0 {
+		t.Fatalf("expected EncryptedData after Commit")
+	}
+
+	// Simulate a fresh fetch from the server: clear runtime state, then
+	// Unlock should restore the items.
+	cold := *v
+	cold.aesKey = nil
+	cold.items = nil
+
+	if err := cold.Unlock(unlocked); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	got := cold.ItemsCollection()
+	if len(got.Items) != 1 {
+		t.Fatalf("expected 1 item after Unlock, got %d", len(got.Items))
+	}
+	if got.Items["item-1"].Name != "TOTP" {
+		t.Fatalf("unexpected item: %+v", got.Items["item-1"])
+	}
+}
+
+func TestVaultItemCollection_MergePreservesLocalChanges(t *testing.T) {
+	local := NewVaultItemCollection()
+	local.Update(VaultItem{ID: "a", Name: "local-a"})
+
+	remote := NewVaultItemCollection()
+	remote.Items["a"] = VaultItem{ID: "a", Name: "remote-a"}
+	remote.Items["b"] = VaultItem{ID: "b", Name: "remote-b"}
+
+	local.Merge(remote)
+
+	if local.Items["a"].Name != "local-a" {
+		t.Fatalf("locally-changed item should win, got %q", local.Items["a"].Name)
+	}
+	if local.Items["b"].Name != "remote-b" {
+		t.Fatalf("expected remote-only item to be added, got %+v", local.Items["b"])
+	}
+}
+
+func TestVaultItemCollection_RoundTrip(t *testing.T) {
+	c := NewVaultItemCollection()
+	c.Update(VaultItem{ID: "x", Name: "X"}, VaultItem{ID: "y", Name: "Y"})
+	bytes, err := c.ToBytes()
+	if err != nil {
+		t.Fatalf("ToBytes: %v", err)
+	}
+	out := NewVaultItemCollection()
+	if err := out.FromBytes(bytes); err != nil {
+		t.Fatalf("FromBytes: %v", err)
+	}
+	if len(out.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(out.Items))
+	}
+	if out.Items["x"].Name != "X" || out.Items["y"].Name != "Y" {
+		t.Fatalf("unexpected items after round-trip: %+v", out.Items)
+	}
+}
+
+func TestDirKVStorage_PutGetListDelete(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewDirKVStorage(dir)
+	if err != nil {
+		t.Fatalf("NewDirKVStorage: %v", err)
+	}
+
+	in := map[string]string{"hello": "world"}
+	if err := s.Put("test", "k1", in); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	out := map[string]string{}
+	if err := s.Get("test", "k1", &out); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if out["hello"] != "world" {
+		t.Fatalf("expected world, got %q", out["hello"])
+	}
+
+	ids, err := s.List("test")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "k1" {
+		t.Fatalf("expected [k1], got %v", ids)
+	}
+
+	if err := s.Delete("test", "k1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	ids, _ = s.List("test")
+	if len(ids) != 0 {
+		t.Fatalf("expected empty list after delete, got %v", ids)
+	}
+}

--- a/cli/pkg/wizard/vault_crypto_test.go
+++ b/cli/pkg/wizard/vault_crypto_test.go
@@ -26,7 +26,10 @@ func buildTestAccount(t *testing.T, password string) *Account {
 	if err != nil {
 		t.Fatalf("marshal pub: %v", err)
 	}
-	privDER := x509.MarshalPKCS1PrivateKey(priv)
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal pkcs8 priv: %v", err)
+	}
 	signingKey := generateRandomBytes(32)
 
 	salt := generateRandomBytes(16)

--- a/cli/pkg/wizard/vault_crypto_test.go
+++ b/cli/pkg/wizard/vault_crypto_test.go
@@ -26,7 +26,10 @@ func buildTestAccount(t *testing.T, password string) *Account {
 	if err != nil {
 		t.Fatalf("marshal pub: %v", err)
 	}
-	privDER := x509.MarshalPKCS1PrivateKey(priv)
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal PKCS8: %v", err)
+	}
 	signingKey := generateRandomBytes(32)
 
 	salt := generateRandomBytes(16)
@@ -53,22 +56,25 @@ func buildTestAccount(t *testing.T, password string) *Account {
 		ID:        "acc-1",
 		DID:       "did:test:1",
 		Name:      "tester",
-		PublicKey: base64.URLEncoding.EncodeToString(pubDER),
+		PublicKey: base64.RawURLEncoding.EncodeToString(pubDER),
 		KeyParams: KeyParams{
 			Algorithm:  "PBKDF2",
 			Hash:       "SHA-256",
 			KeySize:    256,
 			Iterations: iter,
-			Salt:       base64.URLEncoding.EncodeToString(salt),
+			Salt:       base64.RawURLEncoding.EncodeToString(salt),
+			Version:    "4.0.0",
 		},
 		EncryptionParams: EncryptionParams{
 			Algorithm:      "AES-GCM",
 			TagSize:        128,
 			KeySize:        256,
-			IV:             base64.URLEncoding.EncodeToString(iv),
-			AdditionalData: base64.URLEncoding.EncodeToString(aad),
+			IV:             base64.RawURLEncoding.EncodeToString(iv),
+			AdditionalData: base64.RawURLEncoding.EncodeToString(aad),
+			Kind:           "r",
+			Version:        "4.0.0",
 		},
-		EncryptedData: base64.URLEncoding.EncodeToString(ciphertext),
+		EncryptedData: base64.RawURLEncoding.EncodeToString(ciphertext),
 	}
 }
 

--- a/cli/pkg/wizard/wizard.go
+++ b/cli/pkg/wizard/wizard.go
@@ -85,8 +85,8 @@ func (w *ActivationWizard) RunWizard() error {
 			return fmt.Errorf("activation failed with status: %s", status)
 		}
 
-		// Check in-progress status (ref: updateInfo line 238-244)
-		if status == "vault_activating" || status == "system_activating" || status == "network_activating" || status == "wait_activate_network" {
+		// Check in-progress / waiting statuses (ref: ActivateWizard.vue)
+		if status == "wait_activate_vault" || status == "vault_activating" || status == "system_activating" || status == "network_activating" || status == "wait_activate_network" {
 			log.Printf("⏳ System is %s, waiting...", status)
 		} else {
 			// Handle specific status (ref: updateInfo line 246-284)


### PR DESCRIPTION
## Summary

This branch reworks the CLI activation flow into a new `wizard` subcommand and brings the Go CLI's auth/vault behavior in line with the TS SDK (`apps/packages/sdk/src/core/app.ts`).

Highlights:

- New `olares-cli wizard activate` command (moved from `user activate`), with `--authurl` flag.
- App state persistence (`AppState`, `Storage`) plus vault crypto (encrypt/decrypt, key derivation) and synchronize logic ported from the TS SDK.
- Auth fixes: share cookie-jar HTTP client across firstfactor/secondfactor; post RPC requests directly to `baseURL`; treat `wait_activate_vault` as in-progress in the poll loop; align `Login` localvault merge with `app.ts`.
- Stop double-persisting vaults to per-id files (vaults are serialized inline in `AppState`).
- `TerminusDefaultDomain` switched to `olares.com`.
- `DeviceInfo.Platform` renamed `go-cli` -> `olares-cli`, with on-load migration for previously persisted devices.

## Commits

- fix(cli/wizard): rename device platform to olares-cli
- feat(cli/wizard): move activate command from user to new wizard subcommand
- fix(cli/wizard): share cookie-jar client across firstfactor/secondfactor
- fix(cli/wizard): stop double-persisting vaults to per-id files
- fix(cli/wizard): align Login localvault merge with TS app.ts
- feat(cli/wizard): add app state persistence, vault crypto, and synchronize
- fix(cli/wizard): post RPC requests directly to baseURL
- fix(cli/wizard): treat wait_activate_vault as in-progress in poll loop
- fix(cli): change TerminusDefaultDomain to olares.com
- feat(cli): add --authurl flag to user activate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches activation, authentication, RPC signing semantics, and vault cryptography/state persistence, so regressions could block logins or corrupt/lose vault data if the TS-compatibility assumptions are wrong.
> 
> **Overview**
> Introduces a new top-level `wizard` command and migrates the end-to-end activation flow from `user activate` to `wizard activate`, adding an `--authurl` override and wiring the command into the root CLI.
> 
> Reworks the `cli/pkg/wizard` implementation to **persist client state** (new `AppState` + filesystem `Storage` under `~/.olares/<did>`), add TS-SDK-compatible **vault/account crypto** (PKCS#8 private keys, AES-GCM/RSA-OAEP helpers), and implement **server synchronization** (`GetAuthInfo`/`GetOrg`/`GetVault`, vault merge/push, localvault migration) including TOTP item injection into the main vault.
> 
> Fixes several protocol/activation issues: RPC sender now POSTs directly to the provided endpoint, RPC `params` is always serialized (no `omitempty`) to avoid signature mismatches, first/second factor auth now shares a cookie-jar HTTP client and sends `X-Authorization` for TOTP, activation polling treats `wait_activate_vault` as in-progress, and default auth domain changes to `olares.com` with `DeviceInfo.Platform` migrated to `olares-cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bee11ba24b93de856594a2b59673817474a9d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->