### PR TITLE
vault: add DNS configuration options

### DIFF
--- a/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
+++ b/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
@@ -165,6 +165,9 @@ spec:
           value: vault_os_framework
         - name: PL_DATA_POSTGRES_PASSWORD
           value: {{ $pg_password | b64dec }}
+      dnsConfig:  
+        options:
+          - name: single-request-reopen
       volumes:
       - name: vault-data
         hostPath:


### PR DESCRIPTION
* **Background**
```
              single-request-reopen (since glibc 2.9)
                     Sets RES_SNGLKUPREOP in _res.options.  The resolver
                     uses the same socket for the A and AAAA requests.
                     Some hardware mistakenly sends back only one reply.
                     When that happens the client system will sit and
                     wait for the second reply.  Turning this option on
                     changes this behavior so that if two requests from
                     the same port are not handled correctly it will
                     close the socket and open a new one before sending
                     the second request.
```
add DNS option `single-request-reopen` to Vault Server container, to avoid DNS query response missing.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
Vault server responses errors when system activation

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only change that adjusts Kubernetes DNS resolver behavior for the Vault Server pod; main risk is unintended DNS behavior differences in-cluster.
> 
> **Overview**
> Adds a Kubernetes pod-level `dnsConfig` to the `vault-server` `Deployment`, enabling the resolver option `single-request-reopen` to mitigate intermittent DNS query issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9711a1932eaf7e13199543bf8b9edd805b512207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->