### PR TITLE
fix(bfl): check status before network activation reconcile

### DIFF
--- a/framework/bfl/pkg/watchers/network_activation/network_activation.go
+++ b/framework/bfl/pkg/watchers/network_activation/network_activation.go
@@ -60,8 +60,7 @@ func (s *Subscriber) Handler() cache.ResourceEventHandler {
 			if u.Name != constants.Username {
 				return false
 			}
-			status := u.Annotations[constants.UserTerminusWizardStatus]
-			return status == string(constants.NetworkActivating)
+			return isNetworkActivating(u)
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    handle,
@@ -84,6 +83,9 @@ func (s *Subscriber) Do(ctx context.Context, obj interface{}, _ watchers.Action)
 	current, err := userOp.GetUser(u.Name)
 	if err != nil {
 		return fmt.Errorf("get user failed: %w", err)
+	}
+	if !isNetworkActivating(current) {
+		return nil
 	}
 
 	terminusName := current.Annotations[constants.UserAnnotationTerminusNameKey]
@@ -139,6 +141,9 @@ func (s *Subscriber) markSuccess(ctx context.Context, user *iamV1alpha2.User, zo
 	}
 	return userOp.UpdateUser(user, []func(*iamV1alpha2.User){
 		func(u *iamV1alpha2.User) {
+			if !isNetworkActivating(u) {
+				return
+			}
 			if u.Annotations == nil {
 				u.Annotations = map[string]string{}
 			}
@@ -152,6 +157,13 @@ func (s *Subscriber) markSuccess(ctx context.Context, user *iamV1alpha2.User, zo
 	})
 }
 
+func isNetworkActivating(user *iamV1alpha2.User) bool {
+	if user == nil {
+		return false
+	}
+	return user.Annotations[constants.UserTerminusWizardStatus] == string(constants.NetworkActivating)
+}
+
 func (s *Subscriber) markFailed(ctx context.Context, user *iamV1alpha2.User, errorMsg string) error {
 	userOp, err := operator.NewUserOperatorWithContext(ctx)
 	if err != nil {
@@ -159,6 +171,9 @@ func (s *Subscriber) markFailed(ctx context.Context, user *iamV1alpha2.User, err
 	}
 	return userOp.UpdateUser(user, []func(*iamV1alpha2.User){
 		func(u *iamV1alpha2.User) {
+			if !isNetworkActivating(u) {
+				return
+			}
 			if u.Annotations == nil {
 				u.Annotations = map[string]string{}
 			}


### PR DESCRIPTION
* **Background**
The network activation watcher will do reconciliation and push the activation status to the password reset phase, if triggered twice shortly, the reconciliation might race with the password reset phase and cause a state revert, a check is added to avoid such race condition.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none 

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized gating change in a watcher to avoid race-driven status overwrites; main risk is skipping updates if status transitions unexpectedly.
> 
> **Overview**
> Adds a shared `isNetworkActivating` helper and uses it to **re-check the latest `UserTerminusWizardStatus`** before running network activation work.
> 
> `Do`, `markSuccess`, and `markFailed` now **no-op unless the current user status is still `NetworkActivating`**, preventing duplicate watcher triggers from overwriting a later wizard phase (e.g., password reset) and causing state regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0b279ab41a6bf46c22f3edf75f5155195b87f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->