### PR TITLE
fix(bfl): check status before network activation reconcile

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.44
+        image: beclab/bfl:v0.4.45
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/framework/bfl/pkg/watchers/network_activation/network_activation.go
+++ b/framework/bfl/pkg/watchers/network_activation/network_activation.go
@@ -60,8 +60,7 @@ func (s *Subscriber) Handler() cache.ResourceEventHandler {
 			if u.Name != constants.Username {
 				return false
 			}
-			status := u.Annotations[constants.UserTerminusWizardStatus]
-			return status == string(constants.NetworkActivating)
+			return isNetworkActivating(u)
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    handle,
@@ -84,6 +83,9 @@ func (s *Subscriber) Do(ctx context.Context, obj interface{}, _ watchers.Action)
 	current, err := userOp.GetUser(u.Name)
 	if err != nil {
 		return fmt.Errorf("get user failed: %w", err)
+	}
+	if !isNetworkActivating(current) {
+		return nil
 	}
 
 	terminusName := current.Annotations[constants.UserAnnotationTerminusNameKey]
@@ -139,6 +141,9 @@ func (s *Subscriber) markSuccess(ctx context.Context, user *iamV1alpha2.User, zo
 	}
 	return userOp.UpdateUser(user, []func(*iamV1alpha2.User){
 		func(u *iamV1alpha2.User) {
+			if !isNetworkActivating(u) {
+				return
+			}
 			if u.Annotations == nil {
 				u.Annotations = map[string]string{}
 			}
@@ -152,6 +157,13 @@ func (s *Subscriber) markSuccess(ctx context.Context, user *iamV1alpha2.User, zo
 	})
 }
 
+func isNetworkActivating(user *iamV1alpha2.User) bool {
+	if user == nil {
+		return false
+	}
+	return user.Annotations[constants.UserTerminusWizardStatus] == string(constants.NetworkActivating)
+}
+
 func (s *Subscriber) markFailed(ctx context.Context, user *iamV1alpha2.User, errorMsg string) error {
 	userOp, err := operator.NewUserOperatorWithContext(ctx)
 	if err != nil {
@@ -159,6 +171,9 @@ func (s *Subscriber) markFailed(ctx context.Context, user *iamV1alpha2.User, err
 	}
 	return userOp.UpdateUser(user, []func(*iamV1alpha2.User){
 		func(u *iamV1alpha2.User) {
+			if !isNetworkActivating(u) {
+				return
+			}
 			if u.Annotations == nil {
 				u.Annotations = map[string]string{}
 			}


### PR DESCRIPTION
* **Background**
The network activation watcher will do reconciliation and push the activation status to the password reset phase, if triggered twice shortly, the reconciliation might race with the password reset phase and cause a state revert, a check is added to avoid such race condition.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none 

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the network-activation state transition logic and updates the deployed `bfl` image tag, which could affect user onboarding flow if the status checks are incorrect. Scope is small and mainly adds early-exit guards to prevent races.
> 
> **Overview**
> Prevents network-activation reconciliation from overwriting later wizard phases by **re-checking the user’s wizard status** (`NetworkActivating`) before running the reconcile and again inside `markSuccess`/`markFailed` updates.
> 
> Also bumps the `bfl` StatefulSet container image from `beclab/bfl:v0.4.44` to `beclab/bfl:v0.4.45` in the launcher template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e827272ca4d438267c8c70b766a6b75d133d8d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->