### PR TITLE
daemon: extend ignored filesystem types to include CIFS, SMB, NFS

### DIFF
--- a/daemon/pkg/utils/filesystem.go
+++ b/daemon/pkg/utils/filesystem.go
@@ -27,7 +27,7 @@ type FilesystemStat struct {
 
 const (
 	ignoredMountPointsPattern = "^/(dev|proc|sys|var/lib/docker/.+|var/lib/containerd/.+|var/lib/kubelet/.+)($|/)"
-	ignoredFSTypesPattern     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+	ignoredFSTypesPattern     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|cifs|smb|nfs|nfs4)$"
 )
 
 func GetNodeFilesystemTotalSize() (uint64, error) {

--- a/daemon/pkg/utils/filesystem.go
+++ b/daemon/pkg/utils/filesystem.go
@@ -27,7 +27,7 @@ type FilesystemStat struct {
 
 const (
 	ignoredMountPointsPattern = "^/(dev|proc|sys|var/lib/docker/.+|var/lib/containerd/.+|var/lib/kubelet/.+)($|/)"
-	ignoredFSTypesPattern     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|cifs|smb|nfs|nfs4)$"
+	ignoredFSTypesPattern     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|cifs|smb3|smb|nfs|nfs4)$"
 )
 
 func GetNodeFilesystemTotalSize() (uint64, error) {


### PR DESCRIPTION
* **Background**
Ignore the CIFS, SMB, NFS mount points when getting the disk size

* **Target Version for Merge**
v1.12.6, v1.127

* **Related Issues**
Olaresd hung in 2 minutes when getting the node state if the mount point is broken

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small regex filter change that only affects which mount types are included in disk-size/stat collection, with minimal blast radius beyond reported node filesystem metrics.
> 
> **Overview**
> Updates the filesystem stats filtering to **exclude network filesystem types** by default.
> 
> `ignoredFSTypesPattern` now ignores `cifs`, `smb*`, and `nfs*` mounts, preventing size/stat collection from touching potentially broken network mounts (and avoiding hangs during node state gathering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e0fc4a6e764177e21229c4768bebba8e78771f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->