### PR TITLE
fix: fix hash value like search sort order

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -241,7 +241,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.1.8
+        image: beclab/search3:v0.1.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -302,7 +302,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.1.8
+        image: beclab/search3monitor:v0.1.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.1.8
+        image: beclab/search3validation:v0.1.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: fix hash value like search sort order
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
when file name like "3f40f02d9827a692", search sort order error, then miss right target

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.6
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/171
* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rolls forward the core search service, monitor daemonset, and validation webhook binaries; any behavioral change is entirely driven by the new images.
> 
> **Overview**
> Updates the cluster deployment manifests to roll `search3`, `search3monitor`, and the `search3-validation` webhook from `v0.1.8` to `v0.1.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7596e8b6463737dba88ce098569f28a77853af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->