### PR TITLE
docs: add example output for multi-node cluster

### DIFF
--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -138,7 +138,6 @@ kubectl get nodes
 
 Example output:
 ```bash
-olares@oloares:~$ kubectl get nodes
 NAME            STATUS   ROLES                         AGE   VERSION
 olares          Ready    control-plane,master,worker   2h    v1.33.3+k3s1
 olares-worker   Ready    worker                        50m   v1.33.3+k3s1

--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -136,6 +136,14 @@ Check the status of all nodes in the Kubernetes cluster with the following comma
 kubectl get nodes
 ```
 
+Example output:
+```bash
+olares@oloares:~$ kubectl get nodes
+NAME            STATUS   ROLES                         AGE   VERSION
+olares          Ready    control-plane,master,worker   2h    v1.33.3+k3s1
+olares-worker   Ready    worker                        50m   v1.33.3+k3s1
+```
+
 ## Resources
 - [Olares CLI](../developer/install/cli/node.md): Explore the Olares CLI.
 - [Olares environment variables](../developer/install/environment-variables.md): Learn about the environment variables that enable advanced configurations of Olares.


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
1.12
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an illustrative command output snippet; no code or behavior changes.
> 
> **Overview**
> Adds an **example `kubectl get nodes` output block** to the multi-node cluster setup guide (`docs/one/connect-two-olares-one.md`) so readers can verify what a healthy master/worker join looks like during *Step 3: Verify the cluster*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f53702e7baabf45b174cb0db3e4c74442597ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->