### PR TITLE
files(feat): notify terminusd /v1/new_items after posix upload completes

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.158
+          image: beclab/files-server:v0.2.162
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -248,6 +248,8 @@ spec:
             - name: TERMINUSD_HOST
               value: $(NODE_IP):18088  
 {{ end }}
+            - name: UPLOAD_WEBHOOK_ENABLED
+              value: "True"
             - name: EXTERNAL_PREFIX
               value: '/External/'
             - name: ES_ENABLED


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
notify terminusd /v1/new_items after posix upload completes

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/files/pull/200
https://github.com/beclab/files/pull/202


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the deployed `files-server` image version and turns on `UPLOAD_WEBHOOK_ENABLED`, which can alter upload post-processing/notifications behavior at runtime. Risk is moderate because it affects production deployment configuration, but scope is limited to a single workload env var and image tag bump.
> 
> **Overview**
> Updates the `files` DaemonSet deployment to use `beclab/files-server:v0.2.162` (from `v0.2.158`) and enables upload webhooks by setting `UPLOAD_WEBHOOK_ENABLED="True"` for the `files` container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8411df60f7cd265b1a2c3add29822b28582d84ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->