### PR TITLE
provide clearer semantic meaning

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -342,7 +342,7 @@ func (h *installHandlerHelper) resolveInstallType(appConfig *appcfg.ApplicationC
 		return "", err
 	}
 	if !exists {
-		return appcfg.InstallOrUpgradeServerAndClient, nil
+		return appcfg.InstallOrUpgradeClientAndServer, nil
 	}
 	return appcfg.InstallOrUpgradeClientOnly, nil
 }

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -219,7 +219,7 @@ func (h *upgradeHandlerHelper) resolveUpgradeType(appConfig *appcfg.ApplicationC
 		return appcfg.InstallOrUpgradeV1
 	}
 	if isAdmin {
-		return appcfg.InstallOrUpgradeServerAndClient
+		return appcfg.InstallOrUpgradeClientAndServer
 	}
 	return appcfg.InstallOrUpgradeClientOnly
 }

--- a/framework/app-service/pkg/appcfg/appcfg_types.go
+++ b/framework/app-service/pkg/appcfg/appcfg_types.go
@@ -43,8 +43,8 @@ type AppConfiguration struct {
 	// Only for v2 c/s apps to share the api to other cluster scope apps
 	SharedEntrances []v1alpha1.Entrance `yaml:"sharedEntrances,omitempty" json:"sharedEntrances,omitempty"`
 
-	Server *ConfigOverlay `yaml:"server,omitempty" json:"server,omitempty"`
-	Client *ConfigOverlay `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientAndServer *ConfigOverlay `yaml:"clientAndServer,omitempty" json:"clientAndServer,omitempty"`
+	Client          *ConfigOverlay `yaml:"client,omitempty" json:"client,omitempty"`
 }
 
 type AppSpec struct {
@@ -210,7 +210,7 @@ type SpecialResource struct {
 
 const (
 	InstallOrUpgradeClientOnly      string = "clientOnly"
-	InstallOrUpgradeServerAndClient string = "clientAndServer"
+	InstallOrUpgradeClientAndServer string = "clientAndServer"
 	InstallOrUpgradeV1              string = "v1"
 )
 

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -105,7 +105,7 @@ type ApplicationConfig struct {
 	Resources            []ResourceMode
 	InstallType          string
 	Client               *ConfigOverlay
-	Server               *ConfigOverlay
+	ClientAndServer      *ConfigOverlay
 }
 
 func (c *ApplicationConfig) IsMiddleware() bool {
@@ -201,8 +201,8 @@ func (c *ApplicationConfig) applyConfigOverlay(installType string) {
 	var overlay *ConfigOverlay
 	klog.Infof("applyConfigOverlay: installType: %v", installType)
 	switch installType {
-	case InstallOrUpgradeServerAndClient:
-		overlay = c.Server
+	case InstallOrUpgradeClientAndServer:
+		overlay = c.ClientAndServer
 	case InstallOrUpgradeClientOnly:
 		overlay = c.Client
 	}
@@ -281,7 +281,7 @@ func (c *ApplicationConfig) ResolveRequirement(selectedGpu, installType string) 
 		}
 		req := parseResourceRequirement(mode.Client)
 		return &req, nil
-	case InstallOrUpgradeServerAndClient:
+	case InstallOrUpgradeClientAndServer:
 		req := sumResourceRequirements(mode.Server, mode.Client)
 		return &req, nil
 	}

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -149,14 +149,19 @@ func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig
 		}
 	}
 
-	values["client"] = true
-	if appConfig.InstallType == appcfg.InstallOrUpgradeServerAndClient {
-		values["server"] = true
+	if appConfig.APIVersion == appcfg.V2 {
+		values["client"] = true
+		if appConfig.InstallType == appcfg.InstallOrUpgradeClientAndServer {
+			values["clientAndServer"] = true
+			values["client"] = false
+		}
+
+		if isUpgrade && isAdmin {
+			values["clientAndServer"] = true
+			values["client"] = false
+		}
 	}
 
-	if isUpgrade && isAdmin {
-		values["server"] = true
-	}
 	return values, nil
 }
 

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -975,7 +975,7 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		SelectedGpuType:      opt.SelectedGpu,
 		Resources:            cfg.Spec.Resources,
 		Client:               cfg.Client,
-		Server:               cfg.Server,
+		ClientAndServer:      cfg.ClientAndServer,
 	}, chart, nil
 }
 


### PR DESCRIPTION


* **Background**
manifest field provide clearer semantic meaning

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the manifest schema/overlay field names and the install/upgrade type constant used to drive overlay selection and Helm values, which could break v2 install/upgrade behavior if any charts or manifests still rely on the old keys.
> 
> **Overview**
> Clarifies v2 install/upgrade semantics by renaming the combined install type from `serverAndClient` to `clientAndServer` and consolidating the manifest overlay from separate `server`/`client` sections into `clientAndServer` plus `client`.
> 
> Install/upgrade resolution, overlay application, resource requirement calculation, and Helm value generation are updated to use the new `clientAndServer` mode (including setting `.Values.clientAndServer` and disabling `.Values.client` when both parts are needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4d848943cfd3cab2619aed2035c3283878ba42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->