### PR TITLE
feat(olares-app): release new version to v1.10.18

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -440,7 +440,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.89
+          image: beclab/user-service:v0.0.90
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -318,7 +318,7 @@ spec:
             chown -R 1000:1000 /uploadstemp && \
             chown -R 1000:1000 /appdata 
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.17
+          image: beclab/system-frontend:v1.10.18
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -23,7 +23,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.10
+        image: beclab/monitoring-server-v1:v0.3.11
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**
olares-app: files adapt for mobile
dashboard: optimize the application list
desktop: WebSocket reconnect when SharedWorker 

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1077
https://github.com/beclab/TermiPass/pull/1078
https://github.com/beclab/TermiPass/pull/1079
https://github.com/beclab/user-service/pull/74
https://github.com/beclab/user-service/pull/73

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this only updates container image tags, but the new `system-frontend`, `user-service`, and `monitoring-server` versions can change runtime behavior across core UI, user-space services, and monitoring.
> 
> **Overview**
> Updates Kubernetes/Helm deployment manifests to roll forward released container versions.
> 
> `olares-app` now uses `beclab/system-frontend:v1.10.18` (init container) and bumps `beclab/user-service` to `v0.0.90`, and the monitoring stack bumps `beclab/monitoring-server-v1` to `v0.3.11`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9408a837bddd1c693ccdd53634cadc8b926aeae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->