### PR TITLE
fix(cli): post-merge Bugbot fixes for market + files

### DIFF
--- a/cli/cmd/ctl/files/path.go
+++ b/cli/cmd/ctl/files/path.go
@@ -76,31 +76,31 @@ type FrontendPath struct {
 	Extend string
 	// SubPath is the path inside Extend, always starting with '/'. Root is "/".
 	// A trailing slash present in the input is preserved (the backend uses it
-	// as a "this is a directory" hint in some places).
+	// as a "this is a directory" hint in some places). It is also synthesized
+	// for `<fileType>/<extend>` (no subpath), where the only valid backend
+	// interpretation is "the extend root", because the backend's
+	// FileParam.convert() splits on '/' and rejects len < 3 for non-root
+	// resources.
 	SubPath string
-	// trailingSlash records whether the original input ended with '/'. It's
-	// preserved through String() so we don't accidentally drop the trailing
-	// slash that the backend's FileParam.convert() requires for directory
-	// listings (it splits on '/' and rejects len < 3).
-	trailingSlash bool
 }
 
 // ParseFrontendPath parses a user-supplied path string into a FrontendPath.
 //
 // Examples:
 //
-//	"drive/Home/"                    → {drive, Home, "/", trailingSlash}
+//	"drive/Home/"                    → {drive, Home, "/"}
+//	"drive/Home"                     → {drive, Home, "/"}    (root synthesized)
 //	"drive/Home/Documents"           → {drive, Home, "/Documents"}
-//	"drive/Home/Documents/"          → {drive, Home, "/Documents/", trailingSlash}
+//	"drive/Home/Documents/"          → {drive, Home, "/Documents/"}
 //	"sync/<repo_id>/sub/dir"         → {sync, <repo_id>, "/sub/dir"}
 //	"awss3/<account>/<bucket>/k.txt" → {awss3, <account>, "/<bucket>/k.txt"}
 //
 // Validation:
 //   - Path must have at least 2 non-empty segments (fileType + extend).
-//     `drive/Home` (no trailing slash) is accepted by ParseFrontendPath but
-//     callers that hit /api/resources will need a trailing slash to satisfy
-//     the backend's len(split) >= 3 check; String() preserves it from the
-//     original input.
+//     `drive/Home` (no trailing slash, no subpath) is accepted and treated as
+//     the extend root, because the backend's FileParam.convert() splits on
+//     '/' and rejects len < 3 — there is no valid reading of a bare extend
+//     other than "the root directory".
 //   - FileType must be a known value (case-sensitive lowercase). Unknown
 //     values fail fast on the client to avoid an opaque 500 from the server.
 //   - When FileType=="drive", Extend must be "Home" or "Data" (case-sensitive).
@@ -155,10 +155,9 @@ func ParseFrontendPath(raw string) (FrontendPath, error) {
 	}
 
 	return FrontendPath{
-		FileType:      fileType,
-		Extend:        extend,
-		SubPath:       sub,
-		trailingSlash: hadTrailingSlash,
+		FileType: fileType,
+		Extend:   extend,
+		SubPath:  sub,
 	}, nil
 }
 
@@ -183,7 +182,13 @@ func (p FrontendPath) URLPath() string {
 	return encodepath.EncodeURL(p.String())
 }
 
-// HasTrailingSlash reports whether the original input ended with '/'. Useful
-// for callers that want to disambiguate "list this directory" from "fetch this
-// resource by exact name" without re-parsing.
-func (p FrontendPath) HasTrailingSlash() bool { return p.trailingSlash }
+// HasTrailingSlash reports whether String() ends with '/' — i.e. whether the
+// path represents a directory. Useful for callers that want to disambiguate
+// "list this directory" from "fetch this resource by exact name" without
+// re-parsing. Derived from SubPath so it always agrees with String(); in
+// particular, `<fileType>/<extend>` (no subpath, no trailing slash on input)
+// reports true because SubPath is "/" — the only valid interpretation of a
+// bare extend reference is its root directory.
+func (p FrontendPath) HasTrailingSlash() bool {
+	return strings.HasSuffix(p.SubPath, "/")
+}

--- a/cli/cmd/ctl/files/path_test.go
+++ b/cli/cmd/ctl/files/path_test.go
@@ -26,6 +26,19 @@ func TestParseFrontendPath(t *testing.T) {
 			wantString:   "drive/Home/",
 		},
 		{
+			// Regression: previously HasTrailingSlash() reported false here
+			// while String() rendered "drive/Home/" — an inconsistency that
+			// misled callers branching on directory-vs-file. The bare
+			// `<fileType>/<extend>` form has no valid non-directory reading.
+			name:         "drive Home root without trailing slash",
+			input:        "drive/Home",
+			wantFileType: "drive",
+			wantExtend:   "Home",
+			wantSubPath:  "/",
+			wantTrailing: true,
+			wantString:   "drive/Home/",
+		},
+		{
 			name:         "drive Home subdir",
 			input:        "drive/Home/Documents",
 			wantFileType: "drive",

--- a/cli/cmd/ctl/files/upload.go
+++ b/cli/cmd/ctl/files/upload.go
@@ -164,6 +164,13 @@ func runUpload(
 		if err != nil {
 			return fmt.Errorf("fetch upload nodes: %w", err)
 		}
+		// Defense in depth: client.FetchNodes already errors on empty
+		// data, but guard the index so a future regression in the
+		// lower layer surfaces as a clean error here instead of an
+		// "index out of range" panic at the call site.
+		if len(nodes) == 0 {
+			return fmt.Errorf("upload node list returned by /api/nodes/ is empty")
+		}
 		// Mirrors the web app's getUploadNode() — first node wins. A
 		// future iteration can pick by master flag or by --node, but
 		// the web app's default is good enough for the common case.

--- a/cli/cmd/ctl/market/get.go
+++ b/cli/cmd/ctl/market/get.go
@@ -154,7 +154,12 @@ func resolveI18nField(m map[string]interface{}, path ...string) string {
 		return ""
 	}
 	fieldName := path[len(path)-1]
-	i18nPath := append(path[:len(path)-1], "i18n")
+	// Allocate a fresh slice so we don't mutate the caller's variadic
+	// argument: append(path[:len(path)-1], "i18n") would write "i18n" into
+	// path[len(path)-1] whenever path has spare capacity.
+	i18nPath := make([]string, 0, len(path))
+	i18nPath = append(i18nPath, path[:len(path)-1]...)
+	i18nPath = append(i18nPath, "i18n")
 
 	i18n := getNestedValue(m, i18nPath...)
 	i18nMap, ok := i18n.(map[string]interface{})

--- a/cli/cmd/ctl/market/get_test.go
+++ b/cli/cmd/ctl/market/get_test.go
@@ -1,0 +1,54 @@
+package market
+
+import "testing"
+
+// TestResolveI18nFieldDoesNotMutateCaller locks down the slice-aliasing fix in
+// resolveI18nField: append(path[:len(path)-1], "i18n") used to write "i18n"
+// into path[len(path)-1] whenever the caller's variadic slice had spare
+// capacity, silently corrupting the caller's data.
+func TestResolveI18nFieldDoesNotMutateCaller(t *testing.T) {
+	t.Run("happy path returns localized value", func(t *testing.T) {
+		// Mirror the call shape used in printAppDetail: callers pass
+		// "i18n" as the second-to-last segment, so resolveI18nField
+		// strips the trailing field name and re-appends "i18n",
+		// landing on m.app_info.app_entry.i18n.i18n.<locale>.metadata.<field>.
+		m := map[string]interface{}{
+			"app_info": map[string]interface{}{
+				"app_entry": map[string]interface{}{
+					"i18n": map[string]interface{}{
+						"i18n": map[string]interface{}{
+							"en-US": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"title": "Firefox",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		got := resolveI18nField(m, "app_info", "app_entry", "i18n", "title")
+		if got != "Firefox" {
+			t.Fatalf("resolveI18nField = %q, want %q", got, "Firefox")
+		}
+	})
+
+	t.Run("does not mutate caller's variadic slice", func(t *testing.T) {
+		// Build a slice with explicit spare capacity. Without the fix,
+		// append(path[:len(path)-1], "i18n") would land in the
+		// final slot and overwrite "title" with "i18n".
+		path := make([]string, 4, 8)
+		path[0], path[1], path[2], path[3] = "app_info", "app_entry", "i18n", "title"
+
+		m := map[string]interface{}{} // i18n map missing → resolveI18nField returns ""
+		_ = resolveI18nField(m, path...)
+
+		want := []string{"app_info", "app_entry", "i18n", "title"}
+		for i, w := range want {
+			if path[i] != w {
+				t.Fatalf("path[%d] = %q after call, want %q (caller's slice was mutated)",
+					i, path[i], w)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Three small, independently-reviewable Bugbot fixes that landed against #2949 after merge. Each one is a separate commit so reviewers can take them one at a time.

- **`fix(cli): clone variadic path in market resolveI18nField`** — `append(path[:len(path)-1], "i18n")` mutated the caller's variadic slice whenever it had spare capacity. Allocate a fresh prefix and add `TestResolveI18nFieldDoesNotMutateCaller`. Addresses Bugbot [`3143232464`](https://github.com/beclab/Olares/pull/2949#issuecomment-3143232464).
- **`fix(cli): guard empty /api/nodes/ response in files upload`** — `runUpload` indexed `nodes[0]` without a length check, panicking on an empty list. `client.FetchNodes` already errors on empty data, but the call-site guard makes the failure mode explicit. Addresses Bugbot [`3143056106`](https://github.com/beclab/Olares/pull/2949#issuecomment-3143056106).
- **`fix(cli): derive HasTrailingSlash from SubPath for parse consistency`** — `HasTrailingSlash()` reported the raw-input flag, which disagreed with `String()` for `drive/Home` (no trailing slash, no subpath). Derive `HasTrailingSlash()` from `strings.HasSuffix(SubPath, "/")` so it always agrees with `String()`. Adds a dedicated `drive/Home` test case. Addresses Bugbot [`3143065025`](https://github.com/beclab/Olares/pull/2949#issuecomment-3143065025).

The other four Bugbot reports from #2949 (`3142103059`, `3142103064`, `3142103065`, `3143042187`) were already fixed in earlier follow-up commits inside #2949 itself; no additional work is needed for them in this PR.

`.gitignore` cleanups (`/files/`, `/market/`, `cli/docs/`) and the concurrent `fmt.Fprintf` in `cli/cmd/ctl/files/upload.go` are intentionally out of scope (deferred per request / pre-existing low-severity).

## Test plan

- [x] `cd cli && go build ./...`
- [x] `cd cli && go vet ./cmd/ctl/market/... ./cmd/ctl/files/... ./internal/files/...`
- [x] `cd cli && go test ./cmd/ctl/market/... ./cmd/ctl/files/... ./internal/files/...` — all green, including the new `TestResolveI18nFieldDoesNotMutateCaller` and the new `drive/Home` no-trailing-slash case in `path_test.go`.
- [ ] Manual smoke: `olares-cli market get firefox` still resolves the i18n title (covered indirectly by the test fixture mirroring the production call shape).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive fixes in CLI-only helpers (path parsing, upload node selection, and market i18n field lookup) plus added regression tests; no protocol or data model changes.
> 
> **Overview**
> Fixes a `files` path parsing inconsistency by deriving `FrontendPath.HasTrailingSlash()` from `SubPath`, and treats bare `<fileType>/<extend>` (e.g. `drive/Home`) as the extend root so `String()`/directory semantics always agree; adds a regression test for the no-trailing-slash root case.
> 
> Hardens `files upload` by explicitly erroring when `/api/nodes/` returns an empty list before indexing `nodes[0]`, avoiding a potential panic.
> 
> Prevents `market get`’s `resolveI18nField` from mutating the caller’s variadic `path` slice by allocating a new slice before appending, and adds a dedicated unit test to lock down the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a60b1e929489e10a14cd7d1ec84c209c2e73dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->