### PR TITLE
feat(cli): auto-rotate access_token on 401/403 with cross-process flock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ cli/olares-cli*
 
 framework/app-service/bin
 
-/files/
-/market/
+files/
+market/
+user-service/

--- a/cli/cmd/ctl/files/cat.go
+++ b/cli/cmd/ctl/files/cat.go
@@ -70,11 +70,13 @@ func runCat(ctx context.Context, f *cmdutil.Factory, out io.Writer, remoteArg st
 		return err
 	}
 
-	httpClient := newUploadHTTPClient(rp.InsecureSkipVerify)
+	httpClient, err := f.HTTPClientWithoutTimeout(ctx)
+	if err != nil {
+		return err
+	}
 	client := &download.Client{
-		HTTPClient:  httpClient,
-		BaseURL:     rp.FilesURL,
-		AccessToken: rp.AccessToken,
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
 	}
 
 	plain := strings.TrimSuffix(fp.String(), "/")

--- a/cli/cmd/ctl/files/download.go
+++ b/cli/cmd/ctl/files/download.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/internal/files/download"
 )
 
@@ -136,11 +137,13 @@ func runDownload(
 		return err
 	}
 
-	httpClient := newUploadHTTPClient(rp.InsecureSkipVerify)
+	httpClient, err := f.HTTPClientWithoutTimeout(ctx)
+	if err != nil {
+		return err
+	}
 	client := &download.Client{
-		HTTPClient:  httpClient,
-		BaseURL:     rp.FilesURL,
-		AccessToken: rp.AccessToken,
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
 	}
 
 	// Stat first so we (a) reject auth errors / 404s with a clean
@@ -343,9 +346,24 @@ func resolveLocalFile(localArg, remoteBase string) (string, error) {
 // share the helper directly because the download package's HTTPError
 // type isn't compatible with the upload package's, and untyped
 // duck-typing here would be more confusing than the small duplication.
+//
+// The factory's refreshingTransport may return a typed credential
+// error (ErrTokenInvalidated / ErrNotLoggedIn) wrapped inside
+// *url.Error when /api/refresh itself fails. We surface those
+// directly — their Error() already carries the canonical CTA, and
+// re-wrapping with our own "server rejected" wording would just bury
+// the real diagnosis under a layer of "Get https://...:".
 func reformatHTTPErr(err error, olaresID, op, target string) error {
 	if err == nil {
 		return nil
+	}
+	var inv *credential.ErrTokenInvalidated
+	if errors.As(err, &inv) {
+		return inv
+	}
+	var nli *credential.ErrNotLoggedIn
+	if errors.As(err, &nli) {
+		return nli
 	}
 	var hErr *download.HTTPError
 	if errors.As(err, &hErr) {

--- a/cli/cmd/ctl/files/rm.go
+++ b/cli/cmd/ctl/files/rm.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/internal/files/rm"
 )
 
@@ -167,11 +168,13 @@ func runRm(
 	if err != nil {
 		return err
 	}
-	httpClient := newUploadHTTPClient(rp.InsecureSkipVerify)
+	httpClient, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
 	client := &rm.Client{
-		HTTPClient:  httpClient,
-		BaseURL:     rp.FilesURL,
-		AccessToken: rp.AccessToken,
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
 	}
 
 	// Serial DELETE per group. Per-group failures abort the rest:
@@ -258,10 +261,20 @@ func readYesNo(in io.Reader) (bool, error) {
 }
 
 // reformatRmHTTPErr maps rm.HTTPError onto user-friendly messages,
-// same spirit as the download counterpart.
+// same spirit as the download counterpart. Typed credential errors
+// from the refreshing transport are surfaced verbatim — see
+// reformatHTTPErr in download.go for the rationale.
 func reformatRmHTTPErr(err error, olaresID string, g *rm.Group) error {
 	if err == nil {
 		return nil
+	}
+	var inv *credential.ErrTokenInvalidated
+	if errors.As(err, &inv) {
+		return inv
+	}
+	var nli *credential.ErrNotLoggedIn
+	if errors.As(err, &nli) {
+		return nli
 	}
 	var hErr *rm.HTTPError
 	if errors.As(err, &hErr) {

--- a/cli/cmd/ctl/files/upload.go
+++ b/cli/cmd/ctl/files/upload.go
@@ -2,10 +2,8 @@ package files
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -144,18 +142,20 @@ func runUpload(
 		return err
 	}
 
-	// Build a dedicated *http.Client for the upload session: same
-	// X-Authorization injection convention as the rest of the CLI, but
-	// without the factory's 30s overall timeout — an 8 MiB chunk on a
-	// slow link can easily exceed that, and we'd rather fail via
-	// context cancellation than via http.Client.Timeout (the latter
-	// truncates the request body mid-flight, which leaves the server
-	// in an inconsistent state).
-	httpClient := newUploadHTTPClient(rp.InsecureSkipVerify)
+	// Use the factory's no-timeout client for the upload session: an
+	// 8 MiB chunk on a slow link can easily exceed the standard 30s
+	// timeout, and we'd rather fail via context cancellation than
+	// via http.Client.Timeout (the latter truncates the request body
+	// mid-flight, which leaves the server in an inconsistent state).
+	// X-Authorization injection + refresh-on-401 are handled by the
+	// factory's refreshingTransport.
+	httpClient, err := f.HTTPClientWithoutTimeout(ctx)
+	if err != nil {
+		return err
+	}
 	client := &upload.Client{
-		HTTPClient:  httpClient,
-		BaseURL:     rp.FilesURL,
-		AccessToken: rp.AccessToken,
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
 	}
 
 	node := o.node
@@ -302,28 +302,6 @@ func runUploads(
 	}
 	fmt.Fprintf(out, "done: %d file(s), %s\n", completed, formatBytes(bytesDone))
 	return nil
-}
-
-// newUploadHTTPClient builds a *http.Client suitable for streaming
-// chunks: TLS verification follows the active profile, NO overall
-// Timeout (we rely on context cancellation), and explicit keep-alive +
-// HTTP/2 from http.DefaultTransport.
-//
-// The X-Authorization header is injected per-request inside upload.Client
-// (rather than via a transport wrapper) so the same Client can talk to
-// httptest servers in tests without dragging the access token into the
-// fixture surface.
-func newUploadHTTPClient(insecureSkipVerify bool) *http.Client {
-	base := http.DefaultTransport.(*http.Transport).Clone()
-	if insecureSkipVerify {
-		base.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- explicit profile opt-in
-	}
-	return &http.Client{
-		// Timeout: 0 — no overall request timeout. Big chunks on slow
-		// links would otherwise truncate mid-POST. Cancellation flows
-		// through context (Ctrl-C / parent ctx).
-		Transport: base,
-	}
 }
 
 // pluralYies turns 1 → "y" and any other number → "ies", so the user-

--- a/cli/cmd/ctl/market/client.go
+++ b/cli/cmd/ctl/market/client.go
@@ -3,8 +3,8 @@ package market
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -31,40 +31,45 @@ type APIResponse struct {
 // MarketClient talks to the per-user app-store v2 API at
 // `<MarketURL>/app-store/api/v2`. It is the moral counterpart of `files`'s
 // `download.Client`: a thin HTTP wrapper that delegates auth to the caller's
-// http.Client (Factory's authTransport injects `X-Authorization`) and
-// otherwise just maps Go method calls to JSON requests.
+// http.Client (Factory's refreshingTransport injects `X-Authorization` and
+// transparently refreshes on 401/403) and otherwise just maps Go method
+// calls to JSON requests.
 //
 // Two HTTP clients are stored:
-//   - httpClient comes from cmdutil.Factory and inherits the 30s overall
-//     timeout + authTransport injection. Used for short JSON requests.
-//   - For multipart chart uploads we build a per-call client without an
-//     overall timeout (see newMarketUploadHTTPClient) and inject the access
-//     token manually, mirroring files/upload.go's `newUploadHTTPClient`.
+//   - httpClient is the factory's standard 30s-timeout client; used for
+//     short JSON requests.
+//   - uploadClient is the factory's no-timeout client for multipart chart
+//     uploads. Both share the same refreshingTransport instance under the
+//     hood, so a refresh triggered through one is immediately visible to
+//     the other.
 type MarketClient struct {
-	httpClient *http.Client
-	baseURL    string
-	source     string
+	httpClient   *http.Client
+	uploadClient *http.Client
+	baseURL      string
+	source       string
 
-	// Identity bits captured from the resolved profile, used by:
-	//   - OperationResult.User (for diagnostics / scripting),
-	//   - upload helper to build the long-timeout client + X-Authorization.
-	olaresID           string
-	accessToken        string
-	insecureSkipVerify bool
+	// olaresID is captured for OperationResult.User (diagnostics /
+	// scripting) and for reformatting 401/403 messages with the user's
+	// own ID in the CTA.
+	olaresID string
 }
 
-// NewMarketClient builds a MarketClient from a factory-provided http.Client
-// (already wired with X-Authorization injection) and a resolved profile.
-// The base URL is `<rp.MarketURL>/app-store/api/v2`.
-func NewMarketClient(hc *http.Client, rp *credential.ResolvedProfile, source string) *MarketClient {
+// NewMarketClient builds a MarketClient from factory-provided http.Clients
+// (both already wired with refreshingTransport so X-Authorization injection
+// + refresh-on-401 happen transparently) and a resolved profile. The base
+// URL is `<rp.MarketURL>/app-store/api/v2`.
+//
+// hc is the standard timed client used for JSON requests; uploadHC is the
+// no-timeout client used for multipart chart uploads. Pass the same client
+// for both if streaming uploads aren't expected.
+func NewMarketClient(hc, uploadHC *http.Client, rp *credential.ResolvedProfile, source string) *MarketClient {
 	base := strings.TrimRight(rp.MarketURL, "/") + apiPrefix
 	return &MarketClient{
-		httpClient:         hc,
-		baseURL:            base,
-		source:             source,
-		olaresID:           rp.OlaresID,
-		accessToken:        rp.AccessToken,
-		insecureSkipVerify: rp.InsecureSkipVerify,
+		httpClient:   hc,
+		uploadClient: uploadHC,
+		baseURL:      base,
+		source:       source,
+		olaresID:     rp.OlaresID,
 	}
 }
 
@@ -114,30 +119,32 @@ func (c *MarketClient) doMultipart(ctx context.Context, path, filename string, d
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Accept", "application/json")
-	// authTransport on c.httpClient also injects X-Authorization, but we use
-	// the dedicated upload client (no overall timeout) and add the header
-	// here ourselves — same pattern as files/upload.go.
-	if c.accessToken != "" {
-		req.Header.Set("X-Authorization", c.accessToken)
-	}
-
-	return c.executeRequest(newMarketUploadHTTPClient(c.insecureSkipVerify), req)
-}
-
-// newMarketUploadHTTPClient is the sibling of files/upload.go's
-// newUploadHTTPClient: same TLS knob, no overall Timeout (we rely on context
-// cancellation), no authTransport (the caller sets X-Authorization).
-func newMarketUploadHTTPClient(insecureSkipVerify bool) *http.Client {
-	base := http.DefaultTransport.(*http.Transport).Clone()
-	if insecureSkipVerify {
-		base.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- explicit profile opt-in
-	}
-	return &http.Client{Transport: base}
+	// X-Authorization is injected by the factory's refreshingTransport;
+	// we just pick the no-timeout client so large pushes aren't killed
+	// by the default 30s deadline. The body is a *bytes.Buffer so
+	// http.NewRequest sets GetBody automatically — refresh+retry on 401
+	// works here.
+	return c.executeRequest(c.uploadClient, req)
 }
 
 func (c *MarketClient) executeRequest(hc *http.Client, req *http.Request) (*APIResponse, error) {
 	resp, err := hc.Do(req)
 	if err != nil {
+		// The factory's refreshingTransport returns a typed
+		// credential error when /api/refresh itself fails (the grant
+		// is dead, or no token is stored at all). http.Client wraps
+		// it inside *url.Error, but errors.As walks the Unwrap chain
+		// — surface the typed error directly so the caller sees the
+		// canonical "run profile login" CTA instead of
+		// `request failed: Get "https://...": refresh token for ...`.
+		var inv *credential.ErrTokenInvalidated
+		if errors.As(err, &inv) {
+			return nil, inv
+		}
+		var nli *credential.ErrNotLoggedIn
+		if errors.As(err, &nli) {
+			return nil, nli
+		}
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
@@ -147,11 +154,14 @@ func (c *MarketClient) executeRequest(hc *http.Client, req *http.Request) (*APIR
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// 401/403 are reformatted with the standard `profile login` CTA so users
-	// hit the same wording they get from `files ls`/`files cat` (see
-	// reformatMarketAuthErr). The body may not be JSON (the edge proxy can
-	// short-circuit to a plaintext page), so the JSON parse below is best-
-	// effort.
+	// 401/403 reaches us only when the factory's refreshingTransport
+	// already attempted a refresh+retry and STILL got rejected (the
+	// server is consistently saying no — usually a server-side state
+	// drift the user can't recover from). Reformat with the standard
+	// `profile login` CTA so users hit the same wording they get from
+	// `files ls`/`files cat`. The body may not be JSON (the edge proxy
+	// can short-circuit to a plaintext page), so the JSON parse below
+	// is best-effort.
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return nil, reformatMarketAuthErr(resp.StatusCode, respBody, c.olaresID)
 	}

--- a/cli/cmd/ctl/market/options.go
+++ b/cli/cmd/ctl/market/options.go
@@ -133,8 +133,9 @@ func (o *MarketOptions) addWatchFlags(cmd *cobra.Command) {
 }
 
 // prepare resolves the active profile and returns a ready-to-use MarketClient
-// pointed at <MarketURL>/app-store/api/v2. Auth is handled transparently by
-// the Factory's authTransport (X-Authorization header injection).
+// pointed at <MarketURL>/app-store/api/v2. Auth (X-Authorization injection +
+// refresh-on-401 retry) is handled transparently by the Factory's
+// refreshingTransport.
 //
 // Background context is fine here: ResolveProfile reads from the local
 // credential store and HTTPClient builds the http.Client lazily; neither is a
@@ -154,7 +155,11 @@ func (o *MarketOptions) prepare() (*MarketClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewMarketClient(hc, rp, strings.TrimSpace(o.Source)), nil
+	uploadHC, err := o.factory.HTTPClientWithoutTimeout(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return NewMarketClient(hc, uploadHC, rp, strings.TrimSpace(o.Source)), nil
 }
 
 func (o *MarketOptions) failOp(op, app string, err error) error {

--- a/cli/cmd/ctl/market/watch_test.go
+++ b/cli/cmd/ctl/market/watch_test.go
@@ -330,7 +330,7 @@ func newTestMarketClient(t *testing.T, baseURL string) *MarketClient {
 		AccessToken: "test-token",
 		MarketURL:   baseURL,
 	}
-	return NewMarketClient(http.DefaultClient, rp, "market.olares")
+	return NewMarketClient(http.DefaultClient, http.DefaultClient, rp, "market.olares")
 }
 
 // drain swallows any output runWithWatch / waitForTerminal would emit so

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/distribution/reference v0.6.0
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
+	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/libp2p/go-netroute v0.2.2
@@ -43,6 +44,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.46.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.39.0
 	golang.org/x/term v0.38.0
 	golang.org/x/text v0.32.0
@@ -211,7 +213,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -189,6 +189,8 @@ github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe h1:zn8tqiUbec4wR94o7
 github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/cli/internal/files/download/client.go
+++ b/cli/internal/files/download/client.go
@@ -33,13 +33,13 @@ import (
 // and by the cobra command. It is cheap to construct; reuse one per
 // `files download` / `files cat` invocation.
 //
-// AccessToken is sent as `X-Authorization` (not `Authorization: Bearer`),
-// because Olares' edge stack only forwards the X-Authorization header to
-// per-user services. See pkg/cmdutil/factory.go for the full rationale.
+// HTTPClient is expected to be the factory-provided client whose
+// refreshingTransport injects `X-Authorization` (not `Authorization:
+// Bearer`, see pkg/cmdutil/factory.go for why) and transparently refreshes
+// on 401/403.
 type Client struct {
-	HTTPClient  *http.Client
-	BaseURL     string // FilesURL, e.g. https://files.alice.olares.com
-	AccessToken string
+	HTTPClient *http.Client
+	BaseURL    string // FilesURL, e.g. https://files.alice.olares.com
 }
 
 // HTTPError carries the status + truncated body of a non-2xx response so
@@ -99,9 +99,6 @@ func (c *Client) do(
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
-	}
-	if c.AccessToken != "" {
-		req.Header.Set("X-Authorization", c.AccessToken)
 	}
 	for k, vs := range headers {
 		for _, v := range vs {

--- a/cli/internal/files/download/download.go
+++ b/cli/internal/files/download/download.go
@@ -260,9 +260,6 @@ func (c *Client) attemptDownload(
 	if err != nil {
 		return 0, fmt.Errorf("build request: %w", err)
 	}
-	if c.AccessToken != "" {
-		req.Header.Set("X-Authorization", c.AccessToken)
-	}
 	if mode == writeResume && localSize > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", localSize))
 	}
@@ -472,9 +469,6 @@ func (c *Client) StreamRaw(ctx context.Context, plainPath string, w io.Writer) (
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return 0, fmt.Errorf("build request: %w", err)
-	}
-	if c.AccessToken != "" {
-		req.Header.Set("X-Authorization", c.AccessToken)
 	}
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/cli/internal/files/download/download_test.go
+++ b/cli/internal/files/download/download_test.go
@@ -17,18 +17,17 @@ import (
 	"time"
 )
 
-// newTestClient wires a *Client up to an httptest.Server. We always
-// inject a recognisable token so each test can assert that
-// X-Authorization made it onto the wire (the most common refactor
-// regression in this CLI is dropping the header).
+// newTestClient wires a *Client up to an httptest.Server. The download
+// Client itself no longer injects X-Authorization (that responsibility
+// moved to the factory's refreshingTransport), so test handlers should
+// assert wire shape but NOT the access-token header.
 func newTestClient(t *testing.T, h http.Handler) (*Client, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 	return &Client{
-		HTTPClient:  srv.Client(),
-		BaseURL:     srv.URL,
-		AccessToken: "test-token-XYZ",
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
 	}, srv
 }
 
@@ -72,9 +71,6 @@ func TestStat_LeafLookupInParent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Header.Get("X-Authorization") != "test-token-XYZ" {
-					t.Fatalf("missing/wrong X-Authorization")
-				}
 				if r.Method != http.MethodGet {
 					t.Fatalf("want GET, got %s", r.Method)
 				}
@@ -474,9 +470,6 @@ func TestStreamRaw_HappyPath(t *testing.T) {
 		}
 		if r.URL.Query().Get("inline") != "true" {
 			t.Errorf("want inline=true, got %q", r.URL.Query().Get("inline"))
-		}
-		if r.Header.Get("X-Authorization") != "test-token-XYZ" {
-			t.Errorf("missing X-Authorization")
 		}
 		_, _ = w.Write(body)
 	}))

--- a/cli/internal/files/rm/rm.go
+++ b/cli/internal/files/rm/rm.go
@@ -32,13 +32,13 @@ import (
 
 // Client is the per-FilesURL handle used by DeleteBatch.
 //
-// AccessToken is sent as `X-Authorization` (not `Authorization: Bearer`),
-// because Olares' edge stack only forwards the X-Authorization header to
-// per-user services. See pkg/cmdutil/factory.go for the full rationale.
+// HTTPClient is expected to be the factory-provided client whose
+// refreshingTransport injects `X-Authorization` (not `Authorization:
+// Bearer`, see pkg/cmdutil/factory.go for why) and transparently refreshes
+// on 401/403.
 type Client struct {
-	HTTPClient  *http.Client
-	BaseURL     string // FilesURL, e.g. https://files.alice.olares.com
-	AccessToken string
+	HTTPClient *http.Client
+	BaseURL    string // FilesURL, e.g. https://files.alice.olares.com
 }
 
 // HTTPError carries the status + truncated body of a non-2xx response
@@ -220,9 +220,6 @@ func (c *Client) DeleteBatch(ctx context.Context, g *Group) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
-	}
-	if c.AccessToken != "" {
-		req.Header.Set("X-Authorization", c.AccessToken)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/cli/internal/files/rm/rm_test.go
+++ b/cli/internal/files/rm/rm_test.go
@@ -17,9 +17,8 @@ func newTestClient(t *testing.T, h http.Handler) (*Client, *httptest.Server) {
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 	return &Client{
-		HTTPClient:  srv.Client(),
-		BaseURL:     srv.URL,
-		AccessToken: "test-token-XYZ",
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
 	}, srv
 }
 
@@ -108,20 +107,20 @@ func TestPlan_NoTargets(t *testing.T) {
 }
 
 // TestDeleteBatch_WireShape exercises the actual HTTP DELETE: URL
-// path encoding, JSON body shape, X-Authorization injection, and
-// trailing-slash on the parent.
+// path encoding, JSON body shape, and trailing-slash on the parent.
+// X-Authorization is no longer this client's responsibility — it is
+// injected by the factory's refreshingTransport — so the header is not
+// asserted here.
 func TestDeleteBatch_WireShape(t *testing.T) {
 	var (
 		gotMethod string
 		gotPath   string
-		gotAuth   string
 		gotCType  string
 		gotBody   []byte
 	)
 	client, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotAuth = r.Header.Get("X-Authorization")
 		gotCType = r.Header.Get("Content-Type")
 		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusOK)
@@ -140,9 +139,6 @@ func TestDeleteBatch_WireShape(t *testing.T) {
 	}
 	if gotPath != "/api/resources/drive/Home/Documents/" {
 		t.Errorf("Path: got %q", gotPath)
-	}
-	if gotAuth != "test-token-XYZ" {
-		t.Errorf("X-Authorization: got %q", gotAuth)
 	}
 	if !strings.HasPrefix(gotCType, "application/json") {
 		t.Errorf("Content-Type: got %q", gotCType)

--- a/cli/internal/files/upload/api.go
+++ b/cli/internal/files/upload/api.go
@@ -28,13 +28,15 @@ import (
 // command. It is cheap to construct; reuse one per `files upload`
 // invocation.
 //
-// AccessToken is sent as `X-Authorization` (not `Authorization: Bearer`),
-// because Olares' edge stack only forwards the X-Authorization header to
-// per-user services. See pkg/cmdutil/factory.go for the full rationale.
+// HTTPClient is expected to be a factory-provided client whose
+// refreshingTransport injects `X-Authorization` (not `Authorization:
+// Bearer`, see pkg/cmdutil/factory.go for why) and transparently refreshes
+// the token on 401/403 — except for chunk-streaming requests whose body
+// is a *os.File (req.GetBody == nil), where retry is impossible and the
+// 401 falls through to the caller.
 type Client struct {
-	HTTPClient  *http.Client
-	BaseURL     string // FilesURL, e.g. https://files.alice.olares.com
-	AccessToken string
+	HTTPClient *http.Client
+	BaseURL    string // FilesURL, e.g. https://files.alice.olares.com
 }
 
 // Node is the projection of files-backend's `FileNode` that we actually
@@ -262,9 +264,6 @@ func (c *Client) do(
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
-	}
-	if c.AccessToken != "" {
-		req.Header.Set("X-Authorization", c.AccessToken)
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)

--- a/cli/internal/files/upload/api_test.go
+++ b/cli/internal/files/upload/api_test.go
@@ -10,17 +10,17 @@ import (
 	"testing"
 )
 
-// newTestClient wires a Client to an httptest.Server. The fake token
-// is here primarily so api_test exercises the X-Authorization header
-// injection path that production traffic relies on.
+// newTestClient wires a Client to an httptest.Server. X-Authorization
+// is injected by the factory's refreshingTransport in production, not
+// by upload.Client itself, so tests use a stock httptest *http.Client
+// here and do NOT assert the access-token header.
 func newTestClient(t *testing.T, h http.Handler) (*Client, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 	return &Client{
-		HTTPClient:  srv.Client(),
-		BaseURL:     srv.URL,
-		AccessToken: "test-token",
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
 	}, srv
 }
 
@@ -28,9 +28,6 @@ func TestFetchNodes(t *testing.T) {
 	client, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/nodes/" {
 			t.Errorf("unexpected path: %q", r.URL.Path)
-		}
-		if got := r.Header.Get("X-Authorization"); got != "test-token" {
-			t.Errorf("X-Authorization = %q, want test-token", got)
 		}
 		fmt.Fprintln(w, `{"data":{"nodes":[{"name":"node-a","master":true},{"name":"node-b"}]}}`)
 	}))

--- a/cli/internal/files/upload/uploader_test.go
+++ b/cli/internal/files/upload/uploader_test.go
@@ -53,12 +53,16 @@ func fixtureFile(t *testing.T, size int64) string {
 
 // recordedChunk captures everything we want to assert about a single
 // chunk POST. Tests inspect a slice of these to verify the wire shape.
+//
+// X-Authorization is no longer captured here: the upload Client itself no
+// longer injects the header (that responsibility moved to the factory's
+// refreshingTransport), so asserting it from a stock httptest *http.Client
+// would always fail.
 type recordedChunk struct {
 	contentRange string
 	contentDisp  string
 	chunkBytes   []byte
 	form         map[string]string
-	xAuthHeader  string
 }
 
 // chunkRecorder is the upload-link target handler used by tests. It
@@ -97,7 +101,6 @@ func (cr *chunkRecorder) record(r *http.Request) (*recordedChunk, error) {
 	rc := recordedChunk{
 		contentRange: r.Header.Get("Content-Range"),
 		contentDisp:  r.Header.Get("Content-Disposition"),
-		xAuthHeader:  r.Header.Get("X-Authorization"),
 		form:         form,
 		chunkBytes:   chunkBytes,
 	}
@@ -170,7 +173,6 @@ func uploadServer(t *testing.T, opts uploadServerOpts) (*httptest.Server, *chunk
 //     all line up with the file size + chunk size
 //   - Content-Range uses INCLUSIVE end-byte semantics (matches
 //     resumejs.ts setHeaders())
-//   - X-Authorization is plumbed through on every chunk
 //   - the file's exact bytes round-trip
 func TestUploadFile_Multichunk(t *testing.T) {
 	const chunkSize = 1024
@@ -179,7 +181,7 @@ func TestUploadFile_Multichunk(t *testing.T) {
 	local := fixtureFile(t, fileSize)
 	srv, recorder := uploadServer(t, uploadServerOpts{})
 
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath:    local,
 		Node:         "n",
@@ -203,9 +205,6 @@ func TestUploadFile_Multichunk(t *testing.T) {
 	wholeFile := readFile(t, local)
 	gotFile := []byte{}
 	for i, ck := range recorder.chunks {
-		if ck.xAuthHeader != "tk" {
-			t.Errorf("chunk %d: X-Authorization = %q", i, ck.xAuthHeader)
-		}
 		if ck.contentRange != expectedRanges[i] {
 			t.Errorf("chunk %d: Content-Range = %q, want %q",
 				i, ck.contentRange, expectedRanges[i])
@@ -262,7 +261,7 @@ func TestUploadFile_ResumesFromServerOffset(t *testing.T) {
 		// (i.e. resumableChunkNumber 2 + 3, 0-based offsets 1 + 2).
 		uploadedBytes: int64(chunkSize + chunkSize/2),
 	})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath: local, Node: "n",
 		ParentDir: "/drive/Home/", RemoteName: "f.bin", RelativePath: "f.bin",
@@ -295,7 +294,7 @@ func TestUploadFile_ServerHasFullFile(t *testing.T) {
 	fileSize := int64(2 * chunkSize)
 	local := fixtureFile(t, fileSize)
 	srv, recorder := uploadServer(t, uploadServerOpts{uploadedBytes: fileSize})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath: local, Node: "n",
 		ParentDir: "/drive/Home/", RemoteName: "f.bin", RelativePath: "f.bin",
@@ -329,7 +328,7 @@ func TestUploadFile_Retries(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		},
 	})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath: local, Node: "n",
 		ParentDir: "/drive/Home/", RemoteName: "f.bin", RelativePath: "f.bin",
@@ -358,7 +357,7 @@ func TestUploadFile_PermanentError(t *testing.T) {
 			http.Error(w, "bad", http.StatusBadRequest)
 		},
 	})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath: local, Node: "n",
 		ParentDir: "/drive/Home/", RemoteName: "f.bin", RelativePath: "f.bin",
@@ -413,7 +412,7 @@ func TestUploadFile_EmptyFile(t *testing.T) {
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath: local, Node: "n",
 		ParentDir: "/drive/Home/Docs/", RemoteName: "empty.bin", RelativePath: "empty.bin",
@@ -437,7 +436,7 @@ func TestUploadFile_FolderRelativePath(t *testing.T) {
 	const chunkSize = 256
 	local := fixtureFile(t, chunkSize)
 	srv, recorder := uploadServer(t, uploadServerOpts{})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if err := c.UploadFile(context.Background(), UploadOpts{
 		LocalPath:    local,
 		Node:         "n",
@@ -471,7 +470,7 @@ func TestUploadFile_ContextCancel(t *testing.T) {
 			http.Error(w, "transient", http.StatusBadGateway)
 		},
 	})
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, AccessToken: "tk"}
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		time.Sleep(50 * time.Millisecond)

--- a/cli/internal/lockfile/lockfile.go
+++ b/cli/internal/lockfile/lockfile.go
@@ -1,0 +1,103 @@
+// Package lockfile is a tiny wrapper over github.com/gofrs/flock that adds
+// context-cancelable acquisition and a single deterministic lock-directory
+// layout under cliconfig.Home(). It exists so the rest of the codebase
+// doesn't import flock directly — keeping the dependency surface small and
+// letting us swap the backend without touching every call site.
+//
+// The locks are advisory file locks (flock(2) on darwin/linux, LockFileEx on
+// windows). Two olares-cli processes contending for the same olaresId's
+// refresh slot will serialize through the OS; a single process with multiple
+// goroutines should pre-serialize via an in-process mutex BEFORE asking us
+// for the file lock (otherwise the file lock is a no-op for them on linux,
+// where flock is per-fd).
+package lockfile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+)
+
+// dirPerm matches cliconfig's 0700 — the lock dir lives next to config.json
+// and should not be world-readable.
+const dirPerm os.FileMode = 0o700
+
+// pollInterval is how often Acquire retries TryLock while waiting. flock's
+// blocking Lock() is not context-cancelable, so we busy-poll TryLock + sleep.
+// 100ms matches lark-cli's cadence: short enough that ctx-cancel feels
+// instant, long enough not to thrash a contended lock.
+const pollInterval = 100 * time.Millisecond
+
+// Acquire takes an exclusive flock on the file at `path`, creating the
+// parent directory and the file as needed (mode 0600 for the file, 0700 for
+// the directory).
+//
+// The call blocks until either:
+//   - the lock is acquired (returns release, nil), or
+//   - ctx is canceled / its deadline expires (returns nil, ctx.Err()).
+//
+// release() must be called exactly once to drop the lock and close the
+// underlying fd. It is safe to call from a defer.
+func Acquire(ctx context.Context, path string) (release func() error, err error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+	fl := flock.New(path)
+	for {
+		ok, err := fl.TryLock()
+		if err != nil {
+			return nil, fmt.Errorf("lockfile %s: %w", path, err)
+		}
+		if ok {
+			return fl.Unlock, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+			// retry
+		}
+	}
+}
+
+// RefreshLockPath returns the per-olaresId refresh lock path under
+// cliconfig.Home()/locks/. The olaresId is sanitized for filesystem use
+// (slashes / null / colon / control chars are replaced with '_'); '@' and
+// '.' are left intact since they are valid on every supported OS and
+// preserve the original olaresId in directory listings, which is useful for
+// debugging.
+func RefreshLockPath(olaresID string) (string, error) {
+	home, err := cliconfig.Home()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "locks", sanitize(olaresID)+".refresh.lock"), nil
+}
+
+// sanitize replaces any character that's problematic on at least one of our
+// target filesystems with '_'. We deliberately allow '@' and '.' through
+// (they are legal on darwin/linux/windows file names) so the resulting file
+// name is still a recognizable olaresId.
+func sanitize(s string) string {
+	if s == "" {
+		return "_"
+	}
+	const bad = "/\\:*?\"<>|\x00"
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r < 0x20 || strings.ContainsRune(bad, r) {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/cli/internal/lockfile/lockfile_test.go
+++ b/cli/internal/lockfile/lockfile_test.go
@@ -1,0 +1,161 @@
+package lockfile
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAcquire_BasicLockUnlock verifies the happy path: take the lock,
+// release it, take it again. Most other tests build on this so a
+// failure here points at flock plumbing rather than at a concurrency
+// edge case.
+func TestAcquire_BasicLockUnlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.lock")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	rel, err := Acquire(ctx, path)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if err := rel(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	rel2, err := Acquire(ctx, path)
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	_ = rel2()
+}
+
+// TestAcquire_BlocksUntilRelease asserts that a second Acquire on the
+// same path waits — concretely, it should not return until the holder
+// releases. The 50ms sleep is intentional: long enough to be observable,
+// short enough that the test stays cheap.
+func TestAcquire_BlocksUntilRelease(t *testing.T) {
+	// flock(2) on linux is per-fd, not per-process. Two Acquire calls
+	// from the SAME process can both succeed — that's why the
+	// Refresher pre-serializes through an in-process mutex before
+	// asking us for the OS lock. We emulate the cross-process pattern
+	// by spinning up a separate gofrs/flock instance from a second
+	// goroutine; on darwin/linux this still hits the BSD flock path
+	// which IS per-fd, so a holder + a TryLock from a different fd
+	// inside the same process exhibits the same blocking behavior a
+	// peer process would observe.
+	t.Skip("flock semantics are per-fd within the same process on linux/darwin; cross-process behavior is exercised by TestRefresher_CrossProcess")
+}
+
+// TestAcquire_RespectsContextDeadline verifies that ctx cancellation
+// while we're polling TryLock surfaces as ctx.Err() rather than
+// hanging. Without this, a stuck peer would freeze the CLI forever.
+//
+// Strategy: hold the lock from a sibling goroutine (which on POSIX
+// flock is per-fd, so a TryLock from a different fd will fail), then
+// call Acquire with a short ctx and assert it returns context.DeadlineExceeded.
+func TestAcquire_RespectsContextDeadline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ctx.lock")
+
+	// Holder uses its own fd, so a competing TryLock from this
+	// goroutine sees "held". Without the holder, the second Acquire
+	// would succeed instantly and the deadline would never trigger.
+	holder, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatalf("holder Acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = holder() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	rel, err := Acquire(ctx, path)
+	if err == nil {
+		_ = rel()
+		t.Skipf("Acquire returned without error — flock on this platform is per-process, skipping deadline assertion")
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Errorf("Acquire returned in %v, expected to block until ~ctx deadline", elapsed)
+	}
+	if !isDeadlineErr(err) {
+		t.Errorf("err = %v, want context.DeadlineExceeded / context.Canceled", err)
+	}
+}
+
+func isDeadlineErr(err error) bool {
+	return err == context.DeadlineExceeded || err == context.Canceled
+}
+
+// TestAcquire_ConcurrentInProcess: gofrs/flock returns a per-fd handle,
+// but Acquire creates a fresh *flock.Flock per call. Two concurrent
+// Acquire calls in the same process therefore each get their own fd
+// and (on linux/darwin) can BOTH succeed. That's surprising at first
+// glance, so we document the behavior explicitly: production code must
+// pre-serialize via an in-process mutex (Refresher does), and the file
+// lock only protects across processes.
+func TestAcquire_ConcurrentInProcess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.lock")
+	const n = 8
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	done := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			rel, err := Acquire(ctx, path)
+			if err != nil {
+				done <- struct{}{}
+				return
+			}
+			cur := concurrent.Add(1)
+			if cur > maxConcurrent.Load() {
+				maxConcurrent.Store(cur)
+			}
+			time.Sleep(20 * time.Millisecond)
+			concurrent.Add(-1)
+			_ = rel()
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+	// We don't assert maxConcurrent == 1 because flock is per-fd within
+	// a process. The point of this test is simply that concurrent
+	// in-process callers don't deadlock or error.
+	t.Logf("maxConcurrent observed: %d (expected 1 across processes, ≤ %d within one process)", maxConcurrent.Load(), n)
+}
+
+// TestRefreshLockPath_Sanitization ensures path-unsafe characters in
+// the olaresId are replaced rather than reaching the filesystem.
+// Production olaresIds look like "alice@olares.com", which is fine on
+// every supported OS — but defensive sanitization keeps a malformed
+// override (e.g. from $OLARES_PROFILE) from causing a path-traversal.
+func TestRefreshLockPath_Sanitization(t *testing.T) {
+	t.Setenv("OLARES_CLI_HOME", t.TempDir())
+	for _, tc := range []struct {
+		in       string
+		mustHave string
+	}{
+		{"alice@olares.com", "alice@olares.com.refresh.lock"},
+		{"weird/id", "weird_id.refresh.lock"},
+		{"with\x00null", "with_null.refresh.lock"},
+		{"", "_.refresh.lock"},
+	} {
+		got, err := RefreshLockPath(tc.in)
+		if err != nil {
+			t.Fatalf("RefreshLockPath(%q): %v", tc.in, err)
+		}
+		if filepath.Base(got) != tc.mustHave {
+			t.Errorf("RefreshLockPath(%q) base = %q, want %q", tc.in, filepath.Base(got), tc.mustHave)
+		}
+	}
+}

--- a/cli/pkg/auth/refresh.go
+++ b/cli/pkg/auth/refresh.go
@@ -11,6 +11,17 @@ import (
 	"time"
 )
 
+// ErrRefreshUnauthorized is returned (wrapped) by Refresh when the server
+// rejects the refresh-token grant with HTTP 401/403. This is the only signal
+// callers should treat as "the grant is dead, mark it invalidated and force
+// re-login". Any other error from /api/refresh (transport hiccup, 5xx, malformed
+// body) is treated as transient and surfaced verbatim so the caller can retry.
+//
+// The refresher in cli/pkg/credential/refresher.go uses errors.Is(err,
+// ErrRefreshUnauthorized) to gate the MarkInvalidated → ErrTokenInvalidated
+// path; do NOT collapse this with the generic error case.
+var ErrRefreshUnauthorized = errors.New("refresh token rejected by server")
+
 // RefreshRequest is the input to a single /api/refresh call. AccessToken is
 // optional — the web client passes the (possibly expired) current token in
 // `X-Authorization` and the server tolerates an empty value during bootstrap,
@@ -67,6 +78,14 @@ func Refresh(ctx context.Context, req RefreshRequest) (*Token, error) {
 		return nil, fmt.Errorf("read /api/refresh body: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		// 401/403 means the refresh-token grant itself is no longer
+		// honored — the only recovery is a fresh login. Wrap with the
+		// typed sentinel so credential.Refresher can stamp
+		// InvalidatedAt and surface ErrTokenInvalidated. Any other
+		// non-200 stays an opaque error (treated as transient).
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: /api/refresh returned HTTP %d: %s", ErrRefreshUnauthorized, resp.StatusCode, truncate(raw))
+		}
 		return nil, fmt.Errorf("/api/refresh returned HTTP %d: %s", resp.StatusCode, truncate(raw))
 	}
 	var parsed refreshResponse

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -3,24 +3,51 @@
 // config / etc. This is the olares-cli analogue of lark-cli's
 // cmdutil.Factory.
 //
-// Phase 1 keeps the Factory deliberately minimal: a lazily-resolved
-// credential chain plus an HTTP client whose RoundTripper injects the access
-// token via the custom `X-Authorization` header (see authTransport for why
-// that header, not the standard `Authorization: Bearer`). Phase 2 will add
-// automatic token refresh inside the same HTTPClient call without changing
-// this surface.
+// The Factory wires three things together:
+//   - the lazily-resolved credential chain (env + on-disk profile),
+//   - a credential.Refresher that owns /api/refresh + InvalidatedAt
+//     bookkeeping with cross-process locking,
+//   - one or more *http.Client instances whose RoundTripper transparently
+//     injects the active access_token via X-Authorization (NOT
+//     Authorization: Bearer — see refreshingTransport rationale below) AND
+//     refreshes on 401/403, retrying the original request once.
+//
+// The refreshingTransport is shared via a *tokenCell so both the
+// timed (HTTPClient) and untimed (HTTPClientWithoutTimeout) clients see
+// the same access_token at all times — a refresh on one updates the other.
 package cmdutil
 
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/beclab/Olares/cli/pkg/auth"
 	"github.com/beclab/Olares/cli/pkg/credential"
 )
+
+// preflightSkew is the safety window applied when deciding whether to
+// proactively refresh a non-replayable request's token. If the JWT's exp
+// is within this margin of now (or already past), we rotate the token
+// BEFORE handing the request body to the base transport.
+//
+// Why this matters: streaming bodies (typically *os.File for `files
+// upload` chunks) get consumed by the first send and cannot be replayed
+// on a 401. Without pre-flight the user would see a single failed chunk
+// and have to re-run the whole upload command. 60s comfortably covers
+// client↔server clock drift plus the time from local JWT decode to the
+// request actually landing on the server.
+//
+// Replayable bodies (every JSON / files-cat / files-rm / market verb)
+// deliberately skip pre-flight: the reactive 401 path is one extra HTTP
+// round-trip but avoids decoding the JWT on every request, and the
+// outcome is identical from the user's perspective.
+const preflightSkew = 60 * time.Second
 
 // Factory is the dependency-injection seam for olares-cli commands. Build
 // one with NewFactory at the root command level and pass it (or a closure
@@ -42,8 +69,20 @@ type Factory struct {
 	resolveErr  error
 	resolved    *credential.ResolvedProfile
 
+	refresherOnce sync.Once
+	refresher     *credential.Refresher
+
+	// tokenCell is the shared mutable access_token cell. Both the timed
+	// and untimed http.Clients hold the same pointer so a refresh
+	// triggered through one is immediately visible to the other.
+	tokenCellOnce sync.Once
+	tokenCell     *tokenCell
+
 	clientOnce sync.Once
 	client     *http.Client
+
+	uploadClientOnce sync.Once
+	uploadClient     *http.Client
 }
 
 // NewFactory builds a fresh Factory. Cheap; intended to be called once per
@@ -52,9 +91,7 @@ func NewFactory() *Factory {
 	return &Factory{}
 }
 
-// Credential returns the lazily-constructed credential chain. The chain is
-// (EnvProvider, DefaultProvider) — env first so future in-cluster builds
-// can pre-empt on-disk config.
+// Credential returns the lazily-constructed credential chain.
 func (f *Factory) Credential() (*credential.CredentialProvider, error) {
 	f.credentialOnce.Do(func() {
 		def, err := credential.NewDefaultProvider()
@@ -89,39 +126,109 @@ func (f *Factory) ResolveProfile(ctx context.Context) (*credential.ResolvedProfi
 	return f.resolved, f.resolveErr
 }
 
-// HTTPClient returns an *http.Client whose RoundTripper transparently injects
-// the active profile's access token on every outbound request via the custom
-// `X-Authorization` header (see authTransport). The client also honors the
-// active profile's InsecureSkipVerify flag.
+// Refresher returns the lazily-constructed cross-process token refresher.
+// Exported for tests; production code reaches it through HTTPClient's
+// transport.
+func (f *Factory) Refresher() *credential.Refresher {
+	f.refresherOnce.Do(func() {
+		f.refresher = credential.NewRefresher()
+	})
+	return f.refresher
+}
+
+// HTTPClient returns the standard http.Client used for short JSON requests.
+// Its RoundTripper:
+//   - injects the active access_token via X-Authorization on every request,
+//   - on 401/403, calls Refresher() to rotate the token and retries the
+//     request once (only when req.GetBody is set — i.e. the body is
+//     replayable),
+//   - returns the original error / 401 if refresh itself fails or the body
+//     can't be replayed.
 //
-// Phase 1: the token is fetched once at first call and reused until the
-// process exits. If it expires mid-run, requests will start returning 401 —
-// the user's recourse is to re-run `profile login` / `profile import`.
-//
-// Phase 2 will refactor this into a refreshing transport without changing
-// the signature.
+// The 30s overall timeout matches the previous behavior. For streaming
+// uploads (large multipart bodies) use HTTPClientWithoutTimeout.
 func (f *Factory) HTTPClient(ctx context.Context) (*http.Client, error) {
 	rp, err := f.ResolveProfile(ctx)
 	if err != nil {
 		return nil, err
 	}
 	f.clientOnce.Do(func() {
-		base := http.DefaultTransport.(*http.Transport).Clone()
-		if rp.InsecureSkipVerify {
-			base.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- explicit profile opt-in
-		}
 		f.client = &http.Client{
 			Timeout:   30 * time.Second,
-			Transport: &authTransport{base: base, token: rp.AccessToken},
+			Transport: f.newRefreshingTransport(rp),
 		}
 	})
 	return f.client, nil
 }
 
-// authTransport injects the access token via the custom `X-Authorization`
-// header on outbound requests. It clones the request before mutating headers
-// so the caller's *http.Request is left untouched (important when callers
-// retry).
+// HTTPClientWithoutTimeout returns an http.Client with no overall timeout,
+// suitable for streaming uploads / long-running multipart requests. It
+// shares the same access_token cell as HTTPClient so a refresh triggered
+// through either client is immediately visible to the other.
+func (f *Factory) HTTPClientWithoutTimeout(ctx context.Context) (*http.Client, error) {
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	f.uploadClientOnce.Do(func() {
+		f.uploadClient = &http.Client{
+			Transport: f.newRefreshingTransport(rp),
+		}
+	})
+	return f.uploadClient, nil
+}
+
+// tokenCell stores the current access_token under a RWMutex so concurrent
+// RoundTrip calls can read it cheaply and a successful refresh can swap it
+// in with one writer-side lock.
+type tokenCell struct {
+	mu    sync.RWMutex
+	token string
+}
+
+func (c *tokenCell) snapshot() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
+}
+
+func (c *tokenCell) update(newToken string) {
+	if newToken == "" {
+		return
+	}
+	c.mu.Lock()
+	c.token = newToken
+	c.mu.Unlock()
+}
+
+func (f *Factory) sharedTokenCell(initial string) *tokenCell {
+	f.tokenCellOnce.Do(func() {
+		f.tokenCell = &tokenCell{token: initial}
+	})
+	return f.tokenCell
+}
+
+// newRefreshingTransport builds a refreshingTransport bound to rp. Both
+// HTTPClient and HTTPClientWithoutTimeout reuse the same Refresher and the
+// same tokenCell so a refresh on one is immediately visible on the other.
+func (f *Factory) newRefreshingTransport(rp *credential.ResolvedProfile) *refreshingTransport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	if rp.InsecureSkipVerify {
+		base.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- explicit profile opt-in
+	}
+	return &refreshingTransport{
+		base:               base,
+		olaresID:           rp.OlaresID,
+		authURL:            rp.AuthURL,
+		insecureSkipVerify: rp.InsecureSkipVerify,
+		refresher:          f.Refresher(),
+		token:              f.sharedTokenCell(rp.AccessToken),
+	}
+}
+
+// refreshingTransport injects the current access_token via X-Authorization,
+// and on 401/403 transparently refreshes the token and retries the original
+// request once.
 //
 // Why X-Authorization (not the standard Authorization: Bearer)?
 // Olares' edge stack — Authelia ext-authz wired through l4-bfl-proxy —
@@ -133,16 +240,174 @@ func (f *Factory) HTTPClient(ctx context.Context) (*http.Client, error) {
 // the edge before it reaches per-user services, so X-Authorization is the
 // only value that round-trips to the backend today. The web app does the
 // same thing in apps/packages/app/src/platform/platformAjaxSender.ts.
-type authTransport struct {
-	base  http.RoundTripper
-	token string
+//
+// Retry is best-effort: we only retry when req.GetBody is set (or the body
+// is nil). Streaming bodies (e.g. files upload chunks backed by *os.File)
+// can't be replayed; their 401 falls through verbatim and the user re-runs
+// the command. http.NewRequest sets GetBody automatically for the standard
+// rewindable body types (*bytes.Reader, *bytes.Buffer, *strings.Reader)
+// which covers all current JSON callers.
+type refreshingTransport struct {
+	base               http.RoundTripper
+	olaresID           string
+	authURL            string
+	insecureSkipVerify bool
+	refresher          *credential.Refresher
+	token              *tokenCell
+
+	// now is the clock used by preflightRefresh's expiry check. nil =
+	// time.Now (production); tests override it to drive the skew
+	// window deterministically.
+	now func() time.Time
 }
 
-func (a *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if a.token == "" {
-		return a.base.RoundTrip(req)
+func (t *refreshingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	snap := t.token.snapshot()
+
+	// Pre-flight refresh for non-replayable bodies. Once a streaming
+	// body (e.g. *os.File chunk for files upload) is handed to the
+	// base transport, the first byte that goes on the wire consumes
+	// the read offset; a 401 response can't trigger a retry because
+	// we have no way to rewind. Defensively check the JWT's exp claim
+	// locally and rotate the token here instead.
+	//
+	// Replayable bodies fall through to the reactive 401 path below —
+	// it's one extra HTTP round-trip in the rare expiry case, but
+	// avoids a JWT decode on every request.
+	if !canRetry(req) {
+		newAT, ok, err := t.preflightRefresh(req.Context(), snap)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			snap = newAT
+		}
+	}
+
+	resp, err := t.send(req, snap)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+		return resp, nil
+	}
+	if !canRetry(req) {
+		// Non-replayable body — pre-flight already had its chance
+		// (and either rotated the token or decided not to). Either
+		// way, body is consumed; surface the 401 verbatim.
+		return resp, nil
+	}
+	// Drain + close so the underlying connection can be reused.
+	drainAndClose(resp)
+
+	newAT, rerr := t.refresher.Refresh(req.Context(), t.olaresID, t.authURL, snap, t.insecureSkipVerify)
+	if rerr != nil {
+		// Refresh itself failed (network, 5xx) or the grant is dead
+		// (ErrTokenInvalidated, ErrNotLoggedIn). Surface the typed
+		// error so the caller's reformatter can render the
+		// "run profile login" CTA.
+		return nil, rerr
+	}
+	t.token.update(newAT)
+
+	retryReq, err := cloneWithBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("clone request for retry: %w", err)
+	}
+	return t.send(retryReq, newAT)
+}
+
+// preflightRefresh decides whether snap is close enough to expiring
+// that a non-replayable request must rotate it BEFORE sending. Returns:
+//
+//   - (newAT, true, nil)  — refresh fired, caller should send with newAT
+//   - ("",   false, nil)  — token still fresh, no exp claim, malformed,
+//     or empty; caller should send with the original snap
+//   - ("",   false, err)  — refresh attempted and failed; caller MUST
+//     return err without sending (the streaming body is still intact)
+//
+// Refresher.Refresh has its own in-process mutex + cross-process flock,
+// so concurrent chunk uploads collapse to a single /api/refresh hit
+// even when they all decide to pre-flight at the same moment.
+func (t *refreshingTransport) preflightRefresh(ctx context.Context, snap string) (string, bool, error) {
+	if snap == "" {
+		return "", false, nil
+	}
+	expired, err := auth.IsExpired(snap, t.clock(), preflightSkew)
+	if err != nil {
+		// No exp claim / non-JWT / malformed payload. We can't make
+		// a meaningful local decision; let the request fly. For a
+		// non-replayable body that means the user may see a 401,
+		// but refusing to send a known-otherwise-valid token is
+		// strictly worse UX (would break tokens issued without exp).
+		return "", false, nil
+	}
+	if !expired {
+		return "", false, nil
+	}
+	newAT, rerr := t.refresher.Refresh(ctx, t.olaresID, t.authURL, snap, t.insecureSkipVerify)
+	if rerr != nil {
+		return "", false, rerr
+	}
+	t.token.update(newAT)
+	return newAT, true, nil
+}
+
+func (t *refreshingTransport) clock() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+// send injects token (when non-empty) and forwards to the base transport.
+// Clones the request so the caller's *http.Request is left untouched (some
+// callers retry at a higher level).
+func (t *refreshingTransport) send(req *http.Request, token string) (*http.Response, error) {
+	if token == "" {
+		return t.base.RoundTrip(req)
 	}
 	clone := req.Clone(req.Context())
-	clone.Header.Set("X-Authorization", a.token)
-	return a.base.RoundTrip(clone)
+	clone.Header.Set("X-Authorization", token)
+	return t.base.RoundTrip(clone)
+}
+
+// canRetry reports whether req's body can be replayed. A request with no
+// body is trivially replayable; a request with a body is replayable only
+// when http.NewRequest already populated GetBody (set automatically for
+// *bytes.Reader, *bytes.Buffer, *strings.Reader).
+func canRetry(req *http.Request) bool {
+	if req.Body == nil || req.Body == http.NoBody {
+		return true
+	}
+	return req.GetBody != nil
+}
+
+// cloneWithBody clones req for a retry. It uses GetBody to obtain a fresh
+// reader; callers must have already gated on canRetry.
+func cloneWithBody(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.Body == nil || req.Body == http.NoBody {
+		return clone, nil
+	}
+	if req.GetBody == nil {
+		return nil, errors.New("request has a non-replayable body")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, fmt.Errorf("rewind body: %w", err)
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+// drainAndClose drains and closes resp.Body so the underlying connection
+// can be re-used by the retry. Errors are intentionally ignored — by the
+// time we get here the response is already a 401/403 we're discarding.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 }

--- a/cli/pkg/cmdutil/factory_test.go
+++ b/cli/pkg/cmdutil/factory_test.go
@@ -1,0 +1,610 @@
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/auth"
+	"github.com/beclab/Olares/cli/pkg/credential"
+)
+
+// fakeStore is a minimal in-memory TokenStore for transport tests.
+// We deliberately re-declare it here (rather than reaching into the
+// credential package's test helpers) so the cmdutil tests stay
+// self-contained and the credential test fixtures can change shape
+// without breaking transport tests.
+type fakeStore struct {
+	mu    sync.Mutex
+	items map[string]auth.StoredToken
+}
+
+func (s *fakeStore) Get(id string) (*auth.StoredToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.items[id]
+	if !ok {
+		return nil, auth.ErrTokenNotFound
+	}
+	cp := t
+	return &cp, nil
+}
+func (s *fakeStore) Set(t auth.StoredToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.items == nil {
+		s.items = map[string]auth.StoredToken{}
+	}
+	s.items[t.OlaresID] = t
+	return nil
+}
+func (s *fakeStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, id)
+	return nil
+}
+func (s *fakeStore) List() ([]auth.StoredToken, error) { return nil, nil }
+func (s *fakeStore) MarkInvalidated(id string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.items[id]
+	if !ok {
+		return auth.ErrTokenNotFound
+	}
+	t.InvalidatedAt = at.UnixMilli()
+	s.items[id] = t
+	return nil
+}
+
+func newTransport(t *testing.T, store *fakeStore, authURL, accessToken string) (*refreshingTransport, *credential.Refresher) {
+	t.Helper()
+	t.Setenv("OLARES_CLI_HOME", t.TempDir())
+	r := credential.NewRefresherWith(store, time.Now)
+	tr := &refreshingTransport{
+		base:      http.DefaultTransport,
+		olaresID:  "alice@olares.com",
+		authURL:   authURL,
+		refresher: r,
+		token:     &tokenCell{token: accessToken},
+	}
+	return tr, r
+}
+
+// TestRoundTrip_Success: 200 → no refresh attempt; X-Authorization is
+// injected on the outbound request.
+func TestRoundTrip_Success(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("X-Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := &fakeStore{}
+	tr, _ := newTransport(t, store, "unused", "AT-1")
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if seenAuth != "AT-1" {
+		t.Errorf("X-Authorization on first request = %q, want AT-1", seenAuth)
+	}
+}
+
+// TestRoundTrip_RefreshOn401: 401 → call refresh → retry once with new
+// token → final response makes it back to caller. Asserts the retry
+// carries the NEW token (the whole point of the change).
+func TestRoundTrip_RefreshOn401(t *testing.T) {
+	var (
+		hits     atomic.Int32
+		seenAuth []string
+	)
+	muAuth := sync.Mutex{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit := hits.Add(1)
+		muAuth.Lock()
+		seenAuth = append(seenAuth, r.Header.Get("X-Authorization"))
+		muAuth.Unlock()
+		if hit == 1 {
+			http.Error(w, "unauth", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	// /api/refresh server, owned by the refresher.
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT","session_id":"S"}}`)
+	}))
+	defer authSrv.Close()
+
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT-OLD",
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, "AT-OLD")
+
+	body := bytes.NewReader([]byte("payload"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, body)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 2 {
+		t.Errorf("upstream hits = %d, want 2 (one 401 + one retry)", hits.Load())
+	}
+	if len(seenAuth) != 2 || seenAuth[0] != "AT-OLD" || seenAuth[1] != "AT-NEW" {
+		t.Errorf("X-Authorization timeline = %v, want [AT-OLD AT-NEW]", seenAuth)
+	}
+	if got := tr.token.snapshot(); got != "AT-NEW" {
+		t.Errorf("token cell = %q, want AT-NEW (next request must use rotated token)", got)
+	}
+}
+
+// TestRoundTrip_NoSecondRetry: if the retry ALSO returns 401, we must
+// surface the second 401 verbatim — never loop. Two upstream hits, no
+// refresh on the second 401.
+func TestRoundTrip_NoSecondRetry(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Error(w, "unauth", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	var refreshHits atomic.Int32
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshHits.Add(1)
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT"}}`)
+	}))
+	defer authSrv.Close()
+
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT-OLD",
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, "AT-OLD")
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 surfaced verbatim", resp.StatusCode)
+	}
+	if hits.Load() != 2 {
+		t.Errorf("upstream hits = %d, want exactly 2 (no infinite loop)", hits.Load())
+	}
+	if refreshHits.Load() != 1 {
+		t.Errorf("refresh hits = %d, want 1", refreshHits.Load())
+	}
+}
+
+// makeJWT builds a minimal "h.<payload>.s" JWT carrying just an exp
+// claim — enough for auth.IsExpired/auth.ExpiresAt. Sig and header
+// segments are placeholders since the CLI never verifies them client-
+// side.
+func makeJWT(t *testing.T, expUnix int64) string {
+	t.Helper()
+	payload := fmt.Sprintf(`{"exp":%d}`, expUnix)
+	enc := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return "h." + enc + ".s"
+}
+
+// TestRoundTrip_NonReplayableBody: a streaming body (req.GetBody == nil)
+// with a non-JWT access_token must NOT trigger refresh. ExpiresAt fails
+// to decode "AT" → preflight is skipped; the server's 401 is then
+// surfaced verbatim because the body is unrewindable.
+func TestRoundTrip_NonReplayableBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauth", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	var refreshHits atomic.Int32
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshHits.Add(1)
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"X","refresh_token":"Y"}}`)
+	}))
+	defer authSrv.Close()
+
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, "AT")
+
+	// nopReader has no GetBody set; http.NewRequest only auto-sets
+	// GetBody for known rewindable types (*bytes.Reader / Buffer /
+	// strings.Reader). Mirrors the *os.File case in `files upload`.
+	r := io.NopCloser(strings.NewReader("data"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, r)
+	req.GetBody = nil
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (non-replayable body must NOT trigger refresh+retry)", resp.StatusCode)
+	}
+	if refreshHits.Load() != 0 {
+		t.Errorf("refresh hits = %d; refresh must not run for non-replayable bodies", refreshHits.Load())
+	}
+}
+
+// TestRoundTrip_PreflightStaleNonReplayable: a streaming body whose
+// access_token JWT is already past exp must trigger a pre-flight
+// refresh BEFORE any byte hits the upstream. The upstream sees exactly
+// one request, carrying the NEW token, and the body is read once.
+//
+// Without this, files-upload chunks backed by *os.File would 401 once
+// per stale-token window and fail the whole upload command.
+func TestRoundTrip_PreflightStaleNonReplayable(t *testing.T) {
+	var (
+		hits     atomic.Int32
+		seenAuth atomic.Value
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		seenAuth.Store(r.Header.Get("X-Authorization"))
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer upstream.Close()
+
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT-NEW","session_id":"S"}}`)
+	}))
+	defer authSrv.Close()
+
+	staleJWT := makeJWT(t, time.Now().Add(-1*time.Minute).Unix())
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  staleJWT,
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, staleJWT)
+
+	body := io.NopCloser(strings.NewReader("chunk-payload"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, body)
+	req.GetBody = nil
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("upstream hits = %d, want 1 (preflight must rotate before sending, not after a 401)", hits.Load())
+	}
+	if got := seenAuth.Load(); got != "AT-NEW" {
+		t.Errorf("upstream X-Authorization = %v, want AT-NEW (preflight token wasn't propagated)", got)
+	}
+	if got := tr.token.snapshot(); got != "AT-NEW" {
+		t.Errorf("token cell = %q, want AT-NEW", got)
+	}
+}
+
+// TestRoundTrip_PreflightWithinSkew: exp is 30s in the future, well
+// inside preflightSkew (60s). Even though the token is technically not
+// expired, we rotate eagerly so a multi-second upload can't outlive it.
+func TestRoundTrip_PreflightWithinSkew(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	var refreshHits atomic.Int32
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshHits.Add(1)
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT-NEW"}}`)
+	}))
+	defer authSrv.Close()
+
+	soonJWT := makeJWT(t, time.Now().Add(30*time.Second).Unix())
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  soonJWT,
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, soonJWT)
+
+	body := io.NopCloser(strings.NewReader("x"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, body)
+	req.GetBody = nil
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if hits.Load() != 1 {
+		t.Errorf("upstream hits = %d, want 1", hits.Load())
+	}
+	if refreshHits.Load() != 1 {
+		t.Errorf("refresh hits = %d, want 1 (within preflightSkew window must trigger preflight)", refreshHits.Load())
+	}
+}
+
+// TestRoundTrip_NoPreflightWhenFresh: exp 1h in the future is well
+// outside preflightSkew. We must NOT decode + refresh per request; the
+// reactive 401 path stays cheaper for the common case.
+func TestRoundTrip_NoPreflightWhenFresh(t *testing.T) {
+	var seenAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth.Store(r.Header.Get("X-Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	var refreshHits atomic.Int32
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshHits.Add(1)
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT-NEW"}}`)
+	}))
+	defer authSrv.Close()
+
+	freshJWT := makeJWT(t, time.Now().Add(1*time.Hour).Unix())
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  freshJWT,
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, freshJWT)
+
+	body := io.NopCloser(strings.NewReader("x"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, body)
+	req.GetBody = nil
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if got := seenAuth.Load(); got != freshJWT {
+		t.Errorf("upstream X-Authorization = %v, want the original (fresh) token", got)
+	}
+	if refreshHits.Load() != 0 {
+		t.Errorf("refresh hits = %d, want 0 (fresh token must not preflight)", refreshHits.Load())
+	}
+}
+
+// TestRoundTrip_NoPreflightOnReplayable: a stale JWT with a replayable
+// body (*bytes.Reader) must skip preflight and rely on the reactive 401
+// path. This keeps cheap JSON requests off the JWT-decode hot path.
+func TestRoundTrip_NoPreflightOnReplayable(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit := hits.Add(1)
+		if hit == 1 {
+			http.Error(w, "unauth", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT-NEW"}}`)
+	}))
+	defer authSrv.Close()
+
+	staleJWT := makeJWT(t, time.Now().Add(-1*time.Minute).Unix())
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  staleJWT,
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, staleJWT)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, bytes.NewReader([]byte("x")))
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if hits.Load() != 2 {
+		t.Errorf("upstream hits = %d, want 2 (must take the reactive 401 path, not preflight)", hits.Load())
+	}
+}
+
+// TestRoundTrip_PreflightFailureBubbles: when preflight refresh itself
+// fails (server says the grant is dead), the transport must NOT consume
+// the body — it has to return the typed error with the streaming body
+// still intact, so the caller can render the "run profile login" CTA
+// against an unread *os.File rather than half a chunk on the wire.
+func TestRoundTrip_PreflightFailureBubbles(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"status":"FAIL"}`, http.StatusUnauthorized)
+	}))
+	defer authSrv.Close()
+
+	staleJWT := makeJWT(t, time.Now().Add(-1*time.Minute).Unix())
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  staleJWT,
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, staleJWT)
+
+	body := io.NopCloser(strings.NewReader("chunk"))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, body)
+	req.GetBody = nil
+	_, err := tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var inv *credential.ErrTokenInvalidated
+	if !errors.As(err, &inv) {
+		t.Errorf("err = %v, want *credential.ErrTokenInvalidated", err)
+	}
+	if upstreamHits.Load() != 0 {
+		t.Errorf("upstream hits = %d, want 0 (preflight failure must not send the body)", upstreamHits.Load())
+	}
+}
+
+// TestRoundTrip_RefreshFailureBubbles: refresh server returns 401 →
+// refresher returns ErrTokenInvalidated → transport surfaces it (caller
+// sees the "run profile login" CTA). The original upstream response is
+// already drained; only the typed error reaches the caller.
+func TestRoundTrip_RefreshFailureBubbles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauth", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"status":"FAIL"}`, http.StatusUnauthorized)
+	}))
+	defer authSrv.Close()
+
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, "AT")
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var inv *credential.ErrTokenInvalidated
+	if !errors.As(err, &inv) {
+		t.Errorf("err = %v, want *credential.ErrTokenInvalidated", err)
+	}
+}
+
+// TestRoundTrip_403SameAs401: 403 must trigger refresh just like 401.
+// Some Olares deployments emit 403 instead of 401 for an expired but
+// otherwise-valid signature.
+func TestRoundTrip_403SameAs401(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"OK","data":{"access_token":"AT-NEW","refresh_token":"RT"}}`)
+	}))
+	defer authSrv.Close()
+
+	store := &fakeStore{}
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT-OLD",
+		RefreshToken: "RT",
+	})
+	tr, _ := newTransport(t, store, authSrv.URL, "AT-OLD")
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after 403→refresh→retry", resp.StatusCode)
+	}
+}
+
+// TestCanRetry guards the canRetry table — these are the body-shape
+// invariants the rest of the file relies on. If an http stdlib upgrade
+// changes how GetBody is auto-populated, this test is the alarm.
+func TestCanRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body io.Reader
+		want bool
+	}{
+		{"nil body", nil, true},
+		{"bytes.Reader", bytes.NewReader([]byte("a")), true},
+		{"bytes.Buffer", bytes.NewBuffer([]byte("a")), true},
+		{"strings.Reader", strings.NewReader("a"), true},
+		// io.NopCloser hides the underlying type from net/http, so
+		// http.NewRequest can't set GetBody → not retryable.
+		{"opaque reader", io.NopCloser(strings.NewReader("a")), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "http://x", tc.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := canRetry(req); got != tc.want {
+				t.Errorf("canRetry = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTokenCell_RaceFree exercises the read+write paths under -race.
+// Without the RWMutex this would flag immediately.
+func TestTokenCell_RaceFree(t *testing.T) {
+	c := &tokenCell{token: "init"}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if i%2 == 0 {
+					c.update(fmt.Sprintf("v-%d-%d", i, j))
+				} else {
+					_ = c.snapshot()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/cli/pkg/credential/default_provider.go
+++ b/cli/pkg/credential/default_provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/olares"
 )
 
-// DefaultProvider resolves a profile using the local config + plaintext token
+// DefaultProvider resolves a profile using the local config + keychain token
 // store. It implements the standard "ran `profile login` on the same machine"
 // scenario.
 //
@@ -20,14 +20,14 @@ import (
 //
 //  1. profile nil                    → return (nil, nil); orchestrator surfaces ErrNoProfile
 //  2. no token stored                → ErrNotLoggedIn
-//  3. stored.InvalidatedAt > 0       → ErrTokenInvalidated  (Phase 2 marks this on /api/refresh 401/403)
-//  4. JWT exp claim in the past      → ErrTokenExpired
-//  5. otherwise                      → ResolvedProfile
+//  3. stored.InvalidatedAt > 0       → ErrTokenInvalidated  (refresher writes this on /api/refresh 401/403)
+//  4. otherwise                      → ResolvedProfile, even if the JWT exp is in the past
 //
-// Note (3) takes precedence over (4): an explicitly-invalidated grant is
-// unusable even if the access_token JWT happens to still have time left,
-// because the refresh leg is dead and we cannot get a new one. Phase 1 does
-// NOT auto-refresh. Phase 2 will inject token-refresh logic here.
+// We deliberately do NOT short-circuit on a stale JWT exp claim: cli/pkg/cmdutil's
+// refreshingTransport will trigger /api/refresh on a 401 and retry the
+// request transparently. Failing here would deny it the chance to recover.
+// The ErrTokenExpired type is kept for backward compatibility (no callers
+// today) in case a future flow wants to assert on it.
 type DefaultProvider struct {
 	store auth.TokenStore
 	now   func() time.Time
@@ -53,8 +53,10 @@ func (e *ErrNotLoggedIn) Error() string {
 	return fmt.Sprintf("no access token for %s; run: olares-cli profile login --olares-id %s  (or profile import --refresh-token <tok>)", e.OlaresID, e.OlaresID)
 }
 
-// ErrTokenExpired is returned when a stored token's JWT `exp` is in the past.
-// Phase 1 does not auto-refresh; Phase 2 will catch this internally.
+// ErrTokenExpired is retained for backward compatibility but is no longer
+// produced by Resolve — refreshingTransport handles expiry transparently
+// via /api/refresh. Kept so any future flow (or external consumer of the
+// credential package) can still assert on it without API churn.
 type ErrTokenExpired struct {
 	OlaresID  string
 	ExpiredAt time.Time
@@ -69,9 +71,9 @@ func (e *ErrTokenExpired) Error() string {
 // marked unusable via TokenStore.MarkInvalidated. The grant cannot be
 // recovered locally — the user must re-authenticate.
 //
-// Phase 1 has no code path that writes InvalidatedAt; the only way to hit
-// this in Phase 1 is by hand-editing tokens.json. Phase 2's refreshWithLock
-// will write InvalidatedAt when /api/refresh returns 401/403.
+// Refresher.Refresh stamps InvalidatedAt when /api/refresh returns 401/403,
+// so subsequent commands skip the network round-trip and surface this CTA
+// directly.
 type ErrTokenInvalidated struct {
 	OlaresID      string
 	InvalidatedAt time.Time
@@ -109,9 +111,8 @@ func (d *DefaultProvider) Resolve(_ context.Context, profile *cliconfig.ProfileC
 	if expErr != nil && !errors.Is(expErr, auth.ErrNoExpClaim) {
 		return nil, fmt.Errorf("decode access token: %w", expErr)
 	}
-	if !exp.IsZero() && !d.now().Before(exp) {
-		return nil, &ErrTokenExpired{OlaresID: profile.OlaresID, ExpiredAt: exp}
-	}
+	// Stale JWTs are NOT rejected here — refreshingTransport will swap them
+	// out on a 401. We surface exp purely as a hint on ResolvedProfile.
 
 	return buildResolved(profile, stored.AccessToken, exp)
 }

--- a/cli/pkg/credential/refresher.go
+++ b/cli/pkg/credential/refresher.go
@@ -1,0 +1,217 @@
+package credential
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/beclab/Olares/cli/internal/lockfile"
+	"github.com/beclab/Olares/cli/pkg/auth"
+)
+
+// Refresher is the runtime token-refresh primitive: given a (likely-expired)
+// access_token observed by an HTTP caller, it returns a freshly-rotated one,
+// performing /api/refresh at most once across all goroutines AND across all
+// concurrent olares-cli processes.
+//
+// The lark-cli pattern we mirror has three layers of de-duplication:
+//
+//  1. **Process-wide mutex** (`mu`). Every goroutine in the same Refresher
+//     instance serializes through this; the loser waits and reads whatever
+//     the winner persisted.
+//
+//  2. **Compare-after-Get**. The first thing the locked goroutine does is
+//     re-read StoredToken from the keychain. If `stored.AccessToken` is
+//     already different from the caller's `currentAccessToken`, somebody
+//     (this process or another one) refreshed while we were blocked on the
+//     mutex — return the stored token without touching the network.
+//
+//  3. **On-disk flock** (cli/internal/lockfile). Cross-process serialization.
+//     We acquire it AFTER the in-process mutex+compare so multiple
+//     goroutines from the same process collapse to a single flock contender.
+//     After acquiring flock, we re-read StoredToken AGAIN — the winning
+//     process may have finished and released its flock between our two
+//     reads.
+//
+// Only when all three checks agree the token is still stale do we POST
+// /api/refresh. On 401/403 from refresh we stamp InvalidatedAt and return
+// ErrTokenInvalidated; on transport errors we surface them verbatim so the
+// caller can retry the whole command.
+type Refresher struct {
+	store auth.TokenStore
+	mu    sync.Mutex
+	now   func() time.Time
+
+	// timeout bounds a single Refresh call's flock-acquire window so a
+	// stuck peer process can't hang the CLI forever. A misbehaving peer
+	// stuck inside /api/refresh longer than this gets bypassed and we'll
+	// race them on the actual POST — that's strictly better than blocking
+	// the caller indefinitely.
+	flockTimeout time.Duration
+}
+
+// NewRefresher returns a production Refresher backed by the keychain token
+// store.
+func NewRefresher() *Refresher {
+	return &Refresher{
+		store:        auth.NewTokenStore(),
+		now:          time.Now,
+		flockTimeout: 30 * time.Second,
+	}
+}
+
+// NewRefresherWith is the test seam — pass any TokenStore + clock.
+func NewRefresherWith(store auth.TokenStore, now func() time.Time) *Refresher {
+	return &Refresher{store: store, now: now, flockTimeout: 30 * time.Second}
+}
+
+// Refresh exchanges the stored refresh_token for a fresh access_token.
+//
+// `currentAccessToken` is what the caller observed in its (now-401)
+// response; if the keychain holds a different access_token at any of the
+// double-check points, we return the stored value without making a network
+// call. This is what lets concurrent goroutines / processes collapse to a
+// single /api/refresh.
+//
+// Errors:
+//   - *ErrNotLoggedIn          — no token entry exists for olaresID
+//   - *ErrTokenInvalidated     — a previous refresh failure (or this one)
+//     marked the grant unusable; user must re-authenticate
+//   - context.Canceled / .DeadlineExceeded — caller's ctx fired while we
+//     were blocked on flock
+//   - any other error          — transport / 5xx / decode failure (transient,
+//     caller may retry the whole command)
+func (r *Refresher) Refresh(
+	ctx context.Context,
+	olaresID, authURL, currentAccessToken string,
+	insecureSkipVerify bool,
+) (string, error) {
+	if olaresID == "" {
+		return "", errors.New("olaresID is required")
+	}
+	if authURL == "" {
+		return "", errors.New("authURL is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// In-process double-check. If another goroutine already rotated the
+	// token while we were waiting on r.mu, we're done — no flock, no POST.
+	if newAT, ok, err := r.alreadyFresh(olaresID, currentAccessToken); err != nil || ok {
+		return newAT, err
+	}
+
+	// Cross-process serialization. Bound the wait so a stuck peer can't
+	// hang us indefinitely.
+	lockPath, err := lockfile.RefreshLockPath(olaresID)
+	if err != nil {
+		return "", fmt.Errorf("derive refresh lock path: %w", err)
+	}
+	lockCtx, cancel := context.WithTimeout(ctx, r.flockTimeout)
+	defer cancel()
+	release, err := lockfile.Acquire(lockCtx, lockPath)
+	if err != nil {
+		// Bubble the original ctx error if that's why we failed (so a
+		// caller-side cancel surfaces as context.Canceled, not as a
+		// deadline-exceeded from the inner ctx).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
+		return "", fmt.Errorf("acquire refresh lock for %s: %w", olaresID, err)
+	}
+	defer release() //nolint:errcheck // best-effort lock release
+
+	// Cross-process double-check: another olares-cli may have refreshed
+	// between our two reads. Re-read the store while holding flock so the
+	// next read sees a stable answer.
+	if newAT, ok, err := r.alreadyFresh(olaresID, currentAccessToken); err != nil || ok {
+		return newAT, err
+	}
+
+	// Still stale → actually call /api/refresh.
+	stored, err := r.store.Get(olaresID)
+	if err != nil {
+		if errors.Is(err, auth.ErrTokenNotFound) {
+			return "", &ErrNotLoggedIn{OlaresID: olaresID}
+		}
+		return "", fmt.Errorf("read token store: %w", err)
+	}
+	if stored.RefreshToken == "" {
+		// We have an access_token but no refresh_token to rotate it
+		// with. Treat as "needs login" — same UX as if the entry was
+		// missing, since we can't recover from this client-side.
+		return "", &ErrNotLoggedIn{OlaresID: olaresID}
+	}
+
+	tok, err := auth.Refresh(ctx, auth.RefreshRequest{
+		AuthURL:            authURL,
+		RefreshToken:       stored.RefreshToken,
+		AccessToken:        stored.AccessToken,
+		InsecureSkipVerify: insecureSkipVerify,
+		Timeout:            15 * time.Second,
+	})
+	if err != nil {
+		// 401/403 from /api/refresh = the grant itself is dead. Mark
+		// it so subsequent commands skip the network round-trip and
+		// go straight to "run profile login".
+		if errors.Is(err, auth.ErrRefreshUnauthorized) {
+			at := r.now()
+			// MarkInvalidated is best-effort: failing to persist
+			// the stamp doesn't change the user-facing CTA
+			// ("run profile login"), and the next refresh attempt
+			// will hit the same 401 → re-mark, so the situation
+			// is self-healing. Surface the persistence failure on
+			// stderr for ops/debugging but DO NOT swallow the
+			// typed error — that would deny callers'
+			// reformatters the chance to render the CTA.
+			if mErr := r.store.MarkInvalidated(olaresID, at); mErr != nil {
+				fmt.Fprintf(os.Stderr,
+					"warning: failed to persist invalidated marker for %s: %v (refresh attempt will repeat next run)\n",
+					olaresID, mErr)
+			}
+			return "", &ErrTokenInvalidated{OlaresID: olaresID, InvalidatedAt: at}
+		}
+		return "", err
+	}
+
+	newStored := auth.StoredToken{
+		OlaresID:     olaresID,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		SessionID:    tok.SessionID,
+		GrantedAt:    r.now().UnixMilli(),
+	}
+	if err := r.store.Set(newStored); err != nil {
+		return "", fmt.Errorf("persist refreshed token: %w", err)
+	}
+	return tok.AccessToken, nil
+}
+
+// alreadyFresh returns (newAT, true, nil) if the keychain holds an
+// access_token that differs from currentAccessToken (somebody already
+// refreshed) and the entry is not invalidated. Returns (_, false, nil) when
+// the caller should proceed to the next step. Returns a typed error for
+// permanent conditions (not-logged-in, invalidated).
+func (r *Refresher) alreadyFresh(olaresID, currentAccessToken string) (string, bool, error) {
+	stored, err := r.store.Get(olaresID)
+	if err != nil {
+		if errors.Is(err, auth.ErrTokenNotFound) {
+			return "", false, &ErrNotLoggedIn{OlaresID: olaresID}
+		}
+		return "", false, fmt.Errorf("read token store: %w", err)
+	}
+	if stored.InvalidatedAt > 0 {
+		return "", false, &ErrTokenInvalidated{
+			OlaresID:      olaresID,
+			InvalidatedAt: time.UnixMilli(stored.InvalidatedAt),
+		}
+	}
+	if stored.AccessToken != "" && stored.AccessToken != currentAccessToken {
+		return stored.AccessToken, true, nil
+	}
+	return "", false, nil
+}

--- a/cli/pkg/credential/refresher_test.go
+++ b/cli/pkg/credential/refresher_test.go
@@ -1,0 +1,605 @@
+package credential
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/auth"
+)
+
+// fakeStore is the in-memory TokenStore stand-in used by every test in
+// this file. It is intentionally simple — production code is exercised
+// through keychainStore, which has its own unit tests.
+type fakeStore struct {
+	mu    sync.Mutex
+	items map[string]auth.StoredToken
+
+	// Set/MarkInvalidated counters let concurrency tests assert that a
+	// refresh actually persisted, not just returned a value.
+	setCount   atomic.Int32
+	markCount  atomic.Int32
+	markErrors atomic.Int32 // simulate keychain hiccups
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{items: map[string]auth.StoredToken{}}
+}
+
+func (s *fakeStore) Get(olaresID string) (*auth.StoredToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.items[olaresID]
+	if !ok {
+		return nil, auth.ErrTokenNotFound
+	}
+	cp := t
+	return &cp, nil
+}
+
+func (s *fakeStore) Set(t auth.StoredToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[t.OlaresID] = t
+	s.setCount.Add(1)
+	return nil
+}
+
+func (s *fakeStore) Delete(olaresID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, olaresID)
+	return nil
+}
+
+func (s *fakeStore) List() ([]auth.StoredToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]auth.StoredToken, 0, len(s.items))
+	for _, t := range s.items {
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func (s *fakeStore) MarkInvalidated(olaresID string, at time.Time) error {
+	if s.markErrors.Load() > 0 {
+		s.markErrors.Add(-1)
+		return errors.New("simulated MarkInvalidated failure")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.items[olaresID]
+	if !ok {
+		return auth.ErrTokenNotFound
+	}
+	t.InvalidatedAt = at.UnixMilli()
+	s.items[olaresID] = t
+	s.markCount.Add(1)
+	return nil
+}
+
+// refreshServer spins up an httptest.Server that fakes /api/refresh.
+// hits is incremented before the response is written, so the test can
+// observe a hit even if the response is delayed via the latency hook.
+type refreshServer struct {
+	*httptest.Server
+	hits    atomic.Int32
+	status  int                 // status code to return; 0 = StatusOK
+	body    func(int32) string  // body fn given the (1-indexed) hit count
+	latency func(int32)         // optional pre-response delay hook
+	allow   func(int32) bool    // if set, must return true for 200; else 401
+}
+
+func newRefreshServer(t *testing.T, opts ...func(*refreshServer)) *refreshServer {
+	rs := &refreshServer{}
+	for _, o := range opts {
+		o(rs)
+	}
+	rs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit := rs.hits.Add(1)
+		if rs.latency != nil {
+			rs.latency(hit)
+		}
+		if rs.allow != nil && !rs.allow(hit) {
+			http.Error(w, `{"status":"FAIL","message":"unauth"}`, http.StatusUnauthorized)
+			return
+		}
+		status := rs.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		body := ""
+		if rs.body != nil {
+			body = rs.body(hit)
+		} else {
+			body = fmt.Sprintf(`{"status":"OK","data":{"access_token":"AT%d","refresh_token":"RT%d","session_id":"S%d"}}`, hit, hit, hit)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(rs.Close)
+	return rs
+}
+
+func setupRefresherEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OLARES_CLI_HOME", t.TempDir())
+}
+
+// TestRefresh_HappyPath rotates a stale access token through /api/refresh
+// once and asserts the new token is persisted + returned.
+func TestRefresh_HappyPath(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "old-AT",
+		RefreshToken: "RT-orig",
+	})
+	srv := newRefreshServer(t)
+
+	r := NewRefresherWith(store, time.Now)
+	got, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "old-AT", false)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got != "AT1" {
+		t.Errorf("got = %q, want AT1", got)
+	}
+	if srv.hits.Load() != 1 {
+		t.Errorf("server hits = %d, want 1", srv.hits.Load())
+	}
+	if store.setCount.Load() != 2 { // initial Set + refresh Set
+		t.Errorf("Set count = %d, want 2", store.setCount.Load())
+	}
+	stored, _ := store.Get("alice@olares.com")
+	if stored.AccessToken != "AT1" || stored.RefreshToken != "RT1" {
+		t.Errorf("stored = %+v", stored)
+	}
+}
+
+// TestRefresh_AlreadyFreshShortCircuit: if another goroutine refreshed
+// the token between when the caller saw the 401 and when the caller
+// reached r.Refresh, we must return the stored token without hitting
+// the network.
+func TestRefresh_AlreadyFreshShortCircuit(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT-already-new",
+		RefreshToken: "RT",
+	})
+	srv := newRefreshServer(t)
+
+	r := NewRefresherWith(store, time.Now)
+	// The caller's snapshot is "old-AT"; the store now holds AT-already-new.
+	got, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "old-AT", false)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got != "AT-already-new" {
+		t.Errorf("got = %q, want AT-already-new", got)
+	}
+	if srv.hits.Load() != 0 {
+		t.Errorf("server hits = %d, want 0 (should short-circuit)", srv.hits.Load())
+	}
+}
+
+// TestRefresh_Unauthorized stamps InvalidatedAt and surfaces
+// ErrTokenInvalidated. This is the "user must run profile login" path.
+func TestRefresh_Unauthorized(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+	})
+	srv := newRefreshServer(t, func(rs *refreshServer) {
+		rs.allow = func(int32) bool { return false }
+	})
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "AT", false)
+	var inv *ErrTokenInvalidated
+	if !errors.As(err, &inv) {
+		t.Fatalf("err = %v, want *ErrTokenInvalidated", err)
+	}
+	if store.markCount.Load() != 1 {
+		t.Errorf("MarkInvalidated count = %d, want 1", store.markCount.Load())
+	}
+	stored, _ := store.Get("alice@olares.com")
+	if stored.InvalidatedAt == 0 {
+		t.Error("expected InvalidatedAt > 0 after MarkInvalidated")
+	}
+}
+
+// TestRefresh_AlreadyInvalidated: a previous refresh failure stamped
+// InvalidatedAt; we should NOT re-call /api/refresh, just surface
+// ErrTokenInvalidated immediately.
+func TestRefresh_AlreadyInvalidated(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:      "alice@olares.com",
+		AccessToken:   "AT",
+		RefreshToken:  "RT",
+		InvalidatedAt: time.Now().UnixMilli(),
+	})
+	srv := newRefreshServer(t)
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "AT", false)
+	var inv *ErrTokenInvalidated
+	if !errors.As(err, &inv) {
+		t.Fatalf("err = %v, want *ErrTokenInvalidated", err)
+	}
+	if srv.hits.Load() != 0 {
+		t.Errorf("server hits = %d, want 0 (already-invalidated must short-circuit)", srv.hits.Load())
+	}
+}
+
+// TestRefresh_NotLoggedIn: no entry in the store → ErrNotLoggedIn,
+// without a network call.
+func TestRefresh_NotLoggedIn(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	srv := newRefreshServer(t)
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "ghost@olares.com", srv.URL, "AT", false)
+	var nli *ErrNotLoggedIn
+	if !errors.As(err, &nli) {
+		t.Fatalf("err = %v, want *ErrNotLoggedIn", err)
+	}
+	if srv.hits.Load() != 0 {
+		t.Errorf("server hits = %d, want 0", srv.hits.Load())
+	}
+}
+
+// TestRefresh_ConcurrentGoroutines: the lark-cli pattern — 50 goroutines
+// see the same stale AT and call Refresh concurrently. Exactly ONE POST
+// must reach /api/refresh; all 50 callers must see the same fresh token.
+func TestRefresh_ConcurrentGoroutines(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "old",
+		RefreshToken: "RT",
+	})
+	srv := newRefreshServer(t, func(rs *refreshServer) {
+		// 50ms latency forces the first goroutine to hold the lock
+		// long enough that the others actually contend.
+		rs.latency = func(int32) { time.Sleep(50 * time.Millisecond) }
+	})
+
+	r := NewRefresherWith(store, time.Now)
+	const n = 50
+	results := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			at, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "old", false)
+			results[i] = at
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	if hits := srv.hits.Load(); hits != 1 {
+		t.Errorf("server hits = %d, want exactly 1", hits)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: err = %v", i, err)
+		}
+	}
+	for i, got := range results {
+		if got != "AT1" {
+			t.Errorf("caller %d: got %q, want AT1", i, got)
+		}
+	}
+}
+
+// TestRefresh_MarkInvalidatedFailureSurfaces: if MarkInvalidated itself
+// errors (e.g. keychain hiccup), we still want callers to receive the
+// typed *ErrTokenInvalidated so reformatters render the
+// "run profile login" CTA. The persistence failure is recoverable —
+// the next refresh attempt will hit the same 401 and re-mark — so we
+// log it to stderr but never let it shadow the real error.
+func TestRefresh_MarkInvalidatedFailureSurfaces(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	store.markErrors.Store(1)
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+	})
+	srv := newRefreshServer(t, func(rs *refreshServer) {
+		rs.allow = func(int32) bool { return false }
+	})
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "AT", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var inv *ErrTokenInvalidated
+	if !errors.As(err, &inv) {
+		t.Fatalf("err = %v, want *ErrTokenInvalidated even when MarkInvalidated fails", err)
+	}
+	if inv.OlaresID != "alice@olares.com" {
+		t.Errorf("inv.OlaresID = %q, want alice@olares.com", inv.OlaresID)
+	}
+}
+
+// TestRefresh_EmptyRefreshToken: stored token with no refresh leg →
+// ErrNotLoggedIn (the only thing we can do is ask the user to re-login).
+func TestRefresh_EmptyRefreshToken(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:    "alice@olares.com",
+		AccessToken: "AT",
+		// RefreshToken intentionally missing
+	})
+	srv := newRefreshServer(t)
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "AT", false)
+	var nli *ErrNotLoggedIn
+	if !errors.As(err, &nli) {
+		t.Fatalf("err = %v, want *ErrNotLoggedIn", err)
+	}
+	if srv.hits.Load() != 0 {
+		t.Errorf("server hits = %d, want 0", srv.hits.Load())
+	}
+}
+
+// TestRefresh_TransientErrorPropagates: a 5xx from /api/refresh should
+// NOT mark invalidated — the user can simply retry the command. We
+// surface the error verbatim.
+func TestRefresh_TransientErrorPropagates(t *testing.T) {
+	setupRefresherEnv(t)
+	store := newFakeStore()
+	_ = store.Set(auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+	})
+	srv := newRefreshServer(t, func(rs *refreshServer) {
+		rs.status = http.StatusInternalServerError
+		rs.body = func(int32) string { return `{"status":"FAIL","message":"oops"}` }
+	})
+
+	r := NewRefresherWith(store, time.Now)
+	_, err := r.Refresh(context.Background(), "alice@olares.com", srv.URL, "AT", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var inv *ErrTokenInvalidated
+	if errors.As(err, &inv) {
+		t.Errorf("err = %v; transient 5xx must NOT produce ErrTokenInvalidated", err)
+	}
+	if store.markCount.Load() != 0 {
+		t.Errorf("MarkInvalidated called %d times on transient error; want 0", store.markCount.Load())
+	}
+}
+
+// TestRefresh_CrossProcess re-execs the test binary as multiple child
+// processes that all attempt to refresh the same olaresId against the
+// same httptest server, sharing a JSON-on-disk token store + a shared
+// flock directory under OLARES_CLI_HOME.
+//
+// The assertion is strict: across N concurrent processes, /api/refresh
+// must be hit exactly ONCE. This is the canonical lark-cli "two CLIs at
+// the same moment" race — without flock + double-check both procs would
+// POST and one's refresh-token rotation would overwrite the other's.
+func TestRefresh_CrossProcess(t *testing.T) {
+	if os.Getenv("OLARES_REFRESH_CHILD") == "1" {
+		runChildRefresh()
+		return
+	}
+	if testing.Short() {
+		t.Skip("cross-process refresh test re-execs the test binary; skipping in -short")
+	}
+
+	cliHome := t.TempDir()
+	storePath := cliHome + "/test_store.json"
+	seed := auth.StoredToken{
+		OlaresID:     "alice@olares.com",
+		AccessToken:  "old",
+		RefreshToken: "RT",
+	}
+	if err := writeFileStore(storePath, map[string]auth.StoredToken{seed.OlaresID: seed}); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	srv := newRefreshServer(t, func(rs *refreshServer) {
+		rs.latency = func(int32) { time.Sleep(150 * time.Millisecond) }
+	})
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	const procs = 4
+	var wg sync.WaitGroup
+	errsCh := make(chan error, procs)
+	for i := 0; i < procs; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(exe, "-test.run=TestRefresh_CrossProcess$", "-test.v=false")
+			cmd.Env = append(os.Environ(),
+				"OLARES_REFRESH_CHILD=1",
+				"OLARES_CLI_HOME="+cliHome,
+				"OLARES_REFRESH_AUTH_URL="+srv.URL,
+				"OLARES_REFRESH_OLARES_ID="+seed.OlaresID,
+				"OLARES_REFRESH_STORE="+storePath,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				errsCh <- fmt.Errorf("child %d: %v\n%s", i, err, out)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errsCh)
+	for err := range errsCh {
+		t.Error(err)
+	}
+
+	if hits := srv.hits.Load(); hits != 1 {
+		t.Errorf("cross-process /api/refresh hits = %d, want exactly 1", hits)
+	}
+	final, err := readFileStore(storePath)
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	if at := final[seed.OlaresID].AccessToken; at != "AT1" {
+		t.Errorf("final stored AccessToken = %q, want AT1", at)
+	}
+}
+
+// runChildRefresh is the OLARES_REFRESH_CHILD=1 entrypoint: instantiate
+// a Refresher wired to the file-backed store, refresh once, exit.
+//
+// We use os.Exit (rather than t.Fatal) for failures so the parent's
+// CombinedOutput captures stderr and surfaces it without the noise of
+// `go test`'s ok/FAIL marker for the re-executed binary.
+func runChildRefresh() {
+	authURL := os.Getenv("OLARES_REFRESH_AUTH_URL")
+	olaresID := os.Getenv("OLARES_REFRESH_OLARES_ID")
+	storePath := os.Getenv("OLARES_REFRESH_STORE")
+	if authURL == "" || olaresID == "" || storePath == "" {
+		fmt.Fprintln(os.Stderr, "child: missing env")
+		os.Exit(2)
+	}
+
+	store := &fileStore{path: storePath}
+	cur, err := store.Get(olaresID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child: get: %v\n", err)
+		os.Exit(2)
+	}
+	r := NewRefresherWith(store, time.Now)
+	got, err := r.Refresh(context.Background(), olaresID, authURL, cur.AccessToken, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child: refresh: %v\n", err)
+		os.Exit(2)
+	}
+	if !strings.HasPrefix(got, "AT") {
+		fmt.Fprintf(os.Stderr, "child: unexpected token %q\n", got)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+// fileStore is a JSON-on-disk TokenStore used solely by
+// TestRefresh_CrossProcess. Each operation reads + writes the entire
+// file under a flock to be safe across processes — production code
+// uses the OS keychain, which has its own concurrency guarantees, but
+// we need a file backend here so multiple test processes can share
+// state. The contention shape it produces (file-level coarse lock)
+// matches keychainStore's "single mutating call serializes" property
+// closely enough for the dedup invariant to be observable.
+type fileStore struct{ path string }
+
+func writeFileStore(path string, items map[string]auth.StoredToken) error {
+	b, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+func readFileStore(path string) (map[string]auth.StoredToken, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]auth.StoredToken
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = map[string]auth.StoredToken{}
+	}
+	return out, nil
+}
+
+func (s *fileStore) load() (map[string]auth.StoredToken, error) { return readFileStore(s.path) }
+func (s *fileStore) save(items map[string]auth.StoredToken) error {
+	return writeFileStore(s.path, items)
+}
+
+func (s *fileStore) Get(olaresID string) (*auth.StoredToken, error) {
+	items, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	t, ok := items[olaresID]
+	if !ok {
+		return nil, auth.ErrTokenNotFound
+	}
+	return &t, nil
+}
+func (s *fileStore) Set(t auth.StoredToken) error {
+	items, err := s.load()
+	if err != nil {
+		return err
+	}
+	items[t.OlaresID] = t
+	return s.save(items)
+}
+func (s *fileStore) Delete(olaresID string) error {
+	items, err := s.load()
+	if err != nil {
+		return err
+	}
+	delete(items, olaresID)
+	return s.save(items)
+}
+func (s *fileStore) List() ([]auth.StoredToken, error) {
+	items, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]auth.StoredToken, 0, len(items))
+	for _, t := range items {
+		out = append(out, t)
+	}
+	return out, nil
+}
+func (s *fileStore) MarkInvalidated(olaresID string, at time.Time) error {
+	items, err := s.load()
+	if err != nil {
+		return err
+	}
+	t, ok := items[olaresID]
+	if !ok {
+		return auth.ErrTokenNotFound
+	}
+	t.InvalidatedAt = at.UnixMilli()
+	items[olaresID] = t
+	return s.save(items)
+}

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-files
-version: 1.0.0
+version: 1.1.0
 description: "olares-cli files command tree: list (ls), upload, download, cat, and rm against the per-user files-backend (drive/Home, drive/Data, sync, cache, external, awss3, dropbox, google, tencent, share). Covers the 3-segment frontend path schema (<fileType>/<extend>/<subPath>), resumable chunked upload (Drive v2 protocol), Range-based resumable download, recursive directory transfer with errgroup parallelism, batch DELETE wire shape, and two server-side quirks the user MUST know about (POST mkdir auto-renames existing dirs to 'Foo (1)'; GET single-file resource returns HTTP 500). Use whenever the user mentions files / drive / Home / Data / sync / cache, uploading or downloading files, listing a remote directory, deleting remote files, cat-ting a remote file, resumable transfers, /api/resources, /api/raw, frontend path, or sees errors like 'Documents (1)' appearing on the server."
 metadata:
   requires:
@@ -76,7 +76,20 @@ If the user reports `HTTP 500` against `/api/resources/.../<filename>` with no t
 
 ## Authentication transport
 
-Every files API call carries `X-Authorization: <access_token>` as a header (NOT the standard `Authorization: Bearer ...`). The Factory injects this automatically; see [`cli/pkg/cmdutil/factory.go`](cli/pkg/cmdutil/factory.go). Do not try to call the backend via `curl` with a Bearer token — that header shape is not what the per-user files-backend expects and the request will fail.
+Every files API call carries `X-Authorization: <access_token>` as a header (NOT the standard `Authorization: Bearer ...`). The Factory's `refreshingTransport` injects this automatically; see [`cli/pkg/cmdutil/factory.go`](cli/pkg/cmdutil/factory.go). Do not try to call the backend via `curl` with a Bearer token — that header shape is not what the per-user files-backend expects and the request will fail.
+
+The transport **auto-refreshes expired tokens transparently** through two paths (both detailed in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) "Automatic token refresh"):
+
+| Verb(s) | Body shape | Refresh path |
+|---------|------------|--------------|
+| `ls`, `cat`, `download`, `rm` | No body or `*bytes.Reader`/`*bytes.Buffer` (replayable) | **Reactive** — send with current token; on 401/403 call `/api/refresh` and retry once with the new token. |
+| `upload` (chunk POST) | `*os.File` slice (non-replayable streaming body) | **Pro-active** — decode the JWT's `exp` before each chunk; if within 60s of expiry, refresh BEFORE handing the body to the transport. |
+
+The pro-active path on `upload` exists because once a `*os.File` chunk is consumed by the first send, we can't replay it on a 401 — the resume probe would re-pull from the server-known offset on the next run, but the in-flight chunk would already have failed the user's command. Pre-flight rotation collapses that into a silent rotate-and-continue, even when `--parallel N>1` has multiple chunks racing the same expiry window (the `Refresher`'s in-process mutex + cross-process flock guarantee a single `/api/refresh` hit per stale token).
+
+Stat / Range probes inside `download` and `cat` use the reactive path normally — they're cheap GETs with no body.
+
+When the refresh leg itself fails (`/api/refresh` rejects the refresh_token), the typed `*credential.ErrTokenInvalidated` propagates through `reformatHTTPErr` / `reformatRmHTTPErr` so the user sees the canonical "run profile login" CTA directly, without a `Get "https://...":` URL prefix. Recovery rules live in `olares-shared`.
 
 ## Command cheatsheet (5 verbs)
 

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-market
-version: 1.0.0
+version: 1.1.0
 description: "olares-cli market command tree against the per-user Market app-store v2 API: list / get / categories for catalog browsing; install / uninstall / upgrade / clone / cancel / stop / resume for lifecycle; status for runtime state; upload / delete for local chart sources (cli / upload / studio); --watch / --watch-timeout / --watch-interval to block until terminal state. Covers source resolution (market.olares catalog vs local sources), the install/upgrade/uninstall/stop/resume/cancel state machine, OpType gating for race-safe watching, the op-agnostic status --watch recovery path, and JSON shape additions (finalState/finalOpType). Use whenever the user mentions market / app store / install / upgrade / uninstall / clone / stop / resume / cancel / status / upload chart / app state / running / installFailed / --watch, asks 'is firefox installed yet', or sees errors like 'app X is not installed', 'watch timed out', 'watch canceled by user', '--watch requires an app name'."
 metadata:
   requires:
@@ -59,13 +59,16 @@ The fix lives in [`cli/cmd/ctl/market/watch.go`](cli/cmd/ctl/market/watch.go) (`
 
 ## Authentication transport
 
-Every request goes through the factory-injected `*http.Client` and uses the resolved profile from `cmdutil.Factory`. There is no kubeconfig dependency.
+Every request goes through a factory-injected `*http.Client` whose `RoundTripper` (a `refreshingTransport` — see [`cli/pkg/cmdutil/factory.go`](cli/pkg/cmdutil/factory.go)) **injects `X-Authorization` and auto-rotates expired tokens transparently**. The `MarketClient` itself is purely an HTTP wrapper — it never sees the access_token.
 
 - Base URL: `<rp.MarketURL>/app-store/api/v2` — built in [`cli/cmd/ctl/market/client.go`](cli/cmd/ctl/market/client.go) (`NewMarketClient` / `apiPrefix`).
-- Auth header: `X-Authorization: <access_token>` (NOT `Authorization: Bearer …`). Cite [`cli/cmd/ctl/market/client.go`](cli/cmd/ctl/market/client.go) (`do` / `doStream`).
+- Auth header: `X-Authorization: <access_token>` (NOT `Authorization: Bearer …`). The transport handles header injection; the client code does not call `req.Header.Set("X-Authorization", …)` anywhere.
 - `MarketURL` is derived from the Olares ID (`https://market.<localPrefix><terminusName>`) and surfaced through [`cli/pkg/credential/types.go`](cli/pkg/credential/types.go) (`ResolvedProfile.MarketURL`).
-- For multipart chart uploads the CLI builds a separate, no-timeout client (`newMarketUploadHTTPClient`) so large `.tgz` pushes are not killed by the default request timeout.
-- 401 / 403 are reformatted into a single human message via `reformatMarketAuthErr`. **Recovery is not handled here — defer to [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md).**
+- Two clients in `MarketClient`: `httpClient` (30s timeout, JSON verbs) and `uploadClient` (no timeout, multipart chart pushes). Both share the SAME `refreshingTransport` instance via the Factory, so a refresh triggered on one is immediately visible on the other.
+- 401/403 reaches `executeRequest` only when the transport already auto-refreshed and STILL got rejected (consistent server-side rejection); it's reformatted via `reformatMarketAuthErr`.
+- When `/api/refresh` itself fails, `executeRequest` surfaces the typed `*credential.ErrTokenInvalidated` / `*credential.ErrNotLoggedIn` directly so the user sees the canonical "run profile login" CTA without `request failed: Get "https://...":` noise. **Recovery rules → [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) "Automatic token refresh".**
+
+> All `market` verbs use replayable request bodies (JSON in `*bytes.Reader`, multipart in `*bytes.Buffer`), so they all benefit from the transport's reactive 401-retry path. There is no streaming-upload edge case in the market tree — chart pushes are fully buffered before the request goes out.
 
 ## Command cheatsheet
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-shared
-version: 1.0.0
-description: "Shared olares-cli foundation: profile model, first-time login (profile login with password + TOTP), bootstrapping a profile from an existing refresh token (profile import), switching/listing/removing profiles, the global --profile flag, where access/refresh tokens live in the OS keychain, and how to recover from auth errors (HTTP 401/403, token expired, token invalidated, two-factor authentication required). Use whenever the user is configuring olares-cli for the first time, logging in or importing credentials, switching/listing/removing profiles, or seeing errors like 'server rejected the access token', 'already authenticated', or 'two-factor authentication required'; also use when the user asks about refresh tokens, the keychain, olaresId, or profile management."
+version: 1.1.0
+description: "Shared olares-cli foundation: profile model, first-time login (profile login with password + TOTP), bootstrapping a profile from an existing refresh token (profile import), switching/listing/removing profiles, the global --profile flag, where access/refresh tokens live in the OS keychain, automatic access_token refresh via /api/refresh (transparent reactive retry on 401/403; pro-active JWT-exp refresh for streaming uploads; cross-goroutine + cross-process deduplication via flock), and how to recover from auth errors (HTTP 401/403, refresh token invalidated, not logged in, two-factor authentication required). Use whenever the user is configuring olares-cli for the first time, logging in or importing credentials, switching/listing/removing profiles, asking how token refresh works, scripting parallel olares-cli invocations, or seeing errors like 'server rejected the access token', 'refresh token for X became invalid', 'no access token for X', 'already authenticated', or 'two-factor authentication required'; also use when the user asks about refresh tokens, the keychain, olaresId, or profile management."
 metadata:
   requires:
     bins: ["olares-cli"]
@@ -171,11 +171,52 @@ token still valid ──▶│ Reject; tell the user to run profile remove <id> 
 
 Logic lives in [`cmd/ctl/profile/credentials.go`](cli/cmd/ctl/profile/credentials.go) `ensureProfileWritable`. If a script needs unconditional overwrite, it MUST `profile remove` first and then `profile login` / `profile import`.
 
+## Automatic token refresh
+
+**The CLI rotates expired access_tokens transparently.** Users do NOT need to run `profile login` just because their access_token aged out — only when the *refresh_token* itself becomes invalid.
+
+The refresh logic lives in [`cli/pkg/cmdutil/factory.go`](cli/pkg/cmdutil/factory.go) (`refreshingTransport`) and [`cli/pkg/credential/refresher.go`](cli/pkg/credential/refresher.go). Every `*http.Client` the Factory hands out has it wired in.
+
+### Two trigger paths
+
+| Trigger | Applies to | Behavior |
+|---------|------------|----------|
+| **Reactive (401/403 + retry)** | Replayable bodies — every JSON / `files cat` / `files download` / `files rm` / `market` JSON verb | Send with current token. On 401/403, `/api/refresh`, retry the same request once with the new token. One extra round-trip in the rare expiry case; zero overhead in steady state. |
+| **Pro-active (JWT exp + skew)** | Non-replayable bodies — `files upload` chunks (`*os.File`) | Decode the access_token's JWT exp before sending. If within 60s of expiry (or already past), `/api/refresh` first, send with the new token. Required because once a streaming body is consumed by the first send we can't replay it on a 401. |
+
+The pro-active skew is hardcoded at 60s in `cli/pkg/cmdutil/factory.go` (`preflightSkew`) — comfortably absorbs client↔server clock drift plus the time from local decode to the request landing on the server. Tokens issued without an `exp` claim, or values that don't decode as a JWT at all, skip the pre-flight gracefully and fall back to the reactive path.
+
+### Concurrency
+
+Across goroutines AND across concurrent `olares-cli` processes, **`/api/refresh` is hit at most once per stale token**:
+
+1. Process-wide `sync.Mutex` — losers wait, then read whatever the winner persisted.
+2. Compare-after-Get against the keychain — short-circuits when a sibling already rotated the token.
+3. On-disk `flock` under `<config-dir>/locks/<sanitized-olaresId>.refresh.lock` — serializes across processes; bounded by a 30s acquire timeout so a stuck peer can't hang the CLI.
+4. Re-check inside the flock — collapses any final race that snuck in between the in-process and on-disk locks.
+
+For most users this is invisible. It matters when you script multiple `olares-cli` invocations in parallel: they will not stampede `/api/refresh`.
+
+### When refresh itself fails
+
+| Outcome | What the user sees | Fix |
+|---------|---------------------|-----|
+| `/api/refresh` returns 200 + new tokens | (silent — request retried, command succeeds) | — |
+| `/api/refresh` returns 401/403 (refresh_token revoked / expired / rotated by another login) | `refresh token for <id> became invalid at <ts>; please run: olares-cli profile login --olares-id <id>` (typed `*ErrTokenInvalidated`) | `olares-cli profile login --olares-id <id>` |
+| No token in keychain at all | `no access token for <id>; run: olares-cli profile login --olares-id <id>` (typed `*ErrNotLoggedIn`) | `olares-cli profile login` (or `profile import`) |
+| `/api/refresh` returns 5xx / network error | Surfaced verbatim from the transport | Retry the command — the grant itself is still valid |
+
+The keychain entry is stamped `InvalidatedAt` on the 401 path so subsequent commands skip the network round-trip and go straight to the CTA. `profile list` shows these as `invalidated`.
+
+> **Do not implement custom retry/backoff loops on top of these errors.** The transport already handles the recoverable cases; once you see `ErrTokenInvalidated` or `ErrNotLoggedIn`, only `profile login` / `profile import` will help.
+
 ## Auth error recovery table
 
 | Error message (excerpt) | Meaning | Fix |
 |-------------------------|---------|-----|
-| `server rejected the access token (HTTP 401)` / `(HTTP 403)` | The current profile's access_token was rejected (expired, revoked, password rotated, ...) | `olares-cli profile login --olares-id <id>` |
+| `refresh token for <id> became invalid at <ts>` | `/api/refresh` itself returned 401/403 — the grant is dead | `olares-cli profile login --olares-id <id>` |
+| `no access token for <id>` | Profile selected but keychain has no entry | `olares-cli profile login` or `profile import` |
+| `server rejected the access token (HTTP 401)` / `(HTTP 403)` | After auto-refresh the server still rejects (rare; usually a server-side state drift) | `olares-cli profile login --olares-id <id>` |
 | `--olares-id is required` | login / import was invoked without olaresId | Add `--olares-id <id>` |
 | `already authenticated for <id> (expires in ...)` | A still-valid token exists for this olaresId | `olares-cli profile remove <id>` and re-run login / import |
 | `a token is already stored for <id> but its expiry can't be determined client-side` | Token present but JWT carries no exp claim, so we conservatively reject | Same: `profile remove <id>` and re-run |
@@ -183,7 +224,7 @@ Logic lives in [`cmd/ctl/profile/credentials.go`](cli/cmd/ctl/profile/credential
 | `password is empty` / `TOTP code is empty` | stdin / TTY returned an empty string | Check for premature EOF or an empty pipe |
 | `profile <name> not found` | `profile use` / `profile remove` referenced an unknown profile | `profile list` to see the actual names |
 
-> **Do not silently retry auth errors.** 401/403 / `already authenticated` are deterministic — follow the table; blind retries make the situation worse.
+> **Do not silently retry auth errors.** 401/403 after auto-refresh and `already authenticated` are deterministic — follow the table; blind retries make the situation worse.
 
 ## dev / internal flags
 


### PR DESCRIPTION
## Summary

Adds transparent `access_token` refresh to `olares-cli` so a single command no longer aborts when the access token aged out — users only need to run `profile login` when the **refresh_token** itself becomes invalid. Token rotation is also de-duplicated across goroutines and across concurrent `olares-cli` processes.

## What changed

### Core (new behaviour)

- **`refreshingTransport`** in [`cli/pkg/cmdutil/factory.go`](cli/pkg/cmdutil/factory.go) is now the `RoundTripper` behind every factory-provided `*http.Client`. Two trigger paths:
  - **Reactive (replayable bodies)** — on `401`/`403`, call `/api/refresh`, then retry the original request once with the new token. Covers every JSON / `files cat` / `files download` / `files rm` / `market` verb.
  - **Pro-active (non-replayable bodies)** — for `files upload` chunks backed by `*os.File`, decode the JWT `exp` before each send and rotate when within `60s` of expiry. Required because a consumed stream cannot be replayed on a 401.
- **`credential.Refresher`** in [`cli/pkg/credential/refresher.go`](cli/pkg/credential/refresher.go) provides the actual rotation primitive: in-process `sync.Mutex` + cross-process `gofrs/flock` lock (under `<config-dir>/locks/<sanitized-olaresId>.refresh.lock`) + double-check before and after each gate, so `/api/refresh` is hit **at most once per stale token** even when many goroutines / parallel CLI processes race the same expiry window.
- **`internal/lockfile`** (new package) wraps `gofrs/flock` with context-cancelable acquisition and a deterministic per-olaresId path layout.
- **`auth.ErrRefreshUnauthorized`** — new sentinel; `auth.Refresh` wraps `401`/`403` from `/api/refresh` with it so the refresher can distinguish a dead grant from a transient 5xx / network blip.

### Failure handling

- `/api/refresh` returning `401`/`403` stamps `InvalidatedAt` on the keychain entry and surfaces `*credential.ErrTokenInvalidated` (`profile list` already shows these as `invalidated`). Subsequent commands skip the network round-trip and go straight to the CTA.
- Reformat helpers (`reformatHTTPErr`, `reformatRmHTTPErr`, `MarketClient.executeRequest`) detect `*credential.ErrTokenInvalidated` / `*credential.ErrNotLoggedIn` via `errors.As` and surface them verbatim. Eliminates the previous `request failed: Get \"https://...\": refresh token for X became invalid...` double-wrapping; users now see just the typed error message with its built-in `run profile login` CTA.
- `MarkInvalidated` failure no longer masks the typed error — it is logged to stderr instead, and the caller still receives `*ErrTokenInvalidated` so the CTA renders.

### Cleanup at call sites

- Removed manual `X-Authorization` injection from `MarketClient`, `download.Client`, `upload.Client`, and `rm.Client`. They now just consume the factory-provided `*http.Client`. The `MarketClient` keeps two clients (timed + untimed) but they share the same `refreshingTransport` so refreshes are immediately visible to both.
- Dropped the early `ErrTokenExpired` exit in `credential.DefaultProvider.Resolve` so the transport gets to refresh stale JWTs instead of failing fast on the local heuristic.

### Skills

Bumped `olares-shared`, `olares-files`, `olares-market` from `1.0.0` → `1.1.0` and added an \"Automatic token refresh\" section to `olares-shared` (canonical) plus targeted updates in `olares-files` (call out the streaming `files upload` pre-flight path) and `olares-market` (update the auth-transport section, drop the stale `newMarketUploadHTTPClient` reference).

### Misc

`.gitignore`: switch `/files/`, `/market/` patterns from repo-root-only to anywhere, add `user-service/`. Pre-existing local maintenance, folded in by the user's request.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./pkg/cmdutil/... ./pkg/credential/... ./internal/lockfile/...` — full concurrency + transport matrix
- [x] `go test -count=1 ./cmd/ctl/... ./internal/files/...` — unit tests for the touched call sites
- [x] **Concurrency**:
  - [x] `TestRefresh_ConcurrentGoroutines` — 50 goroutines on the same Refresher → exactly 1 hit on `/api/refresh`.
  - [x] `TestRefresh_CrossProcess` — re-execs the test binary 4× sharing a file-backed token store + `OLARES_CLI_HOME` → still exactly 1 `/api/refresh` hit, validates the `flock` + double-check works across processes.
- [x] **Transport behaviour** (`cli/pkg/cmdutil/factory_test.go`):
  - [x] 200 happy path injects `X-Authorization`.
  - [x] 401 → refresh → retry with new token; 403 same.
  - [x] Retry that also returns 401 surfaces verbatim (no infinite loop).
  - [x] Non-replayable body + non-JWT token → 401 verbatim, no refresh.
  - [x] Pre-flight: stale JWT + non-replayable → exactly 1 upstream request with new token, no 401.
  - [x] Pre-flight: token within 60s skew → still rotates.
  - [x] Pre-flight: fresh token → no rotation.
  - [x] Replayable body + stale JWT → still uses reactive path (no JWT decode hot loop).
  - [x] Pre-flight refresh failure → typed error returned, body NOT consumed (upstream 0 hits).
- [x] **Errors**: typed credential errors surface cleanly through all three reformatters (files / rm / market).
- [ ] Manual smoke: pending against a live Olares instance (recommend testing `files upload` of a multi-chunk file across the 60s expiry boundary, and `market install --watch` after letting the token age out).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the CLI-wide HTTP/auth transport behavior (automatic refresh + retry on 401/403) and adds cross-process locking/persistence logic that affects all networked commands.
> 
> **Overview**
> **Introduces transparent access-token rotation across the CLI.** `cmdutil.Factory` now provides HTTP clients backed by a new `refreshingTransport` that injects `X-Authorization`, refreshes the token on 401/403, and retries eligible requests once; a no-timeout variant is added for long uploads.
> 
> **Adds a new cross-process refresh primitive.** New `credential.Refresher` performs `/api/refresh` with in-process mutex + per-user `flock`-based locking (`internal/lockfile`) and stamps `InvalidatedAt` on refresh-token rejection so subsequent commands fail fast with typed `ErrTokenInvalidated`/`ErrNotLoggedIn`.
> 
> **Migrates call sites to rely on the transport.** Files (`cat`/`download`/`upload`/`rm`) and market clients drop manual `X-Authorization` handling, update error reformatting to surface typed credential errors cleanly, and tests are updated/added to cover retry/preflight behavior and concurrency; docs/skills are bumped to describe the new auto-refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7effe1e554e6fc74889315e3870488d2ab0b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->