### PR TITLE
refactor(cli): integrate olares ID parsing for target URLs in login flow

### DIFF
--- a/cli/pkg/auth/login.go
+++ b/cli/pkg/auth/login.go
@@ -13,6 +13,8 @@ import (
 	"net/http/cookiejar"
 	"strings"
 	"time"
+
+	"github.com/beclab/Olares/cli/pkg/olares"
 )
 
 // Token mirrors the Authelia /api/firstfactor + /api/secondfactor/totp +
@@ -214,9 +216,15 @@ type firstFactorResponse struct {
 // L19-26: vault.<name>/server by default, desktop.<name>/ when the caller
 // asks for the 2FA-bearing policy via NeedTwoFactor.
 func firstFactorWithClient(ctx context.Context, client *http.Client, req LoginRequest) (*Token, error) {
-	targetURL := "https://vault." + req.TerminusName + "/server"
+
+	id, err := olares.ParseID(req.TerminusName)
+	if err != nil {
+		return nil, err
+	}
+
+	targetURL := id.VaultURL("")
 	if req.NeedTwoFactor {
-		targetURL = "https://desktop." + req.TerminusName + "/"
+		targetURL = id.DesktopURL("")
 	}
 	body := firstFactorBody{
 		Username:       req.LocalName,
@@ -262,8 +270,14 @@ func postSecondFactorTOTP(ctx context.Context, client *http.Client, req LoginReq
 	// be sent to after a successful second factor. The auth backend validates
 	// its scheme/host but otherwise just relays it back, so we hard-code the
 	// desktop subdomain pattern to match BindTerminusBusiness.ts.
+
+	id, err := olares.ParseID(req.TerminusName)
+	if err != nil {
+		return nil, err
+	}
+
 	body := secondFactorBody{
-		TargetURL: "https://desktop." + req.TerminusName + "/",
+		TargetURL: id.DesktopURL(""),
 		Token:     req.TOTP,
 	}
 	headers := map[string]string{


### PR DESCRIPTION
* **Background**
Updated the login process to utilize the olares package for deriving target URLs based on the TerminusName. This change enhances the clarity and maintainability of the code by centralizing URL construction logic. The first factor and second factor TOTP functions now leverage the new URL generation methods, ensuring consistent handling of vault and desktop URLs.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the auth login path by changing how `vault`/`desktop` redirect target URLs are constructed; incorrect parsing or URL formatting could break first/second-factor login for some `TerminusName` inputs.
> 
> **Overview**
> Updates the login flow in `cli/pkg/auth/login.go` to build first-factor `targetURL` and second-factor TOTP `targetUrl` via `olares.ParseID(...).VaultURL/DeskTopURL` rather than manual `https://vault.<terminus>/server` and `https://desktop.<terminus>/` concatenation.
> 
> This centralizes URL construction and adds validation/parsing errors from `ParseID` to the login path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9be01cd923b6adcd0d060350d8c77ef74ad0bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->