### PR TITLE
daemon: prevent ICMP port-unreachable responses 

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -26,6 +26,7 @@ build-arm: fmt vet ;$(info $(M)...Begin to build terminusd (linux version).) @
 build-linux-in-docker:
 	docker run -it --platform linux/amd64 --rm \
 		-v $(current_dir):/olaresd \
+		-v $(current_dir)/../cli:/cli \
 		-w /olaresd \
 		-e DEBIAN_FRONTEND=noninteractive \
 		golang:1.24.11 \
@@ -34,6 +35,7 @@ build-linux-in-docker:
 build-arm-in-docker:
 	docker run -it --platform linux/arm64 --rm \
 		-v $(current_dir):/olaresd \
+		-v $(current_dir)/../cli:/cli \
 		-w /olaresd \
 		-e DEBIAN_FRONTEND=noninteractive \
 		golang:1.24.11 \

--- a/daemon/internel/intranet/dsr.go
+++ b/daemon/internel/intranet/dsr.go
@@ -1,6 +1,9 @@
 package intranet
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"net"
+)
 
 func ipv4Checksum(hdr []byte) uint16 {
 	var sum uint32
@@ -12,6 +15,51 @@ func ipv4Checksum(hdr []byte) uint16 {
 		sum = (sum & 0xffff) + (sum >> 16)
 	}
 	return ^uint16(sum)
+}
+
+// udpChecksum computes the UDP checksum over the IPv4 pseudo-header and the
+// UDP datagram (header + payload). srcIP and dstIP must be 4-byte IPv4
+// addresses. udp must contain the full UDP datagram with the checksum field
+// (bytes 6:8) ALREADY zeroed by the caller.
+//
+// Per RFC 768, if the computed checksum is 0 it is transmitted as 0xFFFF to
+// distinguish it from "no checksum" (which is 0).
+func udpChecksum(srcIP, dstIP net.IP, udp []byte) uint16 {
+	src := srcIP.To4()
+	dst := dstIP.To4()
+	if src == nil || dst == nil {
+		return 0
+	}
+
+	udpLen := uint32(len(udp))
+	var sum uint32
+
+	// Pseudo-header: src(4) + dst(4) + zero(1) + proto(1) + udpLen(2)
+	sum += uint32(binary.BigEndian.Uint16(src[0:2]))
+	sum += uint32(binary.BigEndian.Uint16(src[2:4]))
+	sum += uint32(binary.BigEndian.Uint16(dst[0:2]))
+	sum += uint32(binary.BigEndian.Uint16(dst[2:4]))
+	sum += uint32(17) // protocol UDP, with the leading zero byte = 0x0011
+	sum += udpLen
+
+	// UDP header + payload
+	i := 0
+	for ; i+1 < len(udp); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(udp[i : i+2]))
+	}
+	if i < len(udp) {
+		// odd byte: pad with zero on the right
+		sum += uint32(udp[i]) << 8
+	}
+
+	for (sum >> 16) != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	csum := ^uint16(sum)
+	if csum == 0 {
+		csum = 0xffff
+	}
+	return csum
 }
 
 // fragmentIPv4 attempts to split an Ethernet frame carrying an IPv4 packet

--- a/daemon/internel/intranet/dsr_linux.go
+++ b/daemon/internel/intranet/dsr_linux.go
@@ -34,6 +34,12 @@ type DSRProxy struct {
 	responseConn *raw.Conn
 	backendConn  *raw.Conn
 
+	// dnsSink holds VIP:53 open so the kernel does NOT reply with
+	// ICMP port-unreachable for DNS queries that pcap is intercepting.
+	// The socket is intentionally never read from; incoming datagrams are
+	// simply discarded by the kernel's UDP receive buffer.
+	dnsSink *net.UDPConn
+
 	mu     sync.Mutex
 	stopCh chan struct{}
 
@@ -118,6 +124,10 @@ func (d *DSRProxy) Close() {
 	if d.backendConn != nil {
 		d.backendConn.Close()
 		d.backendConn = nil
+	}
+	if d.dnsSink != nil {
+		d.dnsSink.Close()
+		d.dnsSink = nil
 	}
 
 }
@@ -288,17 +298,20 @@ func (d *DSRProxy) start() error {
 
 						log.Printf("New IP checksum: 0x%04x", csum)
 
-						// For UDP (protocol 17), recalculate UDP checksum
+						// For UDP (protocol 17), recompute UDP checksum with the new dst IP.
 						if protocol == 17 && len(data) >= ipStart+ipHeaderLen+8 {
 							udpStart := ipStart + ipHeaderLen
-							// UDP checksum is optional for IPv4, can be set to 0
-							// But if present, we need to update it
 							oldChecksum := binary.BigEndian.Uint16(data[udpStart+6 : udpStart+8])
-							if oldChecksum != 0 {
-								// For simplicity, set UDP checksum to 0 (valid for IPv4)
-								data[udpStart+6] = 0
-								data[udpStart+7] = 0
-								log.Printf("UDP checksum set to 0 (was 0x%04x)", oldChecksum)
+							// Zero before recompute
+							data[udpStart+6] = 0
+							data[udpStart+7] = 0
+							udpLen := binary.BigEndian.Uint16(data[udpStart+4 : udpStart+6])
+							if int(udpLen) >= 8 && len(data) >= udpStart+int(udpLen) {
+								newSrcIP := net.IP(data[ipStart+12 : ipStart+16])
+								newDstIP := net.IP(data[ipStart+16 : ipStart+20])
+								ucsum := udpChecksum(newSrcIP, newDstIP, data[udpStart:udpStart+int(udpLen)])
+								binary.BigEndian.PutUint16(data[udpStart+6:udpStart+8], ucsum)
+								log.Printf("UDP checksum recomputed: 0x%04x -> 0x%04x", oldChecksum, ucsum)
 							}
 						}
 					}
@@ -420,7 +433,7 @@ func (d *DSRProxy) handleResponse(data []byte, conn net.PacketConn) {
 		log.Printf("Response: Rewriting src_ip %s -> %s", srcIP, d.vip)
 	}
 
-	// Fix UDP source port if it's not 53
+	// Fix UDP source port if it's not 53, then recompute UDP checksum
 	if protocol == 17 && len(data) >= ipStart+ipHeaderLen+8 {
 		udpStart := ipStart + ipHeaderLen
 		srcPort := binary.BigEndian.Uint16(data[udpStart : udpStart+2])
@@ -430,9 +443,17 @@ func (d *DSRProxy) handleResponse(data []byte, conn net.PacketConn) {
 			binary.BigEndian.PutUint16(data[udpStart:udpStart+2], 53)
 		}
 
-		// Set UDP checksum to 0 (optional for IPv4)
+		// Recompute UDP checksum with the new src IP / src port.
+		// Must zero the checksum field before computing.
 		data[udpStart+6] = 0
 		data[udpStart+7] = 0
+		udpLen := binary.BigEndian.Uint16(data[udpStart+4 : udpStart+6])
+		if int(udpLen) >= 8 && len(data) >= udpStart+int(udpLen) {
+			newSrcIP := net.IP(data[ipStart+12 : ipStart+16])
+			newDstIP := net.IP(data[ipStart+16 : ipStart+20])
+			ucsum := udpChecksum(newSrcIP, newDstIP, data[udpStart:udpStart+int(udpLen)])
+			binary.BigEndian.PutUint16(data[udpStart+6:udpStart+8], ucsum)
+		}
 	}
 
 	log.Printf("Response AFTER: src_ip=%s, dst_ip=%s", d.vip, dstIP)
@@ -496,7 +517,44 @@ func (d *DSRProxy) regonfigure() error {
 		return err
 	}
 
+	// Bind a UDP socket on VIP:53 so the kernel does not emit
+	// ICMP port-unreachable for DNS queries directed at the VIP.
+	// pcap still captures the packet first (and we DSR it to the backend);
+	// the socket merely keeps the port "open" from the kernel's view and
+	// silently drops anything it receives.
+	if err := d.startDNSSink(); err != nil {
+		klog.Errorf("start dns sink on %s:53 failed: %v", d.vip.String(), err)
+		return err
+	}
+
 	d.configChanged = false
+
+	return nil
+}
+
+// startDNSSink binds a UDP socket on VIP:53 to absorb DNS queries at the
+// kernel level. This prevents the kernel from sending ICMP destination
+// unreachable (port unreachable) back to the client when pcap-based DSR
+// intercepts and forwards the actual packets.
+func (d *DSRProxy) startDNSSink() error {
+	addr := &net.UDPAddr{IP: d.vip, Port: 53}
+	conn, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		return err
+	}
+	d.dnsSink = conn
+	klog.Infof("DNS sink listening on %s:53 (suppresses ICMP unreachable)", d.vip.String())
+
+	go func(c *net.UDPConn) {
+		buf := make([]byte, 2048)
+		for {
+			if _, _, err := c.ReadFromUDP(buf); err != nil {
+				// Socket closed during reconfigure / shutdown.
+				return
+			}
+			// Drop silently: pcap path already handled this packet.
+		}
+	}(conn)
 
 	return nil
 }


### PR DESCRIPTION
* **Background**
When clients on Linux send DNS queries to the VIP, the kernel responds with ICMP unreachable since there's no listening socket—the DSR proxy only intercepts via packet capture, not actual port binding. Add  binding UDP socket on VIP:53 to prevent ICMP port-unreachable responses.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
DNS clients on Linux got the `connection refused` when sending DNS queries to the Olares DNS Server.

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level packet rewriting on the DNS path (raw sockets/pcap) and changes checksum behavior, which could break DNS forwarding if incorrect, but scope is limited to the DSR proxy.
> 
> **Overview**
> Prevents Linux clients from receiving ICMP *port-unreachable* when sending DNS queries to the VIP by binding a "sink" UDP socket on `VIP:53` that discards packets while pcap-based DSR continues to forward them.
> 
> Improves correctness of packet rewriting by adding `udpChecksum` and recomputing UDP checksums after IP/port rewrites (instead of zeroing the checksum), and ensures the new `dnsSink` socket is closed on reconfigure/shutdown. Also updates docker build targets to mount `../cli` into the build container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fde0a18c9bc8993c6df177bbaa913c53ff4ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->