### PR TITLE
docs: add BIOS blind reset guide for troubleshooting Olares One HG black screen issue

### DIFF
--- a/docs/.vitepress/one.en.ts
+++ b/docs/.vitepress/one.en.ts
@@ -17,7 +17,17 @@ export const oneSidebar: DefaultTheme.Sidebar = {
         {
           text: "Known issues",
           link: "/one/known-issues",
-        },        
+        },
+        {
+          text: "Troubleshooting",
+          collapsed: true,
+          items: [
+            {
+              text: "Cannot enter BIOS",
+              link: "/one/ts-bios-black-screen",
+            },
+          ],
+        },                
       ],
     },
     {

--- a/docs/.vitepress/one.zh.ts
+++ b/docs/.vitepress/one.zh.ts
@@ -18,6 +18,16 @@ export const oneSidebar: DefaultTheme.Sidebar = {
           text: "Known issues",
           link: "/zh/one/known-issues",
         },
+        {
+          text: "Troubleshooting",
+          collapsed: true,
+          items: [
+            {
+              text: "Cannot enter BIOS",
+              link: "/zh/one/ts-bios-black-screen",
+            },
+          ],
+        },         
       ],
     },
     {

--- a/docs/one/ts-bios-black-screen.md
+++ b/docs/one/ts-bios-black-screen.md
@@ -1,25 +1,25 @@
 ---
 outline: [2, 3]
-description: Troubleshoot the issue where your Olares One experiences a black screen, and you cannot access the BIOS setup menu.
+description: Troubleshoot the issue where your Olares One experiences a black screen, and you cannot access the BIOS setup interface.
 ---
 
 # Cannot enter BIOS (Black screen)
 
-Use this guide if your Olares One shows no display during startup, and you cannot access the BIOS setup screen.
+Use this guide if your Olares One shows no display during startup, and you cannot access the BIOS setup interface.
 
 ## Condition
 
-When you power on Olares One and attempt to enter the BIOS setup, the screen remains black, preventing the boot menu from displaying.
+When you power on Olares One and attempt to enter BIOS, the monitor screen remains black, preventing the BIOS setup interface from displaying.
 
 ## Cause
 
-This issue typically occurs if the `Primary Display` setting in the BIOS was changed from `Auto` (dedicated GPU mode) to `HG` (hybrid graphics mode).
+This issue typically occurs if the `Primary Display` setting in the BIOS was changed from `Discrete GPU` to `HG` (Hybrid Graphics).
 
-When `Primary Display` is set to `HG`, the video output during the early boot stage might be sent to a different display interface (e.g., integrated graphics) that your monitor does not detect. The system might actually enter BIOS successfully, but your monitor screen stays black, making it impossible to see the BIOS interface.
+When `Primary Display` is set to `HG`, the video output during the early boot stage might be sent to a different display interface (e.g., integrated graphics) that your monitor does not detect. The system might actually enter BIOS successfully, but your monitor screen stays black, making it impossible to see the BIOS setup interface.
 
 ## Solution
 
-Follow these steps to blindly reset the BIOS to factory defaults. This restores the `Primary Display` setting to its default value `Auto` (the dedicated GPU mode).
+Follow these steps to blindly reset the BIOS to factory defaults. This restores the `Primary Display` setting to its default value.
 
 :::warning
 - These steps require physical removal of storage devices. Ensure that you power off the device and disconnect the power cable before proceeding.   
@@ -38,7 +38,7 @@ Follow these steps to blindly reset the BIOS to factory defaults. This restores 
 ### Step 2: Perform a blind reset
 
 1. Power on Olares One, and then immediately press and hold the **Delete** key for about 20 seconds. 
-2. Verify that the system is receiving keyboard inputs by pressing the **Caps Lock** key: If the Caps Lock indicator light on your keyboard turns on and off, you have successfully entered the BIOS menu.
+2. Verify that the system is receiving keyboard inputs by pressing the **Caps Lock** key: If the Caps Lock indicator light on your keyboard turns on and off, you have successfully entered BIOS.
 3. Press the **F9** key, and then press **Enter**. This shortcut loads the factory default BIOS settings.
 4. Press the **F10** key, and then press **Enter**. This shortcut saves the configuration and prompts the device to restart.
 

--- a/docs/one/ts-bios-black-screen.md
+++ b/docs/one/ts-bios-black-screen.md
@@ -1,0 +1,50 @@
+---
+outline: [2, 3]
+description: Troubleshoot the issue where your Olares One experiences a black screen, and you cannot access the BIOS setup menu.
+---
+
+# Cannot enter BIOS (Black screen)
+
+Use this guide if your Olares One shows no display during startup, and you cannot access the BIOS setup screen.
+
+## Condition
+
+When you power on Olares One and attempt to enter the BIOS setup, the screen remains black, preventing the boot menu from displaying.
+
+## Cause
+
+This issue typically occurs if the `Primary Display` setting in the BIOS was changed from `Auto` (dedicated GPU mode) to `HG` (hybrid graphics mode).
+
+When `Primary Display` is set to `HG`, the video output during the early boot stage might be sent to a different display interface (e.g., integrated graphics) that your monitor does not detect. The system might actually enter BIOS successfully, but your monitor screen stays black, making it impossible to see the BIOS interface.
+
+## Solution
+
+Follow these steps to blindly reset the BIOS to factory defaults. This restores the `Primary Display` setting to its default value `Auto` (the dedicated GPU mode).
+
+:::warning
+- These steps require physical removal of storage devices. Ensure that you power off the device and disconnect the power cable before proceeding.   
+- The screen will remain black until Step 3. Use the keyboard Caps Lock indicator to confirm BIOS entry.
+:::
+
+### Step 1: Prepare the device
+
+1. Power off Olares One.
+2. Disconnect the power cable.
+3. Disconnect all external storage drives, such as USB flash drives or external hard drives.
+4. Open the device enclosure and temporarily remove the internal NVMe SSD.
+5. Connect a keyboard and monitor to the device.
+6. Reconnect the power cable.
+
+### Step 2: Perform a blind reset
+
+1. Power on Olares One, and then immediately press and hold the **Delete** key for about 20 seconds. 
+2. Verify that the system is receiving keyboard inputs by pressing the **Caps Lock** key: If the Caps Lock indicator light on your keyboard turns on and off, you have successfully entered the BIOS menu.
+3. Press the **F9** key, and then press **Enter**. This shortcut loads the factory default BIOS settings.
+4. Press the **F10** key, and then press **Enter**. This shortcut saves the configuration and prompts the device to restart.
+
+### Step 3: Verify the fix
+
+1. Wait for the device to restart. The Olares One logo should appear, indicating that the normal display output is restored.
+2. Power off the device and disconnect the power cable.
+3. Reinstall your internal NVMe SSD and reconnect any external drives.
+4. Reconnect the power cable and power on the device to resume normal BIOS operations.

--- a/docs/zh/one/ts-bios-black-screen.md
+++ b/docs/zh/one/ts-bios-black-screen.md
@@ -1,0 +1,1 @@
+<!--@include: ../../one/ts-bios-black-screen.md-->


### PR DESCRIPTION
Title: Add troubleshooting guide for Olares One black screen issue when attempting to enter BIOS

* **Background**
See title.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus sidebar navigation updates; no product code or runtime behavior is affected.
> 
> **Overview**
> Adds a new Olares One troubleshooting doc, `ts-bios-black-screen`, explaining the “cannot enter BIOS / black screen” scenario caused by switching BIOS `Primary Display` to `HG` and providing a step-by-step *blind reset* procedure (F9/F10) to restore defaults.
> 
> Updates both English and Chinese VitePress sidebars to include a new **Troubleshooting** section linking to this guide; the Chinese page reuses the English content via an include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e934ff4794da1aa08f5f402b9ea1622e183bffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->