### PR TITLE
feat(olares-app): release new version to v1.10.19

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -300,17 +300,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-        - name: init-files-data
-          image: busybox:1.28
-          securityContext:
-            privileged: true
-            runAsNonRoot: false
-            runAsUser: 0
-          volumeMounts:
-            - name: fb-data
-              mountPath: /appdata
-            - name: uploads-temp
-              mountPath: /uploadstemp
         - name: olares-app-init
           image: beclab/system-frontend:v1.10.19
           imagePullPolicy: IfNotPresent

--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -311,14 +311,8 @@ spec:
               mountPath: /appdata
             - name: uploads-temp
               mountPath: /uploadstemp
-          command:
-          - sh
-          - -c
-          - |
-            chown -R 1000:1000 /uploadstemp && \
-            chown -R 1000:1000 /appdata 
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.18
+          image: beclab/system-frontend:v1.10.19
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -440,7 +434,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.90
+          image: beclab/user-service:v0.0.91
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.41
+        image: beclab/notifications-api:v1.12.42
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**
user-service, notificaiton-server: remove unused log.
files: fix some bugs
olares-app: remove uploadstemp and appdata 1000 permission

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1082
https://github.com/beclab/notifications/pull/20
https://github.com/beclab/user-service/pull/75

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only changes, mainly container image bumps; the only behavioral change is removing the privileged init `chown`, which could affect runtime file permissions if workloads still rely on it.
> 
> **Overview**
> Updates deployment manifests to roll forward component versions: `system-frontend` init image to `v1.10.19`, `user-service` to `v0.0.91`, and `notifications-api` to `v1.12.42`.
> 
> Removes the privileged `init-files-data` initContainer that previously `chown`’d `uploads-temp` and `fb-data` to UID/GID 1000, shifting responsibility for those directory permissions elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f1e2dd3847680ed5960b31881c5d394c105e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->