### PR TITLE
download: remove init container && remove credentials from logs

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -133,24 +133,6 @@ spec:
         runAsUser: 0
         runAsNonRoot: false
 
-      initContainers:
-      - name: init-data
-        image: busybox:1.28
-        securityContext:
-          privileged: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - name: config-dir
-          mountPath: /config
-        - name: download-dir
-          mountPath: /downloads
-        command:
-        - sh
-        - -c
-        - |
-          chown -R 1000:1000 /config && \
-          chown -R 1000:1000 /downloads
       containers:
       - name: aria2
         image: "beclab/aria2:v0.0.4"
@@ -180,12 +162,11 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v0.1.22"
+        image: "beclab/download-server:v0.1.23"
         imagePullPolicy: IfNotPresent
         securityContext:
-          runAsUser: 0
-          runAsNonRoot: false
-
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
         env:
         - name: DEBUG
           value: "false"


### PR DESCRIPTION
Background
Remove credentials from logs
Remove the initContainers block (init-data) from the download DaemonSet 
Update download-server container security settings to runAsUser: 1000 

Target Version for Merge
v1.12.6, v1.12.7

Related Issues:

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1afbdcdf496d7432779a151bac7335d71b011603. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->