### PR TITLE
fix: remove debug logs that leak middleware credentials

### DIFF
--- a/framework/app-service/pkg/tapr/middleware.go
+++ b/framework/app-service/pkg/tapr/middleware.go
@@ -237,7 +237,6 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"password": resp.Password,
 			"vhosts":   resp.Vhosts,
 		}
-		klog.Infof("values.rabbitmq: %v", vals["rabbitmq"])
 	}
 
 	if middleware.Elasticsearch != nil {
@@ -259,7 +258,6 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"indexes":     resp.Indexes,
 			"indexPrefix": resp.IndexPrefix,
 		}
-		klog.Infof("values.elasticsearch: %v", vals["elasticsearch"])
 	}
 
 	if middleware.Nats != nil {
@@ -280,11 +278,9 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"subjects": resp.Subjects,
 			"refs":     resp.Refs,
 		}
-		klog.Infof("vals[nats]: %v", vals["nats"])
 	}
 
 	if middleware.MariaDB != nil {
-		klog.Infof("middleware.MariaDB: %#v", middleware.MariaDB)
 		username := fmt.Sprintf("%s-%s-%s", middleware.MariaDB.Username, ownerName, appName)
 		err := process(kubeConfig, appName, appNamespace, namespace, username, TypeMariaDB, ownerName, middleware)
 		if err != nil {
@@ -302,7 +298,6 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"password":  resp.Password,
 			"databases": resp.Databases,
 		}
-		klog.Infof("values.mariadb: %v", vals["mariadb"])
 	}
 
 	if middleware.MySQL != nil {
@@ -324,7 +319,6 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"password":  resp.Password,
 			"databases": resp.Databases,
 		}
-		klog.Infof("values.mysql: %v", vals["mysql"])
 	}
 	if middleware.ClickHouse != nil {
 		username := fmt.Sprintf("%s-%s-%s", middleware.ClickHouse.Username, ownerName, appName)
@@ -344,7 +338,6 @@ func Apply(middleware *Middleware, kubeConfig *rest.Config, appName, appNamespac
 			"password":  resp.Password,
 			"databases": resp.Databases,
 		}
-		klog.Infof("values.clickhouse: %v", vals["clickhouse"])
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Drop `klog.Infof` calls in `framework/app-service/pkg/tapr/middleware.go` `Apply` paths that printed full middleware values (including passwords) for rabbitmq, elasticsearch, nats, mariadb, mysql and clickhouse.
- Prevents middleware credentials from ending up in plaintext logs.

## Test plan
- [ ] Build app-service and confirm no behavior change beyond log output.
- [ ] Deploy and verify middleware Apply still succeeds for each backend (rabbitmq / elasticsearch / nats / mariadb / mysql / clickhouse).
- [ ] Check pod logs no longer contain raw middleware spec dumps.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only removes informational logging; runtime behavior is unchanged while reducing the chance of leaking credentials in plaintext logs.
> 
> **Overview**
> Prevents middleware credentials from being written to logs by removing `klog.Infof` statements that dumped the generated `vals[...]` connection configs during `Apply` for RabbitMQ, Elasticsearch, NATS, MariaDB, MySQL, and ClickHouse.
> 
> No functional behavior is changed beyond reduced log output; middleware requests and `vals` population remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3e3c597b9934561134fbc8e6ea921415b9a58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->