### PR TITLE
docs: update node dev image to beclab/node20-ts-dev:1.0.1

### DIFF
--- a/docs/developer/contribute/system-app/deployment.md
+++ b/docs/developer/contribute/system-app/deployment.md
@@ -196,7 +196,7 @@ spec:
                 fieldPath: status.podIP
       containers:
         - name: desktop
-          image: "aboveos/node-ts-dev"
+          image: "beclab/node20-ts-dev:1.0.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: port

--- a/docs/zh/developer/contribute/system-app/deployment.md
+++ b/docs/zh/developer/contribute/system-app/deployment.md
@@ -195,7 +195,7 @@ spec:
                 fieldPath: status.podIP
       containers:
         - name: desktop
-          image: "aboveos/node-ts-dev"
+          image: "beclab/node20-ts-dev:1.0.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: port


### PR DESCRIPTION
## Summary
- Replace the deprecated `aboveos/node-ts-dev` image with the pinned `beclab/node20-ts-dev:1.0.1` in the system-app deployment guides
- Updates both English (`docs/developer/contribute/system-app/deployment.md`) and Chinese (`docs/zh/developer/contribute/system-app/deployment.md`) versions to keep them in sync
- Ensures contributors following the system-app deployment instructions pull a maintained, version-locked Node.js dev image

## Test plan
- [x] Verify the rendered docs (EN/ZH) display the new image reference
- [ ] Confirm `kubectl apply` of the example manifest pulls `beclab/node20-ts-dev:1.0.1` successfully

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates an example container image reference; no runtime code or production configuration is modified.
> 
> **Overview**
> Updates the system-app `deployment.yaml` examples in both the English and Chinese contributor guides to replace the deprecated `aboveos/node-ts-dev` container image with the pinned `beclab/node20-ts-dev:1.0.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86168b54e07c6c4b44913ae73560ae5a360427a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->