### PR TITLE
fix: multiple files bug fixes for file operations, sharing, and upload and clean sensitive logs for files and seafile

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -105,8 +105,6 @@ spec:
           - --rc-addr
           - :5572
           - --rc-no-auth
-          - --log-level
-          - INFO
           - --no-check-certificate
           - --s3-directory-markers
           - --fs-cache-expire-duration
@@ -144,7 +142,7 @@ spec:
 {{ end }}
 
         - name: samba-server
-          image: beclab/samba-server:0.0.8
+          image: beclab/samba-server:0.0.9
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -210,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.163
+          image: beclab/files-server:v0.2.164
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.162
+          image: beclab/files-server:v0.2.163
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -810,9 +810,11 @@ data:
           proxy_buffering off;
 
           proxy_connect_timeout 15s;
-          proxy_send_timeout 90s;
-          proxy_read_timeout 90s;
-          send_timeout 90s;
+          proxy_send_timeout    1800s;
+          proxy_read_timeout    1800s;
+          send_timeout          1800s;
+          client_body_timeout   1800s;
+          keepalive_timeout     1830s;
           proxy_max_temp_file_size 0;
 
           client_body_buffer_size 64m;

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -142,7 +142,7 @@ spec:
 {{ end }}
 
         - name: samba-server
-          image: beclab/samba-server:0.0.9
+          image: beclab/samba-server:0.0.10
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -227,7 +227,7 @@ spec:
     spec:
       initContainers:
       - name: seahub-init
-        image: beclab/seahub-init:v0.0.7
+        image: beclab/seahub-init:v0.0.8
         env:
           - name: DB_HOST
             value: citus-headless.os-platform.svc.cluster.local
@@ -249,7 +249,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.21
+        image: beclab/pg_seafile_server:v0.0.22
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- fix: multiple files bug fixes for file operations, sharing, and upload and clean sensitive logs
- fix: clean sensitive logs for files and seafile

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/206
- https://github.com/beclab/files/pull/207
- https://github.com/beclab/files/pull/208
- https://github.com/beclab/files/pull/209
- https://github.com/beclab/files/pull/210
- https://github.com/beclab/files/pull/211
- https://github.com/beclab/files/pull/212
- https://github.com/beclab/files/pull/214
- https://github.com/beclab/files/pull/215
- https://github.com/beclab/files/pull/216
- https://github.com/beclab/files/pull/217
- https://github.com/beclab/files/pull/218
- https://github.com/beclab/files/pull/219
- https://github.com/beclab/files/pull/220
- https://github.com/beclab/seafile-server/pull/6
- https://github.com/beclab/seafile-server/pull/7

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily deployment/config changes, but image bumps plus significantly longer upload/proxy timeouts can change runtime behavior and resource usage under load.
> 
> **Overview**
> Rolls forward the deployed container images for files and seafile components (e.g., `files-server`, `samba-server`, `seahub-init`, `pg_seafile_server`) to pick up upstream bug fixes.
> 
> Adjusts the files Nginx `/upload` proxy configuration to tolerate long-running uploads by raising read/send/body timeouts to ~30 minutes and adding `client_body_timeout`/`keepalive_timeout`, and removes explicit `rclone` log-level arguments from the DaemonSet command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9da8513937aa89937c8c8c4ac47528a93598145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->