### PR TITLE
docs: fix worker node description

### DIFF
--- a/docs/manual/best-practices/install-olares-multi-node.md
+++ b/docs/manual/best-practices/install-olares-multi-node.md
@@ -45,7 +45,7 @@ If you have already installed an Olares cluster using the default installation c
 To set up the master node with the JuiceFS support, run the following command:
 
 ```bash
-export JUICEFS = 1 \
+export JUICEFS=1 \
 && curl -sSfL https://olares.sh | bash -
 ```
 
@@ -56,6 +56,10 @@ If you already have your own MinIO cluster or an S3 (or S3-compatible) bucket, y
 :::
 
 ## Step 2: Add a worker node to the cluster
+
+::: tip Worker node prerequisites
+The worker node must be in a clean Linux state, with no Olares installed. If Olares was previously installed on the worker, run `olares-cli uninstall --all` first to wipe the device back to a clean Linux state.
+:::
 
 1. On the worker node, download `joincluster.sh` using:
 

--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -12,7 +12,7 @@ For advanced use cases requiring higher availability and distributed storage, yo
 ## Learning objectives
 - Configure a master node with distributed storage support.
 - Resolve hostname conflicts between nodes.
-- Join a worker node to the cluster using the Olares CLI.
+- Join a worker node to the cluster using `joincluster.sh`.
 
 ## Before you begin
 - The default username and password for Olares One are both `olares`.
@@ -24,7 +24,6 @@ For advanced use cases requiring higher availability and distributed storage, yo
 ## Prerequisites
 **Hardware**<br>
 - Two Olares One units connected to the same local area network.
-- Both units running the same version of Olares OS.
 - You know the local IP addresses of both units.
 
 **Experience**<br>
@@ -78,6 +77,16 @@ After setup is complete, the LarePass app returns to the home screen, and the Wi
 
 ## Step 2: Set up the worker node
 
+:::info Worker node requirements before joining
+The worker must be in one of these states:
+
+- **Factory state (Olares pre-installed)**: Olares is pre-installed and the version matches the master node.
+
+  If the versions no longer match (for example, the master was upgraded to v1.12.5 while the worker still runs v1.12.4), run `sudo olares-cli uninstall --all` first to wipe the worker to a clean Linux state.
+
+- **Clean Linux**: No Olares installed.
+:::
+
 1. Access the worker node via SSH.
     ```bash
     ssh olares@<Worker-IP-Address>
@@ -89,43 +98,29 @@ After setup is complete, the LarePass app returns to the home screen, and the Wi
     :::info
     By default, all Olares One units have the hostname `olares`. Kubernetes requires unique hostnames for every node in a cluster. Before joining it to the cluster, you must ensure it has a unique hostname.
     :::
+3. Download `joincluster.sh`:
 
-3. Verify that the worker node can communicate with the master and that versions are compatible.
-    ```bash
-    sudo olares-cli node masterinfo \
-    --master-host=<Master-IP-Address> \
-    --master-ssh-user=olares \
-    --master-ssh-password=<Password>
+    ::: code-group
+    ```bash [curl]
+    # This command is for users who have curl installed.
+    curl -fsSL https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh -o joincluster.sh
     ```
 
-   Example output:
+    ```bash [wget]
+    # This command is for users who have wget installed.
+    wget https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh
+    ```
+    :::
+4. Run the script with the master node details:
     ```bash
-    current: root
-    2026-01-13T06:10:41.874Z        [Job] [Get Master Info] start ...
-    2026-01-13T06:10:41.874Z        [Module] GetMasterInfo
-    2026-01-13T06:10:42.528Z        Got master info:
-    OlaresVersion: 1.12.3
-    JuiceFSEnabled: true
-    KubernetesType: k3s
-    MasterNodeName: olares
-    AllNodes: olares
-    
-    2026-01-13T06:10:42.528Z        [A] olares: GetMasterInfo success (654.711582ms)
-    2026-01-13T06:10:42.529Z        [A] olares-worker: AddNodePrecheck success (37.084µs)
-    2026-01-13T06:10:42.529Z        [Job] Get Master Info execute successfully!!! (654.871193ms)
+    export MASTER_HOST=<Master-IP-Address> \
+        MASTER_NODE_NAME=olares \
+        MASTER_SSH_USER=olares \
+        MASTER_SSH_PASSWORD=<Password>
+    ./joincluster.sh
     ```
 
-4. Run the add node command. Ensure the `--version` matches the version found in the pre-check output (e.g., `1.12.3`):
-
-    ```bash
-    sudo olares-cli node add \
-    --master-host=<Master-IP-Address> \
-    --master-ssh-user=olares \
-    --master-ssh-password=<Password> \
-    --version=<Olares-Version>
-    ```
-
-5. Perform the same installation and activation steps for the worker node.
+   The script automatically detects whether Olares is already installed on the worker, runs the pre-install check against the master, and joins the cluster.
 
 ## Step 3: Verify the cluster
 

--- a/docs/zh/manual/best-practices/install-olares-multi-node.md
+++ b/docs/zh/manual/best-practices/install-olares-multi-node.md
@@ -53,6 +53,11 @@ export JUICEFS=1 \
 :::
 
 ## 第二步：向集群添加子节点
+
+::: tip 子节点前置条件
+子节点必须处于干净的 Linux 状态，未安装 Olares。如果子节点上之前安装过 Olares，请先运行 `olares-cli uninstall --all` 将设备清理为干净的 Linux 状态。
+:::
+
 1. 在子节点上，使用以下方式下载 `joincluster.sh`：
 ::: code-group
 


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
1.12
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, but incorrect guidance could still cause user setup failures if not reviewed for accuracy.
> 
> **Overview**
> Clarifies multi-node cluster docs by explicitly stating worker-node preconditions (clean Linux/factory state and version-match expectations) before joining.
> 
> Reworks the Olares One two-node guide to use `joincluster.sh` (with curl/wget download examples and required env vars) instead of the `olares-cli node add/masterinfo` flow, and fixes a small shell export typo (`JUICEFS=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eaa260c684584f5fa7024404be5992ccecba423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->