### PR TITLE
system-server: redact sensitive data from logs

### DIFF
--- a/framework/system-server/pkg/apiserver/v1alpha1/legacy/v1alpha1/handler.go
+++ b/framework/system-server/pkg/apiserver/v1alpha1/legacy/v1alpha1/handler.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"reflect"
 
 	"bytetrade.io/web3os/system-server/pkg/apiserver/v1alpha1/api"
 	permission "bytetrade.io/web3os/system-server/pkg/permission/v1alpha1"
 	prodiverregistry "bytetrade.io/web3os/system-server/pkg/providerregistry/v1alpha1"
 	serviceproxy "bytetrade.io/web3os/system-server/pkg/serviceproxy/v1alpha1"
+	"bytetrade.io/web3os/system-server/pkg/utils"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/go-resty/resty/v2"
@@ -52,9 +52,8 @@ func (h *Handler) do(req *restful.Request, resp *restful.Response) {
 
 	switch proxyResp := proxyRespIntf.(type) {
 	case *resty.Response:
-		dump, e := httputil.DumpRequest(proxyResp.Request.RawRequest, true)
-		if e != nil {
-			klog.Error("dump request err: ", e)
+		if dump, dumpErr := utils.DumpRequestOutRedacted(proxyResp.Request.RawRequest); dumpErr != nil {
+			klog.Error("dump request err: ", dumpErr)
 		} else {
 			klog.Info("proxy request: ", string(dump))
 		}
@@ -64,9 +63,8 @@ func (h *Handler) do(req *restful.Request, resp *restful.Response) {
 			return
 		}
 
-		dump, err = httputil.DumpResponse(proxyResp.RawResponse, false)
-		if err != nil {
-			klog.Error("dump response err: ", err)
+		if dump, dumpErr := utils.DumpResponseRedacted(proxyResp.RawResponse); dumpErr != nil {
+			klog.Error("dump response err: ", dumpErr)
 		} else {
 			klog.Info("proxy response: ", string(dump))
 		}
@@ -140,9 +138,8 @@ func (h *Handler) doV2(req *restful.Request, resp *restful.Response) {
 	}
 	switch proxyResp := proxyRespIntf.(type) {
 	case *resty.Response:
-		dump, e := httputil.DumpRequest(proxyResp.Request.RawRequest, true)
-		if e != nil {
-			klog.Error("dump request err: ", e)
+		if dump, dumpErr := utils.DumpRequestOutRedacted(proxyResp.Request.RawRequest); dumpErr != nil {
+			klog.Error("dump request err: ", dumpErr)
 		} else {
 			klog.Info("proxy request: ", string(dump))
 		}
@@ -151,9 +148,8 @@ func (h *Handler) doV2(req *restful.Request, resp *restful.Response) {
 			api.HandleError(resp, req, err)
 			return
 		}
-		dump, err = httputil.DumpResponse(proxyResp.RawResponse, false)
-		if err != nil {
-			klog.Error("dump response err: ", err)
+		if dump, dumpErr := utils.DumpResponseRedacted(proxyResp.RawResponse); dumpErr != nil {
+			klog.Error("dump response err: ", dumpErr)
 		} else {
 			klog.Info("proxy response: ", string(dump))
 		}

--- a/framework/system-server/pkg/permission/v1alpha1/access.go
+++ b/framework/system-server/pkg/permission/v1alpha1/access.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	sysv1alpha1 "bytetrade.io/web3os/system-server/pkg/apis/sys/v1alpha1"
-	"bytetrade.io/web3os/system-server/pkg/utils"
 
 	"github.com/jellydator/ttlcache/v3"
 	"golang.org/x/crypto/bcrypt"
@@ -43,7 +42,7 @@ func (a *AccessManager) getAccessToken(accReq *AccessTokenRequest, ap *sysv1alph
 
 	compareHash := accReq.AppKey + strconv.Itoa(int(accReq.Timestamp)) + ap.Spec.Secret
 	if err := bcrypt.CompareHashAndPassword([]byte(accReq.Token), []byte(compareHash)); err != nil {
-		klog.Error("invalid request: ", utils.PrettyJSON(accReq))
+		klog.Errorf("invalid access token request, app_key=%s, timestamp=%d", accReq.AppKey, accReq.Timestamp)
 		return "", fmt.Errorf("invalid auth token: %s", err.Error())
 	}
 

--- a/framework/system-server/pkg/permission/v1alpha1/register.go
+++ b/framework/system-server/pkg/permission/v1alpha1/register.go
@@ -136,7 +136,6 @@ func ValidateAppKey(appKey, subPath, dataType, version, group, signature string)
 	sha.Write([]byte(appSecret))
 	sha.Write([]byte(timestamp))
 	hash := hex.EncodeToString(sha.Sum(nil))
-	klog.Infof("hash = %s", hash)
 	if hash != signature {
 		return errors.New("invalid signature ")
 	}

--- a/framework/system-server/pkg/permission/v2alpha1/authn.go
+++ b/framework/system-server/pkg/permission/v2alpha1/authn.go
@@ -61,13 +61,12 @@ func (l *lldapTokenAuthenticator) AuthenticateRequest(req *http.Request) (*authe
 	}
 
 	// verify token
-	res, err := TokenVerify(l.lldapServer, token, token)
-	if err != nil {
+	if _, err := TokenVerify(l.lldapServer, token, token); err != nil {
 		klog.Errorf("Token verification failed: %v", err)
 		return nil, false, fmt.Errorf("token verification failed: %w", err)
 	}
 
-	klog.Info("token verified in lldap successfully, ", res)
+	klog.Info("token verified in lldap successfully")
 
 	c, err := parseToken(token)
 	if err != nil {

--- a/framework/system-server/pkg/permission/v2alpha1/lldap.go
+++ b/framework/system-server/pkg/permission/v2alpha1/lldap.go
@@ -32,23 +32,22 @@ func TokenVerify(baseURL, accessToken, validToken string) (map[string]interface{
 			"access_token": validToken,
 		}).Post(url)
 	if err != nil {
-		klog.Infof("send request failed: %v", err)
+		klog.Errorf("send token verify request failed: %v", err)
 		return nil, err
 	}
 	if resp.StatusCode() != http.StatusOK {
-		klog.Infof("not 200, %v, body: %v", resp.StatusCode(), string(resp.Body()))
-		return nil, errors.New(resp.String())
+		klog.Errorf("token verify returned non-200 status: %d", resp.StatusCode())
+		return nil, fmt.Errorf("token verify returned status %d", resp.StatusCode())
 	}
 	var response map[string]interface{}
 	err = json.Unmarshal(resp.Body(), &response)
 	if err != nil {
-		klog.Infof("unmarshal failed: %v", err)
+		klog.Errorf("unmarshal token verify response failed: %v", err)
 		return nil, err
 	}
-	klog.Infof("token verify res: %v", response)
 
 	if status, ok := response["status"]; ok && status == "invalid token" {
-		klog.Infof("token verify failed, status: %s", status)
+		klog.Info("token verify failed: invalid token")
 		return nil, errors.New("token verification failed")
 	}
 	return response, nil

--- a/framework/system-server/pkg/serviceproxy/v1alpha1/dispatcher.go
+++ b/framework/system-server/pkg/serviceproxy/v1alpha1/dispatcher.go
@@ -11,7 +11,6 @@ import (
 	apiv1alpha1 "bytetrade.io/web3os/system-server/pkg/apiserver/v1alpha1/api"
 	"bytetrade.io/web3os/system-server/pkg/constants"
 	prodiverregistry "bytetrade.io/web3os/system-server/pkg/providerregistry/v1alpha1"
-	"bytetrade.io/web3os/system-server/pkg/utils"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/go-resty/resty/v2"
@@ -78,7 +77,7 @@ func (d *Dispatcher) dispatch(obj interface{}) error {
 		return fmt.Errorf("invalid dispatch obj, %s, %v", reflect.TypeOf(obj), obj)
 	}
 
-	klog.Info("dispatch request, ", utils.PrettyJSON(request))
+	klog.Info("dispatch request, ", request.SafeString())
 
 	watchers, err := d.registry.GetWatchers(d.serverCtx,
 		request.DataType,

--- a/framework/system-server/pkg/serviceproxy/v1alpha1/proxy.go
+++ b/framework/system-server/pkg/serviceproxy/v1alpha1/proxy.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strings"
 	"time"
@@ -57,7 +56,7 @@ func NewProxy(registry *prodiverregistry.Registry) *Proxy {
 // DoRequest send request to provider.
 func (p *Proxy) DoRequest(req *restful.Request, op string, proxyrequest *ProxyRequest) (ret map[string]interface{}, statusCode int, err error) {
 
-	klog.Info("send request to provider: ", utils.PrettyJSON(proxyrequest))
+	klog.Info("send request to provider: ", proxyrequest.SafeString())
 
 	if !utils.ListContains(SUPPORTED_DATA_TYPE, proxyrequest.DataType) {
 		klog.Warning("unsupported data type, ", proxyrequest.DataType)
@@ -120,7 +119,7 @@ func (p *Proxy) ProxyLegacyAPI(ctx context.Context,
 	resp *restful.Response,
 ) (interface{}, error) {
 	klog.Info("send request to legacy api")
-	klog.Infof("proxyLegacyAPI: header: %v", req.Request.Header)
+	klog.Infof("proxyLegacyAPI: header: %v", utils.RedactedHeader(req.Request.Header))
 
 	version := req.PathParameter(apiv1alpha1.ParamVersion)
 	group := req.PathParameter(apiv1alpha1.ParamGroup)
@@ -183,11 +182,12 @@ func (p *Proxy) ProxyLegacyAPI(ctx context.Context,
 		}
 		return wsProxy.doWs(req.Request, resp, wsURL)
 	default:
-		dump, err := httputil.DumpRequest(req.Request, true)
-		if err != nil {
-			klog.Error("dump request err: ", err)
+		dump, dumpErr := utils.DumpRequestRedacted(req.Request)
+		if dumpErr != nil {
+			klog.Error("dump request err: ", dumpErr)
+		} else {
+			klog.Info("orig request: ", string(dump))
 		}
-		klog.Info("orig request: ", string(dump))
 
 		client := resty.New()
 		bodyData, err := ioutil.ReadAll(req.Request.Body)
@@ -257,11 +257,12 @@ func (p *Proxy) ProxyLegacyAPIV2(ctx context.Context,
 		}
 		return wsProxy.doWs(req.Request, resp, wsURL)
 	default:
-		dump, err := httputil.DumpRequest(req.Request, true)
-		if err != nil {
-			klog.Error("dump request err: ", err)
+		dump, dumpErr := utils.DumpRequestRedacted(req.Request)
+		if dumpErr != nil {
+			klog.Error("dump request err: ", dumpErr)
+		} else {
+			klog.Info("orig request: ", string(dump))
 		}
-		klog.Info("orig request: ", string(dump))
 
 		client := resty.New()
 		bodyData, err := ioutil.ReadAll(req.Request.Body)

--- a/framework/system-server/pkg/serviceproxy/v1alpha1/types.go
+++ b/framework/system-server/pkg/serviceproxy/v1alpha1/types.go
@@ -1,6 +1,7 @@
 package serviceproxy
 
 import (
+	"fmt"
 	"strconv"
 
 	sysv1alpha1 "bytetrade.io/web3os/system-server/pkg/apis/sys/v1alpha1"
@@ -25,6 +26,16 @@ type ProxyRequest struct {
 	Param    interface{} `json:"param,omitempty"`
 	Data     interface{} `json:"data,omitempty"`
 	Token    string
+}
+
+// SafeString returns a log-safe representation that omits the access token
+// and any user-supplied payload (Param/Data) which may contain PII.
+func (p *ProxyRequest) SafeString() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("op=%s datatype=%s version=%s group=%s appkey=%s",
+		p.Op, p.DataType, p.Version, p.Group, p.AppKey)
 }
 
 type GetOpParam struct {

--- a/framework/system-server/pkg/utils/redact.go
+++ b/framework/system-server/pkg/utils/redact.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+// sensitiveHeaders enumerates HTTP headers whose values must never be written
+// to logs. Header names are matched case-insensitively.
+var sensitiveHeaders = map[string]struct{}{
+	"authorization":         {},
+	"proxy-authorization":   {},
+	"cookie":                {},
+	"set-cookie":            {},
+	"x-auth-signature":      {},
+	"x-app-key":             {},
+	"x-authorization-token": {},
+	"x-backend-token":       {},
+	"x-bfl-user":            {},
+	"x-authelia-nonce":      {},
+}
+
+// RedactedHeader returns a shallow copy of h with the values of well-known
+// sensitive headers replaced by "[REDACTED]". The input header is not
+// modified.
+func RedactedHeader(h http.Header) http.Header {
+	if h == nil {
+		return nil
+	}
+	out := make(http.Header, len(h))
+	for k, v := range h {
+		if _, ok := sensitiveHeaders[strings.ToLower(k)]; ok {
+			out[k] = []string{"[REDACTED]"}
+			continue
+		}
+		copied := make([]string, len(v))
+		copy(copied, v)
+		out[k] = copied
+	}
+	return out
+}
+
+// DumpRequestRedacted is a logging-safe replacement for httputil.DumpRequest.
+// It strips sensitive headers before dumping and never includes the body to
+// avoid leaking credentials carried in request payloads.
+func DumpRequestRedacted(req *http.Request) ([]byte, error) {
+	if req == nil {
+		return nil, nil
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = RedactedHeader(req.Header)
+	return httputil.DumpRequest(clone, false)
+}
+
+// DumpRequestOutRedacted is a logging-safe replacement for
+// httputil.DumpRequestOut. It strips sensitive headers and excludes the body.
+func DumpRequestOutRedacted(req *http.Request) ([]byte, error) {
+	if req == nil {
+		return nil, nil
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = RedactedHeader(req.Header)
+	return httputil.DumpRequestOut(clone, false)
+}
+
+// DumpResponseRedacted dumps a response without its body and with sensitive
+// headers (e.g. Set-Cookie) redacted.
+func DumpResponseRedacted(resp *http.Response) ([]byte, error) {
+	if resp == nil {
+		return nil, nil
+	}
+	clone := *resp
+	clone.Header = RedactedHeader(resp.Header)
+	return httputil.DumpResponse(&clone, false)
+}


### PR DESCRIPTION
## Summary

Stop leaking access tokens, request signatures, and other authentication
material via `klog` while keeping the existing log statements for debugging.

### Changes

- **`pkg/utils/redact.go`** (new): `RedactedHeader`, `DumpRequestRedacted`,
  `DumpRequestOutRedacted`, `DumpResponseRedacted` helpers. They mask
  `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`,
  `X-Auth-Signature`, `X-App-Key`, `X-Authorization-Token`,
  `X-Backend-Token`, `X-Bfl-User`, `X-Authelia-Nonce` and never include
  request/response bodies.
- **`pkg/permission/v1alpha1/register.go`**: remove the `klog.Infof("hash = %s", ...)`
  print — that hash is the server-side comparison value for `X-Auth-Signature`,
  i.e. logging it leaks a valid request signature for the current minute.
- **`pkg/permission/v1alpha1/access.go`**: replace
  `klog.Error("invalid request: ", PrettyJSON(accReq))` (which contained the
  raw bcrypt-compared `Token`) with a log line carrying only `app_key` and
  `timestamp`.
- **`pkg/permission/v2alpha1/lldap.go`** + **`authn.go`**: drop the LLDAP
  token-verify response body / parsed claims from logs; only log status
  codes and high-level outcomes.
- **`pkg/serviceproxy/v1alpha1/proxy.go`** and
  **`pkg/apiserver/v1alpha1/legacy/v1alpha1/handler.go`**: route the
  `httputil.DumpRequest` / `DumpResponse` calls through the redacting
  helpers so `Authorization` / `Cookie` / `Set-Cookie` and request bodies
  no longer hit the logs. Incoming header maps are wrapped with
  `utils.RedactedHeader` before printing.
- **`pkg/serviceproxy/v1alpha1/types.go`**: add `ProxyRequest.SafeString()`
  and use it in the `dispatch request` / `send request to provider` log
  lines so the embedded access `Token`, `AppKey`-bound payload, and
  user-supplied `Param` / `Data` are never serialized into logs.
  (`Token` keeps its existing JSON wire format — sanitization is
  log-side only.)

### Affected binaries

Both binaries built from this module need to be rebuilt:

- `system-server` (`cmd/server/main.go`, `Dockerfile`)
- `provider-proxy` (`cmd/proxy/main.go`, `Dockerfile.provider`)

### Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Bring up `system-server` and `provider-proxy`, exercise auth /
      proxy paths, verify no `Authorization`, `Cookie`, raw token, hash
      signature, or LLDAP claim payload appears in logs.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily logging-only changes that reduce sensitive-data exposure; main risk is reduced observability since request/response bodies and some details are no longer logged.
> 
> **Overview**
> Redacts authentication material and user payloads from `klog` output across legacy API proxying, service proxy dispatching, and permission/auth flows.
> 
> Introduces `utils` helpers to dump HTTP requests/responses with sensitive headers masked and bodies excluded, swaps existing `httputil.Dump*`/header logs to use them, and replaces JSON logging of proxy/dispatch requests with `SafeString()` to avoid leaking tokens/PII. Also removes or downgrades logs that exposed signature hashes, raw access-token request contents, and LLDAP token verification details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc76cf57ac4d9279683974ef411b2d9d62fa5974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->