### PR TITLE
fix: remove credentials from logs

### DIFF
--- a/platform/tapr/cmd/websocket/app/handler.go
+++ b/platform/tapr/cmd/websocket/app/handler.go
@@ -92,7 +92,7 @@ func (a *appController) SendMessage(c *fiber.Ctx) error {
 	var message sendMesssageReq
 	err := json.Unmarshal(body, &message)
 	if err != nil {
-		klog.Errorf("send message data invalid, %+v, data: %s", err, string(body))
+		klog.Errorf("send message data invalid, %+v", err)
 		return c.JSON(fiber.Map{
 			"code":    http.StatusBadRequest,
 			"message": "send data invalid, " + err.Error(),
@@ -100,7 +100,7 @@ func (a *appController) SendMessage(c *fiber.Ctx) error {
 	}
 
 	if message.ConnId == "" && (message.Users == nil || len(message.Users) == 0) && (message.Tokens == nil || len(message.Tokens) == 0) {
-		klog.Errorf("send message target is nil,  data: %s", string(body))
+		klog.Error("send message target is nil")
 		return c.JSON(fiber.Map{
 			"code":    http.StatusBadRequest,
 			"message": "send message target is nil",

--- a/platform/tapr/pkg/ws/client.go
+++ b/platform/tapr/pkg/ws/client.go
@@ -74,7 +74,7 @@ func (client *Client) onConnection() {
 				return
 			}
 
-			klog.Infof("read message, type: %d, accessPublic: %v, connId: %s, user: %s, data: %s", mt, accessPublic, connId, userName, string(msg))
+			klog.Infof("read message, type: %d, accessPublic: %v, connId: %s, user: %s", mt, accessPublic, connId, userName)
 
 			if client.checkPingMessage(msg) {
 				client.writeHandler(connId, websocket.TextMessage, map[string]interface{}{"event": "pong"})
@@ -84,7 +84,7 @@ func (client *Client) onConnection() {
 
 			var data = map[string]interface{}{}
 			if err = json.Unmarshal(msg, &data); err != nil {
-				klog.Errorf("unmarshal message error %+v, data: %s", err, string(msg))
+				klog.Errorf("unmarshal message error %+v", err)
 			}
 
 			client.readHandler(accessPublic, token, connId, userName, data, cookie, ACTION_MESSAGE)

--- a/platform/tapr/pkg/ws/server.go
+++ b/platform/tapr/pkg/ws/server.go
@@ -291,11 +291,11 @@ func (server *Server) routineWrite() {
 			}
 			msg, err := json.Marshal(elem.Message)
 			if err != nil {
-				klog.Errorf("send message marshal error %+v, data: %v", err, elem.Message)
+				klog.Errorf("send message marshal error %+v", err)
 				continue
 			}
 
-			klog.Infof("send message data: %s, connId: %s, token: %v, users: %v", string(msg), elem.ConnId, elem.Tokens, elem.Users)
+			klog.Infof("send message connId: %s, token: %v, users: %v", elem.ConnId, elem.Tokens, elem.Users)
 
 			var filter = NewFilter(server)
 			if elem.Users != nil && len(elem.Users) > 0 {


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
remove credentials from logs

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust log messages to stop printing request/message bodies; runtime behavior for websocket handling is unchanged.
> 
> **Overview**
> Removes potentially sensitive message content (request bodies and websocket payloads) from various websocket gateway logs.
> 
> Updates error/info logging in `SendMessage`, websocket client reads, and server writes to log metadata (connId/users/tokens/types) without including raw message data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93684bf61c34409721b3ea7794f8401f43f64f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->