### PR TITLE
fix: system server github workflow

### DIFF
--- a/.github/workflows/module_systemserver_publish_docker.yaml
+++ b/.github/workflows/module_systemserver_publish_docker.yaml
@@ -32,6 +32,6 @@ jobs:
                   push: true
                   tags: beclab/system-server:${{ github.event.inputs.tags }}
                   context: framework/system-server
-                  file: Dockerfile
+                  file: framework/system-server/Dockerfile
                   platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION


* **Background**
fix: system server github workflow
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that fixes the Docker build configuration; the main impact is on the CI/CD pipeline publishing the image.
> 
> **Overview**
> Fixes the SystemServer Docker publish GitHub Actions workflow by pointing `docker/build-push-action` at the correct `framework/system-server/Dockerfile` (instead of relying on `context` + `Dockerfile`). This should prevent misbuilds/failures when building and pushing multi-arch images to Docker Hub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a36623323de0dc48ee2cc87e3e4ef1c0b0709a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->