### PR TITLE
chore(ws-gateway): stop logging forwarded payloads to avoid potential credential leakage

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -200,7 +200,7 @@ spec:
         - name: GENERATED_APPS
           value: "citus,mongo-cluster-cfg,mongo-cluster-mongos,mongo-cluster-rs0,frp-agent,l4-bfl-proxy,drc-redis-cluster,appdata-backend,argoworkflows,argoworkflow-workflow-controller,velero,kvrocks"
         - name: WS_CONTAINER_IMAGE
-          value: "beclab/ws-gateway:v1.0.3"
+          value: "beclab/ws-gateway:v1.0.4"
         - name: UPLOAD_CONTAINER_IMAGE
           value: "beclab/upload:v1.0.3"
         - name: JOB_IMAGE

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -200,7 +200,7 @@ spec:
         - name: GENERATED_APPS
           value: "citus,mongo-cluster-cfg,mongo-cluster-mongos,mongo-cluster-rs0,frp-agent,l4-bfl-proxy,drc-redis-cluster,appdata-backend,argoworkflows,argoworkflow-workflow-controller,velero,kvrocks"
         - name: WS_CONTAINER_IMAGE
-          value: "beclab/ws-gateway:v1.0.4"
+          value: "beclab/ws-gateway:v1.0.5"
         - name: UPLOAD_CONTAINER_IMAGE
           value: "beclab/upload:v1.0.3"
         - name: JOB_IMAGE

--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_elasticsearch.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_elasticsearch.go
@@ -28,8 +28,7 @@ func (c *controller) createOrUpdateElasticsearchRequest(req *aprv1.MiddlewareReq
 	}
 
 	endpoint := c.getElasticsearchEndpoint()
-	klog.Infof("req.Spec.Elasticsearch %#v", req.Spec.Elasticsearch)
-	klog.Infof("req.Spec.Elasticsearch.Password %#v", req.Spec.Elasticsearch.Password)
+	klog.Infof("createOrUpdateElasticsearchRequest user=%s namespace=%s", req.Spec.Elasticsearch.User, req.Namespace)
 
 	userPassword, err := req.Spec.Elasticsearch.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {

--- a/platform/tapr/cmd/websocket/app/handler.go
+++ b/platform/tapr/cmd/websocket/app/handler.go
@@ -92,7 +92,7 @@ func (a *appController) SendMessage(c *fiber.Ctx) error {
 	var message sendMesssageReq
 	err := json.Unmarshal(body, &message)
 	if err != nil {
-		klog.Errorf("send message data invalid, %+v, data: %s", err, string(body))
+		klog.Errorf("send message data invalid, %+v", err)
 		return c.JSON(fiber.Map{
 			"code":    http.StatusBadRequest,
 			"message": "send data invalid, " + err.Error(),
@@ -100,7 +100,7 @@ func (a *appController) SendMessage(c *fiber.Ctx) error {
 	}
 
 	if message.ConnId == "" && (message.Users == nil || len(message.Users) == 0) && (message.Tokens == nil || len(message.Tokens) == 0) {
-		klog.Errorf("send message target is nil,  data: %s", string(body))
+		klog.Error("send message target is nil")
 		return c.JSON(fiber.Map{
 			"code":    http.StatusBadRequest,
 			"message": "send message target is nil",

--- a/platform/tapr/pkg/postgres/client.go
+++ b/platform/tapr/pkg/postgres/client.go
@@ -104,7 +104,7 @@ func newClient(dsn string, builder *clientBuilder) (*client, error) {
 
 	dbProxy := DBLogger{DB: db}
 
-	dbProxy.Debug()
+	// dbProxy.Debug()
 
 	return &client{DB: &dbProxy, builder: builder}, nil
 }

--- a/platform/tapr/pkg/vault/infisical/controllers/admin.go
+++ b/platform/tapr/pkg/vault/infisical/controllers/admin.go
@@ -200,7 +200,7 @@ func (a *adminController) CreateAppSecret(c *fiber.Ctx) error {
 	)
 
 	if err != nil {
-		klog.Error("create secret error, ", err, ", ", secret.Key, ", ", secret.Value)
+		klog.Error("create secret error, ", err, ", key=", secret.Key)
 		return c.JSON(fiber.Map{
 			"code":    http.StatusInternalServerError,
 			"message": "create secret error, " + err.Error(),

--- a/platform/tapr/pkg/vault/infisical/controllers/secret.go
+++ b/platform/tapr/pkg/vault/infisical/controllers/secret.go
@@ -383,7 +383,7 @@ func (s *secretClient) CreateSecretInWorkspace(user *infisical.UserEncryptionKey
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		klog.Error("create secret response error, ", string(resp.Body()))
+		klog.Errorf("create secret response error, status=%d", resp.StatusCode())
 		return errors.New(string(resp.Body()))
 	}
 
@@ -413,7 +413,7 @@ func (s *secretClient) GetSecretInWorkspace(token, workspaceId, projectKey, env,
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		klog.Error("get secret response error, ", string(resp.Body()))
+		klog.Errorf("get secret response error, status=%d", resp.StatusCode())
 		return "", "", errors.New(string(resp.Body()))
 	}
 
@@ -475,7 +475,7 @@ func (s *secretClient) ListSecretInWorkspace(token, workspaceId, projectKey, env
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		klog.Error("list secret response error, ", string(resp.Body()))
+		klog.Errorf("list secret response error, status=%d", resp.StatusCode())
 		return nil, errors.New(string(resp.Body()))
 	}
 
@@ -544,7 +544,7 @@ func (s *secretClient) DeleteSecretInWorkspace(token, workspaceId, projectKey, e
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		klog.Error("delete secret response error, ", string(resp.Body()))
+		klog.Errorf("delete secret response error, status=%d", resp.StatusCode())
 		return errors.New(string(resp.Body()))
 	}
 
@@ -583,7 +583,7 @@ func (s *secretClient) UpdateSecretInWorkspace(user *infisical.UserEncryptionKey
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		klog.Error("update secret response error, ", string(resp.Body()))
+		klog.Errorf("update secret response error, status=%d", resp.StatusCode())
 		return errors.New(string(resp.Body()))
 	}
 

--- a/platform/tapr/pkg/vault/infisical/init.go
+++ b/platform/tapr/pkg/vault/infisical/init.go
@@ -61,7 +61,7 @@ func InitSuperAdmin(ctx context.Context, pg *PostgresClient) error {
 }
 
 func InsertKsUserToPostgres(ctx context.Context, pg *PostgresClient, username, email, password string) error {
-	klog.Info("insert user: ", username, ", email: ", email, ", password: ", password)
+	klog.Info("insert user: ", username, ", email: ", email)
 
 	publicKeyBytes, privateKeyBytes, err := box.GenerateKey(rand.Reader)
 	if err != nil {
@@ -128,7 +128,7 @@ func InsertKsUserToPostgres(ctx context.Context, pg *PostgresClient, username, e
 }
 
 func InsertKsUserToMongo(ctx context.Context, mongo *MongoClient, username, email, password string) error {
-	klog.Info("insert user: ", username, ", email: ", email, ", password: ", password)
+	klog.Info("insert user: ", username, ", email: ", email)
 	publicKeyBytes, privateKeyBytes, err := box.GenerateKey(rand.Reader)
 	if err != nil {
 		return err

--- a/platform/tapr/pkg/workload/nats/conf.go
+++ b/platform/tapr/pkg/workload/nats/conf.go
@@ -63,7 +63,7 @@ func renderConfigFile(config *Config) ([]byte, error) {
 	funcMap := template.FuncMap{
 		"quoteOrNot": quoteOrNot,
 	}
-	klog.Infof("renderConfigFile: %##v\n", config)
+	// klog.Infof("renderConfigFile: %##v\n", config)
 	var buf bytes.Buffer
 	tpl := template.Must(template.New("config").Funcs(funcMap).Parse(tmpl))
 	err := tpl.Execute(&buf, config)

--- a/platform/tapr/pkg/workload/nats/helper.go
+++ b/platform/tapr/pkg/workload/nats/helper.go
@@ -345,7 +345,7 @@ func getAdminPassword() (string, error) {
 	}
 	secret, err := clientSet.CoreV1().Secrets(constants.PlatformNamespace).Get(context.TODO(), "nats-secrets", metav1.GetOptions{})
 	if err != nil {
-		klog.Infof("get secret err=%v", secret)
+		klog.Infof("get nats-secrets err=%v", err)
 		return "", err
 	}
 	password, ok := secret.Data["nats_password"]

--- a/platform/tapr/pkg/ws/client.go
+++ b/platform/tapr/pkg/ws/client.go
@@ -74,7 +74,7 @@ func (client *Client) onConnection() {
 				return
 			}
 
-			klog.Infof("read message, type: %d, accessPublic: %v, connId: %s, user: %s, data: %s", mt, accessPublic, connId, userName, string(msg))
+			klog.Infof("read message, type: %d, accessPublic: %v, connId: %s, user: %s", mt, accessPublic, connId, userName)
 
 			if client.checkPingMessage(msg) {
 				client.writeHandler(connId, websocket.TextMessage, map[string]interface{}{"event": "pong"})
@@ -84,7 +84,7 @@ func (client *Client) onConnection() {
 
 			var data = map[string]interface{}{}
 			if err = json.Unmarshal(msg, &data); err != nil {
-				klog.Errorf("unmarshal message error %+v, data: %s", err, string(msg))
+				klog.Errorf("unmarshal message error %+v", err)
 			}
 
 			client.readHandler(accessPublic, token, connId, userName, data, cookie, ACTION_MESSAGE)

--- a/platform/tapr/pkg/ws/middleware/middleware.go
+++ b/platform/tapr/pkg/ws/middleware/middleware.go
@@ -34,7 +34,8 @@ func RequireHeader() func(c *fiber.Ctx) error {
 		var forwarded = headers[constants.WsHeaderForwardeFor]
 		var cookie = headers[constants.WsHeaderCookie]
 
-		klog.Infof("ws-client conn: %s, accessPublic: %v, token: %s, user: %s , header: %+v", connId, accessPublic, token, userName, headers)
+		klog.Infof("ws-client conn: %s, accessPublic: %v, tokenFp: %s, user: %s, userAgent: %v, forwarded: %v",
+			connId, accessPublic, utils.MD5(token), userName, userAgent, forwarded)
 
 		var secWebsocketProtocol, ok = headers[constants.WsHeaderSecWebsocketProtocol]
 		if ok && len(secWebsocketProtocol) > 0 {

--- a/platform/tapr/pkg/ws/server.go
+++ b/platform/tapr/pkg/ws/server.go
@@ -6,10 +6,26 @@ import (
 	"sync"
 	"time"
 
+	"bytetrade.io/web3os/tapr/pkg/utils"
 	"github.com/gofiber/contrib/websocket"
 	"github.com/gofiber/fiber/v2"
 	"k8s.io/klog/v2"
 )
+
+func maskTokens(tokens []string) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
+	masked := make([]string, len(tokens))
+	for i, t := range tokens {
+		if t == "" {
+			masked[i] = ""
+			continue
+		}
+		masked[i] = utils.MD5(t)
+	}
+	return masked
+}
 
 type callback func(data *ReadMessage)
 
@@ -291,11 +307,11 @@ func (server *Server) routineWrite() {
 			}
 			msg, err := json.Marshal(elem.Message)
 			if err != nil {
-				klog.Errorf("send message marshal error %+v", err)
+				klog.Errorf("send message marshal error %+v, data: %v", err, elem.Message)
 				continue
 			}
 
-			klog.Infof("send message connId: %s, token: %v, users: %v", elem.ConnId, elem.Tokens, elem.Users)
+			klog.Infof("send message len=%d, connId: %s, tokenFp: %v, users: %v", len(msg), elem.ConnId, maskTokens(elem.Tokens), elem.Users)
 
 			var filter = NewFilter(server)
 			if elem.Users != nil && len(elem.Users) > 0 {

--- a/platform/tapr/pkg/ws/server.go
+++ b/platform/tapr/pkg/ws/server.go
@@ -291,11 +291,11 @@ func (server *Server) routineWrite() {
 			}
 			msg, err := json.Marshal(elem.Message)
 			if err != nil {
-				klog.Errorf("send message marshal error %+v, data: %v", err, elem.Message)
+				klog.Errorf("send message marshal error %+v", err)
 				continue
 			}
 
-			klog.Infof("send message data: %s, connId: %s, token: %v, users: %v", string(msg), elem.ConnId, elem.Tokens, elem.Users)
+			klog.Infof("send message connId: %s, token: %v, users: %v", elem.ConnId, elem.Tokens, elem.Users)
 
 			var filter = NewFilter(server)
 			if elem.Users != nil && len(elem.Users) > 0 {


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
stop logging forwarded payloads to avoid potential credential leakage

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/pull/3000


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly logging changes, but it also bumps the deployed `ws-gateway` image version, which could introduce behavioral changes at runtime. Reduced log detail may also impact troubleshooting if not compensated by other observability.
> 
> **Overview**
> Updates `app-service` to deploy `beclab/ws-gateway:v1.0.5`.
> 
> Reduces the chance of credential/secret leakage by removing or masking sensitive values in logs across websocket, Infisical, Elasticsearch middleware, Postgres, and NATS (e.g., no longer logging request bodies, tokens, passwords, secret values, or full payloads; tokens are logged only as MD5 fingerprints; some debug logging is disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8936acc637435fdfa282ef5ef7f9aa1b2563fb8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->