### PR TITLE
fix(bfl,tapr): remove privileged chown init containers

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -237,19 +237,13 @@ spec:
         - sh
         - -c
         - |
-          init=$(test -d /userspace/Home; echo $?) && \
           mkdir -p /userspace/Home/Documents && \
           mkdir -p /userspace/Home/Downloads && \
           mkdir -p /userspace/Home/Pictures && \
           mkdir -p /userspace/Home/Movies && \
           mkdir -p /userspace/Home/Music && \
           mkdir -p /userspace/Home/Code && \
-          mkdir -p /userspace/Data; \
-          if [ $init -ne 0 ]; then \
-          chown -R 1000:1000 /userspace/Home && \
-          chown -R 1000:1000 /userspace/Data && \
-          chown -R 1000:1000 /appdata; \
-          fi 
+          mkdir -p /userspace/Data
       - name: setsysctl
         image: 'busybox:1.28'
         command:

--- a/platform/tapr/.olares/config/user/helm-charts/tapr/templates/tapr_deploy.yaml
+++ b/platform/tapr/.olares/config/user/helm-charts/tapr/templates/tapr_deploy.yaml
@@ -26,21 +26,6 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      initContainers:
-        - name: init-data
-          image: busybox:1.28
-          securityContext:
-            privileged: true
-            runAsNonRoot: false
-            runAsUser: 0
-          volumeMounts:
-          - name: image-upload
-            mountPath: /data
-          command:
-          - sh
-          - -c
-          - |
-            chown -R 1000:1000 /data 
       containers:
       - name: tapr-images-uploader
         image: beclab/images-uploader:0.2.3


### PR DESCRIPTION
## Summary

Drop the privileged `chown` work done by init containers in two helm
templates and rely on the existing pod-level security context for
volume ownership where applicable.

### Changes

- **`framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml`**
  - Remove the first-time detection
    (`init=$(test -d /userspace/Home; echo $?)`) and the conditional
    `chown -R 1000:1000 /userspace/Home /userspace/Data /appdata` block
    from the `init-userspace` container.
  - The init container now only runs idempotent `mkdir -p` calls for
    the user-space layout.

- **`platform/tapr/.olares/config/user/helm-charts/tapr/templates/tapr_deploy.yaml`**
  - Remove the entire `init-data` initContainer that ran `chown -R
    1000:1000 /data` as `runAsUser: 0` with `privileged: true`.
  - The pod template already declares
    `runAsUser/runAsGroup/fsGroup: 1000`, so kubelet handles volume
    ownership via fsGroup; the privileged chown step is no longer
    needed.

### Test plan

- [ ] Fresh install: confirm `bfl` pod's init-userspace creates the
      user-space subtree and the `api` container can read/write under
      `/userspace`.
- [ ] Fresh install: confirm `tapr-images-uploader` can write into
      `/data` (host path `<userData>/Pictures`) without the privileged
      init container.
- [ ] Upgrade existing cluster: verify no permission regressions on
      pre-existing volumes.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: removes init-time `chown` steps and relies on `fsGroup`/existing volume permissions, which could cause permission regressions on fresh installs or upgrades if underlying volumes aren’t group-writable as expected.
> 
> **Overview**
> Removes privileged init-container ownership fixes in two Helm templates to avoid running `chown` as root.
> 
> In `bfl_deploy.yaml`, the `init-userspace` init container now only creates the `/userspace` directory layout and no longer detects “first run” or conditionally `chown`s `/userspace`, `/appdata`, and `/userspace/Data`. In `tapr_deploy.yaml`, the root+privileged `init-data` initContainer that `chown`s `/data` is deleted, relying on the pod’s `runAsUser/runAsGroup/fsGroup: 1000` for volume access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8082ba4e81f91acc9297e281e1c111da2c08ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->