### PR TITLE
fix: disable debug logging in DBLogger and config rendering

### DIFF
--- a/platform/tapr/pkg/postgres/client.go
+++ b/platform/tapr/pkg/postgres/client.go
@@ -104,7 +104,7 @@ func newClient(dsn string, builder *clientBuilder) (*client, error) {
 
 	dbProxy := DBLogger{DB: db}
 
-	dbProxy.Debug()
+	// dbProxy.Debug()
 
 	return &client{DB: &dbProxy, builder: builder}, nil
 }

--- a/platform/tapr/pkg/workload/nats/conf.go
+++ b/platform/tapr/pkg/workload/nats/conf.go
@@ -63,7 +63,7 @@ func renderConfigFile(config *Config) ([]byte, error) {
 	funcMap := template.FuncMap{
 		"quoteOrNot": quoteOrNot,
 	}
-	klog.Infof("renderConfigFile: %##v\n", config)
+	// klog.Infof("renderConfigFile: %##v\n", config)
 	var buf bytes.Buffer
 	tpl := template.Must(template.New("config").Funcs(funcMap).Parse(tmpl))
 	err := tpl.Execute(&buf, config)


### PR DESCRIPTION

Disable debug logging in DBLogger and NATS config rendering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes/guards debug logging; no functional behavior changes besides reduced log output.
> 
> **Overview**
> Disables default debug output in the Postgres `DBLogger` by commenting out the `dbProxy.Debug()` call during client creation, preventing query logs from being emitted.
> 
> Also silences an info-level log in NATS `renderConfigFile` that dumped the full rendered config input, reducing log noise and avoiding accidental leakage of configuration details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96543fb468c106d9fadec94bc1ff3de4bc83e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->