### PR TITLE
fix(controller): comment out logging of sensitive information

### DIFF
--- a/framework/osnode-init/pkg/controller/cloud.go
+++ b/framework/osnode-init/pkg/controller/cloud.go
@@ -166,15 +166,15 @@ func getClusterId(ctx context.Context, client dynamic.Interface) (cluster_id, ak
 	annotations := data.GetAnnotations()
 	if annotations != nil {
 		if ak, ok = annotations[LABEL_ACCESS_KEY]; ok {
-			klog.Info("found access key, ", ak)
+			// klog.Info("found access key, ", ak)
 		}
 
 		if sk, ok = annotations[LABEL_SECRET_KEY]; ok {
-			klog.Info("found secret key, ", sk)
+			// klog.Info("found secret key, ", sk)
 		}
 
 		if st, ok = annotations[LABEL_SESSION_TOKEN]; ok {
-			klog.Info("found session token, ", st)
+			// klog.Info("found session token, ", st)
 		}
 
 		return

--- a/framework/osnode-init/pkg/controller/controller.go
+++ b/framework/osnode-init/pkg/controller/controller.go
@@ -97,7 +97,7 @@ func NewNodeInitController(c client.Client, schema *runtime.Scheme, config *rest
 					account.Token,
 				}
 
-				klog.Info("refresh juicefs config with ", args)
+				// klog.Info("refresh juicefs config with ", args)
 				out, err := exec.Command("/usr/local/bin/juicefs", args...).CombinedOutput()
 				if err != nil {
 					klog.Errorf("%s, %v", string(out), err)


### PR DESCRIPTION
comment out logging of sensitive information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes logging statements; runtime behavior is unchanged, with reduced exposure of secrets in logs.
> 
> **Overview**
> Prevents sensitive credential leakage by commenting out info-level logs that printed S3 access key/secret/session token values pulled from the `terminus` annotations.
> 
> Also suppresses logging of the full `juicefs config` argument list (which includes the same credentials) during the periodic refresh job, while leaving the refresh/update behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26d6ae80b60eb981179f647274b8b384cd34673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->