### PR TITLE
fix(headscale): drop init-1000 container; redact password logging

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -132,24 +132,6 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       initContainers:
-      - name: init-data
-        image: busybox:1.28
-        securityContext:
-          privileged: true
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - name: config
-          mountPath: /etc/headscale
-        - name: headscale-data
-          mountPath: /var/lib/headscale
-        - name: config-parent
-          mountPath: /headscale
-        command:
-        - sh
-        - -c
-        - |
-          chown -R 1000:1000 /headscale 
       - args:
         - |
           set -euo pipefail
@@ -183,7 +165,7 @@ spec:
         - mountPath: /certs
           name: tls-cert
       - name: init
-        image: beclab/headscale-init:v0.1.13
+        image: beclab/headscale-init:v0.1.14
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -152,6 +152,7 @@ spec:
           echo "→ Fixing permissions..."
           chmod 644 /certs/tls.crt /certs/ca.crt
           chmod 600 /certs/tls.key
+          chown -R 1000:1000 /certs
         command:
         - sh
         - -c
@@ -161,6 +162,9 @@ spec:
         image: alpine/openssl:3.5.5
         imagePullPolicy: IfNotPresent
         name: init-cert
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
         volumeMounts:
         - mountPath: /certs
           name: tls-cert
@@ -169,6 +173,8 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
+          runAsNonRoot: false
+          runAsUser: 0
         env:
         - name: COREDNS_SVC
           value: {{ $corednsIP }}
@@ -283,10 +289,6 @@ spec:
         hostPath:
           type: DirectoryOrCreate
           path: '{{ .Values.userspace.appCache }}/headscale/data'
-      - name: config-parent
-        hostPath:
-          type: DirectoryOrCreate
-          path: '{{ .Values.userspace.appCache  }}/headscale'
       - name: acl-config
         configMap:
           defaultMode: 420


### PR DESCRIPTION
* **Background**

  Removes the redundant `busybox` `init-data` init container (`chown` on `/headscale`). Bumps `beclab/headscale-init` from `v0.1.13` to `v0.1.14` for safer init logging. Headscale previously ran an extra privileged init that only adjusted ownership on `/headscale`; that step is removed to simplify startup. The newer init image also avoids printing raw password material in logs.

* **Target Version for Merge**



* **Related Issues**



* **PRs Involving Sub-Systems**



* **Other information**



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes init-container behavior, privileges, and filesystem ownership, which can affect startup and volume permissions; also updates an init image version with security/logging implications.
> 
> **Overview**
> Removes the privileged `init-data` busybox init container (and its associated `config-parent` hostPath volume) that only performed a `chown` on the parent Headscale directory, simplifying pod startup.
> 
> Updates the remaining init steps by (a) running `init-cert` as root to `chown -R 1000:1000 /certs` after generating/fixing TLS artifacts, and (b) bumping `beclab/headscale-init` from `v0.1.13` to `v0.1.14` (intended to avoid logging sensitive password material) while explicitly setting it to run as root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e95c6d5b57d5fc43b80abf7431597e60ef80d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->