### PR TITLE
fix: bump component images to remove credentials from logs

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.50
+        image: beclab/auth:0.2.51
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
+++ b/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
@@ -231,7 +231,7 @@ spec:
           subPath: nginx.conf
 
       - name: tapr-sidecar
-        image: beclab/secret-vault:0.1.15
+        image: beclab/secret-vault:0.1.16
         imagePullPolicy: IfNotPresent
         ports:
         - name: proxy

--- a/framework/integration/.olares/config/cluster/deploy/integration_deploy.yaml
+++ b/framework/integration/.olares/config/cluster/deploy/integration_deploy.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: provider-proxy
-          image: beclab/provider-proxy:0.1.0
+          image: beclab/provider-proxy:0.1.2
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr

--- a/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
+++ b/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: provider-proxy
-          image: beclab/provider-proxy:0.1.1
+          image: beclab/provider-proxy:0.1.2
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr

--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
@@ -82,7 +82,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: system-server
-        image: beclab/system-server:0.1.33
+        image: beclab/system-server:0.1.34
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -202,7 +202,7 @@ spec:
             - name: NATS_SUBJECT_SYSTEM_GROUPS
               value: "os.groups"
 
-          image: beclab/lldap:0.0.17
+          image: beclab/lldap:0.0.18
           imagePullPolicy: IfNotPresent
           name: lldap
           ports:

--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.34
+        image: beclab/middleware-operator:0.2.35
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
## Summary

Bump multiple component images to versions that include logging fixes (removing credentials from logs and other log-related improvements):

- `beclab/auth`: 0.2.50 → 0.2.51
- `beclab/secret-vault`: 0.1.15 → 0.1.16
- `beclab/provider-proxy`: 0.1.0 / 0.1.1 → 0.1.2
- `beclab/system-server`: 0.1.33 → 0.1.34
- `beclab/lldap`: 0.0.17 → 0.0.18
- `beclab/middleware-operator`: 0.2.34 → 0.2.35

## Test plan

- [ ] Deploy and verify each component starts with the new image
- [ ] Verify logs no longer contain sensitive credentials

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version bumps affect several cluster-critical services (auth, secret vault sidecar, provider proxy, system server, lldap, middleware operator), so regressions would impact login/infra despite no manifest logic changes.
> 
> **Overview**
> Updates Kubernetes/Helm deployment manifests to **bump container images** for multiple cluster components, primarily to pick up logging fixes that avoid leaking credentials.
> 
> Image versions updated: `beclab/auth` `0.2.50→0.2.51`, `beclab/secret-vault` `0.1.15→0.1.16`, `beclab/provider-proxy` `0.1.0/0.1.1→0.1.2`, `beclab/system-server` `0.1.33→0.1.34`, `beclab/lldap` `0.0.17→0.0.18`, and `beclab/middleware-operator` `0.2.34→0.2.35`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a2c25f42231a770f8f2857ea633c77d6cb4420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->