### PR TITLE
feat(cli): add gpu type strix-halo

### DIFF
--- a/cli/pkg/bootstrap/precheck/tasks.go
+++ b/cli/pkg/bootstrap/precheck/tasks.go
@@ -390,13 +390,13 @@ func (r *RocmChecker) Check(runtime connector.Runtime) error {
 		return nil
 	}
 
-	// detect AMD APU/GPU presence
-	amdGPUExists, err := connector.HasAmdAPUOrGPU(runtime)
+	// detect Strix-Halo presence
+	strixHaloExists, err := connector.HasStrixHalo(runtime)
 	if err != nil {
 		return err
 	}
-	// no AMD APU/GPU found, no need to check rocm
-	if !amdGPUExists {
+	// no Strix-Halo found, no need to check rocm
+	if !strixHaloExists {
 		return nil
 	}
 

--- a/cli/pkg/core/connector/amdgpu.go
+++ b/cli/pkg/core/connector/amdgpu.go
@@ -98,6 +98,22 @@ func HasAmdAPUOrGPU(execRuntime Runtime) (bool, error) {
 	})
 }
 
+func HasStrixHaloLocal() (bool, error) {
+	return hasStrixHaloChip(func(s string) (string, error) {
+		out, err := exec.Command("sh", "-c", s).Output()
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	})
+}
+
+func HasStrixHalo(execRuntime Runtime) (bool, error) {
+	return hasStrixHaloChip(func(s string) (string, error) {
+		return execRuntime.GetRunner().SudoCmd(s, false, false)
+	})
+}
+
 func RocmVersion() (*semver.Version, error) {
 	const rocmVersionFile = "/opt/rocm/.info/version"
 	data, err := os.ReadFile(rocmVersionFile)
@@ -114,4 +130,32 @@ func RocmVersion() (*semver.Version, error) {
 		return nil, fmt.Errorf("invalid rocm version: %s", curStr)
 	}
 	return cur, nil
+}
+
+func hasStrixHaloChip(cmdExec func(s string) (string, error)) (bool, error) {
+	target := "Ryzen AI Max"
+
+	// try lscpu first: extract 'Model name' field
+	out, err := cmdExec("lscpu 2>/dev/null | awk -F': *' '/^Model name/{print $2; exit}' || true")
+	if err != nil {
+		return false, err
+	}
+	if out != "" {
+		lo := strings.ToLower(strings.TrimSpace(out))
+		if strings.Contains(lo, strings.ToLower(target)) {
+			return true, nil
+		}
+	}
+	// fallback to /proc/cpuinfo
+	out, err = cmdExec("awk -F': *' '/^model name/{print $2; exit}' /proc/cpuinfo 2>/dev/null || true")
+	if err != nil {
+		return false, err
+	}
+	if out != "" {
+		lo := strings.ToLower(strings.TrimSpace(out))
+		if strings.Contains(lo, strings.ToLower(target)) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -82,6 +82,7 @@ type Systems interface {
 	IsAmdGPU() bool
 	IsAmdGPUOrAPU() bool
 	IsMThreadsM1000() bool
+	IsStrixHalo() bool
 
 	IsUbuntu() bool
 	IsDebian() bool
@@ -252,6 +253,10 @@ func (s *SystemInfo) IsAmdApu() bool {
 
 func (s *SystemInfo) IsAmdGPU() bool {
 	return s.HasAmdGPU
+}
+
+func (s *SystemInfo) IsStrixHalo() bool {
+	return s.CpuInfo.IsStrixHalo
 }
 
 func (s *SystemInfo) IsAmdGPUOrAPU() bool {
@@ -475,6 +480,7 @@ type CpuInfo struct {
 	IsGB10Chip       bool   `json:"is_gb10_chip,omitempty"`
 	HasAmdAPU        bool   `json:"has_amd_apu,omitempty"`
 	IsMThreadsM1000  bool   `json:"is_mthreads_m1000,omitempty"`
+	IsStrixHalo      bool   `json:"is_strix_halo,omitempty"`
 }
 
 // Not considering the case where AMD GPU and AMD APU coexist.
@@ -543,11 +549,19 @@ func getCpu() *CpuInfo {
 		hasAmdAPU = false
 	}
 
+	// check if it is Strix Halo
+	isStrixHalo, err := HasStrixHaloLocal()
+	if err != nil {
+		fmt.Printf("Error checking Strix Halo: %v\n", err)
+		isStrixHalo = false
+	}
+
 	// check if it is mthreads m1000
 	ret.IsMThreadsM1000 = IsMThreadsAIBookM1000Local()
 
 	ret.IsGB10Chip = isGB10Chip
 	ret.HasAmdAPU = hasAmdAPU
+	ret.IsStrixHalo = isStrixHalo
 
 	return ret
 }

--- a/cli/pkg/gpu/amdgpu/module.go
+++ b/cli/pkg/gpu/amdgpu/module.go
@@ -79,8 +79,8 @@ func (m *InstallAmdPluginModule) Init() {
 
 	// update node with AMD GPU labels
 	updateNode := &task.LocalTask{
-		Name:   "UpdateNodeAmdGPUInfo",
-		Action: new(UpdateNodeAmdGPUInfo),
+		Name:   "UpdateNodeStrixHaloInfo",
+		Action: new(UpdateNodeStrixHaloInfo),
 		Retry:  1,
 	}
 

--- a/cli/pkg/gpu/amdgpu/tasks.go
+++ b/cli/pkg/gpu/amdgpu/tasks.go
@@ -54,12 +54,12 @@ func (t *InstallAmdRocm) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 
-	amdGPUExists, err := connector.HasAmdAPUOrGPU(runtime)
+	strixHaloExists, err := connector.HasStrixHalo(runtime)
 	if err != nil {
 		return err
 	}
 	// skip rocm install
-	if !amdGPUExists {
+	if !strixHaloExists {
 		return nil
 	}
 	rocmV, _ := connector.RocmVersion()
@@ -216,24 +216,24 @@ func (t *GenerateAndValidateAmdCDI) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-// UpdateNodeAmdGPUInfo updates Kubernetes node labels with AMD GPU information.
-type UpdateNodeAmdGPUInfo struct {
+// UpdateNodeStrixHaloInfo updates Kubernetes node labels with Strix-Halo information.
+type UpdateNodeStrixHaloInfo struct {
 	common.KubeAction
 }
 
-func (u *UpdateNodeAmdGPUInfo) Execute(runtime connector.Runtime) error {
+func (u *UpdateNodeStrixHaloInfo) Execute(runtime connector.Runtime) error {
 	client, err := clientset.NewKubeClient()
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 	}
 
-	// Check if AMD GPU/APU exists
-	amdGPUExists, err := connector.HasAmdAPUOrGPU(runtime)
+	// Check if Strix-Halo exists
+	strixHaloExists, err := connector.HasStrixHalo(runtime)
 	if err != nil {
 		return err
 	}
-	if !amdGPUExists {
-		logger.Info("AMD GPU/APU is not detected")
+	if !strixHaloExists {
+		logger.Info("Strix-Halo is not detected")
 		return nil
 	}
 
@@ -246,11 +246,7 @@ func (u *UpdateNodeAmdGPUInfo) Execute(runtime connector.Runtime) error {
 
 	rocmVersion := rocmV.Original()
 
-	// Determine GPU type (APU vs discrete GPU)
-	gpuType := gpu.AmdGpuCardType
-	if runtime.GetSystemInfo().IsAmdApu() {
-		gpuType = gpu.AmdApuCardType
-	}
+	gpuType := gpu.StrixHaloChipType
 
 	// Use ROCm version as both driver and "cuda" version for AMD
 	return gpu.UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), &rocmVersion, nil, nil, &gpuType)

--- a/cli/pkg/gpu/mtgpu/tasks.go
+++ b/cli/pkg/gpu/mtgpu/tasks.go
@@ -31,7 +31,7 @@ func (u *UpdateNodeMThreadsGPUInfo) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 
-	if runtime.GetSystemInfo().IsAmdApu() {
+	if runtime.GetSystemInfo().IsMThreadsM1000() {
 		return gpu.UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), nil, nil, nil, ptr.To(gpu.MThreadsM1000Type))
 	}
 

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -61,7 +61,7 @@ func (l *linuxInstallPhaseBuilder) installGpuPlugin() phase {
 		&gpu.RestartK3sServiceModule{Skip: !(l.runtime.Arg.Kubetype == common.K3s)},
 		&gpu.InstallPluginModule{Skip: skipGpuPlugin},
 		&amdgpu.InstallAmdPluginModule{Skip: func() bool {
-			if l.runtime.GetSystemInfo().IsAmdGPUOrAPU() {
+			if l.runtime.GetSystemInfo().IsStrixHalo() {
 				return false
 			}
 			return true

--- a/cli/pkg/phase/system/linux.go
+++ b/cli/pkg/phase/system/linux.go
@@ -84,7 +84,7 @@ func (l *linuxPhaseBuilder) build() []module.Module {
 			return []module.Module{
 				&amdgpu.InstallAmdRocmModule{},
 				&amdgpu.InstallAmdContainerToolkitModule{Skip: func() bool {
-					if l.runtime.GetSystemInfo().IsAmdGPUOrAPU() {
+					if l.runtime.GetSystemInfo().IsStrixHalo() {
 						return false
 					}
 					return true

--- a/cli/pkg/terminus/welcome.go
+++ b/cli/pkg/terminus/welcome.go
@@ -72,7 +72,7 @@ func (t *WelcomeMessage) Execute(runtime connector.Runtime) error {
 
 	// If AMD GPU on Ubuntu 22.04/24.04, print warning about reboot for ROCm
 	if si := runtime.GetSystemInfo(); si.IsUbuntu() && (si.IsUbuntuVersionEqual(connector.Ubuntu2204) || si.IsUbuntuVersionEqual(connector.Ubuntu2404)) {
-		if hasAmd, _ := connector.HasAmdAPUOrGPU(runtime); hasAmd {
+		if hasStrixHalo, _ := connector.HasStrixHalo(runtime); hasStrixHalo {
 			logger.Warnf("\x1b[31mWarning: To enable ROCm, please reboot your machine after activation.\x1b[0m")
 			fmt.Println()
 		}


### PR DESCRIPTION

* **Background**
add gpu type strix-halo
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GPU/ROCm gating logic to rely on new Strix Halo CPU-model detection, which could incorrectly skip or trigger ROCm/plugin installation and node labeling on affected Ubuntu hosts.
> 
> **Overview**
> Adds **Strix Halo** hardware support by introducing `connector.HasStrixHalo`/`HasStrixHaloLocal` (CPU model string match for "Ryzen AI Max") and wiring the result into `SystemInfo` via a new `IsStrixHalo()` flag.
> 
> Updates AMD ROCm prechecks, ROCm installation, Kubernetes node GPU labeling, and the post-install reboot warning to run **only when Strix Halo is detected** (replacing the prior AMD APU/GPU presence checks). Cluster/system phase GPU module skip conditions are adjusted accordingly, and the MThreads node-label update condition is corrected to use `IsMThreadsM1000()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bdd2bd03f8d0c4be95dd7eb7d46951f4ce4160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->