### PR TITLE
fix(oac): dry run with crds in chart cause helm panic

### DIFF
--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.3
+	github.com/beclab/api v0.0.4
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -27,6 +27,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/api v0.0.3 h1:7c4XqiCuQRey38aLU+U9B+ebdw6Mnmire6Ee4XOlioc=
 github.com/beclab/api v0.0.3/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.4 h1:EPSMGtVorbbjpvNyW0qPNJSSHagFDErGF1H6FqxJzoo=
+github.com/beclab/api v0.0.4/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/internal/helmrender/render.go
+++ b/framework/oac/internal/helmrender/render.go
@@ -104,6 +104,7 @@ func newActionConfig() (*action.Configuration, error) {
 		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
 		Capabilities:   chartutil.DefaultCapabilities,
 		RegistryClient: registryClient,
+		Log:            func(s string, i ...interface{}) {},
 	}
 	return &cfg, nil
 }


### PR DESCRIPTION


* **Background**
dry run with crds in chart cause helm panic

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Helm rendering configuration and bumps an external dependency (`github.com/beclab/api`), which could subtly change dry-run/render behavior; impact is limited to OAC’s chart-render/lint paths.
> 
> **Overview**
> Fixes Helm dry-run rendering crashes for charts that include CRDs by providing a no-op `Log` function in the Helm `action.Configuration` used by `helmrender`.
> 
> Also bumps the `github.com/beclab/api` dependency from `v0.0.3` to `v0.0.4` (updating `go.mod`/`go.sum`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553492c74ed0b121a1d5edd3e9e21ff6872ee181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->