### PR TITLE
fix: add default supported gpu strix-halo

### DIFF
--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -835,7 +835,7 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 	if !oac.IsNewOlaresManifestVersion(cfg.ConfigVersion) {
 		// Default supportedGpu list when the manifest leaves it empty.
 		if len(cfg.Spec.SupportedGpu) == 0 {
-			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType}
+			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType}
 		}
 
 		if selectedGpu != "" {

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -838,7 +838,7 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType}
 		}
 
-		if selectedGpu != "" {
+		if selectedGpu != "" && gpu != nil && !gpu.IsZero() {
 			found := false
 			for _, supportedGpu := range cfg.Spec.SupportedGpu {
 				if str, ok := supportedGpu.(string); ok && str == selectedGpu {


### PR DESCRIPTION

* **Background**
add default supported gpu strix-halo
* **Target Version for Merge**
v1.12.6, v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to legacy manifest GPU requirement parsing that mainly broadens defaults and avoids rejecting configs when no GPU is requested.
> 
> **Overview**
> Legacy (<0.12.0) manifest parsing now includes `utils.StrixHaloChipType` in the default `spec.supportedGpu` list when a manifest omits it.
> 
> The selected-GPU validation/override logic in `parseLegacyAppRequirement` now only runs when `spec.requiredGPU` parses to a non-zero quantity, preventing unnecessary "GPU not supported" errors for CPU-only installs that still pass a `selectedGpu` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5479f08ad28d3a5465321ad6ccb089378e699b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->