### PR TITLE
fix(appservice): add default supported gpu strix-halo

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.17
+        image: beclab/app-service:0.5.18
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -835,10 +835,10 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 	if !oac.IsNewOlaresManifestVersion(cfg.ConfigVersion) {
 		// Default supportedGpu list when the manifest leaves it empty.
 		if len(cfg.Spec.SupportedGpu) == 0 {
-			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType}
+			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType}
 		}
 
-		if selectedGpu != "" {
+		if selectedGpu != "" && gpu != nil && !gpu.IsZero() {
 			found := false
 			for _, supportedGpu := range cfg.Spec.SupportedGpu {
 				if str, ok := supportedGpu.(string); ok && str == selectedGpu {


### PR DESCRIPTION

* **Background**
add default supported gpu strix-halo
* **Target Version for Merge**
v1.12.6, v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to legacy GPU requirement parsing plus a container image version bump; main risk is unintended behavior change for manifests that set `selectedGpu` but no GPU quantity.
> 
> **Overview**
> Updates the `app-service` deployment image from `0.5.17` to `0.5.18`.
> 
> Adjusts legacy manifest requirement parsing (`parseLegacyAppRequirement`) to include `strix-halo` in the default `supportedGpu` list and to only validate/resolve `selectedGpu` when a non-zero `requiredGPU` is specified, avoiding spurious “GPU not supported” errors when no GPU is requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c677ba3e7a35f5146a879a3cd208fea02f6c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->