### PR TITLE
feat(olares-app): update system-frontend image tag to v1.10.22 in olares-app.yaml

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.19
+          image: beclab/system-frontend:v1.10.22
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
files, settings:  fix some bugs in the bug list
olares-app: fix some theme color adaptation issues

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1109

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm change that only updates a container image tag; behavior changes are confined to whatever is shipped in the new `system-frontend` image.
> 
> **Overview**
> Updates the `olares-app-init` initContainer in `olares-app.yaml` to use `beclab/system-frontend:v1.10.22` instead of `v1.10.19`, affecting the frontend assets copied into the `/www` volume at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6f95fe667a53acf7224915a7b3905554507c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->