### PR TITLE
fix(cli): surface command errors on stderr instead of swallowing them

### DIFF
--- a/cli/cmd/main.go
+++ b/cli/cmd/main.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"github.com/beclab/Olares/cli/cmd/ctl"
+	"fmt"
 	"os"
+
+	"github.com/beclab/Olares/cli/cmd/ctl"
 )
 
 func main() {
 	cmd := ctl.NewDefaultCommand()
 
 	if err := cmd.Execute(); err != nil {
-		// fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

`cli/cmd/main.go` previously discarded the error returned by cobra's `Execute()` and exited with code `1` silently — the `fmt.Println(err)` call had been commented out. Users running `olares-cli` had no way to see *why* a command failed without digging into the JSON log files under `~/.terminus/logs/`.

This change writes the error message to stderr (`Error: <msg>`) before `os.Exit(1)`, matching the convention used by virtually every other cobra-based CLI.

## Test plan

- [x] `go build ./cmd/...` in `cli/`
- [x] `go vet ./cmd/...` in `cli/`
- [ ] Run `olares-cli node add` without required flags and confirm an actionable message is printed to stderr

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the CLI entrypoint to display `Execute()` errors on stderr before exiting, without altering command behavior or data handling.
> 
> **Overview**
> Ensures `cli/cmd/main.go` no longer fails silently when a Cobra command returns an error.
> 
> On `cmd.Execute()` failure, the CLI now prints `Error: <msg>` to `os.Stderr` before exiting with status `1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316a6e0f3df0888a0a2e042a3cc202cc6a5e628d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->