### PR TITLE
fix(cli): avoid data race on host maps when RemoteTask runs in parallel

### DIFF
--- a/cli/pkg/core/connector/runtime.go
+++ b/cli/pkg/core/connector/runtime.go
@@ -244,8 +244,37 @@ func (b *BaseRuntime) GetCommandSed() string {
 	return b.cmdSed
 }
 
+// Copy returns a per-goroutine snapshot of BaseRuntime that is safe to
+// mutate concurrently with the original (and with sibling copies).
+//
+// The previous implementation was a single-line `runtime := *b` shallow
+// copy. The struct, however, owns three mutable collections that get
+// written during a pipeline run (`allHosts` slice via AppendHost /
+// DeleteHost, `roleHosts` and `deprecatedHosts` maps via the same paths
+// plus AppendRoleMap / RoleMapDelete). Combined with
+// `RemoteTask.Execute`'s per-host `selfRuntime := t.Runtime.Copy()` in
+// `Parallel` mode, any concurrent mutation of the parent runtime (or
+// another sibling copy) would race on the shared backing array / maps.
+//
+// We now allocate fresh slice / map containers while intentionally
+// keeping the `Host` values themselves shared (they own SSH connection
+// state and must not be duplicated) and the runner pointer / Argument
+// pointer shared (read-mostly after construction).
 func (b *BaseRuntime) Copy() Runtime {
 	runtime := *b
+
+	runtime.allHosts = append([]Host(nil), b.allHosts...)
+
+	runtime.roleHosts = make(map[string][]Host, len(b.roleHosts))
+	for role, hosts := range b.roleHosts {
+		runtime.roleHosts[role] = append([]Host(nil), hosts...)
+	}
+
+	runtime.deprecatedHosts = make(map[string]string, len(b.deprecatedHosts))
+	for k, v := range b.deprecatedHosts {
+		runtime.deprecatedHosts[k] = v
+	}
+
 	return &runtime
 }
 


### PR DESCRIPTION
## Summary

`BaseRuntime.Copy()` was a single-line `runtime := *b` shallow copy. The struct, however, owns three mutable collections that get written during a pipeline run:

- `allHosts` (slice; mutated by `AppendHost` / `DeleteHost`)
- `roleHosts` (`map[string][]Host`; mutated by `AppendRoleMap` / `RoleMapDelete`)
- `deprecatedHosts` (`map[string]string`; mutated by `DeleteHost`)

`RemoteTask.Execute` calls `selfRuntime := t.Runtime.Copy()` for every host and, when `Parallel` is `true`, runs them concurrently. Any concurrent mutation of the parent runtime (or another sibling copy) ends up hitting the same backing array / map, which is a textbook Go data race.

This change makes `Copy()` allocate fresh slice / map containers while intentionally keeping:

- the `Host` values themselves shared — they own the SSH connection state and must not be duplicated, and
- the `Argument` pointer shared — it is read-only after construction.

## Test plan

- [x] `go build ./...` in `cli/`
- [x] `go vet ./pkg/core/...` in `cli/`
- [ ] `go test -race ./pkg/core/...` (best-effort; pre-existing race issues, if any, would be flagged separately)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared runtime state used across goroutines; while the change is localized, incorrect copying could subtly affect host/role tracking under parallel execution.
> 
> **Overview**
> Prevents data races in parallel task execution by changing `BaseRuntime.Copy()` from a shallow struct copy to allocating new containers for `allHosts`, `roleHosts`, and `deprecatedHosts`.
> 
> Each runtime copy now gets its own slice/map backing storage while still sharing underlying `Host` objects (SSH state) and other read-mostly pointers, making per-host `t.Runtime.Copy()` safe under `RemoteTask.Parallel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efccdbf9e727e0ae0385b4cccd15be6e7ae96fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->