### PR TITLE
refactor(cli): stop calling os.Exit(1) inside core runtime/pipeline library code

### DIFF
--- a/cli/pkg/common/kube_runtime.go
+++ b/cli/pkg/common/kube_runtime.go
@@ -466,8 +466,11 @@ func NewKubeRuntime(arg Argument) (*KubeRuntime, error) {
 		return nil, err
 	}
 
-	base := connector.NewBaseRuntime(cluster.Name, connector.NewDialer(),
+	base, err := connector.NewBaseRuntime(cluster.Name, connector.NewDialer(),
 		arg.BaseDir, arg.OlaresVersion, arg.ConsoleLogFileName, arg.ConsoleLogTruncate, arg.SystemInfo)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create base runtime")
+	}
 
 	clusterSpec := &cluster.Spec
 	defaultCluster, roleGroups := clusterSpec.SetDefaultClusterSpec(arg.InCluster, arg.SystemInfo.IsDarwin())

--- a/cli/pkg/core/connector/runtime.go
+++ b/cli/pkg/core/connector/runtime.go
@@ -18,7 +18,6 @@ package connector
 
 import (
 	"fmt"
-	"os"
 	"os/user"
 	"path"
 	"path/filepath"
@@ -48,7 +47,7 @@ type BaseRuntime struct {
 	k8sClient       *kubernetes.Clientset
 }
 
-func NewBaseRuntime(name string, connector Connector, baseDir string, olaresVersion string, consoleLogFileName string, consoleLogTruncate bool, systemInfo Systems) BaseRuntime {
+func NewBaseRuntime(name string, connector Connector, baseDir string, olaresVersion string, consoleLogFileName string, consoleLogTruncate bool, systemInfo Systems) (BaseRuntime, error) {
 	base := BaseRuntime{
 		ObjName:         name,
 		connector:       connector,
@@ -64,19 +63,16 @@ func NewBaseRuntime(name string, connector Connector, baseDir string, olaresVers
 		baseDir = fmt.Sprintf("%s\\%s", systemInfo.GetHomeDir(), common.DefaultBaseDir)
 	}
 	if err := base.GenerateBaseDir(baseDir); err != nil {
-		fmt.Printf("[ERRO]: Failed to create base dir: %s\n", err)
-		os.Exit(1)
+		return BaseRuntime{}, errors.Wrap(err, "failed to create base dir")
 	}
 	if err := base.GenerateWorkDir(); err != nil {
-		fmt.Printf("[ERRO]: Failed to create work dir: %s\n", err)
-		os.Exit(1)
+		return BaseRuntime{}, errors.Wrap(err, "failed to create work dir")
 	}
 	if err := base.InitLogger(consoleLogFileName, consoleLogTruncate); err != nil {
-		fmt.Printf("[ERRO]: Failed to init log entry: %s\n", err)
-		os.Exit(1)
+		return BaseRuntime{}, errors.Wrap(err, "failed to init log entry")
 	}
 
-	return base
+	return base, nil
 }
 
 func (b *BaseRuntime) GetSystemInfo() Systems {

--- a/cli/pkg/core/pipeline/pipeline.go
+++ b/cli/pkg/core/pipeline/pipeline.go
@@ -17,7 +17,6 @@
 package pipeline
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -127,10 +126,16 @@ func (p *Pipeline) RunModule(m module.Module) *ending.ModuleResult {
 			}
 
 		case module.GoroutineModuleType:
+			// We previously os.Exit(1)'d here on failure, which skipped
+			// every defer in the pipeline (SSH cleanup, log flush, ...).
+			// We now surface the failure through the shared
+			// ModuleResult and log it; a follow-up will wire ctx
+			// cancellation so the rest of the pipeline can bail out.
 			go func() {
 				m.Run(result)
 				if result.IsFailed() {
-					os.Exit(1)
+					logger.Errorf("[Module] %s (goroutine) failed: %v",
+						m.GetName(), result.CombineResult)
 				}
 			}()
 		default:


### PR DESCRIPTION
## Summary

Two long-standing `os.Exit(1)` calls in the framework are replaced with proper error propagation:

1. **`core/connector/runtime.NewBaseRuntime`** previously printed `[ERRO]: ...` and called `os.Exit(1)` if base-dir creation, work-dir creation, or logger init failed. The constructor now returns `(BaseRuntime, error)` so callers (currently a single site in `pkg/common/kube_runtime.go`) can decide what to do.

2. **`core/pipeline.RunModule`'s `GoroutineModuleType` branch** called `os.Exit(1)` from a background goroutine on failure. That bypassed every `defer` in the pipeline — SSH connections, sftp clients, log flush. We now log the failure and let the pipeline observe the result through `*ending.ModuleResult`. (No concrete module uses `GoroutineModuleType` today, so this is mainly a footgun removal; ctx-based cancellation will land in a follow-up PR.)

Other `os.Exit(1)` sites under `pkg/{bootstrap,gpu,terminus}/...` and the thin `pkg/pipelines/*.go` precondition checks are intentionally out of scope here — they live at the task / command boundary and will be migrated together with the `context.Context` plumbing PR.

## Test plan

- [x] `go build ./...` in `cli/`
- [x] `go vet ./pkg/core/...` in `cli/` (the `pkg/common`, `pkg/kubesphere`, `pkg/terminus` vet warnings reported by `go vet ./...` are pre-existing on `main`)
- [ ] Manual: trigger a failure inside `NewBaseRuntime` (e.g. by pointing `--base-dir` at an unwritable parent) and confirm the CLI surfaces the error through the regular cobra error path instead of exiting silently

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI library control-flow by replacing `os.Exit(1)` with error propagation/logging; callers and failure handling paths may behave differently and need validation under failure scenarios.
> 
> **Overview**
> Stops hard process termination inside core CLI framework code.
> 
> `connector.NewBaseRuntime` now returns `(BaseRuntime, error)` and surfaces base/work dir or logger init failures to the caller; `common.NewKubeRuntime` is updated to handle and wrap this error.
> 
> In `pipeline.RunModule`, failures in `GoroutineModuleType` modules no longer call `os.Exit(1)` from a background goroutine; they now log the failure and rely on the shared `ModuleResult` for downstream handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addad9f133734bc7ed36e2d9e5daec3538c64534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->