### PR TITLE
refactor(cli): inject typed Options into mainline pipelines instead of reading viper inside the pipeline body

### DIFF
--- a/cli/cmd/ctl/os/install.go
+++ b/cli/cmd/ctl/os/install.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewCmdInstallOs() *cobra.Command {
@@ -14,7 +15,25 @@ func NewCmdInstallOs() *cobra.Command {
 		Use:   "install",
 		Short: "Install Olares",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := pipelines.CliInstallTerminusPipeline(); err != nil {
+			opts := pipelines.InstallTerminusOptions{
+				KubeType:        viper.GetString(common.FlagKubeType),
+				OlaresVersion:   viper.GetString(common.FlagVersion),
+				MinikubeProfile: viper.GetString(common.FlagMiniKubeProfile),
+				Storage:         pipelines.StorageOptionsFromViper(),
+				Swap: common.SwapConfig{
+					EnablePodSwap:    viper.GetBool(common.FlagEnablePodSwap),
+					Swappiness:       viper.GetInt(common.FlagSwappiness),
+					EnableZRAM:       viper.GetBool(common.FlagEnableZRAM),
+					ZRAMSize:         viper.GetString(common.FlagZRAMSize),
+					ZRAMSwapPriority: viper.GetInt(common.FlagZRAMSwapPriority),
+				},
+				WithJuiceFS: viper.GetBool(common.FlagEnableJuiceFS),
+			}
+			if viper.IsSet(common.FlagEnableReverseProxy) {
+				val := viper.GetBool(common.FlagEnableReverseProxy)
+				opts.EnableReverseProxy = &val
+			}
+			if err := pipelines.CliInstallTerminusPipeline(opts); err != nil {
 				log.Fatalf("error: %v", err)
 			}
 		},

--- a/cli/cmd/ctl/os/prepare.go
+++ b/cli/cmd/ctl/os/prepare.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewCmdPrepare() *cobra.Command {
@@ -14,7 +15,12 @@ func NewCmdPrepare() *cobra.Command {
 		Use:   "prepare [component1 component2 ...]",
 		Short: "Prepare install",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := pipelines.PrepareSystemPipeline(args); err != nil {
+			opts := pipelines.PrepareSystemOptions{
+				KubeType:        viper.GetString(common.FlagKubeType),
+				MinikubeProfile: viper.GetString(common.FlagMiniKubeProfile),
+				Storage:         pipelines.StorageOptionsFromViper(),
+			}
+			if err := pipelines.PrepareSystemPipeline(opts, args); err != nil {
 				log.Fatalf("error: %v", err)
 			}
 		},

--- a/cli/cmd/ctl/os/uninstall.go
+++ b/cli/cmd/ctl/os/uninstall.go
@@ -16,7 +16,12 @@ func NewCmdUninstallOs() *cobra.Command {
 		Use:   "uninstall",
 		Short: "Uninstall Olares",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := pipelines.UninstallTerminusPipeline()
+			opts := pipelines.UninstallTerminusOptions{
+				Phase:   viper.GetString(common.FlagUninstallPhase),
+				All:     viper.GetBool(common.FlagUninstallAll),
+				Storage: pipelines.StorageOptionsFromViper(),
+			}
+			err := pipelines.UninstallTerminusPipeline(opts)
 			if err != nil {
 				log.Fatalf("error: %v", err)
 			}

--- a/cli/pkg/pipelines/install_terminus.go
+++ b/cli/pkg/pipelines/install_terminus.go
@@ -10,33 +10,43 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/phase/cluster"
-	"github.com/spf13/viper"
 )
 
-func CliInstallTerminusPipeline() error {
+// InstallTerminusOptions carries the user-supplied configuration for
+// CliInstallTerminusPipeline. All flag / env / viper resolution happens
+// in the cmd/ctl layer; the pipeline itself receives a fully populated
+// options value and never reads the global viper registry.
+type InstallTerminusOptions struct {
+	KubeType        string
+	OlaresVersion   string
+	MinikubeProfile string
+	Storage         *common.Storage
+	Swap            common.SwapConfig
+	WithJuiceFS     bool
+
+	// EnableReverseProxy is tri-state: nil means "not set, decide at
+	// runtime"; non-nil means the user explicitly chose true/false.
+	EnableReverseProxy *bool
+}
+
+func CliInstallTerminusPipeline(opts InstallTerminusOptions) error {
 	var terminusVersion, _ = phase.GetOlaresVersion()
 	if terminusVersion != "" {
 		return errors.New("Olares is already installed, please uninstall it first.")
 	}
 
 	arg := common.NewArgument()
-	arg.SetKubeVersion(viper.GetString(common.FlagKubeType))
-	arg.SetOlaresVersion(viper.GetString(common.FlagVersion))
-	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))
-	arg.SetStorage(getStorageConfig())
-	arg.SetSwapConfig(common.SwapConfig{
-		EnablePodSwap:    viper.GetBool(common.FlagEnablePodSwap),
-		Swappiness:       viper.GetInt(common.FlagSwappiness),
-		EnableZRAM:       viper.GetBool(common.FlagEnableZRAM),
-		ZRAMSize:         viper.GetString(common.FlagZRAMSize),
-		ZRAMSwapPriority: viper.GetInt(common.FlagZRAMSwapPriority),
-	})
+	arg.SetKubeVersion(opts.KubeType)
+	arg.SetOlaresVersion(opts.OlaresVersion)
+	arg.SetMinikubeProfile(opts.MinikubeProfile)
+	arg.SetStorage(opts.Storage)
+	arg.SetSwapConfig(opts.Swap)
 	if err := arg.SwapConfig.Validate(); err != nil {
 		return err
 	}
-	arg.WithJuiceFS = viper.GetBool(common.FlagEnableJuiceFS)
-	if viper.IsSet(common.FlagEnableReverseProxy) {
-		val := viper.GetBool(common.FlagEnableReverseProxy)
+	arg.WithJuiceFS = opts.WithJuiceFS
+	if opts.EnableReverseProxy != nil {
+		val := *opts.EnableReverseProxy
 		arg.NetworkSettings.EnableReverseProxy = &val
 	}
 	runtime, err := common.NewKubeRuntime(*arg)

--- a/cli/pkg/pipelines/prepare_system.go
+++ b/cli/pkg/pipelines/prepare_system.go
@@ -19,20 +19,28 @@ import (
 	"github.com/beclab/Olares/cli/pkg/manifest"
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/phase/system"
-	"github.com/spf13/viper"
 )
 
-func PrepareSystemPipeline(components []string) error {
+// PrepareSystemOptions carries the user-supplied configuration for
+// PrepareSystemPipeline. All flag / env / viper resolution happens
+// in the cmd/ctl layer.
+type PrepareSystemOptions struct {
+	KubeType        string
+	MinikubeProfile string
+	Storage         *common.Storage
+}
+
+func PrepareSystemPipeline(opts PrepareSystemOptions, components []string) error {
 	var terminusVersion, _ = phase.GetOlaresVersion()
 	if terminusVersion != "" && len(components) == 0 {
 		return errors.New("Olares is already installed, please uninstall it first.")
 	}
 
 	var arg = common.NewArgument()
-	arg.SetKubeVersion(viper.GetString(common.FlagKubeType))
-	arg.SetMinikubeProfile(viper.GetString(common.FlagMiniKubeProfile))
+	arg.SetKubeVersion(opts.KubeType)
+	arg.SetMinikubeProfile(opts.MinikubeProfile)
 	arg.SetOlaresVersion(version.VERSION)
-	arg.SetStorage(getStorageConfig())
+	arg.SetStorage(opts.Storage)
 	arg.ClearMasterHostConfig()
 
 	runtime, err := common.NewKubeRuntime(*arg)

--- a/cli/pkg/pipelines/storage.go
+++ b/cli/pkg/pipelines/storage.go
@@ -20,7 +20,7 @@ func CliInstallStoragePipeline() error {
 
 	arg := common.NewArgument()
 	arg.SetOlaresVersion(version.VERSION)
-	arg.SetStorage(getStorageConfig())
+	arg.SetStorage(StorageOptionsFromViper())
 
 	runtime, err := common.NewKubeRuntime(*arg)
 	if err != nil {
@@ -33,7 +33,11 @@ func CliInstallStoragePipeline() error {
 	return system.InstallStoragePipeline(runtime).Start()
 }
 
-func getStorageConfig() *common.Storage {
+// StorageOptionsFromViper reads the storage-related flags from the
+// global viper registry. It is the single bridge between viper and
+// the *common.Storage configuration consumed by pipelines; the cmd/ctl
+// layer is the only intended caller.
+func StorageOptionsFromViper() *common.Storage {
 	storageType := viper.GetString(common.FlagStorageType)
 	if storageType == "" {
 		storageType = common.ManagedMinIO

--- a/cli/pkg/pipelines/uninstall_terminus.go
+++ b/cli/pkg/pipelines/uninstall_terminus.go
@@ -8,10 +8,25 @@ import (
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/phase/cluster"
 	"github.com/beclab/Olares/cli/version"
-	"github.com/spf13/viper"
 )
 
-func UninstallTerminusPipeline() error {
+// UninstallTerminusOptions carries the user-supplied configuration for
+// UninstallTerminusPipeline. All flag / env / viper resolution happens
+// in the cmd/ctl layer.
+type UninstallTerminusOptions struct {
+	// Phase is the uninstall phase requested via --phase. Ignored
+	// when All is true.
+	Phase string
+	// All requests a complete uninstall (--all). When true, Phase is
+	// internally overridden to "download" so the pipeline tears
+	// everything down.
+	All bool
+	// Storage carries the storage backend parameters used to remove
+	// remote artifacts during uninstall.
+	Storage *common.Storage
+}
+
+func UninstallTerminusPipeline(opts UninstallTerminusOptions) error {
 	kubeType := phase.GetKubeType()
 
 	sysversion, _ := phase.GetOlaresVersion()
@@ -23,13 +38,11 @@ func UninstallTerminusPipeline() error {
 	arg.SetOlaresVersion(sysversion)
 	arg.SetConsoleLog("uninstall.log", true)
 	arg.SetKubeVersion(kubeType)
-	arg.SetStorage(getStorageConfig())
+	arg.SetStorage(opts.Storage)
 	arg.ClearMasterHostConfig()
 
-	phase := viper.GetString(common.FlagUninstallPhase)
-	all := viper.GetBool(common.FlagUninstallAll)
-
-	if err := checkPhase(phase, all, arg.SystemInfo.GetOsType()); err != nil {
+	uninstallPhase := opts.Phase
+	if err := checkPhase(uninstallPhase, opts.All, arg.SystemInfo.GetOsType()); err != nil {
 		return err
 	}
 
@@ -38,11 +51,11 @@ func UninstallTerminusPipeline() error {
 		return err
 	}
 
-	if all {
-		phase = cluster.PhaseDownload.String()
+	if opts.All {
+		uninstallPhase = cluster.PhaseDownload.String()
 	}
 
-	var p = cluster.UninstallTerminus(phase, runtime)
+	var p = cluster.UninstallTerminus(uninstallPhase, runtime)
 	if err := p.Start(); err != nil {
 		logger.Errorf("uninstall Olares failed: %v", err)
 		return err


### PR DESCRIPTION
## Summary

Three mainline pipelines under [cli/pkg/pipelines/](cli/pkg/pipelines/) used to read configuration straight from the global `viper` registry inside their function body. That made them hard to test (the inputs were implicit and global) and tightly coupled the pipeline package to whatever flag names the cmd layer happened to register.

This change moves the `viper.Get*` calls out of the pipeline package and into the `cmd/ctl` layer:

- [pipelines.CliInstallTerminusPipeline](cli/pkg/pipelines/install_terminus.go) now takes a typed `pipelines.InstallTerminusOptions` (KubeType, OlaresVersion, MinikubeProfile, Storage, Swap, WithJuiceFS, EnableReverseProxy).
- [pipelines.UninstallTerminusPipeline](cli/pkg/pipelines/uninstall_terminus.go) now takes a typed `pipelines.UninstallTerminusOptions` (Phase, All, Storage).
- [pipelines.PrepareSystemPipeline](cli/pkg/pipelines/prepare_system.go) now takes a typed `pipelines.PrepareSystemOptions` (KubeType, MinikubeProfile, Storage) plus the existing `components []string`.
- The shared `getStorageConfig` helper is exported as [pipelines.StorageOptionsFromViper](cli/pkg/pipelines/storage.go). It is now the only viper-aware function in `pkg/pipelines` and is called exclusively from `cmd/ctl` handlers (and from the existing `CliInstallStoragePipeline`, which is intentionally out of scope for this PR).

## Out of scope

- Two of the originally-prioritised mainline pipelines, `UpgradeOlaresPipeline` and `AddNodePipeline`, have no direct `viper.Get*` calls in their bodies and are left untouched.
- The viper-coupling that lives inside `common.NewArgument()` itself (`User`, `RegistryMirrors`, `OlaresCDNService`, …) is intentionally out of scope — migrating that would cascade through every single pipeline. It should be a follow-up PR.
- The download / changeip / GPU pipelines still read viper inside their bodies. They are lower-traffic and can be migrated incrementally.

## Test plan

- [x] `go build ./...` in `cli/`
- [x] `go vet ./pkg/pipelines/... ./cmd/ctl/...` in `cli/`
- [x] `rg 'viper\.' cli/pkg/pipelines/install_terminus.go cli/pkg/pipelines/uninstall_terminus.go cli/pkg/pipelines/prepare_system.go` returns no matches
- [ ] Manual: run `olares-cli os install`, `olares-cli os uninstall --phase install`, `olares-cli os prepare images` and confirm flags still take effect end-to-end

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to changed pipeline function signatures and moved flag resolution, which could subtly alter CLI behavior if any option mapping/defaults diverge from previous viper reads.
> 
> **Overview**
> Refactors the `os install`, `os prepare`, and `os uninstall` flows so pipelines no longer read from global `viper`; the cmd layer now constructs typed option structs (`InstallTerminusOptions`, `PrepareSystemOptions`, `UninstallTerminusOptions`) and passes them into the pipelines.
> 
> Centralizes storage flag parsing into `pipelines.StorageOptionsFromViper()` and updates install/uninstall/prepare pipelines to consume the injected `*common.Storage`, swap config, kube/minikube settings, and uninstall phase/all selection (including tri-state handling for `EnableReverseProxy`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f613648ceed982f010084cfb8ecde483b7debcda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->