### PR TITLE
chore(olares-app): update system-frontend image tag to v1.10.24 in olares-app.yaml

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.22
+          image: beclab/system-frontend:v1.10.24
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
1. handle NaN values in MylineChart4 and improve metrics fetching logic
2. improve social UI and slider interactions
3. improve file search and menu selection

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
* https://github.com/beclab/TermiPass/pull/1110
https://github.com/beclab/TermiPass/pull/1111
https://github.com/beclab/TermiPass/pull/1112
* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only updates the `beclab/system-frontend` initContainer image tag; main impact is pulling a new frontend artifact during deployment.
> 
> **Overview**
> Updates the `olares-app-init` initContainer in `olares-app.yaml` to use `beclab/system-frontend:v1.10.24` instead of `v1.10.22`, so deployments pick up the newer system-frontend assets copied into `/www`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac3ebd0b31291934ee7296522a41b9d554afa05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->