### PR TITLE
feat: refactor search3

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -241,7 +241,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.2.0
+        image: beclab/search3:v0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -302,7 +302,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.2.0
+        image: beclab/search3monitor:v0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.2.0
+        image: beclab/search3validation:v0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: refactor search3
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. refactor search3 for more reliability, safty
2.  add attribute for exclude pattern rule pattern which can not be deleted
3.  fix when olares  create user fail, the search3 start fail
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.6
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/175
*  https://github.com/Above-Os/search3/pull/176
*  https://github.com/Above-Os/search3/pull/177
*  https://github.com/Above-Os/search3/pull/178
* https://github.com/Above-Os/search3/pull/179
*  https://github.com/Above-Os/search3/pull/180

*  https://github.com/Above-Os/search3/pull/182
* https://github.com/Above-Os/search3/pull/183
*  https://github.com/Above-Os/search3/pull/184
* https://github.com/Above-Os/search3/pull/185
*  https://github.com/Above-Os/search3/pull/186
*  https://github.com/Above-Os/search3/pull/188

* https://github.com/Above-Os/search3/pull/189
*  https://github.com/Above-Os/search3/pull/190
* https://github.com/Above-Os/search3/pull/191



* **Other information**:



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the deployed `search3`, `search3monitor`, and `search3validation` container images, so behavior changes depend on the new upstream image contents and could affect cluster search/monitoring at runtime.
> 
> **Overview**
> Bumps the Kubernetes deployment manifests to use `beclab/search3`, `beclab/search3monitor`, and `beclab/search3validation` **from `v0.2.0` to `v0.2.8`**, rolling the cluster to the newer Search3 component versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c7a58252a00dd06e2ce6b09c24844a250a7628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->