### PR TITLE
docs: update Olares One USB reinstall guide and add bootable USB guide

### DIFF
--- a/docs/.vitepress/one.en.ts
+++ b/docs/.vitepress/one.en.ts
@@ -267,6 +267,10 @@ export const oneSidebar: DefaultTheme.Sidebar = {
               text: "Reinstall Olares OS",
               link: "/one/create-drive",
             },
+            {
+              text: "Create bootable USB drive",
+              link: "/one/create-bootable-usb",
+            },
           ],
         },
       ]

--- a/docs/.vitepress/one.zh.ts
+++ b/docs/.vitepress/one.zh.ts
@@ -268,6 +268,10 @@ export const oneSidebar: DefaultTheme.Sidebar = {
               text: "Reinstall Olares OS",
               link: "/zh/one/create-drive",
             },
+            {
+              text: "Create bootable USB drive",
+              link: "/zh/one/create-bootable-usb",
+            },
           ],
         },
       ]

--- a/docs/one/create-bootable-usb.md
+++ b/docs/one/create-bootable-usb.md
@@ -46,7 +46,7 @@ Do not use Olares ISO images linked from other Olares installation documentation
 
    c. Click **Flash!** to write the installer to the USB drive.
 
-   ![Bootable USB](/images/one/balenaEtcher.png#bordered)
+   ![Balena Etcher flashing screen](/images/one/balenaEtcher.png#bordered)
 
 5. Wait until flashing and validation are complete.
 

--- a/docs/one/create-bootable-usb.md
+++ b/docs/one/create-bootable-usb.md
@@ -1,0 +1,57 @@
+---
+outline: [2, 3]
+description: Create a bootable USB drive with the latest Olares One ISO to reinstall or recover Olares OS on Olares One.
+head:
+  - - meta
+    - name: keywords
+      content: Olares One, bootable USB, Olares One ISO, reinstall Olares OS, recovery USB, Balena Etcher
+---
+
+# Create an Olares One bootable USB drive <Badge type="tip" text="15 min"/>
+
+Create a bootable USB drive with the latest Olares One ISO when you need to reinstall or recover Olares OS on Olares One.
+
+Use this guide if the included USB drive is unavailable, contains an earlier OS image, or if you want to reinstall Olares One directly with the latest OS image.
+
+:::warning Use the Olares One ISO only
+Use only the Olares One ISO linked in this guide to create the bootable USB drive.
+
+Do not use any Olares ISO downloaded from other Olares installation pages. Otherwise, your device may be recognized as **Generic** instead of **Olares One**, and some Olares One-specific features may be unavailable.
+:::
+
+## Prerequisites
+
+- USB flash drive: A drive with 8 GB or larger capacity.
+
+    :::warning Data loss
+    The selected USB drive will be erased when you create the bootable drive. Back up any important files before continuing.
+    :::
+
+- Computer: A Windows, macOS, or Linux computer to perform the setup.
+- Internet connection: A stable connection for downloading the ISO file and Balena Etcher.
+
+## Create the bootable USB drive
+
+1. Download [the latest official Olares One ISO image](https://cdn.olares.com/one/olares-latest-amd64.iso) to your computer.
+
+2. Download and install [**Balena Etcher**](https://etcher.balena.io/).
+
+3. Insert the USB flash drive into your computer.
+
+4. Open Balena Etcher and follow these steps:
+
+   a. Click **Flash from file** and select the Olares One ISO you downloaded.
+
+   b. Click **Select target** and select your USB drive.
+
+   c. Click **Flash!** to write the installer to the USB drive.
+
+   ![Bootable USB](/images/one/balenaEtcher.png#bordered)
+
+5. Wait until flashing and validation are complete.
+
+6. Safely eject the USB drive.
+
+## Next steps
+
+Use the bootable USB drive to reinstall Olares OS on Olares One. For detailed instructions, see [Reinstall Olares OS using bootable USB](create-drive.md).

--- a/docs/one/create-bootable-usb.md
+++ b/docs/one/create-bootable-usb.md
@@ -16,7 +16,7 @@ Use this guide if the included USB drive is unavailable, contains an earlier OS 
 :::warning Use the Olares One ISO only
 Use only the Olares One ISO linked in this guide to create the bootable USB drive.
 
-Do not use any Olares ISO downloaded from other Olares installation pages. Otherwise, your device may be recognized as **Generic** instead of **Olares One**, and some Olares One-specific features may be unavailable.
+Do not use Olares ISO images linked from other Olares installation documentation, as they are intended for generic hardware. If you use a standard self-hosted ISO, your device may be recognized as **Generic** instead of **Olares One**, and some Olares One-specific features may be unavailable.
 :::
 
 ## Prerequisites

--- a/docs/one/create-drive.md
+++ b/docs/one/create-drive.md
@@ -18,10 +18,6 @@ This will permanently delete all accounts, settings, and data on the device. Thi
 ## Prerequisites
 
 - A monitor and keyboard connected to Olares One.
-- A bootable USB drive for Olares One. You can use either:
-
-  - **The included USB drive.** It may contain an earlier OS image, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
-
 - The bootable USB drive that came with Olares One.
  
    :::info Installed OS version
@@ -89,7 +85,7 @@ After the reboot, the system starts in a clean factory state and shows a text-ba
 
 You can then activate Olares One again via LarePass. For detailed instructions, see [First boot](first-boot.md).
 
-## Step 5: Check for system updates
+## Step 5: Check for system updates (optional)
 
 The included USB drive may install an earlier OS version. After activation, you can update Olares OS in LarePass. For detailed steps, see [Update OS](update.md).
 

--- a/docs/one/create-drive.md
+++ b/docs/one/create-drive.md
@@ -9,19 +9,29 @@ head:
 
 # Reinstall Olares OS using bootable USB <Badge type="tip" text="15 min"/>
 
-Reinstalling Olares OS returns your Olares One to a clean initial state. You can do this using the bootable USB drive included with Olares One.
+Reinstalling Olares OS returns your Olares One to a clean initial state.
 
 :::warning Data loss
 This will permanently delete all accounts, settings, and data on the device. This action cannot be undone.
 :::
 
 ## Prerequisites
-**Hardware**<br>
-- The bootable USB drive that came with Olares One.
-   :::tip Don't have the USB drive?
-   Download the [Olares One ISO](https://cdn.olares.com/one/olares-latest-amd64.iso), which is device-specific and different from the standard Olares ISO, and flash it to a USB drive (8 GB or larger) using a tool such as [Balena Etcher](https://etcher.balena.io/).
-   :::
+
+### Hardware
+
 - A monitor and keyboard connected to Olares One.
+
+### Installation media
+
+- A bootable USB drive for Olares One. You can use either:
+
+   - **The included USB drive.** It may contain an earlier OS image, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
+
+   - **A new bootable USB drive.** To install the latest OS image directly, create a bootable USB drive from the [Olares One ISO](https://cdn.olares.com/one/olares-latest-amd64.iso) using a tool such as [Balena Etcher](https://etcher.balena.io/). For detailed instructions, see [Create an Olares One bootable USB drive](create-bootable-usb.md).
+
+  :::warning Use the Olares One ISO only
+  Do not use the standard self-hosted Olares ISO. Otherwise, your device will be recognized as **Generic** instead of **Olares One**, and some Olares One-specific features may be unavailable.
+  :::
 
 ## Step 1: Boot from the USB drive
 
@@ -82,3 +92,9 @@ After the reboot, the system starts in a clean factory state and shows a text-ba
 ## Step 4: Complete activation via LarePass
 
 You can then activate Olares One again via LarePass. For detailed instructions, see [First boot](first-boot.md).
+
+## Step 5: Optional: Update Olares OS
+
+If you reinstalled Olares One using the included USB drive, the installed OS version may not be the latest. After activation, check for system updates in LarePass.
+
+For detailed instructions, see [Update OS](update.md).

--- a/docs/one/create-drive.md
+++ b/docs/one/create-drive.md
@@ -88,5 +88,3 @@ You can then activate Olares One again via LarePass. For detailed instructions, 
 ## Step 5: Check for system updates (optional)
 
 The included USB drive may install an earlier OS version. After activation, you can update Olares OS in LarePass. For detailed steps, see [Update OS](update.md).
-
-For detailed instructions, see [Update OS](update.md).

--- a/docs/one/create-drive.md
+++ b/docs/one/create-drive.md
@@ -17,21 +17,12 @@ This will permanently delete all accounts, settings, and data on the device. Thi
 
 ## Prerequisites
 
-### Hardware
-
 - A monitor and keyboard connected to Olares One.
-
-### Installation media
-
 - A bootable USB drive for Olares One. You can use either:
 
-   - **The included USB drive.** It may contain an earlier OS image, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
+  - **The included USB drive.** It may contain an earlier OS image, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
 
-   - **A new bootable USB drive.** To install the latest OS image directly, create a bootable USB drive from the [Olares One ISO](https://cdn.olares.com/one/olares-latest-amd64.iso) using a tool such as [Balena Etcher](https://etcher.balena.io/). For detailed instructions, see [Create an Olares One bootable USB drive](create-bootable-usb.md).
-
-  :::warning Use the Olares One ISO only
-  Do not use the standard self-hosted Olares ISO. Otherwise, your device will be recognized as **Generic** instead of **Olares One**, and some Olares One-specific features may be unavailable.
-  :::
+  - **A new bootable USB drive.** To install the latest OS image directly, create a new bootable USB drive for Olares One. For detailed instructions, see [Create an Olares One bootable USB drive](create-bootable-usb.md).
 
 ## Step 1: Boot from the USB drive
 
@@ -93,7 +84,7 @@ After the reboot, the system starts in a clean factory state and shows a text-ba
 
 You can then activate Olares One again via LarePass. For detailed instructions, see [First boot](first-boot.md).
 
-## Step 5: Optional: Update Olares OS
+## Step 5: Check for system updates
 
 If you reinstalled Olares One using the included USB drive, the installed OS version may not be the latest. After activation, check for system updates in LarePass.
 

--- a/docs/one/create-drive.md
+++ b/docs/one/create-drive.md
@@ -22,7 +22,12 @@ This will permanently delete all accounts, settings, and data on the device. Thi
 
   - **The included USB drive.** It may contain an earlier OS image, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
 
-  - **A new bootable USB drive.** To install the latest OS image directly, create a new bootable USB drive for Olares One. For detailed instructions, see [Create an Olares One bootable USB drive](create-bootable-usb.md).
+- The bootable USB drive that came with Olares One.
+ 
+   :::info Installed OS version
+   The OS image on the included USB drive may be an earlier version, depending on when your device was shipped. You can still use it to reinstall the system, then update Olares OS after activation if needed.
+
+   If you need the latest OS image, create a new bootable USB drive from the [Olares One ISO](https://cdn.olares.com/one/olares-latest-amd64.iso). For detailed steps, see [Create an Olares One bootable USB drive](create-bootable-usb.md).
 
 ## Step 1: Boot from the USB drive
 
@@ -86,6 +91,6 @@ You can then activate Olares One again via LarePass. For detailed instructions, 
 
 ## Step 5: Check for system updates
 
-If you reinstalled Olares One using the included USB drive, the installed OS version may not be the latest. After activation, check for system updates in LarePass.
+The included USB drive may install an earlier OS version. After activation, you can update Olares OS in LarePass. For detailed steps, see [Update OS](update.md).
 
 For detailed instructions, see [Update OS](update.md).

--- a/docs/zh/one/create-bootable-usb.md
+++ b/docs/zh/one/create-bootable-usb.md
@@ -1,0 +1,1 @@
+<!--@include: ../../one/create-bootable-usb.md-->


### PR DESCRIPTION
* **Background**
See title.

* **Target Version for Merge**

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is broken navigation/links or confusing instructions if the new pages aren’t correctly wired.
> 
> **Overview**
> Adds a new `Create bootable USB drive` doc that walks through downloading the **device-specific** Olares One ISO and flashing it with Balena Etcher, with warnings about using the wrong ISO.
> 
> Updates the existing USB reinstall guide to remove inline USB-creation instructions, clarify that the included USB may contain an older image, link out to the new bootable-USB guide, and add an optional post-activation step to check for OS updates.
> 
> Wires the new page into both English and Chinese sidebars and adds a zh page that includes the English content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da12bb0bb1223b683c2ef9d9b68a80bb13862a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->