### PR TITLE
feat(cli): add NewCmdFrp to wizard command

### DIFF
--- a/cli/cmd/ctl/wizard/frp.go
+++ b/cli/cmd/ctl/wizard/frp.go
@@ -1,0 +1,167 @@
+package wizard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	wizardpkg "github.com/beclab/Olares/cli/pkg/wizard"
+	"github.com/spf13/cobra"
+)
+
+// `olares-cli wizard frp <olaresId>`
+//
+// Public, unauthenticated lookup against the Olares-tunnel registry —
+// the same call the activation wizard's "select tunnel" step makes
+// before the user has finished binding (see
+// TermiPass/packages/app/src/stores/wizard-step.ts:getFrpList).
+//
+// Useful for picking the `--host` value to feed into
+// `olares-cli wizard activate ... --enable-tunnel --host <host>` from
+// scripts.
+func NewCmdFrp() *cobra.Command {
+	var (
+		outputFormat string
+		locale       string
+		environment  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "frp {Olares ID (e.g., user@example.com)}",
+		Short: "list public Olares-tunnel (FRP) servers for an Olares ID",
+		Long: `Fetch the public Olares-tunnel (FRP) server registry for an Olares ID
+without requiring authentication.
+
+The endpoint is auto-selected from the olaresId suffix:
+  - *.olares.cn  → https://api.olares.cn/frp/v2/servers
+  - everything else → https://api.olares.com/frp/v2/servers
+
+Use --env=cn|en to override.
+
+Default output is a table with REGION / NAME / HOST columns; use
+--output=json for the raw response (multilingual name map + every
+machine host).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			olaresID := strings.TrimSpace(args[0])
+			if olaresID == "" {
+				return fmt.Errorf("olaresId is required")
+			}
+
+			format, err := parseFRPOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+
+			env, err := parseFRPEnvironment(environment)
+			if err != nil {
+				return err
+			}
+
+			list, err := wizardpkg.FetchFrpList(cmd.Context(), olaresID, wizardpkg.FrpListOptions{
+				Environment: env,
+			})
+			if err != nil {
+				return err
+			}
+
+			switch format {
+			case frpFormatJSON:
+				return writeFRPJSON(cmd.OutOrStdout(), list)
+			default:
+				return writeFRPTable(cmd.OutOrStdout(), list, locale)
+			}
+		},
+	}
+
+	cmd.SilenceUsage = true
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format: table | json")
+	cmd.Flags().StringVar(&locale, "lang", "en-US", "locale to render the NAME column (e.g. en-US, zh-CN)")
+	cmd.Flags().StringVar(&environment, "env", "", "force API environment: cn | en (default: auto-derived from olaresId)")
+	return cmd
+}
+
+type frpOutputFormat int
+
+const (
+	frpFormatTable frpOutputFormat = iota
+	frpFormatJSON
+)
+
+func parseFRPOutputFormat(s string) (frpOutputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "table":
+		return frpFormatTable, nil
+	case "json":
+		return frpFormatJSON, nil
+	default:
+		return frpFormatTable, fmt.Errorf("unsupported output format %q (want table | json)", s)
+	}
+}
+
+func parseFRPEnvironment(s string) (wizardpkg.FrpEnvironment, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return "", nil
+	case "cn":
+		return wizardpkg.FrpEnvCN, nil
+	case "en", "com":
+		return wizardpkg.FrpEnvEN, nil
+	default:
+		return "", fmt.Errorf("unsupported --env %q (want cn | en)", s)
+	}
+}
+
+func writeFRPJSON(w io.Writer, list []wizardpkg.FrpServer) error {
+	if list == nil {
+		list = []wizardpkg.FrpServer{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(list)
+}
+
+func writeFRPTable(w io.Writer, list []wizardpkg.FrpServer, locale string) error {
+	if len(list) == 0 {
+		_, err := fmt.Fprintln(w, "no FRP servers")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "REGION\tNAME\tHOST"); err != nil {
+		return err
+	}
+	for _, s := range list {
+		region := nonEmptyStr(s.Region)
+		name := nonEmptyStr(s.LocalizedName(locale))
+		hosts := collectHosts(s.Machine)
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", region, name, hosts); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func collectHosts(ms []wizardpkg.FrpMachine) string {
+	if len(ms) == 0 {
+		return "-"
+	}
+	hosts := make([]string, 0, len(ms))
+	for _, m := range ms {
+		if h := strings.TrimSpace(m.Host); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	if len(hosts) == 0 {
+		return "-"
+	}
+	return strings.Join(hosts, ",")
+}
+
+func nonEmptyStr(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cli/cmd/ctl/wizard/root.go
+++ b/cli/cmd/ctl/wizard/root.go
@@ -8,5 +8,6 @@ func NewWizardCommand() *cobra.Command {
 		Short: "activation wizard operations",
 	}
 	cmd.AddCommand(NewCmdActivate())
+	cmd.AddCommand(NewCmdFrp())
 	return cmd
 }

--- a/cli/pkg/wizard/frp.go
+++ b/cli/pkg/wizard/frp.go
@@ -1,0 +1,187 @@
+// frp.go: fetch the public Olares-tunnel (FRP) registry by olaresId.
+//
+// Mirrors the TS reference in
+// TermiPass/packages/app/src/stores/wizard-step.ts (getFrpList) and the
+// shared host map in TermiPass/packages/core/src/global.ts:
+//
+//   - olaresId ending with `olares.cn` → https://api.olares.cn/frp
+//   - everything else                  → https://api.olares.com/frp
+//
+// We POST `/v2/servers` with `{"name": "<olaresId>"}` and decode the
+// returned `OlaresTunneV2Interface[]` shape:
+//
+//   [{ region: string, name: { "en-US": ..., "zh-CN": ... }, machine: [{ host: string }] }]
+//
+// This endpoint is public (no auth header) and is the same one the
+// activation wizard's "select tunnel" step calls before the user has
+// finished binding to a per-user namespace.
+package wizard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FrpEnvironment selects which public Olares API host to talk to.
+type FrpEnvironment string
+
+const (
+	FrpEnvCN FrpEnvironment = "cn"
+	FrpEnvEN FrpEnvironment = "en"
+)
+
+// frpListURLs mirrors GolbalHost.FRP_LIST_URL in
+// TermiPass/packages/core/src/global.ts.
+var frpListURLs = map[FrpEnvironment]string{
+	FrpEnvEN: "https://api.olares.com/frp",
+	FrpEnvCN: "https://api.olares.cn/frp",
+}
+
+// FrpServer is one entry of the public Olares-tunnel registry. The
+// `Name` field is a {locale: label} map (e.g. `en-US`, `zh-CN`) — the
+// caller picks which locale to render.
+type FrpServer struct {
+	Region  string            `json:"region"`
+	Name    map[string]string `json:"name"`
+	Machine []FrpMachine      `json:"machine"`
+}
+
+// FrpMachine is one of the (potentially many) reachable hosts for a
+// region. The TS code uses `machine[0].host` as the default selection;
+// we surface every host so callers can decide.
+type FrpMachine struct {
+	Host string `json:"host"`
+}
+
+// FrpListOptions tunes the FetchFrpList call. The zero value is valid
+// and uses sane defaults.
+type FrpListOptions struct {
+	// Environment forces the API host. When empty, FetchFrpList falls
+	// back to FrpEnvironmentForOlaresID(olaresID).
+	Environment FrpEnvironment
+	// HTTPClient overrides the default 10s-timeout client. Useful for
+	// tests; production callers should leave this nil.
+	HTTPClient *http.Client
+	// Timeout overrides the default 10s timeout when HTTPClient is
+	// nil. Ignored when HTTPClient is set.
+	Timeout time.Duration
+}
+
+// FrpEnvironmentForOlaresID picks the right environment based on the
+// olaresId suffix, matching TS userNameToEnvironment().
+func FrpEnvironmentForOlaresID(olaresID string) FrpEnvironment {
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(olaresID)), "olares.cn") {
+		return FrpEnvCN
+	}
+	return FrpEnvEN
+}
+
+// FrpListBaseURL returns the public Olares API base URL the FRP list
+// call targets for `env`. Unknown envs fall back to the EN endpoint
+// (same defensive default as the TS code).
+func FrpListBaseURL(env FrpEnvironment) string {
+	if u, ok := frpListURLs[env]; ok {
+		return u
+	}
+	return frpListURLs[FrpEnvEN]
+}
+
+// FetchFrpList calls POST <FrpListBaseURL>/v2/servers and returns the
+// decoded server list. The endpoint is unauthenticated; the only input
+// is the olaresId, which the registry uses to scope the response.
+func FetchFrpList(ctx context.Context, olaresID string, opts FrpListOptions) ([]FrpServer, error) {
+	if strings.TrimSpace(olaresID) == "" {
+		return nil, fmt.Errorf("olaresId is required")
+	}
+
+	env := opts.Environment
+	if env == "" {
+		env = FrpEnvironmentForOlaresID(olaresID)
+	}
+	endpoint := FrpListBaseURL(env) + "/v2/servers"
+
+	client := opts.HTTPClient
+	if client == nil {
+		timeout := opts.Timeout
+		if timeout <= 0 {
+			timeout = 10 * time.Second
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+
+	body, err := json.Marshal(map[string]string{"name": olaresID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("POST %s: HTTP %d: %s", endpoint, resp.StatusCode, truncateFRPBody(raw))
+	}
+
+	var list []FrpServer
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("decode response: %w (body=%s)", err, truncateFRPBody(raw))
+	}
+	return list, nil
+}
+
+// LocalizedName returns the label for `locale`, falling back to en-US
+// then any non-empty entry. Mirrors TS olaresTunnelsV2Options() in
+// stores/settings/network.ts.
+func (s FrpServer) LocalizedName(locale string) string {
+	if s.Name == nil {
+		return ""
+	}
+	if v, ok := s.Name[locale]; ok && v != "" {
+		return v
+	}
+	if v, ok := s.Name["en-US"]; ok && v != "" {
+		return v
+	}
+	for _, v := range s.Name {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// FirstHost returns the first reachable host (matching TS
+// `machine[0].host`), or "" when the entry has no machines.
+func (s FrpServer) FirstHost() string {
+	if len(s.Machine) == 0 {
+		return ""
+	}
+	return s.Machine[0].Host
+}
+
+func truncateFRPBody(b []byte) string {
+	const max = 256
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "...(truncated)"
+}


### PR DESCRIPTION

* **Background**
This commit introduces a new command, NewCmdFrp, to the activation wizard operations in the CLI. This enhances the functionality of the wizard by providing additional command options for users.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive CLI command and client wrapper that performs a read-only, unauthenticated HTTP lookup; no existing activation flow logic is modified.
> 
> **Overview**
> Adds a new `olares-cli wizard frp <olaresId>` subcommand to **publicly list available Olares-tunnel (FRP) servers** for a given Olares ID, with `table` (default) or `json` output and locale-aware names.
> 
> Introduces a small wizard package client (`FetchFrpList`) that selects the `.cn` vs `.com` API base URL (or via `--env`) and POSTs to `/frp/v2/servers`, decoding the response into typed `FrpServer` data and surfacing hosts for scripting (e.g., to feed `wizard activate --enable-tunnel --host ...`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489b56b3982703628f5dedc3cf287e5206ba9ce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->