### PR TITLE
fix(tapr): improve zone annotation retrieval in RegenerateCorefile

### DIFF
--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -189,7 +189,12 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 			return nil
 		}
 
-		zone := userList.Items[0].GetAnnotations()[UserAnnotationZoneKey]
+		var zone string
+		for _, u := range userList.Items {
+			if zone = u.GetAnnotations()[UserAnnotationZoneKey]; zone != "" {
+				break
+			}
+		}
 		if len(zone) == 0 {
 			klog.Info("no zone annotation found in user, skip adding shared entrance dns records")
 			return nil


### PR DESCRIPTION
Improve finding the zone of os, not only from the first user annotations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to how `RegenerateCorefile` selects the zone when generating shared-entrance DNS records; behavior is otherwise unchanged.
> 
> **Overview**
> `RegenerateCorefile` no longer assumes the first user has a `bytetrade.io/zone` annotation when generating **shared entrance** DNS records. It now scans the user list and uses the first non-empty zone annotation found, avoiding skipped shared-entrance record generation when the first user lacks the annotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0b7340c947e9fc821f1196a2c43c9713f2bd33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->