### PR TITLE
fix: Async upload finalize for large files to avoid proxy timeouts

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.166
+          image: beclab/files-server:v0.2.167
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -808,11 +808,11 @@ data:
           proxy_buffering off;
 
           proxy_connect_timeout 15s;
-          proxy_send_timeout    1800s;
-          proxy_read_timeout    1800s;
-          send_timeout          1800s;
-          client_body_timeout   1800s;
-          keepalive_timeout     1830s;
+          proxy_send_timeout    300s;
+          proxy_read_timeout    300s;
+          send_timeout          300s;
+          client_body_timeout   300s;
+          keepalive_timeout     305s;
           proxy_max_temp_file_size 0;
 
           client_body_buffer_size 64m;


### PR DESCRIPTION
Background
- fix: Async upload finalize for large files to avoid proxy timeouts

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/311

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the deployed `files-server` version and materially alters Nginx timeout settings on the `/upload` route, which could impact large/slow uploads and client retry behavior if the backend assumptions are wrong.
> 
> **Overview**
> Updates the `files` DaemonSet to deploy `beclab/files-server` `v0.2.167` (from `v0.2.166`).
> 
> Tightens Nginx timeouts for the `/upload` location (send/read/client/keepalive) from ~30 minutes down to ~5 minutes, aligning upload request handling with the newer server behavior and reducing long-lived proxy connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010f09c4dfec048bda747abfcec3f974a00364b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->