### PR TITLE
docs: add steps for verifying firmware versions before update

### DIFF
--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -17,7 +17,7 @@ Review the following changelogs for features or fixes included in each update.
 
 :::tip How to check your current firmware versions
 1. Power on the device or restart it if it is already running.
-2. When the Olares logo appears, immediately press and hold the **F7**, select **Enter Setup**, and then check the versions on the **Main** tab.
+2. When the Olares logo appears, immediately press and hold the **F7**, select **Enter Setup** to access the BIOS, and then check the versions on the **Main** tab.
 
     ![Check current firmware versions in BIOS](/images/one/enter-setup-bios1.png#bordered){width=70%}
 ::: 

--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -17,7 +17,7 @@ Review the following changelogs for features or fixes included in each update.
 
 :::tip How to check your current firmware versions
 1. Power on the device or restart it if it is already running.
-2. When the Olares logo appears, immediately press and hold the **F7**, select **Enter Setup** to access the BIOS, and then check the versions on the **Main** tab.
+2. When the Olares logo appears, immediately press and hold **F7**, select **Enter Setup** to access the BIOS, and then check the versions on the **Main** tab.
 
     ![Check current firmware versions in BIOS](/images/one/enter-setup-bios1.png#bordered){width=70%}
 ::: 

--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -9,30 +9,11 @@ head:
 
 # Update firmware
 
-To ensure system stability and access the latest hardware features, you might need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
+To ensure system stability and access the latest hardware features, you may need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
 
-## Prerequisites
+## Version history
 
-- A USB flash drive formatted to `FAT32`.
-- A monitor and a USB keyboard connected to your Olares One.
-
-## Check current firmware versions
-
-Before proceeding with an update, check your current system versions to determine if an update is needed.
-
-1. Power on the Olares One device or restart it if it is already running.
-2. When the Olares logo appears, immediately press and hold the **F7** key to enter the boot menu.
-3. Select **Enter Setup** to access the BIOS.
-
-    ![Enter setup for BIOS](/images/one/enter-setup-bios.png#bordered)
-
-4. On the **Main** tab, check the values next to **System BIOS Version** and **EC FW Version**.
-
-    ![Verify versions in BIOS](/images/one/enter-setup-bios1.png#bordered)
-
-## Download firmware updates
-
-If your current versions are older than the ones listed below, download the packages to your computer to proceed.
+Review the following changelogs for features or fixes included in each update.
 
 :::info
 Only the latest firmware versions are available for download.
@@ -53,6 +34,12 @@ Only the latest firmware versions are available for download.
 | [1.01 (Download)](http://cdn.olares.com/common/OlaresOne_BIOS_1.01.zip) | 2025-12-04 | <ul><li>Fix the issue where SSDs unexpectedly disconnect by disabling ASPM and L-state power management for SSD1 and SSD2.</li></ul> |
 | 1.00 | 2025-11-28 | <ul><li>Update version naming convention.</li></ul> |
 | C400 | 2025-11-05 | <ul><li>Hide advanced BIOS options by default.</li><li>Remove MCU version display.</li><li>Fix the issue where memory tests report errors by enabling SAGV.</li></ul> |
+
+## Prerequisites
+
+- A USB flash drive formatted to `FAT32`.
+- A monitor and a USB keyboard connected to your Olares One.
+- The EC or BIOS update package, downloaded to your computer.
 
 ## Update the EC firmware
 

--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -9,11 +9,30 @@ head:
 
 # Update firmware
 
-To ensure system stability and access the latest hardware features, you may need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
+To ensure system stability and access the latest hardware features, you might need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
 
-## Version history
+## Prerequisites
 
-Review the following changelogs for features or fixes included in each update.
+- A USB flash drive formatted to `FAT32`.
+- A monitor and a USB keyboard connected to your Olares One.
+
+## Check current firmware versions
+
+Before proceeding with an update, check your current system versions to determine if an update is needed.
+
+1. Power on the Olares One device or restart it if it is already running.
+2. When the Olares logo appears, immediately press and hold the **F7** key to enter the boot menu.
+3. Select **Enter Setup** to access the BIOS.
+
+    ![Enter setup for BIOS](/images/one/enter-setup-bios.png#bordered)
+
+4. On the **Main** tab, check the values next to **System BIOS Version** and **EC FW Version**.
+
+    ![Verify versions in BIOS](/images/one/enter-setup-bios1.png#bordered)
+
+## Download firmware updates
+
+If your current versions are older than the ones listed below, download the packages to your computer to proceed.
 
 :::info
 Only the latest firmware versions are available for download.
@@ -34,12 +53,6 @@ Only the latest firmware versions are available for download.
 | [1.01 (Download)](http://cdn.olares.com/common/OlaresOne_BIOS_1.01.zip) | 2025-12-04 | <ul><li>Fix the issue where SSDs unexpectedly disconnect by disabling ASPM and L-state power management for SSD1 and SSD2.</li></ul> |
 | 1.00 | 2025-11-28 | <ul><li>Update version naming convention.</li></ul> |
 | C400 | 2025-11-05 | <ul><li>Hide advanced BIOS options by default.</li><li>Remove MCU version display.</li><li>Fix the issue where memory tests report errors by enabling SAGV.</li></ul> |
-
-## Prerequisites
-
-- A USB flash drive formatted to `FAT32`.
-- A monitor and a USB keyboard connected to your Olares One.
-- The EC or BIOS update package, downloaded to your computer.
 
 ## Update the EC firmware
 

--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -9,15 +9,18 @@ head:
 
 # Update firmware
 
-To ensure system stability and access the latest hardware features, you may need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
+To ensure system stability and access the latest hardware features, you might need to update the Embedded Controller (EC) and BIOS firmware on your Olares One device.
 
 ## Version history
 
 Review the following changelogs for features or fixes included in each update.
 
-:::info
-Only the latest firmware versions are available for download.
-:::
+:::tip How to check your current firmware versions
+1. Power on the device or restart it if it is already running.
+2. When the Olares logo appears, immediately press and hold the **F7**, select **Enter Setup**, and then check the versions on the **Main** tab.
+
+    ![Check current firmware versions in BIOS](/images/one/enter-setup-bios1.png#bordered){width=70%}
+::: 
 
 ### EC versions
 


### PR DESCRIPTION
Title: Add steps for verifying firmware versions before update

* **Background**
See title.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds pre-update verification steps and a screenshot; no product logic or tooling is modified.
> 
> **Overview**
> Adds a new **“How to check your current firmware versions”** tip in `docs/one/update-firmware.md` with BIOS entry instructions (F7 → Enter Setup) and a screenshot to help users verify EC/BIOS versions before updating.
> 
> Also makes a small wording tweak in the intro ("may" → "might") and removes the prior note about only the latest firmware being downloadable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2511d15f1a947906c31ceac0409f126835fe861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->