### PR TITLE
fix(cli): handle Olares' edge "auth failed" status 459 in error responses

### DIFF
--- a/cli/cmd/ctl/files/ls.go
+++ b/cli/cmd/ctl/files/ls.go
@@ -356,11 +356,13 @@ func runLs(ctx context.Context, f *cmdutil.Factory, out io.Writer, rawPath strin
 	return renderListing(out, fp, listing)
 }
 
-// formatHTTPError turns a non-2xx response into a user-facing error. 401/403
-// is special-cased to match DefaultProvider's CTA so the user sees the same
-// hint whether the local check or the remote check is what failed.
+// formatHTTPError turns a non-2xx response into a user-facing error.
+// 401/403/459 are special-cased to match DefaultProvider's CTA so the user
+// sees the same hint whether the local check or the remote check is what
+// failed. 459 is Olares' edge (Authelia) "auth failed" status — see
+// pkg/cmdutil/factory.go::statusAuthFailureOlares459.
 func formatHTTPError(status int, body []byte, olaresID, url string) error {
-	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+	if status == http.StatusUnauthorized || status == http.StatusForbidden || status == 459 {
 		return fmt.Errorf("server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",
 			status, olaresID)
 	}

--- a/cli/cmd/ctl/files/mkdir.go
+++ b/cli/cmd/ctl/files/mkdir.go
@@ -314,7 +314,7 @@ func reformatMkdirHTTPErr(err error, olaresID, displayPath string) error {
 	var hErr *mkdir.HTTPError
 	if errors.As(err, &hErr) {
 		switch hErr.Status {
-		case 401, 403:
+		case 401, 403, 459:
 			if olaresID != "" {
 				return fmt.Errorf(
 					"server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",

--- a/cli/cmd/ctl/files/share.go
+++ b/cli/cmd/ctl/files/share.go
@@ -498,7 +498,7 @@ func reformatShareHTTPErr(err error, olaresID, op string) error {
 	var hErr *share.HTTPError
 	if errors.As(err, &hErr) {
 		switch hErr.Status {
-		case 401, 403:
+		case 401, 403, 459:
 			if olaresID != "" {
 				return fmt.Errorf("server rejected the access token (HTTP %d) during %s; please run: olares-cli profile login --olares-id %s",
 					hErr.Status, op, olaresID)

--- a/cli/internal/files/upload/uploader.go
+++ b/cli/internal/files/upload/uploader.go
@@ -172,8 +172,18 @@ type UploadResult struct {
 // Resumable.js treats as non-retryable (resumable.js: see the
 // `permanentErrors` option, which the web app passes as the array
 // below). 5xx is partial: 500/501 are fatal, 502/503/504 are not.
+//
+// 459 is Olares' edge "auth failed" status (see
+// pkg/cmdutil/factory.go::statusAuthFailureOlares459). For chunk
+// uploads the body is non-replayable, so the transport's reactive
+// 401/459 retry can't fire — pre-flight refresh handles the common
+// case, but if the chunk still gets a 459 (e.g. JWT had no exp claim
+// so pre-flight skipped, or the refreshed token was also rejected),
+// retrying the same chunk with the same token will keep failing.
+// Mark it permanent so the user sees the auth-failure CTA instead of
+// a backoff loop.
 var permanentStatuses = map[int]struct{}{
-	400: {}, 401: {}, 403: {}, 404: {}, 409: {}, 415: {},
+	400: {}, 401: {}, 403: {}, 404: {}, 409: {}, 415: {}, 459: {},
 	440: {}, 441: {}, 442: {}, 443: {},
 	500: {}, 501: {},
 }

--- a/cli/pkg/auth/refresh.go
+++ b/cli/pkg/auth/refresh.go
@@ -78,12 +78,23 @@ func Refresh(ctx context.Context, req RefreshRequest) (*Token, error) {
 		return nil, fmt.Errorf("read /api/refresh body: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		// 401/403 means the refresh-token grant itself is no longer
-		// honored — the only recovery is a fresh login. Wrap with the
-		// typed sentinel so credential.Refresher can stamp
-		// InvalidatedAt and surface ErrTokenInvalidated. Any other
-		// non-200 stays an opaque error (treated as transient).
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		// 401/403/459 mean the refresh-token grant itself is no
+		// longer honored — the only recovery is a fresh login. Wrap
+		// with the typed sentinel so credential.Refresher can stamp
+		// InvalidatedAt and surface ErrTokenInvalidated.
+		//
+		// 459 is Olares' edge (Authelia ext-authz wired through
+		// l4-bfl-proxy) signalling "auth failed" with a JSON body
+		// like `{"fa2":false,"session_id":"...","target_url":"..."}`.
+		// /api/refresh sits on auth.<terminus> which usually doesn't
+		// pass through that filter, but we treat 459 here the same as
+		// 401/403 to stay consistent with the SPA's mapping in
+		// apps/packages/app/src/platform/platformAjaxSender.ts:89
+		// (459 → ErrorCode.TOKE_INVILID). Any other non-200 stays an
+		// opaque error (treated as transient).
+		if resp.StatusCode == http.StatusUnauthorized ||
+			resp.StatusCode == http.StatusForbidden ||
+			resp.StatusCode == 459 {
 			return nil, fmt.Errorf("%w: /api/refresh returned HTTP %d: %s", ErrRefreshUnauthorized, resp.StatusCode, truncate(raw))
 		}
 		return nil, fmt.Errorf("/api/refresh returned HTTP %d: %s", resp.StatusCode, truncate(raw))

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -31,6 +31,34 @@ import (
 	"github.com/beclab/Olares/cli/pkg/credential"
 )
 
+// statusAuthFailureOlares459 is the non-standard status code Olares' edge
+// stack (Authelia ext-authz wired through l4-bfl-proxy) returns when an
+// otherwise-valid request fails authentication — typically because the
+// X-Authorization JWT has expired or 2FA needs re-arming. The body looks
+// like `{"fa2":false,"method":"...","session_id":"<edge-jwt>","target_url":"..."}`.
+//
+// The web app treats 459 as a refresh trigger, parallel to 401:
+// `apps/packages/app/src/platform/platformAjaxSender.ts:89` maps it to
+// `ErrorCode.TOKE_INVILID`. We mirror that here — without this, every
+// expired-token request through the per-service hosts (files.<terminus>,
+// dashboard.<terminus>, etc.) returns 459 verbatim and refreshingTransport
+// never gets the chance to rotate the token. The 401 path is still kept
+// for endpoints that DON'T sit behind the Authelia edge (notably
+// /api/refresh on auth.<terminus>, which the SPA also special-cases).
+const statusAuthFailureOlares459 = 459
+
+// isAuthFailureStatus reports whether resp.StatusCode means "request was
+// rejected because the caller's token is no longer accepted, please get
+// a fresh one and retry". Centralised so the two callers (RoundTrip's
+// reactive path and any future pre-validation) stay in sync.
+func isAuthFailureStatus(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, statusAuthFailureOlares459:
+		return true
+	}
+	return false
+}
+
 // preflightSkew is the safety window applied when deciding whether to
 // proactively refresh a non-replayable request's token. If the JWT's exp
 // is within this margin of now (or already past), we rotate the token
@@ -287,13 +315,13 @@ func (t *refreshingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+	if !isAuthFailureStatus(resp.StatusCode) {
 		return resp, nil
 	}
 	if !canRetry(req) {
 		// Non-replayable body — pre-flight already had its chance
 		// (and either rotated the token or decided not to). Either
-		// way, body is consumed; surface the 401 verbatim.
+		// way, body is consumed; surface the auth failure verbatim.
 		return resp, nil
 	}
 	// Drain + close so the underlying connection can be reused.

--- a/cli/pkg/whoami/preflight.go
+++ b/cli/pkg/whoami/preflight.go
@@ -97,6 +97,13 @@ func WrapPermissionErr(err error, olaresID, verbDescr string) error {
 		status = http.StatusForbidden
 	case isHTTPStatus(err, http.StatusUnauthorized):
 		status = http.StatusUnauthorized
+	case isHTTPStatus(err, 459):
+		// Olares' edge (Authelia ext-authz) signals "auth failed" with
+		// 459 — see pkg/cmdutil/factory.go::statusAuthFailureOlares459.
+		// The transport already retried after a /api/refresh; reaching
+		// here means the refreshed token was ALSO rejected, which the
+		// user should treat as "re-login + role check" same as 401/403.
+		status = 459
 	default:
 		return err
 	}


### PR DESCRIPTION

* **Background**
This update adds handling for the non-standard HTTP status code 459 across various components, including ls, mkdir, share, and refresh functionalities. The code now treats 459 similarly to 401 and 403, providing appropriate user-facing error messages and ensuring consistent behavior when authentication fails. This change enhances the user experience by clearly indicating when a re-login is required due to token invalidation.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates authentication failure detection and retry/refresh behavior across the CLI transport and multiple file commands; incorrect handling could cause unnecessary re-login prompts or retry loops on expired/invalid tokens.
> 
> **Overview**
> The CLI now treats Olares’ non-standard edge status `459` (auth failed) as an authentication/token-rejection signal alongside `401/403`, triggering the same refresh-or-relogin paths and user-facing CTAs.
> 
> This is wired into the shared HTTP `refreshingTransport` via a centralized `isAuthFailureStatus` helper, extends `/api/refresh` to classify `459` as `ErrRefreshUnauthorized`, and updates `files ls`, `files mkdir`, `files share`, and permission wrapping to surface consistent “please run `profile login`” guidance. Chunked uploads also mark `459` as a permanent (non-retryable) status to avoid backoff loops on non-replayable bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c4f009b064266e7aec454a51c5438295d7e7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->