### PR TITLE
feat(ci): publish olares-cli in release assets

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -218,6 +218,18 @@ jobs:
         run: |
           bash build/build.sh ${{ needs.daily-version.outputs.version }} ${{ needs.release-id.outputs.id }}
 
+      - name: Download CLI release assets
+        env:
+          VERSION: ${{ needs.daily-version.outputs.version }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
+          REPO_PATH: ${{ secrets.REPO_PATH }}
+        run: |
+          mkdir -p cli-output
+          for target in linux_amd64 linux_arm linux_arm64 darwin_arm64 windows_amd64; do
+            file="olares-cli-v${VERSION}_${target}.${RELEASE_ID}.tar.gz"
+            curl -sSfL -o "cli-output/${file}" "https://cdn.olares.com${REPO_PATH}${file}"
+          done
+
       - name: 'Archives'
         run: |
           cp .dist/install-wizard/install.sh build/base-package
@@ -239,6 +251,7 @@ jobs:
             build/base-package/publicAddnode.sh
             build/base-package/version.hint
             build/base-package/publicRestoreInstaller.sh
+            cli-output/*.tar.gz
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,6 +240,18 @@ jobs:
       - name: Package installer
         run: |
           bash build/build.sh ${{ github.event.inputs.tags }} ${{ needs.release-id.outputs.id }}
+
+      - name: Download CLI release assets
+        env:
+          VERSION: ${{ github.event.inputs.tags }}
+          RELEASE_ID: ${{ needs.release-id.outputs.id }}
+          REPO_PATH: ${{ secrets.REPO_PATH }}
+        run: |
+          mkdir -p cli-output
+          for target in linux_amd64 linux_arm linux_arm64 darwin_arm64 windows_amd64; do
+            file="olares-cli-v${VERSION}_${target}.${RELEASE_ID}.tar.gz"
+            curl -sSfL -o "cli-output/${file}" "https://cdn.olares.com${REPO_PATH}${file}"
+          done
           
       - name: 'Archives'
         run: |
@@ -266,6 +278,7 @@ jobs:
             build/base-package/joincluster.sh
             build/base-package/version.hint
             build/base-package/publicRestoreInstaller.sh
+            cli-output/*.tar.gz
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* **Background**
Publish olares-cli of different os/arch when releasing daily/main version of Olares.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but releases can fail if the CDN paths/`REPO_PATH` secret or expected CLI tarball names/targets are incorrect.
> 
> **Overview**
> Both `release-daily.yaml` and `release.yaml` now **pull prebuilt `olares-cli` tarballs from the CDN** (for multiple OS/arch targets) into a `cli-output/` directory during the release job.
> 
> Those downloaded CLI archives are then **attached to the GitHub Release** alongside the existing installer artifacts via `cli-output/*.tar.gz`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95730ae9a72bf77ee223cf4affc13c875c489587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->