### PR TITLE
fix(cli): resolve directory upload regression for namespace root paths

### DIFF
--- a/cli/cmd/ctl/files/upload.go
+++ b/cli/cmd/ctl/files/upload.go
@@ -209,9 +209,7 @@ func runUpload(
 	if err != nil {
 		return err
 	}
-	// SubPath always starts with '/' from the parser; strip the leading
-	// slash so BuildPlan sees a relative form like "Documents/Backups/".
-	remoteSub := strings.TrimPrefix(fp.SubPath, "/")
+	remoteSub := subPathForBuildPlan(fp)
 
 	rp, err := f.ResolveProfile(ctx)
 	if err != nil {
@@ -605,4 +603,46 @@ func pluralYies(n int) string {
 		return "y"
 	}
 	return "ies"
+}
+
+// subPathForBuildPlan converts a parsed FrontendPath into the form
+// upload.BuildPlan expects (a "relative" sub path, e.g.
+// "Documents/Backups/"), preserving the trailing-slash directory hint
+// even when the user is targeting the namespace root.
+//
+// FrontendPath.SubPath always starts with '/'. Naively stripping that
+// prefix is enough for any non-root path ("/Documents/" → "Documents/"),
+// but the namespace root collapses to SubPath="/" → "" — at which
+// point BuildPlan can no longer tell "user typed `drive/Home/` and
+// wants a directory upload" from "user typed `drive/Home` (or did
+// something equivalent) and wants a single-file upload with no
+// destination subpath". The bug user-visible symptom is:
+//
+//	$ olares-cli files upload ./mydir/ drive/Home/
+//	Error: local "./mydir/" is a directory; remote "" must end with '/'
+//
+// — even though the source path's trailing slash and the parsed
+// directory intent both agree it's a directory upload. Re-adding the
+// '/' here so the directory hint survives the conversion fixes the
+// regression for ALL namespace-root targets uniformly (drive/Home/,
+// drive/Data/, sync/<repo>/, cache/<node>/, external/<node>/,
+// awss3/<account>/, google/<account>/, dropbox/<account>/) without
+// touching BuildPlan's contract — BuildPlan already treats "/" as
+// "directory upload to the root" via its `strings.Trim(..., "/")`
+// + `strings.HasSuffix(..., "/")` pair.
+//
+// For single-file uploads to the root (e.g.
+// `upload aaa.txt drive/Home/`) this is a no-op:
+// planForFile's `cleanRemote=="" && remoteIsDir` branch and the
+// previous `cleanRemote=="" && !remoteIsDir` branch both compute
+// `relativeRoot==""` + `remoteName=base`, so the wire-level
+// parent_dir is identical.
+func subPathForBuildPlan(fp FrontendPath) string {
+	sub := strings.TrimPrefix(fp.SubPath, "/")
+	if sub == "" {
+		// The lone trailing '/' — preserve it so BuildPlan reads
+		// the destination as a directory.
+		return "/"
+	}
+	return sub
 }

--- a/cli/cmd/ctl/files/upload_test.go
+++ b/cli/cmd/ctl/files/upload_test.go
@@ -26,8 +26,12 @@
 package files
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/beclab/Olares/cli/internal/files/upload"
 )
 
 // TestUploadRootAndDriveType exercises every supported upload
@@ -224,6 +228,204 @@ func TestUploadRootAndDriveType_DirectConstruction(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.wantSub) {
 				t.Errorf("err = %q, want substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestSubPathForBuildPlan pins the FrontendPath.SubPath →
+// upload.BuildPlan-input conversion so the namespace-root regression
+// (`upload ./mydir/ drive/Home/` failing with `remote "" must end
+// with '/'`) cannot return without breaking this test.
+//
+// The conversion has to satisfy two invariants simultaneously:
+//
+//  1. The trailing-slash directory hint MUST survive when the
+//     destination is the namespace root (SubPath="/"). Stripping the
+//     leading '/' verbatim collapses the only slash, leaving "" which
+//     BuildPlan reads as "no directory hint" and rejects directory
+//     uploads.
+//  2. Non-root paths MUST come through in the relative form
+//     BuildPlan expects ("Documents/Backups/"), not the absolute
+//     form ParseFrontendPath emits ("/Documents/Backups/"). Otherwise
+//     ParentDir computation in parentDirFor would double the leading
+//     slash on the way out.
+//
+// Anchoring this here (rather than implicitly through a runUpload
+// integration test) keeps the contract obvious for future readers:
+// the conversion is a self-contained function with a tiny test, so
+// any change has to update both at once.
+func TestSubPathForBuildPlan(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		wantSub  string
+	}{
+		// The bug: bare extend (with or without trailing slash) used
+		// to produce "" → BuildPlan rejected directory uploads. Both
+		// forms must now return "/" so directory uploads to the
+		// namespace root succeed across every fileType.
+		{
+			name:    "drive Home root, trailing slash (regression: was '', now '/')",
+			path:    "drive/Home/",
+			wantSub: "/",
+		},
+		{
+			name:    "drive Home bare extend, no trailing slash (parser synthesizes SubPath='/')",
+			path:    "drive/Home",
+			wantSub: "/",
+		},
+		{
+			name:    "drive Data root",
+			path:    "drive/Data/",
+			wantSub: "/",
+		},
+		{
+			name:    "sync repo root",
+			path:    "sync/repo-abc/",
+			wantSub: "/",
+		},
+		{
+			name:    "cache node root",
+			path:    "cache/node-1/",
+			wantSub: "/",
+		},
+		{
+			name:    "external node root",
+			path:    "external/node-1/",
+			wantSub: "/",
+		},
+		{
+			name:    "awss3 account root",
+			path:    "awss3/account-x/",
+			wantSub: "/",
+		},
+		{
+			name:    "google account root",
+			path:    "google/account-x/",
+			wantSub: "/",
+		},
+		{
+			name:    "dropbox account root",
+			path:    "dropbox/account-x/",
+			wantSub: "/",
+		},
+
+		// Non-root paths: leading '/' is stripped, trailing '/' is
+		// preserved so BuildPlan can still see the directory hint.
+		{
+			name:    "drive Home subdir with trailing slash",
+			path:    "drive/Home/Documents/",
+			wantSub: "Documents/",
+		},
+		{
+			name:    "drive Home subdir without trailing slash (file rename target)",
+			path:    "drive/Home/Documents/2026.pdf",
+			wantSub: "Documents/2026.pdf",
+		},
+		{
+			name:    "deep subdir with trailing slash",
+			path:    "drive/Home/Documents/Backups/",
+			wantSub: "Documents/Backups/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fp, err := ParseFrontendPath(tc.path)
+			if err != nil {
+				t.Fatalf("ParseFrontendPath(%q): %v", tc.path, err)
+			}
+			got := subPathForBuildPlan(fp)
+			if got != tc.wantSub {
+				t.Errorf("subPathForBuildPlan(%q) = %q, want %q",
+					tc.path, got, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestSubPathForBuildPlan_DirectoryUploadToRoot is the end-to-end
+// regression test for the original bug report: uploading a directory
+// to a namespace root failed with `local "./mydir/" is a directory;
+// remote "" must end with '/'`. We exercise the full chain
+// ParseFrontendPath → subPathForBuildPlan → upload.BuildPlan with
+// a real directory on disk to make sure the fix is wired correctly
+// (i.e. that the helper's output is what runUpload actually feeds to
+// BuildPlan). Without the fix, BuildPlan would return the
+// "must end with '/'" error for every namespace tested here.
+func TestSubPathForBuildPlan_DirectoryUploadToRoot(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		apiRoot   string
+		chunkRoot string
+		wantPD    string
+	}{
+		{
+			name:      "drive Home root",
+			path:      "drive/Home/",
+			apiRoot:   "/drive/Home",
+			chunkRoot: "/drive/Home",
+			wantPD:    "/drive/Home/",
+		},
+		{
+			name:      "drive Data root",
+			path:      "drive/Data/",
+			apiRoot:   "/drive/Data",
+			chunkRoot: "/drive/Data",
+			wantPD:    "/drive/Data/",
+		},
+		// Sync's chunkRoot is empty (chunks go to seafhttp/upload-aj
+		// which expects an inside-repo parent_dir); the API parent_dir
+		// still anchors at /sync/<repo>/.
+		{
+			name:      "sync repo root (chunkRoot empty by design)",
+			path:      "sync/repo-abc/",
+			apiRoot:   "/sync/repo-abc",
+			chunkRoot: "",
+			wantPD:    "/sync/repo-abc/",
+		},
+		{
+			name:      "cache node root",
+			path:      "cache/node-1/",
+			apiRoot:   "/cache/node-1",
+			chunkRoot: "/cache/node-1",
+			wantPD:    "/cache/node-1/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "mydir")
+			if err := os.MkdirAll(src, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("a"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			fp, err := ParseFrontendPath(tc.path)
+			if err != nil {
+				t.Fatalf("ParseFrontendPath(%q): %v", tc.path, err)
+			}
+			remoteSub := subPathForBuildPlan(fp)
+			plan, err := upload.BuildPlan(src, remoteSub, tc.apiRoot, tc.chunkRoot)
+			if err != nil {
+				t.Fatalf("BuildPlan: directory upload to %q rejected: %v",
+					tc.path, err)
+			}
+			if plan.ParentDir != tc.wantPD {
+				t.Errorf("ParentDir = %q, want %q", plan.ParentDir, tc.wantPD)
+			}
+			if len(plan.Files) != 1 {
+				t.Fatalf("Files = %d, want 1", len(plan.Files))
+			}
+			// The source folder name should appear as the first
+			// path component (mydir/a.txt), matching the LarePass
+			// folder-upload UX where the picked folder's name is
+			// preserved on the server.
+			if plan.Files[0].RelativePath != "mydir/a.txt" {
+				t.Errorf("Files[0].RelativePath = %q, want %q",
+					plan.Files[0].RelativePath, "mydir/a.txt")
 			}
 		})
 	}


### PR DESCRIPTION
* **Background**
This commit introduces a new test, TestSubPathForBuildPlan, to ensure that the conversion of FrontendPath.SubPath to the format expected by upload.BuildPlan correctly handles directory uploads to namespace root paths. The subPathForBuildPlan function is updated to preserve the trailing slash for root paths, preventing errors when uploading directories. Additionally, TestSubPathForBuildPlan_DirectoryUploadToRoot is added as an end-to-end regression test to validate the fix against real directory uploads.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to how `files upload` normalizes remote subpaths, plus new unit/regression tests; it mainly affects directory uploads targeting namespace roots.
> 
> **Overview**
> Fixes a regression in `files upload` where uploading a directory to a namespace root like `drive/Home/` could be misinterpreted as having an empty remote path and rejected.
> 
> This replaces the previous `TrimPrefix` logic with a new `subPathForBuildPlan` helper that preserves the trailing-slash directory hint at root destinations, and adds targeted unit + end-to-end regression tests to ensure root and non-root subpath normalization behaves correctly across supported namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6bdfadc5f6802b42b44f16db454ee31c2e1264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->