### PR TITLE
feat(upgrade): add upgrader for NVIDIA driver version 595.71.05

### DIFF
--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -23,7 +23,7 @@ import (
 const (
 	DefaultK8sVersion          = "v1.33.3"
 	DefaultK3sVersion          = "v1.33.3-k3s"
-	CurrentVerifiedCudaVersion = "13.1"
+	CurrentVerifiedCudaVersion = "13.2"
 )
 
 const (

--- a/cli/pkg/upgrade/1_12_6_20260512.go
+++ b/cli/pkg/upgrade/1_12_6_20260512.go
@@ -1,0 +1,44 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_6_20260512 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_6_20260512) Version() *semver.Version {
+	return semver.MustParse("1.12.6-20260512")
+}
+
+func (u upgrader_1_12_6_20260512) NeedRestart() bool {
+	return true
+}
+
+func (u upgrader_1_12_6_20260512) PrepareForUpgrade() []task.Interface {
+	return u.upgraderBase.PrepareForUpgrade()
+}
+
+func (u upgrader_1_12_6_20260512) UpdateOlaresVersion() []task.Interface {
+	var tasks []task.Interface
+	tasks = append(tasks,
+		&task.LocalTask{
+			Name:   "UpgradeGPUDriver",
+			Action: new(upgradeGPUDriverIfNeeded),
+		},
+	)
+	tasks = append(tasks, u.upgraderBase.UpdateOlaresVersion()...)
+	tasks = append(tasks,
+		&task.LocalTask{
+			Name:   "RebootIfNeeded",
+			Action: new(rebootIfNeeded),
+		},
+	)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_6_20260512{})
+}

--- a/infrastructure/cuda/.olares/Olares.yaml
+++ b/infrastructure/cuda/.olares/Olares.yaml
@@ -4,9 +4,9 @@ output:
   binaries:
     - 
       id: cuda-driver
-      name: cuda-driver-590.44.01.run
-      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/590.44.01/NVIDIA-Linux-x86_64-590.44.01.run
-      arm64: https://us.download.nvidia.com/XFree86/aarch64/590.44.01/NVIDIA-Linux-aarch64-590.44.01.run
+      name: cuda-driver-595.71.05.run
+      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.71.05/NVIDIA-Linux-x86_64-595.71.05.run
+      arm64: https://us.download.nvidia.com/XFree86/aarch64/595.71.05/NVIDIA-Linux-aarch64-595.71.05.run
     - 
       id: libnvidia-gpgkey 
       name: libnvidia-gpgkey


### PR DESCRIPTION
* **Background**
Upgrade NVIDIA driver version to 595.71.05

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it can install/replace NVIDIA GPU drivers on hosts and may trigger an automatic reboot, which could impact running workloads if misdetected or if the driver install fails.
> 
> **Overview**
> Updates the CUDA/NVIDIA driver bundle to `595.71.05` (new runfile URLs for amd64/arm64) and bumps `CurrentVerifiedCudaVersion` from `13.1` to `13.2`.
> 
> Adds a new daily upgrader `1.12.6-20260512` that inserts `UpgradeGPUDriver` before the version update and runs `RebootIfNeeded` after, marking the upgrade as requiring restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b52ecf0905032a8350091eb0affe1a8ed196cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->