### PR TITLE
chore: bump hami version to v2.6.16 in configuration files

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.15"
+version: "v2.6.16"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.15
+      name: beclab/hami:v2.6.16
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Upgrade HAMi core version

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it affects the deployed HAMi image version and could introduce behavioral changes from the upstream release.
> 
> **Overview**
> Updates HAMi deployment configuration to use **`v2.6.16`** instead of **`v2.6.15`**.
> 
> This bumps both the Helm values `version` in `infrastructure/gpu/.olares/config/gpu/hami/values.yaml` and the prebuilt container reference `beclab/hami:v2.6.16` in `platform/hami/.olares/Olares.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43c08977e3727929b57407ad4c34e0580a3567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->