### PR TITLE
feat: reduce image size

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -241,7 +241,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.2.8
+        image: beclab/search3:v0.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -302,7 +302,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.2.8
+        image: beclab/search3monitor:v0.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.2.8
+        image: beclab/search3validation:v0.3.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: reduce search image size
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
 1. reduce search relate docker image size
 2. fix wrong merged task status
 3. refactor, remove unused websockedt code, mv testtool code from src to another location


* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.6
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/195
*  https://github.com/Above-Os/search3/pull/194
*  https://github.com/Above-Os/search3/pull/193
*  https://github.com/Above-Os/search3/pull/192

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this upgrades runtime container images for core search services; behavior changes/regressions would come from the new images rather than config changes.
> 
> **Overview**
> Updates Kubernetes deployment manifests to pull `beclab/search3`, `beclab/search3monitor`, and `beclab/search3validation` from `v0.2.8` to `v0.3.2`, rolling forward the deployed Search3 server, monitor daemonset, and validation webhook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7319eda3f63603b873798ab1bcc6fb484054042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->