### PR TITLE
fix: unsupported resize format such as webp, heic preview bug; paste from sync root dst with double slash bug

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.167
+          image: beclab/files-server:v0.2.168
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: unsupported resize format such as webp, heic preview bug
- fix: paste from sync root dst with double slash bug
- fix: other ci and lint changes

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/312
- https://github.com/beclab/files/pull/313
- https://github.com/beclab/files/pull/314
- https://github.com/beclab/files/pull/315
- https://github.com/beclab/files/pull/316
- https://github.com/beclab/files/pull/317

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this changes the deployed `files-server` container version; behavior changes depend entirely on what’s included in the new image tag.
> 
> **Overview**
> Updates the `files` DaemonSet deployment to use `beclab/files-server:v0.2.168` instead of `v0.2.167`, rolling out the newer `files-server` image across the cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049ccaefee680732756479065661d6cc345ddd58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->