### PR TITLE
chore(cli): update daily upgrader for cuda 13.2

### DIFF
--- a/cli/pkg/upgrade/1_12_7_20260513.go
+++ b/cli/pkg/upgrade/1_12_7_20260513.go
@@ -5,23 +5,23 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/task"
 )
 
-type upgrader_1_12_6_20260512 struct {
+type upgrader_1_12_7_20260513 struct {
 	breakingUpgraderBase
 }
 
-func (u upgrader_1_12_6_20260512) Version() *semver.Version {
-	return semver.MustParse("1.12.6-20260512")
+func (u upgrader_1_12_7_20260513) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260513")
 }
 
-func (u upgrader_1_12_6_20260512) NeedRestart() bool {
+func (u upgrader_1_12_7_20260513) NeedRestart() bool {
 	return true
 }
 
-func (u upgrader_1_12_6_20260512) PrepareForUpgrade() []task.Interface {
+func (u upgrader_1_12_7_20260513) PrepareForUpgrade() []task.Interface {
 	return u.upgraderBase.PrepareForUpgrade()
 }
 
-func (u upgrader_1_12_6_20260512) UpdateOlaresVersion() []task.Interface {
+func (u upgrader_1_12_7_20260513) UpdateOlaresVersion() []task.Interface {
 	var tasks []task.Interface
 	tasks = append(tasks,
 		&task.LocalTask{
@@ -40,5 +40,5 @@ func (u upgrader_1_12_6_20260512) UpdateOlaresVersion() []task.Interface {
 }
 
 func init() {
-	registerDailyUpgrader(upgrader_1_12_6_20260512{})
+	registerDailyUpgrader(upgrader_1_12_7_20260513{})
 }


### PR DESCRIPTION
* **Background**
Add an upgrader for daily version `1.12.7-20260513` to upgrade cuda to 13.2

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new daily upgrade path that can upgrade NVIDIA GPU drivers and trigger a reboot, which can impact system stability if the driver upgrade fails or is misdetected.
> 
> **Overview**
> Registers a new daily upgrader for `1.12.7-20260513` by renaming/bumping the previous `1.12.6-20260512` upgrader to the new version.
> 
> The upgrader continues to run `UpgradeGPUDriver` before the base version update and `RebootIfNeeded` after, and still reports `NeedRestart()` as `true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52c5cf0e57d076dd5f26e9c488e6dec45bd6516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->