### PR TITLE
chore(cli): update upgrader for cuda 13.2 in mainline version 1.12.6

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -33,6 +33,10 @@ func (u upgrader_1_12_6) AddedBreakingChange() bool {
 	return false
 }
 
+func (u upgrader_1_12_6) NeedRestart() bool {
+	return true
+}
+
 func (u upgrader_1_12_6) PrepareForUpgrade() []task.Interface {
 	tasks := make([]task.Interface, 0)
 	tasks = append(tasks, upgradeKsConfig()...)
@@ -78,6 +82,24 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 			Delay:  5 * time.Second,
 		},
 	)
+}
+
+func (u upgrader_1_12_6) UpdateOlaresVersion() []task.Interface {
+	var tasks []task.Interface
+	tasks = append(tasks,
+		&task.LocalTask{
+			Name:   "UpgradeGPUDriver",
+			Action: new(upgradeGPUDriverIfNeeded),
+		},
+	)
+	tasks = append(tasks, u.upgraderBase.UpdateOlaresVersion()...)
+	tasks = append(tasks,
+		&task.LocalTask{
+			Name:   "RebootIfNeeded",
+			Action: new(rebootIfNeeded),
+		},
+	)
+	return tasks
 }
 
 func init() {


### PR DESCRIPTION
* **Background**
Upgrade cuda to 13.2 in the stable version 1.12.6

* **Target Version for Merge**
1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds GPU driver upgrade and conditional reboot steps to the 1.12.6 upgrade flow, which can impact host stability and requires restart behavior to be correct.
> 
> **Overview**
> Updates the `1.12.6` upgrader to always report `NeedRestart()`.
> 
> Extends the `UpdateOlaresVersion()` pipeline to run `UpgradeGPUDriver` before the base version-update tasks and `RebootIfNeeded` after, aligning the mainline `1.12.6` upgrade flow with GPU/CUDA driver requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9298d613f316c36c9fca77858c77b82e428de041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->