### PR TITLE
chore(cli): update daily upgrader for disk metric

### DIFF
--- a/cli/pkg/upgrade/1_12_7_20260514.go
+++ b/cli/pkg/upgrade/1_12_7_20260514.go
@@ -5,26 +5,25 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/task"
 )
 
-type upgrader_1_12_6_20260509 struct {
+type upgrader_1_12_7_20260514 struct {
 	breakingUpgraderBase
 }
 
-func (u upgrader_1_12_6_20260509) Version() *semver.Version {
-	return semver.MustParse("1.12.6-20260509")
+func (u upgrader_1_12_7_20260514) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260514")
 }
 
-func (u upgrader_1_12_6_20260509) PrepareForUpgrade() []task.Interface {
+func (u upgrader_1_12_7_20260514) PrepareForUpgrade() []task.Interface {
 	tasks := make([]task.Interface, 0)
 	tasks = append(tasks, upgradeKsConfig()...)
 	tasks = append(tasks, upgradeKubernetesPrometheusRule()...)
 	tasks = append(tasks, upgradeNodeExporterServiceMonitor()...)
 	tasks = append(tasks, upgradeNodeExporter()...)
-	tasks = append(tasks, upgradeKSCore()...)
 
 	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
 	return tasks
 }
 
 func init() {
-	registerDailyUpgrader(upgrader_1_12_6_20260509{})
+	registerDailyUpgrader(upgrader_1_12_7_20260514{})
 }


### PR DESCRIPTION


* **Background**
update daily upgrader for disk metric
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: simple version bump and task list tweak in the CLI upgrade pipeline; behavior change is limited to which upgrade tasks run in this daily upgrader.
> 
> **Overview**
> Bumps the daily upgrader implementation from `1.12.6-20260509` to `1.12.7-20260514` and updates registration accordingly.
> 
> Adjusts `PrepareForUpgrade` to **no longer append `upgradeKSCore()` explicitly**, leaving KS core upgrade to be handled via the shared `upgraderBase.PrepareForUpgrade()` task set while still running the disk-metrics related Prometheus/node-exporter upgrade tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00da9c2b3ce39ed34a3bdc21c0f1b52c0d1e569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->