### PR TITLE
daemon: implement mount watcher and notification for broken mounts

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/beclab/Olares/daemon/internel/watcher"
 	"github.com/beclab/Olares/daemon/internel/watcher/cert"
 	intranetwatcher "github.com/beclab/Olares/daemon/internel/watcher/intranet"
+	mountwatcher "github.com/beclab/Olares/daemon/internel/watcher/mount"
 	"github.com/beclab/Olares/daemon/internel/watcher/system"
 	"github.com/beclab/Olares/daemon/internel/watcher/systemenv"
 	"github.com/beclab/Olares/daemon/internel/watcher/upgrade"
@@ -106,6 +107,7 @@ func main() {
 		cert.NewCertWatcher(),
 		systemenv.NewSystemEnvWatcher(),
 		intranetwatcher.NewApplicationWatcher(),
+		mountwatcher.NewMountWatcher(),
 	}, func() {
 		if s != nil {
 			if err := s.Restart(); err != nil {

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eball/zeroconf v0.2.5
+	github.com/go-resty/resty/v2 v2.16.5
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/google/gopacket v1.1.19

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -127,6 +127,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
+github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
+github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/daemon/internel/apiserver/handlers/handler_mounted_path.go
+++ b/daemon/internel/apiserver/handlers/handler_mounted_path.go
@@ -6,57 +6,13 @@ import (
 	"github.com/beclab/Olares/daemon/pkg/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/shirou/gopsutil/disk"
-	"k8s.io/klog/v2"
 )
 
-type mountedPath struct {
-	disk.UsageStat `json:",inline"`
-	Type           string `json:"type"`
-	Invalid        bool   `json:"invalid"`
-	IDSerial       string `json:"id_serial"`
-	IDSerialShort  string `json:"id_serial_short"`
-	PartitionUUID  string `json:"partition_uuid"`
-	Device         string `json:"device"`
-	ReadOnly       bool   `json:"read_only"`
-}
-
 func (h *Handlers) getMountedPath(ctx *fiber.Ctx, mutate func(*disk.UsageStat) *disk.UsageStat) error {
-	paths, err := utils.MountedPath(ctx.Context())
+	res, err := utils.GetMountedPathDetail(ctx.Context(), mutate)
 	if err != nil {
 		return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
 	}
-
-	klog.Info("mounted path, ", paths)
-
-	var res []*mountedPath
-	for _, p := range paths {
-		u, err := disk.UsageWithContext(ctx.Context(), p.Path)
-		if err != nil {
-			klog.Error("get path usage error, ", err, ", ", p)
-			// return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
-
-			u = &disk.UsageStat{Path: p.Path}
-			p.Invalid = true
-		}
-
-		if mutate != nil {
-			u = mutate(u)
-		}
-
-		if u != nil {
-			res = append(res, &mountedPath{
-				*u,
-				string(p.Type),
-				p.Invalid,
-				p.IDSerial,
-				p.IDSerialShort,
-				p.PartitionUUID,
-				p.Device,
-				p.ReadOnly,
-			})
-		}
-	}
-
 	return h.OkJSON(ctx, "success", res)
 }
 

--- a/daemon/internel/apiserver/handlers/handler_mounted_smb.go
+++ b/daemon/internel/apiserver/handlers/handler_mounted_smb.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"net/http"
+	"slices"
 
+	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/shirou/gopsutil/disk"
@@ -15,6 +17,7 @@ type mountedSmbPathResponse struct {
 	Device         string `json:"device"`
 }
 
+// Deprecated: GetMountedSmb is deprecated, use GetMountedPathInCluster instead
 func (h *Handlers) getMountedSmb(ctx *fiber.Ctx, mutate func(*disk.UsageStat) *disk.UsageStat) error {
 	paths, err := utils.MountedSambaPath(ctx.Context())
 	if err != nil {
@@ -24,11 +27,14 @@ func (h *Handlers) getMountedSmb(ctx *fiber.Ctx, mutate func(*disk.UsageStat) *d
 	klog.Info("mounted path, ", paths)
 
 	var res []*mountedSmbPathResponse
+	var mountedMountPoints []string
 	for _, p := range paths {
+		mountedMountPoints = append(mountedMountPoints, p.Path)
 		u, err := disk.UsageWithContext(ctx.Context(), p.Path)
 		if err != nil {
 			klog.Error("get path usage error, ", err, ", ", p)
-			return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
+			u = &disk.UsageStat{Path: p.Path}
+			p.Invalid = true
 		}
 
 		if mutate != nil {
@@ -36,6 +42,24 @@ func (h *Handlers) getMountedSmb(ctx *fiber.Ctx, mutate func(*disk.UsageStat) *d
 		}
 
 		res = append(res, &mountedSmbPathResponse{*u, p.Invalid, p.Device})
+	}
+
+	records, err := utils.LoadMountRecords(commands.MOUNT_RECORDS_FILE)
+	if err != nil {
+		klog.Warning("load mount records error, ", err)
+	}
+	for _, r := range records {
+		if r.Type != utils.SMB {
+			continue
+		}
+		if slices.Contains(mountedMountPoints, r.MountPoint) {
+			continue
+		}
+		u := &disk.UsageStat{Path: r.MountPoint}
+		if mutate != nil {
+			u = mutate(u)
+		}
+		res = append(res, &mountedSmbPathResponse{*u, true, r.SmbPath})
 	}
 
 	return h.OkJSON(ctx, "success", res)

--- a/daemon/internel/watcher/mount/watcher.go
+++ b/daemon/internel/watcher/mount/watcher.go
@@ -1,0 +1,65 @@
+package mount
+
+import (
+	"context"
+	"slices"
+
+	"github.com/beclab/Olares/daemon/internel/watcher"
+	"github.com/beclab/Olares/daemon/pkg/cluster/state"
+	"github.com/beclab/Olares/daemon/pkg/commands"
+	"github.com/beclab/Olares/daemon/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+var _ watcher.Watcher = &mountWatcher{}
+
+type mountWatcher struct{}
+
+func NewMountWatcher() *mountWatcher {
+	return &mountWatcher{}
+}
+
+func (w *mountWatcher) Watch(ctx context.Context) {
+	if state.CurrentState.TerminusState != state.TerminusRunning {
+		return
+	}
+
+	records, err := utils.LoadMountRecords(commands.MOUNT_RECORDS_FILE)
+	if err != nil {
+		klog.Warning("load mount records error, ", err)
+		return
+	}
+
+	if len(records) == 0 {
+		return
+	}
+
+	mountedPoints, err := utils.GetMountedPoints(ctx)
+	if err != nil {
+		klog.Warning("list mounted path error in mount watcher, ", err)
+		return
+	}
+
+	for _, record := range records {
+		if slices.Contains(mountedPoints, record.MountPoint) {
+			continue
+		}
+
+		klog.Infof("attempting to remount %s (%s)", record.MountPoint, record.Type)
+
+		switch record.Type {
+		case utils.SMB:
+			if err := utils.MountSambaDriver(ctx, commands.MOUNT_BASE_DIR, record.SmbPath, record.User, record.Password); err != nil {
+				klog.Warningf("remount smb %s failed: %v", record.MountPoint, err)
+			} else {
+				klog.Infof("remount smb %s success", record.MountPoint)
+			}
+		case utils.NFS:
+			if err := utils.MountNfsDriver(ctx, commands.MOUNT_BASE_DIR, record.MountName, record.Server, record.NfsPath); err != nil {
+				klog.Warningf("remount nfs %s failed: %v", record.MountPoint, err)
+			} else {
+				klog.Infof("remount nfs %s success", record.MountPoint)
+			}
+		}
+	}
+}

--- a/daemon/internel/watcher/usb/watchers.go
+++ b/daemon/internel/watcher/usb/watchers.go
@@ -90,7 +90,7 @@ func NewUmountWatcher() *umountWatcher {
 }
 
 func (w *umountWatcher) Watch(ctx context.Context) {
-	if err := utils.UmountBrokenMount(ctx, commands.MOUNT_BASE_DIR); err != nil {
+	if err := utils.UmountOrRecordBrokenMounts(ctx, commands.MOUNT_BASE_DIR); err != nil {
 		klog.Error("umount broken mount point error, ", err)
 	}
 }

--- a/daemon/pkg/commands/constants.go
+++ b/daemon/pkg/commands/constants.go
@@ -29,6 +29,7 @@ var (
 	LOG_FILE               = "install.log"
 	TERMINUS_BASE_DIR      = ""
 	MOUNT_BASE_DIR         = path.Join(OS_ROOT_DIR, "share")
+	MOUNT_RECORDS_FILE     = "/etc/mounttab"
 	PREPARE_LOCK           = ".prepared"
 	REDIS_CONF             = OS_ROOT_DIR + "/data/redis/etc/redis.conf"
 	EXPORT_POD_LOGS_DIR    = "Home/pod_logs"

--- a/daemon/pkg/commands/mount_nfs/cmd.go
+++ b/daemon/pkg/commands/mount_nfs/cmd.go
@@ -3,6 +3,7 @@ package mountnfs
 import (
 	"context"
 	"errors"
+	"path/filepath"
 
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
@@ -33,6 +34,19 @@ func (i *mountNfs) Execute(ctx context.Context, p any) (res any, err error) {
 	err = utils.MountNfsDriver(ctx, param.MountBaseDir, param.MountPath, param.Server, param.NfsPath)
 	if err != nil {
 		klog.Error("mount nfs driver error, ", err)
+		return
+	}
+
+	mountPoint := filepath.Join(param.MountBaseDir, param.MountPath)
+
+	if saveErr := utils.AddMountRecord(commands.MOUNT_RECORDS_FILE, utils.MountRecord{
+		Type:       utils.NFS,
+		MountPoint: mountPoint,
+		Server:     param.Server,
+		NfsPath:    param.NfsPath,
+		MountName:  param.MountPath,
+	}); saveErr != nil {
+		klog.Warning("save mount record error, ", saveErr)
 	}
 
 	return

--- a/daemon/pkg/commands/mount_smb/cmd.go
+++ b/daemon/pkg/commands/mount_smb/cmd.go
@@ -3,6 +3,8 @@ package mountsmb
 import (
 	"context"
 	"errors"
+	"path/filepath"
+	"strings"
 
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
@@ -33,6 +35,22 @@ func (i *mountSmb) Execute(ctx context.Context, p any) (res any, err error) {
 	err = utils.MountSambaDriver(ctx, param.MountBaseDir, param.SmbPath, param.User, param.Password)
 	if err != nil {
 		klog.Error("mount samba driver error, ", err)
+		return
+	}
+
+	smbPath := strings.TrimRight(param.SmbPath, "/")
+	pathToken := strings.Split(strings.TrimLeft(smbPath, "//"), "/")
+	sharePath := pathToken[len(pathToken)-1]
+	mountPoint := filepath.Join(param.MountBaseDir, sharePath)
+
+	if saveErr := utils.AddMountRecord(commands.MOUNT_RECORDS_FILE, utils.MountRecord{
+		Type:       utils.SMB,
+		MountPoint: mountPoint,
+		SmbPath:    param.SmbPath,
+		User:       param.User,
+		Password:   param.Password,
+	}); saveErr != nil {
+		klog.Warning("save mount record error, ", saveErr)
 	}
 
 	return

--- a/daemon/pkg/commands/umount_nfs/cmd.go
+++ b/daemon/pkg/commands/umount_nfs/cmd.go
@@ -33,6 +33,11 @@ func (i *umountNfs) Execute(ctx context.Context, p any) (res any, err error) {
 	err = utils.UmountNfsDriver(ctx, param.MountPath)
 	if err != nil {
 		klog.Error("umount nfs driver error, ", err)
+		return
+	}
+
+	if removeErr := utils.RemoveMountRecord(commands.MOUNT_RECORDS_FILE, param.MountPath); removeErr != nil {
+		klog.Warning("remove mount record error, ", removeErr)
 	}
 
 	return

--- a/daemon/pkg/commands/umount_smb/cmd.go
+++ b/daemon/pkg/commands/umount_smb/cmd.go
@@ -33,6 +33,11 @@ func (i *umountSmb) Execute(ctx context.Context, p any) (res any, err error) {
 	err = utils.UmountSambaDriver(ctx, param.MountPath)
 	if err != nil {
 		klog.Error("umount samba driver error, ", err)
+		return
+	}
+
+	if removeErr := utils.RemoveMountRecord(commands.MOUNT_RECORDS_FILE, param.MountPath); removeErr != nil {
+		klog.Warning("remove mount record error, ", removeErr)
 	}
 
 	return

--- a/daemon/pkg/utils/drivers_linux.go
+++ b/daemon/pkg/utils/drivers_linux.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -417,7 +418,10 @@ func UmountUsbDevice(ctx context.Context, path string) error {
 	return errors.New("not a mounted usb path")
 }
 
-var brokenMounts []string
+var (
+	brokenMounts   []string
+	brokenMountsMu sync.RWMutex
+)
 
 func UmountOrRecordBrokenMounts(ctx context.Context, baseDir string) error {
 	mounter := mountutils.New("")
@@ -451,9 +455,13 @@ func UmountOrRecordBrokenMounts(ctx context.Context, baseDir string) error {
 		}
 	}
 
-	brokenMounts = currentBrokenMounts
-	if len(brokenMounts) > 0 {
-		klog.Infof("current broken mounts: %v", brokenMounts)
+	updatedBrokenMounts := slices.Clone(currentBrokenMounts)
+	brokenMountsMu.Lock()
+	brokenMounts = updatedBrokenMounts
+	brokenMountsMu.Unlock()
+
+	if len(updatedBrokenMounts) > 0 {
+		klog.Infof("current broken mounts: %v", updatedBrokenMounts)
 		// notify broken mounts
 		NotifyBrokenMounts(ctx)
 	}
@@ -461,6 +469,9 @@ func UmountOrRecordBrokenMounts(ctx context.Context, baseDir string) error {
 }
 
 func IsBrokenMount(path string) bool {
+	brokenMountsMu.RLock()
+	defer brokenMountsMu.RUnlock()
+
 	return slices.Contains(brokenMounts, path)
 }
 

--- a/daemon/pkg/utils/drivers_linux.go
+++ b/daemon/pkg/utils/drivers_linux.go
@@ -417,7 +417,9 @@ func UmountUsbDevice(ctx context.Context, path string) error {
 	return errors.New("not a mounted usb path")
 }
 
-func UmountBrokenMount(ctx context.Context, baseDir string) error {
+var brokenMounts []string
+
+func UmountOrRecordBrokenMounts(ctx context.Context, baseDir string) error {
 	mounter := mountutils.New("")
 	list, err := mounter.List()
 	if err != nil {
@@ -425,14 +427,20 @@ func UmountBrokenMount(ctx context.Context, baseDir string) error {
 		return err
 	}
 
+	var currentBrokenMounts []string
 	for _, m := range list {
 		if strings.HasPrefix(m.Path, baseDir) && !strings.HasPrefix(m.Path, path.Join(baseDir, "ai")) {
 			if r := checkMount(m.Path, time.Second); r.Broken {
 
-				klog.Infof("broken mountpoint: %v, %v, %v", m.Path, m.Device, r.Reason)
-
-				if err = umountAndRemovePath(ctx, m.Path); err != nil {
-					return err
+				switch m.Type {
+				case "cifs", "nfs":
+					// record the broken mount record, and notify via the files API
+					currentBrokenMounts = append(currentBrokenMounts, m.Path)
+				default:
+					klog.Infof("broken mountpoint: %v, %v, %v", m.Path, m.Device, r.Reason)
+					if err = umountAndRemovePath(ctx, m.Path); err != nil {
+						return err
+					}
 				}
 			} else if !isDeviceExists(m.Device) {
 				klog.Infof("device not exists mountpoint: %v, %v", m.Path, m.Device)
@@ -443,7 +451,17 @@ func UmountBrokenMount(ctx context.Context, baseDir string) error {
 		}
 	}
 
+	brokenMounts = currentBrokenMounts
+	if len(brokenMounts) > 0 {
+		klog.Infof("current broken mounts: %v", brokenMounts)
+		// notify broken mounts
+		NotifyBrokenMounts(ctx)
+	}
 	return nil
+}
+
+func IsBrokenMount(path string) bool {
+	return slices.Contains(brokenMounts, path)
 }
 
 // apt install cifs-utils
@@ -582,7 +600,7 @@ func MountedSambaPath(ctx context.Context) ([]mountedPath, error) {
 	var paths []mountedPath
 	for _, m := range list {
 		if m.Type == "cifs" {
-			paths = append(paths, mountedPath{m.Path, SMB, IsCifsInvalid(&m), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
 		}
 	}
 
@@ -623,9 +641,9 @@ func MountedPath(ctx context.Context) ([]mountedPath, error) {
 		}():
 			paths = append(paths, mountedPath{m.Path, HDD, false, hdds[idx].IDSerial, hdds[idx].IDSerialShort, hdds[idx].PartitionUUID, "", false})
 		case m.Type == "cifs":
-			paths = append(paths, mountedPath{m.Path, SMB, IsCifsInvalid(&m), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
 		case m.Type == "nfs":
-			paths = append(paths, mountedPath{m.Path, NFS, IsNfsInvalid(&m), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, NFS, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
 		}
 
 	}

--- a/daemon/pkg/utils/mount_store.go
+++ b/daemon/pkg/utils/mount_store.go
@@ -1,0 +1,126 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+type MountRecord struct {
+	Type       DeviceType `json:"type"`
+	MountPoint string     `json:"mountPoint"`
+
+	// SMB fields
+	SmbPath  string `json:"smbPath,omitempty"`
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+
+	// NFS fields
+	Server    string `json:"server,omitempty"`
+	NfsPath   string `json:"nfsPath,omitempty"`
+	MountName string `json:"mountName,omitempty"`
+}
+
+var mountStoreMu sync.Mutex
+
+func LoadMountRecords(filePath string) ([]MountRecord, error) {
+	mountStoreMu.Lock()
+	defer mountStoreMu.Unlock()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var records []MountRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+func saveMountRecords(filePath string, records []MountRecord) error {
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0600)
+}
+
+func AddMountRecord(filePath string, record MountRecord) error {
+	mountStoreMu.Lock()
+	defer mountStoreMu.Unlock()
+
+	data, err := os.ReadFile(filePath)
+	var records []MountRecord
+	if err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &records); err != nil {
+			records = nil
+		}
+	}
+
+	for i, r := range records {
+		if r.MountPoint == record.MountPoint {
+			records[i] = record
+			return saveMountRecords(filePath, records)
+		}
+	}
+
+	records = append(records, record)
+	return saveMountRecords(filePath, records)
+}
+
+// GetMountedPoints returns a list of currently mounted path strings.
+func GetMountedPoints(ctx context.Context) ([]string, error) {
+	paths, err := MountedPath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var points []string
+	for _, p := range paths {
+		points = append(points, p.Path)
+	}
+	return points, nil
+}
+
+func RemoveMountRecord(filePath string, mountPoint string) error {
+	mountStoreMu.Lock()
+	defer mountStoreMu.Unlock()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	var records []MountRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		return err
+	}
+
+	filtered := records[:0]
+	for _, r := range records {
+		if r.MountPoint != mountPoint {
+			filtered = append(filtered, r)
+		}
+	}
+
+	return saveMountRecords(filePath, filtered)
+}

--- a/daemon/pkg/utils/notify.go
+++ b/daemon/pkg/utils/notify.go
@@ -1,0 +1,177 @@
+package utils
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/daemon/pkg/commands"
+	"github.com/go-resty/resty/v2"
+	"github.com/shirou/gopsutil/disk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+type MountedPathDetail struct {
+	disk.UsageStat `json:",inline"`
+	Type           string `json:"type"`
+	Invalid        bool   `json:"invalid"`
+	IDSerial       string `json:"id_serial"`
+	IDSerialShort  string `json:"id_serial_short"`
+	PartitionUUID  string `json:"partition_uuid"`
+	Device         string `json:"device"`
+	ReadOnly       bool   `json:"read_only"`
+}
+
+func NotifyBrokenMounts(ctx context.Context) {
+	// find the master files pod
+	client, err := GetKubeClient()
+	if err != nil {
+		klog.Error("failed to get kube client: ", err)
+		return
+	}
+
+	pods, err := client.CoreV1().Pods("os-framework").List(ctx, metav1.ListOptions{LabelSelector: "app=files"})
+	if err != nil {
+		klog.Error("failed to list pods: ", err)
+		return
+	}
+
+	nodeName, _, nodeRole, err := GetThisNodeName(ctx, client)
+	if err != nil {
+		klog.Error("failed to get this node name: ", err)
+		return
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName == nodeName && nodeRole == "master" {
+			status := pod.Status.Phase
+			if status != "Running" {
+				klog.Warningf("pod %s is not running, status: %s, skip", pod.Name, status)
+				continue
+			}
+
+			ip := pod.Status.PodIP
+			if ip == "" {
+				klog.Warningf("pod %s has no IP, skip", pod.Name)
+				return
+			}
+
+			mountedPath, err := GetMountedPathDetail(ctx, func(us *disk.UsageStat) *disk.UsageStat {
+				path := us.Path
+				if strings.HasPrefix(path, commands.MOUNT_BASE_DIR) {
+					path = strings.TrimPrefix(path, commands.MOUNT_BASE_DIR+"/")
+				} else {
+					// not in cluster path, ignore
+					return nil
+				}
+
+				us.Path = path
+
+				return us
+			})
+			if err != nil {
+				klog.Error("failed to get mounted path detail: ", err)
+				return
+			}
+
+			// send notification to the files pod, and let it handle the broken mount point
+			url := "http://" + ip + ":8080/api/mounted_states/"
+			httpClient := resty.New().SetTimeout(5 * time.Second)
+			res, err := httpClient.R().
+				SetContext(ctx).
+				SetHeader("Content-Type", "application/json").
+				SetBody(mountedPath).Post(url)
+
+			if err != nil {
+				klog.Error("failed to send notification: ", err)
+				return
+			}
+
+			if res.StatusCode() != 200 {
+				klog.Error("failed to send notification, status code: ", res.StatusCode())
+				return
+			}
+
+			klog.Infof("successfully sent broken mount notification to pod %s", pod.Name)
+			return
+		}
+	}
+
+	klog.Warning("no files pod found on this node to notify")
+}
+
+func GetMountedPathDetail(ctx context.Context, mutate func(*disk.UsageStat) *disk.UsageStat) ([]*MountedPathDetail, error) {
+	paths, err := MountedPath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.Info("mounted path, ", paths)
+
+	var res []*MountedPathDetail
+	var mountedMountPoints []string
+	for _, p := range paths {
+		mountedMountPoints = append(mountedMountPoints, p.Path)
+		u, err := disk.UsageWithContext(ctx, p.Path)
+		if err != nil {
+			klog.Error("get path usage error, ", err, ", ", p)
+
+			u = &disk.UsageStat{Path: p.Path}
+			p.Invalid = true
+		}
+
+		if mutate != nil {
+			u = mutate(u)
+		}
+
+		if u != nil {
+			res = append(res, &MountedPathDetail{
+				*u,
+				string(p.Type),
+				p.Invalid,
+				p.IDSerial,
+				p.IDSerialShort,
+				p.PartitionUUID,
+				p.Device,
+				p.ReadOnly,
+			})
+		}
+	}
+
+	records, err := LoadMountRecords(commands.MOUNT_RECORDS_FILE)
+	if err != nil {
+		klog.Warning("load mount records error, ", err)
+	}
+	for _, r := range records {
+		if r.Type != SMB && r.Type != NFS {
+			continue
+		}
+		if slices.Contains(mountedMountPoints, r.MountPoint) {
+			continue
+		}
+		device := r.SmbPath
+		if r.Type == NFS {
+			device = r.Server + ":" + r.NfsPath
+		}
+		u := &disk.UsageStat{Path: r.MountPoint}
+		if mutate != nil {
+			u = mutate(u)
+		}
+		if u != nil {
+			res = append(res, &MountedPathDetail{
+				*u,
+				string(r.Type),
+				true,
+				"",
+				"",
+				"",
+				device,
+				false,
+			})
+		}
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
* **Background**
1. Auto-mount the SMB and NFS mount points when the device reboots
2. Send a notification to `Files` pod of the master node when the SMB or NFS mount points are broken.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistent mount-record storage (including SMB credentials) and automated remount/notification behavior, which can affect filesystem availability and has security implications if `/etc/mounttab` handling is incorrect.
> 
> **Overview**
> Adds a persistent mount-record store (`/etc/mounttab`) and updates SMB/NFS mount + umount commands to **save/remove records** so mounts can be re-established after reboot.
> 
> Introduces a new `mount` watcher wired into `terminusd` that periodically **remounts missing SMB/NFS mount points** based on saved records.
> 
> Changes broken-mount handling to **record (rather than immediately unmount) broken `cifs`/`nfs` mounts**, exposes that status via unified `utils.GetMountedPathDetail`, and adds a notifier that POSTs current mounted/broken states to the local master `files` pod (`/api/mounted_states/`) using `resty`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7d73ffbb612f2538eccf64bbd6acdbffdbc1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->