### PR TITLE
revert(bfl): revert ownership setting for user directories

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -237,13 +237,19 @@ spec:
         - sh
         - -c
         - |
+          init=$(test -d /userspace/Home; echo $?) && \          
           mkdir -p /userspace/Home/Documents && \
           mkdir -p /userspace/Home/Downloads && \
           mkdir -p /userspace/Home/Pictures && \
           mkdir -p /userspace/Home/Movies && \
           mkdir -p /userspace/Home/Music && \
           mkdir -p /userspace/Home/Code && \
-          mkdir -p /userspace/Data
+          mkdir -p /userspace/Data && \
+          if [ $init -ne 0 ]; then \
+          chown -R 1000:1000 /userspace/Home && \
+          chown -R 1000:1000 /userspace/Data && \
+          chown -R 1000:1000 /appdata; \
+          fi 
       - name: setsysctl
         image: 'busybox:1.28'
         command:


### PR DESCRIPTION
* **Background**
Revert ownership setting for user directories

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init-container ownership logic for persisted volumes; incorrect detection could leave directories with wrong permissions and break user write access on upgrade.
> 
> **Overview**
> Updates the `init-userspace` initContainer script in `bfl_deploy.yaml` to detect whether `/userspace/Home` already exists and **only then** run recursive `chown` on `/userspace/Home`, `/userspace/Data`, and `/appdata`.
> 
> This effectively stops repeated ownership resets on subsequent pod restarts while keeping directory creation behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d6ef40a28d0eb530d84f58cbf4d5ae920c25b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->