### PR TITLE
fix: Security fixes and share upload memory optimization

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -142,7 +142,7 @@ spec:
 {{ end }}
 
         - name: samba-server
-          image: beclab/samba-server:0.0.12
+          image: beclab/samba-server:0.0.13
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.168
+          image: beclab/files-server:v0.2.169
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- Security: close ffprobe RCE, stop CORS origin reflection, tighten share path matching, allowlist ORDER BY inputs, fail-closed on token RNG failure.
- Perf: spool share upload body to disk above 4 MiB.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/318
- https://github.com/beclab/files/pull/319
- https://github.com/beclab/files/pull/320
- https://github.com/beclab/files/pull/321
- https://github.com/beclab/files/pull/322
- https://github.com/beclab/files/pull/323
- https://github.com/beclab/files/pull/324

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this changes the runtime images for core file and SMB services, which can introduce behavioral regressions despite being a small manifest-only diff.
> 
> **Overview**
> Updates the `files` DaemonSet deployment to roll forward container versions: `beclab/samba-server` from `0.0.12` to `0.0.13` and `beclab/files-server` from `v0.2.168` to `v0.2.169`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005fce3b6e86a98015afb906f803a69ae1561bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->