### PR TITLE
feat: auth add support v3 app

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.51
+        image: beclab/auth:0.2.52
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION


* **Background**
add ACL rules for v3 applications

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/54

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the deployed `authelia-backend` container image, which can change authentication/ACL behavior at runtime even though the manifest diff is small.
> 
> **Overview**
> Updates the `authelia-backend` Deployment to run `beclab/auth:0.2.52` instead of `0.2.51`, effectively rolling forward the Auth/Authelia backend version used in the cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e57cc513c1ad933930cba19bf112558ed764c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->