### PR TITLE
chore(helm): update olares-app image version to v1.10.29

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.27
+          image: beclab/system-frontend:v1.10.29
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
files, vault: fix some ui bugs

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1122


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk Helm change that only bumps the `beclab/system-frontend` init container image; functional impact is limited to whatever is inside the new image.
> 
> **Overview**
> Updates the `olares-app` Helm deployment to use `beclab/system-frontend:v1.10.29` (was `v1.10.27`) for the `olares-app-init` init container that seeds `/www` content before nginx starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb3826efa6192e372d55d0e18f068ad67c8eb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->