### PR TITLE
cli: make DID URL param serialization deterministic

### DIFF
--- a/cli/pkg/web5/dids/did/did.go
+++ b/cli/pkg/web5/dids/did/did.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -49,8 +50,15 @@ type DID struct {
 func (d DID) URL() string {
 	url := d.URI
 	if len(d.Params) > 0 {
-		var pairs []string
-		for key, value := range d.Params {
+		keys := make([]string, 0, len(d.Params))
+		for key := range d.Params {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		pairs := make([]string, 0, len(d.Params))
+		for _, key := range keys {
+			value := d.Params[key]
 			pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
 		}
 		url += ";" + strings.Join(pairs, ";")
@@ -141,7 +149,7 @@ func Parse(input string) (DID, error) {
 		params := strings.Split(match[4][1:], ";")
 		parsedParams := make(map[string]string)
 		for _, p := range params {
-			kv := strings.Split(p, "=")
+			kv := strings.SplitN(p, "=", 2)
 			parsedParams[kv[0]] = kv[1]
 		}
 		did.Params = parsedParams

--- a/cli/pkg/web5/dids/did/did_test.go
+++ b/cli/pkg/web5/dids/did/did_test.go
@@ -37,10 +37,10 @@ func TestParse(t *testing.T) {
 		{
 			input: "did:example:123456789abcdefghi;foo=bar;baz=qux",
 			output: map[string]interface{}{
-				"alternate": "did:example:123456789abcdefghi;baz=qux;foo=bar",
-				"method":    "example",
-				"id":        "123456789abcdefghi",
-				"uri":       "did:example:123456789abcdefghi",
+				"method": "example",
+				"id":     "123456789abcdefghi",
+				"uri":    "did:example:123456789abcdefghi",
+				"url":    "did:example:123456789abcdefghi;baz=qux;foo=bar",
 				"params": map[string]string{
 					"foo": "bar",
 					"baz": "qux",
@@ -78,13 +78,13 @@ func TestParse(t *testing.T) {
 		{
 			input: "did:example:123456789abcdefghi;foo=bar;baz=qux?p1=v1&p2=v2#keys-1",
 			output: map[string]interface{}{
-				"alternate": "did:example:123456789abcdefghi;baz=quxfoo=bar;?p1=v1&p2=v2#keys-1",
-				"method":    "example",
-				"id":        "123456789abcdefghi",
-				"uri":       "did:example:123456789abcdefghi",
-				"params":    map[string]string{"foo": "bar", "baz": "qux"},
-				"query":     "p1=v1&p2=v2",
-				"fragment":  "keys-1",
+				"method":   "example",
+				"id":       "123456789abcdefghi",
+				"uri":      "did:example:123456789abcdefghi",
+				"url":      "did:example:123456789abcdefghi;baz=qux;foo=bar?p1=v1&p2=v2#keys-1",
+				"params":   map[string]string{"foo": "bar", "baz": "qux"},
+				"query":    "p1=v1&p2=v2",
+				"fragment": "keys-1",
 			},
 		},
 	}
@@ -104,12 +104,8 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			// The Params map doesn't have a reliable order, so check both
-			alt, ok := v.output["alternate"]
-			if ok {
-				firstOrder := v.input == did.URL()
-				secondOrder := alt == did.URL()
-				assert.True(t, firstOrder || secondOrder, "expected one of the orders to match")
+			if v.output["url"] != nil {
+				assert.Equal[interface{}](t, v.output["url"], did.URL())
 			} else {
 				assert.Equal[interface{}](t, v.input, did.URL())
 			}
@@ -141,7 +137,7 @@ func TestDID_ScanValueRoundtrip(t *testing.T) {
 	tests := []struct {
 		object  did.DID
 		raw     string
-		alt     string
+		want    string
 		wantErr bool
 	}{
 		{
@@ -150,7 +146,7 @@ func TestDID_ScanValueRoundtrip(t *testing.T) {
 		},
 		{
 			raw:    "did:example:123456789abcdefghi;foo=bar;baz=qux",
-			alt:    "did:example:123456789abcdefghi;baz=qux;foo=bar",
+			want:   "did:example:123456789abcdefghi;baz=qux;foo=bar",
 			object: did.MustParse("did:example:123456789abcdefghi;foo=bar;baz=qux"),
 		},
 		{
@@ -167,7 +163,7 @@ func TestDID_ScanValueRoundtrip(t *testing.T) {
 		},
 		{
 			raw:    "did:example:123456789abcdefghi;foo=bar;baz=qux?foo=bar&baz=qux#keys-1",
-			alt:    "did:example:123456789abcdefghi;baz=qux;foo=bar?foo=bar&baz=qux#keys-1",
+			want:   "did:example:123456789abcdefghi;baz=qux;foo=bar?foo=bar&baz=qux#keys-1",
 			object: did.MustParse("did:example:123456789abcdefghi;foo=bar;baz=qux?foo=bar&baz=qux#keys-1"),
 		},
 	}
@@ -183,8 +179,8 @@ func TestDID_ScanValueRoundtrip(t *testing.T) {
 			assert.NoError(t, err)
 			actual, ok := value.(string)
 			assert.True(t, ok)
-			if tt.alt != "" {
-				assert.True(t, actual == tt.raw || actual == tt.alt)
+			if tt.want != "" {
+				assert.Equal(t, tt.want, actual)
 			} else {
 				assert.Equal(t, tt.raw, actual)
 			}


### PR DESCRIPTION
Title: cli: make DID URL param serialization deterministic

* **Background**
DID.URL() ranged over Params, so URLs with 2+ params could serialize in random order. This made TestParse flaky, classic small papercut.

Repro before the fix:
```bash
cd cli
go test ./pkg/web5/dids/did -run TestParse -count=100
```

This sorts param keys before joining them. no behavior drama, just stable output.

Checked:
```bash
go test ./pkg/web5/dids/did -run 'TestParse|TestDID_ScanValueRoundtrip' -count=1000
go test ./pkg/web5/dids/...
```

* **Target Version for Merge**
main

* **Related Issues**
None found.

* **PRs Involving Sub-Systems**
None found.

* **Other information**:
The trigger is real for any DID with multiple params; it is just Go map iteration order, no external quota or infra limit needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect ordering/serialization of DID `Params` and test expectations, with no new external I/O or security-sensitive logic.
> 
> **Overview**
> Makes `DID.URL()` deterministic by sorting `Params` keys before serializing, ensuring stable DID URL strings.
> 
> Tightens parsing of parameter pairs by using `strings.SplitN(..., 2)` and updates tests to assert a single canonical `url`/`want` string instead of allowing multiple map-iteration orders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bc9f933d218da78726585f01652ea749f4a583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->