### PR TITLE
fix(media): unbreak HLS playback after argv switch in ffprobe invocation

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.169
+          image: beclab/files-server:v0.2.170
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix(media): unbreak HLS playback after argv switch in ffprobe invocation

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/325

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the deployed `files` DaemonSet to a new `beclab/files-server` image version, which can change runtime behavior despite being a small config diff.
> 
> **Overview**
> Updates the `files` DaemonSet deployment to pull `beclab/files-server:v0.2.170` instead of `v0.2.169`, rolling out the newer backend build with no other manifest changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669fd77cd8319eee71f7016c73d35b70a6b48c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->