### PR TITLE
fix(oac): yaml tag and full manifest check

### DIFF
--- a/framework/oac/appconfig_fields_test.go
+++ b/framework/oac/appconfig_fields_test.go
@@ -1,0 +1,340 @@
+package oac_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/oac"
+	"sigs.k8s.io/yaml"
+)
+
+const testdataFullManifest = "testdata/full_manifest"
+
+// TestLoadAppConfiguration_PreservesAllYAMLFields loads an OlaresManifest.yaml
+// that exercises many yaml-tagged fields and asserts that LoadAppConfiguration
+// does not drop leaf values when compared after parse → struct → marshal.
+//
+// Raw manifests often use flat keys (e.g. olaresManifest.version) while
+// yaml.Marshal may emit nested maps; structs that only have json tags (e.g.
+// TailScale, metav1.LabelSelector) may marshal with different key casing than
+// hand-written YAML. normalizeYAMLTreeForCompare removes those false positives
+// before leaf-path comparison.
+func TestLoadAppConfiguration_PreservesAllYAMLFields(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(testdataFullManifest, oac.ManifestFileName))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var inputDoc any
+	if err := yaml.Unmarshal(raw, &inputDoc); err != nil {
+		t.Fatalf("unmarshal input yaml: %v", err)
+	}
+	inputNorm := normalizeYAMLTreeForCompare(inputDoc)
+	inputLeaves := make(map[string]any)
+	collectYAMLLeaves("", inputNorm, inputLeaves)
+	if len(inputLeaves) == 0 {
+		t.Fatal("fixture must declare at least one leaf field")
+	}
+
+	cfg, err := oac.LoadAppConfiguration(testdataFullManifest)
+	if err != nil {
+		t.Fatalf("LoadAppConfiguration: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected non-nil *AppConfiguration")
+	}
+	if cfg.ConfigVersion == "" || cfg.ConfigType == "" {
+		t.Fatalf("LoadAppConfiguration must populate olaresManifest meta: ConfigVersion=%q ConfigType=%q",
+			cfg.ConfigVersion, cfg.ConfigType)
+	}
+
+	outBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal loaded cfg: %v", err)
+	}
+	var outputDoc any
+	if err := yaml.Unmarshal(outBytes, &outputDoc); err != nil {
+		t.Fatalf("unmarshal output yaml: %v", err)
+	}
+	outputNorm := normalizeYAMLTreeForCompare(outputDoc)
+
+	var missing, mismatched []string
+	for path, want := range inputLeaves {
+		got, ok := lookupTestYAMLPath(outputNorm, path)
+		if !ok {
+			missing = append(missing, path)
+			continue
+		}
+		if !yamlLeafValuesEqual(want, got) {
+			mismatched = append(mismatched, fmt.Sprintf("%s: input=%#v output=%#v", path, want, got))
+		}
+	}
+
+	if len(missing) > 0 || len(mismatched) > 0 {
+		sort.Strings(missing)
+		sort.Strings(mismatched)
+		var b strings.Builder
+		b.WriteString("LoadAppConfiguration dropped or altered yaml-tagged fields:\n")
+		for _, path := range missing {
+			fmt.Fprintf(&b, "  missing after load: %s (input=%#v)\n", path, inputLeaves[path])
+		}
+		for _, line := range mismatched {
+			fmt.Fprintf(&b, "  value mismatch: %s\n", line)
+		}
+		t.Fatal(b.String())
+	}
+}
+
+// normalizeYAMLTreeForCompare returns a deep copy of v with:
+//   - map[interface{}]interface{} coerced to map[string]any
+//   - flat keys "olaresManifest.<subkey>" merged into nested olaresManifest
+//   - common json-vs-yaml key spellings unified (subRoutes, matchLabels)
+func normalizeYAMLTreeForCompare(v any) any {
+	v = yamlToGenericMap(v)
+	switch x := v.(type) {
+	case map[string]any:
+		promoteOlaresManifestFlatKeys(x)
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[canonicalYAMLMapKey(k)] = normalizeYAMLTreeForCompare(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, el := range x {
+			out[i] = normalizeYAMLTreeForCompare(el)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func yamlToGenericMap(v any) any {
+	switch x := v.(type) {
+	case map[interface{}]interface{}:
+		m := make(map[string]any, len(x))
+		for k, vv := range x {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			m[ks] = yamlToGenericMap(vv)
+		}
+		return m
+	case map[string]any:
+		m := make(map[string]any, len(x))
+		for k, vv := range x {
+			m[k] = yamlToGenericMap(vv)
+		}
+		return m
+	case []any:
+		out := make([]any, len(x))
+		for i, el := range x {
+			out[i] = yamlToGenericMap(el)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+const olaresManifestKeyPrefix = "olaresManifest."
+
+// promoteOlaresManifestFlatKeys turns top-level keys like olaresManifest.version
+// into olaresManifest: { version: ... } so they match yaml.Marshal output.
+func promoteOlaresManifestFlatKeys(m map[string]any) {
+	extras := make(map[string]any)
+	for k, v := range m {
+		if strings.HasPrefix(k, olaresManifestKeyPrefix) && len(k) > len(olaresManifestKeyPrefix) {
+			sub := k[len(olaresManifestKeyPrefix):]
+			extras[sub] = v
+			delete(m, k)
+		}
+	}
+	if len(extras) == 0 {
+		return
+	}
+	if om, ok := m["olaresManifest"].(map[string]any); ok {
+		for sk, sv := range extras {
+			if _, has := om[sk]; !has {
+				om[sk] = sv
+			}
+		}
+	} else {
+		m["olaresManifest"] = extras
+	}
+}
+
+// canonicalYAMLMapKey aligns hand-written YAML keys with what encoding/json-only
+// structs typically emit under gopkg.in/yaml.v3.
+func canonicalYAMLMapKey(k string) string {
+	switch {
+	case strings.EqualFold(k, "subroutes"):
+		return "subRoutes"
+	case strings.EqualFold(k, "matchlabels"):
+		return "matchLabels"
+	default:
+		return k
+	}
+}
+
+// collectYAMLLeaves records every scalar / leaf collection in a YAML tree using
+// dotted paths (e.g. "spec.resources.0.mode", "metadata.name").
+func collectYAMLLeaves(prefix string, v any, out map[string]any) {
+	switch node := v.(type) {
+	case map[string]any:
+		for k, child := range node {
+			p := k
+			if prefix != "" {
+				p = prefix + "." + k
+			}
+			collectYAMLLeaves(p, child, out)
+		}
+	case map[interface{}]interface{}:
+		for k, child := range node {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			p := ks
+			if prefix != "" {
+				p = prefix + "." + ks
+			}
+			collectYAMLLeaves(p, child, out)
+		}
+	case []any:
+		for i, child := range node {
+			p := fmt.Sprintf("%s.%d", prefix, i)
+			collectYAMLLeaves(p, child, out)
+		}
+	default:
+		if prefix != "" {
+			out[prefix] = v
+		}
+	}
+}
+
+// lookupTestYAMLPath walks a dotted path. If a map has no single-segment key
+// for the next step, it tries the longest composite key formed from the
+// remaining path segments (handles flat keys like "olaresManifest.version").
+func lookupTestYAMLPath(root any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	cur := root
+	for i := 0; i < len(parts); i++ {
+		if cur == nil {
+			return nil, false
+		}
+		part := parts[i]
+		switch v := cur.(type) {
+		case map[string]any:
+			if n, ok := v[part]; ok {
+				cur = n
+				continue
+			}
+			found := false
+			for j := len(parts) - 1; j > i; j-- {
+				composite := strings.Join(parts[i:j+1], ".")
+				if n, ok := v[composite]; ok {
+					cur = n
+					i = j
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, false
+			}
+		case map[interface{}]interface{}:
+			if n, ok := v[part]; ok {
+				cur = n
+				continue
+			}
+			found := false
+			for j := len(parts) - 1; j > i; j-- {
+				composite := strings.Join(parts[i:j+1], ".")
+				if n, ok := v[composite]; ok {
+					cur = n
+					i = j
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, false
+			}
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil, false
+			}
+			cur = v[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+func yamlLeafValuesEqual(a, b any) bool {
+	return reflect.DeepEqual(normalizeYAMLLeaf(a), normalizeYAMLLeaf(b))
+}
+
+func normalizeYAMLLeaf(v any) any {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case bool:
+		return x
+	case string:
+		return strings.TrimRight(x, "\n")
+	case int:
+		return int64(x)
+	case int32:
+		return int64(x)
+	case int64:
+		return x
+	case float32:
+		return normalizeFloat(float64(x))
+	case float64:
+		return normalizeFloat(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = normalizeYAMLLeaf(item)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, item := range x {
+			out[k] = normalizeYAMLLeaf(item)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]any, len(x))
+		for k, item := range x {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			out[ks] = normalizeYAMLLeaf(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func normalizeFloat(x float64) any {
+	if x == float64(int64(x)) {
+		return int64(x)
+	}
+	return x
+}

--- a/framework/oac/apps_report_test.go
+++ b/framework/oac/apps_report_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"github.com/beclab/Olares/framework/oac/internal/manifest"
 	"github.com/beclab/Olares/framework/oac/internal/resources"

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,15 +4,15 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.5
+	github.com/beclab/api v0.0.7
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.5
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
 	k8s.io/cli-runtime v0.34.2
 	k8s.io/client-go v0.34.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -118,6 +118,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/apiserver v0.34.2 // indirect
 	k8s.io/component-base v0.34.2 // indirect
@@ -132,5 +133,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.4
+	github.com/beclab/api v0.0.5
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -25,8 +25,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/api v0.0.5 h1:ulPsQIzvVP42M8GaNjRvcdAksMahdz7ItwYBaOHf19s=
-github.com/beclab/api v0.0.5/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.7 h1:lpeJHgWNDUv2GG1iP/kv40Ub6fKSHTNfdk4l0/8vxUM=
+github.com/beclab/api v0.0.7/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -25,10 +25,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/api v0.0.3 h1:7c4XqiCuQRey38aLU+U9B+ebdw6Mnmire6Ee4XOlioc=
-github.com/beclab/api v0.0.3/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
-github.com/beclab/api v0.0.4 h1:EPSMGtVorbbjpvNyW0qPNJSSHagFDErGF1H6FqxJzoo=
-github.com/beclab/api v0.0.4/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.5 h1:ulPsQIzvVP42M8GaNjRvcdAksMahdz7ItwYBaOHf19s=
+github.com/beclab/api v0.0.5/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/internal/chartfolder/folder.go
+++ b/framework/oac/internal/chartfolder/folder.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	olm "github.com/beclab/Olares/framework/oac/internal/manifest"
 )

--- a/framework/oac/internal/manifest/parse.go
+++ b/framework/oac/internal/manifest/parse.go
@@ -3,7 +3,7 @@ package manifest
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 // ManifestStrategy parses YAML into github.com/beclab/api/manifest.AppConfiguration

--- a/framework/oac/testdata/full_manifest/OlaresManifest.yaml
+++ b/framework/oac/testdata/full_manifest/OlaresManifest.yaml
@@ -1,0 +1,271 @@
+olaresManifest.version: "0.12.0"
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: fullmanifest
+  icon: https://example.com/icon.png
+  description: comprehensive OlaresManifest fixture
+  appid: full-app-id
+  title: Full Manifest
+  version: "1.0.0"
+  categories:
+    - Utilities
+  rating: 4.5
+  target: user
+  type: app
+entrances:
+  - name: web
+    host: web
+    port: 8080
+    icon: https://example.com/entrance.png
+    title: Web
+    authLevel: public
+    invisible: true
+    url: https://example.com/web
+    openMethod: default
+    windowPushState: true
+    skip: true
+ports:
+  - name: api
+    host: api
+    port: 9090
+    exposePort: 9091
+    protocol: tcp
+    addToTailscaleAcl: true
+tailscale:
+  acls:
+    - action: accept
+      src:
+        - tag:client
+      proto: tcp
+      dst:
+        - 10.0.0.0/8:443
+  subRoutes:
+    - route-a
+sharedEntrances:
+  - name: shared
+    host: shared
+    port: 8081
+    title: Shared
+spec:
+  namespace: userspace-fullmanifest
+  onlyAdmin: true
+  versionName: v1.0.0
+  fullDescription: |
+    Full description line one.
+    Full description line two.
+  upgradeDescription: upgrade notes
+  promoteImage:
+    - https://example.com/promo1.png
+  promoteVideo: https://example.com/promo.mp4
+  subCategory: browser
+  developer: Example Dev
+  supportClient:
+    edge: supported
+    android: supported
+    ios: supported
+    windows: supported
+    mac: supported
+    linux: supported
+    chrome: supported
+  runAsUser: true
+  runAsInternal: true
+  podGpuConsumePolicy: single
+  subCharts:
+    - name: extra
+      shared: true
+  hardware:
+    cpu:
+      vendor: intel
+      arch: amd64
+    gpu:
+      vendor: nvidia
+      arch:
+        - cuda
+      singleMemory: 8Gi
+      totalMemory: 16Gi
+  resources:
+    - mode: cpu
+      supportMultiCard: true
+      supportMultiNodes: true
+      requiredCpu: 100m
+      limitedCpu: 200m
+      requiredMemory: 128Mi
+      limitedMemory: 256Mi
+      requiredDisk: 1Gi
+      limitedDisk: 2Gi
+      requiredGPUMemory: 1Gi
+      limitedGPUMemory: 2Gi
+  supportArch:
+    - amd64
+  website: https://example.com
+  sourceCode: https://github.com/example/app
+  submitter: Olares
+  locale:
+    - en-US
+    - zh-CN
+  doc: https://example.com/doc
+  license:
+    - text: MIT
+      url: https://opensource.org/licenses/MIT
+permission:
+  appData: true
+  appCache: true
+  userData:
+    - Home
+  serviceAccount: full-sa
+  provider:
+    - appName: provider-app
+      namespace: userspace-provider
+      providerName: data-provider
+      podSelectors:
+        - matchLabels:
+            app: provider
+middleware:
+  postgres:
+    username: pguser
+    password: pgpass
+    databases:
+      - name: appdb
+        extensions:
+          - pg_trgm
+        scripts:
+          - init.sql
+        distributed: true
+  redis:
+    password: redispass
+    namespace: app-redis
+  mongodb:
+    username: mgouser
+    password: mgopass
+    databases:
+      - name: appmongo
+  nats:
+    username: natsuser
+    password: natspass
+    subjects:
+      - name: events
+        permission:
+          pub: allow
+          sub: allow
+        export:
+          - pub: allow
+            sub: allow
+    refs:
+      - appName: ref-app
+        appNamespace: userspace-ref
+        subjects:
+          - name: events
+            perm:
+              - pub
+              - sub
+  minio:
+    username: miniou
+    password: miniop
+    allowNamespaceBuckets: true
+    buckets:
+      - name: uploads
+  rabbitmq:
+    username: rmquser
+    password: rmqpass
+    vhosts:
+      - name: app-vhost
+  elasticsearch:
+    username: esuser
+    password: espass
+    allowNamespaceIndexes: true
+    indexes:
+      - name: logs
+  mariadb:
+    username: mariauser
+    password: mariapass
+    databases:
+      - name: mariadbapp
+  mysql:
+    username: mysqluser
+    password: mysqlpass
+    databases:
+      - name: mysqlapp
+  argo:
+    required: true
+  clickHouse:
+    username: chuser
+    password: chpass
+    databases:
+      - name: analytics
+options:
+  mobileSupported: true
+  policies:
+    - entranceName: web
+      description: sample policy
+      uriRegex: ^/api/.*
+      level: admin
+      oneTime: true
+      validDuration: 1h
+  resetCookie:
+    enabled: true
+  dependencies:
+    - name: olares
+      version: ">=1.10.0"
+      type: system
+      mandatory: true
+      selfRely: true
+  conflicts:
+    - name: rival-app
+      type: application
+  appScope:
+    clusterScoped: true
+    appRef:
+      - ref-app
+    systemService: true
+  websocket:
+    port: 8765
+    url: /ws
+  upload:
+    fileType:
+      - image/png
+    dest: /tmp/upload
+    limitedSize: 1024
+  syncProvider:
+    - name: sync
+      endpoint: https://sync.example.com
+  oidc:
+    enabled: true
+    redirectUri: https://example.com/callback
+    entranceName: web
+  apiTimeout: 30
+  allowedOutboundPorts:
+    - 443
+    - 8080
+  images:
+    - ghcr.io/example/app:1.0.0
+  allowMultipleInstall: true
+  needsSharedAccess: true
+provider:
+  - name: api-provider
+    entrance: web
+    paths:
+      - /api/v1
+    verbs:
+      - get
+      - post
+envs:
+  - envName: LOG_LEVEL
+    value: debug
+    default: info
+    editable: true
+    type: string
+    required: true
+    title: Log Level
+    description: application log level
+    options:
+      - title: Debug
+        value: debug
+      - title: Info
+        value: info
+    remoteOptions: https://example.com/options.json
+    regex: ^(debug|info|warn)$
+    applyOnChange: true
+    valueFrom:
+      envName: SYSTEM_LOG
+      status: active


### PR DESCRIPTION
* **Background**
yaml tag and full manifest check
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching YAML marshal/unmarshal implementation and bumping the shared `beclab/api` dependency can subtly change parsing behavior and field mappings for manifests/Chart.yaml, though changes are localized and covered by new fixtures/tests.
> 
> **Overview**
> Adds a comprehensive `testdata/full_manifest/OlaresManifest.yaml` fixture plus `TestLoadAppConfiguration_PreservesAllYAMLFields` to ensure `LoadAppConfiguration` round-trips manifests without dropping or mutating yaml-tagged leaf fields (with normalization to avoid known key-shape/casing false positives).
> 
> Standardizes YAML handling across OAC by replacing `gopkg.in/yaml.v3` with `sigs.k8s.io/yaml` in parsing/reporting code and updates module deps (`github.com/beclab/api` to `v0.0.7`, adds direct `sigs.k8s.io/yaml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5272f62bd947c564c2343462ad3affd6ef15fe4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->