### PR TITLE
fix(auth): fit v3 app per-user settings

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.52
+        image: beclab/auth:0.2.53
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION


* **Background**
fit v3 app per-user settings
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/55

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm/Kubernetes manifest change that only updates the `beclab/auth` container image tag; behavior changes depend on the new image contents.
> 
> **Overview**
> Updates the `authelia-backend` Deployment to run `beclab/auth:0.2.53` instead of `0.2.52`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39976943c90777eab205ac0f4ce279d09da9778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->