### PR TITLE
fix(app-service): wait for pods to terminate before host-path cleanup on uninstall

### DIFF
--- a/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
@@ -19,9 +19,14 @@ import (
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
+
+// waitForPodsDeletedTimeout caps how long uninstall waits for pods owned by
+// the release to terminate before proceeding with host-path cleanup.
+const waitForPodsDeletedTimeout = 30 * time.Minute
 
 // UninstallAll do a uninstall operation for release.
 func (h *HelmOps) UninstallAll() error {
@@ -48,6 +53,15 @@ func (h *HelmOps) UninstallAll() error {
 	}
 
 	h.ClearMiddlewareRequests(fmt.Sprintf("%s-%s", "user-system", h.app.OwnerName))
+
+	// Host-path cache/data is shared with pod mounts; wait for the release's
+	// pods to fully terminate before deleting their backing directories.
+	if len(appCacheDirs) > 0 || (deleteData && len(appDataDirs) > 0) {
+		if err := h.WaitForPodsDeleted(client, h.app.Namespace); err != nil {
+			err = fmt.Errorf("wait for pods in namespace %s to be deleted failed, proceeding with cleanup: %v", h.app.Namespace, err)
+			return err
+		}
+	}
 
 	err = h.ClearCache(client, appCacheDirs)
 	if err != nil {
@@ -116,6 +130,38 @@ func (h *HelmOps) Uninstall_(client kubernetes.Interface, actionConfig *action.C
 	}
 
 	return nil
+}
+
+// WaitForPodsDeleted blocks until no pods remain in the given namespace, up to
+// waitForPodsDeletedTimeout. It is intended to be called after the helm
+// release has been uninstalled and before any destructive host-path cleanup
+// (e.g. ClearCache / ClearData), so that pods still holding host-path volumes
+// have a chance to terminate gracefully.
+//
+// Protected (system) namespaces are skipped because they are never torn down
+// during app uninstall. A missing namespace counts as success. Any other list
+// error aborts the wait immediately and is returned to the caller, since
+// further polling can't make progress; the caller decides how to handle it.
+func (h *HelmOps) WaitForPodsDeleted(client kubernetes.Interface, namespace string) error {
+	if apputils.IsProtectedNamespace(namespace) {
+		return nil
+	}
+
+	klog.Infof("waiting for all pods in namespace %s to be deleted before cleanup", namespace)
+	return utilwait.PollImmediate(2*time.Second, waitForPodsDeletedTimeout, func() (bool, error) {
+		pods, err := client.CoreV1().Pods(namespace).List(h.ctx, metav1.ListOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if len(pods.Items) == 0 {
+			return true, nil
+		}
+		klog.V(2).Infof("%d pod(s) still terminating in namespace %s", len(pods.Items), namespace)
+		return false, nil
+	})
 }
 
 func (h *HelmOps) ClearCache(client kubernetes.Interface, appCacheDirs []string) error {

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_uninstall.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"fmt"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"strings"
 
@@ -48,6 +49,15 @@ func (h *HelmOpsV2) UninstallAll() error {
 			}
 
 			h.ClearMiddlewareRequests("os-platform")
+
+			// Host-path cache is shared with pod mounts; wait for the release's
+			// pods to fully terminate before deleting their backing directories.
+			if len(appCacheDirs) > 0 {
+				if err := h.WaitForPodsDeleted(client, namespace); err != nil {
+					err = fmt.Errorf("wait for pods in namespace %s to be deleted failed, proceeding with cleanup: %v", namespace, err)
+					return err
+				}
+			}
 
 			err = h.ClearCache(client, appCacheDirs)
 			if err != nil {


### PR DESCRIPTION
## Summary

- When apps use volume `subPath` mounts, deleting the backing host-path directory before the pods have fully terminated leaves kubelet unable to unmount the volumes, which prevents the pods (and the release namespace) from being removed.
- Before running `ClearCache` / `ClearData` host-path cleanup, wait for all pods in the release namespace to be deleted. This applies to both the v1 and v2 helm uninstall paths.
- Adds a new `WaitForPodsDeleted` helper with a 30‑minute cap; protected (system) namespaces are skipped, and a `NotFound` namespace counts as success.

## Test plan

- [ ] Install an app that uses host-path-backed volumes with `subPath`.
- [ ] Uninstall the app and confirm pods terminate cleanly before host-path directories are removed.
- [ ] Confirm the release namespace is fully deleted afterwards.
- [ ] Verify v2 apps follow the same wait-then-clean order.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes uninstall sequencing by adding a namespace-wide pod-termination wait (up to 30 minutes) before deleting host-path cache/data, which could lengthen or fail uninstalls if pods never exit or pod listing errors occur.
> 
> **Overview**
> Ensures app uninstalls don’t delete host-path-backed cache/data directories while pods are still terminating.
> 
> Adds a `WaitForPodsDeleted` helper (polling until no pods remain, with a 30‑minute cap and protected-namespace/NotFound handling) and wires it into both v1 and v2 uninstall paths so the wait happens after Helm uninstall and before `ClearCache`/`ClearData` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82f8d8ed3a107264445fb3c5cea8f3271a9d00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->