### PR TITLE
docs: add known issue page for LarePass VPN + Chrome 148 WebSocket block

### DIFF
--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -34,6 +34,10 @@ const side = {
           collapsed: true,
           items: [
             {
+              text: "Known issues",
+              link: "/manual/help/known-issues",
+            },
+            {
               text: "Insufficient memory or memory not freed",
               link: "/manual/help/ts-free-memory",
             },

--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -33,6 +33,10 @@ const side = {
           collapsed: true,
           items: [
             {
+              text: "已知问题",
+              link: "/zh/manual/help/known-issues",
+            },
+            {
               text: "内存不足或没有释放",
               link: "/zh/manual/help/ts-free-memory",
             },

--- a/docs/manual/help/known-issues.md
+++ b/docs/manual/help/known-issues.md
@@ -19,7 +19,7 @@ Olares will update this page when issues are identified, mitigated, or resolved.
 | --- | --- |
 | Affected platform | macOS |
 | Affected browser | Google Chrome 148 or later |
-| Trigger conditions | LarePass VPN enabled and accessing Olares through an `olares.com` URL |
+| Trigger conditions | Accessing Olares through an `olares.com` URL in Chrome while LarePass VPN is enabled |
 | Impact | WebSocket-based real-time updates may stop working |
 | Status | Pending fix in an upcoming Olares release |
 
@@ -47,7 +47,25 @@ Olares does not currently include this header in the WebSocket upgrade response,
 
 Use one of the following workarounds until you upgrade to an Olares version that includes the fix.
 
-#### Option 1: Use the .local address
+#### Option 1: Temporarily disable Chrome's local network access check
+
+If you need to keep using the `olares.com` URL with LarePass VPN, you can temporarily disable Chrome's local network access check.
+
+:::warning
+This changes a browser security setting. Use it only as a temporary workaround. After you upgrade to an Olares version that includes the fix, restore this flag to **Default** or **Enabled**.
+:::
+
+1. In Chrome, open:
+
+   ```text
+   chrome://flags/#local-network-access-check
+   ```
+
+2. Set **Local Network Access Checks** to **Disabled**.
+3. Click **Relaunch** to restart Chrome.
+4. Open Olares again using your `olares.com` URL.
+
+#### Option 2: Use the .local address
 
 If your Mac and Olares are on the same local network, use the `.local` address instead of the `olares.com` address. This is the recommended workaround for LAN access.
 
@@ -69,29 +87,3 @@ If Chrome cannot open the `.local` address, make sure Chrome has local network a
 2. Go to **Privacy & Security** > **Local Network**.
 3. Turn on **Google Chrome** and **Google Chrome Helper**.
 4. Restart Chrome and try the `.local` URL again.
-
-#### Option 2: Temporarily disable Chrome's local network access check
-
-If you need to keep using the `olares.com` URL with LarePass VPN, you can temporarily disable Chrome's local network access check.
-
-:::warning
-This changes a browser security setting. Use it only as a temporary workaround. After you upgrade to an Olares version that includes the fix, restore this flag to **Default** or **Enabled**.
-:::
-
-1. In Chrome, open:
-
-   ```text
-   chrome://flags/#local-network-access-check
-   ```
-
-2. Set **Local Network Access Checks** to **Disabled**.
-3. Click **Relaunch** to restart Chrome.
-4. Open Olares again using your `olares.com` URL.
-
-#### Option 3: Refresh the page to recover
-
-If you cannot apply the workarounds above, refresh the page when you notice stalled updates. This restores the current view until the next disconnect.
-
-1. Press `F5`, or click the refresh button in Chrome.
-2. Wait for the page to reload.
-3. Check whether the app status or real-time content updates correctly.

--- a/docs/manual/help/known-issues.md
+++ b/docs/manual/help/known-issues.md
@@ -1,0 +1,97 @@
+---
+outline: [2, 3]
+description: Known issues in Olares, including affected environments, impact, workarounds, and fix status.
+---
+
+# Known issues
+
+This page lists confirmed issues that may affect Olares users. Each issue includes the affected environment, user impact, current status, and available workarounds.
+
+:::info Status update
+Olares will update this page when issues are identified, mitigated, or resolved.
+:::
+
+## Chrome real-time updates may stop when LarePass VPN is enabled
+
+### Summary
+
+| Item | Details |
+| --- | --- |
+| Affected platform | macOS |
+| Affected browser | Google Chrome 148 or later |
+| Trigger conditions | LarePass VPN enabled and accessing Olares through an `olares.com` URL |
+| Impact | WebSocket-based real-time updates may stop working |
+| Status | Pending fix in an upcoming Olares release |
+
+### Description
+
+When this issue occurs, Olares pages still open in Chrome, but parts of the page that depend on live updates may stop refreshing.
+
+You may notice one or more of the following symptoms:
+
+- App status, notifications, or task progress do not update automatically.
+- A page appears to be stuck until you refresh it.
+- Live messages or WebSocket-powered panels stop updating.
+
+Your data is safe. This issue affects real-time communication in the browser only. It does not indicate data loss, data corruption, account damage, app damage, or device storage issues.
+
+### Cause
+
+Starting in Chrome 148, Chrome enforces stricter Local Network Access checks for requests that cross from a public web origin to a local or private network address.
+
+When LarePass VPN is enabled and you open Olares through an `olares.com` address, Chrome may treat some WebSocket connections as local network requests. For WebSocket connections, Chrome checks the `101 Switching Protocols` response. If the response is missing the header Chrome expects, the connection is blocked.
+
+Olares does not currently include this header in the WebSocket upgrade response, which triggers the block. A fix is planned for an upcoming release.
+
+### Workarounds
+
+Use one of the following workarounds until you upgrade to an Olares version that includes the fix.
+
+#### Option 1: Use the .local address
+
+If your Mac and Olares are on the same local network, use the `.local` address instead of the `olares.com` address. This is the recommended workaround for LAN access.
+
+Convert the standard Olares URL to the `.local` URL:
+
+**Standard URL**
+```text
+https://<entrance_id>.<username>.olares.com
+```
+
+**Local URL**
+```text
+http://<entrance_id>.<username>.olares.local
+```
+
+If Chrome cannot open the `.local` address, make sure Chrome has local network access on macOS:
+
+1. Open the Apple menu and go to **System Settings**.
+2. Go to **Privacy & Security** > **Local Network**.
+3. Turn on **Google Chrome** and **Google Chrome Helper**.
+4. Restart Chrome and try the `.local` URL again.
+
+#### Option 2: Temporarily disable Chrome's local network access check
+
+If you need to keep using the `olares.com` URL with LarePass VPN, you can temporarily disable Chrome's local network access check.
+
+:::warning
+This changes a browser security setting. Use it only as a temporary workaround. After you upgrade to an Olares version that includes the fix, restore this flag to **Default** or **Enabled**.
+:::
+
+1. In Chrome, open:
+
+   ```text
+   chrome://flags/#local-network-access-check
+   ```
+
+2. Set **Local Network Access Checks** to **Disabled**.
+3. Click **Relaunch** to restart Chrome.
+4. Open Olares again using your `olares.com` URL.
+
+#### Option 3: Refresh the page to recover
+
+If you cannot apply the workarounds above, refresh the page when you notice stalled updates. This restores the current view until the next disconnect.
+
+1. Press `F5`, or click the refresh button in Chrome.
+2. Wait for the page to reload.
+3. Check whether the app status or real-time content updates correctly.

--- a/docs/zh/manual/help/known-issues.md
+++ b/docs/zh/manual/help/known-issues.md
@@ -19,7 +19,7 @@ Olares 会在问题确认、缓解或修复后同步更新本页面。
 | --- | --- |
 | 影响平台 | macOS |
 | 影响浏览器 | Google Chrome 148 或更高版本 |
-| 触发条件 | 在 LarePass 专用网络下通过 `olares.com` 地址访问 Olares |
+| 触发条件 | 启用 LarePass 专用网络后通过 Chrome 使用 `olares.com` 地址访问 Olares |
 | 影响 | 依赖 WebSocket 的实时更新可能停止工作 |
 | 状态 | 计划在后续 Olares 版本中修复 |
 
@@ -47,7 +47,25 @@ Olares 目前未在 WebSocket upgrade 响应中携带该响应头，因此会被
 
 在升级到包含修复的 Olares 新版本前，可使用以下任一方式临时绕过。
 
-#### 方案 1：使用 .local 地址
+#### 方案 1：临时关闭 Chrome 本地网络访问检查
+
+如果你需要继续通过 `olares.com` 地址在 LarePass 专用网络下访问 Olares，可临时关闭 Chrome 的本地网络访问检查。
+
+:::warning
+这会修改浏览器安全设置。建议仅作为临时绕过方式使用。升级到包含修复的 Olares 新版本后，请将该设置恢复为 **Default** 或 **Enabled**。
+:::
+
+1. 在 Chrome 中打开：
+
+   ```text
+   chrome://flags/#local-network-access-check
+   ```
+
+2. 将 **Local Network Access Checks** 设置为 **Disabled**。
+3. 点击 **Relaunch** 重启 Chrome。
+4. 重新使用 `olares.com` 地址打开 Olares。
+
+#### 方案 2：使用 .local 地址
 
 如果你的 Mac 和 Olares 位于同一局域网，建议使用 `.local` 地址，而不是 `olares.com` 地址。这是推荐的局域网访问方式。
 
@@ -69,29 +87,3 @@ http://<entrance_id>.<username>.olares.local
 2. 进入**隐私与安全性** > **本地网络**。
 3. 打开 **Google Chrome** 和 **Google Chrome Helper** 的开关。
 4. 重启 Chrome 后再次尝试 `.local` URL。
-
-#### 方案 2：临时关闭 Chrome 本地网络访问检查
-
-如果你需要继续通过 `olares.com` 地址在 LarePass 专用网络下访问 Olares，可临时关闭 Chrome 的本地网络访问检查。
-
-:::warning
-这会修改浏览器安全设置。建议仅作为临时绕过方式使用。升级到包含修复的 Olares 新版本后，请将该设置恢复为 **Default** 或 **Enabled**。
-:::
-
-1. 在 Chrome 中打开：
-
-   ```text
-   chrome://flags/#local-network-access-check
-   ```
-
-2. 将 **Local Network Access Checks** 设置为 **Disabled**。
-3. 点击 **Relaunch** 重启 Chrome。
-4. 重新使用 `olares.com` 地址打开 Olares。
-
-#### 方案 3：刷新页面以恢复
-
-如果暂时无法采用上述方案，可在实时更新停止时刷新页面查看最新进度。
-
-1. 按 `F5`，或点击 Chrome 的刷新按钮。
-2. 等待页面重新加载。
-3. 检查应用状态或实时内容是否恢复更新。

--- a/docs/zh/manual/help/known-issues.md
+++ b/docs/zh/manual/help/known-issues.md
@@ -1,0 +1,97 @@
+---
+outline: [2, 3]
+description: Olares 已知问题，包括影响范围、影响说明、临时绕过方式和修复状态。
+---
+
+# 已知问题
+
+本页面记录已确认可能影响 Olares 用户的问题，并提供问题的影响范围、当前状态和临时方案。
+
+:::info 状态更新
+Olares 会在问题确认、缓解或修复后同步更新本页面。
+:::
+
+## 启用 LarePass 专用网络后，Chrome 实时更新可能异常
+
+### 摘要
+
+| 项目 | 说明 |
+| --- | --- |
+| 影响平台 | macOS |
+| 影响浏览器 | Google Chrome 148 或更高版本 |
+| 触发条件 | 在 LarePass 专用网络下通过 `olares.com` 地址访问 Olares |
+| 影响 | 依赖 WebSocket 的实时更新可能停止工作 |
+| 状态 | 计划在后续 Olares 版本中修复 |
+
+### 问题表现
+
+问题发生时，Chrome 中的 Olares 页面仍能打开，但依赖实时更新的内容可能停止刷新。
+
+你可能会看到以下一种或多种现象：
+
+- 应用状态、通知或任务进度不会自动更新。
+- 页面看起来卡住，需要刷新后才恢复。
+- 实时消息或依赖 WebSocket 的面板停止更新。
+
+该问题只影响浏览器中的实时通信，不会造成数据丢失、数据损坏、账户异常、应用损坏或设备存储问题。
+
+### 原因
+
+从 Chrome 148 开始，Chrome 对从公共网页来源访问本地或私有网络地址的请求执行了更严格的 Local Network Access 检查。
+
+启用 LarePass 专用网络后通过 `olares.com` 地址打开 Olares 时，Chrome 可能会将部分 WebSocket 连接视为本地网络请求。对于 WebSocket 连接，Chrome 会检查 `101 Switching Protocols` 响应。如果响应中缺少 Chrome 期望的响应头，连接会被拦截。
+
+Olares 目前未在 WebSocket upgrade 响应中携带该响应头，因此会被 Chrome 拦截。该响应头会在后续版本中补充。
+
+### 临时绕过方式
+
+在升级到包含修复的 Olares 新版本前，可使用以下任一方式临时绕过。
+
+#### 方案 1：使用 .local 地址
+
+如果你的 Mac 和 Olares 位于同一局域网，建议使用 `.local` 地址，而不是 `olares.com` 地址。这是推荐的局域网访问方式。
+
+将标准 Olares URL 改为 `.local` URL：
+
+**标准 URL**
+```text
+https://<entrance_id>.<username>.olares.com
+```
+
+**本地 URL**
+```text
+http://<entrance_id>.<username>.olares.local
+```
+
+如果 Chrome 无法打开 `.local` 地址，请确认 macOS 已允许 Chrome 访问本地网络：
+
+1. 打开 Apple 菜单，进入**系统设置**。
+2. 进入**隐私与安全性** > **本地网络**。
+3. 打开 **Google Chrome** 和 **Google Chrome Helper** 的开关。
+4. 重启 Chrome 后再次尝试 `.local` URL。
+
+#### 方案 2：临时关闭 Chrome 本地网络访问检查
+
+如果你需要继续通过 `olares.com` 地址在 LarePass 专用网络下访问 Olares，可临时关闭 Chrome 的本地网络访问检查。
+
+:::warning
+这会修改浏览器安全设置。建议仅作为临时绕过方式使用。升级到包含修复的 Olares 新版本后，请将该设置恢复为 **Default** 或 **Enabled**。
+:::
+
+1. 在 Chrome 中打开：
+
+   ```text
+   chrome://flags/#local-network-access-check
+   ```
+
+2. 将 **Local Network Access Checks** 设置为 **Disabled**。
+3. 点击 **Relaunch** 重启 Chrome。
+4. 重新使用 `olares.com` 地址打开 Olares。
+
+#### 方案 3：刷新页面以恢复
+
+如果暂时无法采用上述方案，可在实时更新停止时刷新页面查看最新进度。
+
+1. 按 `F5`，或点击 Chrome 的刷新按钮。
+2. 等待页面重新加载。
+3. 检查应用状态或实时内容是否恢复更新。


### PR DESCRIPTION
## Summary

- Adds a new Known issues page (EN + ZH) documenting the Chrome 148 Local Network Access check that blocks WebSocket connections when LarePass VPN is enabled and users access Olares via `olares.com`.
- Documents three workarounds: switch to the `.local` address, disable Chrome's `local-network-access-check` flag, or refresh the page to recover the current view.
- Moves the Known issues / 已知问题 sidebar entry under the Troubleshooting / 故障排查 group in both `en.ts` and `zh.ts`.

## Test plan

- [x] Pages render correctly in VitePress dev preview (EN and ZH).
- [x] Sidebar shows Known issues / 已知问题 as the first entry under Troubleshooting / 故障排查.
- [x] All internal anchors and Chrome flag URL resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus sidebar navigation updates; no runtime or product logic is modified.
> 
> **Overview**
> Adds a new `Known issues` / `已知问题` help page (EN + ZH) describing the Chrome 148 Local Network Access check that can block WebSocket real-time updates when using LarePass VPN via `olares.com`, including environment/impact/status and suggested workarounds.
> 
> Updates the VitePress sidebar configs (`en.ts`, `zh.ts`) to surface the new page as the first entry under **Troubleshooting / 故障排查** (and fixes file formatting/newline at EOF).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8355fa03f311c836b1cb5337fe6dff389db889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->