### PR TITLE
hami: support time-slicing in cuMemAllocAsync

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.16"
+version: "v2.6.17"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.16
+      name: beclab/hami:v2.6.17
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Support time-slicing mode in cuMemAllocAsync function

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/23580a25c5eac9b0e575a39198cdb502e1e2e8e2

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades the core GPU scheduler/device-plugin image used in clusters, which can affect GPU workload scheduling and allocation behavior.
> 
> **Overview**
> Updates HAMi to **`v2.6.17`** by bumping the configured `version` in `hami/values.yaml` and the referenced prebuilt image tag in `Olares.yaml` (from `v2.6.16`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360643c81c51dc153435efb2d4b7b25b7b83fa3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->