### PR TITLE
olares-app: update image tags for olares-app and user-service in helm chart

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.29
+          image: beclab/system-frontend:v1.10.32
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.92
+          image: beclab/user-service:v0.0.93
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
files: supports more file types
desktop:  hide applications during uninstallation
olares-app: fix the issue of WebSocket connection failure

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1129
https://github.com/beclab/TermiPass/pull/1136
https://github.com/beclab/TermiPass/pull/1138
https://github.com/beclab/TermiPass/pull/1139

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates container image tags in the `system-apps` Helm template; risk is mainly that the new images could introduce runtime regressions, but no chart logic changes are included.
> 
> **Overview**
> Updates the `system-apps` Helm template to deploy newer images: `beclab/system-frontend` from `v1.10.29` to `v1.10.32` (init container) and `beclab/user-service` from `v0.0.92` to `v0.0.93`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ac4d72dd3c3e90f01e4beb892b23da4b3d50f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->