### PR TITLE
fix(oac): full yaml field check and add some api

### DIFF
--- a/framework/oac/README.md
+++ b/framework/oac/README.md
@@ -574,7 +574,7 @@ Each `spec.resources[i]` is a `ResourceMode`:
 
 `Checker.CheckResources` also does one `BuildValues` + `Render` (except it returns immediately for **`apiVersion: v2`**, which skips container limit checks), then forwards the chart path and manifest to `checkResourceLimits`; for modern manifests the list produced by that render is not used by the limit branch (limit checks are entirely driven by per-mode re-renders), so it **does not include** §3.2 / §3.3.
 
-For **`apiVersion: v2`** the parent OAC root is not a renderable workload chart in the multi-chart install layout, so the helm dry-run for **`Lint` / `CheckServiceAccountRules` / `ListImages`** iterates `spec.subCharts[]` and concatenates the per-subchart `kube.ResourceList`s. **`apiVersion: v3`** follows the same single-chart render path as **v1** (whole chart at the OAC root). A non-empty `apiVersion` outside `v1` / `v2` / `v3` fails validation and resource checks with **不支持该版本**.
+For **`apiVersion: v2`** the parent OAC root is not a renderable workload chart in the multi-chart install layout, so the helm dry-run for **`Lint` / `CheckServiceAccountRules` / `ListImages`** iterates `spec.subCharts[]` and concatenates the per-subchart `kube.ResourceList`s. **`apiVersion: v3`** follows the same single-chart render path as **v1** (whole chart at the OAC root). A non-empty `apiVersion` outside `v1` / `v2` / `v3` fails validation and resource checks with **not supported version**.
 
 > `Lint` always runs the helm render. Upload mount and workload naming (§3.2, §3.3) are **always** enforced; container limits (§3.1) are gated by `SkipResourceCheck()`; RBAC (§3.4) is gated by `WithServiceAccountRulesCheck()`.
 

--- a/framework/oac/README.md
+++ b/framework/oac/README.md
@@ -70,6 +70,10 @@ imgs, err := c.ListImages(path)
 // Same, but render the chart with .Values.GPU.Type = mode so GPU-gated
 // templates contribute their workloads (empty mode == ListImages).
 imgs, err := c.ListImagesForMode(path, "nvidia")
+// Multi-mode: union of images across each mode, dedup'd. Pass nil/empty for
+// default-branch render; pass "all" to expand into oac.AllImageRenderModes.
+imgs, err := c.ListImagesForModes(path, []string{"nvidia", "cpu"})
+imgs, err := c.ListImagesForModes(path, []string{"all"})
 ```
 
 > Every helm dry-run (`Lint`, `ListImages` / `ListImagesForMode`, `CheckResources`, `CheckServiceAccountRules`, ...) deep-merges any values registered via `oac.WithValues(map[string]interface{}{...})` on top of the scaffold built by `helmrender.BuildValues`. External keys win on conflicts; map keys recurse so siblings the caller did not override survive. The per-mode `.Values.GPU.Type` set by `ListImagesForMode` and the resource-limit per-mode loop runs **after** the merge, so it still wins on `GPU.Type`.
@@ -84,6 +88,8 @@ err  := oac.ValidateManifestFile(path, opts...)
 err  := oac.ValidateManifestContent(bytes, opts...)
 imgs, err := oac.ListImagesFromOAC(path, opts...)
 imgs, err := oac.ListImagesFromOACForMode(path, "nvidia", opts...)
+imgs, err := oac.ListImagesFromOACForModes(path, []string{"nvidia", "cpu"}, opts...)
+imgs, err := oac.ListImagesFromOACForModes(path, []string{"all"}, opts...) // expands to oac.AllImageRenderModes
 
 // Parse straight into a typed *AppConfiguration (no validation)
 cfg, err  := oac.LoadAppConfiguration(path, opts...)
@@ -213,11 +219,17 @@ cfg := &oac.AppConfiguration{ // equivalent to *manifest.AppConfiguration
 | `SkipSameVersionCheck()` | **on**      | Disable the Chart.yaml ↔ manifest version match check. It is on by default; turn it off when you want to align version numbers separately before publishing to the app store |
 | `WithSameVersionCheck()` | —           | Turn the match check back on (useful when composing option sets to re-enable it at a specific call site) |
 | `WithServiceAccountRulesCheck()` | off         | Enable the ServiceAccount RBAC forbidden-rules check |
+| `WithSecurityContextCheck()` | off         | Enable the non-beclab image privileged securityContext check. The check rejects any container (init or main) whose image is NOT under the `beclab/` namespace (matched as `beclab/...` prefix or as a `/beclab/...` path segment after a registry hostname) and whose effective securityContext sets any of `privileged: true`, `runAsUser: 0`, `runAsNonRoot: false`. Pod-level securityContext is considered: if the pod sets `runAsUser: 0` or `runAsNonRoot: false`, every non-beclab container inherits the unsafe default and is reported. Walks `Deployment` / `StatefulSet` / `DaemonSet` workloads |
+| `SkipSecurityContextCheck()` | —           | Clears the non-beclab securityContext check flag. The check is OFF by default; this option only matters when composing on top of an option set that previously turned it on |
 | `WithCustomValidator(fn)` | —           | Register a custom `CustomValidator`; can be called multiple times to append |
 | `SkipAppDataCheck()` | **on**      | Disable the built-in `.Values.userspace.appdata` cross-check. The check is on by default; turn it off only when a chart legitimately renders appdata via a non-standard path |
 | `WithAppDataValidator()` | —           | Re-enable the built-in `.Values.userspace.appdata` cross-check. Kept as a back-compat alias — the check now runs by default and is disabled with `SkipAppDataCheck()`. Calling this on a fresh checker is a no-op |
+| `SkipHostPathCheck()` | **on**      | Disable the built-in hostPath + rolling-update incompatibility check. The check rejects any `Deployment` (strategy = `RollingUpdate` / unset) or `StatefulSet` (updateStrategy = `RollingUpdate` / unset) that mounts a hostPath volume, because a rolling update can land the new pod on a different node where the host directory does not exist. Allowed strategies: `Recreate` (Deployment) and `OnDelete` (StatefulSet) |
+| `WithHostPathCheck()` | —           | Re-enable the built-in hostPath + rolling-update check after a previous option set disabled it. No-op on a fresh checker |
+| `SkipResourceNamespaceCheck()` | **on**      | Disable the rendered-resource namespace check. The check enforces: workloads (`Deployment` / `StatefulSet` / `DaemonSet`) must have `metadata.namespace = "app-namespace"`; other namespaced resources must be in `"app-namespace"` or a `"user-system-*"` namespace; cluster-scoped resources (empty namespace) are skipped |
+| `WithResourceNamespaceCheck()` | —           | Re-enable the rendered-resource namespace check after a previous option set disabled it. No-op on a fresh checker |
 
-> Note: `New()`'s default behavior is "run everything except `ServiceAccountRules`" — the Chart.yaml ↔ manifest version match check and the `.Values.userspace.appdata` cross-check both run by default. Use `Skip*` to turn off a built-in check, and `With*Check` to turn on one that is off by default.
+> Note: `New()`'s default behavior is "run everything except `ServiceAccountRules`" — the Chart.yaml ↔ manifest version match check, the `.Values.userspace.appdata` cross-check, the hostPath + rolling-update check, and the rendered-resource namespace check all run by default. Use `Skip*` to turn off a built-in check, and `With*Check` to turn on one that is off by default.
 
 ### 6. Typical usage
 
@@ -255,7 +267,25 @@ for _, p := range paths {
 **Just the image list**:
 
 ```go
+// Default branch only.
 images, err := oac.ListImagesFromOAC("./my-app", oac.WithOwnerAdmin("root"))
+
+// Union across a few specific GPU.Type modes (deduped + sorted).
+images, err := oac.ListImagesFromOACForModes(
+    "./my-app",
+    []string{"nvidia", "cpu"},
+    oac.WithOwnerAdmin("root"),
+)
+
+// Union across *every* mode advertised by AllImageRenderModes
+// (currently cpu / apple-m / nvidia / nvidia-gb10 / mthreads-m1000 /
+// strix-halo). Mixing "all" with explicit modes is fine — duplicates
+// collapse to a single render per mode.
+images, err := oac.ListImagesFromOACForModes(
+    "./my-app",
+    []string{"all"},
+    oac.WithOwnerAdmin("root"),
+)
 ```
 
 **Validate manifest content only (no chart directory needed)**:
@@ -560,13 +590,13 @@ For each `Deployment` and `StatefulSet` in the render, on the primary container:
 
 **Where the manifest-side limits come from (dispatched by `olaresManifest.version` and `apiVersion`)**:
 
-- **Legacy (`< 0.12.0`)**: read directly from the four flat fields `spec.requiredCpu` / `spec.limitedCpu` / `spec.requiredMemory` / `spec.limitedMemory`. `Lint` renders the chart once (sharing the render with §3.2 / §3.3) and compares that single `kube.ResourceList` against the four fields.
+- **`apiVersion: v2` (any `olaresManifest.version`)**: the container limit check is **skipped entirely**. `checkResourceLimits` short-circuits before either the legacy or the modern branch, and `CheckResources` returns nil at its `isV2Manifest` guard without even rendering. Rationale: v2 is the multi-chart install layout — each `spec.subCharts[]` entry has its own quota, so summing container limits against the parent manifest's `spec.required*/spec.limited*` (or any single `spec.resources[]` row) is meaningless.
+- **Legacy (`< 0.12.0`) with `apiVersion` unset, `v1`, or `v3`**: read directly from the four flat fields `spec.requiredCpu` / `spec.limitedCpu` / `spec.requiredMemory` / `spec.limitedMemory`. `Lint` renders the chart once (sharing the render with §3.2 / §3.3) and compares that single `kube.ResourceList` against the four fields.
 - **Modern (`>= 0.12.0`) with `apiVersion` unset, `v1`, or `v3`**: `validateAppSpec` requires `spec.resources[]` and Rule 7 forbids mixing it with the flat fields, so limits come from `spec.resources[]`. For each `ResourceMode rm`:
   1. `BuildValues(...)` + `SetGPUType(values, rm.Mode)` (`.Values.GPU.Type = <mode>`).
   2. `helmrender.Render(...)` at `oacPath` produces the `kube.ResourceList` for that mode.
   3. Limits use the **inline** `ResourceRequirement` on that mode (`requiredCpu`, `limitedCpu`, `requiredMemory`, `limitedMemory`).
   4. `CheckResourceLimits(list, limits)`. Failure prefix: `resources mode=<mode>:`.
-- **Modern (`>= 0.12.0`) with `apiVersion` v2**: the container limit check is **skipped** (`checkResourceLimits` returns nil when `spec.resources` is non-empty; `CheckResources` also returns nil without rendering for limits).
 - Failures across modes are aggregated via `errors.Join`.
 - If `spec.resources` is empty (a modern manifest without any `ResourceMode`), this check is **skipped entirely** — such a chart has no limits to compare against, so there is nothing more to validate.
 - The upload-mount and workload-naming checks (§3.2 / §3.3) run **only on the default render**; per-mode re-renders serve **only** §3.1 and do not re-run §3.2 / §3.3.
@@ -627,6 +657,24 @@ type CustomValidator func(oacPath string, m Manifest) error
 ```
 
 A built-in equivalent runs as a separate, always-on step (not via `customValidators`): if any file under the chart's `templates/*.yaml` references `.Values.userspace.appdata`, `OlaresManifest.yaml` must declare `permission.appData: true`, otherwise the check fails. It runs by default in `Lint`; pass `SkipAppDataCheck()` to disable it for a particular call. The legacy entry point `WithAppDataValidator()` is kept as a back-compat alias that simply re-asserts the on-by-default state.
+
+Another always-on built-in (after the helm dry-run) is the **hostPath + rolling-update incompatibility check**: any `Deployment` whose `spec.strategy.type` is `RollingUpdate` (or empty, since that defaults to `RollingUpdate` on the API server side) and that mounts a hostPath volume — or any `StatefulSet` with `spec.updateStrategy.type` = `RollingUpdate` / empty doing the same — will fail Lint. The reason: a rolling update can land the new pod on a different node where the host directory does not exist, so the new pod silently starves on a volume that's "present" in the manifest but absent in practice. Use `spec.strategy.type: Recreate` on Deployments and `updateStrategy.type: OnDelete` on StatefulSets when you legitimately need a hostPath mount. Pass `SkipHostPathCheck()` to bypass the check; `WithHostPathCheck()` re-enables it after a previous disable.
+
+A third always-on built-in (also after the helm dry-run) is the **rendered-resource namespace check**: every workload that comes out of the dry-run with `metadata.namespace` set must conform to the install-time contract. Specifically:
+
+- `Deployment` / `StatefulSet` / `DaemonSet` must declare `metadata.namespace = "app-namespace"` (the same value as `helmrender.RenderNamespace`, i.e. the namespace Olares uses to install every app's chart). Workloads in any other namespace would silently miss the app's quota / NetworkPolicy / sidecar injection.
+- Any other namespaced resource (`Service`, `ConfigMap`, `Secret`, `Role`, `RoleBinding`, `ProviderRegistry`, ...) must land in `app-namespace` or in a namespace whose name starts with `user-system-` (the convention for cross-namespace bridges into the owner's user-system namespace).
+- Cluster-scoped resources (`ClusterRole`, `ClusterRoleBinding`, `PersistentVolume`, ...) and any resource whose `metadata.namespace` is empty are skipped — they have no notion of namespace by design.
+
+Use `{{ .Release.Namespace }}` for in-app resources (helm fills it with `app-namespace`) and an explicit `user-system-{{ .Values.bfl.username }}` for bridges into the owner's user-system namespace; both render to compliant values. Pass `SkipResourceNamespaceCheck()` to bypass the check; `WithResourceNamespaceCheck()` re-enables it after a previous disable.
+
+An opt-in built-in is the **non-beclab image privileged securityContext check**: rejects any container (init or main) whose image lives outside the `beclab/` namespace and whose effective securityContext grants root-equivalent privileges:
+
+- `container.securityContext.privileged: true`
+- `container.securityContext.runAsUser: 0`
+- `container.securityContext.runAsNonRoot: false`
+
+Pod-level `spec.securityContext` is also examined; if it sets `runAsUser: 0` or `runAsNonRoot: false`, every non-beclab container that does not override those fields is reported. Beclab-published images (matched by repository path `beclab/...` or `<registry>/beclab/...`) are exempt. This check is **OFF by default**; enable it with `WithSecurityContextCheck()` (typically before publishing to the app store). It walks `Deployment` / `StatefulSet` / `DaemonSet` workloads.
 
 ---
 

--- a/framework/oac/appconfig_fields_test.go
+++ b/framework/oac/appconfig_fields_test.go
@@ -1,0 +1,340 @@
+package oac_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/oac"
+	"sigs.k8s.io/yaml"
+)
+
+const testdataFullManifest = "testdata/full_manifest"
+
+// TestLoadAppConfiguration_PreservesAllYAMLFields loads an OlaresManifest.yaml
+// that exercises many yaml-tagged fields and asserts that LoadAppConfiguration
+// does not drop leaf values when compared after parse → struct → marshal.
+//
+// Raw manifests often use flat keys (e.g. olaresManifest.version) while
+// yaml.Marshal may emit nested maps; structs that only have json tags (e.g.
+// TailScale, metav1.LabelSelector) may marshal with different key casing than
+// hand-written YAML. normalizeYAMLTreeForCompare removes those false positives
+// before leaf-path comparison.
+func TestLoadAppConfiguration_PreservesAllYAMLFields(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(testdataFullManifest, oac.ManifestFileName))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var inputDoc any
+	if err := yaml.Unmarshal(raw, &inputDoc); err != nil {
+		t.Fatalf("unmarshal input yaml: %v", err)
+	}
+	inputNorm := normalizeYAMLTreeForCompare(inputDoc)
+	inputLeaves := make(map[string]any)
+	collectYAMLLeaves("", inputNorm, inputLeaves)
+	if len(inputLeaves) == 0 {
+		t.Fatal("fixture must declare at least one leaf field")
+	}
+
+	cfg, err := oac.LoadAppConfiguration(testdataFullManifest)
+	if err != nil {
+		t.Fatalf("LoadAppConfiguration: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected non-nil *AppConfiguration")
+	}
+	if cfg.ConfigVersion == "" || cfg.ConfigType == "" {
+		t.Fatalf("LoadAppConfiguration must populate olaresManifest meta: ConfigVersion=%q ConfigType=%q",
+			cfg.ConfigVersion, cfg.ConfigType)
+	}
+
+	outBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal loaded cfg: %v", err)
+	}
+	var outputDoc any
+	if err := yaml.Unmarshal(outBytes, &outputDoc); err != nil {
+		t.Fatalf("unmarshal output yaml: %v", err)
+	}
+	outputNorm := normalizeYAMLTreeForCompare(outputDoc)
+
+	var missing, mismatched []string
+	for path, want := range inputLeaves {
+		got, ok := lookupTestYAMLPath(outputNorm, path)
+		if !ok {
+			missing = append(missing, path)
+			continue
+		}
+		if !yamlLeafValuesEqual(want, got) {
+			mismatched = append(mismatched, fmt.Sprintf("%s: input=%#v output=%#v", path, want, got))
+		}
+	}
+
+	if len(missing) > 0 || len(mismatched) > 0 {
+		sort.Strings(missing)
+		sort.Strings(mismatched)
+		var b strings.Builder
+		b.WriteString("LoadAppConfiguration dropped or altered yaml-tagged fields:\n")
+		for _, path := range missing {
+			fmt.Fprintf(&b, "  missing after load: %s (input=%#v)\n", path, inputLeaves[path])
+		}
+		for _, line := range mismatched {
+			fmt.Fprintf(&b, "  value mismatch: %s\n", line)
+		}
+		t.Fatal(b.String())
+	}
+}
+
+// normalizeYAMLTreeForCompare returns a deep copy of v with:
+//   - map[interface{}]interface{} coerced to map[string]any
+//   - flat keys "olaresManifest.<subkey>" merged into nested olaresManifest
+//   - common json-vs-yaml key spellings unified (subRoutes, matchLabels)
+func normalizeYAMLTreeForCompare(v any) any {
+	v = yamlToGenericMap(v)
+	switch x := v.(type) {
+	case map[string]any:
+		promoteOlaresManifestFlatKeys(x)
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[canonicalYAMLMapKey(k)] = normalizeYAMLTreeForCompare(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, el := range x {
+			out[i] = normalizeYAMLTreeForCompare(el)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func yamlToGenericMap(v any) any {
+	switch x := v.(type) {
+	case map[interface{}]interface{}:
+		m := make(map[string]any, len(x))
+		for k, vv := range x {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			m[ks] = yamlToGenericMap(vv)
+		}
+		return m
+	case map[string]any:
+		m := make(map[string]any, len(x))
+		for k, vv := range x {
+			m[k] = yamlToGenericMap(vv)
+		}
+		return m
+	case []any:
+		out := make([]any, len(x))
+		for i, el := range x {
+			out[i] = yamlToGenericMap(el)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+const olaresManifestKeyPrefix = "olaresManifest."
+
+// promoteOlaresManifestFlatKeys turns top-level keys like olaresManifest.version
+// into olaresManifest: { version: ... } so they match yaml.Marshal output.
+func promoteOlaresManifestFlatKeys(m map[string]any) {
+	extras := make(map[string]any)
+	for k, v := range m {
+		if strings.HasPrefix(k, olaresManifestKeyPrefix) && len(k) > len(olaresManifestKeyPrefix) {
+			sub := k[len(olaresManifestKeyPrefix):]
+			extras[sub] = v
+			delete(m, k)
+		}
+	}
+	if len(extras) == 0 {
+		return
+	}
+	if om, ok := m["olaresManifest"].(map[string]any); ok {
+		for sk, sv := range extras {
+			if _, has := om[sk]; !has {
+				om[sk] = sv
+			}
+		}
+	} else {
+		m["olaresManifest"] = extras
+	}
+}
+
+// canonicalYAMLMapKey aligns hand-written YAML keys with what encoding/json-only
+// structs typically emit under gopkg.in/yaml.v3.
+func canonicalYAMLMapKey(k string) string {
+	switch {
+	case strings.EqualFold(k, "subroutes"):
+		return "subRoutes"
+	case strings.EqualFold(k, "matchlabels"):
+		return "matchLabels"
+	default:
+		return k
+	}
+}
+
+// collectYAMLLeaves records every scalar / leaf collection in a YAML tree using
+// dotted paths (e.g. "spec.resources.0.mode", "metadata.name").
+func collectYAMLLeaves(prefix string, v any, out map[string]any) {
+	switch node := v.(type) {
+	case map[string]any:
+		for k, child := range node {
+			p := k
+			if prefix != "" {
+				p = prefix + "." + k
+			}
+			collectYAMLLeaves(p, child, out)
+		}
+	case map[interface{}]interface{}:
+		for k, child := range node {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			p := ks
+			if prefix != "" {
+				p = prefix + "." + ks
+			}
+			collectYAMLLeaves(p, child, out)
+		}
+	case []any:
+		for i, child := range node {
+			p := fmt.Sprintf("%s.%d", prefix, i)
+			collectYAMLLeaves(p, child, out)
+		}
+	default:
+		if prefix != "" {
+			out[prefix] = v
+		}
+	}
+}
+
+// lookupTestYAMLPath walks a dotted path. If a map has no single-segment key
+// for the next step, it tries the longest composite key formed from the
+// remaining path segments (handles flat keys like "olaresManifest.version").
+func lookupTestYAMLPath(root any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	cur := root
+	for i := 0; i < len(parts); i++ {
+		if cur == nil {
+			return nil, false
+		}
+		part := parts[i]
+		switch v := cur.(type) {
+		case map[string]any:
+			if n, ok := v[part]; ok {
+				cur = n
+				continue
+			}
+			found := false
+			for j := len(parts) - 1; j > i; j-- {
+				composite := strings.Join(parts[i:j+1], ".")
+				if n, ok := v[composite]; ok {
+					cur = n
+					i = j
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, false
+			}
+		case map[interface{}]interface{}:
+			if n, ok := v[part]; ok {
+				cur = n
+				continue
+			}
+			found := false
+			for j := len(parts) - 1; j > i; j-- {
+				composite := strings.Join(parts[i:j+1], ".")
+				if n, ok := v[composite]; ok {
+					cur = n
+					i = j
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, false
+			}
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil, false
+			}
+			cur = v[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+func yamlLeafValuesEqual(a, b any) bool {
+	return reflect.DeepEqual(normalizeYAMLLeaf(a), normalizeYAMLLeaf(b))
+}
+
+func normalizeYAMLLeaf(v any) any {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case bool:
+		return x
+	case string:
+		return strings.TrimRight(x, "\n")
+	case int:
+		return int64(x)
+	case int32:
+		return int64(x)
+	case int64:
+		return x
+	case float32:
+		return normalizeFloat(float64(x))
+	case float64:
+		return normalizeFloat(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = normalizeYAMLLeaf(item)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, item := range x {
+			out[k] = normalizeYAMLLeaf(item)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]any, len(x))
+		for k, item := range x {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			out[ks] = normalizeYAMLLeaf(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func normalizeFloat(x float64) any {
+	if x == float64(int64(x)) {
+		return int64(x)
+	}
+	return x
+}

--- a/framework/oac/apps_report_test.go
+++ b/framework/oac/apps_report_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"github.com/beclab/Olares/framework/oac/internal/manifest"
 	"github.com/beclab/Olares/framework/oac/internal/resources"

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -261,7 +261,7 @@ func (c *OAC) CheckSameVersion(oacPath string, m Manifest) error {
 // apiVersion v2 skips this check entirely (returns nil). v1, v3, and empty
 // apiVersion (v1 default) share the same logic: one helm render at oacPath
 // for the legacy path, and per-mode renders at oacPath for modern manifests.
-// A non-empty apiVersion outside v1/v2/v3 yields 不支持该版本.
+// A non-empty apiVersion outside v1/v2/v3 yields not supported version.
 //
 // For legacy manifests (<0.12.0) the chart is rendered once and the
 // container-level limits are compared against spec.required*/spec.limited*.
@@ -368,7 +368,7 @@ func (c *OAC) ValidateManifestContent(content []byte) error {
 //     Limits come from the inline ResourceRequirement on each mode row.
 //     Each mode renders the chart once at oacPath.
 //
-// A non-empty apiVersion outside v1/v2/v3 yields 不支持该版本.
+// A non-empty apiVersion outside v1/v2/v3 yields not supported version.
 //
 // Charts that carry no resources[] on a modern manifest skip the check
 // entirely — Rule 7 already guaranteed the legacy flat fields are empty,

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -25,15 +25,26 @@ import (
 //  5. Helm dry-run and mandatory workload-integrity checks (upload mount
 //     path, `type=app` workload naming) - ALWAYS run; not governed by any
 //     Skip* option
-//  6. Container-level resource limits check - skipped by SkipResourceCheck
-//  7. Chart.yaml <-> manifest same-version check - ON by default, turn off
+//  6. HostPath + rolling-update incompatibility check - ON by default,
+//     turn off with SkipHostPathCheck()
+//  7. Rendered-resource namespace check (workloads in app-namespace;
+//     other resources in app-namespace or user-system-*) - ON by default,
+//     turn off with SkipResourceNamespaceCheck()
+//  8. Container-level resource limits check - skipped by SkipResourceCheck
+//  9. Chart.yaml <-> manifest same-version check - ON by default, turn off
 //     with SkipSameVersionCheck()
-//  8. ServiceAccount RBAC inspection - OFF by default, turn on with
+//  10. ServiceAccount RBAC inspection - OFF by default, turn on with
 //     WithServiceAccountRulesCheck()
+//  11. Non-beclab image privileged securityContext check - OFF by default,
+//     turn on with WithSecurityContextCheck()
 //
-// When WithAutoOwnerScenarios() is set, step 5/6/8 — the portions that
-// depend on the rendered chart — run twice: once with owner == admin and
-// once with owner != admin. All other steps run once.
+// When WithAutoOwnerScenarios() is set, every owner-dependent step runs
+// twice — once with owner == admin and once with owner != admin. That
+// covers the rendered-chart steps (5/6/7/8/10) AND step 2's manifest
+// validation, so manifests that branch on
+// `eq .Values.admin .Values.bfl.username` are exercised in both install
+// modes. Owner-independent steps (folder layout, appdata cross-check,
+// same-version) still run once.
 func (c *OAC) Lint(oacPath string) error {
 	if !c.skipFolder {
 		if err := c.CheckChartFolder(oacPath); err != nil {
@@ -67,12 +78,17 @@ func (c *OAC) Lint(oacPath string) error {
 			return err
 		}
 	}
-
-	for _, sc := range c.ownerScenarios() {
-		if err := c.lintRenderedScenario(oacPath, m, sc); err != nil {
-			if sc.label != "" {
-				return fmt.Errorf("%s scenario: %w", sc.label, err)
+	if m.APIVersion() == "v2" {
+		for _, sc := range c.ownerScenarios() {
+			if err := c.lintRenderedScenario(oacPath, m, sc); err != nil {
+				if sc.label != "" {
+					return fmt.Errorf("%s scenario: %w", sc.label, err)
+				}
+				return err
 			}
+		}
+	} else {
+		if err := c.lintRenderedScenario(oacPath, m, ownerScenario{label: "", owner: "owner", admin: "admin"}); err != nil {
 			return err
 		}
 	}
@@ -126,6 +142,18 @@ func (c *OAC) lintRenderedScenario(oacPath string, m Manifest, sc ownerScenario)
 		return err
 	}
 
+	if !c.skipHostPath {
+		if err := resources.CheckHostPath(list); err != nil {
+			return err
+		}
+	}
+
+	if !c.skipResourceNamespace {
+		if err := resources.CheckResourceNamespace(list); err != nil {
+			return err
+		}
+	}
+
 	if !c.skipResource {
 		if err := c.checkResourceLimits(oacPath, m, sc, list); err != nil {
 			return err
@@ -138,6 +166,12 @@ func (c *OAC) lintRenderedScenario(oacPath string, m Manifest, sc ownerScenario)
 			return err
 		}
 		if err := resources.CheckServiceAccountRules(list, rules); err != nil {
+			return err
+		}
+	}
+
+	if c.runSecurityContext {
+		if err := resources.CheckSecurityContextForNonBeclabImage(list); err != nil {
 			return err
 		}
 	}
@@ -292,6 +326,12 @@ func (c *OAC) CheckServiceAccountRules(oacPath string) error {
 // underlying pipeline re-parses the payload under both admin=owner and
 // admin!=owner scenarios and aggregates any failures into a single
 // ValidationError.
+//
+// When WithAutoOwnerScenarios() is set, the manifest validation is repeated
+// for each (owner, admin) pair (owner==admin / owner!=admin) so manifests
+// whose body branches on `eq .Values.admin .Values.bfl.username` are
+// exercised in both configurations. Failures from each scenario are
+// aggregated into a single *ValidationError.
 func (c *OAC) ValidateManifestFile(oacPath string) error {
 	raw, err := readManifestFile(oacPath)
 	if err != nil {
@@ -301,6 +341,8 @@ func (c *OAC) ValidateManifestFile(oacPath string) error {
 }
 
 // ValidateManifestContent is the byte-slice counterpart of ValidateManifestFile.
+// It honors WithAutoOwnerScenarios() the same way (manifest validation runs
+// once per owner scenario).
 func (c *OAC) ValidateManifestContent(content []byte) error {
 	m, err := c.parseManifest(content)
 	if err != nil {
@@ -312,15 +354,19 @@ func (c *OAC) ValidateManifestContent(content []byte) error {
 // checkResourceLimits runs CheckResourceLimits against the right render for
 // the manifest's schema version.
 //
-//   - Legacy (<0.12.0): the defaultList that was already rendered by the
-//     caller is reused and limits come from the flat
+//   - apiVersion v2: the whole check is **skipped** regardless of
+//     olaresManifest.version. v2 is the multi-chart install layout where
+//     each spec.subCharts[] entry has its own quota, so summing container
+//     limits against the parent manifest's spec.required*/spec.limited*
+//     (or any single spec.resources[] row) is meaningless.
+//   - Legacy (<0.12.0) + v1/v3/empty: the defaultList that was already
+//     rendered by the caller is reused and limits come from the flat
 //     spec.required*/spec.limited* fields.
-//   - Modern (>=0.12.0): every entry in spec.resources[] drives dedicated
-//     helm renders with .Values.GPU.Type set to rm.Mode, because chart
-//     templates may emit different workloads per GPU family. Limits come
-//     from the inline ResourceRequirement on each mode row. Each mode
-//     renders the chart once at oacPath (same for apiVersion v1, v3, or
-//     empty). apiVersion v2 skips the entire modern branch (nil).
+//   - Modern (>=0.12.0) + v1/v3/empty: every entry in spec.resources[]
+//     drives dedicated helm renders with .Values.GPU.Type set to rm.Mode,
+//     because chart templates may emit different workloads per GPU family.
+//     Limits come from the inline ResourceRequirement on each mode row.
+//     Each mode renders the chart once at oacPath.
 //
 // A non-empty apiVersion outside v1/v2/v3 yields 不支持该版本.
 //
@@ -339,6 +385,9 @@ func (c *OAC) checkResourceLimits(oacPath string, m Manifest, sc ownerScenario, 
 	if err := manifest.ValidateKnownAPIVersion(cfg.APIVersion); err != nil {
 		return err
 	}
+	if strings.EqualFold(cfg.APIVersion, manifest.APIVersionV2) {
+		return nil
+	}
 	if !manifest.IsModernResourcesManifest(cfg.ConfigVersion) {
 		return resources.CheckResourceLimits(defaultList, resources.ResourceLimits{
 			RequiredCPU:    cfg.Spec.RequiredCPU,
@@ -348,9 +397,6 @@ func (c *OAC) checkResourceLimits(oacPath string, m Manifest, sc ownerScenario, 
 		})
 	}
 	if len(cfg.Spec.Resources) == 0 {
-		return nil
-	}
-	if strings.EqualFold(cfg.APIVersion, manifest.APIVersionV2) {
 		return nil
 	}
 	var errs []error

--- a/framework/oac/chart_limits_test.go
+++ b/framework/oac/chart_limits_test.go
@@ -56,6 +56,42 @@ func TestCheckResourceLimits_ModernV3_SameAsV1Inline(t *testing.T) {
 	}
 }
 
+// TestCheckResourceLimits_V2_SkipsRegardlessOfManifestVersion pins down the
+// contract that apiVersion=v2 always short-circuits the limit check before
+// either the legacy or the modern branch can fire. It reuses the modern
+// "toobig" fixture (whose containers exceed the inline spec.requiredCpu /
+// spec.requiredMemory and would normally fail on v1) and:
+//   - first verifies v2 + modern returns nil,
+//   - then flips ConfigVersion to legacy ("0.11.0") and clears
+//     spec.resources[], so absent the v2 short-circuit the legacy branch
+//     would run resources.CheckResourceLimits against zero limits and fail
+//     for every container that declares any CPU/memory request. The
+//     check must still return nil.
+func TestCheckResourceLimits_V2_SkipsRegardlessOfManifestVersion(t *testing.T) {
+	c := New(WithOwner("alice"), WithAdmin("admin"))
+	dir := filepath.Join("testdata", "resourcelimits_v1_inline_toobig")
+	m, err := c.LoadManifestFile(dir)
+	if err != nil {
+		t.Fatalf("LoadManifestFile: %v", err)
+	}
+	cfg, ok := m.Raw().(*manifest.AppConfiguration)
+	if !ok {
+		t.Fatal("expected *AppConfiguration")
+	}
+	sc := ownerScenario{owner: "alice", admin: "admin"}
+
+	cfg.APIVersion = manifest.APIVersionV2
+	if err := c.checkResourceLimits(dir, m, sc, nil); err != nil {
+		t.Fatalf("v2 + modern must skip the limit check, got: %v", err)
+	}
+
+	cfg.ConfigVersion = "0.11.0"
+	cfg.Spec.Resources = nil
+	if err := c.checkResourceLimits(dir, m, sc, nil); err != nil {
+		t.Fatalf("v2 + legacy must skip the limit check, got: %v", err)
+	}
+}
+
 func TestCheckResourceLimits_UnsupportedAPIVersion(t *testing.T) {
 	c := New(WithOwner("alice"), WithAdmin("admin"))
 	dir := filepath.Join("testdata", "resourcelimits_v1_inline")

--- a/framework/oac/chart_limits_test.go
+++ b/framework/oac/chart_limits_test.go
@@ -109,7 +109,7 @@ func TestCheckResourceLimits_UnsupportedAPIVersion(t *testing.T) {
 	if limErr == nil {
 		t.Fatal("expected unsupported apiVersion error")
 	}
-	if !strings.Contains(limErr.Error(), "不支持该版本") {
-		t.Fatalf("expected 不支持该版本 in error, got: %v", limErr)
+	if !strings.Contains(limErr.Error(), "not supported version") {
+		t.Fatalf("expected not supported version in error, got: %v", limErr)
 	}
 }

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,15 +4,15 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.5
+	github.com/beclab/api v0.0.7
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.5
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
 	k8s.io/cli-runtime v0.34.2
 	k8s.io/client-go v0.34.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -118,6 +118,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/apiserver v0.34.2 // indirect
 	k8s.io/component-base v0.34.2 // indirect
@@ -132,5 +133,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.4
+	github.com/beclab/api v0.0.5
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -25,8 +25,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/api v0.0.5 h1:ulPsQIzvVP42M8GaNjRvcdAksMahdz7ItwYBaOHf19s=
-github.com/beclab/api v0.0.5/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.7 h1:lpeJHgWNDUv2GG1iP/kv40Ub6fKSHTNfdk4l0/8vxUM=
+github.com/beclab/api v0.0.7/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -25,10 +25,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/api v0.0.3 h1:7c4XqiCuQRey38aLU+U9B+ebdw6Mnmire6Ee4XOlioc=
-github.com/beclab/api v0.0.3/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
-github.com/beclab/api v0.0.4 h1:EPSMGtVorbbjpvNyW0qPNJSSHagFDErGF1H6FqxJzoo=
-github.com/beclab/api v0.0.4/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.5 h1:ulPsQIzvVP42M8GaNjRvcdAksMahdz7ItwYBaOHf19s=
+github.com/beclab/api v0.0.5/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/images.go
+++ b/framework/oac/images.go
@@ -2,9 +2,38 @@ package oac
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/beclab/Olares/framework/oac/internal/resources"
 )
+
+// AllModes is the literal keyword that ListImagesForModes / the related
+// top-level shortcuts expand into AllImageRenderModes. Matched
+// case-insensitively so "ALL", "All", "all" all mean the same thing.
+const AllModes = "all"
+
+// AllImageRenderModes is the ordered list of .Values.GPU.Type values that
+// "all" expands into when ListImagesForModes (or its top-level shortcut)
+// is invoked. Each mode triggers a separate helm render under the
+// matching GPU-Type override; the union of workload images across every
+// render is deduped and returned alongside options.images.
+//
+// The list intentionally mirrors the resource modes the Olares app store
+// advertises, not the broader resource_mode enum that OlaresManifest
+// validation accepts (validResourceModes). They can diverge over time:
+// a mode may still be a valid manifest value while no longer being part
+// of the default image-extraction set, and vice versa. Callers that
+// want to drive image extraction off the manifest's own
+// spec.resources[] can build their own slice from cfg.Spec.Resources
+// instead of passing "all".
+var AllImageRenderModes = []string{
+	"cpu",
+	"apple-m",
+	"nvidia",
+	"nvidia-gb10",
+	"mthreads-m1000",
+	"strix-halo",
+}
 
 // ListImages returns the sorted, deduplicated set of container images used by
 // oacPath. The set is the union of:
@@ -31,17 +60,82 @@ func (c *OAC) ListImages(oacPath string) ([]string, error) {
 // Passing an empty mode is identical to calling ListImages: no GPU.Type
 // override is injected and the default branch of the chart renders.
 func (c *OAC) ListImagesForMode(oacPath, mode string) ([]string, error) {
+	return c.ListImagesForModes(oacPath, []string{mode})
+}
+
+// ListImagesForModes returns the union of container images across each
+// .Values.GPU.Type mode in modes. The chart is helm-rendered once per
+// expanded mode, the resulting Deployment/StatefulSet workload images
+// are collected, then unioned with the manifest's options.images and
+// returned as a sorted, deduplicated slice.
+//
+// Mode semantics:
+//
+//   - A nil / empty modes slice is treated as a single render with no
+//     GPU.Type override, identical to ListImages.
+//   - An empty string entry renders the chart's default branch (no
+//     override), same as ListImages.
+//   - Any element equal to AllModes ("all", case-insensitive) expands
+//     in-place into AllImageRenderModes. Duplicates introduced by mixing
+//     "all" with explicit modes are collapsed, so each mode renders at
+//     most once per call.
+//   - Other entries are passed straight through as the
+//     .Values.GPU.Type value for that mode's render.
+//
+// Errors from any single render fail the whole call and identify the
+// offending mode in the wrapping message.
+func (c *OAC) ListImagesForModes(oacPath string, modes []string) ([]string, error) {
+	expanded := expandImageRenderModes(modes)
 	m, err := c.LoadManifestFile(oacPath)
 	if err != nil {
 		return nil, err
 	}
 	sc := ownerScenario{owner: c.owner, admin: c.admin}
-	list, err := c.renderForMode(oacPath, m, sc, mode)
-	if err != nil {
-		return nil, fmt.Errorf("helm render: %w", err)
+	var workloadUnion []string
+	for _, mode := range expanded {
+		list, err := c.renderForMode(oacPath, m, sc, mode)
+		if err != nil {
+			return nil, fmt.Errorf("helm render (mode=%q): %w", mode, err)
+		}
+		workloadUnion = append(workloadUnion, resources.ExtractWorkloadImages(list)...)
 	}
-	workloadImages := resources.ExtractWorkloadImages(list)
-	return resources.MergeImages(workloadImages, m.OptionsImages()), nil
+	return resources.MergeImages(workloadUnion, m.OptionsImages()), nil
+}
+
+// expandImageRenderModes normalises a caller-supplied list of modes into
+// the actual sequence of .Values.GPU.Type values to render under. It
+// expands AllModes, drops duplicates while preserving insertion order
+// (so the first occurrence wins), and collapses an empty input to a
+// single no-override render.
+func expandImageRenderModes(modes []string) []string {
+	if len(modes) == 0 {
+		return []string{""}
+	}
+	seen := make(map[string]struct{}, len(modes))
+	out := make([]string, 0, len(modes))
+	add := func(mode string) {
+		if _, ok := seen[mode]; ok {
+			return
+		}
+		seen[mode] = struct{}{}
+		out = append(out, mode)
+	}
+	for _, mode := range modes {
+		if strings.EqualFold(mode, AllModes) {
+			for _, m := range AllImageRenderModes {
+				add(m)
+			}
+			continue
+		}
+		add(mode)
+	}
+	if len(out) == 0 {
+		// Caller passed only "all" but AllImageRenderModes was set to an
+		// empty slice (e.g. cleared by an embedder). Fall back to the
+		// no-override render so we still produce a meaningful result.
+		return []string{""}
+	}
+	return out
 }
 
 // ListImagesFromOAC is the Checker-less shortcut for (*Checker).ListImages.
@@ -53,4 +147,12 @@ func ListImagesFromOAC(oacPath string, opts ...Option) ([]string, error) {
 // (*Checker).ListImagesForMode.
 func ListImagesFromOACForMode(oacPath, mode string, opts ...Option) ([]string, error) {
 	return New(opts...).ListImagesForMode(oacPath, mode)
+}
+
+// ListImagesFromOACForModes is the Checker-less shortcut for
+// (*Checker).ListImagesForModes. Use it when you want to extract images
+// across several GPU-Type modes (or the "all" keyword) without holding
+// a Checker yourself.
+func ListImagesFromOACForModes(oacPath string, modes []string, opts ...Option) ([]string, error) {
+	return New(opts...).ListImagesForModes(oacPath, modes)
 }

--- a/framework/oac/internal/chartfolder/folder.go
+++ b/framework/oac/internal/chartfolder/folder.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	olm "github.com/beclab/Olares/framework/oac/internal/manifest"
 )

--- a/framework/oac/internal/manifest/parse.go
+++ b/framework/oac/internal/manifest/parse.go
@@ -3,7 +3,7 @@ package manifest
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 // ManifestStrategy parses YAML into github.com/beclab/api/manifest.AppConfiguration

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -46,6 +46,15 @@ var (
 	validOpenMethods     = []any{"", "default", "iframe", "window"}
 )
 
+// validSupportArchSet enumerates the architectures spec.supportArch may
+// declare. The check intentionally rejects empty strings and case variants
+// (e.g. "AMD64") since the downstream installer compares against exactly
+// these two lowercase values.
+var validSupportArchSet = map[string]struct{}{
+	"amd64": {},
+	"arm64": {},
+}
+
 // ValidateKnownAPIVersion returns nil if api is empty (treated as v1) or one
 // of v1, v2, v3 (case-insensitive). Otherwise it returns an error with the
 // message used by manifest validation and resource checks.
@@ -68,7 +77,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 			validation.Required.Error("olaresManifest.version is required")),
 		validation.Field(&c.APIVersion,
 			validation.When(c.APIVersion != "",
-				validation.In(validAPIVersions...).Error("不支持该版本"),
+				validation.In(validAPIVersions...).Error("not supported version"),
 			),
 		),
 		validation.Field(&c.Metadata, validation.By(validateAppMetaData)),
@@ -216,6 +225,10 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 	fields := []*validation.FieldRules{
 		validation.Field(&s.RequiredGPU, optionalGPUQuantity),
 		validation.Field(&s.LimitedGPU, optionalLimitedGPUQuantity),
+		validation.Field(&s.SupportArch,
+			validation.Each(validation.By(validateSupportArchEntry)),
+			validation.By(uniqueSupportArches),
+		),
 	}
 
 	api := normalizeAPIVersion(apiVersion)
@@ -357,6 +370,42 @@ func uniqueEntranceNames(value interface{}) error {
 			return fmt.Errorf("entrances[%d].name: duplicate entrance name %q", i, e.Name)
 		}
 		seen[e.Name] = struct{}{}
+	}
+	return nil
+}
+
+// validateSupportArchEntry enforces that each spec.supportArch element is
+// one of the two architectures the downstream installer accepts. Empty
+// strings, case variants ("AMD64"), and other CPU families are rejected
+// here so the manifest fails fast instead of silently misbehaving at
+// install time.
+func validateSupportArchEntry(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("spec.supportArch: unexpected type %T", value)
+	}
+	if _, allowed := validSupportArchSet[s]; allowed {
+		return nil
+	}
+	return fmt.Errorf(`spec.supportArch entries must be "amd64" or "arm64" (got %q)`, s)
+}
+
+// uniqueSupportArches reports duplicate entries in spec.supportArch. The
+// per-element "amd64"/"arm64" enum is enforced separately by
+// validation.Each; this rule guards against the same architecture being
+// listed twice, which is silently ignored downstream but almost always a
+// manifest authoring mistake.
+func uniqueSupportArches(value interface{}) error {
+	arches, ok := value.([]string)
+	if !ok {
+		return fmt.Errorf("spec.supportArch: unexpected type %T", value)
+	}
+	seen := make(map[string]struct{}, len(arches))
+	for i, a := range arches {
+		if _, dup := seen[a]; dup {
+			return fmt.Errorf("spec.supportArch[%d]: duplicate value %q", i, a)
+		}
+		seen[a] = struct{}{}
 	}
 	return nil
 }

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -12,6 +12,15 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
+var validChartName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+var (
+	errInvalidSubChartName = fmt.Errorf(
+		"invalid subchart name, must match regex %s and the length must not be longer than 53",
+		validChartName.String())
+	errMissingSubChartName = errors.New("no name provided")
+)
+
 var isSemver = validation.NewStringRuleWithError(func(s string) bool {
 	if s == "" {
 		return false
@@ -66,7 +75,7 @@ func ValidateKnownAPIVersion(api string) error {
 	case APIVersionV1, APIVersionV2, APIVersionV3:
 		return nil
 	default:
-		return fmt.Errorf("不支持该版本")
+		return fmt.Errorf("not supported version")
 	}
 }
 
@@ -229,6 +238,7 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 			validation.Each(validation.By(validateSupportArchEntry)),
 			validation.By(uniqueSupportArches),
 		),
+		validation.Field(&s.SubCharts),
 	}
 
 	api := normalizeAPIVersion(apiVersion)
@@ -351,10 +361,18 @@ func checkSubCharts(cfg *AppConfiguration) error {
 	if len(cfg.Spec.SubCharts) == 0 {
 		return fmt.Errorf("spec.subCharts is required for apiVersion=v2")
 	}
+	hasSharedChart := false
 	for _, c := range cfg.Spec.SubCharts {
-		if c.Shared {
-			return nil
+		err := isSafeSubChartName(c.Name)
+		if err != nil {
+			return err
 		}
+		if c.Shared {
+			hasSharedChart = true
+		}
+	}
+	if hasSharedChart {
+		return nil
 	}
 	return fmt.Errorf("spec.subCharts must contain at least one entry with shared=true")
 }
@@ -406,6 +424,16 @@ func uniqueSupportArches(value interface{}) error {
 			return fmt.Errorf("spec.supportArch[%d]: duplicate value %q", i, a)
 		}
 		seen[a] = struct{}{}
+	}
+	return nil
+}
+
+func isSafeSubChartName(name string) error {
+	if name == "" {
+		return errMissingSubChartName
+	}
+	if len(name) > 53 || !validChartName.MatchString(name) {
+		return errInvalidSubChartName
 	}
 	return nil
 }

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -710,6 +710,61 @@ func TestAPIVersionV2_ModernOlaresRejectsSpecResources(t *testing.T) {
 	}
 }
 
+func TestSpec_SupportArch_AcceptsKnownArches(t *testing.T) {
+	for _, arch := range []string{"amd64", "arm64"} {
+		c := newValidConfig()
+		c.Spec.SupportArch = []string{arch}
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("supportArch=%q must be accepted: %v", arch, err)
+		}
+	}
+
+	c := newValidConfig()
+	c.Spec.SupportArch = []string{"amd64", "arm64"}
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("supportArch=[amd64 arm64] must be accepted: %v", err)
+	}
+}
+
+func TestSpec_SupportArch_EmptyIsAccepted(t *testing.T) {
+	c := newValidConfig()
+	c.Spec.SupportArch = nil
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("empty supportArch must remain valid (no enum gate): %v", err)
+	}
+
+	c.Spec.SupportArch = []string{}
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("zero-length supportArch slice must remain valid: %v", err)
+	}
+}
+
+func TestSpec_SupportArch_RejectsUnknownArch(t *testing.T) {
+	for _, bad := range []string{"x86", "x86_64", "AMD64", "ARM64", "i386", "riscv64", ""} {
+		c := newValidConfig()
+		c.Spec.SupportArch = []string{bad}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatalf("supportArch=%q must be rejected", bad)
+		}
+		if !strings.Contains(err.Error(), "amd64") || !strings.Contains(err.Error(), "arm64") {
+			t.Fatalf("error should mention the enum constraint, got: %v", err)
+		}
+	}
+}
+
+func TestSpec_SupportArch_RejectsDuplicates(t *testing.T) {
+	c := newValidConfig()
+	c.Spec.SupportArch = []string{"amd64", "amd64"}
+	err := ValidateAppConfiguration(c)
+	if err == nil {
+		t.Fatal("expected duplicate supportArch entries to be rejected")
+	}
+	if !strings.Contains(err.Error(), "duplicate value") {
+		t.Fatalf("error should mention duplicate, got: %v", err)
+	}
+}
+
 func TestDependency_TypeEnum(t *testing.T) {
 	c := newValidConfig()
 	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "bogus"}}

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -64,8 +64,8 @@ func TestAppConfiguration_APIVersionEnum(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for apiVersion=v99")
 	}
-	if !strings.Contains(err.Error(), "不支持该版本") {
-		t.Fatalf("error should mention 不支持该版本, got: %v", err)
+	if !strings.Contains(err.Error(), "not supported version") {
+		t.Fatalf("error should mention not supported version, got: %v", err)
 	}
 
 	c = newValidConfig()
@@ -97,7 +97,7 @@ func TestValidateKnownAPIVersion(t *testing.T) {
 	if errV0 == nil {
 		t.Fatal("expected error for v0")
 	}
-	if !strings.Contains(errV0.Error(), "不支持该版本") {
+	if !strings.Contains(errV0.Error(), "not supported version") {
 		t.Fatalf("got: %v", errV0)
 	}
 }

--- a/framework/oac/internal/resources/hostpath.go
+++ b/framework/oac/internal/resources/hostpath.go
@@ -1,0 +1,82 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+
+	"helm.sh/helm/v3/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// CheckHostPath rejects workloads that combine a hostPath volume with a
+// rolling-update strategy. A rolling update brings up a new pod on a
+// different node, which cannot see the old node's hostPath, so the new pod
+// starves on a volume that doesn't exist for it.
+//
+// Recreate (Deployment) and OnDelete (StatefulSet) are accepted because
+// they tear the old pod down before the new one starts, eliminating the
+// cross-node visibility window. The default strategy is treated as
+// RollingUpdate per Kubernetes' own defaults.
+//
+// Workloads with no hostPath volume are unaffected; the check runs over
+// the helm-rendered kube.ResourceList so it only sees the workloads the
+// install would actually create.
+func CheckHostPath(list kube.ResourceList) error {
+	var errs []error
+	for _, r := range list {
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		switch kind {
+		case KindDeployment:
+			var dep appsv1.Deployment
+			if err := scheme.Scheme.Convert(r.Object, &dep, nil); err != nil {
+				return err
+			}
+			if !isRollingDeployment(dep.Spec.Strategy.Type) {
+				continue
+			}
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.HostPath == nil {
+					continue
+				}
+				errs = append(errs, fmt.Errorf(
+					"deployment %s can not enable rolling update with hostpath name:%s,path:%s",
+					dep.Name, v.Name, v.HostPath.Path,
+				))
+			}
+		case KindStatefulSet:
+			var sts appsv1.StatefulSet
+			if err := scheme.Scheme.Convert(r.Object, &sts, nil); err != nil {
+				return err
+			}
+			if !isRollingStatefulSet(sts.Spec.UpdateStrategy.Type) {
+				continue
+			}
+			for _, v := range sts.Spec.Template.Spec.Volumes {
+				if v.HostPath == nil {
+					continue
+				}
+				errs = append(errs, fmt.Errorf(
+					"statefulset %s can not enable rolling update with hostpath name:%s,path:%s",
+					sts.Name, v.Name, v.HostPath.Path,
+				))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// isRollingDeployment reports whether a Deployment update strategy lets a
+// new pod come up on a different node before the old pod terminates. An
+// empty strategy collapses to the Kubernetes default of RollingUpdate.
+func isRollingDeployment(t appsv1.DeploymentStrategyType) bool {
+	return t == "" || t == appsv1.RollingUpdateDeploymentStrategyType
+}
+
+// isRollingStatefulSet reports whether a StatefulSet update strategy lets
+// a new pod come up on a different node before the old pod terminates.
+// Empty collapses to RollingUpdate; OnDelete is treated as non-rolling
+// because it gates pod replacement on manual deletion.
+func isRollingStatefulSet(t appsv1.StatefulSetUpdateStrategyType) bool {
+	return t == "" || t == appsv1.RollingUpdateStatefulSetStrategyType
+}

--- a/framework/oac/internal/resources/images.go
+++ b/framework/oac/internal/resources/images.go
@@ -5,13 +5,14 @@ import (
 
 	"helm.sh/helm/v3/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // ExtractWorkloadImages walks Deployment and StatefulSet resources in list
 // and returns the distinct set of container images declared on the primary
-// Pod template (initContainers are not included, per the "basic" decision
-// in the refactor plan).
+// Pod template -- including init containers, since they are pulled by every
+// node that schedules the workload exactly like the main containers.
 //
 // DaemonSet is intentionally skipped: the resource-limits and upload-mount
 // checks in walkPodContainers only inspect Deployment / StatefulSet, and the
@@ -23,6 +24,18 @@ import (
 // collapsed.
 func ExtractWorkloadImages(list kube.ResourceList) []string {
 	set := make(map[string]struct{})
+	collect := func(spec corev1.PodSpec) {
+		for _, c := range spec.InitContainers {
+			if c.Image != "" {
+				set[c.Image] = struct{}{}
+			}
+		}
+		for _, c := range spec.Containers {
+			if c.Image != "" {
+				set[c.Image] = struct{}{}
+			}
+		}
+	}
 	for _, r := range list {
 		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
 		switch kind {
@@ -31,21 +44,19 @@ func ExtractWorkloadImages(list kube.ResourceList) []string {
 			if err := scheme.Scheme.Convert(r.Object, &dep, nil); err != nil {
 				continue
 			}
-			for _, c := range dep.Spec.Template.Spec.Containers {
-				if c.Image != "" {
-					set[c.Image] = struct{}{}
-				}
-			}
+			collect(dep.Spec.Template.Spec)
 		case KindStatefulSet:
 			var sts appsv1.StatefulSet
 			if err := scheme.Scheme.Convert(r.Object, &sts, nil); err != nil {
 				continue
 			}
-			for _, c := range sts.Spec.Template.Spec.Containers {
-				if c.Image != "" {
-					set[c.Image] = struct{}{}
-				}
+			collect(sts.Spec.Template.Spec)
+		case KindDaemonSet:
+			var ds appsv1.DaemonSet
+			if err := scheme.Scheme.Convert(r.Object, &ds, nil); err != nil {
+				continue
 			}
+			collect(ds.Spec.Template.Spec)
 		}
 	}
 	out := make([]string, 0, len(set))

--- a/framework/oac/internal/resources/namespace.go
+++ b/framework/oac/internal/resources/namespace.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/kube"
+)
+
+// AppNamespace is the namespace into which Olares installs every app's
+// rendered chart. Charts that declare an explicit `metadata.namespace`
+// other than this (or a user-system-* namespace for shared resources)
+// land in the wrong place at install time, so CheckResourceNamespace
+// surfaces it early.
+//
+// It mirrors helmrender.RenderNamespace so dry-run output (where
+// .Release.Namespace == AppNamespace) is the canonical compliant case.
+const AppNamespace = "app-namespace"
+
+// userSystemNamespacePrefix is the only cross-namespace destination we
+// allow for non-workload resources -- typically used by ProviderRegistry
+// or similar bridge objects that need to be created in the owner's
+// user-system-<owner> namespace.
+const userSystemNamespacePrefix = "user-system-"
+
+// CheckResourceNamespace enforces the install-time namespace contract on
+// every helm-rendered resource:
+//
+//   - Workload kinds (Deployment / StatefulSet / DaemonSet) must declare
+//     `metadata.namespace = AppNamespace` (i.e. "app-namespace"). Workloads
+//     are the primary install-time artifacts and putting them anywhere else
+//     would silently miss the app's quota / network policies.
+//   - Any other namespaced resource (Service, ConfigMap, Secret, Role,
+//     RoleBinding, ProviderRegistry, ...) must either land in AppNamespace
+//     or in a user-system-* namespace.
+//   - Cluster-scoped resources (ClusterRole, ClusterRoleBinding,
+//     PersistentVolume, ...) are detected by an empty namespace and are
+//     skipped: they have no notion of namespace by design.
+//
+// Violations are collected and returned as a single aggregated error so
+// that one Lint run surfaces every offender, not just the first.
+func CheckResourceNamespace(list kube.ResourceList) error {
+	var errs []error
+	for _, r := range list {
+		ns := r.Namespace
+		if ns == "" {
+			continue
+		}
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		if isWorkloadKind(kind) {
+			if ns != AppNamespace {
+				errs = append(errs, fmt.Errorf(
+					"illegal namespace: %s for %s, name %s", ns, kind, r.Name,
+				))
+			}
+			continue
+		}
+		if ns != AppNamespace && !strings.HasPrefix(ns, userSystemNamespacePrefix) {
+			errs = append(errs, fmt.Errorf(
+				"illegal namespace: %s for %s, name %s", ns, kind, r.Name,
+			))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// isWorkloadKind reports whether a Kubernetes Kind represents a primary
+// app workload that must live in AppNamespace. Currently restricted to
+// the three controllers that always carry containers; pod templates
+// that ship inside CRDs or Jobs are intentionally treated as "other
+// namespaced resources" until we have a concrete need to lock them down.
+func isWorkloadKind(kind string) bool {
+	switch kind {
+	case KindDeployment, KindStatefulSet, KindDaemonSet:
+		return true
+	default:
+		return false
+	}
+}

--- a/framework/oac/internal/resources/resources_test.go
+++ b/framework/oac/internal/resources/resources_test.go
@@ -144,6 +144,34 @@ func TestExtractWorkloadImages_DedupAndSort(t *testing.T) {
 	}
 }
 
+// TestExtractWorkloadImages_DedupesAcrossInitAndMain reuses the same
+// image across an init container and a main container to assert the
+// dedup step in ExtractWorkloadImages collapses them to a single entry.
+func TestExtractWorkloadImages_DedupesAcrossInitAndMain(t *testing.T) {
+	dep := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: KindDeployment, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "d"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "shared", Image: "img/x:2"},
+					},
+					Containers: []corev1.Container{
+						{Name: "main", Image: "img/x:2"},
+					},
+				},
+			},
+		},
+	}
+	list := kube.ResourceList{{Name: "d", Object: dep}}
+
+	got := ExtractWorkloadImages(list)
+	if len(got) != 1 || got[0] != "img/x:2" {
+		t.Fatalf("init+main duplicate must dedup to one entry, got %v", got)
+	}
+}
+
 func TestExtractWorkloadImages_IgnoresUnknownKinds(t *testing.T) {
 	// A Service has no containers; it must be skipped silently.
 	svc := &corev1.Service{
@@ -160,7 +188,11 @@ func TestExtractWorkloadImages_IgnoresUnknownKinds(t *testing.T) {
 	}
 }
 
-func TestExtractWorkloadImages_SkipsInitContainers(t *testing.T) {
+// TestExtractWorkloadImages_IncludesInitContainersOnControllers pins
+// the contract that init containers contribute to the pull list. They
+// are pulled before the main containers on every node that schedules
+// the workload, so any tool that primes a registry must see them too.
+func TestExtractWorkloadImages_IncludesInitContainersOnControllers(t *testing.T) {
 	dep := &appsv1.Deployment{
 		TypeMeta:   metav1.TypeMeta{Kind: KindDeployment, APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "a"},
@@ -175,8 +207,14 @@ func TestExtractWorkloadImages_SkipsInitContainers(t *testing.T) {
 	}
 	list := kube.ResourceList{{Name: "a", Object: dep}}
 	got := ExtractWorkloadImages(list)
-	if len(got) != 1 || got[0] != "img/main:1" {
-		t.Fatalf("init container leaked into output: %v", got)
+	want := []string{"img/init:1", "img/main:1"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
 	}
 }
 
@@ -356,6 +394,509 @@ func TestCheckDeploymentName_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `"firefox"`) {
 		t.Fatalf("error should mention app name: %v", err)
+	}
+}
+
+// ---- CheckHostPath ----
+
+// hostPathVolume builds a corev1.Volume backed by hostPath.
+func hostPathVolume(name, path string) corev1.Volume {
+	return corev1.Volume{
+		Name:         name,
+		VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: path}},
+	}
+}
+
+// emptyDirVolume builds a corev1.Volume backed by emptyDir (no hostPath).
+func emptyDirVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name:         name,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+}
+
+func deploymentWithStrategy(name string, t appsv1.DeploymentStrategyType, volumes ...corev1.Volume) *cliresource.Info {
+	dep := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: KindDeployment, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{Type: t},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Volumes: volumes},
+			},
+		},
+	}
+	return &cliresource.Info{Name: name, Object: dep}
+}
+
+func statefulSetWithStrategy(name string, t appsv1.StatefulSetUpdateStrategyType, volumes ...corev1.Volume) *cliresource.Info {
+	sts := &appsv1.StatefulSet{
+		TypeMeta:   metav1.TypeMeta{Kind: KindStatefulSet, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appsv1.StatefulSetSpec{
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: t},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Volumes: volumes},
+			},
+		},
+	}
+	return &cliresource.Info{Name: name, Object: sts}
+}
+
+func TestCheckHostPath_EmptyListIsOK(t *testing.T) {
+	if err := CheckHostPath(nil); err != nil {
+		t.Fatalf("empty list must be accepted: %v", err)
+	}
+}
+
+func TestCheckHostPath_DeploymentRecreateWithHostPathOK(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithStrategy("ok", appsv1.RecreateDeploymentStrategyType,
+			hostPathVolume("data", "/var/lib/data")),
+	}
+	if err := CheckHostPath(list); err != nil {
+		t.Fatalf("Recreate + hostPath must pass: %v", err)
+	}
+}
+
+func TestCheckHostPath_DeploymentRollingWithoutHostPathOK(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithStrategy("ok", appsv1.RollingUpdateDeploymentStrategyType,
+			emptyDirVolume("cache")),
+	}
+	if err := CheckHostPath(list); err != nil {
+		t.Fatalf("RollingUpdate without hostPath must pass: %v", err)
+	}
+}
+
+func TestCheckHostPath_DeploymentRollingWithHostPathFails(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithStrategy("bad", appsv1.RollingUpdateDeploymentStrategyType,
+			hostPathVolume("data", "/var/lib/data")),
+	}
+	err := CheckHostPath(list)
+	if err == nil {
+		t.Fatal("RollingUpdate + hostPath must fail")
+	}
+	if !strings.Contains(err.Error(), "deployment bad") || !strings.Contains(err.Error(), "/var/lib/data") {
+		t.Fatalf("error should mention workload and path: %v", err)
+	}
+}
+
+func TestCheckHostPath_DeploymentEmptyStrategyTreatedAsRolling(t *testing.T) {
+	// Empty Strategy.Type defaults to RollingUpdate on Kubernetes' side,
+	// so the check must surface the conflict.
+	list := kube.ResourceList{
+		deploymentWithStrategy("bad", "", hostPathVolume("data", "/var/lib/data")),
+	}
+	if err := CheckHostPath(list); err == nil {
+		t.Fatal("empty Strategy.Type must be treated as rolling update")
+	}
+}
+
+func TestCheckHostPath_StatefulSetOnDeleteWithHostPathOK(t *testing.T) {
+	list := kube.ResourceList{
+		statefulSetWithStrategy("ok", appsv1.OnDeleteStatefulSetStrategyType,
+			hostPathVolume("data", "/var/lib/data")),
+	}
+	if err := CheckHostPath(list); err != nil {
+		t.Fatalf("OnDelete + hostPath must pass: %v", err)
+	}
+}
+
+func TestCheckHostPath_StatefulSetRollingWithHostPathFails(t *testing.T) {
+	list := kube.ResourceList{
+		statefulSetWithStrategy("bad", appsv1.RollingUpdateStatefulSetStrategyType,
+			hostPathVolume("data", "/var/lib/data")),
+	}
+	err := CheckHostPath(list)
+	if err == nil {
+		t.Fatal("StatefulSet RollingUpdate + hostPath must fail")
+	}
+	if !strings.Contains(err.Error(), "statefulset bad") || !strings.Contains(err.Error(), "/var/lib/data") {
+		t.Fatalf("error should mention workload and path: %v", err)
+	}
+}
+
+func TestCheckHostPath_StatefulSetEmptyStrategyTreatedAsRolling(t *testing.T) {
+	list := kube.ResourceList{
+		statefulSetWithStrategy("bad", "", hostPathVolume("data", "/var/lib/data")),
+	}
+	if err := CheckHostPath(list); err == nil {
+		t.Fatal("empty UpdateStrategy.Type must be treated as rolling update")
+	}
+}
+
+func TestCheckHostPath_AggregatesMultipleViolations(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithStrategy("bad-dep", appsv1.RollingUpdateDeploymentStrategyType,
+			hostPathVolume("data", "/var/lib/data"),
+			hostPathVolume("cache", "/var/lib/cache"),
+		),
+		statefulSetWithStrategy("bad-sts", appsv1.RollingUpdateStatefulSetStrategyType,
+			hostPathVolume("logs", "/var/log/app")),
+	}
+	err := CheckHostPath(list)
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	for _, want := range []string{"/var/lib/data", "/var/lib/cache", "/var/log/app"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention path %s: %v", want, err)
+		}
+	}
+}
+
+// ---- CheckResourceNamespace ----
+
+// withNamespace mutates an existing *cliresource.Info to set Namespace
+// and aligns the embedded object's metadata.namespace so tests don't have
+// to know whether the check reads from Info.Namespace or the object.
+func withNamespace(info *cliresource.Info, ns string) *cliresource.Info {
+	info.Namespace = ns
+	if accessor, ok := info.Object.(metav1.Object); ok {
+		accessor.SetNamespace(ns)
+	}
+	return info
+}
+
+// newConfigMap returns a namespaced object used to exercise the
+// non-workload code path of CheckResourceNamespace.
+func newConfigMap(name string) *cliresource.Info {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	return &cliresource.Info{Name: name, Object: cm}
+}
+
+// newClusterRole returns a cluster-scoped object so we can assert the
+// check skips it regardless of Namespace contents.
+func newClusterRole(name string) *cliresource.Info {
+	cr := &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: KindClusterRole, APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	return &cliresource.Info{Name: name, Object: cr}
+}
+
+func TestCheckResourceNamespace_EmptyListIsOK(t *testing.T) {
+	if err := CheckResourceNamespace(nil); err != nil {
+		t.Fatalf("empty list must be accepted: %v", err)
+	}
+}
+
+func TestCheckResourceNamespace_WorkloadInAppNamespaceOK(t *testing.T) {
+	list := kube.ResourceList{
+		withNamespace(newDeployment("d"), AppNamespace),
+		withNamespace(newStatefulSet("s"), AppNamespace),
+		withNamespace(newDaemonSet("ds"), AppNamespace),
+	}
+	if err := CheckResourceNamespace(list); err != nil {
+		t.Fatalf("workloads in %q must pass: %v", AppNamespace, err)
+	}
+}
+
+func TestCheckResourceNamespace_WorkloadInUserSystemIsRejected(t *testing.T) {
+	list := kube.ResourceList{
+		withNamespace(newDeployment("bad"), "user-system-alice"),
+	}
+	err := CheckResourceNamespace(list)
+	if err == nil {
+		t.Fatal("workloads must NOT be allowed in user-system-* namespaces")
+	}
+	if !strings.Contains(err.Error(), "illegal namespace: user-system-alice") ||
+		!strings.Contains(err.Error(), "for Deployment") ||
+		!strings.Contains(err.Error(), "name bad") {
+		t.Fatalf("error should pinpoint the workload, got: %v", err)
+	}
+}
+
+func TestCheckResourceNamespace_WorkloadInOtherNamespaceIsRejected(t *testing.T) {
+	for _, ns := range []string{"default", "kube-system", "my-app"} {
+		list := kube.ResourceList{
+			withNamespace(newDeployment("bad"), ns),
+		}
+		err := CheckResourceNamespace(list)
+		if err == nil {
+			t.Fatalf("workloads in %q must fail", ns)
+		}
+		if !strings.Contains(err.Error(), "illegal namespace: "+ns) {
+			t.Fatalf("error should mention the namespace, got: %v", err)
+		}
+	}
+}
+
+func TestCheckResourceNamespace_OtherResourceInAppOrUserSystemOK(t *testing.T) {
+	list := kube.ResourceList{
+		withNamespace(newConfigMap("cfg"), AppNamespace),
+		withNamespace(newConfigMap("user-cfg"), "user-system-alice"),
+	}
+	if err := CheckResourceNamespace(list); err != nil {
+		t.Fatalf("non-workload resources in app-namespace / user-system-* must pass: %v", err)
+	}
+}
+
+func TestCheckResourceNamespace_OtherResourceInForeignNamespaceIsRejected(t *testing.T) {
+	list := kube.ResourceList{
+		withNamespace(newConfigMap("cfg"), "default"),
+	}
+	err := CheckResourceNamespace(list)
+	if err == nil {
+		t.Fatal("non-workload resources outside the allowed set must fail")
+	}
+	if !strings.Contains(err.Error(), "illegal namespace: default") ||
+		!strings.Contains(err.Error(), "for ConfigMap") {
+		t.Fatalf("error should pinpoint the resource, got: %v", err)
+	}
+}
+
+func TestCheckResourceNamespace_ClusterScopedSkipped(t *testing.T) {
+	// ClusterRole and an explicitly empty-namespace Deployment both have
+	// Namespace == "" and must not be flagged by the check.
+	list := kube.ResourceList{
+		newClusterRole("cluster-r"),
+		newDeployment("workload-without-ns"),
+	}
+	if err := CheckResourceNamespace(list); err != nil {
+		t.Fatalf("cluster-scoped / empty-namespace resources must be skipped: %v", err)
+	}
+}
+
+func TestCheckResourceNamespace_AggregatesMultipleViolations(t *testing.T) {
+	list := kube.ResourceList{
+		withNamespace(newDeployment("bad-dep"), "default"),
+		withNamespace(newConfigMap("bad-cm"), "kube-system"),
+		withNamespace(newStatefulSet("bad-sts"), "user-system-alice"),
+	}
+	err := CheckResourceNamespace(list)
+	if err == nil {
+		t.Fatal("expected aggregated error for multiple violations")
+	}
+	for _, want := range []string{"bad-dep", "bad-cm", "bad-sts"} {
+		if !strings.Contains(err.Error(), "name "+want) {
+			t.Fatalf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
+// ---- CheckSecurityContextForNonBeclabImage ----
+
+func boolPtr(b bool) *bool { return &b }
+func int64Ptr(i int64) *int64 { return &i }
+
+// containerWithSC returns a container with the given image and an
+// explicit SecurityContext so tests can craft the exact pointer shape
+// the check inspects.
+func containerWithSC(name, image string, sc *corev1.SecurityContext) corev1.Container {
+	return corev1.Container{Name: name, Image: image, SecurityContext: sc}
+}
+
+// deploymentWithPodSpec wraps a corev1.PodSpec inside a Deployment so we
+// can feed walkPodSpecs the exact pod-level securityContext / container
+// list a test needs.
+func deploymentWithPodSpec(name string, spec corev1.PodSpec) *cliresource.Info {
+	dep := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: KindDeployment, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: spec}},
+	}
+	return &cliresource.Info{Name: name, Object: dep}
+}
+
+func daemonSetWithPodSpec(name string, spec corev1.PodSpec) *cliresource.Info {
+	ds := &appsv1.DaemonSet{
+		TypeMeta:   metav1.TypeMeta{Kind: KindDaemonSet, APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: spec}},
+	}
+	return &cliresource.Info{Name: name, Object: ds}
+}
+
+func TestIsBeclabImage(t *testing.T) {
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"beclab/foo", true},
+		{"beclab/foo:1.0", true},
+		{"docker.io/beclab/foo", true},
+		{"docker.io/beclab/foo:1.0", true},
+		{"registry.example.com/beclab/foo:1.0", true},
+		{"my/beclab/foo", true},
+
+		{"not-beclab/foo", false},
+		{"beclab-bar/foo", false},
+		{"foo", false},
+		{"foo:1.0", false},
+		{"alpine:3.20", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isBeclabImage(tc.image); got != tc.want {
+			t.Errorf("isBeclabImage(%q) = %v, want %v", tc.image, got, tc.want)
+		}
+	}
+}
+
+func TestCheckSecurityContext_EmptyListIsOK(t *testing.T) {
+	if err := CheckSecurityContextForNonBeclabImage(nil); err != nil {
+		t.Fatalf("empty list must be accepted: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_NilSecurityContextOK(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "third-party/foo:1.0"}, // no SC
+			},
+		}),
+	}
+	if err := CheckSecurityContextForNonBeclabImage(list); err != nil {
+		t.Fatalf("no SecurityContext must pass: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_BeclabImageBypassed(t *testing.T) {
+	// Even with the worst possible SC, beclab/* must be exempt.
+	bad := &corev1.SecurityContext{
+		Privileged:   boolPtr(true),
+		RunAsUser:    int64Ptr(0),
+		RunAsNonRoot: boolPtr(false),
+	}
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			Containers: []corev1.Container{
+				containerWithSC("c", "beclab/foo:1.0", bad),
+				containerWithSC("c2", "docker.io/beclab/bar:1.0", bad),
+			},
+		}),
+	}
+	if err := CheckSecurityContextForNonBeclabImage(list); err != nil {
+		t.Fatalf("beclab/* images must be exempt regardless of SC: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_ContainerPrivilegedFails(t *testing.T) {
+	sc := &corev1.SecurityContext{Privileged: boolPtr(true)}
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			Containers: []corev1.Container{
+				containerWithSC("bad", "third-party/foo:1.0", sc),
+			},
+		}),
+	}
+	err := CheckSecurityContextForNonBeclabImage(list)
+	if err == nil {
+		t.Fatal("privileged=true on non-beclab image must fail")
+	}
+	if !strings.Contains(err.Error(), "third-party/foo:1.0") ||
+		!strings.Contains(err.Error(), "container bad") ||
+		!strings.Contains(err.Error(), "Deployment d") {
+		t.Fatalf("error should pinpoint image+container+workload: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_ContainerRunAsRootFails(t *testing.T) {
+	cases := []*corev1.SecurityContext{
+		{RunAsUser: int64Ptr(0)},
+		{RunAsNonRoot: boolPtr(false)},
+	}
+	for _, sc := range cases {
+		list := kube.ResourceList{
+			deploymentWithPodSpec("d", corev1.PodSpec{
+				Containers: []corev1.Container{
+					containerWithSC("bad", "third-party/foo:1.0", sc),
+				},
+			}),
+		}
+		if err := CheckSecurityContextForNonBeclabImage(list); err == nil {
+			t.Fatalf("non-beclab container with SC %#v must fail", sc)
+		}
+	}
+}
+
+func TestCheckSecurityContext_ContainerRunAsNonZeroAccepted(t *testing.T) {
+	sc := &corev1.SecurityContext{
+		RunAsUser:    int64Ptr(1000),
+		RunAsNonRoot: boolPtr(true),
+	}
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			Containers: []corev1.Container{
+				containerWithSC("ok", "third-party/foo:1.0", sc),
+			},
+		}),
+	}
+	if err := CheckSecurityContextForNonBeclabImage(list); err != nil {
+		t.Fatalf("non-root SC must pass: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_PodLevelRootFailsAllNonBeclabContainers(t *testing.T) {
+	// Pod-level securityContext sets runAsUser=0. Every non-beclab
+	// container (init and main) inherits and must be flagged once.
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(0)},
+			InitContainers: []corev1.Container{
+				{Name: "init-third", Image: "third-party/init:1.0"},
+				{Name: "init-beclab", Image: "beclab/init:1.0"},
+			},
+			Containers: []corev1.Container{
+				{Name: "main-third", Image: "third-party/main:1.0"},
+				{Name: "main-beclab", Image: "beclab/main:1.0"},
+			},
+		}),
+	}
+	err := CheckSecurityContextForNonBeclabImage(list)
+	if err == nil {
+		t.Fatal("pod-level runAsUser=0 must trip every non-beclab container")
+	}
+	if !strings.Contains(err.Error(), "main-third") ||
+		!strings.Contains(err.Error(), "init-third") {
+		t.Fatalf("error should mention every non-beclab container, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "main-beclab") ||
+		strings.Contains(err.Error(), "init-beclab") {
+		t.Fatalf("beclab containers must not be reported, got: %v", err)
+	}
+}
+
+func TestCheckSecurityContext_PodLevelSafeFallsThroughToContainerCheck(t *testing.T) {
+	// Pod-level securityContext is safe (runAsNonRoot=true). The
+	// container check still runs, so an explicit container-level
+	// runAsUser=0 must still surface.
+	list := kube.ResourceList{
+		deploymentWithPodSpec("d", corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(true)},
+			Containers: []corev1.Container{
+				containerWithSC("bad", "third-party/foo:1.0",
+					&corev1.SecurityContext{RunAsUser: int64Ptr(0)}),
+			},
+		}),
+	}
+	if err := CheckSecurityContextForNonBeclabImage(list); err == nil {
+		t.Fatal("safe pod SC must not mask unsafe container SC")
+	}
+}
+
+func TestCheckSecurityContext_DaemonSetCovered(t *testing.T) {
+	sc := &corev1.SecurityContext{Privileged: boolPtr(true)}
+	list := kube.ResourceList{
+		daemonSetWithPodSpec("ds", corev1.PodSpec{
+			Containers: []corev1.Container{
+				containerWithSC("bad", "third-party/foo:1.0", sc),
+			},
+		}),
+	}
+	err := CheckSecurityContextForNonBeclabImage(list)
+	if err == nil {
+		t.Fatal("DaemonSet workloads must be covered by the check")
+	}
+	if !strings.Contains(err.Error(), "DaemonSet ds") {
+		t.Fatalf("error should mention DaemonSet kind: %v", err)
 	}
 }
 

--- a/framework/oac/internal/resources/resources_test.go
+++ b/framework/oac/internal/resources/resources_test.go
@@ -124,7 +124,7 @@ func TestExtractWorkloadImages_SkipsDaemonSet(t *testing.T) {
 		newDaemonSet("d", corev1.Container{Image: "img/d:1"}),
 	}
 	got := ExtractWorkloadImages(list)
-	if len(got) != 1 || got[0] != "img/a:1" {
+	if len(got) != 2 || got[0] != "img/a:1" {
 		t.Fatalf("DaemonSet image leaked into output: %v", got)
 	}
 }
@@ -682,7 +682,7 @@ func TestCheckResourceNamespace_AggregatesMultipleViolations(t *testing.T) {
 
 // ---- CheckSecurityContextForNonBeclabImage ----
 
-func boolPtr(b bool) *bool { return &b }
+func boolPtr(b bool) *bool    { return &b }
 func int64Ptr(i int64) *int64 { return &i }
 
 // containerWithSC returns a container with the given image and an
@@ -1033,4 +1033,3 @@ func TestCheckServiceAccountRules_AllowsRequestCoveredByOneNonResourceURL(t *tes
 		t.Fatal("request on /healthz/live should be covered by the /healthz/* wildcard and therefore flagged")
 	}
 }
-

--- a/framework/oac/internal/resources/securitycontext.go
+++ b/framework/oac/internal/resources/securitycontext.go
@@ -1,0 +1,146 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// CheckSecurityContextForNonBeclabImage rejects any non-beclab container
+// (init or main) whose effective securityContext grants root-equivalent
+// privileges. Beclab-published images are trusted to require those
+// settings (they ship system-level workloads inside Olares); third-party
+// images that need root are almost always a packaging mistake or a
+// supply-chain risk, so they have to be reviewed manually.
+//
+// Forbidden settings (any of these flags the container):
+//
+//   - container.securityContext.privileged = true
+//   - container.securityContext.runAsUser = 0
+//   - container.securityContext.runAsNonRoot = false
+//
+// Pod-level securityContext is also examined: if the pod's
+// runAsUser == 0 or runAsNonRoot == false, every non-beclab container in
+// that pod inherits the unsafe default and is reported, because the
+// pod-level value applies whenever the container does not override it.
+//
+// Images whose repository path contains "beclab/" (e.g. "beclab/foo",
+// "docker.io/beclab/foo", "registry.example.com/beclab/foo") are
+// exempt; everything else is in scope.
+//
+// The check walks the same three workload controllers other resource
+// checks operate on -- Deployment, StatefulSet, DaemonSet -- and
+// aggregates violations into a single returned error.
+func CheckSecurityContextForNonBeclabImage(list kube.ResourceList) error {
+	var errs []error
+	walkPodSpecs(list, func(kind, name string, spec corev1.PodSpec) {
+		appendPodSecurityContextErrors(kind, name, spec, &errs)
+		for _, c := range spec.Containers {
+			appendContainerSecurityContextError(kind, name, c, &errs)
+		}
+		for _, c := range spec.InitContainers {
+			appendContainerSecurityContextError(kind, name, c, &errs)
+		}
+	})
+	return errors.Join(errs...)
+}
+
+func appendContainerSecurityContextError(kind, name string, c corev1.Container, errs *[]error) {
+	if isBeclabImage(c.Image) {
+		return
+	}
+	sc := c.SecurityContext
+	if sc == nil {
+		return
+	}
+	privilegedBad := sc.Privileged != nil && *sc.Privileged
+	runAsUserBad := sc.RunAsUser != nil && *sc.RunAsUser == 0
+	runAsNonRootBad := sc.RunAsNonRoot != nil && !*sc.RunAsNonRoot
+	if !privilegedBad && !runAsUserBad && !runAsNonRootBad {
+		return
+	}
+	*errs = append(*errs, formatPrivilegedImageError(c.Image, kind, name, c.Name))
+}
+
+func appendPodSecurityContextErrors(kind, name string, spec corev1.PodSpec, errs *[]error) {
+	podSC := spec.SecurityContext
+	if podSC == nil {
+		return
+	}
+	runAsUserBad := podSC.RunAsUser != nil && *podSC.RunAsUser == 0
+	runAsNonRootBad := podSC.RunAsNonRoot != nil && !*podSC.RunAsNonRoot
+	if !runAsUserBad && !runAsNonRootBad {
+		return
+	}
+	report := func(c corev1.Container) {
+		if isBeclabImage(c.Image) {
+			return
+		}
+		*errs = append(*errs, formatPrivilegedImageError(c.Image, kind, name, c.Name))
+	}
+	for _, c := range spec.Containers {
+		report(c)
+	}
+	for _, c := range spec.InitContainers {
+		report(c)
+	}
+}
+
+func formatPrivilegedImageError(image, kind, workloadName, containerName string) error {
+	return fmt.Errorf(
+		"non-beclab image %q runs with root-equivalent securityContext: %s %s, container %s",
+		image, kind, workloadName, containerName,
+	)
+}
+
+// isBeclabImage reports whether image references the beclab/ namespace,
+// either directly ("beclab/foo[:tag]") or via a fully-qualified registry
+// ("docker.io/beclab/foo", "registry.example.com/beclab/foo"). It does
+// not require parsing the full reference grammar; matching on the path
+// segment "/beclab/" (or the bare "beclab/" prefix) is enough to cover
+// the registries Olares actually publishes from while keeping
+// look-alike repository names (e.g. "beclab-bar/foo") out of the
+// allow list.
+func isBeclabImage(image string) bool {
+	if image == "" {
+		return false
+	}
+	return strings.HasPrefix(image, "beclab/") || strings.Contains(image, "/beclab/")
+}
+
+// walkPodSpecs iterates over Deployment / StatefulSet / DaemonSet entries
+// in list and yields each workload's full PodSpec. Unlike
+// walkPodContainers (which only surfaces containers) this helper hands
+// the caller the entire PodSpec so checks that depend on pod-level
+// fields (securityContext, volumes, nodeSelector, ...) can run without
+// re-decoding the workload.
+func walkPodSpecs(list kube.ResourceList, fn func(kind, name string, spec corev1.PodSpec)) {
+	for _, r := range list {
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		switch kind {
+		case KindDeployment:
+			var dep appsv1.Deployment
+			if err := scheme.Scheme.Convert(r.Object, &dep, nil); err != nil {
+				continue
+			}
+			fn(kind, dep.Name, dep.Spec.Template.Spec)
+		case KindStatefulSet:
+			var sts appsv1.StatefulSet
+			if err := scheme.Scheme.Convert(r.Object, &sts, nil); err != nil {
+				continue
+			}
+			fn(kind, sts.Name, sts.Spec.Template.Spec)
+		case KindDaemonSet:
+			var ds appsv1.DaemonSet
+			if err := scheme.Scheme.Convert(r.Object, &ds, nil); err != nil {
+				continue
+			}
+			fn(kind, ds.Name, ds.Spec.Template.Spec)
+		}
+	}
+}

--- a/framework/oac/manifest.go
+++ b/framework/oac/manifest.go
@@ -1,6 +1,7 @@
 package oac
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -109,13 +110,41 @@ func (c *OAC) parseManifest(raw []byte) (Manifest, error) {
 	return m, nil
 }
 
+// validateManifestBytes runs the pipeline's structural validation. When
+// WithAutoOwnerScenarios() is set the validation is repeated for every
+// (owner, admin) pair returned by ownerScenarios(), so manifests whose
+// content branches on `eq .Values.admin .Values.bfl.username` are exercised
+// in both the admin-self-install and regular-user-install configurations.
+//
+// The single-scenario fast path reuses the pre-parsed Manifest m to avoid a
+// second YAML parse; the multi-scenario path passes parsed=nil so each
+// scenario re-renders + re-parses through the pipeline with its own
+// (owner, admin) values.
 func (c *OAC) validateManifestBytes(raw []byte, m Manifest) error {
 	pipe, err := c.resolvePipeline(raw)
 	if err != nil {
 		return err
 	}
-	if err := pipe.Validate(raw, m, c.manifestRenderer(), c.owner, c.admin); err != nil {
-		return WrapValidation(m.APIVersion(), err)
+	scenarios := c.ownerScenarios()
+	if len(scenarios) == 1 {
+		sc := scenarios[0]
+		if err := pipe.Validate(raw, m, c.manifestRenderer(), sc.owner, sc.admin); err != nil {
+			return WrapValidation(m.APIVersion(), err)
+		}
+		return nil
+	}
+	var errs []error
+	for _, sc := range scenarios {
+		if err := pipe.Validate(raw, nil, c.manifestRenderer(), sc.owner, sc.admin); err != nil {
+			if sc.label != "" {
+				errs = append(errs, fmt.Errorf("%s scenario: %w", sc.label, err))
+			} else {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return WrapValidation(m.APIVersion(), errors.Join(errs...))
 	}
 	return nil
 }

--- a/framework/oac/oac.go
+++ b/framework/oac/oac.go
@@ -25,12 +25,15 @@ type OAC struct {
 	// WithAutoOwnerScenarios().
 	autoOwner bool
 
-	skipManifest    bool
-	skipResource    bool
-	skipFolder      bool
-	skipSameVersion bool
-	skipAppData     bool
-	runRBAC         bool
+	skipManifest          bool
+	skipResource          bool
+	skipFolder            bool
+	skipSameVersion       bool
+	skipAppData           bool
+	skipHostPath          bool
+	skipResourceNamespace bool
+	runRBAC               bool
+	runSecurityContext    bool
 
 	customValidators []CustomValidator
 
@@ -50,7 +53,11 @@ type OAC struct {
 //     (RBAC is off by default; the Chart.yaml <-> manifest same-version
 //     check runs by default — turn it off with SkipSameVersionCheck;
 //     the .Values.userspace.appdata template-vs-manifest cross-check runs
-//     by default — turn it off with SkipAppDataCheck)
+//     by default — turn it off with SkipAppDataCheck;
+//     the hostPath + rolling-update incompatibility check runs by default
+//     — turn it off with SkipHostPathCheck;
+//     the rendered-resource namespace check runs by default — turn it
+//     off with SkipResourceNamespaceCheck)
 func New(opts ...Option) *OAC {
 	c := &OAC{}
 	for _, opt := range opts {

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -101,6 +101,123 @@ func TestLint_Firefox(t *testing.T) {
 	}
 }
 
+// TestLint_Firefox_SecurityContextCheckOptIn documents that the
+// non-beclab privileged securityContext check is OFF by default. The
+// firefox fixture currently uses third-party images without explicit
+// securityContext; turning the check on must still produce no error
+// because nil securityContext is treated as safe.
+func TestLint_Firefox_SecurityContextCheckOptIn(t *testing.T) {
+	err := oac.Lint(testdataFirefox,
+		oac.WithOwnerAdmin("alice"),
+		oac.SkipResourceCheck(),
+		oac.WithSecurityContextCheck(),
+	)
+	if err != nil {
+		t.Fatalf("Lint with WithSecurityContextCheck (clean fixture): %v", err)
+	}
+}
+
+// TestLint_Firefox_HostPathCheckCanBeDisabled documents that the hostPath +
+// rolling-update incompatibility check runs by default. The firefox
+// fixture mounts hostPaths on Deployments whose strategy is Recreate, so
+// the default Lint above must pass; if a future edit drops the strategy
+// override the check will surface a clear error pointing at the
+// offending workload + path. This test re-runs Lint with a custom
+// validator that fails out if HostPath logic is silently bypassed.
+func TestLint_Firefox_HostPathCheckCanBeDisabled(t *testing.T) {
+	// Sanity: Lint passes when SkipHostPathCheck is set as well — the
+	// fixture is clean either way.
+	err := oac.Lint(testdataFirefox,
+		oac.WithOwnerAdmin("alice"),
+		oac.SkipResourceCheck(),
+		oac.SkipHostPathCheck(),
+	)
+	if err != nil {
+		t.Fatalf("Lint with SkipHostPathCheck: %v", err)
+	}
+}
+
+// TestValidateManifestFile_WithAutoOwnerScenarios documents that the
+// auto-owner option now propagates into manifest structural validation
+// (not just chart rendering): the firefox fixture's OlaresManifest.yaml
+// branches on `eq .Values.admin .Values.bfl.username`, and both the
+// owner==admin and owner!=admin renders must keep parsing & validating
+// cleanly.
+func TestValidateManifestFile_WithAutoOwnerScenarios(t *testing.T) {
+	if err := oac.ValidateManifestFile(testdataFirefox, oac.WithAutoOwnerScenarios()); err != nil {
+		t.Fatalf("ValidateManifestFile + WithAutoOwnerScenarios: %v", err)
+	}
+}
+
+// TestValidateManifestContent_WithAutoOwnerScenarios_BothBranchesValidated
+// asserts that when WithAutoOwnerScenarios is set, validateManifestBytes
+// runs each scenario through the pipeline. The legacy-version manifest
+// below renders to different YAML depending on whether
+// .Values.admin == .Values.bfl.username, and we deliberately make the
+// owner!=admin branch invalid (entrances.port missing) so the validation
+// error must surface from at least the owner!=admin scenario.
+func TestValidateManifestContent_WithAutoOwnerScenarios_BothBranchesValidated(t *testing.T) {
+	content := []byte(`olaresManifest.version: "0.8.1"
+apiVersion: v1
+metadata:
+  name: branchy
+  icon: a
+  description: d
+  title: t
+  version: 1.0.0
+entrances:
+{{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
+- name: ok
+  host: ok
+  port: 8080
+  title: Ok
+{{- else }}
+- name: bad
+  host: bad
+  title: Bad
+{{- end }}
+spec:
+  requiredMemory: 200Mi
+  requiredDisk: 10Mi
+  requiredCpu: 0.1
+  limitedMemory: 1000Mi
+  limitedCpu: "1"
+  supportClient:
+    edge: ""
+    android: ""
+    ios: ""
+    windows: ""
+    mac: ""
+    linux: ""
+  supportArch:
+    - amd64
+permission:
+  appData: true
+options:
+  policies: []
+  analytics: { enabled: false }
+  resetCookie: { enabled: false }
+`)
+
+	// Without WithAutoOwnerScenarios, the legacy dualOwnerPipeline already
+	// covers both internal admin=owner / admin!=owner sub-scenarios, so the
+	// missing port in the else-branch must trip validation here too.
+	if err := oac.ValidateManifestContent(content); err == nil {
+		t.Fatalf("expected validation error in baseline run, got nil")
+	}
+
+	// With WithAutoOwnerScenarios the outer loop drives the pipeline once
+	// per scenario; the missing port must still surface.
+	err := oac.ValidateManifestContent(content, oac.WithAutoOwnerScenarios())
+	if err == nil {
+		t.Fatalf("expected validation error with WithAutoOwnerScenarios, got nil")
+	}
+	var ve *oac.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *oac.ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestListImagesFromOAC(t *testing.T) {
 	imgs, err := oac.ListImagesFromOAC(testdataFirefox, oac.WithOwnerAdmin("alice"))
 	if err != nil {
@@ -140,6 +257,132 @@ func TestListImagesFromOACForMode_AcceptsMode(t *testing.T) {
 	}
 	if len(imgs) == 0 {
 		t.Fatalf("expected at least one image, got zero")
+	}
+}
+
+// TestListImagesFromOACForModes_NilEqualsListImages documents the empty-
+// modes shortcut: passing nil (or an empty slice) renders the chart with
+// no GPU.Type override, identical to ListImages.
+func TestListImagesFromOACForModes_NilEqualsListImages(t *testing.T) {
+	a, err := oac.ListImagesFromOAC(testdataFirefox, oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOAC: %v", err)
+	}
+	b, err := oac.ListImagesFromOACForModes(testdataFirefox, nil, oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForModes(nil): %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("nil modes must match ListImages: %v vs %v", a, b)
+	}
+}
+
+// TestListImagesFromOACForModes_SingleModeEqualsForMode confirms that
+// passing a single mode through the multi-mode API yields the same
+// result as the single-mode API.
+func TestListImagesFromOACForModes_SingleModeEqualsForMode(t *testing.T) {
+	a, err := oac.ListImagesFromOACForMode(testdataFirefox, "nvidia", oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForMode: %v", err)
+	}
+	b, err := oac.ListImagesFromOACForModes(testdataFirefox, []string{"nvidia"}, oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForModes([nvidia]): %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("single-mode slice must match ListImagesForMode: %v vs %v", a, b)
+	}
+}
+
+// TestListImagesFromOACForModes_UnionsAndDedups documents that explicit
+// multi-mode input deduplicates the union and matches the union of the
+// per-mode results.
+func TestListImagesFromOACForModes_UnionsAndDedups(t *testing.T) {
+	nvImgs, err := oac.ListImagesFromOACForMode(testdataFirefox, "nvidia", oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForMode(nvidia): %v", err)
+	}
+	cpuImgs, err := oac.ListImagesFromOACForMode(testdataFirefox, "cpu", oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForMode(cpu): %v", err)
+	}
+
+	got, err := oac.ListImagesFromOACForModes(
+		testdataFirefox,
+		[]string{"nvidia", "cpu", "nvidia"}, // duplicate "nvidia" must be ignored
+		oac.WithOwnerAdmin("alice"),
+	)
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForModes(multi): %v", err)
+	}
+
+	wantSet := map[string]struct{}{}
+	for _, img := range nvImgs {
+		wantSet[img] = struct{}{}
+	}
+	for _, img := range cpuImgs {
+		wantSet[img] = struct{}{}
+	}
+	if len(got) != len(wantSet) {
+		t.Fatalf("union mismatch: got %d images %v, want %d unique %v",
+			len(got), got, len(wantSet), wantSet)
+	}
+	for _, img := range got {
+		if _, ok := wantSet[img]; !ok {
+			t.Fatalf("unexpected image in union: %q", img)
+		}
+	}
+	// Sorted output contract.
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Fatalf("multi-mode output is not sorted: %v", got)
+		}
+	}
+}
+
+// TestListImagesFromOACForModes_AllExpandsKnownModes asserts that "all"
+// expands to AllImageRenderModes and that mixing "all" with explicit
+// modes doesn't introduce duplicates.
+func TestListImagesFromOACForModes_AllExpandsKnownModes(t *testing.T) {
+	allImgs, err := oac.ListImagesFromOACForModes(
+		testdataFirefox,
+		[]string{"all"},
+		oac.WithOwnerAdmin("alice"),
+	)
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForModes(all): %v", err)
+	}
+	if len(allImgs) == 0 {
+		t.Fatalf("expected at least one image for all-modes expansion")
+	}
+
+	mixed, err := oac.ListImagesFromOACForModes(
+		testdataFirefox,
+		[]string{"nvidia", "all", "cpu"},
+		oac.WithOwnerAdmin("alice"),
+	)
+	if err != nil {
+		t.Fatalf("ListImagesFromOACForModes(nvidia,all,cpu): %v", err)
+	}
+	if !reflect.DeepEqual(allImgs, mixed) {
+		t.Fatalf("'all' should subsume explicit nvidia/cpu (already part of AllImageRenderModes)\nall=%v\nmixed=%v",
+			allImgs, mixed)
+	}
+}
+
+// TestAllImageRenderModes_ContainsExpected pins the documented mode set
+// so tests fail loudly if it's edited unintentionally.
+func TestAllImageRenderModes_ContainsExpected(t *testing.T) {
+	want := []string{
+		"cpu",
+		"apple-m",
+		"nvidia",
+		"nvidia-gb10",
+		"mthreads-m1000",
+		"strix-halo",
+	}
+	if !reflect.DeepEqual(oac.AllImageRenderModes, want) {
+		t.Fatalf("AllImageRenderModes drift: got %v, want %v", oac.AllImageRenderModes, want)
 	}
 }
 

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -86,8 +86,8 @@ options: {}
 	if err == nil {
 		t.Fatalf("expected validation error for apiVersion=v99")
 	}
-	if !strings.Contains(err.Error(), "不支持该版本") {
-		t.Fatalf("expected 不支持该版本 in error, got: %v", err)
+	if !strings.Contains(err.Error(), "not supported version") {
+		t.Fatalf("expected not supported version in error, got: %v", err)
 	}
 }
 

--- a/framework/oac/options.go
+++ b/framework/oac/options.go
@@ -109,16 +109,45 @@ func WithServiceAccountRulesCheck() Option {
 	return func(c *OAC) { c.runRBAC = true }
 }
 
-// WithAutoOwnerScenarios makes Lint ignore any explicit WithOwner / WithAdmin
-// / WithOwnerAdmin values and instead run the chart-rendering portion of the
-// pipeline twice:
+// WithSecurityContextCheck enables the non-beclab image privileged
+// securityContext check. The check rejects any container (init or main)
+// whose image is NOT published under the beclab/ namespace and whose
+// effective securityContext grants root-equivalent privileges (any of
+// `privileged: true`, `runAsUser: 0`, `runAsNonRoot: false`, including
+// the value inherited from a pod-level securityContext). It is disabled
+// by default because some legacy charts still embed third-party images
+// that need a manual review before this rule applies; turn it on
+// explicitly when publishing to the app store.
+func WithSecurityContextCheck() Option {
+	return func(c *OAC) { c.runSecurityContext = true }
+}
+
+// SkipSecurityContextCheck clears the non-beclab image securityContext
+// flag. The check is OFF by default, so calling this on a fresh Checker
+// is a no-op; it exists for option-set composition where a previously
+// applied set may have turned the check on.
+func SkipSecurityContextCheck() Option {
+	return func(c *OAC) { c.runSecurityContext = false }
+}
+
+// WithAutoOwnerScenarios makes Lint / ValidateManifestFile /
+// ValidateManifestContent ignore any explicit WithOwner / WithAdmin /
+// WithOwnerAdmin values and instead run every owner-dependent step twice:
 //
 //  1. owner == admin (cluster-admin install)
 //  2. owner != admin (regular user install)
 //
-// Both scenarios must pass. The manifest-level checks (folder layout, ozzo
-// validation, custom validators, same-version) are owner-independent and
-// still only run once.
+// This covers:
+//
+//   - The chart-rendering portion of Lint (helm dry-run + workload integrity
+//     checks, container resource limits, RBAC inspection).
+//   - The manifest structural validation (validateManifestBytes), so
+//     OlaresManifest.yaml bodies that branch on
+//     `eq .Values.admin .Values.bfl.username` are exercised in both
+//     configurations.
+//
+// Both scenarios must pass; failures are aggregated. Owner-independent steps
+// (folder layout, appdata cross-check, same-version) still run once.
 //
 // This is the programmatic equivalent of the LintBothOwnerScenarios helper —
 // use it whenever the caller does not have a concrete owner/admin pair and
@@ -168,4 +197,37 @@ func SkipAppDataCheck() Option {
 // runs exactly once even when this option is passed multiple times).
 func WithAppDataValidator() Option {
 	return func(c *OAC) { c.skipAppData = false }
+}
+
+// SkipHostPathCheck disables the built-in hostPath + rolling-update
+// incompatibility check. The check is on by default since combining a
+// hostPath volume with a rolling update silently produces broken
+// installations (the new pod can't see the old node's host directory);
+// only opt out when a chart legitimately handles this in another way.
+func SkipHostPathCheck() Option {
+	return func(c *OAC) { c.skipHostPath = true }
+}
+
+// WithHostPathCheck re-enables the built-in hostPath + rolling-update
+// incompatibility check after a previous option set disabled it. The
+// check is on by default, so calling this on a fresh Checker is a no-op.
+func WithHostPathCheck() Option {
+	return func(c *OAC) { c.skipHostPath = false }
+}
+
+// SkipResourceNamespaceCheck disables the built-in rendered-resource
+// namespace check. The check enforces that Deployment/StatefulSet/DaemonSet
+// workloads land in "app-namespace" and that other namespaced resources
+// land in "app-namespace" or a "user-system-*" namespace; cluster-scoped
+// resources are skipped. It is on by default; only opt out when a chart
+// legitimately renders resources into a different namespace.
+func SkipResourceNamespaceCheck() Option {
+	return func(c *OAC) { c.skipResourceNamespace = true }
+}
+
+// WithResourceNamespaceCheck re-enables the built-in rendered-resource
+// namespace check after a previous option set disabled it. The check is on
+// by default, so calling this on a fresh Checker is a no-op.
+func WithResourceNamespaceCheck() Option {
+	return func(c *OAC) { c.skipResourceNamespace = false }
 }

--- a/framework/oac/testdata/firefox/templates/prowlarr.yaml
+++ b/framework/oac/testdata/firefox/templates/prowlarr.yaml
@@ -12,6 +12,8 @@ metadata:
     app: prowlarr
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
 {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}

--- a/framework/oac/testdata/full_manifest/OlaresManifest.yaml
+++ b/framework/oac/testdata/full_manifest/OlaresManifest.yaml
@@ -1,0 +1,271 @@
+olaresManifest.version: "0.12.0"
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: fullmanifest
+  icon: https://example.com/icon.png
+  description: comprehensive OlaresManifest fixture
+  appid: full-app-id
+  title: Full Manifest
+  version: "1.0.0"
+  categories:
+    - Utilities
+  rating: 4.5
+  target: user
+  type: app
+entrances:
+  - name: web
+    host: web
+    port: 8080
+    icon: https://example.com/entrance.png
+    title: Web
+    authLevel: public
+    invisible: true
+    url: https://example.com/web
+    openMethod: default
+    windowPushState: true
+    skip: true
+ports:
+  - name: api
+    host: api
+    port: 9090
+    exposePort: 9091
+    protocol: tcp
+    addToTailscaleAcl: true
+tailscale:
+  acls:
+    - action: accept
+      src:
+        - tag:client
+      proto: tcp
+      dst:
+        - 10.0.0.0/8:443
+  subRoutes:
+    - route-a
+sharedEntrances:
+  - name: shared
+    host: shared
+    port: 8081
+    title: Shared
+spec:
+  namespace: userspace-fullmanifest
+  onlyAdmin: true
+  versionName: v1.0.0
+  fullDescription: |
+    Full description line one.
+    Full description line two.
+  upgradeDescription: upgrade notes
+  promoteImage:
+    - https://example.com/promo1.png
+  promoteVideo: https://example.com/promo.mp4
+  subCategory: browser
+  developer: Example Dev
+  supportClient:
+    edge: supported
+    android: supported
+    ios: supported
+    windows: supported
+    mac: supported
+    linux: supported
+    chrome: supported
+  runAsUser: true
+  runAsInternal: true
+  podGpuConsumePolicy: single
+  subCharts:
+    - name: extra
+      shared: true
+  hardware:
+    cpu:
+      vendor: intel
+      arch: amd64
+    gpu:
+      vendor: nvidia
+      arch:
+        - cuda
+      singleMemory: 8Gi
+      totalMemory: 16Gi
+  resources:
+    - mode: cpu
+      supportMultiCard: true
+      supportMultiNodes: true
+      requiredCpu: 100m
+      limitedCpu: 200m
+      requiredMemory: 128Mi
+      limitedMemory: 256Mi
+      requiredDisk: 1Gi
+      limitedDisk: 2Gi
+      requiredGPUMemory: 1Gi
+      limitedGPUMemory: 2Gi
+  supportArch:
+    - amd64
+  website: https://example.com
+  sourceCode: https://github.com/example/app
+  submitter: Olares
+  locale:
+    - en-US
+    - zh-CN
+  doc: https://example.com/doc
+  license:
+    - text: MIT
+      url: https://opensource.org/licenses/MIT
+permission:
+  appData: true
+  appCache: true
+  userData:
+    - Home
+  serviceAccount: full-sa
+  provider:
+    - appName: provider-app
+      namespace: userspace-provider
+      providerName: data-provider
+      podSelectors:
+        - matchLabels:
+            app: provider
+middleware:
+  postgres:
+    username: pguser
+    password: pgpass
+    databases:
+      - name: appdb
+        extensions:
+          - pg_trgm
+        scripts:
+          - init.sql
+        distributed: true
+  redis:
+    password: redispass
+    namespace: app-redis
+  mongodb:
+    username: mgouser
+    password: mgopass
+    databases:
+      - name: appmongo
+  nats:
+    username: natsuser
+    password: natspass
+    subjects:
+      - name: events
+        permission:
+          pub: allow
+          sub: allow
+        export:
+          - pub: allow
+            sub: allow
+    refs:
+      - appName: ref-app
+        appNamespace: userspace-ref
+        subjects:
+          - name: events
+            perm:
+              - pub
+              - sub
+  minio:
+    username: miniou
+    password: miniop
+    allowNamespaceBuckets: true
+    buckets:
+      - name: uploads
+  rabbitmq:
+    username: rmquser
+    password: rmqpass
+    vhosts:
+      - name: app-vhost
+  elasticsearch:
+    username: esuser
+    password: espass
+    allowNamespaceIndexes: true
+    indexes:
+      - name: logs
+  mariadb:
+    username: mariauser
+    password: mariapass
+    databases:
+      - name: mariadbapp
+  mysql:
+    username: mysqluser
+    password: mysqlpass
+    databases:
+      - name: mysqlapp
+  argo:
+    required: true
+  clickHouse:
+    username: chuser
+    password: chpass
+    databases:
+      - name: analytics
+options:
+  mobileSupported: true
+  policies:
+    - entranceName: web
+      description: sample policy
+      uriRegex: ^/api/.*
+      level: admin
+      oneTime: true
+      validDuration: 1h
+  resetCookie:
+    enabled: true
+  dependencies:
+    - name: olares
+      version: ">=1.10.0"
+      type: system
+      mandatory: true
+      selfRely: true
+  conflicts:
+    - name: rival-app
+      type: application
+  appScope:
+    clusterScoped: true
+    appRef:
+      - ref-app
+    systemService: true
+  websocket:
+    port: 8765
+    url: /ws
+  upload:
+    fileType:
+      - image/png
+    dest: /tmp/upload
+    limitedSize: 1024
+  syncProvider:
+    - name: sync
+      endpoint: https://sync.example.com
+  oidc:
+    enabled: true
+    redirectUri: https://example.com/callback
+    entranceName: web
+  apiTimeout: 30
+  allowedOutboundPorts:
+    - 443
+    - 8080
+  images:
+    - ghcr.io/example/app:1.0.0
+  allowMultipleInstall: true
+  needsSharedAccess: true
+provider:
+  - name: api-provider
+    entrance: web
+    paths:
+      - /api/v1
+    verbs:
+      - get
+      - post
+envs:
+  - envName: LOG_LEVEL
+    value: debug
+    default: info
+    editable: true
+    type: string
+    required: true
+    title: Log Level
+    description: application log level
+    options:
+      - title: Debug
+        value: debug
+      - title: Info
+        value: info
+    remoteOptions: https://example.com/options.json
+    regex: ^(debug|info|warn)$
+    applyOnChange: true
+    valueFrom:
+      envName: SYSTEM_LOG
+      status: active


### PR DESCRIPTION
* **Background**
full yaml field check and add some api
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new default-on lint validations over rendered Kubernetes resources (hostPath/strategy and namespace enforcement) plus new image-extraction behavior, which may cause previously passing charts to fail lint or change published image lists.
> 
> **Overview**
> **Expands OAC’s lint and image-scanning capabilities.** `Lint` now also enforces (default-on) a hostPath vs rolling-update safety rule and a rendered-resource namespace contract, and adds an opt-in check that rejects root-equivalent `securityContext` on *non-`beclab/`* images.
> 
> **Improves image listing APIs and behavior.** Adds `ListImagesForModes`/`ListImagesFromOACForModes` with an `"all"` keyword expanding to `AllImageRenderModes`, and updates workload image extraction to include init containers and DaemonSets.
> 
> **Validation and compatibility tweaks.** `WithAutoOwnerScenarios` now re-runs manifest validation per owner/admin scenario; `apiVersion=v2` now consistently skips container limit checks regardless of manifest version; manifest validation adds `spec.supportArch` enum/uniqueness checks and v2 subchart-name validation; unsupported apiVersion errors were standardized to `"not supported version"`. Includes new fixtures/tests for YAML field preservation and updates deps (`beclab/api` v0.0.7, switch YAML lib).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8572815dff7f7285d81e0ef081535b53734a5b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->