### PR TITLE
feat(appservice): manage compute resource in app lifecycle

### DIFF
--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/security"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
@@ -265,11 +266,11 @@ func (r *SecurityReconciler) reconcileNamespaceLabels(ctx context.Context, ns *c
 		// ApplicationManager list using the deterministic
 		// SharedAppNamespace(app) ↔ AM mapping.
 		if _, exists := ns.Labels[security.NamespaceOwnerLabel]; !exists {
-			recovered, err := r.findV3SharedAppOwner(ctx, ns.Name)
+			owner, err := kubesphere.GetClusterOwner(ctx)
 			if err != nil {
-				logger.Info("V3 ns owner reconstruction failed", "ns", ns.Name, "err", err)
-			} else if recovered != "" {
-				ns.Labels[security.NamespaceOwnerLabel] = recovered
+				logger.Info("Failed to get cluster owner", "err", err)
+			} else {
+				ns.Labels[security.NamespaceOwnerLabel] = owner
 				updated = true
 			}
 		}

--- a/framework/app-service/pkg/apiserver/api/types.go
+++ b/framework/app-service/pkg/apiserver/api/types.go
@@ -20,6 +20,18 @@ const (
 	AppImagesKey                     = "bytetrade.io/images"
 )
 
+const (
+	CodeSuccess                    int32 = 200
+	CodeComputeBindingRequired     int32 = 4601
+	CodeComputeBindingUnavailable  int32 = 4602
+	CodeComputeDeviceSwitchBlocked int32 = 4603
+	// CodeComputeAmbiguousMode is returned by the install endpoint when
+	// the caller did not pick a selectedGpuType and more than one mode in
+	// the manifest is runnable on this cluster. The body carries the
+	// install compute plan so the client can let the user pick.
+	CodeComputeAmbiguousMode int32 = 4604
+)
+
 // Response represents the code for response.
 type Response struct {
 	Code int32 `json:"code"`

--- a/framework/app-service/pkg/apiserver/handler_app.go
+++ b/framework/app-service/pkg/apiserver/handler_app.go
@@ -766,29 +766,26 @@ func (h *Handler) oamValues(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	gpuType := "none"
+	gpuType := utils.CPUType
 	selectedGpuType := req.QueryParameter("gputype")
-	if len(gpuTypes) > 0 {
-		if selectedGpuType != "" {
-			if _, ok := gpuTypes[selectedGpuType]; ok {
-				gpuType = selectedGpuType
-			} else {
-				err := fmt.Errorf("selected gpu type %s not found in cluster", selectedGpuType)
-				klog.Error(err)
-				api.HandleError(resp, req, err)
-				return
-			}
-		} else {
-			if len(gpuTypes) == 1 {
-				gpuType = maps.Keys(gpuTypes)[0]
-			} else {
-				err := fmt.Errorf("multiple gpu types found in cluster, please specify one")
-				klog.Error(err)
-				api.HandleError(resp, req, err)
-				return
-			}
+	if selectedGpuType != "" {
+		if _, ok := gpuTypes[selectedGpuType]; !ok && selectedGpuType != utils.CPUType {
+			err := fmt.Errorf("selected gpu type %s not found in cluster", selectedGpuType)
+			klog.Error(err)
+			api.HandleError(resp, req, err)
+			return
 		}
+		gpuType = selectedGpuType
+	} else if len(gpuTypes) == 1 {
+		// Single-GPU-flavour cluster: auto-pick it so legacy charts that
+		// switch behaviour on .Values.GPU.Type render correctly without the
+		// caller having to plumb ?gputype= through.
+		gpuType = maps.Keys(gpuTypes)[0]
 	}
+	// Multi-flavour cluster with no explicit selection (e.g. the chart-repo
+	// "Rendered Chart Verification" path) falls through to CPU. Charts that
+	// declare spec.resources[] for multiple modes still validate fine because
+	// the matrix is consumed by app-service post-install, not by helm render.
 
 	values["GPU"] = map[string]interface{}{
 		"Type": gpuType,

--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -1,0 +1,357 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"github.com/emicklei/go-restful/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ComputeResourcesResponse struct {
+	api.Response `json:",inline"`
+	Data         []compute.Node `json:"data"`
+}
+
+type ComputeAvailabilityResponse struct {
+	api.Response `json:",inline"`
+	Data         *compute.AvailabilityResult      `json:"data"`
+	Validation   *compute.BindingValidationResult `json:"validation,omitempty"`
+}
+
+type ComputeBindingResponse struct {
+	api.Response `json:",inline"`
+	Data         []compute.Allocation `json:"data"`
+}
+
+// InstallComputePlanResponse is returned by the install endpoint
+// (POST /apps/{name}/install) when the caller did not pick a
+// selectedGpuType and more than one mode in the manifest is runnable on
+// this cluster. Code is api.CodeComputeAmbiguousMode and Data lists the
+// per-mode install plan so the client can let the user choose.
+type InstallComputePlanResponse struct {
+	api.Response `json:",inline"`
+	Data         []compute.ModePlanResult `json:"data"`
+}
+
+type UpdateDeviceSupportTypeRequest struct {
+	SupportType string `json:"supportType"`
+}
+
+type DeviceSupportTypeSwitchResponse struct {
+	api.Response `json:",inline"`
+	Data         DeviceSupportTypeSwitchResult `json:"data"`
+}
+
+type DeviceSupportTypeSwitchResult struct {
+	Status      string            `json:"status"`
+	Device      compute.Device    `json:"device"`
+	StoppedApps []StoppedBoundApp `json:"stoppedApps,omitempty"`
+	BlockedApps []BlockedBoundApp `json:"blockedApps,omitempty"`
+}
+
+type StoppedBoundApp struct {
+	AppName string `json:"appName"`
+	Owner   string `json:"owner"`
+	State   string `json:"state"`
+}
+
+type BlockedBoundApp struct {
+	AppName string `json:"appName"`
+	Owner   string `json:"owner"`
+	State   string `json:"state"`
+	Reason  string `json:"reason"`
+}
+
+func (h *Handler) updateDeviceSupportType(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+
+	owner := req.Attribute(constants.UserContextAttribute).(string)
+	isAdmin, err := kubesphere.IsAdmin(ctx, h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if !isAdmin {
+		api.HandleBadRequest(resp, req, fmt.Errorf("only admin user can switch compute device mode"))
+		return
+	}
+
+	nodeName := req.PathParameter(ParamNodeName)
+	deviceID := req.PathParameter(ParamDeviceID)
+	body := &UpdateDeviceSupportTypeRequest{}
+	if err := req.ReadEntity(body); err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+	if body.SupportType == "" {
+		api.HandleBadRequest(resp, req, fmt.Errorf("supportType is required"))
+		return
+	}
+
+	node, device, err := compute.FindDevice(ctx, h.ctrlClient, nodeName, deviceID)
+	if err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+	if !compute.IsHAMIMode(node.GPUType) {
+		api.HandleBadRequest(resp, req, fmt.Errorf("device mode switching is not supported for gpu type %s", node.GPUType))
+		return
+	}
+	if !compute.SupportTypeAvailable(device.AvailableSupportTypes, body.SupportType) {
+		api.HandleBadRequest(resp, req, fmt.Errorf("support type %s is not available for gpu type %s", body.SupportType, node.GPUType))
+		return
+	}
+	if device.SupportType == body.SupportType {
+		resp.WriteAsJson(DeviceSupportTypeSwitchResponse{
+			Response: api.Response{Code: api.CodeSuccess},
+			Data: DeviceSupportTypeSwitchResult{
+				Status: "unchanged",
+				Device: device,
+			},
+		})
+		return
+	}
+
+	// Plan stops for every distinct app currently bound to the device. Bail
+	// out without touching anything if any of them can't be stopped right now.
+	plan, err := h.planStopForBoundApps(ctx, device.Bindings)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if len(plan.blocked) > 0 {
+		resp.WriteAsJson(DeviceSupportTypeSwitchResponse{
+			Response: api.Response{Code: api.CodeComputeDeviceSwitchBlocked},
+			Data: DeviceSupportTypeSwitchResult{
+				Status:      "bound-apps-stop-blocked",
+				Device:      device,
+				BlockedApps: plan.blocked,
+			},
+		})
+		return
+	}
+
+	// Submit StopOp for each bound app and tear down its allocation/binding
+	// immediately so the device is free even before the SuspendingApp finishes
+	// its state transition.
+	stopped, err := h.commitStopForBoundApps(ctx, plan.stoppable)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	if err := compute.SwitchDeviceMode(ctx, h.ctrlClient, nodeName, deviceID, body.SupportType); err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	device.SupportType = body.SupportType
+	device.Bindings = nil
+	resp.WriteAsJson(DeviceSupportTypeSwitchResponse{
+		Response: api.Response{Code: api.CodeSuccess},
+		Data: DeviceSupportTypeSwitchResult{
+			Status:      "switched",
+			Device:      device,
+			StoppedApps: stopped,
+		},
+	})
+}
+
+type stoppableApp struct {
+	appName              string
+	owner                string
+	managerName          string
+	manager              *appv1alpha1.ApplicationManager
+	managesSharedServer  bool
+	previousAppMgrStatus appv1alpha1.ApplicationManagerState
+}
+
+type stopPlan struct {
+	stoppable []stoppableApp
+	blocked   []BlockedBoundApp
+}
+
+// planStopForBoundApps inspects each unique (appName, owner) pair from
+// `bindings` and classifies it as either stoppable or blocked. It does not
+// mutate any cluster state, so callers can safely abort if anything is
+// blocked.
+func (h *Handler) planStopForBoundApps(ctx context.Context, bindings []compute.Allocation) (stopPlan, error) {
+	plan := stopPlan{}
+	seen := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		key := binding.AppName + "/" + binding.Owner
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		// ResolveAppMgrName handles both v1/v2 (FmtAppMgrName style) and v3
+		// (cluster-wide '{app}-shared-{app}' AM). A v3 app whose GPU
+		// binding is being torn down also goes through here.
+		name, _, err := apputils.ResolveAppMgrName(ctx, binding.AppName, binding.Owner)
+		if err != nil {
+			return plan, err
+		}
+		var am appv1alpha1.ApplicationManager
+		if err := h.ctrlClient.Get(ctx, types.NamespacedName{Name: name}, &am); err != nil {
+			return plan, err
+		}
+
+		// Stopping / Stopped apps are already done from a state perspective;
+		// we just need to make sure their allocations get cleared below.
+		if am.Status.State == appv1alpha1.Stopping || am.Status.State == appv1alpha1.Stopped {
+			plan.stoppable = append(plan.stoppable, stoppableApp{
+				appName:              binding.AppName,
+				owner:                binding.Owner,
+				managerName:          name,
+				manager:              am.DeepCopy(),
+				previousAppMgrStatus: am.Status.State,
+			})
+			continue
+		}
+
+		if !appstate.IsOperationAllowed(am.Status.State, appv1alpha1.StopOp) {
+			plan.blocked = append(plan.blocked, BlockedBoundApp{
+				AppName: binding.AppName,
+				Owner:   binding.Owner,
+				State:   am.Status.State.String(),
+				Reason:  "stop-operation-not-allowed",
+			})
+			continue
+		}
+
+		var appCfg appcfg.ApplicationConfig
+		if err := appcfg.GetAppConfig(&am, &appCfg); err != nil {
+			return plan, err
+		}
+		managesSharedServer, err := compute.ManagesSharedServer(ctx, h.ctrlClient, &appCfg)
+		if err != nil {
+			return plan, err
+		}
+		plan.stoppable = append(plan.stoppable, stoppableApp{
+			appName:              binding.AppName,
+			owner:                binding.Owner,
+			managerName:          name,
+			manager:              am.DeepCopy(),
+			managesSharedServer:  managesSharedServer,
+			previousAppMgrStatus: am.Status.State,
+		})
+	}
+	return plan, nil
+}
+
+// commitStopForBoundApps submits a StopOp for each app that isn't already
+// stopping/stopped and clears the compute allocation/HAMi binding for every
+// app in the plan.
+func (h *Handler) commitStopForBoundApps(ctx context.Context, apps []stoppableApp) ([]StoppedBoundApp, error) {
+	stopped := make([]StoppedBoundApp, 0, len(apps))
+	for _, a := range apps {
+		if a.previousAppMgrStatus != appv1alpha1.Stopping && a.previousAppMgrStatus != appv1alpha1.Stopped {
+			if a.manager.Annotations == nil {
+				a.manager.Annotations = make(map[string]string)
+			}
+			a.manager.Annotations[api.AppStopAllKey] = fmt.Sprintf("%t", a.managesSharedServer)
+			a.manager.Spec.OpType = appv1alpha1.StopOp
+			if err := h.ctrlClient.Update(ctx, a.manager); err != nil {
+				return stopped, err
+			}
+			now := metav1.Now()
+			opID := strconv.FormatInt(now.Unix(), 10)
+			status := appv1alpha1.ApplicationManagerStatus{
+				OpType:     appv1alpha1.StopOp,
+				OpID:       opID,
+				State:      appv1alpha1.Stopping,
+				Reason:     constants.AppStopByUser,
+				Message:    fmt.Sprintf("app %s was stopped before compute device mode switch", a.appName),
+				StatusTime: &now,
+				UpdateTime: &now,
+			}
+			if _, err := apputils.UpdateAppMgrStatus(a.managerName, status); err != nil {
+				return stopped, err
+			}
+		}
+
+		// SuspendingApp will also call DeleteAllocationsForComputeTarget once
+		// it finishes; doing it here is idempotent but lets us flip the
+		// device's support type immediately.
+		if err := compute.DeleteAllocationsForApp(ctx, h.ctrlClient, a.appName, a.owner); err != nil {
+			return stopped, err
+		}
+		stopped = append(stopped, StoppedBoundApp{
+			AppName: a.appName,
+			Owner:   a.owner,
+			State:   appv1alpha1.Stopping.String(),
+		})
+	}
+	return stopped, nil
+}
+
+func (h *Handler) listComputeResources(req *restful.Request, resp *restful.Response) {
+	nodes, err := compute.FetchNodeComputeAllocations(req.Request.Context(), h.ctrlClient)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	resp.WriteAsJson(ComputeResourcesResponse{
+		Response: api.Response{Code: api.CodeSuccess},
+		Data:     nodes,
+	})
+}
+
+func (h *Handler) listComputeBindings(req *restful.Request, resp *restful.Response) {
+	appName := req.PathParameter(ParamAppName)
+	appCfg, err := h.installedComputeAppConfig(req)
+	if err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+	allocations, err := compute.FindAllocationsForApp(req.Request.Context(), h.ctrlClient, appName, appCfg.OwnerName)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	resp.WriteAsJson(ComputeBindingResponse{
+		Response: api.Response{Code: api.CodeSuccess},
+		Data:     allocations,
+	})
+}
+
+func (h *Handler) installedComputeAppConfig(req *restful.Request) (*appcfg.ApplicationConfig, error) {
+	appName := req.PathParameter(ParamAppName)
+	owner := req.Attribute(constants.UserContextAttribute).(string)
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), appName, owner)
+	if err != nil {
+		return nil, err
+	}
+	var manager appv1alpha1.ApplicationManager
+	if err := h.ctrlClient.Get(req.Request.Context(), types.NamespacedName{Name: name}, &manager); err != nil {
+		return nil, err
+	}
+	var cfg appcfg.ApplicationConfig
+	if err := appcfg.GetAppConfig(&manager, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func readOptionalEntity(req *restful.Request, into any) error {
+	if err := req.ReadEntity(into); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/framework/app-service/pkg/apiserver/handler_gpu.go
+++ b/framework/app-service/pkg/apiserver/handler_gpu.go
@@ -25,6 +25,10 @@ func (h *Handler) getGpuTypes(req *restful.Request, resp *restful.Response) {
 		api.HandleError(resp, req, err)
 		return
 	}
+	// Always surface "cpu" as a selectable option: every cluster can host
+	// CPU-only workloads, so the frontend should be able to offer that mode
+	// regardless of which (if any) GPU flavours the cluster declares.
+	gpuTypes[utils.CPUType] = struct{}{}
 
 	resp.WriteAsJson(&map[string]interface{}{
 		"gpu_types": maps.Keys(gpuTypes),

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
@@ -17,15 +22,9 @@ import (
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
-	"golang.org/x/exp/maps"
-	"net/http"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"slices"
-	"strconv"
 
 	"github.com/emicklei/go-restful/v3"
 	"helm.sh/helm/v3/pkg/time"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -109,36 +108,6 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		if err != nil {
 			api.HandleBadRequest(resp, req, err)
 			return
-		}
-	}
-
-	// check selected gpu type can be supported
-	// if selectedGpuType != "" , then check if the gpu type exists in cluster
-	// if selectedGpuType == "" , and only one gpu type exists in cluster, then use it
-	var nodes corev1.NodeList
-	err = h.ctrlClient.List(req.Request.Context(), &nodes, &client.ListOptions{})
-	if err != nil {
-		klog.Errorf("list node failed %v", err)
-		api.HandleError(resp, req, err)
-		return
-	}
-	gpuTypes, err := utils.GetAllGpuTypesFromNodes(&nodes)
-	if err != nil {
-		klog.Errorf("get gpu type failed %v", err)
-		api.HandleError(resp, req, err)
-		return
-	}
-
-	if insReq.SelectedGpuType != "" {
-		if _, ok := gpuTypes[insReq.SelectedGpuType]; !ok {
-			klog.Errorf("selected gpu type %s not found in cluster", insReq.SelectedGpuType)
-			api.HandleBadRequest(resp, req, fmt.Errorf("selected gpu type %s not found in cluster", insReq.SelectedGpuType))
-			return
-		}
-	} else {
-		if len(gpuTypes) == 1 {
-			insReq.SelectedGpuType = maps.Keys(gpuTypes)[0]
-			klog.Infof("only one gpu type %s found in cluster, use it as selected gpu type", insReq.SelectedGpuType)
 		}
 	}
 
@@ -252,6 +221,65 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		(appCfg.AllowMultipleInstall && apiVersion == appcfg.V2) {
 		klog.Errorf("app %s can not be clone", app)
 		api.HandleBadRequest(resp, req, fmt.Errorf("app %s can not be clone", app))
+		return
+	}
+
+	// When the caller didn't explicitly pick a compute mode, try to derive
+	// one from the cluster + manifest. An empty SelectedGpuType is treated
+	// as "no selection" (NOT as "cpu") — callers who genuinely want cpu
+	// must pass "cpu" explicitly. See compute.AutoSelectMode for the rules.
+	//
+	// If the caller did pass something explicitly we leave it alone here;
+	// the subsequent compute.AppInstallable check is what surfaces the
+	// "you picked a mode the cluster doesn't have" error.
+	if insReq.SelectedGpuType == "" {
+		var chosen string
+		chosen, err = compute.AutoSelectMode(req.Request.Context(), h.ctrlClient, appCfg)
+		// More than one declared mode is runnable on this cluster — let the
+		// caller pick by surfacing the full per-mode install plan with a
+		// dedicated code, instead of failing the install outright.
+		if errors.Is(err, compute.ErrAmbiguousComputeMode) {
+			plan, planErr := compute.BuildInstallComputePlan(req.Request.Context(), h.ctrlClient, appCfg)
+			if planErr != nil {
+				api.HandleError(resp, req, planErr)
+				return
+			}
+			resp.WriteAsJson(InstallComputePlanResponse{
+				Response: api.Response{Code: api.CodeComputeAmbiguousMode},
+				Data:     plan,
+			})
+			return
+		}
+		if err != nil {
+			klog.Errorf("Failed to auto-select compute mode for app %s: %v", app, err)
+			api.HandleBadRequest(resp, req, err)
+			return
+		}
+		// Reload appCfg with the chosen mode so its Requirement reflects
+		// the GPU-mode resource needs we'll actually schedule against.
+		// Just patching SelectedGpuType in place isn't enough: for legacy
+		// apps the first GetAppConfig call (with empty selectedGpu) ran
+		// ResolveRequirement under cpu mode and dropped the GPU values
+		// from appCfg.Requirement, so we need to re-parse from the
+		// manifest with the chosen mode to recover them.
+		if chosen != appCfg.SelectedGpuType {
+			appCfg, err = helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, chosen)
+			if err != nil {
+				klog.Errorf("Failed to reload appConfig with auto-selected gpu type %s: %v", chosen, err)
+				api.HandleError(resp, req, err)
+				return
+			}
+		}
+	}
+
+	computeEnough, err := compute.AppInstallable(req.Request.Context(), h.ctrlClient, appCfg)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	if !computeEnough {
+		api.HandleBadRequest(resp, req, fmt.Errorf("compute resource is not enough for app %s with mode %s", app, appCfg.SelectedGpuType))
 		return
 	}
 
@@ -600,6 +628,12 @@ func (h *installHandlerHelper) applyAppMgr(name string, extraLabels map[string]s
 		images = h.insReq.Images
 	}
 	imagesStr, _ := json.Marshal(images)
+	// For v1/v2 appConfig.OwnerName == h.owner (the install caller). For
+	// v3 it is the cluster owner that GetAppConfig resolved at chart
+	// load time — independent of which admin is currently operating, so
+	// the AM stays addressed to a stable user across multi-admin
+	// install / upgrade cycles.
+	appOwner := h.appConfig.OwnerName
 	appMgr := &v1alpha1.ApplicationManager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -617,7 +651,7 @@ func (h *installHandlerHelper) applyAppMgr(name string, extraLabels map[string]s
 			AppName:      h.app,
 			RawAppName:   h.rawAppName,
 			AppNamespace: h.appConfig.Namespace,
-			AppOwner:     h.owner,
+			AppOwner:     appOwner,
 			Config:       string(config),
 			Source:       h.insReq.Source.String(),
 			Type:         v1alpha1.Type(h.appConfig.Type),
@@ -671,6 +705,7 @@ func (h *installHandlerHelper) applyAppMgr(name string, extraLabels map[string]s
 				"opType":     v1alpha1.InstallOp,
 				"config":     string(config),
 				"source":     h.insReq.Source.String(),
+				"appOwner":   appOwner,
 				"rawAppName": h.rawAppName,
 			},
 		}

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
@@ -86,6 +87,11 @@ func (h *Handler) suspend(req *restful.Request, resp *restful.Response) {
 func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 	app := req.PathParameter(ParamAppName)
 	owner := req.Attribute(constants.UserContextAttribute).(string)
+	request := &ResumeRequest{}
+	if err := readOptionalEntity(req, request); err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
 	token, err := h.GetUserServiceAccountToken(req.Request.Context(), owner)
 	if err != nil {
 		klog.Error("Failed to get user service account token: ", err)
@@ -133,18 +139,57 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	am.Spec.OpType = v1alpha1.ResumeOp
 	// if current user is admin, also resume server side
 	isAdmin, err := kubesphere.IsAdmin(req.Request.Context(), h.kubeConfig, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
+	includeSharedServer, err := compute.ShouldIncludeSharedServerForResume(req.Request.Context(), h.ctrlClient, appCfg, isAdmin)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	bindingResult, err := compute.ApplyBindingSelection(req.Request.Context(), h.ctrlClient, appCfg, request.ComputeBinding, includeSharedServer)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	switch bindingResult.Status {
+	case compute.BindingApplyStatusRequired:
+		writeComputeAvailability(resp, api.CodeComputeBindingRequired, bindingResult.Availability, bindingResult.Validation)
+		return
+	case compute.BindingApplyStatusUnavailable:
+		writeComputeAvailability(resp, api.CodeComputeBindingUnavailable, bindingResult.Availability, bindingResult.Validation)
+		return
+	case compute.BindingApplyStatusApplied:
+	case compute.BindingApplyStatusNotRequired:
+	}
+
+	bindingAccepted := bindingResult.Status != compute.BindingApplyStatusApplied
+	defer func() {
+		if bindingAccepted {
+			return
+		}
+		targetApp, targetOwner := bindingResult.TargetApp, bindingResult.TargetOwner
+		if targetApp == "" {
+			targetApp = appCfg.AppName
+		}
+		if targetOwner == "" {
+			targetOwner = appCfg.OwnerName
+		}
+		if cleanupErr := compute.DeleteAllocationsForApp(req.Request.Context(), h.ctrlClient, targetApp, targetOwner); cleanupErr != nil {
+			klog.Warningf("cleanup compute allocation for failed resume %s failed: %v", appCfg.AppName, cleanupErr)
+		}
+	}()
+
+	am.Spec.OpType = v1alpha1.ResumeOp
 	if am.Annotations == nil {
-		am.Annotations = make(map[string]string)
+		am.Annotations = map[string]string{}
 	}
 	am.Annotations[api.AppResumeAllKey] = fmt.Sprintf("%t", false)
-	if isAdmin {
+	if includeSharedServer {
 		am.Annotations[api.AppResumeAllKey] = fmt.Sprintf("%t", true)
 	}
 	err = h.ctrlClient.Update(req.Request.Context(), &am)
@@ -169,8 +214,26 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	resp.WriteEntity(api.InstallationResponse{
-		Response: api.Response{Code: 200},
+	bindingAccepted = true
+
+	resp.WriteAsJson(api.InstallationResponse{
+		Response: api.Response{Code: api.CodeSuccess},
 		Data:     api.InstallationResponseData{UID: app, OpID: opID},
+	})
+}
+
+type ResumeRequest struct {
+	ComputeBinding []compute.BindingSelection `json:"computeBinding,omitempty"`
+}
+
+func writeComputeAvailability(resp *restful.Response, code int32, availability *compute.AvailabilityResult, validation ...*compute.BindingValidationResult) {
+	var bindingValidation *compute.BindingValidationResult
+	if len(validation) > 0 {
+		bindingValidation = validation[0]
+	}
+	resp.WriteAsJson(ComputeAvailabilityResponse{
+		Response:   api.Response{Code: code},
+		Data:       availability,
+		Validation: bindingValidation,
 	})
 }

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -11,6 +11,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/provider"
@@ -301,13 +302,24 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		return resp
 	}
 
-	gpuRequired := appcfg.Requirement.GPU
-	if gpuRequired == nil {
+	computeReq, ok := compute.SelectedRequirement(appcfg)
+	if !ok {
+		return resp
+	}
+	GPUType := computeReq.Mode
+
+	// no gpu found, no need to inject env, just return.
+	if GPUType == "" || GPUType == utils.CPUType {
 		return resp
 	}
 
 	var injectContainer []string
 	injectAll := false
+	// TODO: when a pod has only a single container, we can drop the
+	// applicationGpuInjectKey opt-in and derive injection purely from
+	// spec.resources. The annotation exists today to keep multi-container pods
+	// from getting GPU resource limits attached to every container (which would
+	// make the scheduler think each container needs its own GPU).
 	if injectValue, ok := annotations[applicationGpuInjectKey]; !ok || injectValue == "false" || injectValue == "" {
 		return resp
 	} else {
@@ -324,13 +336,6 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		}
 	}
 
-	GPUType := appcfg.GetSelectedGpuTypeValue()
-
-	// no gpu found, no need to inject env, just return.
-	if GPUType == "none" || GPUType == "" {
-		return resp
-	}
-
 	envs := []webhook.EnvKeyValue{
 		{
 			Key:   constants.EnvGPUType,
@@ -338,19 +343,42 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		},
 	}
 
-	gpuRequiredValue := gpuRequired.Value() / 1024 / 1024 // HAMi gpu memory format
-	hamiFormatGpuRequired := resource.NewQuantity(gpuRequiredValue, resource.DecimalSI)
+	var hamiGpuMemory *string
+	if compute.IsHAMIMode(GPUType) && computeReq.RequiredGPU > 0 {
+		gpuRequiredValue := computeReq.RequiredGPU / 1024 / 1024 // HAMi gpu memory format
+		hamiFormatGpuRequired := resource.NewQuantity(gpuRequiredValue, resource.DecimalSI)
+		hamiGpuMemory = ptr.To(hamiFormatGpuRequired.String())
+	}
 	patchBytes, err := webhook.CreatePatchForDeployment(
 		tpl,
 		injectAll,
 		injectContainer,
 		h.getGPUResourceTypeKey(GPUType),
-		ptr.To(hamiFormatGpuRequired.String()),
+		hamiGpuMemory,
 		envs,
 	)
 	if err != nil {
 		klog.Errorf("create patch error %v", err)
 		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	if !compute.IsHAMIMode(GPUType) && GPUType != utils.CPUType {
+		allocations, err := compute.FindAllocationsForApp(ctx, h.ctrlClient, appName, appcfg.OwnerName)
+		if err != nil {
+			klog.Errorf("find compute allocation for app %s failed %v", appName, err)
+			return h.sidecarWebhook.AdmissionError(req.UID, err)
+		}
+		if len(allocations) == 0 || allocations[0].NodeName == "" {
+			klog.Warningf("compute allocation for app %s is not found", appName)
+			return resp
+			// err := fmt.Errorf("compute allocation for app %s is not found", appName)
+			// klog.Error(err)
+			// return h.sidecarWebhook.AdmissionError(req.UID, err)
+		}
+		patchBytes, err = appendNodeSelectorPatch(patchBytes, tpl, allocations[0].NodeName)
+		if err != nil {
+			klog.Errorf("append node selector patch error %v", err)
+			return h.sidecarWebhook.AdmissionError(req.UID, err)
+		}
 	}
 	klog.Info("patchBytes:", string(patchBytes))
 	if len(patchBytes) > 0 {
@@ -366,18 +394,41 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 		return constants.NvidiaGPU
 	case utils.GB10ChipType:
 		return constants.NvidiaGPU
-	case utils.AmdApuCardType:
-		return constants.AMDGPU
-	case utils.AmdGpuCardType:
-		return constants.AMDGPU
-	case utils.StrixHaloChipType:
-		return constants.AMDGPU
 	case utils.CPUType:
 		klog.Info("CPU type is selected, no GPU resource will be injected")
 		return ""
 	default:
 		return ""
 	}
+}
+
+func appendNodeSelectorPatch(patchBytes []byte, tpl *corev1.PodTemplateSpec, nodeName string) ([]byte, error) {
+	var patches []map[string]any
+	if len(patchBytes) > 0 {
+		if err := json.Unmarshal(patchBytes, &patches); err != nil {
+			return nil, err
+		}
+	}
+	if len(tpl.Spec.NodeSelector) == 0 {
+		patches = append(patches, map[string]any{
+			"op":   constants.PatchOpAdd,
+			"path": "/spec/template/spec/nodeSelector",
+			"value": map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			},
+		})
+	} else {
+		op := constants.PatchOpAdd
+		if _, ok := tpl.Spec.NodeSelector["kubernetes.io/hostname"]; ok {
+			op = constants.PatchOpReplace
+		}
+		patches = append(patches, map[string]any{
+			"op":    op,
+			"path":  "/spec/template/spec/nodeSelector/kubernetes.io~1hostname",
+			"value": nodeName,
+		})
+	}
+	return json.Marshal(patches)
 }
 
 func (h *Handler) providerRegistryValidate(req *restful.Request, resp *restful.Response) {
@@ -839,9 +890,19 @@ func makePatches(req *admissionv1.AdmissionRequest, appCfg *appcfg.ApplicationCo
 	var patchBytes []byte
 	var tpl *corev1.PodTemplateSpec
 	var gpuPolicy string
-	if strings.TrimSpace(appCfg.RequiredGPU) != "" {
-		if p := strings.TrimSpace(appCfg.PodGPUConsumePolicy); p == "all" || p == "single" {
+	computeReq, ok := compute.SelectedRequirement(appCfg)
+	requiresGPU := ok && computeReq.Mode != utils.CPUType
+	if requiresGPU {
+		switch p := strings.TrimSpace(appCfg.PodGPUConsumePolicy); p {
+		case "all", "single":
 			gpuPolicy = p
+		case "":
+			if computeReq.SupportMultiNodes {
+				// Multi-node deployments should let each replica consume one binding.
+				gpuPolicy = "single"
+			} else if computeReq.SupportMultiCards {
+				gpuPolicy = "all"
+			}
 		}
 	}
 
@@ -976,7 +1037,7 @@ func (h *Handler) validateUser(ctx context.Context, req *admissionv1.AdmissionRe
 	if len(user.Spec.InitialPassword) < 8 {
 		resp.Allowed = false
 		resp.Result = &metav1.Status{
-			Message: fmt.Sprintf("invalid initial password lenth must greater than 8 char"),
+			Message: "invalid initial password lenth must greater than 8 char",
 		}
 		return resp
 	}

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -20,6 +20,8 @@ const (
 	ParamServiceName    = "service"
 	ParamEntranceName   = "entrance_name"
 	ParamModelID        = "model_id"
+	ParamNodeName       = "node"
+	ParamDeviceID       = "device"
 
 	ParamWorkflowName = "name"
 	UserName          = "name"
@@ -251,6 +253,21 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
 		Returns(http.StatusOK, "Success to get ", &ResultResponse{}))
 
+	ws.Route(ws.GET("/compute-resources").
+		To(handler.listComputeResources).
+		Doc("list compute resources in the cluster").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Returns(http.StatusOK, "Success to list compute resources", &ComputeResourcesResponse{}))
+
+	ws.Route(ws.PUT("/compute-resources/nodes/{"+ParamNodeName+"}/devices/{"+ParamDeviceID+"}/support-type").
+		To(handler.updateDeviceSupportType).
+		Doc("switch compute device support type").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Param(ws.PathParameter(ParamNodeName, "the node name")).
+		Param(ws.PathParameter(ParamDeviceID, "the device id")).
+		Reads(UpdateDeviceSupportTypeRequest{}).
+		Returns(http.StatusOK, "Success to switch compute device support type", &DeviceSupportTypeSwitchResponse{}))
+
 	// handler_webhook
 	ws.Route(ws.POST("/sandbox/inject").
 		To(handler.sandboxInject).
@@ -335,6 +352,20 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
 		Param(ws.PathParameter(ParamAppName, "the name of a application")).
 		Returns(http.StatusOK, "Success to begin a installation of the application", &api.InstallationResponse{}))
+
+	ws.Route(ws.GET("/apps/{"+ParamAppName+"}/compute-resources/bindings").
+		To(handler.listComputeBindings).
+		Doc("List compute resource bindings for the application").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Param(ws.PathParameter(ParamAppName, "the name of a application")).
+		Returns(http.StatusOK, "Success to list compute resource bindings", &ComputeBindingResponse{}))
+
+	ws.Route(ws.DELETE("/apps/{"+ParamAppName+"}/compute-resources/bindings").
+		To(handler.queued(handler.suspend)).
+		Doc("Suspend the application to release compute resource bindings").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Param(ws.PathParameter(ParamAppName, "the name of a application")).
+		Returns(http.StatusOK, "Success to suspend the application", &api.InstallationResponse{}))
 
 	ws.Route(ws.POST("/apps/{"+ParamAppName+"}/uninstall").
 		To(handler.queued(handler.uninstall)).

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
-	"github.com/beclab/Olares/framework/oac"
 	manifestsysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -22,10 +21,14 @@ type AppCachePermission string
 type UserDataPermission string
 
 type AppRequirement struct {
-	Memory *resource.Quantity
-	Disk   *resource.Quantity
-	GPU    *resource.Quantity
-	CPU    *resource.Quantity
+	Memory        *resource.Quantity
+	Disk          *resource.Quantity
+	GPU           *resource.Quantity
+	CPU           *resource.Quantity
+	LimitedMemory *resource.Quantity
+	LimitedDisk   *resource.Quantity
+	LimitedGPU    *resource.Quantity
+	LimitedCPU    *resource.Quantity
 }
 
 type AppPolicy struct {
@@ -171,36 +174,129 @@ func (c *ApplicationConfig) GenSharedEntranceURL(ctx context.Context) ([]Entranc
 	return GenSharedEntranceURL(ctx, app)
 }
 
-func (c *ApplicationConfig) GetSelectedGpuTypeValue() string {
-	if c.SelectedGpuType == "" {
-		return "none"
+func (c *ApplicationConfig) SelectedResourceMode() (ResourceMode, bool) {
+	modes := c.ComputeResourceModes()
+	if len(modes) == 1 && len(c.Resources) == 0 {
+		return modes[0], true
 	}
-	return c.SelectedGpuType
+	mode := findResourceMode(modes, c.SelectedGpuType)
+	if mode == nil {
+		return ResourceMode{}, false
+	}
+	return *mode, true
 }
 
+// ComputeResourceModes returns the modes the app declares support for.
+// New-format manifests (>= 0.12.0) carry an explicit spec.resources matrix
+// and are returned verbatim. Legacy manifests (< 0.12.0) don't have a
+// per-mode matrix, so we synthesize a single ResourceMode whose Mode is
+// derived from c.SelectedGpuType / c.Requirement.GPU — see
+// legacyComputeMode for the exact rules.
+func (c *ApplicationConfig) ComputeResourceModes() []ResourceMode {
+	if len(c.Resources) > 0 {
+		return c.Resources
+	}
+	mode := legacyComputeMode(c)
+	return []ResourceMode{{
+		Mode:                mode,
+		ResourceRequirement: c.Requirement.ResourceRequirement(mode),
+	}}
+}
+
+// legacyComputeMode picks the synthesized mode for a legacy manifest:
+//
+//   - If SelectedGpuType is set, use it verbatim. This covers the path
+//     where the install caller explicitly picked a GPU type (or the
+//     auto-selector did so on their behalf and we re-loaded the appCfg
+//     with the chosen mode).
+//   - If SelectedGpuType is empty and the manifest has a non-zero
+//     Requirement.GPU, fall back to nvidia — the only legacy-supported
+//     GPU type. This is what the install pre-check and the first
+//     GetAppConfig call see before auto-selection runs.
+//   - Otherwise the app is cpu-only.
+func legacyComputeMode(c *ApplicationConfig) string {
+	if c.SelectedGpuType != "" {
+		return c.SelectedGpuType
+	}
+	if c.Requirement.GPU != nil && !c.Requirement.GPU.IsZero() {
+		return utils.NvidiaCardType
+	}
+	return utils.CPUType
+}
+
+func (r AppRequirement) ResourceRequirement(mode string) ResourceRequirement {
+	req := ResourceRequirement{
+		RequiredCPU:    quantityString(r.CPU),
+		LimitedCPU:     quantityString(r.LimitedCPU),
+		RequiredMemory: quantityString(r.Memory),
+		LimitedMemory:  quantityString(r.LimitedMemory),
+		RequiredDisk:   quantityString(r.Disk),
+		LimitedDisk:    quantityString(r.LimitedDisk),
+	}
+	if mode == utils.NvidiaCardType {
+		req.RequiredGPU = quantityString(r.GPU)
+		req.LimitedGPU = quantityString(r.LimitedGPU)
+	}
+	return req
+}
+
+func quantityString(q *resource.Quantity) string {
+	if q == nil {
+		return ""
+	}
+	return q.String()
+}
+
+// resolveResourceMode picks the ResourceMode the install pipeline should
+// load against. The fallback rules differ depending on whether the caller
+// is expressing "no preference" or "I picked this specific mode":
+//
+//   - selectedGpu == ""  →  caller hasn't decided yet (install pre-check or
+//     the first GetAppConfig before auto-select runs). Prefer the cpu mode
+//     so legacy-style chart values stay stable; if the manifest doesn't
+//     declare a cpu mode (e.g. a GPU-only new-format app), fall back to
+//     the first declared mode as a placeholder. Either way, the install
+//     handler's auto-select step reloads the chart with the real chosen
+//     mode immediately afterwards, so the placeholder Requirement never
+//     reaches AllocateForInstall / AppInstallable.
+//
+//   - selectedGpu != ""  →  caller explicitly picked this mode. Match
+//     exactly and surface a "not declared" error if the manifest doesn't
+//     have it; silently falling back to cpu / first-mode would leave
+//     SelectedGpuType and Requirement out of sync and produce a misleading
+//     "compute resource is not enough" message at the AppInstallable gate.
+//
+// Returns nil only when modes is empty (the caller turns that into an
+// "empty compute resources" error) or when an explicitly selected mode
+// is not declared in the manifest.
 func resolveResourceMode(modes []ResourceMode, selectedGpu string) *ResourceMode {
-	targetMode := selectedGpu
-	if targetMode == "" || targetMode == "none" {
-		targetMode = utils.CPUType
+	if selectedGpu == "" {
+		if cpu := findResourceMode(modes, utils.CPUType); cpu != nil {
+			return cpu
+		}
+		// GPU-only new-format manifest: no cpu mode to fall back to. Use
+		// the first declared mode as a load-time placeholder so the chart
+		// loader can succeed; the install handler's auto-select step will
+		// pick the real mode and reload before any downstream code sees
+		// this Requirement.
+		if len(modes) > 0 {
+			return &modes[0]
+		}
+		return nil
 	}
+	return findResourceMode(modes, selectedGpu)
+}
 
+func findResourceMode(modes []ResourceMode, mode string) *ResourceMode {
 	for i := range modes {
-		if modes[i].Mode == targetMode {
+		if modes[i].Mode == mode {
 			return &modes[i]
 		}
 	}
-
-	// no target mode found fallback to cpu mode
-	for i := range modes {
-		if modes[i].Mode == utils.CPUType {
-			return &modes[i]
-		}
-	}
-
 	return nil
 }
 
-// ParseResourceRequirement converts the scalar required* fields of a
+// ParseResourceRequirement converts the scalar required*/limited* fields of a
 // ResourceRequirement into an AppRequirement. Empty fields and values that
 // fail with resource.ErrFormatWrong are treated as "not set" and produce a
 // nil quantity; any other parse error is returned to the caller. This mirrors
@@ -237,12 +333,32 @@ func ParseResourceRequirement(req *ResourceRequirement) (AppRequirement, error) 
 	if err != nil {
 		return AppRequirement{}, fmt.Errorf("parse required gpu %q: %w", req.RequiredGPU, err)
 	}
+	limCPU, err := parseQty(req.LimitedCPU)
+	if err != nil {
+		return AppRequirement{}, fmt.Errorf("parse limited cpu %q: %w", req.LimitedCPU, err)
+	}
+	limMem, err := parseQty(req.LimitedMemory)
+	if err != nil {
+		return AppRequirement{}, fmt.Errorf("parse limited memory %q: %w", req.LimitedMemory, err)
+	}
+	limDisk, err := parseQty(req.LimitedDisk)
+	if err != nil {
+		return AppRequirement{}, fmt.Errorf("parse limited disk %q: %w", req.LimitedDisk, err)
+	}
+	limGPU, err := parseQty(req.LimitedGPU)
+	if err != nil {
+		return AppRequirement{}, fmt.Errorf("parse limited gpu %q: %w", req.LimitedGPU, err)
+	}
 
 	return AppRequirement{
-		CPU:    cpu,
-		Memory: mem,
-		Disk:   disk,
-		GPU:    gpu,
+		CPU:           cpu,
+		Memory:        mem,
+		Disk:          disk,
+		GPU:           gpu,
+		LimitedCPU:    limCPU,
+		LimitedMemory: limMem,
+		LimitedDisk:   limDisk,
+		LimitedGPU:    limGPU,
 	}, nil
 }
 
@@ -251,28 +367,42 @@ func ParseResourceRequirement(req *ResourceRequirement) (AppRequirement, error) 
 // single source of truth for picking between the new spec.resources matrix
 // and the legacy scalar spec.required* fields.
 //
-//   - New manifest format (>= 0.12.0): pick the ResourceMode that matches
-//     selectedGpu from c.Resources (which must be non-empty).
-//   - Legacy manifest format (< 0.12.0): return c.Requirement directly. The
-//     scalar fields are expected to already be populated (and any
-//     supportedGpu special-resource overrides applied) at conversion time.
+//   - New manifest format (>= 0.12.0): pick the ResourceMode whose Mode
+//     equals selectedGpu from c.Resources. If selectedGpu is empty
+//     (pre-check / first GetAppConfig before auto-select runs), prefer
+//     the cpu mode; if the manifest declares no cpu mode, fall back to
+//     the first declared mode as a placeholder so the chart loader has
+//     something to bind against. The install handler's auto-select step
+//     reloads with the real chosen mode immediately afterwards. If
+//     selectedGpu names a mode the manifest doesn't declare, return an
+//     error rather than silently using cpu / first-mode.
+//   - Legacy manifest format (< 0.12.0): synthesize a single ResourceMode
+//     from c.Requirement. Apps without requiredGpu become cpu mode; apps
+//     with requiredGpu become nvidia mode (or whatever SelectedGpuType
+//     is set to).
 func (c *ApplicationConfig) ResolveRequirement(selectedGpu string) (*AppRequirement, error) {
-	if oac.IsNewOlaresManifestVersion(c.CfgFileVersion) {
-		if len(c.Resources) == 0 {
-			return nil, fmt.Errorf("empty spec resources")
-		}
-		mode := resolveResourceMode(c.Resources, selectedGpu)
-		if mode == nil {
-			return nil, fmt.Errorf("mode %s not found in spec resources", selectedGpu)
-		}
-		req, err := ParseResourceRequirement(&mode.ResourceRequirement)
+	modes := c.ComputeResourceModes()
+	if len(modes) == 0 {
+		return nil, fmt.Errorf("empty compute resources")
+	}
+	if len(c.Resources) == 0 && len(modes) == 1 {
+		req, err := ParseResourceRequirement(&modes[0].ResourceRequirement)
 		if err != nil {
-			return nil, fmt.Errorf("resolve requirement for mode %s: %w", mode.Mode, err)
+			return nil, fmt.Errorf("resolve requirement for mode %s: %w", modes[0].Mode, err)
 		}
 		return &req, nil
 	}
-
-	req := c.Requirement
+	mode := resolveResourceMode(modes, selectedGpu)
+	if mode == nil {
+		// resolveResourceMode only returns nil when an *explicit* mode
+		// wasn't found in the manifest; the empty-selectedGpu case is
+		// handled by the placeholder fallback inside it.
+		return nil, fmt.Errorf("mode %q is not declared in spec.resources", selectedGpu)
+	}
+	req, err := ParseResourceRequirement(&mode.ResourceRequirement)
+	if err != nil {
+		return nil, fmt.Errorf("resolve requirement for mode %s: %w", mode.Mode, err)
+	}
 	return &req, nil
 }
 

--- a/framework/app-service/pkg/appcfg/application_test.go
+++ b/framework/app-service/pkg/appcfg/application_test.go
@@ -1,0 +1,133 @@
+package appcfg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+// TestResolveRequirementSelectedGpuFallbackSemantics covers the empty-vs-explicit
+// distinction in resolveResourceMode for new-format manifests:
+//
+//   - selectedGpu == ""  →  the caller hasn't picked yet (pre-check / first
+//     GetAppConfig before auto-select runs). Prefer cpu, but if the
+//     manifest declares no cpu mode (a GPU-only new-format app), fall
+//     back to the first declared mode as a placeholder so the chart
+//     loader can succeed; the install handler's auto-select step reloads
+//     with the real chosen mode immediately afterwards.
+//   - selectedGpu != ""  →  the caller explicitly picked a mode. If the
+//     manifest doesn't declare it, surface that as an error rather than
+//     silently swapping to cpu / first-mode (which used to leave
+//     SelectedGpuType and Requirement out of sync and produce a
+//     misleading downstream "compute resource is not enough" message at
+//     AppInstallable).
+func TestResolveRequirementSelectedGpuFallbackSemantics(t *testing.T) {
+	nvidiaCpuApp := &ApplicationConfig{
+		AppName: "new-format-multi-mode",
+		Resources: []ResourceMode{
+			{
+				Mode: utils.NvidiaCardType,
+				ResourceRequirement: ResourceRequirement{
+					RequiredCPU: "1", RequiredMemory: "11Gi",
+					RequiredGPU: "8Gi", LimitedGPU: "16Gi",
+				},
+			},
+			{
+				Mode: utils.CPUType,
+				ResourceRequirement: ResourceRequirement{
+					RequiredCPU: "100m", RequiredMemory: "256Mi",
+				},
+			},
+		},
+	}
+	nvidiaOnlyApp := &ApplicationConfig{
+		AppName: "new-format-nvidia-only",
+		Resources: []ResourceMode{
+			{
+				Mode: utils.NvidiaCardType,
+				ResourceRequirement: ResourceRequirement{
+					RequiredCPU: "1", RequiredMemory: "11Gi",
+					RequiredGPU: "8Gi", LimitedGPU: "16Gi",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cfg         *ApplicationConfig
+		selectedGpu string
+		wantMode    string
+		wantGPU     string // expected RequiredGPU on the parsed Requirement, "" means nil
+		wantErrFrag string
+	}{
+		{
+			name:        "empty selectedGpu falls back to cpu placeholder",
+			cfg:         nvidiaCpuApp,
+			selectedGpu: "",
+			wantMode:    utils.CPUType,
+			wantGPU:     "", // cpu mode has no GPU requirement
+		},
+		{
+			name:        "explicit nvidia matches and keeps GPU values",
+			cfg:         nvidiaCpuApp,
+			selectedGpu: utils.NvidiaCardType,
+			wantMode:    utils.NvidiaCardType,
+			wantGPU:     "8Gi",
+		},
+		{
+			name:        "explicit cpu matches",
+			cfg:         nvidiaCpuApp,
+			selectedGpu: utils.CPUType,
+			wantMode:    utils.CPUType,
+			wantGPU:     "",
+		},
+		{
+			name:        "explicit unsupported mode returns clear error (no silent cpu fallback)",
+			cfg:         nvidiaCpuApp,
+			selectedGpu: utils.AppleMChipType,
+			wantErrFrag: "is not declared in spec.resources",
+		},
+		{
+			// GPU-only new-format manifest: no cpu mode to fall back to.
+			// resolveResourceMode picks the first declared mode (nvidia)
+			// as a placeholder so the chart loader succeeds; auto-select
+			// in the install handler will subsequently reload with the
+			// real chosen mode.
+			name:        "empty selectedGpu on nvidia-only manifest falls back to first mode as placeholder",
+			cfg:         nvidiaOnlyApp,
+			selectedGpu: "",
+			wantMode:    utils.NvidiaCardType,
+			wantGPU:     "8Gi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := tt.cfg.ResolveRequirement(tt.selectedGpu)
+			if tt.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got requirement %#v", tt.wantErrFrag, req)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrFrag) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErrFrag, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// We can't directly observe req.Mode here (AppRequirement doesn't
+			// carry it), so verify the GPU side-effect: the cpu fallback
+			// strips RequiredGPU, the nvidia path keeps it.
+			gotGPU := ""
+			if req.GPU != nil {
+				gotGPU = req.GPU.String()
+			}
+			if gotGPU != tt.wantGPU {
+				t.Fatalf("expected RequiredGPU %q, got %q", tt.wantGPU, gotGPU)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/appcfg/utils.go
+++ b/framework/app-service/pkg/appcfg/utils.go
@@ -7,6 +7,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 )
 
@@ -35,7 +36,21 @@ func GetAppInstallationConfig(app, owner string) (*ApplicationConfig, error) {
 	}
 
 	appcfg.Namespace = namespace
-	appcfg.OwnerName = owner
+	// v3 apps share one cluster-wide installation across admins. Persist
+	// the cluster owner as a stable real-user identity so every consumer
+	// (compute allocation, HAMI binding labels, pod labels, kubesphere
+	// user APIs, user-scoped namespaces) sees the same value no matter
+	// which admin operates the app. See pkg/utils/app::GetAppConfig for
+	// the canonical write site at install time.
+	if appcfg.IsV3() {
+		clusterOwner, err := kubesphere.GetClusterOwner(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		appcfg.OwnerName = clusterOwner
+	} else {
+		appcfg.OwnerName = owner
+	}
 
 	return appcfg, nil
 }

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -81,8 +81,9 @@ type HelmOpsInterface interface {
 
 // Opt options for helm ops.
 type Opt struct {
-	Source       string
-	MarketSource string
+	Source             string
+	MarketSource       string
+	SkipWaitForStartUp bool
 }
 
 var _ HelmOpsInterface = &HelmOps{}
@@ -936,6 +937,10 @@ func (h *HelmOps) Install() error {
 	}
 
 	if h.app.Type == appv1alpha1.Middleware.String() {
+		return nil
+	}
+	if h.options.SkipWaitForStartUp {
+		klog.Infof("skip waiting for app %s startup", h.app.AppName)
 		return nil
 	}
 	ok, err := h.WaitForStartUp()

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -55,10 +55,10 @@ func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig
 	values["admin"] = admin
 
 	values["GPU"] = map[string]interface{}{
-		"Type": appConfig.GetSelectedGpuTypeValue(),
+		"Type": appConfig.SelectedGpuType,
 		"Cuda": os.Getenv("OLARES_SYSTEM_CUDA_VERSION"),
 	}
-	values["gpu"] = appConfig.GetSelectedGpuTypeValue()
+	values["gpu"] = appConfig.SelectedGpuType
 
 	terminus, err := utils.GetTerminusVersion(ctx, kubeConfig)
 	if err != nil {

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_install.go
@@ -113,6 +113,10 @@ func (h *HelmOpsV2) Install() error {
 	if h.App().Type == appv1alpha1.Middleware.String() {
 		return nil
 	}
+	if h.Options().SkipWaitForStartUp {
+		klog.Infof("skip waiting for app %s startup", h.App().AppName)
+		return nil
+	}
 	ok, err := h.WaitForStartUp()
 	if err != nil && (errors.Is(err, errcode.ErrPodPending) || errors.Is(err, errcode.ErrServerSidePodPending)) {
 		klog.Errorf("App %s is pending, err=%v", h.App().AppName, err)

--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller/versioned"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/errcode"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
@@ -82,14 +83,6 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 
 	opCtx, cancel := context.WithCancel(context.Background())
 
-	ops, err := versioned.NewHelmOps(opCtx, kubeConfig, appCfg, token,
-		appinstaller.Opt{Source: p.manager.Spec.Source, MarketSource: appcfg.GetMarketSource(p.manager)})
-	if err != nil {
-		klog.Errorf("make helm ops failed %v", err)
-		cancel()
-		return nil, err
-	}
-
 	return appFactory.execAndWatch(opCtx, p,
 		func(c context.Context) (StatefulInProgressApp, error) {
 			in := installingInProgressApp{
@@ -102,9 +95,39 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 
 			go func() {
 				defer cancel()
+				var allocationErr error
+				allocationMessage := ""
+				if _, allocationErr = compute.AllocateForInstall(c, p.client, appCfg); allocationErr != nil {
+					klog.Errorf("allocate compute resource for app %s failed %v", p.manager.Spec.AppName, allocationErr)
+					allocationMessage = fmt.Sprintf("Insufficient compute resource for selected mode %s: %v", appCfg.SelectedGpuType, allocationErr)
+					compute.PublishComputeInsufficientNotification(appCfg, allocationErr)
+				}
+
+				ops, err := versioned.NewHelmOps(c, kubeConfig, appCfg, token,
+					appinstaller.Opt{
+						Source:             p.manager.Spec.Source,
+						MarketSource:       appcfg.GetMarketSource(p.manager),
+						SkipWaitForStartUp: allocationErr != nil,
+					})
+				if err != nil {
+					klog.Errorf("make helm ops failed %v", err)
+					p.finally = func() {
+						klog.Errorf("app %s install failed, update app state to installFailed", p.manager.Spec.AppName)
+						opRecord := makeRecord(p.manager, appsv1.InstallFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
+						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, err.Error(), appsv1.InstallFailed.String())
+						if updateErr != nil {
+							klog.Errorf("update status failed %v", updateErr)
+						}
+					}
+					return
+				}
+
 				err = ops.Install()
 				if err != nil {
 					klog.Errorf("install app %s failed %v", p.manager.Spec.AppName, err)
+					if cleanupErr := compute.DeleteAllocationsForApp(context.TODO(), p.client, appCfg.AppName, appCfg.OwnerName); cleanupErr != nil {
+						klog.Warningf("cleanup compute allocation for failed install %s failed: %v", appCfg.AppName, cleanupErr)
+					}
 					if errors.Is(err, errcode.ErrServerSidePodPending) {
 						p.finally = func() {
 							klog.Infof("app %s server side pods is pending, set stop-all annotation and update app state to stopping", p.manager.Spec.AppName)
@@ -166,6 +189,39 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 
 					return
 				} // end of err != nil
+
+				if allocationErr != nil {
+					p.finally = func() {
+						manager := p.manager
+						var am appsv1.ApplicationManager
+						if err := p.client.Get(context.TODO(), types.NamespacedName{Name: p.manager.Name}, &am); err != nil {
+							klog.Errorf("failed to get application manager: %v", err)
+							return
+						}
+						managesSharedServer, targetErr := compute.ManagesSharedServer(context.TODO(), p.client, appCfg)
+						if targetErr != nil {
+							klog.Warningf("failed to resolve compute target for app %s: %v", appCfg.AppName, targetErr)
+						}
+						if managesSharedServer {
+							if am.Annotations == nil {
+								am.Annotations = make(map[string]string)
+							}
+							am.Annotations[api.AppStopAllKey] = "true"
+						}
+						am.Spec.OpType = appsv1.StopOp
+						am.Status.OpType = appsv1.StopOp
+						if err := p.client.Update(context.TODO(), &am); err != nil {
+							klog.Errorf("failed to update app manager stop metadata: %v", err)
+							return
+						}
+						manager = &am
+						updateErr := p.updateStatus(context.TODO(), manager, appsv1.Stopping, nil, allocationMessage, constants.AppUnschedulable)
+						if updateErr != nil {
+							klog.Errorf("update status failed %v", updateErr)
+						}
+					}
+					return
+				}
 
 				if p.manager.Spec.Type == appsv1.Middleware {
 					ok, err := ops.WaitForLaunch()

--- a/framework/app-service/pkg/appstate/installing_canceling_app.go
+++ b/framework/app-service/pkg/appstate/installing_canceling_app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller/versioned"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
@@ -152,6 +153,10 @@ func (p *InstallingCancelingApp) handleInstallCancel(ctx context.Context) error 
 	}
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 		klog.Errorf("execute uninstall failed %v", err)
+		return err
+	}
+	if err := compute.DeleteAllocationsForApp(ctx, p.client, appCfg.AppName, appCfg.OwnerName); err != nil {
+		klog.Errorf("delete compute allocation for canceled install app %s failed %v", appCfg.AppName, err)
 		return err
 	}
 

--- a/framework/app-service/pkg/appstate/suspending_app.go
+++ b/framework/app-service/pkg/appstate/suspending_app.go
@@ -2,11 +2,14 @@ package appstate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubeblocks"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
@@ -150,6 +153,15 @@ func (p *SuspendingApp) exec(ctx context.Context) error {
 			klog.Errorf("suspend middleware %s failed %v", p.manager.Spec.AppName, err)
 			return err
 		}
+	}
+	var appCfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup failed %v", err)
+		return err
+	}
+	if err := compute.DeleteAllocationsForComputeTarget(ctx, p.client, &appCfg, stopServer); err != nil {
+		klog.Errorf("delete compute allocation for suspended app %s failed %v", p.manager.Spec.AppName, err)
+		return err
 	}
 	return nil
 }

--- a/framework/app-service/pkg/appstate/uninstalling_app.go
+++ b/framework/app-service/pkg/appstate/uninstalling_app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller/versioned"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -194,6 +195,10 @@ func (p *UninstallingApp) exec(ctx context.Context) error {
 	}
 	if err != nil {
 		klog.Errorf("uninstall app %s failed %v", p.manager.Spec.AppName, err)
+		return err
+	}
+	if err = compute.DeleteAllocationsForComputeTarget(ctx, p.client, appCfg, uninstallAll == "true"); err != nil {
+		klog.Errorf("delete compute allocation for app %s failed %v", p.manager.Spec.AppName, err)
 		return err
 	}
 	err = p.waitForDeleteNamespace(ctx)

--- a/framework/app-service/pkg/compute/auto_select.go
+++ b/framework/app-service/pkg/compute/auto_select.go
@@ -1,0 +1,177 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ErrAmbiguousComputeMode is returned by AutoSelectMode when more than one
+// non-cpu mode declared by the app is also runnable on the cluster, so the
+// caller must surface the ambiguity to the user (e.g. by returning the
+// install compute plan and asking for an explicit selectedGpuType).
+var ErrAmbiguousComputeMode = errors.New("multiple gpu types runnable on this cluster; please specify selectedGpuType")
+
+// AutoSelectMode picks a compute mode for `appCfg` when the install caller
+// did not supply one explicitly. It is meant to make the common cases
+// "obvious choice, just pick it" frictionless without ever silently picking
+// the wrong mode when more than one is plausible.
+//
+// Algorithm:
+//
+//  1. Build cluster.gpuTypes = the set of non-cpu GPU types that show up on
+//     any node label gpu.bytetrade.io/type. The cluster always implicitly
+//     supports cpu mode because every GPU node can also run a cpu-mode pod;
+//     cpu therefore is never enumerated in cluster.gpuTypes.
+//
+//  2. Build app.modes = the set of modes the manifest declares support for.
+//     See AppSupportedModes for the exact rules.
+//
+//  3. valid = (modes the app supports) ∩ (modes runnable on this cluster).
+//     - cpu is "runnable" iff app.modes contains cpu.
+//     - any non-cpu mode m is "runnable" iff m ∈ cluster.gpuTypes.
+//
+//  4. Decide:
+//     - exactly one non-cpu entry in valid → return that. (Single GPU
+//     candidate, no ambiguity even if cpu fallback is also valid.)
+//     - zero non-cpu entries in valid, but cpu ∈ valid → return cpu.
+//     (App is effectively cpu-only on this cluster.)
+//     - otherwise (multiple non-cpu candidates, or the intersection is
+//     empty) → return an error and let the caller require an explicit
+//     SelectedGpuType.
+//
+// Worked examples (cluster has nvidia + cpu fallback):
+//
+//	app supports {nvidia, gb10, strix-halo}     -> nvidia
+//	app supports {nvidia, gb10, cpu}            -> nvidia (one non-cpu match)
+//	app supports {strix-halo, apple-m}          -> error (no overlap)
+//	app supports {cpu}                          -> cpu
+//
+// Worked examples (cluster has nvidia + strix-halo + cpu fallback):
+//
+//	app supports {nvidia}                       -> nvidia
+//	app supports {strix-halo}                   -> strix-halo
+//	app supports {nvidia, strix-halo}           -> error (ambiguous)
+//	app supports {cpu}                          -> cpu
+//	app supports {cpu, apple-m}                 -> cpu (apple-m not on cluster)
+func AutoSelectMode(ctx context.Context, c client.Client, appCfg *appcfg.ApplicationConfig) (string, error) {
+	if appCfg == nil {
+		return "", fmt.Errorf("auto select compute mode: nil app config")
+	}
+	// V2 shared-app installs reduce to a "client-only install" whenever the
+	// app's shared subchart is already owned by some other user. The wider
+	// shape of v2 shared-app installs is:
+	//
+	//   - The shared subchart can only be wired up once cluster-wide and
+	//     only by an admin user. Non-admin users trying to install it
+	//     first are rejected upstream by CheckDependencies (the manifest
+	//     declares the cluster-scoped admin install of itself as a
+	//     mandatory dependency for non-admin renders).
+	//   - Subsequent installers — whether non-admin or a second admin —
+	//     all render the manifest's "client" branch (no requiredGpu,
+	//     clusterScoped=false, shared subchart skipped at helm time) and
+	//     do not allocate compute on their own. The original admin's
+	//     server install owns the GPU.
+	//
+	// resolveComputeTarget returning !manage is the precise predicate for
+	// the second case regardless of the caller's admin status: it just
+	// looks at whether the shared namespace is already owned by someone
+	// other than appConfig.OwnerName.
+	//
+	// Force cpu here so SelectedGpuType stays consistent with the
+	// {cpu, installable} placeholder BuildInstallComputePlan emits for
+	// !manage and AppInstallable matches. Picking the manifest's
+	// nvidia/etc. just because the cluster has those GPUs would be
+	// misleading: this install never schedules onto a GPU node.
+	//
+	// Note: this short-circuit only affects the install path. Resume goes
+	// through ApplyBindingSelection (handler_suspend.go::resume) which
+	// uses ShouldIncludeSharedServerForResume to decide whether the
+	// resuming admin should also re-spin the shared server, and routes
+	// allocations onto the original server owner. AutoSelectMode is not
+	// on the resume path.
+	_, manage, err := resolveComputeTarget(ctx, c, appCfg, false)
+	if err != nil {
+		return "", fmt.Errorf("auto select compute mode: resolve compute target: %w", err)
+	}
+	if !manage {
+		return utils.CPUType, nil
+	}
+	var nodes corev1.NodeList
+	if err := c.List(ctx, &nodes); err != nil {
+		return "", fmt.Errorf("auto select compute mode: list nodes: %w", err)
+	}
+	// Reuse utils.GetAllGpuTypesFromNodes — same source of truth used by
+	// /api/v1/gpus and the install-time chart-render auto-detect path. It
+	// already excludes cpu (cpu nodes don't carry the gpu-type label), so
+	// the returned set is exactly the cluster's non-cpu GPU types.
+	clusterGPUTypes, err := utils.GetAllGpuTypesFromNodes(&nodes)
+	if err != nil {
+		return "", fmt.Errorf("auto select compute mode: %w", err)
+	}
+	return autoSelectModeFromInputs(AppSupportedModes(appCfg), clusterGPUTypes)
+}
+
+// autoSelectModeFromInputs is the pure-data core of AutoSelectMode, factored
+// out so unit tests can exercise the decision matrix without spinning up a
+// fake controller-runtime client. See AutoSelectMode for the contract.
+func autoSelectModeFromInputs(appModes []string, clusterGPUTypes map[string]struct{}) (string, error) {
+	var validNonCPU []string
+	var validCPU bool
+	for _, mode := range appModes {
+		if mode == utils.CPUType {
+			validCPU = true
+			continue
+		}
+		if _, ok := clusterGPUTypes[mode]; ok {
+			validNonCPU = append(validNonCPU, mode)
+		}
+	}
+
+	switch len(validNonCPU) {
+	case 1:
+		return validNonCPU[0], nil
+	case 0:
+		if validCPU {
+			return utils.CPUType, nil
+		}
+		return "", fmt.Errorf("no compute mode runnable on this cluster; please install on a compatible cluster")
+	default:
+		return "", ErrAmbiguousComputeMode
+	}
+}
+
+// AppSupportedModes returns the set of GPU modes the app declares support
+// for, by deferring to appCfg.ComputeResourceModes() — the same accessor
+// the rest of the compute package (BuildInstallComputePlan,
+// SelectedResourceMode, …) uses — so the auto-selector and the rest of
+// the install pipeline always see the same view of the manifest:
+//
+//   - New-format manifests (>= 0.12.0): ComputeResourceModes returns the
+//     spec.resources matrix verbatim, one entry per declared mode.
+//   - Legacy manifests (< 0.12.0) with non-zero requiredGpu: it synthesizes
+//     a single {Mode: nvidia} entry. Legacy apps in practice only target
+//     nvidia, so a single-element {nvidia} set is the right answer.
+//   - Legacy manifests with no GPU requirement: it synthesizes a single
+//     {Mode: cpu} entry.
+//
+// Modes are returned in declared order. They are assumed to already be
+// canonical strings (lowercased, no whitespace) since the manifest pipeline
+// and node-label readers are responsible for keeping that contract.
+func AppSupportedModes(appCfg *appcfg.ApplicationConfig) []string {
+	if appCfg == nil {
+		return nil
+	}
+	modes := appCfg.ComputeResourceModes()
+	out := make([]string, 0, len(modes))
+	for _, m := range modes {
+		out = append(out, m.Mode)
+	}
+	return out
+}

--- a/framework/app-service/pkg/compute/auto_select_test.go
+++ b/framework/app-service/pkg/compute/auto_select_test.go
@@ -1,0 +1,366 @@
+package compute
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAppSupportedModes(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *appcfg.ApplicationConfig
+		want []string
+	}{
+		{
+			name: "new format returns spec.resources verbatim in declared order",
+			cfg: &appcfg.ApplicationConfig{
+				Resources: []appcfg.ResourceMode{
+					{Mode: utils.NvidiaCardType},
+					{Mode: utils.CPUType},
+				},
+			},
+			want: []string{utils.NvidiaCardType, utils.CPUType},
+		},
+		{
+			name: "legacy app with non-zero requiredGpu collapses to nvidia",
+			cfg: &appcfg.ApplicationConfig{
+				Requirement: appcfg.AppRequirement{GPU: mustParseQty("10Gi")},
+			},
+			want: []string{utils.NvidiaCardType},
+		},
+		{
+			name: "legacy app with zero requiredGpu is cpu-only",
+			cfg: &appcfg.ApplicationConfig{
+				Requirement: appcfg.AppRequirement{GPU: mustParseQty("0")},
+			},
+			want: []string{utils.CPUType},
+		},
+		{
+			name: "legacy app with no GPU requirement is cpu-only",
+			cfg:  &appcfg.ApplicationConfig{},
+			want: []string{utils.CPUType},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppSupportedModes(tt.cfg)
+			if !equalStringSlices(got, tt.want) {
+				t.Fatalf("AppSupportedModes(%#v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+func mustParseQty(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+// TestAutoSelectModeFromInputs covers both worked-example clusters from the
+// design doc:
+//
+//	cluster A: a single nvidia node (cluster gpu types = {nvidia})
+//	cluster B: nvidia + strix-halo nodes (cluster gpu types = {nvidia, strix-halo})
+//
+// In both clusters cpu is implicit — every node can run a cpu-mode pod —
+// so cpu is never enumerated in the cluster set itself; the auto-selector
+// only treats cpu as a valid choice when the app declares it.
+func TestAutoSelectModeFromInputs(t *testing.T) {
+	clusterNvidiaOnly := stringSet(utils.NvidiaCardType)
+	clusterNvidiaPlusStrix := stringSet(utils.NvidiaCardType, utils.StrixHaloChipType)
+
+	tests := []struct {
+		name        string
+		appModes    []string
+		cluster     map[string]struct{}
+		wantMode    string
+		wantErrFrag string
+	}{
+		// case 1: cluster has only nvidia
+		{
+			name:     "case1/A: app supports nvidia/gb10/strix-halo, only nvidia matches",
+			appModes: []string{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType},
+			cluster:  clusterNvidiaOnly,
+			wantMode: utils.NvidiaCardType,
+		},
+		{
+			name:     "case1/B: app supports nvidia/gb10/cpu, nvidia wins over cpu fallback",
+			appModes: []string{utils.NvidiaCardType, utils.GB10ChipType, utils.CPUType},
+			cluster:  clusterNvidiaOnly,
+			wantMode: utils.NvidiaCardType,
+		},
+		{
+			name:        "case1/C: app supports strix-halo/apple-m, no overlap with cluster, errors",
+			appModes:    []string{utils.StrixHaloChipType, utils.AppleMChipType},
+			cluster:     clusterNvidiaOnly,
+			wantErrFrag: "no compute mode runnable",
+		},
+		{
+			name:     "case1/D: app supports cpu only, picks cpu",
+			appModes: []string{utils.CPUType},
+			cluster:  clusterNvidiaOnly,
+			wantMode: utils.CPUType,
+		},
+
+		// case 2: cluster has both nvidia and strix-halo
+		{
+			name:     "case2/A: app supports nvidia, picks nvidia",
+			appModes: []string{utils.NvidiaCardType},
+			cluster:  clusterNvidiaPlusStrix,
+			wantMode: utils.NvidiaCardType,
+		},
+		{
+			name:     "case2/B: app supports strix-halo, picks strix-halo",
+			appModes: []string{utils.StrixHaloChipType},
+			cluster:  clusterNvidiaPlusStrix,
+			wantMode: utils.StrixHaloChipType,
+		},
+		{
+			name:        "case2/C: app supports both nvidia and strix-halo, ambiguous, errors",
+			appModes:    []string{utils.NvidiaCardType, utils.StrixHaloChipType},
+			cluster:     clusterNvidiaPlusStrix,
+			wantErrFrag: "multiple gpu types",
+		},
+		{
+			name:     "case2/D: app supports cpu only, picks cpu",
+			appModes: []string{utils.CPUType},
+			cluster:  clusterNvidiaPlusStrix,
+			wantMode: utils.CPUType,
+		},
+		{
+			name:     "case2/E: app supports cpu/apple-m on cluster without apple-m, picks cpu",
+			appModes: []string{utils.CPUType, utils.AppleMChipType},
+			cluster:  clusterNvidiaPlusStrix,
+			wantMode: utils.CPUType,
+		},
+
+		// degenerate cluster: no GPU at all
+		{
+			name:     "no GPU in cluster: cpu-supporting app picks cpu",
+			appModes: []string{utils.CPUType, utils.NvidiaCardType},
+			cluster:  stringSet(),
+			wantMode: utils.CPUType,
+		},
+		{
+			name:        "no GPU in cluster: GPU-only app errors",
+			appModes:    []string{utils.NvidiaCardType},
+			cluster:     stringSet(),
+			wantErrFrag: "no compute mode runnable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := autoSelectModeFromInputs(tt.appModes, tt.cluster)
+			if tt.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got mode %q", tt.wantErrFrag, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrFrag) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErrFrag, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantMode {
+				t.Fatalf("expected mode %q, got %q", tt.wantMode, got)
+			}
+		})
+	}
+}
+
+// TestAutoSelectModeShortCircuitsForSharedClientInstall verifies the
+// "client-only install" path of v2 shared apps: when the shared subchart
+// is already owned by some other user, the current install does not
+// allocate compute on its own (the original admin's server install did),
+// so AutoSelectMode must return cpu regardless of cluster GPU types or
+// manifest-declared GPU modes.
+//
+// This branch fires for *any subsequent installer* of a v2 shared app
+// whose admin-owned server is already in place — both a non-admin user
+// installing the client and a second admin (Admin B) installing the same
+// shared app that Admin A already owns. Only the very first installer
+// of a v2 shared app wires up the server, and that first installer must
+// be an admin: non-admin first-installers are rejected upstream by
+// CheckDependencies (the manifest declares its own cluster-scoped admin
+// install as a mandatory application dependency for non-admin renders).
+//
+// resolveComputeTarget returning !manage is the precise predicate for
+// the "subsequent installer" case, and it doesn't look at the caller's
+// admin status at all.
+//
+// Without this short-circuit the auto-selector would happily pick nvidia
+// based on cluster types, then AppInstallable would reject the install
+// because the !manage plan only contains a cpu row.
+func TestAutoSelectModeShortCircuitsForSharedClientInstall(t *testing.T) {
+	const (
+		appName     = "comfyuiv2"
+		sharedChart = "comfyuiv2server"
+		serverOwner = "admin-a"
+	)
+
+	// We exercise the same scenario for both a non-admin caller and a
+	// second-admin caller: in this layer the only signal that matters is
+	// "someone else owns the shared server", so the result must be cpu
+	// in both cases. The fake client setup does not differentiate admin
+	// status — that's checked elsewhere in the install pipeline.
+	cases := []struct {
+		name         string
+		currentOwner string
+	}{
+		{name: "non-admin client install", currentOwner: "alice"},
+		{name: "second-admin install while admin-a owns shared server", currentOwner: "admin-b"},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	// Cluster has a single nvidia node so a naive AutoSelectMode would
+	// otherwise pick nvidia on a legacy GPU app.
+	nvidiaNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-nvidia",
+			Labels: map[string]string{
+				utils.NodeGPUTypeLabel: utils.NvidiaCardType,
+			},
+		},
+	}
+
+	// Pre-existing shared namespace owned by serverOwner, signaling the
+	// shared server has already been installed by another user.
+	sharedNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: appcfg.ChartNamespace(&appcfg.Chart{Name: sharedChart, Shared: true}, serverOwner),
+			Labels: map[string]string{
+				constants.ApplicationNameLabel:        appName,
+				constants.ApplicationInstallUserLabel: serverOwner,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(nvidiaNode, sharedNS).
+				Build()
+
+			cfg := &appcfg.ApplicationConfig{
+				AppName:    appName,
+				OwnerName:  tc.currentOwner,
+				APIVersion: appcfg.V2,
+				SubCharts: []appcfg.Chart{
+					{Name: sharedChart, Shared: true},
+				},
+				// Legacy GPU app: AppSupportedModes would otherwise
+				// return [nvidia] and the cluster has nvidia, so a
+				// non-short-circuited path would confidently pick
+				// nvidia for what is actually a non-managing install.
+				Requirement: appcfg.AppRequirement{GPU: mustParseQty("10Gi")},
+			}
+
+			chosen, err := AutoSelectMode(context.Background(), c, cfg)
+			if err != nil {
+				t.Fatalf("AutoSelectMode unexpected error: %v", err)
+			}
+			if chosen != utils.CPUType {
+				t.Fatalf("expected client-only install to short-circuit to %q, got %q", utils.CPUType, chosen)
+			}
+		})
+	}
+}
+
+// TestAutoSelectModeOnNvidiaOnlyNewFormatApp covers the end-to-end install
+// pre-check + auto-select path for a hypothetical new-format manifest
+// (>= 0.12.0) whose spec.resources matrix declares only an nvidia mode
+// (no cpu fallback).
+//
+// Without the placeholder fallback in resolveResourceMode this case used
+// to crash inside ResolveRequirement on the very first GetAppConfig call
+// with a confusing "no default cpu mode declared in spec.resources"
+// error, which prevented auto-select from ever running. With the
+// placeholder in place, the chart loader binds against the first
+// declared mode (nvidia) and auto-select then picks the real mode based
+// on the cluster.
+func TestAutoSelectModeOnNvidiaOnlyNewFormatApp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	nvidiaNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-nvidia",
+			Labels: map[string]string{
+				utils.NodeGPUTypeLabel: utils.NvidiaCardType,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(nvidiaNode).
+		Build()
+
+	// Simulate the appCfg state right after the *first* GetAppConfig call
+	// with empty selectedGpu: SelectedGpuType is empty, but the
+	// placeholder fallback in resolveResourceMode has bound Requirement
+	// against the first declared mode (nvidia), so AppSupportedModes
+	// reports [nvidia].
+	cfg := &appcfg.ApplicationConfig{
+		AppName:   "nvidia-only-new-format",
+		OwnerName: "alice",
+		Resources: []appcfg.ResourceMode{
+			{
+				Mode: utils.NvidiaCardType,
+				ResourceRequirement: appcfg.ResourceRequirement{
+					RequiredCPU: "1", RequiredMemory: "11Gi",
+					RequiredGPU: "8Gi", LimitedGPU: "16Gi",
+				},
+			},
+		},
+		// Don't set SelectedGpuType — this is the "empty input" state.
+	}
+
+	chosen, err := AutoSelectMode(context.Background(), c, cfg)
+	if err != nil {
+		t.Fatalf("AutoSelectMode unexpected error: %v", err)
+	}
+	if chosen != utils.NvidiaCardType {
+		t.Fatalf("expected nvidia (the only declared mode, also runnable on the cluster), got %q", chosen)
+	}
+}
+
+func stringSet(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		out[v] = struct{}{}
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -1,0 +1,510 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var errBindingUnavailable = errors.New("compute binding unavailable")
+
+func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnapshot) *AvailabilityResult {
+	result := &AvailabilityResult{
+		Requirement: req,
+		Scope:       availabilityScope(req),
+		Nodes:       make([]NodeOption, 0, len(nodes)),
+	}
+	classified := classifyLaunchNodes(req, nodes, pressure)
+	for _, node := range classified {
+		if node.Status == NodeStatusNotMatch {
+			continue
+		}
+		result.Nodes = append(result.Nodes, node)
+	}
+	if len(result.Nodes) == 0 {
+		result.Schedulable = false
+		result.Reason = "no-matching-node"
+		return result
+	}
+	markOperable(result)
+	result.Schedulable, result.Reason = availabilitySummary(req, result.Nodes)
+	return result
+}
+
+func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot) []NodeOption {
+	out := make([]NodeOption, 0, len(nodes))
+	for _, node := range nodes {
+		if node.GPUType != req.Mode {
+			out = append(out, NodeOption{
+				NodeName: node.NodeName,
+				GPUType:  node.GPUType,
+				Status:   NodeStatusNotMatch,
+			})
+			continue
+		}
+		var option NodeOption
+		if req.Mode == utils.NvidiaCardType {
+			option = classifyNvidiaNode(req, node, pressure)
+		} else {
+			option = classifyNonNvidiaNode(req, node, pressure)
+		}
+		out = append(out, option)
+	}
+	return out
+}
+
+func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
+	summary := summarizeNvidiaNode(req, node, pressure)
+	option := NodeOption{
+		NodeName: node.NodeName,
+		GPUType:  node.GPUType,
+		Devices:  summary.devices,
+	}
+	if req.SupportMultiCards || req.SupportMultiNodes {
+		option.Status = nodeStatusFromCapacity(req.RequiredGPU, summary.totalCapacity, summary.totalAvailable)
+		return option
+	}
+	option.Status = nodeStatusFromCapacity(req.RequiredGPU, summary.maxCapacity, summary.maxAvailable)
+	return option
+}
+
+func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
+	option := NodeOption{NodeName: node.NodeName, GPUType: node.GPUType}
+	if len(node.Devices) == 0 {
+		option.Status = NodeStatusNotAvailable
+		return option
+	}
+	devOpt := makeDeviceOption(req, node, node.Devices[0], pressure)
+	option.Devices = []DeviceOption{devOpt}
+	switch {
+	case devOpt.Health != deviceHealthYes:
+		option.Status = NodeStatusNotAvailable
+	case devOpt.Capacity < req.RequiredMemory:
+		option.Status = NodeStatusNotEnough
+	case devOpt.Available >= req.RequiredMemory && !pressure.WouldPressure(node, AddedResources{
+		CPU:    req.RequiredCPU,
+		Memory: req.RequiredMemory,
+	}):
+		option.Status = NodeStatusAvailable
+	default:
+		option.Status = NodeStatusNotAvailable
+	}
+	return option
+}
+
+type nvidiaNodeSummary struct {
+	devices        []DeviceOption
+	totalCapacity  int64
+	totalAvailable int64
+	maxCapacity    int64
+	maxAvailable   int64
+}
+
+func summarizeNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) nvidiaNodeSummary {
+	summary := nvidiaNodeSummary{devices: make([]DeviceOption, 0, len(node.Devices))}
+	for _, device := range node.Devices {
+		devOpt := makeDeviceOption(req, node, device, pressure)
+		summary.devices = append(summary.devices, devOpt)
+		if devOpt.Health != deviceHealthYes {
+			continue
+		}
+		summary.totalCapacity += device.Memory
+		summary.totalAvailable += devOpt.Available
+		if device.Memory > summary.maxCapacity {
+			summary.maxCapacity = device.Memory
+		}
+		if devOpt.Available > summary.maxAvailable {
+			summary.maxAvailable = devOpt.Available
+		}
+	}
+	return summary
+}
+
+func nodeStatusFromCapacity(required, capacity, available int64) string {
+	if capacity < required {
+		return NodeStatusNotEnough
+	}
+	if available >= required {
+		return NodeStatusAvailable
+	}
+	return NodeStatusNotAvailable
+}
+
+func makeDeviceOption(req Requirement, node Node, device Device, pressure PressureSnapshot) DeviceOption {
+	req.RequiredDisk = 0
+	available := deviceAvailableMemory(device)
+	option := DeviceOption{
+		NodeName:    node.NodeName,
+		DeviceID:    device.ID,
+		CardModel:   device.CardModel,
+		SupportType: device.SupportType,
+		Capacity:    device.Memory,
+		Available:   available,
+		Health:      device.Health,
+	}
+	if option.Health == "" {
+		option.Health = deviceHealthYes
+	}
+	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
+		fits, _ := deviceFitsLevel(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes)
+		if fits {
+			option.FitLevel = level
+			break
+		}
+	}
+	return option
+}
+
+func availabilityScope(req Requirement) string {
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
+		return AvailabilityScopeCrossNode
+	}
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
+		return AvailabilityScopeSingleNode
+	}
+	if req.Mode == utils.NvidiaCardType {
+		return AvailabilityScopeCard
+	}
+	return AvailabilityScopeNode
+}
+
+func markOperable(result *AvailabilityResult) {
+	for ni := range result.Nodes {
+		node := &result.Nodes[ni]
+		switch result.Scope {
+		case AvailabilityScopeCrossNode:
+			if node.Status != NodeStatusNotEnough && node.Status != NodeStatusNotAvailable && node.Status != NodeStatusAvailable {
+				continue
+			}
+		default:
+			if node.Status != NodeStatusAvailable {
+				continue
+			}
+		}
+		for di := range node.Devices {
+			node.Devices[di].Operable = node.Devices[di].Health == deviceHealthYes
+		}
+	}
+}
+
+// availabilitySummary decides whether the request is schedulable across the
+// already-classified nodes. By the time we get here, NotMatch nodes have been
+// filtered out by listAvailableForLaunch, and classifyNvidiaNode /
+// classifyNonNvidiaNode have already folded pressure + capacity into
+// node.Status. So:
+//   - CrossNode: sum raw `device.Available` across healthy devices, per PDF.
+//   - Everything else: any node already marked NodeStatusAvailable is enough,
+//     because the classifier already established it can host the request.
+func availabilitySummary(req Requirement, nodes []NodeOption) (bool, string) {
+	scope := availabilityScope(req)
+	if scope == AvailabilityScopeCrossNode {
+		var total int64
+		for _, node := range nodes {
+			for _, device := range node.Devices {
+				if device.Health != deviceHealthYes {
+					continue
+				}
+				total += device.Available
+			}
+		}
+		if total >= req.RequiredGPU {
+			return true, ""
+		}
+		return false, "insufficient-cluster-vram"
+	}
+	for _, node := range nodes {
+		if node.Status == NodeStatusAvailable {
+			return true, ""
+		}
+	}
+	return false, scopeNoAvailableReason(scope)
+}
+
+func scopeNoAvailableReason(scope string) string {
+	switch scope {
+	case AvailabilityScopeSingleNode:
+		return "no-node-with-enough-cards"
+	case AvailabilityScopeCard:
+		return "no-card-with-enough-vram"
+	default:
+		return "no-available-node"
+	}
+}
+
+func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, selections []BindingSelection, includeSharedServer bool) (*BindingApplyResult, error) {
+	if appConfig == nil {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	// For v2 cluster-shared apps the only allocation row and the only
+	// HAMI bindings live at (appName, sharedServerOwner). When the
+	// caller does not intend to touch the shared server (resume the
+	// client only — the server is already running with its existing
+	// allocation), skip compute binding entirely.
+	if appConfig.IsV2() && appConfig.HasClusterSharedCharts() && !includeSharedServer {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	// resolveComputeTarget redirects to the actual server owner's config
+	// when resume-all is triggered by someone who is not the original
+	// installer of the shared server; in every other reachable case it
+	// returns appConfig unchanged.
+	targetConfig, _, err := resolveComputeTarget(ctx, c, appConfig, includeSharedServer)
+	if err != nil {
+		return nil, err
+	}
+	appConfig = targetConfig
+	req, ok := SelectedRequirement(appConfig)
+	if !ok || req.Mode == utils.CPUType {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	pressure, err := FetchPressureSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(selections) == 0 {
+		nodes, err := FetchNodeComputeAllocations(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		return &BindingApplyResult{
+			Status:       BindingApplyStatusRequired,
+			Availability: listAvailableForLaunch(req, nodes, pressure),
+			TargetApp:    appConfig.AppName,
+			TargetOwner:  appConfig.OwnerName,
+		}, nil
+	}
+
+	var allocations []Allocation
+	var unavailable *BindingApplyResult
+	if _, err := mutateAllocations(ctx, c, func(nodes []Node, existing []Allocation) ([]Allocation, *Allocation, error) {
+		resolved, resolveErr := resolveSelection(selections, nodes)
+		if resolveErr != nil {
+			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error()))
+			return nil, nil, errBindingUnavailable
+		}
+		validation := validateResolvedBindingSelection(req, resolved, pressure)
+		if !validation.OK {
+			unavailable = unavailableBindingApplyResult(req, nodes, pressure, validation)
+			return nil, nil, errBindingUnavailable
+		}
+		allocations = allocationsFromResolvedSelection(appConfig, req, resolved)
+		if len(allocations) == 0 {
+			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding"))
+			return nil, nil, errBindingUnavailable
+		}
+		next := replaceAppAllocations(existing, allocations)
+		return next, &allocations[0], nil
+	}); err != nil {
+		if errors.Is(err, errBindingUnavailable) {
+			return unavailable, nil
+		}
+		return nil, err
+	}
+	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
+		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+		return nil, err
+	}
+	for _, allocation := range allocations {
+		if err := createHAMIBinding(ctx, c, allocation); err != nil {
+			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+			return nil, err
+		}
+	}
+	return &BindingApplyResult{
+		Status:      BindingApplyStatusApplied,
+		Allocations: allocations,
+		TargetApp:   appConfig.AppName,
+		TargetOwner: appConfig.OwnerName,
+	}, nil
+}
+
+func unavailableBindingApplyResult(req Requirement, nodes []Node, pressure PressureSnapshot, validation *BindingValidationResult) *BindingApplyResult {
+	return &BindingApplyResult{
+		Status:       BindingApplyStatusUnavailable,
+		Availability: listAvailableForLaunch(req, nodes, pressure),
+		Validation:   validation,
+	}
+}
+
+func ValidateBindingSelection(req Requirement, selections []BindingSelection, nodes []Node, pressure PressureSnapshot) *BindingValidationResult {
+	if len(selections) == 0 {
+		return invalidBinding("empty-selection")
+	}
+	resolved, err := resolveSelection(selections, nodes)
+	if err != nil {
+		return invalidBinding(err.Error())
+	}
+	return validateResolvedBindingSelection(req, resolved, pressure)
+}
+
+func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelection, pressure PressureSnapshot) *BindingValidationResult {
+	selectedNodes := map[string]struct{}{}
+	for _, item := range resolved {
+		selectedNodes[item.node.NodeName] = struct{}{}
+	}
+	if req.Mode == utils.NvidiaCardType {
+		if !req.SupportMultiCards && len(resolved) != 1 {
+			return invalidBinding("multi-card-not-supported")
+		}
+		if !req.SupportMultiNodes && len(selectedNodes) != 1 {
+			return invalidBinding("multi-node-not-supported")
+		}
+	} else if len(resolved) != 1 {
+		return invalidBinding("non-nvidia-must-single-selection")
+	}
+	var totalAssignable int64
+	for _, item := range resolved {
+		if item.device.Health != "" && item.device.Health != deviceHealthYes {
+			return invalidBinding("device-unhealthy:" + item.device.ID)
+		}
+		if item.node.GPUType != req.Mode {
+			return invalidBinding("gpu-type-mismatch")
+		}
+		available := deviceAvailableMemory(item.device)
+		if req.Mode == utils.NvidiaCardType {
+			switch item.device.SupportType {
+			case SupportTypeExclusive:
+				if len(item.device.Bindings) > 0 {
+					return invalidBinding("exclusive-already-bound:" + item.device.ID)
+				}
+			case SupportTypeMemorySlice:
+				if item.memory <= 0 {
+					return invalidBinding("memory-required:" + item.device.ID)
+				}
+				if item.memory > available {
+					return invalidBinding("device-vram-insufficient:" + item.device.ID)
+				}
+				totalAssignable += item.memory
+				continue
+			}
+		}
+		totalAssignable += available
+	}
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
+		if totalAssignable < req.RequiredGPU {
+			return invalidBinding("aggregate-vram-insufficient")
+		}
+	} else if req.Mode == utils.NvidiaCardType {
+		if totalAssignable < req.RequiredGPU {
+			return invalidBinding("device-vram-insufficient")
+		}
+	} else if deviceAvailableMemory(resolved[0].device) < req.RequiredMemory {
+		return invalidBinding("device-memory-insufficient")
+	}
+	for nodeName := range selectedNodes {
+		node := findResolvedNode(nodeName, resolved)
+		hasTimeSlice := false
+		for _, item := range resolved {
+			if item.node.NodeName == nodeName && item.device.SupportType == SupportTypeTimeSlice {
+				hasTimeSlice = true
+				break
+			}
+		}
+		addedGPU := int64(0)
+		if req.Mode == utils.NvidiaCardType && hasTimeSlice {
+			addedGPU = req.LimitedGPU
+		}
+		if pressure.WouldPressure(node, AddedResources{
+			CPU:    req.RequiredCPU,
+			Memory: req.RequiredMemory + addedGPU,
+		}) {
+			return invalidBinding("node-pressure:" + nodeName)
+		}
+	}
+	return &BindingValidationResult{OK: true, Code: BindingValidationReasonValid}
+}
+
+type resolvedSelection struct {
+	node   Node
+	device Device
+	memory int64
+}
+
+func resolveSelection(selections []BindingSelection, nodes []Node) ([]resolvedSelection, error) {
+	out := make([]resolvedSelection, 0, len(selections))
+	seen := make(map[string]struct{}, len(selections))
+	for _, item := range selections {
+		node, ok := findNode(nodes, item.NodeName)
+		if !ok {
+			return nil, fmt.Errorf("node-not-found:%s", item.NodeName)
+		}
+		device, ok := findDevice(node, item.DeviceID)
+		if !ok {
+			return nil, fmt.Errorf("device-not-found:%s", item.DeviceID)
+		}
+		key := item.NodeName + "/" + item.DeviceID
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("duplicate-selection:%s", key)
+		}
+		seen[key] = struct{}{}
+		out = append(out, resolvedSelection{node: node, device: device, memory: item.Memory})
+	}
+	return out, nil
+}
+
+func findNode(nodes []Node, name string) (Node, bool) {
+	for _, node := range nodes {
+		if node.NodeName == name {
+			return node, true
+		}
+	}
+	return Node{}, false
+}
+
+func findDevice(node Node, id string) (Device, bool) {
+	for _, device := range node.Devices {
+		if device.ID == id {
+			return device, true
+		}
+	}
+	return Device{}, false
+}
+
+func findResolvedNode(name string, resolved []resolvedSelection) Node {
+	for _, item := range resolved {
+		if item.node.NodeName == name {
+			return item.node
+		}
+	}
+	return Node{}
+}
+
+func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req Requirement, resolved []resolvedSelection) []Allocation {
+	sort.SliceStable(resolved, func(i, j int) bool {
+		if resolved[i].node.NodeName == resolved[j].node.NodeName {
+			return resolved[i].device.ID < resolved[j].device.ID
+		}
+		return resolved[i].node.NodeName < resolved[j].node.NodeName
+	})
+	target := req.RequiredMemory
+	if req.Mode == utils.NvidiaCardType {
+		target = req.RequiredGPU
+	}
+	out := make([]Allocation, 0, len(resolved))
+	remaining := target
+	for _, item := range resolved {
+		amount := target
+		if item.device.SupportType == SupportTypeMemorySlice && item.memory > 0 {
+			amount = item.memory
+		}
+		if len(resolved) > 1 {
+			if item.device.SupportType != SupportTypeMemorySlice || item.memory <= 0 {
+				amount = minInt64(deviceAvailableMemory(item.device), remaining)
+			}
+		}
+		if amount <= 0 {
+			continue
+		}
+		out = append(out, buildAllocation(appConfig, req, item.node, item.device, amount))
+		remaining -= amount
+	}
+	return out
+}
+
+func invalidBinding(code string) *BindingValidationResult {
+	return &BindingValidationResult{OK: false, Code: code, Reason: BindingValidationReasonInvalid}
+}

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -1,0 +1,433 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const gi = int64(1024 * 1024 * 1024)
+
+func TestCalculateInstallComputePlanUsesPureInputs(t *testing.T) {
+	app := &appcfg.ApplicationConfig{
+		AppName: "ollama",
+		Resources: []appcfg.ResourceMode{
+			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
+			resourceMode(utils.AppleMChipType, "", "1Gi"),
+			resourceMode(utils.StrixHaloChipType, "", "8Gi"),
+		},
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+		computeNode("strix-a", utils.StrixHaloChipType, 4*gi, SupportTypeExclusive),
+	}
+
+	plan := calculateInstallComputePlan(app, nodes)
+	assertModeStatus(t, plan, utils.NvidiaCardType, StatusInstallable)
+	assertModeStatus(t, plan, utils.AppleMChipType, StatusNoMatchingNode)
+	assertModeStatus(t, plan, utils.StrixHaloChipType, StatusInsufficientResources)
+}
+
+func TestInstallComputePlanIgnoresCurrentBindings(t *testing.T) {
+	app := &appcfg.ApplicationConfig{
+		AppName: "llm",
+		Resources: []appcfg.ResourceMode{
+			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
+		},
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a", Device{
+			ID:          "gpu0",
+			Memory:      16 * gi,
+			Health:      deviceHealthYes,
+			SupportType: SupportTypeExclusive,
+			Bindings:    []Allocation{{AppName: "other", Owner: "other", Memory: 16 * gi}},
+		}),
+	}
+
+	plan := calculateInstallComputePlan(app, nodes)
+	assertModeStatus(t, plan, utils.NvidiaCardType, StatusInstallable)
+}
+
+func TestLegacyAppConfigIsMappedToComputeModes(t *testing.T) {
+	cpuApp := &appcfg.ApplicationConfig{
+		AppName: "legacy-cpu",
+		Requirement: appcfg.AppRequirement{
+			Memory:        quantity("1Gi"),
+			LimitedMemory: quantity("2Gi"),
+		},
+	}
+	plan := calculateInstallComputePlan(cpuApp, []Node{
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+	})
+	assertModeStatus(t, plan, utils.CPUType, StatusInstallable)
+
+	gpuApp := &appcfg.ApplicationConfig{
+		AppName: "legacy-gpu",
+		Requirement: appcfg.AppRequirement{
+			GPU:           quantity("2Gi"),
+			LimitedGPU:    quantity("16Gi"),
+			Memory:        quantity("20Gi"),
+			LimitedMemory: quantity("70Gi"),
+		},
+	}
+	mode, ok := gpuApp.SelectedResourceMode()
+	if !ok {
+		t.Fatalf("expected legacy GPU app to resolve a selected compute mode")
+	}
+	req := RequirementFromMode(mode)
+	if req.Mode != utils.NvidiaCardType || req.RequiredGPU != 2*gi || req.LimitedGPU != 16*gi || req.LimitedMemory != 70*gi {
+		t.Fatalf("legacy GPU requirement was not mapped correctly: %#v", req)
+	}
+}
+
+func TestCPUModeFallsBackToGPUTypeNodesWithoutUsingGPUMemory(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "cpu-app"}
+	req := Requirement{
+		Mode:           utils.CPUType,
+		RequiredMemory: 8 * gi,
+		LimitedMemory:  8 * gi,
+	}
+	nodes := []Node{
+		computeNode("cpu-small", utils.CPUType, 4*gi, SupportTypeMemoryShared),
+		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+	}
+
+	result := EvaluateInstallMode(req, nodes)
+	if result.Status != StatusInstallable {
+		t.Fatalf("expected CPU app to fall back to GPU-type node, got %#v", result)
+	}
+	picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+	if ok || len(picked) != 0 {
+		t.Fatalf("CPU mode must not create compute allocations, got ok=%v picked=%#v", ok, picked)
+	}
+}
+
+func TestListAvailableForLaunchFiltersNotMatchAndMarksOperable(t *testing.T) {
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       24 * gi,
+		LimitedGPU:        24 * gi,
+		RequiredMemory:    gi,
+		LimitedMemory:     gi,
+		SupportMultiCards: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+		),
+		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+	}
+
+	result := listAvailableForLaunch(req, nodes, PressureSnapshot{})
+	if len(result.Nodes) != 2 {
+		t.Fatalf("expected not_match nodes to be hidden from launch result, got %d", len(result.Nodes))
+	}
+	if !result.Schedulable {
+		t.Fatalf("expected launch result to be schedulable")
+	}
+	if result.Scope != AvailabilityScopeSingleNode {
+		t.Fatalf("expected single-node scope, got %s", result.Scope)
+	}
+	if result.Nodes[0].Status != NodeStatusAvailable || !result.Nodes[0].Devices[0].Operable || !result.Nodes[0].Devices[1].Operable {
+		t.Fatalf("expected available node devices to be operable: %#v", result.Nodes[0])
+	}
+	if result.Nodes[1].Status != NodeStatusNotEnough || result.Nodes[1].Devices[0].Operable {
+		t.Fatalf("expected not_enough node to be visible but not operable: %#v", result.Nodes[1])
+	}
+}
+
+func TestListAvailableForLaunchReportsNoMatchingNode(t *testing.T) {
+	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: gi, LimitedGPU: gi}
+	result := listAvailableForLaunch(req, []Node{
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+	}, PressureSnapshot{})
+
+	if result.Schedulable || result.Reason != "no-matching-node" || len(result.Nodes) != 0 {
+		t.Fatalf("expected no matching node result, got %#v", result)
+	}
+}
+
+func TestValidateBindingSelectionTopologyAndMemorySlice(t *testing.T) {
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       12 * gi,
+		LimitedGPU:        12 * gi,
+		RequiredMemory:    gi,
+		LimitedMemory:     gi,
+		SupportMultiCards: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "gpu0", Memory: 8 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+			Device{ID: "gpu1", Memory: 8 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+		),
+		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 8 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice}),
+	}
+
+	result := ValidateBindingSelection(req, []BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0", Memory: 8 * gi},
+		{NodeName: "nvidia-b", DeviceID: "gpu0", Memory: 8 * gi},
+	}, nodes, PressureSnapshot{})
+	if result.OK || result.Code != "multi-node-not-supported" {
+		t.Fatalf("expected multi-node rejection, got %#v", result)
+	}
+
+	result = ValidateBindingSelection(req, []BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0"},
+		{NodeName: "nvidia-a", DeviceID: "gpu1", Memory: 8 * gi},
+	}, nodes, PressureSnapshot{})
+	if result.OK || result.Code != "memory-required:gpu0" {
+		t.Fatalf("expected memory slice amount rejection, got %#v", result)
+	}
+
+	result = ValidateBindingSelection(req, []BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0", Memory: 6 * gi},
+		{NodeName: "nvidia-a", DeviceID: "gpu1", Memory: 6 * gi},
+	}, nodes, PressureSnapshot{})
+	if !result.OK {
+		t.Fatalf("expected valid aggregate selection, got %#v", result)
+	}
+}
+
+func TestAvailabilityCrossNodeSumsRawAvailableDespitePerNodePressure(t *testing.T) {
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       24 * gi,
+		LimitedGPU:        24 * gi,
+		RequiredMemory:    2 * gi,
+		LimitedMemory:     2 * gi,
+		SupportMultiCards: true,
+		SupportMultiNodes: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+	}
+	// Pressure on nvidia-a — its single card's FitLevel would be empty, but the
+	// cross-node summary should still count the device's raw available memory.
+	pressure := PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			"nvidia-a": {MemoryCapacity: 4 * gi, MemoryAvailable: 0},
+		},
+	}
+
+	result := listAvailableForLaunch(req, nodes, pressure)
+	if !result.Schedulable {
+		t.Fatalf("expected cross-node cluster total (32Gi) to satisfy 24Gi request, got %#v", result)
+	}
+	if result.Scope != AvailabilityScopeCrossNode {
+		t.Fatalf("expected cross-node scope, got %s", result.Scope)
+	}
+}
+
+func TestAvailabilityNonNvidiaNodeBecomesNotAvailableUnderPressure(t *testing.T) {
+	req := Requirement{
+		Mode:           utils.StrixHaloChipType,
+		RequiredMemory: 4 * gi,
+		LimitedMemory:  4 * gi,
+	}
+	nodes := []Node{computeNode("strix-a", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive)}
+
+	healthyResult := listAvailableForLaunch(req, nodes, PressureSnapshot{})
+	if len(healthyResult.Nodes) != 1 || healthyResult.Nodes[0].Status != NodeStatusAvailable {
+		t.Fatalf("expected strix node to be available without pressure, got %#v", healthyResult)
+	}
+
+	pressure := PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			"strix-a": {MemoryCapacity: 4 * gi, MemoryAvailable: 0},
+		},
+	}
+	pressuredResult := listAvailableForLaunch(req, nodes, pressure)
+	if len(pressuredResult.Nodes) != 1 || pressuredResult.Nodes[0].Status != NodeStatusNotAvailable {
+		t.Fatalf("expected strix node to be not_available under memory pressure, got %#v", pressuredResult)
+	}
+	if pressuredResult.Schedulable {
+		t.Fatalf("expected scheduling to fail under pressure, got %#v", pressuredResult)
+	}
+}
+
+func TestValidateBindingSelectionNonNvidiaRequiresSingleSelection(t *testing.T) {
+	req := Requirement{
+		Mode:           utils.StrixHaloChipType,
+		RequiredMemory: 4 * gi,
+		LimitedMemory:  4 * gi,
+	}
+	nodes := []Node{
+		computeNode("strix-a", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive),
+		computeNode("strix-b", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive),
+	}
+	result := ValidateBindingSelection(req, []BindingSelection{
+		{NodeName: "strix-a", DeviceID: "strix-a-device"},
+		{NodeName: "strix-b", DeviceID: "strix-b-device"},
+	}, nodes, PressureSnapshot{})
+	if result.OK || result.Code != "non-nvidia-must-single-selection" {
+		t.Fatalf("expected non-nvidia multi selection to be rejected, got %#v", result)
+	}
+}
+
+func TestPickAggregateAllocationsAcrossNodes(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice"}
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       24 * gi,
+		LimitedGPU:        24 * gi,
+		SupportMultiCards: true,
+		SupportMultiNodes: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+	}
+	picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+	if !ok || len(picked) != 2 {
+		t.Fatalf("expected 2 cross-node allocations to satisfy 24Gi, got ok=%v picked=%#v", ok, picked)
+	}
+	nodesPicked := map[string]struct{}{}
+	for _, alloc := range picked {
+		nodesPicked[alloc.NodeName] = struct{}{}
+	}
+	if len(nodesPicked) != 2 {
+		t.Fatalf("expected allocations to span both nodes, got %#v", nodesPicked)
+	}
+}
+
+// TestLegacyComputeMode covers the synthesis of the single ResourceMode for
+// a legacy manifest (no spec.resources matrix). The contract is:
+//
+//  1. An explicit SelectedGpuType wins outright — used during install once
+//     the auto-selector (or the user) has picked a mode and the chart is
+//     reloaded with that pick.
+//  2. With SelectedGpuType empty, a non-zero Requirement.GPU collapses to
+//     nvidia (the only legacy-supported GPU type); zero/unset collapses to
+//     cpu. This is the "no choice yet" state hit by the install pre-check
+//     and the first GetAppConfig call inside the install handler.
+func TestLegacyComputeMode(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *appcfg.ApplicationConfig
+		want string
+	}{
+		{
+			name: "no selection, no gpu requirement -> cpu",
+			cfg:  &appcfg.ApplicationConfig{AppName: "no-gpu"},
+			want: utils.CPUType,
+		},
+		{
+			name: "no selection, non-zero requiredGpu -> nvidia",
+			cfg: &appcfg.ApplicationConfig{
+				AppName: "legacy-gpu",
+				Requirement: appcfg.AppRequirement{
+					GPU: quantity("4Gi"),
+				},
+			},
+			want: utils.NvidiaCardType,
+		},
+		{
+			name: "no selection, zero requiredGpu -> cpu",
+			cfg: &appcfg.ApplicationConfig{
+				AppName: "legacy-zero-gpu",
+				Requirement: appcfg.AppRequirement{
+					GPU: quantity("0"),
+				},
+			},
+			want: utils.CPUType,
+		},
+		{
+			name: "explicit SelectedGpuType wins over requirement-derived fallback",
+			cfg: &appcfg.ApplicationConfig{
+				AppName:         "legacy-gpu-explicit",
+				SelectedGpuType: utils.NvidiaCardType,
+				Requirement: appcfg.AppRequirement{
+					GPU: quantity("4Gi"),
+				},
+			},
+			want: utils.NvidiaCardType,
+		},
+		{
+			name: "explicit SelectedGpuType wins even when requirement says cpu",
+			cfg: &appcfg.ApplicationConfig{
+				AppName:         "legacy-pinned-on-strix",
+				SelectedGpuType: utils.StrixHaloChipType,
+			},
+			want: utils.StrixHaloChipType,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			modes := tt.cfg.ComputeResourceModes()
+			if len(modes) != 1 {
+				t.Fatalf("expected a single synthesized mode for legacy app, got %#v", modes)
+			}
+			if got := modes[0].Mode; got != tt.want {
+				t.Fatalf("expected mode %s, got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+func resourceMode(mode, requiredGPU, requiredMemory string) appcfg.ResourceMode {
+	return appcfg.ResourceMode{
+		Mode: mode,
+		ResourceRequirement: appcfg.ResourceRequirement{
+			RequiredGPU:    requiredGPU,
+			LimitedGPU:     requiredGPU,
+			RequiredMemory: requiredMemory,
+			LimitedMemory:  requiredMemory,
+		},
+	}
+}
+
+func nvidiaNode(name string, devices ...Device) Node {
+	node := Node{
+		NodeName:       name,
+		GPUType:        utils.NvidiaCardType,
+		memoryCapacity: 64 * gi,
+		Devices:        devices,
+	}
+	for i := range node.Devices {
+		node.Devices[i].NodeName = name
+	}
+	return node
+}
+
+func computeNode(name, gpuType string, memory int64, supportType string) Node {
+	return Node{
+		NodeName:       name,
+		GPUType:        gpuType,
+		memoryCapacity: 64 * gi,
+		Devices: []Device{{
+			ID:          name + "-device",
+			NodeName:    name,
+			Memory:      memory,
+			Health:      deviceHealthYes,
+			SupportType: supportType,
+		}},
+	}
+}
+
+func assertModeStatus(t *testing.T, plan []ModePlanResult, mode, status string) {
+	t.Helper()
+	for _, item := range plan {
+		if item.ComputeType == mode {
+			if item.Status != status {
+				t.Fatalf("expected %s status %s, got %s", mode, status, item.Status)
+			}
+			return
+		}
+	}
+	t.Fatalf("mode %s not found in plan %#v", mode, plan)
+}
+
+func quantity(value string) *resource.Quantity {
+	q := resource.MustParse(value)
+	return &q
+}

--- a/framework/app-service/pkg/compute/device_mode.go
+++ b/framework/app-service/pkg/compute/device_mode.go
@@ -1,0 +1,82 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func FindDevice(ctx context.Context, c client.Client, nodeName, deviceID string) (Node, Device, error) {
+	nodes, err := FetchNodeComputeAllocations(ctx, c)
+	if err != nil {
+		return Node{}, Device{}, err
+	}
+	for _, node := range nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		for _, device := range node.Devices {
+			if device.ID == deviceID {
+				return node, device, nil
+			}
+		}
+		return Node{}, Device{}, fmt.Errorf("device %s not found on node %s", deviceID, nodeName)
+	}
+	return Node{}, Device{}, fmt.Errorf("node %s not found", nodeName)
+}
+
+// UpdateDeviceSupportType validates and switches a device's share-mode
+// annotation. It refuses to switch when the device still has compute bindings;
+// callers that have already torn the bindings down should use SwitchDeviceMode
+// directly.
+func UpdateDeviceSupportType(ctx context.Context, c client.Client, nodeName, deviceID, supportType string) (Device, error) {
+	node, device, err := FindDevice(ctx, c, nodeName, deviceID)
+	if err != nil {
+		return Device{}, err
+	}
+	if !IsHAMIMode(node.GPUType) {
+		return Device{}, fmt.Errorf("device mode switching is not supported for gpu type %s", node.GPUType)
+	}
+	if !SupportTypeAvailable(device.AvailableSupportTypes, supportType) {
+		return Device{}, fmt.Errorf("support type %s is not available for gpu type %s", supportType, node.GPUType)
+	}
+	if len(device.Bindings) > 0 {
+		return Device{}, fmt.Errorf("device %s still has %d compute bindings", deviceID, len(device.Bindings))
+	}
+	if err := SwitchDeviceMode(ctx, c, nodeName, deviceID, supportType); err != nil {
+		return Device{}, err
+	}
+	device.SupportType = supportType
+	return device, nil
+}
+
+// SwitchDeviceMode flips the share-mode annotation on the underlying k8s node
+// without re-validating bindings/support types. Callers are responsible for
+// ensuring the device is no longer in use (typically by stopping bound apps
+// and clearing their allocations first).
+func SwitchDeviceMode(ctx context.Context, c client.Client, nodeName, deviceID, supportType string) error {
+	shareMode, ok := supportTypeToShareMode(supportType)
+	if !ok {
+		return fmt.Errorf("unsupported support type %s", supportType)
+	}
+	var k8sNode corev1.Node
+	if err := c.Get(ctx, client.ObjectKey{Name: nodeName}, &k8sNode); err != nil {
+		return err
+	}
+	if k8sNode.Annotations == nil {
+		k8sNode.Annotations = make(map[string]string)
+	}
+	k8sNode.Annotations[shareModeAnnotationKey(deviceID)] = shareMode
+	return c.Update(ctx, &k8sNode)
+}
+
+func SupportTypeAvailable(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/app-service/pkg/compute/hami.go
+++ b/framework/app-service/pkg/compute/hami.go
@@ -1,0 +1,119 @@
+package compute
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createHAMIBinding(ctx context.Context, c client.Client, allocation Allocation) error {
+	if !IsHAMIMode(allocation.Mode) {
+		return nil
+	}
+	name := hamiBindingName(allocation)
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(hamiGPUBindingAPIVersion)
+	obj.SetKind(hamiGPUBindingKind)
+	obj.SetName(name)
+	obj.SetLabels(map[string]string{
+		managedByLabelKey:               managedByAppService,
+		constants.ApplicationNameLabel:  allocation.AppName,
+		constants.ApplicationOwnerLabel: allocation.Owner,
+		allocationModeLabelKey:          allocation.Mode,
+	})
+	spec := map[string]any{
+		"uuid":    allocation.DeviceID,
+		"appName": allocation.AppName,
+		"owner":   allocation.Owner,
+		"podSelector": map[string]any{
+			"matchLabels": map[string]any{
+				constants.ApplicationNameLabel:  allocation.AppName,
+				constants.ApplicationOwnerLabel: allocation.Owner,
+			},
+		},
+	}
+	// Omit spec.memory when the allocation does not partition memory
+	// (Exclusive / TimeSlice — buildAllocation persists Memory=0 for
+	// these). Leaving Spec.Memory nil keeps HAMI from emitting the
+	// per-pod gpumem annotation, so the pod is not artificially capped
+	// below the device's full capacity.
+	if allocation.Memory > 0 {
+		mem := resource.NewQuantity(allocation.Memory/mib, resource.DecimalSI)
+		spec["memory"] = mem.String()
+	}
+	obj.Object["spec"] = spec
+
+	if err := c.Create(ctx, obj); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			current := &unstructured.Unstructured{}
+			current.SetAPIVersion(hamiGPUBindingAPIVersion)
+			current.SetKind(hamiGPUBindingKind)
+			if getErr := c.Get(ctx, client.ObjectKey{Name: name}, current); getErr != nil {
+				return getErr
+			}
+			current.SetLabels(obj.GetLabels())
+			current.Object["spec"] = obj.Object["spec"]
+			return c.Update(ctx, current)
+		}
+		return err
+	}
+	return nil
+}
+
+func hamiBindingName(allocation Allocation) string {
+	raw := fmt.Sprintf("%s-%s-%s", allocation.AppName, allocation.Owner, allocation.DeviceID)
+	sum := sha256.Sum256([]byte(raw))
+	suffix := "-" + hex.EncodeToString(sum[:])[:8]
+
+	var b strings.Builder
+	for _, r := range strings.ToLower(raw) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if maxOut := 63 - len(suffix); len(out) > maxOut {
+		out = strings.Trim(out[:maxOut], "-.")
+	}
+	if out == "" {
+		return "gpu-binding"
+	}
+	return out + suffix
+}
+
+func deleteHAMIBindingsForApp(ctx context.Context, c client.Client, appName, owner string) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetAPIVersion(hamiGPUBindingAPIVersion)
+	list.SetKind(hamiGPUBindingListKind)
+	selector := client.MatchingLabels{
+		managedByLabelKey:               managedByAppService,
+		constants.ApplicationNameLabel:  appName,
+		constants.ApplicationOwnerLabel: owner,
+	}
+	if err := c.List(ctx, list, selector); err != nil {
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if err := c.Delete(ctx, item); err != nil && !apierrors.IsNotFound(err) {
+			klog.Warningf("failed to delete GPUBinding %s for app %s owned by %s: %v", item.GetName(), appName, owner, err)
+		}
+	}
+	return nil
+}

--- a/framework/app-service/pkg/compute/notification.go
+++ b/framework/app-service/pkg/compute/notification.go
@@ -1,0 +1,63 @@
+package compute
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+const (
+	notificationSubject                  = "os.notification"
+	notificationTopicComputeInsufficient = "ApplicationComputeResourceInsufficient"
+)
+
+type resourceNotification struct {
+	Topic   string                      `json:"topic"`
+	Payload resourceNotificationPayload `json:"payload"`
+}
+
+type resourceNotificationPayload struct {
+	User      string    `json:"user"`
+	AppName   string    `json:"appName"`
+	Namespace string    `json:"namespace"`
+	Resource  string    `json:"resource"`
+	Mode      string    `json:"mode"`
+	Reason    string    `json:"reason"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func PublishComputeInsufficientNotification(appConfig *appcfg.ApplicationConfig, reason error) {
+	if appConfig == nil {
+		return
+	}
+	message := fmt.Sprintf("No available compute resource for %s mode.", appConfig.SelectedGpuType)
+	if reason != nil {
+		message = reason.Error()
+	}
+	data := resourceNotification{
+		Topic: notificationTopicComputeInsufficient,
+		Payload: resourceNotificationPayload{
+			User:      appConfig.OwnerName,
+			AppName:   appConfig.AppName,
+			Namespace: appConfig.Namespace,
+			Resource:  "compute",
+			Mode:      appConfig.SelectedGpuType,
+			Reason:    "insufficient-resources",
+			Message:   message,
+			Timestamp: time.Now(),
+		},
+	}
+	nc, err := utils.NewNatsConn()
+	if err != nil {
+		klog.Warningf("failed to connect NATS for compute resource notification: %v", err)
+		return
+	}
+	defer nc.Close()
+	if err := utils.PublishEvent(nc, notificationSubject, data); err != nil {
+		klog.Warningf("failed to publish compute resource notification: %v", err)
+	}
+}

--- a/framework/app-service/pkg/compute/pressure.go
+++ b/framework/app-service/pkg/compute/pressure.go
@@ -1,0 +1,47 @@
+package compute
+
+import (
+	"context"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+)
+
+const defaultPressureThreshold = 0.90
+
+func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
+	usage, err := prometheus.GetNodeResourceUsage(ctx)
+	if err != nil {
+		return PressureSnapshot{}, err
+	}
+	return PressureSnapshot{
+		Threshold:   defaultPressureThreshold,
+		UsageByNode: usage,
+	}, nil
+}
+
+func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
+	threshold := p.Threshold
+	if threshold == 0 {
+		threshold = defaultPressureThreshold
+	}
+	usage := p.UsageByNode[node.NodeName]
+	usedCPU := int64(float64(usage.CPUCapacity) * usage.CPUUtilization)
+	usedMemory := usage.MemoryCapacity - usage.MemoryAvailable
+	if usedMemory < 0 {
+		usedMemory = 0
+	}
+	usedDisk := usage.DiskCapacity - usage.DiskAvailable
+	if usedDisk < 0 {
+		usedDisk = 0
+	}
+	return exceedsPressure(usedCPU+added.CPU, usage.CPUCapacity, threshold) ||
+		exceedsPressure(usedMemory+added.Memory, usage.MemoryCapacity, threshold) ||
+		exceedsPressure(usedDisk+added.Disk, usage.DiskCapacity, threshold)
+}
+
+func exceedsPressure(used, total int64, threshold float64) bool {
+	if total <= 0 {
+		return false
+	}
+	return float64(used) > float64(total)*threshold
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -1,0 +1,470 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func BuildInstallComputePlan(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) ([]ModePlanResult, error) {
+	targetConfig, manage, err := resolveComputeTarget(ctx, c, appConfig, false)
+	if err != nil {
+		return nil, err
+	}
+	if !manage {
+		return []ModePlanResult{{ComputeType: utils.CPUType, Status: StatusInstallable}}, nil
+	}
+	nodes, err := FetchNodeComputeAllocations(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return calculateInstallComputePlan(targetConfig, nodes), nil
+}
+
+func calculateInstallComputePlan(appConfig *appcfg.ApplicationConfig, nodes []Node) []ModePlanResult {
+	modes := appConfig.ComputeResourceModes()
+	items := make([]ModePlanResult, 0, len(modes))
+	for _, mode := range modes {
+		req := RequirementFromMode(mode)
+		result := EvaluateInstallMode(req, nodes)
+		items = append(items, result)
+	}
+	return items
+}
+
+func AppInstallable(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, error) {
+	plan, err := BuildInstallComputePlan(ctx, c, appConfig)
+	if err != nil {
+		return false, err
+	}
+	for _, result := range plan {
+		if result.ComputeType == appConfig.SelectedGpuType && result.Status == StatusInstallable {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (*Allocation, error) {
+	targetConfig, manage, err := resolveComputeTarget(ctx, c, appConfig, false)
+	if err != nil {
+		return nil, err
+	}
+	if !manage {
+		return nil, DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	}
+	appConfig = targetConfig
+	req, ok := SelectedRequirement(appConfig)
+	if !ok {
+		return nil, fmt.Errorf("compute type %s not found in application resources", appConfig.SelectedGpuType)
+	}
+	if req.Mode == utils.CPUType {
+		return nil, DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	}
+	pressure, err := FetchPressureSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var pickedAllocations []Allocation
+	allocation, err := mutateAllocations(ctx, c, func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
+		picked, ok := PickAllocations(appConfig, req, nodes, pressure)
+		if !ok {
+			return nil, nil, fmt.Errorf("no available compute resource for type %s", req.Mode)
+		}
+		pickedAllocations = picked
+		next := replaceAppAllocations(allocations, picked)
+		return next, &picked[0], nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
+		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+		return nil, err
+	}
+	for _, item := range pickedAllocations {
+		if err := createHAMIBinding(ctx, c, item); err != nil {
+			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+			return nil, err
+		}
+	}
+	return allocation, nil
+}
+
+func RequirementFromMode(mode appcfg.ResourceMode) Requirement {
+	source := &mode.ResourceRequirement
+	reqCPU := parseQuantityMilli(source.RequiredCPU)
+	reqGPU := parseQuantityBytes(source.RequiredGPU)
+	limGPU := parseQuantityBytes(source.LimitedGPU)
+	if limGPU == 0 {
+		limGPU = reqGPU
+	}
+	reqMem := parseQuantityBytes(source.RequiredMemory)
+	limMem := parseQuantityBytes(source.LimitedMemory)
+	if limMem == 0 {
+		limMem = reqMem
+	}
+	reqDisk := parseQuantityBytes(source.RequiredDisk)
+	supportMultiNodes := mode.Mode == utils.NvidiaCardType && mode.SupportMultiNodes
+	supportMultiCards := mode.Mode == utils.NvidiaCardType && (mode.SupportMultiCard || supportMultiNodes)
+	return Requirement{
+		Mode:              mode.Mode,
+		RequiredCPU:       reqCPU,
+		RequiredGPU:       reqGPU,
+		LimitedGPU:        limGPU,
+		RequiredMemory:    reqMem,
+		LimitedMemory:     limMem,
+		RequiredDisk:      reqDisk,
+		SupportMultiCards: supportMultiCards,
+		SupportMultiNodes: supportMultiNodes,
+	}
+}
+
+func SelectedRequirement(appConfig *appcfg.ApplicationConfig) (Requirement, bool) {
+	if appConfig == nil {
+		return Requirement{}, false
+	}
+	mode, ok := appConfig.SelectedResourceMode()
+	if !ok {
+		return Requirement{}, false
+	}
+	return RequirementFromMode(mode), true
+}
+
+func EvaluateInstallMode(req Requirement, nodes []Node) ModePlanResult {
+	if req.Mode == utils.CPUType {
+		return evaluateCPUInstallMode(req, nodes)
+	}
+	matching := matchingNodes(req.Mode, nodes)
+	if len(matching) == 0 {
+		return ModePlanResult{ComputeType: req.Mode, Status: StatusNoMatchingNode, Reason: "no_matching_node"}
+	}
+
+	if installCapacityFits(req, matching) {
+		return ModePlanResult{ComputeType: req.Mode, Status: StatusInstallable}
+	}
+
+	return ModePlanResult{ComputeType: req.Mode, Status: StatusInsufficientResources, Reason: "insufficient_resources"}
+}
+
+func PickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
+	if req.Mode == utils.CPUType {
+		return nil, false
+	}
+	matching := matchingNodes(req.Mode, nodes)
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
+		return pickAggregateAllocations(appConfig, req, matching, pressure, true)
+	}
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
+		return pickAggregateAllocations(appConfig, req, matching, pressure, false)
+	}
+	return pickSingleAllocation(appConfig, req, matching, pressure)
+}
+
+func matchingNodes(mode string, nodes []Node) []Node {
+	out := make([]Node, 0)
+	for _, node := range nodes {
+		if node.GPUType == mode {
+			out = append(out, node)
+		}
+	}
+	return out
+}
+
+func evaluateCPUInstallMode(req Requirement, nodes []Node) ModePlanResult {
+	for _, node := range nodes {
+		if node.memoryCapacity*75/100 >= req.RequiredMemory {
+			return ModePlanResult{ComputeType: utils.CPUType, Status: StatusInstallable}
+		}
+	}
+	return ModePlanResult{ComputeType: utils.CPUType, Status: StatusInsufficientResources, Reason: "insufficient_resources"}
+}
+
+func installCapacityFits(req Requirement, nodes []Node) bool {
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
+		var total int64
+		for _, node := range nodes {
+			for _, device := range node.Devices {
+				total += device.Memory
+			}
+		}
+		return total >= req.RequiredGPU
+	}
+	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
+		for _, node := range nodes {
+			var total int64
+			for _, device := range node.Devices {
+				total += device.Memory
+			}
+			if total >= req.RequiredGPU {
+				return true
+			}
+		}
+		return false
+	}
+	if req.Mode == utils.NvidiaCardType {
+		for _, node := range nodes {
+			for _, device := range node.Devices {
+				if device.Memory >= req.RequiredGPU {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, node := range nodes {
+		if len(node.Devices) > 0 && node.Devices[0].Memory >= req.RequiredMemory {
+			return true
+		}
+	}
+	return false
+}
+
+func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
+	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
+		for _, supportType := range supportTypeOrder(req.Mode) {
+			candidates := make([]Allocation, 0)
+			for _, node := range nodes {
+				for _, device := range node.Devices {
+					if supportType != "" && device.SupportType != supportType {
+						continue
+					}
+					fits, amount := deviceFitsLevel(req, node, device, pressure, level, false)
+					if fits {
+						assigned := requiredTargetForMode(req)
+						if assigned == 0 {
+							assigned = amount
+						}
+						candidates = append(candidates, buildAllocation(appConfig, req, node, device, assigned))
+					}
+				}
+			}
+			if len(candidates) > 0 {
+				return []Allocation{candidates[rand.Intn(len(candidates))]}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, crossNode bool) ([]Allocation, bool) {
+	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
+		target := targetGPU(req, level)
+		if target <= 0 {
+			continue
+		}
+		if crossNode {
+			picked, ok := collectDevicesForTarget(appConfig, req, nodes, pressure, level, target, req.RequiredGPU)
+			if ok {
+				return picked, ok
+			}
+			continue
+		}
+		for _, node := range nodes {
+			picked, ok := collectDevicesForTarget(appConfig, req, []Node{node}, pressure, level, target, req.RequiredGPU)
+			if ok {
+				return picked, ok
+			}
+		}
+	}
+	return nil, false
+}
+
+func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, level string, target, allocationTarget int64) ([]Allocation, bool) {
+	fitRemaining := target
+	allocationRemaining := allocationTarget
+	var out []Allocation
+	for _, supportType := range supportTypeOrder(req.Mode) {
+		for _, node := range nodes {
+			for _, device := range node.Devices {
+				if supportType != "" && device.SupportType != supportType {
+					continue
+				}
+				fits, amount := deviceFitsLevel(req, node, device, pressure, level, true)
+				if !fits || amount <= 0 {
+					continue
+				}
+				if allocationRemaining > 0 {
+					assigned := minInt64(amount, allocationRemaining)
+					out = append(out, buildAllocation(appConfig, req, node, device, assigned))
+					allocationRemaining -= assigned
+				}
+				fitRemaining -= amount
+				if fitRemaining <= 0 {
+					return out, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool) (bool, int64) {
+	if device.Health != "" && device.Health != deviceHealthYes {
+		return false, 0
+	}
+	required := targetForMode(req, level)
+	if required <= 0 {
+		return pressure.WouldPressure(node, AddedResources{
+			CPU:    req.RequiredCPU,
+			Memory: levelMemory(req, level),
+			Disk:   req.RequiredDisk,
+		}), 0
+	}
+	available := deviceAvailableMemory(device)
+	if available <= 0 {
+		return false, 0
+	}
+	if available < required && !(allowPartial && req.Mode == utils.NvidiaCardType) {
+		return false, available
+	}
+	addedGPU := int64(0)
+	if req.Mode == utils.NvidiaCardType && device.SupportType == SupportTypeTimeSlice {
+		addedGPU = minInt64(available, required)
+	}
+	if pressure.WouldPressure(node, AddedResources{
+		CPU:    req.RequiredCPU,
+		Memory: levelMemory(req, level) + addedGPU,
+		Disk:   req.RequiredDisk,
+	}) {
+		return false, available
+	}
+	return true, available
+}
+
+func targetForMode(req Requirement, level string) int64 {
+	if req.Mode == utils.NvidiaCardType {
+		return targetGPU(req, level)
+	}
+	return levelMemory(req, level)
+}
+
+func requiredTargetForMode(req Requirement) int64 {
+	if req.Mode == utils.NvidiaCardType {
+		return req.RequiredGPU
+	}
+	return req.RequiredMemory
+}
+
+func targetGPU(req Requirement, level string) int64 {
+	if level == FitLevelLimit && req.LimitedGPU > 0 {
+		return req.LimitedGPU
+	}
+	return req.RequiredGPU
+}
+
+func levelMemory(req Requirement, level string) int64 {
+	if level == FitLevelLimit && req.LimitedMemory > 0 {
+		return req.LimitedMemory
+	}
+	return req.RequiredMemory
+}
+
+func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node Node, device Device, memory int64) Allocation {
+	// In Exclusive / TimeSlice modes the pod has access to the entire
+	// card (Exclusive: solo binding; TimeSlice: full memory during the
+	// pod's time slice). Recording a per-pod memory amount here would
+	// cap the pod via the HAMI binding's spec.memory annotation, even
+	// though no slicing is happening. Persist 0 so createHAMIBinding
+	// omits spec.memory and HAMI treats the pod as unrestricted. The
+	// scheduler's accounting (deviceAvailableMemory / remainingMemory)
+	// never reads Allocation.Memory for these modes, so this is safe.
+	if req.Mode == utils.NvidiaCardType &&
+		(device.SupportType == SupportTypeExclusive || device.SupportType == SupportTypeTimeSlice) {
+		memory = 0
+	}
+	return Allocation{
+		AppID:    appConfig.AppID,
+		AppName:  appConfig.AppName,
+		Owner:    appConfig.OwnerName,
+		Mode:     req.Mode,
+		NodeName: node.NodeName,
+		DeviceID: device.ID,
+		Memory:   memory,
+	}
+}
+
+func supportTypeOrder(mode string) []string {
+	if mode == utils.NvidiaCardType {
+		return []string{SupportTypeExclusive, SupportTypeMemorySlice, SupportTypeTimeSlice}
+	}
+	return []string{SupportTypeExclusive, SupportTypeMemoryShared}
+}
+
+func deviceAvailableMemory(device Device) int64 {
+	switch device.SupportType {
+	case SupportTypeExclusive:
+		if len(device.Bindings) > 0 {
+			return 0
+		}
+		return device.Memory
+	case SupportTypeMemorySlice, SupportTypeMemoryShared:
+		return remainingMemory(device)
+	case SupportTypeTimeSlice:
+		return device.Memory
+	default:
+		return device.Memory
+	}
+}
+
+func remainingMemory(device Device) int64 {
+	remaining := device.Memory
+	for _, binding := range device.Bindings {
+		remaining -= binding.Memory
+	}
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func replaceAppAllocations(allocations []Allocation, replacements []Allocation) []Allocation {
+	if len(replacements) == 0 {
+		return allocations
+	}
+	appName := replacements[0].AppName
+	owner := replacements[0].Owner
+	next := make([]Allocation, 0, len(allocations)+len(replacements))
+	for _, existing := range allocations {
+		if existing.AppName == appName && existing.Owner == owner {
+			continue
+		}
+		next = append(next, existing)
+	}
+	return append(next, replacements...)
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func parseQuantityBytes(value string) int64 {
+	if value == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0
+	}
+	return q.Value()
+}
+
+func parseQuantityMilli(value string) int64 {
+	if value == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0
+	}
+	return q.MilliValue()
+}

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -1,0 +1,295 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const mib = int64(1024 * 1024)
+
+type allocationMutation func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error)
+
+func FetchNodeComputeAllocations(ctx context.Context, c client.Client) ([]Node, error) {
+	nodes, err := loadNodeResources(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	allocations, err := loadAllocations(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	attachBindings(nodes, allocations)
+	return nodes, nil
+}
+
+func loadAllocations(ctx context.Context, c client.Client) ([]Allocation, error) {
+	_, allocations, err := loadAllocationConfigMap(ctx, c)
+	return allocations, err
+}
+
+func DeleteAllocationsForApp(ctx context.Context, c client.Client, appName, owner string) error {
+	_, err := mutateAllocations(ctx, c, func(_ []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
+		next := make([]Allocation, 0, len(allocations))
+		for _, allocation := range allocations {
+			if allocation.AppName == appName && allocation.Owner == owner {
+				continue
+			}
+			next = append(next, allocation)
+		}
+		return next, nil, nil
+	})
+	if err != nil {
+		return err
+	}
+	return deleteHAMIBindingsForApp(ctx, c, appName, owner)
+}
+
+func FindAllocationsForApp(ctx context.Context, c client.Client, appName, owner string) ([]Allocation, error) {
+	allocations, err := loadAllocations(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Allocation, 0)
+	for _, allocation := range allocations {
+		if allocation.AppName == appName && allocation.Owner == owner {
+			out = append(out, allocation)
+		}
+	}
+	return out, nil
+}
+
+func mutateAllocations(ctx context.Context, c client.Client, mutation allocationMutation) (*Allocation, error) {
+	var selected *Allocation
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		nodes, err := loadNodeResources(ctx, c)
+		if err != nil {
+			return err
+		}
+		cm, allocations, err := loadAllocationConfigMap(ctx, c)
+		if err != nil {
+			return err
+		}
+		attachBindings(nodes, allocations)
+
+		next, allocation, err := mutation(nodes, allocations)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(next)
+		if err != nil {
+			return err
+		}
+		if cm == nil {
+			if len(next) == 0 {
+				selected = allocation
+				return nil
+			}
+			cm = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: allocationConfigMapNamespace,
+					Name:      allocationConfigMapName,
+				},
+				Data: map[string]string{allocationConfigMapKey: string(data)},
+			}
+			if err := c.Create(ctx, cm); err != nil {
+				return err
+			}
+			selected = allocation
+			return nil
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data[allocationConfigMapKey] = string(data)
+		if err := c.Update(ctx, cm); err != nil {
+			return err
+		}
+		selected = allocation
+		return nil
+	})
+	return selected, err
+}
+
+func loadAllocationConfigMap(ctx context.Context, c client.Client) (*corev1.ConfigMap, []Allocation, error) {
+	var cm corev1.ConfigMap
+	err := c.Get(ctx, types.NamespacedName{
+		Namespace: allocationConfigMapNamespace,
+		Name:      allocationConfigMapName,
+	}, &cm)
+	if apierrors.IsNotFound(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	raw := cm.Data[allocationConfigMapKey]
+	if raw == "" {
+		return &cm, nil, nil
+	}
+	var allocations []Allocation
+	if err := json.Unmarshal([]byte(raw), &allocations); err != nil {
+		return nil, nil, err
+	}
+	return &cm, allocations, nil
+}
+
+func loadNodeResources(ctx context.Context, c client.Client) ([]Node, error) {
+	var nodes corev1.NodeList
+	if err := c.List(ctx, &nodes); err != nil {
+		return nil, err
+	}
+	out := make([]Node, 0, len(nodes.Items))
+	for i := range nodes.Items {
+		out = append(out, buildNodeResource(&nodes.Items[i]))
+	}
+	return out, nil
+}
+
+func buildNodeResource(node *corev1.Node) Node {
+	totalMemory := node.Status.Capacity.Memory().Value()
+	mode := utils.NodeGPUType(node)
+
+	n := Node{
+		NodeName:       node.Name,
+		GPUType:        mode,
+		Health:         nodeHealth(node),
+		memoryCapacity: totalMemory,
+	}
+
+	if IsHAMIMode(mode) {
+		n.Devices = decodeHAMINvidiaDevices(node)
+	} else {
+		supportType := SupportTypeExclusive
+		if mode == utils.CPUType {
+			supportType = SupportTypeMemoryShared
+		}
+		n.Devices = []Device{{
+			ID:                    fmt.Sprintf("%s-%s-0", node.Name, mode),
+			NodeName:              node.Name,
+			Memory:                totalMemory * 75 / 100,
+			Health:                nodeHealth(node),
+			SupportType:           supportType,
+			AvailableSupportTypes: AvailableSupportTypes(mode),
+		}}
+	}
+
+	return n
+}
+
+func decodeHAMINvidiaDevices(node *corev1.Node) []Device {
+	raw := node.Annotations[constants.NodeNvidiaRegistryKey]
+	if !strings.Contains(raw, constants.OneContainerMultiDeviceSplitSymbol) {
+		return nil
+	}
+
+	var devices []Device
+	for _, encoded := range strings.Split(raw, constants.OneContainerMultiDeviceSplitSymbol) {
+		if encoded == "" || !strings.Contains(encoded, ",") {
+			continue
+		}
+		items := strings.Split(encoded, ",")
+		if len(items) != 7 && len(items) != 9 && len(items) != 10 {
+			continue
+		}
+		devmem, _ := strconv.ParseInt(items[2], 10, 64)
+		healthy, _ := strconv.ParseBool(items[6])
+		mode := utils.NodeGPUType(node)
+		devices = append(devices, Device{
+			ID:                    items[0],
+			NodeName:              node.Name,
+			CardModel:             items[4],
+			Memory:                devmem * mib,
+			Health:                boolHealth(healthy),
+			SupportType:           shareModeToSupportType(mode, node.Annotations[shareModeAnnotationKey(items[0])]),
+			AvailableSupportTypes: AvailableSupportTypes(mode),
+		})
+	}
+	return devices
+}
+
+func nodeHealth(node *corev1.Node) string {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return deviceHealthYes
+		}
+	}
+	return deviceHealthNo
+}
+
+func boolHealth(healthy bool) string {
+	if healthy {
+		return deviceHealthYes
+	}
+	return deviceHealthNo
+}
+
+func shareModeToSupportType(gpuType, shareMode string) string {
+	switch shareMode {
+	case "0":
+		return SupportTypeExclusive
+	case "1":
+		return SupportTypeMemorySlice
+	default:
+		if gpuType == utils.GB10ChipType {
+			return SupportTypeMemorySlice
+		}
+		return SupportTypeTimeSlice
+	}
+}
+
+func supportTypeToShareMode(supportType string) (string, bool) {
+	switch supportType {
+	case SupportTypeExclusive:
+		return "0", true
+	case SupportTypeMemorySlice:
+		return "1", true
+	case SupportTypeTimeSlice:
+		return "2", true
+	default:
+		return "", false
+	}
+}
+
+func shareModeAnnotationKey(deviceID string) string {
+	return fmt.Sprintf("sharemode.gpu.bytetrade.io/%s", deviceID)
+}
+
+func AvailableSupportTypes(mode string) []string {
+	switch mode {
+	case utils.NvidiaCardType:
+		return []string{SupportTypeTimeSlice, SupportTypeMemorySlice, SupportTypeExclusive}
+	case utils.GB10ChipType:
+		return []string{SupportTypeMemorySlice, SupportTypeExclusive}
+	case utils.CPUType:
+		return []string{SupportTypeMemoryShared}
+	default:
+		return []string{SupportTypeExclusive}
+	}
+}
+
+func attachBindings(nodes []Node, allocations []Allocation) {
+	for ai := range allocations {
+		for ni := range nodes {
+			if nodes[ni].NodeName != allocations[ai].NodeName {
+				continue
+			}
+			for di := range nodes[ni].Devices {
+				if nodes[ni].Devices[di].ID == allocations[ai].DeviceID {
+					nodes[ni].Devices[di].Bindings = append(nodes[ni].Devices[di].Bindings, allocations[ai])
+				}
+			}
+		}
+	}
+}

--- a/framework/app-service/pkg/compute/target.go
+++ b/framework/app-service/pkg/compute/target.go
@@ -1,0 +1,181 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func resolveComputeTarget(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, includeSharedServer bool) (*appcfg.ApplicationConfig, bool, error) {
+	if appConfig == nil {
+		return nil, false, fmt.Errorf("app config is nil")
+	}
+	if !appConfig.IsV2() || !appConfig.HasClusterSharedCharts() {
+		return appConfig, true, nil
+	}
+	owner, found, err := sharedServerOwner(ctx, c, appConfig)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found || owner == "" || owner == appConfig.OwnerName {
+		return appConfig, true, nil
+	}
+	if !includeSharedServer {
+		return appConfig, false, nil
+	}
+	target, err := loadAppConfigForOwner(ctx, c, appConfig.AppName, owner)
+	if err != nil {
+		return nil, false, err
+	}
+	return target, true, nil
+}
+
+func DeleteAllocationsForComputeTarget(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, includeSharedServer bool) error {
+	if appConfig == nil {
+		return nil
+	}
+	// For v2 cluster-shared apps the only allocation row lives at
+	// (appName, sharedServerOwner). When the caller does not intend to
+	// touch the shared server (suspend / uninstall the client only),
+	// leave that row and its HAMI bindings alone.
+	if appConfig.IsV2() && appConfig.HasClusterSharedCharts() && !includeSharedServer {
+		return nil
+	}
+	// resolveComputeTarget redirects to the actual server owner's config
+	// when stop/uninstall-all is triggered by someone who is not the
+	// original installer of the shared server; in every other reachable
+	// case it returns appConfig unchanged.
+	target, _, err := resolveComputeTarget(ctx, c, appConfig, includeSharedServer)
+	if err != nil {
+		return err
+	}
+	return DeleteAllocationsForApp(ctx, c, target.AppName, target.OwnerName)
+}
+
+func ManagesSharedServer(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, error) {
+	target, manage, err := resolveComputeTarget(ctx, c, appConfig, false)
+	if err != nil {
+		return false, err
+	}
+	return manage && target != nil && target.IsV2() && target.HasClusterSharedCharts(), nil
+}
+
+func ShouldIncludeSharedServerForResume(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, isAdmin bool) (bool, error) {
+	if !isAdmin {
+		return false, nil
+	}
+	if appConfig == nil || !appConfig.IsV2() || !appConfig.HasClusterSharedCharts() {
+		return false, nil
+	}
+	suspended, found, err := sharedServerSuspended(ctx, c, appConfig)
+	if err != nil {
+		return false, err
+	}
+	if found {
+		return suspended, nil
+	}
+	return false, nil
+}
+
+func sharedServerSuspended(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, bool, error) {
+	for _, chart := range appConfig.SubCharts {
+		if !chart.Shared {
+			continue
+		}
+		namespace := appcfg.ChartNamespace(&chart, appConfig.OwnerName)
+		var deployments appsv1.DeploymentList
+		if err := c.List(ctx, &deployments, client.InNamespace(namespace)); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, false, err
+		}
+		found := false
+		for i := range deployments.Items {
+			found = true
+			if !replicasSuspended(deployments.Items[i].Spec.Replicas) {
+				return false, true, nil
+			}
+		}
+		var statefulSets appsv1.StatefulSetList
+		if err := c.List(ctx, &statefulSets, client.InNamespace(namespace)); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, false, err
+		}
+		for i := range statefulSets.Items {
+			found = true
+			if !replicasSuspended(statefulSets.Items[i].Spec.Replicas) {
+				return false, true, nil
+			}
+		}
+		if found {
+			return true, true, nil
+		}
+	}
+	return false, false, nil
+}
+
+func replicasSuspended(replicas *int32) bool {
+	return replicas != nil && *replicas == 0
+}
+
+func sharedServerOwner(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (string, bool, error) {
+	for _, chart := range appConfig.SubCharts {
+		if !chart.Shared {
+			continue
+		}
+		var ns corev1.Namespace
+		err := c.Get(ctx, client.ObjectKey{Name: appcfg.ChartNamespace(&chart, appConfig.OwnerName)}, &ns)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return "", false, err
+		}
+		if ns.Labels[constants.ApplicationNameLabel] != "" && ns.Labels[constants.ApplicationNameLabel] != appConfig.AppName {
+			continue
+		}
+		return ns.Labels[constants.ApplicationInstallUserLabel], true, nil
+	}
+	return "", false, nil
+}
+
+func loadAppConfigForOwner(ctx context.Context, c client.Client, appName, owner string) (*appcfg.ApplicationConfig, error) {
+	manager, err := loadAppManagerForOwner(ctx, c, appName, owner)
+	if err != nil {
+		return nil, err
+	}
+	var cfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(manager.Spec.Config), &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func loadAppManagerForOwner(ctx context.Context, c client.Client, appName, owner string) (*appv1alpha1.ApplicationManager, error) {
+	var managers appv1alpha1.ApplicationManagerList
+	if err := c.List(ctx, &managers); err != nil {
+		return nil, err
+	}
+	for i := range managers.Items {
+		manager := &managers.Items[i]
+		if manager.Spec.AppName != appName || manager.Spec.AppOwner != owner {
+			continue
+		}
+		if manager.Spec.Type != appv1alpha1.App && manager.Spec.Type != appv1alpha1.Middleware {
+			continue
+		}
+		return manager, nil
+	}
+	return nil, fmt.Errorf("compute target app %s owned by %s not found", appName, owner)
+}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -1,0 +1,166 @@
+package compute
+
+import (
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+const (
+	StatusInstallable           = "installable"
+	StatusInsufficientResources = "insufficient-resources"
+	StatusNoMatchingNode        = "no-matching-node"
+
+	SupportTypeTimeSlice    = "TimeSlice"
+	SupportTypeMemorySlice  = "MemorySlice"
+	SupportTypeExclusive    = "Exclusive"
+	SupportTypeMemoryShared = "MemoryShared"
+
+	allocationConfigMapNamespace = "os-framework"
+	allocationConfigMapName      = "app-gpu-allocations"
+	allocationConfigMapKey       = "allocations.json"
+
+	managedByLabelKey      = "app.bytetrade.io/managed-by"
+	allocationModeLabelKey = "gpu.bytetrade.io/mode"
+	managedByAppService    = "app-service"
+
+	hamiGPUBindingAPIVersion = "gpu.bytetrade.io/v1alpha1"
+	hamiGPUBindingKind       = "GPUBinding"
+	hamiGPUBindingListKind   = "GPUBindingList"
+)
+
+type Node struct {
+	NodeName       string `json:"nodeName"`
+	GPUType        string `json:"gpuType"`
+	Health         string `json:"health,omitempty"`
+	memoryCapacity int64
+	Devices        []Device `json:"devices"`
+}
+
+type Device struct {
+	ID                    string       `json:"id"`
+	NodeName              string       `json:"nodeName"`
+	CardModel             string       `json:"cardModel,omitempty"`
+	Memory                int64        `json:"memory"`
+	Health                string       `json:"health"`
+	SupportType           string       `json:"supportType"`
+	AvailableSupportTypes []string     `json:"availableSupportTypes,omitempty"`
+	Bindings              []Allocation `json:"bindings,omitempty"`
+}
+
+type Allocation struct {
+	AppID    string `json:"appId,omitempty"`
+	AppName  string `json:"appName"`
+	Owner    string `json:"owner,omitempty"`
+	Mode     string `json:"mode"`
+	NodeName string `json:"nodeName"`
+	DeviceID string `json:"deviceId"`
+	Memory   int64  `json:"memory"`
+}
+
+type Requirement struct {
+	Mode              string `json:"mode"`
+	RequiredCPU       int64  `json:"requiredCpu"`
+	RequiredGPU       int64  `json:"requiredGpu"`
+	LimitedGPU        int64  `json:"limitedGpu"`
+	RequiredMemory    int64  `json:"requiredMemory"`
+	LimitedMemory     int64  `json:"limitedMemory"`
+	RequiredDisk      int64  `json:"requiredDisk"`
+	SupportMultiCards bool   `json:"supportMultiCards"`
+	SupportMultiNodes bool   `json:"supportMultiNodes"`
+}
+
+type ModePlanResult struct {
+	ComputeType string `json:"computeType"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+const (
+	NodeStatusNotMatch     = "not_match"
+	NodeStatusNotEnough    = "not_enough"
+	NodeStatusNotAvailable = "not_available"
+	NodeStatusAvailable    = "available"
+
+	AvailabilityScopeCard          = "card"
+	AvailabilityScopeSingleNode    = "single-node-cards"
+	AvailabilityScopeCrossNode     = "cross-node-cards"
+	AvailabilityScopeNode          = "node"
+	FitLevelLimit                  = "limit"
+	FitLevelRequired               = "required"
+	BindingApplyStatusNotRequired  = "not-required"
+	BindingApplyStatusRequired     = "required"
+	BindingApplyStatusUnavailable  = "unavailable"
+	BindingApplyStatusApplied      = "applied"
+	BindingValidationReasonValid   = "valid"
+	BindingValidationReasonInvalid = "invalid"
+	deviceHealthYes                = "yes"
+	deviceHealthNo                 = "no"
+)
+
+type DeviceOption struct {
+	NodeName    string `json:"nodeName"`
+	DeviceID    string `json:"deviceId"`
+	CardModel   string `json:"cardModel,omitempty"`
+	SupportType string `json:"supportType"`
+	Capacity    int64  `json:"capacity"`
+	Available   int64  `json:"available"`
+	FitLevel    string `json:"fitLevel,omitempty"`
+	Health      string `json:"health"`
+	Operable    bool   `json:"operable"`
+}
+
+type NodeOption struct {
+	NodeName string         `json:"nodeName"`
+	GPUType  string         `json:"gpuType"`
+	Status   string         `json:"status"`
+	Devices  []DeviceOption `json:"devices"`
+}
+
+type AvailabilityResult struct {
+	Schedulable bool         `json:"schedulable"`
+	Requirement Requirement  `json:"requirement"`
+	Scope       string       `json:"scope"`
+	Nodes       []NodeOption `json:"nodes"`
+	Reason      string       `json:"reason,omitempty"`
+}
+
+type BindingSelection struct {
+	NodeName string `json:"nodeName"`
+	DeviceID string `json:"deviceId"`
+	Memory   int64  `json:"memory,omitempty"`
+}
+
+type BindingValidationResult struct {
+	OK     bool   `json:"ok"`
+	Code   string `json:"code,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type BindingApplyResult struct {
+	Status       string                   `json:"status"`
+	Allocations  []Allocation             `json:"allocations,omitempty"`
+	Availability *AvailabilityResult      `json:"availability,omitempty"`
+	Validation   *BindingValidationResult `json:"validation,omitempty"`
+	TargetApp    string                   `json:"-"`
+	TargetOwner  string                   `json:"-"`
+}
+
+type PressureSnapshot struct {
+	Threshold   float64
+	UsageByNode map[string]prometheus.NodeResourceUsage
+}
+
+type AddedResources struct {
+	CPU    int64
+	Memory int64
+	Disk   int64
+}
+
+func IsHAMIMode(mode string) bool {
+	switch mode {
+	case utils.NvidiaCardType, utils.GB10ChipType:
+		return true
+	default:
+		return false
+	}
+}

--- a/framework/app-service/pkg/kubesphere/kubesphere.go
+++ b/framework/app-service/pkg/kubesphere/kubesphere.go
@@ -185,3 +185,17 @@ func GetOwner(ctx context.Context, kubeConfig *rest.Config) (string, error) {
 	}
 	return "", errors.New("user with role owner not found")
 }
+
+// GetClusterOwner returns the cluster's primary owner user (the one
+// carrying bytetrade.io/owner-role=owner) using ambient controller
+// runtime kubeconfig. Convenience wrapper around GetOwner for callers
+// that do not already hold a *rest.Config — see
+// (*appcfg.ApplicationConfig).GetOwnerName, which delegates here for
+// v3 / cluster-shared apps.
+func GetClusterOwner(ctx context.Context) (string, error) {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return "", err
+	}
+	return GetOwner(ctx, config)
+}

--- a/framework/app-service/pkg/prometheus/prometheus.go
+++ b/framework/app-service/pkg/prometheus/prometheus.go
@@ -226,6 +226,59 @@ func GetNodeCpuResource(ctx context.Context) (map[string]apiserver_api.CPUInfo, 
 	return result, nil
 }
 
+type NodeResourceUsage struct {
+	CPUCapacity     int64
+	CPUUtilization  float64
+	MemoryCapacity  int64
+	MemoryAvailable int64
+	DiskCapacity    int64
+	DiskAvailable   int64
+}
+
+func GetNodeResourceUsage(ctx context.Context) (map[string]NodeResourceUsage, error) {
+	p, err := New(Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	opts := QueryOptions{Level: LevelCluster}
+	metrics := p.GetNamedMetrics(ctx, []string{"node_cpu_capacity", "node_cpu_utilisation", "node_memory_capacity", "node_memory_available", "node_disk_capacity", "node_disk_available"}, time.Now(), opts)
+	result := make(map[string]NodeResourceUsage)
+	for _, m := range metrics {
+		if m.Error != "" {
+			return nil, fmt.Errorf("query %s: %s", m.MetricName, m.Error)
+		}
+		for _, mv := range m.MetricData.MetricValues {
+			if mv.Sample == nil {
+				continue
+			}
+			node := mv.Metadata["node"]
+			if node == "" {
+				node = mv.Metadata["instance"]
+			}
+			if node == "" {
+				continue
+			}
+			usage := result[node]
+			switch m.MetricName {
+			case "node_cpu_capacity":
+				usage.CPUCapacity = int64(mv.Sample[1] * 1000)
+			case "node_cpu_utilisation":
+				usage.CPUUtilization = mv.Sample[1]
+			case "node_memory_capacity":
+				usage.MemoryCapacity = int64(mv.Sample[1])
+			case "node_memory_available":
+				usage.MemoryAvailable = int64(mv.Sample[1])
+			case "node_disk_capacity":
+				usage.DiskCapacity = int64(mv.Sample[1])
+			case "node_disk_available":
+				usage.DiskAvailable = int64(mv.Sample[1])
+			}
+			result[node] = usage
+		}
+	}
+	return result, nil
+}
+
 func GetCurUserResource(ctx context.Context, username string) (*ClusterMetrics, error) {
 	p, err := New(Endpoint)
 	if err != nil {

--- a/framework/app-service/pkg/prometheus/prometheus_types.go
+++ b/framework/app-service/pkg/prometheus/prometheus_types.go
@@ -165,6 +165,12 @@ var promQLTemplates = map[string]string{
 	"cluster_memory_utilisation":   ":node_memory_utilisation:",
 	"node_cpu_frequency_max_hertz": "node_cpu_frequency_max_hertz",
 	"node_cpu_info":                "node_cpu_info",
+	"node_cpu_capacity":            "node:node_num_cpu:sum",
+	"node_cpu_utilisation":         "node:node_cpu_utilisation:avg1m",
+	"node_memory_capacity":         "node:node_memory_bytes_total:sum",
+	"node_memory_available":        "node:node_memory_bytes_available:sum",
+	"node_disk_capacity":           "sum(node:disk_capacity:size) by (node)",
+	"node_disk_available":          "sum(node:disk_avail:size) by (node)",
 }
 
 type NamespaceMetricSlice []struct {

--- a/framework/app-service/pkg/users/userspace/v1/create.go
+++ b/framework/app-service/pkg/users/userspace/v1/create.go
@@ -273,7 +273,7 @@ func (c *Creator) installSysApps(ctx context.Context, bflPod *corev1.Pod) error 
 		"arch": arch,
 	}
 
-	vals["gpu"] = "none" // unused currently
+	vals["gpu"] = utils.CPUType // unused currently
 
 	userIndex, userSubnet, err := c.getUserSubnet(ctx)
 	if err != nil {

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils/files"
@@ -794,7 +795,23 @@ func GetAppConfig(ctx context.Context, options *ConfigOptions) (*appcfg.Applicat
 	}
 
 	appcfg.Namespace = namespace
-	appcfg.OwnerName = options.Owner
+	// v3 apps are cluster-shared and admin-managed: any admin may
+	// install / upgrade / suspend / uninstall the single cluster-wide
+	// instance, so the install caller is not a stable identity. Persist
+	// the cluster owner here so allocation rows, HAMI binding labels,
+	// pod owner labels and every downstream user-scoped API call
+	// (kubesphere user CR, user-system / user-space namespaces,
+	// X-Bfl-User header, helm bfl.username) all key off the same real
+	// user regardless of which admin operates the app.
+	if appcfg.IsV3() {
+		clusterOwner, err := kubesphere.GetClusterOwner(ctx)
+		if err != nil {
+			return nil, chartPath, err
+		}
+		appcfg.OwnerName = clusterOwner
+	} else {
+		appcfg.OwnerName = options.Owner
+	}
 	appcfg.RepoURL = options.RepoURL
 	return appcfg, chartPath, nil
 }
@@ -870,11 +887,27 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 	if err != nil {
 		return appcfg.AppRequirement{}, err
 	}
+	limMem, err := parseQty(cfg.Spec.LimitedMemory)
+	if err != nil {
+		return appcfg.AppRequirement{}, err
+	}
+	limDisk, err := parseQty(cfg.Spec.LimitedDisk)
+	if err != nil {
+		return appcfg.AppRequirement{}, err
+	}
+	limCPU, err := parseQty(cfg.Spec.LimitedCPU)
+	if err != nil {
+		return appcfg.AppRequirement{}, err
+	}
+	limGPU, err := parseQty(cfg.Spec.LimitedGPU)
+	if err != nil {
+		return appcfg.AppRequirement{}, err
+	}
 
 	if !oac.IsNewOlaresManifestVersion(cfg.ConfigVersion) {
 		// Default supportedGpu list when the manifest leaves it empty.
 		if len(cfg.Spec.SupportedGpu) == 0 {
-			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType}
+			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType, utils.CPUType, utils.MthreadsM100ChipType, utils.AppleMChipType}
 		}
 
 		if selectedGpu != "" && gpu != nil && !gpu.IsZero() {
@@ -906,6 +939,10 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 					{dst: &disk, src: sr.RequiredDisk},
 					{dst: &cpu, src: sr.RequiredCPU},
 					{dst: &gpu, src: sr.RequiredGPU},
+					{dst: &limMem, src: sr.LimitedMemory},
+					{dst: &limDisk, src: sr.LimitedDisk},
+					{dst: &limCPU, src: sr.LimitedCPU},
+					{dst: &limGPU, src: sr.LimitedGPU},
 				} {
 					if setter.src == nil || *setter.src == "" {
 						continue
@@ -925,10 +962,14 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 	}
 
 	return appcfg.AppRequirement{
-		Memory: mem,
-		CPU:    cpu,
-		Disk:   disk,
-		GPU:    gpu,
+		Memory:        mem,
+		CPU:           cpu,
+		Disk:          disk,
+		GPU:           gpu,
+		LimitedMemory: limMem,
+		LimitedCPU:    limCPU,
+		LimitedDisk:   limDisk,
+		LimitedGPU:    limGPU,
 	}, nil
 }
 

--- a/framework/app-service/pkg/utils/app/validate.go
+++ b/framework/app-service/pkg/utils/app/validate.go
@@ -235,34 +235,9 @@ func CheckAppRequirement(token string, appConfig *appcfg.ApplicationConfig, op v
 		}
 	}
 
-	// only support nvidia gpu managment by HAMi for now
-	if appConfig.Requirement.GPU != nil &&
-		(appConfig.GetSelectedGpuTypeValue() == utils.NvidiaCardType || appConfig.GetSelectedGpuTypeValue() == utils.GB10ChipType) {
-		if !appConfig.Requirement.GPU.IsZero() && metrics.GPU.Total <= 0 {
-			return constants.GPU, constants.SystemGPUNotAvailable, fmt.Errorf(constants.SystemGPUNotAvailableMessage, op)
-
-		}
-		nodes, err := utils.GetNodeInfo(context.TODO())
-		if err != nil {
-			klog.Errorf("failed to get node info %v", err)
-			return "", "", err
-		}
-		klog.Infof("nodes info: %#v", nodes)
-		var maxNodeGPUMem int64
-		for _, n := range nodes {
-			var sum int64
-			for _, g := range n.GPUS {
-				sum += g.Memory
-			}
-			if sum > maxNodeGPUMem {
-				maxNodeGPUMem = sum
-			}
-		}
-
-		if appConfig.Requirement.GPU.CmpInt64(maxNodeGPUMem) > 0 {
-			return constants.GPU, constants.SystemGPUPressure, fmt.Errorf(constants.SystemGPUPressureMessage, op)
-		}
-	}
+	// GPU availability (per-mode, per-node) is now checked upfront by
+	// compute.BuildInstallComputePlan during install pre-check, so we no
+	// longer reject installs here based on aggregate cluster GPU memory.
 
 	return CheckAppK8sRequestResource(appConfig, op)
 }

--- a/framework/app-service/pkg/utils/gpu_types.go
+++ b/framework/app-service/pkg/utils/gpu_types.go
@@ -1,14 +1,55 @@
 package utils
 
+import corev1 "k8s.io/api/core/v1"
+
 const (
 	NodeGPUTypeLabel = "gpu.bytetrade.io/type"
+
+	// noneGPUTypeLabel is the literal value some node-init paths write to
+	// gpu.bytetrade.io/type to mark a node that doesn't have a GPU. It's
+	// treated identically to a missing or empty label: the node runs cpu
+	// workloads only.
+	noneGPUTypeLabel = "none"
 )
 
 const (
-	CPUType           = "cpu"         // force to use CPU, no GPU
-	NvidiaCardType    = "nvidia"      // handling by HAMi
-	AmdGpuCardType    = "amd-gpu"     //
-	AmdApuCardType    = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
-	GB10ChipType      = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
-	StrixHaloChipType = "strix-halo"  // AMD Strix Halo GPU & unified system memory
+	CPUType              = "cpu"         // force to use CPU, no GPU
+	NvidiaCardType       = "nvidia"      // handling by HAMi
+	AmdGpuCardType       = "amd-gpu"     //
+	AmdApuCardType       = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
+	GB10ChipType         = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
+	AppleMChipType       = "apple-m"     // Apple M-series SoC
+	StrixHaloChipType    = "strix-halo"  // AMD Strix Halo GPU & unified system memory
+	MthreadsM100ChipType = "mthreads-m1000"
 )
+
+// NodeGPUType returns the canonical GPU type string for a node by reading the
+// gpu.bytetrade.io/type label and folding the three "no GPU here" variants —
+// label missing, label set to the empty string, or label set to "none" —
+// into CPUType. Every other value is returned verbatim; the contract assumed
+// across the codebase is that other label values, OlaresManifest mode names,
+// and frontend GPU-type selections are already canonical (lowercased, no
+// whitespace), so no further normalization is necessary.
+//
+// Use this helper at any boundary that ingests a node's label, instead of
+// reading node.Labels[NodeGPUTypeLabel] directly: it keeps the cpu-fallback
+// semantics consistent across the package and is the single place that has
+// to be updated if more "no GPU" sentinel values ever get added.
+func NodeGPUType(node *corev1.Node) string {
+	if node == nil {
+		return CPUType
+	}
+	t, ok := node.Labels[NodeGPUTypeLabel]
+	if !ok || t == "" || t == noneGPUTypeLabel {
+		return CPUType
+	}
+	return t
+}
+
+// IsCPUOnlyNodeLabel reports whether the value read from a node's
+// gpu.bytetrade.io/type label denotes a cpu-only node. Use this at boundaries
+// where you've already extracted the label string and need to decide whether
+// to skip / fall back to CPUType, e.g. inside iteration over a NodeList.
+func IsCPUOnlyNodeLabel(label string, present bool) bool {
+	return !present || label == "" || label == noneGPUTypeLabel
+}

--- a/framework/app-service/pkg/utils/k8sutil.go
+++ b/framework/app-service/pkg/utils/k8sutil.go
@@ -125,15 +125,25 @@ func GetAllNodesTunnelIPCIDRs() (cidrs []string) {
 // 	return gpuType, nil
 // }
 
+// GetAllGpuTypesFromNodes returns the set of explicit GPU types declared by
+// node labels (gpu.bytetrade.io/type). Nodes without the label, or with the
+// label set to an empty string / "none", contribute nothing to the result,
+// so a pure-CPU cluster returns an empty map. Callers that need to surface
+// "CPU" as a user-selectable option should add it on top of this set
+// themselves; mixing it in here would break the chart-render auto-detect
+// path which expects len(gpuTypes)==1 to mean "this cluster has exactly
+// one GPU flavour".
 func GetAllGpuTypesFromNodes(nodes *corev1.NodeList) (map[string]struct{}, error) {
 	gpuTypes := make(map[string]struct{})
 	if nodes == nil {
 		return gpuTypes, errors.New("empty node list")
 	}
 	for _, n := range nodes.Items {
-		if typeLabel, ok := n.Labels[NodeGPUTypeLabel]; ok {
-			gpuTypes[typeLabel] = struct{}{} // TODO: add driver version info
+		typeLabel, ok := n.Labels[NodeGPUTypeLabel]
+		if IsCPUOnlyNodeLabel(typeLabel, ok) {
+			continue
 		}
+		gpuTypes[typeLabel] = struct{}{} // TODO: add driver version info
 	}
 	return gpuTypes, nil
 }

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -19,6 +19,7 @@ const (
 	ResourceModeNvidia        = "nvidia"
 	ResourceModeNvidiaGB10    = "nvidia-gb10"
 	ResourceModeMThreadsM1000 = "mthreads-m1000"
+	ResourceModeStrixHalo     = "strix-halo"
 )
 
 var validResourceModes = []any{
@@ -29,6 +30,7 @@ var validResourceModes = []any{
 	ResourceModeNvidia,
 	ResourceModeNvidiaGB10,
 	ResourceModeMThreadsM1000,
+	ResourceModeStrixHalo,
 }
 
 var modeArchRequirement = map[string]string{
@@ -36,6 +38,7 @@ var modeArchRequirement = map[string]string{
 	ResourceModeNvidia:        "amd64",
 	ResourceModeNvidiaGB10:    "arm64",
 	ResourceModeMThreadsM1000: "arm64",
+	ResourceModeStrixHalo:     "amd64",
 }
 
 var gpuMemoryModes = map[string]struct{}{


### PR DESCRIPTION
## Overview

This PR makes app-service the single owner of compute resource (GPU / CPU) allocation across an app's full lifecycle — install, resume, suspend, uninstall, and "switch a card's mode while it is bound to apps". Today the same logic is split between Helm hooks, the HAMi `GPUBinding` CRD, and ad-hoc decisions inside install/suspend handlers; that makes it hard for a user or the frontend to see, in one place, what is bound to what and whether an app can actually run on the cluster it is being installed on. After this PR there is a single allocation table (a configmap, `os-framework/app-gpu-allocations`) plus a thin REST surface that the frontend can drive.

The user-visible behaviors:

- A user installing a GPU app no longer needs to know which GPU mode (`nvidia`, `gb10`, etc.) the cluster has — app-service auto-picks the right one when it is unambiguous, and asks the user to choose only when there are real choices.
- The system refuses to start an install/resume when there isn't enough GPU on the cluster and tells the frontend exactly which nodes / cards were tried and why.
- When admins flip a GPU card between "exclusive / time-slice / memory-slice" modes, the apps currently using that card are now stopped automatically (with full visibility into which apps are affected) instead of leaving them in a broken state.
- An admin can list every GPU card on every node, see who is using it and how much memory is taken, from one endpoint.

---

## New endpoints

### `GET /compute-resources`
List every node, its GPU type, and every device (card) on that node with current bindings. Used by the admin "compute resources" page.

**Response (200):**
```json
{
  "code": 200,
  "data": [
    {
      "nodeName": "node-1",
      "gpuType": "nvidia",
      "devices": [
        {
          "id": "GPU-abc-123",
          "nodeName": "node-1",
          "cardModel": "NVIDIA RTX 4090",
          "memory": 25769803776,
          "health": "yes",
          "supportType": "MemorySlice",
          "availableSupportTypes": ["Exclusive", "MemorySlice", "TimeSlice"],
          "bindings": [
            { "appName": "comfyui", "owner": "alice", "mode": "nvidia",
              "nodeName": "node-1", "deviceId": "GPU-abc-123", "memory": 8589934592 }
          ]
        }
      ]
    }
  ]
}
```

### `GET /apps/{name}/compute-resources/bindings`
Return what the named app is currently holding. Empty list means the app isn't bound to any compute resource (typical for CPU apps).

**Response (200):**
```json
{
  "code": 200,
  "data": [
    { "appId": "abc12345", "appName": "comfyui", "owner": "alice",
      "mode": "nvidia", "nodeName": "node-1",
      "deviceId": "GPU-abc-123", "memory": 8589934592 }
  ]
}
```

### `DELETE /apps/{name}/compute-resources/bindings`
Release compute bindings for an app by suspending it. Same backend path as `POST /apps/{name}/suspend`; exposed under the compute namespace so the frontend can present "release GPU" as a first-class action.

### `PUT /compute-resources/nodes/{node}/devices/{deviceID}/support-type` (admin only)
Switch a GPU card between Exclusive / TimeSlice / MemorySlice. Apps currently bound to that card are auto-stopped first.

**Request:**
```json
{ "supportType": "Exclusive" }
```

**Response — happy path (200):**
```json
{
  "code": 200,
  "data": {
    "status": "switched",
    "device": { "id": "GPU-abc-123", "supportType": "Exclusive", "..." : "..." },
    "stoppedApps": [
      { "appName": "comfyui", "owner": "alice", "state": "stopping" }
    ]
  }
}
```

**Response — switch blocked (200 + `code: 4603`):**
Returned when one or more bound apps are in a state that does not allow `stop` (e.g. mid-upgrade). Nothing is changed; the caller should retry once the listed apps settle.
```json
{
  "code": 4603,
  "data": {
    "status": "bound-apps-stop-blocked",
    "device": { "...": "..." },
    "blockedApps": [
      { "appName": "comfyui", "owner": "alice",
        "state": "upgrading", "reason": "stop-operation-not-allowed" }
    ]
  }
}
```

**Response — no change needed (200):** `{ "code": 200, "data": { "status": "unchanged", "device": {...} } }`.

---

## Changed endpoint behaviors

### `POST /apps/{name}/install` — smarter compute mode selection

Request body (`InstallRequest`) is unchanged on the wire; behavior of `selectedGpuType` changes:

- **Empty / omitted:** server tries to auto-pick. If exactly one GPU mode declared in the manifest is runnable on this cluster, it is picked silently. If only the CPU mode is runnable, CPU is picked. If more than one non-CPU mode is runnable (e.g. cluster has both nvidia and strix-halo), the install does **not** start — instead it returns the new ambiguous-mode response below and the frontend should prompt the user to pick.
- **Explicit value (e.g. `"nvidia"`, `"gb10"`, `"cpu"`):** used as-is. If the chosen mode is not available on the cluster, install fails with a 400 like before.
- An additional pre-flight check runs even after a mode is chosen: if the cluster doesn't have enough GPU memory / cards for that mode, install is rejected with a clear `compute resource is not enough for app ... with mode ...` error instead of letting the install reach the Helm step and fail there.

**New response — ambiguous mode (200 + `code: 4604`):**
```json
{
  "code": 4604,
  "data": [
    { "computeType": "nvidia",     "status": "installable" },
    { "computeType": "strix-halo", "status": "installable" },
    { "computeType": "cpu",        "status": "installable" }
  ]
}
```
`status` per entry is one of `installable`, `insufficient-resources`, `no-matching-node`. The frontend should render this as a "choose mode" picker and re-issue the install with `selectedGpuType` set.

Success response (`{ "code": 200, "data": { "uid": "...", "opID": "..." } }`) is unchanged.

### `POST /apps/{name}/resume` — optional GPU binding selection

This endpoint now accepts an **optional** request body. CPU apps and apps that are not running in HAMi mode still resume with no body, identical to today.

**Request (optional, GPU apps only):**
```json
{
  "computeBinding": [
    { "nodeName": "node-1", "deviceId": "GPU-abc-123", "memory": 8589934592 }
  ]
}
```

For HAMi-managed GPU apps, the flow is now two-step:

1. Frontend calls `POST /apps/{name}/resume` with no body.
2. If the server needs the user to choose a card, it returns `code: 4601` with the full set of nodes/devices and which ones can host this app.
3. Frontend lets the user pick and re-calls `POST /apps/{name}/resume` with `computeBinding` set.
4. If the chosen card no longer fits (capacity changed, another app grabbed it), server returns `code: 4602` with the same availability shape plus a `validation` object explaining why.

**Response — binding required (200 + `code: 4601`):**
```json
{
  "code": 4601,
  "data": {
    "schedulable": true,
    "requirement": { "mode": "nvidia", "requiredGpu": 8589934592, "...": "..." },
    "scope": "card",
    "nodes": [
      {
        "nodeName": "node-1",
        "gpuType": "nvidia",
        "status": "available",
        "devices": [
          { "deviceId": "GPU-abc-123", "supportType": "MemorySlice",
            "capacity": 25769803776, "available": 17179869184,
            "fitLevel": "limit", "health": "yes", "operable": true }
        ]
      }
    ]
  }
}
```

**Response — binding unavailable (200 + `code: 4602`):**
Same body shape as above, plus:
```json
{
  "code": 4602,
  "validation": { "ok": false, "code": "invalid", "reason": "..." },
  "data": { "...": "..." }
}
```

Success and 400 paths are otherwise unchanged.

### `POST /apps/{name}/suspend` and `POST /apps/{name}/uninstall`

Wire request/response unchanged. The semantic change is that suspend and uninstall now always release the app's compute allocation and HAMi binding as part of the operation; in the old flow these could be left behind on certain failure paths. For v2 cluster-shared apps, releasing happens only when the caller actually tears down the server (`all: true` / `--cascade`); a client-only suspend/uninstall leaves the shared server's allocation untouched.

### New API result codes summary

| Code | Where | Meaning |
| ---- | ----- | ------- |
| `4601` | `POST /apps/{name}/resume` | GPU binding required; pick from `data.nodes`. |
| `4602` | `POST /apps/{name}/resume` | Submitted binding can't be honored anymore. |
| `4603` | `PUT /compute-resources/.../support-type` | One or more bound apps can't be stopped right now. |
| `4604` | `POST /apps/{name}/install` | Multiple GPU modes runnable; user must pick. |

---

## What "manage compute" looks like end-to-end

Old: each lifecycle handler talked to HAMi directly via `GPUBinding` and there was no canonical place to ask "what does app X hold". New flow, same lifecycle:

- **Install** — auto-pick mode if possible → pre-flight cluster fit → create the app → allocate from the configmap → write a HAMi `GPUBinding` (only for HAMi-mode apps) → tag the deployment/statefulset's pod template with the chosen mode, node selector, and GPU memory limit (via the existing `/gpulimit/inject` webhook).
- **Resume** — same as install but driven by user-chosen binding when needed; if the binding can't be applied the resume is rejected before any deployment is touched.
- **Suspend / uninstall** — the app's row in the allocation configmap and its HAMi `GPUBinding` are always removed together with the workload.
- **v2 shared apps** — the allocation row only ever lives at the original server installer, regardless of how many client users install the same app. Stopping/uninstalling a client never touches the server's binding; only an admin's "stop-all" / "uninstall-all" does.
- **Device mode switch** — admin operation that auto-stops bound apps before mutating the device, or refuses outright if any bound app can't be stopped.

The frontend's mental model becomes: read `/compute-resources` to render the page, read `/apps/{name}/compute-resources/bindings` for per-app detail, and for any user action that might need compute (install, resume, device-mode switch), drive a two-step flow with the new 46xx codes.

---

## Internal / refactor (brief, no user-facing impact)

- New `pkg/compute` package (`scheduler.go`, `availability.go`, `auto_select.go`, `target.go`, `store.go`, `hami.go`, `device_mode.go`, `pressure.go`, `notification.go`, `types.go`) owns: requirement parsing from the manifest, node/device snapshot, fit calculation, pick-and-write to the allocation configmap, HAMi binding create/delete, pressure check via Prometheus, and the v2 shared-app target-resolution rules.
- Allocation persistence is a single configmap (`os-framework/app-gpu-allocations`), updated with retry-on-conflict; HAMi `GPUBinding` objects are derived state.
- Manifest decoding (`appcfg/application.go`) now understands the `spec.resources` matrix (one entry per supported mode); legacy manifests without it synthesize a single `{cpu}` or `{nvidia}` entry so old charts keep working.
- App-state hooks in `installing_app`, `installing_canceling_app`, `suspending_app`, `uninstalling_app` call into the new package — no behavior change for non-GPU apps.
- Unit tests added for `auto_select`, calculator, and `appcfg/application` decoding.

40 files changed, +4163 / −185.

## Test plan

- [ ] `go build ./...` and `go vet ./...` in `framework/app-service`
- [ ] `go test ./pkg/compute/... ./pkg/appcfg/...`
- [ ] Manual: install / suspend / resume / uninstall a HAMi-managed GPU app on a single-node cluster; verify `app-gpu-allocations` configmap and HAMi `GPUBinding` stay in sync
- [ ] Manual: hit the new `GET /compute-resources` and `GET /apps/{name}/compute-resources/bindings` endpoints
- [ ] Manual: install a GPU app without `selectedGpuType` on (a) a single-GPU cluster (auto-pick), (b) a multi-GPU cluster (expect `code: 4604`)
- [ ] Manual: resume a GPU app, expect `code: 4601`, then resume again with a `computeBinding` and verify the pod lands on the chosen node/card
- [ ] Manual: admin flips a card's `supportType` while an app is bound — verify the app is auto-stopped and the device's `supportType` is updated
- [ ] Manual: v2 cluster-shared app — install as admin, install as a second user (client-only), verify only the admin's row exists in `app-gpu-allocations`; suspending the second user leaves it alone