### PR TITLE
olares-app: bump system-frontend image to v1.10.33 in helm chart

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.32
+          image: beclab/system-frontend:v1.10.33
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Optimize drag interaction for mobile and desktop

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1124


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single Helm chart change that bumps the `beclab/system-frontend` image tag for the `olares-app-init` initContainer; behavior changes are limited to whatever is inside the new image version.
> 
> **Overview**
> Updates the `olares-app` Helm deployment to use `beclab/system-frontend:v1.10.33` (from `v1.10.32`) for the `olares-app-init` initContainer that populates `/www`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d77658e4d798c1218a3b66836047cf25eecbaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->