### PR TITLE
docs: Command context clarification

### DIFF
--- a/docs/use-cases/hermes.md
+++ b/docs/use-cases/hermes.md
@@ -51,20 +51,21 @@ Run a quick setup to connect Hermes Agent to your local model.
 
 ### Step 1: Get model and endpoint details
 
-1. Check the installed models by running the following command:
+1. Open the Ollama app from the Launchpad.
+2. Check the installed models by running the following command:
 
     ```bash
     ollama list
     ```
-2. Copy and save your model name exactly as shown in the **NAME** column. For example, `qwen3.5:9b`.
-3. Check the context window of the model by running the following command:
+3. Copy and save your model name exactly as shown in the **NAME** column. For example, `qwen3.5:9b`.
+4. Check the context window of the model by running the following command:
 
     ```bash
     ollama ps
     ```
 
-4. Copy and save the value as shown in the **CONTEXT** column. For example, `32768`.
-5. Open Settings, go to **Applications** > **Ollama** > **Shared entrances** > **Ollama API**, and then copy the endpoint address. For example, `http://d54536a50.shared.olares.com`.
+5. Copy and save the value as shown in the **CONTEXT** column. For example, `32768`.
+6. Open Settings, go to **Applications** > **Ollama** > **Shared entrances** > **Ollama API**, and then copy the endpoint address. For example, `http://d54536a50.shared.olares.com`.
 
     ![Obtain Ollama API](/images/manual/use-cases/ollama-endpoint1.png#bordered){width=65%}
 


### PR DESCRIPTION
Title: Update Step 1 to explicitly specify the command-line interface, preventing user misoperation.

* **Background**
See title.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies where to run the Ollama commands; no code or behavior changes.
> 
> **Overview**
> Updates `docs/use-cases/hermes.md` to **explicitly instruct users to open the Ollama app from the Launchpad** before running `ollama list`/`ollama ps`, reducing the chance of running commands in the wrong CLI context. Step numbering is adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebec8edb2a937b17259bb9625f5b537b1e8cbda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->