### PR TITLE
chore(cli): hand GPUBinding management over to app-service on upgrade

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -58,6 +58,17 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},
+		// Apply the GPUBinding CRD schema bump BEFORE the HAMi helm upgrade
+		// runs in upgraderBase.UpgradeSystemComponents(); Helm 3 does not
+		// update objects under chart `crds/` on upgrade, so the new spec
+		// fields (namespace, owner) would otherwise stay unknown to the
+		// apiserver and get pruned out of any binding we write.
+		&task.LocalTask{
+			Name:   "ApplyGPUBindingCRD",
+			Action: new(applyGPUBindingCRD),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
 	}
 	pre = append(pre, u.upgraderBase.UpgradeSystemComponents()...)
 	return append(pre,
@@ -74,6 +85,12 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		&task.LocalTask{
 			Name:   "BackfillAppGPUConfig",
 			Action: new(backfillAppGPUConfig),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+		&task.LocalTask{
+			Name:   "MigrateLegacyGPUBindings",
+			Action: new(migrateLegacyGPUBindings),
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},

--- a/cli/pkg/upgrade/1_12_7_20260520.go
+++ b/cli/pkg/upgrade/1_12_7_20260520.go
@@ -1,0 +1,45 @@
+package upgrade
+
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_7_20260520 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260520) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260520")
+}
+
+func (u upgrader_1_12_7_20260520) UpgradeSystemComponents() []task.Interface {
+	pre := []task.Interface{
+		// Apply the GPUBinding CRD schema bump BEFORE the HAMi helm upgrade
+		// runs in upgraderBase.UpgradeSystemComponents(); Helm 3 does not
+		// update objects under chart `crds/` on upgrade, so the new spec
+		// fields (namespace, owner) would otherwise stay unknown to the
+		// apiserver and get pruned out of any binding we write.
+		&task.LocalTask{
+			Name:   "ApplyGPUBindingCRD",
+			Action: new(applyGPUBindingCRD),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	}
+	pre = append(pre, u.upgraderBase.UpgradeSystemComponents()...)
+	return append(pre,
+		&task.LocalTask{
+			Name:   "MigrateLegacyGPUBindings",
+			Action: new(migrateLegacyGPUBindings),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260520{})
+}

--- a/cli/pkg/upgrade/apply_gpu_binding_crd.go
+++ b/cli/pkg/upgrade/apply_gpu_binding_crd.go
@@ -1,0 +1,107 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apixclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/yaml"
+)
+
+// applyGPUBindingCRD upserts the gpu.bytetrade.io/v1alpha1 GPUBinding CRD into
+// the cluster from the bundled HAMi chart on disk. This is necessary because
+// `helm upgrade` does NOT update objects under a chart's `crds/` directory
+// (only `helm install` does), so any schema change shipped via the chart
+// won't propagate to an already-installed cluster without an explicit apply.
+//
+// The new schema adds spec.namespace / spec.owner, which the app-service
+// migration step and the new HAMi scheduler both rely on; without applying
+// the updated CRD first, the apiserver would prune those fields and the
+// migration would silently produce empty Owner values on legacy bindings.
+type applyGPUBindingCRD struct {
+	common.KubeAction
+}
+
+const gpuBindingCRDRelPath = "wizard/config/gpu/hami/crds/gpu.bytetrade.io_gpubindings.yaml"
+
+func (a *applyGPUBindingCRD) Execute(runtime connector.Runtime) error {
+	crdPath := filepath.Join(runtime.GetInstallerDir(), gpuBindingCRDRelPath)
+	data, err := os.ReadFile(crdPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Infof("GPUBinding CRD manifest not found at %s, skipping CRD upgrade", crdPath)
+			return nil
+		}
+		return fmt.Errorf("read GPUBinding CRD manifest %s: %w", crdPath, err)
+	}
+
+	desired := &apiextensionsv1.CustomResourceDefinition{}
+	if err := yaml.Unmarshal(data, desired); err != nil {
+		return fmt.Errorf("decode GPUBinding CRD manifest: %w", err)
+	}
+	if desired.Name == "" {
+		return fmt.Errorf("GPUBinding CRD manifest at %s has no metadata.name", crdPath)
+	}
+
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get rest config: %w", err)
+	}
+	client, err := apixclientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("create apiextensions client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	existing, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, desired.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// CRD not yet present (e.g. fresh GPU-less cluster being upgraded). It
+		// will get installed by `helm install` later if/when GPU is enabled,
+		// so just no-op here.
+		logger.Infof("GPUBinding CRD %s not found in cluster, skipping CRD upgrade", desired.Name)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get existing GPUBinding CRD: %w", err)
+	}
+
+	// Preserve resource version / status, replace spec + labels + annotations
+	// with the desired manifest. We keep the cluster's status block to avoid
+	// fighting with the apiextensions controller.
+	updated := existing.DeepCopy()
+	updated.Spec = desired.Spec
+	if desired.Labels != nil {
+		if updated.Labels == nil {
+			updated.Labels = map[string]string{}
+		}
+		for k, v := range desired.Labels {
+			updated.Labels[k] = v
+		}
+	}
+	if desired.Annotations != nil {
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		for k, v := range desired.Annotations {
+			updated.Annotations[k] = v
+		}
+	}
+
+	if _, err := client.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update GPUBinding CRD: %w", err)
+	}
+	logger.Infof("GPUBinding CRD %s updated to match bundled manifest", desired.Name)
+	return nil
+}

--- a/cli/pkg/upgrade/migrate_gpu_bindings.go
+++ b/cli/pkg/upgrade/migrate_gpu_bindings.go
@@ -1,0 +1,472 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	appv1alpha1 "github.com/beclab/Olares/framework/app-service/api/app.bytetrade.io/v1alpha1"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	legacyGPUBindingAPIVersion = "gpu.bytetrade.io/v1alpha1"
+	legacyGPUBindingListKind   = "GPUBindingList"
+	gpuAllocationCMNamespace   = "os-framework"
+	gpuAllocationCMName        = "app-gpu-allocations"
+	gpuAllocationCMKey         = "allocations.json"
+	nodeGPUTypeLabel           = "gpu.bytetrade.io/type"
+	nodeNvidiaRegistryKey      = "hami.io/node-nvidia-register"
+	deviceSplitSymbol          = ":"
+	appNameLabelKey            = "applications.app.bytetrade.io/name"
+	appOwnerLabelKey           = "applications.app.bytetrade.io/owner"
+	appInstallUserLabelKey     = "applications.app.bytetrade.io/install_user"
+	managedByLabelKey          = "app.bytetrade.io/managed-by"
+	managedByAppService        = "app-service"
+	allocationModeLabelKey     = "gpu.bytetrade.io/mode"
+	shareModeAnnotationPrefix  = "sharemode.gpu.bytetrade.io/"
+	supportTypeExclusive       = "Exclusive"
+	supportTypeMemorySlice     = "MemorySlice"
+	supportTypeTimeSlice       = "TimeSlice"
+)
+
+type migrateLegacyGPUBindings struct {
+	common.KubeAction
+}
+
+type migratedComputeAllocation struct {
+	AppID    string `json:"appId,omitempty"`
+	AppName  string `json:"appName"`
+	Owner    string `json:"owner,omitempty"`
+	Mode     string `json:"mode"`
+	NodeName string `json:"nodeName"`
+	DeviceID string `json:"deviceId"`
+	Memory   int64  `json:"memory"`
+}
+
+func (m *migrateLegacyGPUBindings) Execute(_ connector.Runtime) error {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to get kubernetes config")
+	}
+
+	scheme := runtime.NewScheme()
+	if err := appv1alpha1.AddToScheme(scheme); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to add app-service scheme")
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to add corev1 scheme")
+	}
+
+	c, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create controller-runtime client")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	bindings := &unstructured.UnstructuredList{}
+	bindings.SetAPIVersion(legacyGPUBindingAPIVersion)
+	bindings.SetKind(legacyGPUBindingListKind)
+	if err := c.List(ctx, bindings); err != nil {
+		if apierrors.IsNotFound(err) || runtime.IsNotRegisteredError(err) || apimeta.IsNoMatchError(err) {
+			logger.Infof("legacy GPUBinding resource not found, skip migration")
+			return nil
+		}
+		return errors.Wrap(errors.WithStack(err), "failed to list legacy GPUBindings")
+	}
+	if len(bindings.Items) == 0 {
+		logger.Infof("no legacy GPUBindings found, skip migration")
+		return nil
+	}
+
+	var managers appv1alpha1.ApplicationManagerList
+	if err := c.List(ctx, &managers); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to list applicationmanagers")
+	}
+	var nodes corev1.NodeList
+	if err := c.List(ctx, &nodes); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to list nodes")
+	}
+	allocations, err := loadMigratedAllocations(ctx, c)
+	if err != nil {
+		return err
+	}
+	allocationKeys := make(map[string]struct{}, len(allocations))
+	for _, allocation := range allocations {
+		allocationKeys[allocationKey(allocation.AppName, allocation.Owner, allocation.DeviceID)] = struct{}{}
+	}
+
+	var migrated, deleted, skipped int
+	for i := range bindings.Items {
+		binding := &bindings.Items[i]
+		appName, _, _ := unstructured.NestedString(binding.Object, "spec", "appName")
+		deviceID, _, _ := unstructured.NestedString(binding.Object, "spec", "uuid")
+		if appName == "" || deviceID == "" {
+			logger.Warnf("skip GPUBinding %s with empty appName or uuid", binding.GetName())
+			skipped++
+			continue
+		}
+
+		owner, _, _ := unstructured.NestedString(binding.Object, "spec", "owner")
+		namespace, _, _ := unstructured.NestedString(binding.Object, "spec", "namespace")
+		am, appConfig, err := resolveBindingApplication(ctx, c, &managers, binding, appName, owner, namespace)
+		if err != nil {
+			return err
+		}
+		if am == nil {
+			if err := c.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+				return errors.Wrapf(errors.WithStack(err), "failed to delete orphan GPUBinding %s", binding.GetName())
+			}
+			logger.Infof("deleted orphan legacy GPUBinding %s for app %s", binding.GetName(), appName)
+			deleted++
+			continue
+		}
+
+		if !shouldMigrateLegacyGPUBinding(am.Status.State.String()) {
+			if err := c.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+				return errors.Wrapf(errors.WithStack(err), "failed to delete stale GPUBinding %s", binding.GetName())
+			}
+			logger.Infof("deleted legacy GPUBinding %s for app %s owner %s in state %s", binding.GetName(), am.Spec.AppName, am.Spec.AppOwner, am.Status.State)
+			deleted++
+			continue
+		}
+
+		nodeName, supportType := findDevicePlacement(&nodes, deviceID)
+		if nodeName == "" {
+			logger.Warnf("skip GPUBinding %s because device %s was not found on any node", binding.GetName(), deviceID)
+			skipped++
+			continue
+		}
+		mode := strings.TrimSpace(appConfig.SelectedGpuType)
+		if mode == "" {
+			mode = "nvidia"
+		}
+		var memory int64
+		if supportType == supportTypeMemorySlice {
+			memoryRaw, _, _ := unstructured.NestedFieldNoCopy(binding.Object, "spec", "memory")
+			memory, err = bindingMemory(memoryRaw)
+			if err != nil {
+				return errors.Wrapf(errors.WithStack(err), "failed to parse memory of GPUBinding %s", binding.GetName())
+			}
+			if memory <= 0 {
+				logger.Warnf("skip MemorySlice GPUBinding %s because spec.memory is empty", binding.GetName())
+				skipped++
+				continue
+			}
+		}
+		key := allocationKey(am.Spec.AppName, am.Spec.AppOwner, deviceID)
+		if _, exists := allocationKeys[key]; !exists {
+			allocations = append(allocations, migratedComputeAllocation{
+				AppID:    appConfig.AppID,
+				AppName:  am.Spec.AppName,
+				Owner:    am.Spec.AppOwner,
+				Mode:     mode,
+				NodeName: nodeName,
+				DeviceID: deviceID,
+				Memory:   memory,
+			})
+			allocationKeys[key] = struct{}{}
+			migrated++
+		}
+		if err := patchMigratedGPUBinding(ctx, c, binding, am, mode); err != nil {
+			return err
+		}
+	}
+
+	if err := saveMigratedAllocations(ctx, c, allocations); err != nil {
+		return err
+	}
+	logger.Infof("migrated legacy GPUBindings: migrated=%d deleted=%d skipped=%d", migrated, deleted, skipped)
+	return nil
+}
+
+func patchMigratedGPUBinding(ctx context.Context, c ctrlclient.Client, binding *unstructured.Unstructured, am *appv1alpha1.ApplicationManager, mode string) error {
+	patch := binding.DeepCopy()
+	labels := patch.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[managedByLabelKey] = managedByAppService
+	labels[appNameLabelKey] = am.Spec.AppName
+	labels[appOwnerLabelKey] = am.Spec.AppOwner
+	labels[allocationModeLabelKey] = mode
+	patch.SetLabels(labels)
+
+	if err := unstructured.SetNestedField(patch.Object, am.Spec.AppName, "spec", "appName"); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "failed to patch appName for GPUBinding %s", binding.GetName())
+	}
+	if err := unstructured.SetNestedField(patch.Object, am.Spec.AppOwner, "spec", "owner"); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "failed to patch owner for GPUBinding %s", binding.GetName())
+	}
+	if err := unstructured.SetNestedStringMap(patch.Object, map[string]string{
+		appNameLabelKey:  am.Spec.AppName,
+		appOwnerLabelKey: am.Spec.AppOwner,
+	}, "spec", "podSelector", "matchLabels"); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "failed to patch podSelector for GPUBinding %s", binding.GetName())
+	}
+
+	if err := c.Patch(ctx, patch, ctrlclient.MergeFrom(binding)); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "failed to patch migrated GPUBinding %s", binding.GetName())
+	}
+	return nil
+}
+
+func resolveBindingApplication(ctx context.Context, c ctrlclient.Client, managers *appv1alpha1.ApplicationManagerList, binding *unstructured.Unstructured, appName, owner, namespace string) (*appv1alpha1.ApplicationManager, *appcfg.ApplicationConfig, error) {
+	if owner != "" {
+		return findApplicationManager(managers, appName, owner)
+	}
+	if namespace != "" {
+		if am, cfg, err := findApplicationManagerByNamespace(managers, namespace); err != nil || am != nil {
+			return am, cfg, err
+		}
+		owner = ownerFromNamespace(ctx, c, namespace, appName)
+		if owner != "" {
+			return findApplicationManager(managers, appName, owner)
+		}
+	}
+	if owner = ownerFromBindingSelector(ctx, c, binding, managers); owner != "" {
+		return findApplicationManager(managers, appName, owner)
+	}
+	return findSingleApplicationManager(managers, appName)
+}
+
+func findApplicationManager(managers *appv1alpha1.ApplicationManagerList, appName, owner string) (*appv1alpha1.ApplicationManager, *appcfg.ApplicationConfig, error) {
+	for i := range managers.Items {
+		am := &managers.Items[i]
+		if am.Spec.AppName != appName || am.Spec.AppOwner != owner {
+			continue
+		}
+		cfg, err := decodeAppConfig(am)
+		return am, cfg, err
+	}
+	return nil, nil, nil
+}
+
+func findApplicationManagerByNamespace(managers *appv1alpha1.ApplicationManagerList, namespace string) (*appv1alpha1.ApplicationManager, *appcfg.ApplicationConfig, error) {
+	for i := range managers.Items {
+		am := &managers.Items[i]
+		if am.Spec.AppNamespace != namespace {
+			continue
+		}
+		cfg, err := decodeAppConfig(am)
+		return am, cfg, err
+	}
+	return nil, nil, nil
+}
+
+func findSingleApplicationManager(managers *appv1alpha1.ApplicationManagerList, appName string) (*appv1alpha1.ApplicationManager, *appcfg.ApplicationConfig, error) {
+	var found *appv1alpha1.ApplicationManager
+	for i := range managers.Items {
+		am := &managers.Items[i]
+		if am.Spec.AppName != appName {
+			continue
+		}
+		if found != nil {
+			return nil, nil, fmt.Errorf("cannot infer owner for legacy GPUBinding app %s: multiple applicationmanagers found", appName)
+		}
+		found = am
+	}
+	if found == nil {
+		return nil, nil, nil
+	}
+	cfg, err := decodeAppConfig(found)
+	return found, cfg, err
+}
+
+func decodeAppConfig(am *appv1alpha1.ApplicationManager) (*appcfg.ApplicationConfig, error) {
+	if am.Spec.Config == "" {
+		return &appcfg.ApplicationConfig{}, nil
+	}
+	var cfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(am.Spec.Config), &cfg); err != nil {
+		return nil, errors.Wrapf(errors.WithStack(err), "failed to unmarshal config for applicationmanager %s", am.Name)
+	}
+	return &cfg, nil
+}
+
+func ownerFromNamespace(ctx context.Context, c ctrlclient.Client, namespace, appName string) string {
+	var ns corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+		return ""
+	}
+	if appName != "" && ns.Labels[appNameLabelKey] != "" && ns.Labels[appNameLabelKey] != appName {
+		return ""
+	}
+	if owner := ns.Labels[appInstallUserLabelKey]; owner != "" {
+		return owner
+	}
+	return ns.Labels[appOwnerLabelKey]
+}
+
+func ownerFromBindingSelector(ctx context.Context, c ctrlclient.Client, binding *unstructured.Unstructured, managers *appv1alpha1.ApplicationManagerList) string {
+	labels, _, _ := unstructured.NestedStringMap(binding.Object, "spec", "podSelector", "matchLabels")
+	if owner := labels[appOwnerLabelKey]; owner != "" {
+		return owner
+	}
+	selector := ctrlclient.MatchingLabels(labels)
+	var pods corev1.PodList
+	if len(labels) == 0 || c.List(ctx, &pods, selector) != nil {
+		return ""
+	}
+	for _, pod := range pods.Items {
+		if am, _, _ := findApplicationManagerByNamespace(managers, pod.Namespace); am != nil {
+			return am.Spec.AppOwner
+		}
+		if owner := ownerFromNamespace(ctx, c, pod.Namespace, ""); owner != "" {
+			return owner
+		}
+	}
+	return ""
+}
+
+// shouldMigrateLegacyGPUBinding decides whether a legacy GPUBinding should be
+// carried over to the new compute-allocation configmap (true) or dropped as
+// stale (false). The list intentionally covers every state in which the app
+// is still considered to be holding its GPU allocation, including the various
+// *Failed states where the in-progress op aborted but the binding wasn't
+// torn down.
+//
+// IMPORTANT: app states are lowercased ("running", "stopFailed", ...) per
+// `api/app.bytetrade.io/v1alpha1/appmanager_states.go`. Earlier versions of
+// this function compared against capitalized names and therefore matched
+// nothing, deleting every legacy binding instead of migrating them.
+func shouldMigrateLegacyGPUBinding(state string) bool {
+	switch state {
+	case "running",
+		"initializing",
+		"resuming",
+		"installing",
+		"upgrading",
+		"applyingEnv",
+		"stopFailed",
+		"resumeFailed",
+		"upgradeFailed",
+		"applyEnvFailed":
+		return true
+	default:
+		return false
+	}
+}
+
+func bindingMemory(raw any) (int64, error) {
+	if raw == nil {
+		return 0, nil
+	}
+	switch value := raw.(type) {
+	case int64:
+		return value, nil
+	case int:
+		return int64(value), nil
+	case int32:
+		return int64(value), nil
+	case float64:
+		return int64(value), nil
+	case string:
+		if value == "" {
+			return 0, nil
+		}
+		q, err := resource.ParseQuantity(value)
+		if err != nil {
+			return 0, err
+		}
+		return q.Value(), nil
+	default:
+		return 0, fmt.Errorf("unsupported memory type %T", raw)
+	}
+}
+
+func findDevicePlacement(nodes *corev1.NodeList, deviceID string) (string, string) {
+	for _, node := range nodes.Items {
+		raw := node.Annotations[nodeNvidiaRegistryKey]
+		for _, encoded := range strings.Split(raw, deviceSplitSymbol) {
+			fields := strings.Split(encoded, ",")
+			if len(fields) > 0 && fields[0] == deviceID {
+				return node.Name, shareModeToSupportType(node.Labels[nodeGPUTypeLabel], node.Annotations[shareModeAnnotationPrefix+deviceID])
+			}
+		}
+	}
+	return "", ""
+}
+
+func shareModeToSupportType(gpuType, mode string) string {
+	switch mode {
+	case "0":
+		return supportTypeExclusive
+	case "1":
+		return supportTypeMemorySlice
+	default:
+		if strings.TrimSpace(gpuType) == "nvidia-gb10" {
+			return supportTypeMemorySlice
+		}
+		return supportTypeTimeSlice
+	}
+}
+
+func loadMigratedAllocations(ctx context.Context, c ctrlclient.Client) ([]migratedComputeAllocation, error) {
+	var cm corev1.ConfigMap
+	err := c.Get(ctx, types.NamespacedName{Namespace: gpuAllocationCMNamespace, Name: gpuAllocationCMName}, &cm)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(errors.WithStack(err), "failed to get GPU allocation configmap")
+	}
+	raw := cm.Data[gpuAllocationCMKey]
+	if raw == "" {
+		return nil, nil
+	}
+	var allocations []migratedComputeAllocation
+	if err := json.Unmarshal([]byte(raw), &allocations); err != nil {
+		return nil, errors.Wrap(errors.WithStack(err), "failed to unmarshal GPU allocations")
+	}
+	return allocations, nil
+}
+
+func saveMigratedAllocations(ctx context.Context, c ctrlclient.Client, allocations []migratedComputeAllocation) error {
+	data, err := json.Marshal(allocations)
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to marshal GPU allocations")
+	}
+	var cm corev1.ConfigMap
+	err = c.Get(ctx, types.NamespacedName{Namespace: gpuAllocationCMNamespace, Name: gpuAllocationCMName}, &cm)
+	if apierrors.IsNotFound(err) {
+		cm = corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: gpuAllocationCMNamespace,
+				Name:      gpuAllocationCMName,
+			},
+			Data: map[string]string{gpuAllocationCMKey: string(data)},
+		}
+		return c.Create(ctx, &cm)
+	}
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to get GPU allocation configmap")
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[gpuAllocationCMKey] = string(data)
+	return c.Update(ctx, &cm)
+}
+
+func allocationKey(appName, owner, deviceID string) string {
+	return appName + "\x00" + owner + "\x00" + deviceID
+}

--- a/infrastructure/gpu/.olares/config/gpu/hami/crds/gpu.bytetrade.io_gpubindings.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/crds/gpu.bytetrade.io_gpubindings.yaml
@@ -45,6 +45,10 @@ spec:
                 - type: string
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              namespace:
+                type: string
+              owner:
+                type: string
               podSelector:
                 description: |-
                   A label selector is a label query over a set of resources. The result of matchLabels and

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.17"
+version: "v2.6.18"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.17
+      name: beclab/hami:v2.6.18
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
## Summary

Companion to the app-service compute subsystem work ([beclab/Olares#3112](https://github.com/beclab/Olares/pull/3112)) and the HAMi scheduler refactor ([beclab/HAMi#19](https://github.com/beclab/HAMi/pull/19)). Hands GPUBinding CRD management over from HAMi to app-service on upgrade, so the binding store stops being HAMi's private state and becomes the authoritative compute-allocation surface app-service drives.

- Bump bundled HAMi image / chart to `v2.6.18` (the version that drops the `/gpus*` HTTP routes and the `CleanupGPUBindingsLoop`).
- Apply the new GPUBinding CRD schema explicitly during upgrade, because Helm 3 does not refresh chart `crds/` directories on `helm upgrade`.
- Walk every legacy GPUBinding produced by old HAMi, resolve it back to its owning ApplicationManager via owner / namespace / pod-selector heuristics, drop the ones whose app is no longer holding an allocation, and re-stamp the survivors with the metadata app-service needs (managed-by labels, app/owner labels, mode label, `spec.owner`, `spec.namespace`). Each migrated binding is also recorded in the new `os-framework/app-gpu-allocations` configmap so app-service inherits the existing placement without rescheduling any running workload.

The upgrade flow is registered both in `upgrader_1_12_6` (one-time path for clusters jumping straight to 1.12.6) and in a new daily upgrader `upgrader_1_12_7_20260520` (catches clusters already on 1.12.6+).

## Test plan

- [ ] `cd cli && make build && go vet ./...`
- [ ] `go test ./cli/pkg/upgrade/...`
- [ ] Manual: fresh single-node GPU install, verify the new GPUBinding CRD ships with `spec.owner` / `spec.namespace` and HAMi pod runs `v2.6.18`
- [ ] Manual: cluster on pre-1.12.6 with HAMi `v2.6.17` and existing GPUBindings — run upgrade, verify (a) CRD has new fields, (b) HAMi rolls to `v2.6.18`, (c) running GPU workloads keep running, (d) their bindings are re-stamped with owner/namespace/labels, (e) `os-framework/app-gpu-allocations` configmap has matching rows
- [ ] Manual: same cluster but with one GPU app in `stopped` / `uninstalled` state — verify its legacy binding is removed and no allocation row is written for it
- [ ] Manual: cluster already on 1.12.6+ — verify the daily upgrader picks it up and the migration is idempotent on a re-run

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kubernetes CRDs and performs in-cluster migration/deletion of `GPUBinding` resources and writes a new allocation ConfigMap; mistakes could prune fields or drop active allocations, but the flow is bounded and largely idempotent/skips when resources are absent.
> 
> **Overview**
> **Upgrade flow now explicitly manages the `GPUBinding` CRD and migrates legacy bindings for app-service.** The `1.12.6` upgrader (and a new daily `1.12.7-20260520` upgrader) runs a new `ApplyGPUBindingCRD` step *before* the HAMi Helm upgrade to ensure the cluster CRD schema includes `spec.namespace`/`spec.owner` (Helm won’t upgrade `crds/`).
> 
> After system components upgrade, the CLI now runs `MigrateLegacyGPUBindings` to walk existing legacy `GPUBinding` objects, resolve the owning `ApplicationManager`, delete orphan/stale bindings, re-stamp surviving bindings with app-service labels/owner fields, and persist placement into `os-framework/app-gpu-allocations`.
> 
> Separately, the bundled HAMi version is bumped to `v2.6.18`, and the GPUBinding CRD manifest is updated to include the new `namespace` and `owner` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b261070e2e453fb22859f2f67672e1a3a35501af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->