### PR TITLE
docs: add ts for Windows dual-display flickering on Olares One

### DIFF
--- a/docs/.vitepress/one.en.ts
+++ b/docs/.vitepress/one.en.ts
@@ -226,6 +226,10 @@ export const oneSidebar: DefaultTheme.Sidebar = {
               {
                 text: "Install drivers on Windows",
                 link: "/one/install-nvidia-driver",
+              },
+              {
+                text: "Troubleshooting",
+                link: "/one/dual-boot-windows-troubleshooting",
               }
             ]
         },

--- a/docs/.vitepress/one.zh.ts
+++ b/docs/.vitepress/one.zh.ts
@@ -227,6 +227,10 @@ export const oneSidebar: DefaultTheme.Sidebar = {
               {
                 text: "Install drivers on Windows",
                 link: "/zh/one/install-nvidia-driver",
+              },
+              {
+                text: "Troubleshooting",
+                link: "/zh/one/dual-boot-windows-troubleshooting",
               }
             ]
         },

--- a/docs/one/dual-boot-windows-troubleshooting.md
+++ b/docs/one/dual-boot-windows-troubleshooting.md
@@ -1,0 +1,47 @@
+---
+outline: [2, 3]
+description: Common issues and solutions for dual-booting Olares OS with Windows on Olares One.
+head:
+  - - meta
+    - name: keywords
+      content: Olares One, dual boot, Windows, troubleshooting, display flickering, HDMI, external monitor
+---
+
+# Troubleshooting
+
+Use this page to identify and resolve common issues when dual-booting Olares OS with Windows on Olares One.
+
+## Monitors flicker when starting Windows with two external displays
+
+### Condition
+
+This issue applies if you experience all of the following:
+
+- Olares One is set up to dual-boot Olares OS and Windows.
+- Windows starts with two external monitors connected.
+- One monitor is connected through HDMI, and the other is connected through a USB-C hub or adapter.
+- One or both monitors flicker during Windows startup or shortly after Windows reaches the desktop.
+
+You can confirm this issue if disconnecting and reconnecting the affected monitor restores normal display output.
+
+### Cause
+
+When Windows starts, it first loads a basic display driver to turn on the screens. This driver is enough to start Windows, but it may not handle high-resolution HDMI output and multi-monitor detection reliably in this dual-boot setup.
+
+After Windows reaches the desktop, the NVIDIA driver takes over display output. However, if a monitor connection has already entered an unstable state during startup, the NVIDIA driver may not recover it automatically. Reconnecting the monitor forces Windows to detect the display again.
+
+This is usually a temporary display initialization issue, not a sign that your monitors or GPU are damaged.
+
+### Solution
+
+If the monitor is currently flickering:
+
+1. Disconnect the affected monitor from Olares One or from the USB-C hub.
+2. Wait a few seconds.
+3. Reconnect the monitor and wait for Windows to detect it again.
+
+To prevent the issue from happening again:
+
+1. Before booting into Windows, disconnect the USB-C display or hub and keep only the HDMI monitor connected.
+2. Start Windows and wait until the desktop is fully loaded.
+3. Connect the second monitor through the USB-C hub or adapter.

--- a/docs/zh/one/dual-boot-windows-troubleshooting.md
+++ b/docs/zh/one/dual-boot-windows-troubleshooting.md
@@ -1,0 +1,1 @@
+<!--@include: ../../one/dual-boot-windows-troubleshooting.md-->


### PR DESCRIPTION
* **Background**

* **Target Version for Merge**

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus sidebar nav updates; no runtime or product logic is affected.
> 
> **Overview**
> Adds a new `dual-boot-windows-troubleshooting` doc covering a specific Windows dual-display flickering issue (conditions, cause, and mitigation steps).
> 
> Updates the English and Chinese Olares One VitePress sidebars to link this new *Troubleshooting* page under **Dual-boot Olares OS with Windows**, and adds a zh doc that includes the English source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c205590dd7decabd71dea1304c469b2e2d915c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->