### PR TITLE
fix: More reliable files paste, sync rename, and share id matching

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.170
+          image: beclab/files-server:v0.2.171
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix:  Paste to a USB drive formatted as FAT/exFAT/NTFS no longer fails on the post-copy chown.
- fix:  Paste source existence is now validated upfront across every backend, eliminating phantom "completed" tasks for missing files.
- fix:  Sync-to-sync copy and move now honour a renamed destination instead of silently keeping the source's filename.
- fix:  Share id matching no longer accepts trailing garbage on the URL parameter as a valid id.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/326
- https://github.com/beclab/files/pull/327

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys a new `files-server` container version, so runtime behavior changes depend on the new image contents and may impact file operations despite the small config diff.
> 
> **Overview**
> Updates the `files` DaemonSet to deploy `beclab/files-server` `v0.2.171` instead of `v0.2.170`, rolling out the newer server build with whatever fixes/behavior changes it contains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7f74ca33f9576c6f3bbf86821148a8329205d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->