### PR TITLE
Revert "hami: support time-slicing in cuMemAllocAsync (#3106)"

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.18"
+version: "v2.6.19"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.18
+      name: beclab/hami:v2.6.19
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Revert "hami: support time-slicing in cuMemAllocAsync (#3106)"

* **Target Version for Merge**
v1.12.6 v。12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates referenced HAMI version/image tags, with no code or configuration logic changes beyond selecting a new upstream release.
> 
> **Overview**
> Updates the HAMI GPU components to **v2.6.19** by bumping the Helm `values.yaml` `version` and the prebuilt container reference in `Olares.yaml` from `v2.6.18` to `v2.6.19`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4edf18ff7b1e577521ce2765643e265b8121c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->