### PR TITLE
olares-app: bump system-frontend image to v1.10.34 in helm chart

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.33
+          image: beclab/system-frontend:v1.10.34
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
desktop:  add search loading
files: implement caching for file nodes 

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1146
https://github.com/beclab/TermiPass/pull/1142

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm change that only bumps the `beclab/system-frontend` image tag for the `olares-app-init` initContainer; any risk is limited to regressions introduced in the new image version.
> 
> **Overview**
> Updates the `system-apps` Helm chart to pull `beclab/system-frontend:v1.10.34` (from `v1.10.33`) for the `olares-app-init` initContainer that seeds `/www` with frontend assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324c5df05a80d7ee98ea31d2bf6295adfb8aa832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->