### PR TITLE
feat(gpu): skip injecting core lib in exclusive mode

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.19"
+version: "v2.6.20"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.19
+      name: beclab/hami:v2.6.20
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Skip injecting HAMi-core interception library for a container if the only used GPU card is in exclusive mode.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/20

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates pinned HAMi versions in deployment/config manifests; behavior changes are limited to whatever is introduced by the upstream `v2.6.20` image.
> 
> **Overview**
> Updates the GPU HAMi deployment to **use `v2.6.20` instead of `v2.6.19`**, bumping both the Helm `values.yaml` `version` and the prebuilt container reference in `Olares.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95ae20c8d15384a28d1f0845df91665db8be851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->