### PR TITLE
docs: clarify DNS setup and .local domain rules in local access guide

### DIFF
--- a/docs/manual/best-practices/local-access.md
+++ b/docs/manual/best-practices/local-access.md
@@ -160,7 +160,9 @@ Once configured, open your standard `olares.com` URLs as usual. They will resolv
 You can install AdGuard Home from the Olares Market to monitor traffic and manage DNS mappings graphically.
 :::
 ## Method 4: Modify hosts files
-If you cannot change router settings and need immediate offline access on a specific computer, you can manually map the domains in your hosts file.
+Method 4 is for standard `olares.com` URLs only. If you use `.local` URLs from [Method 2](#method-2-use-local-domain), you do not need to edit hosts files manually.
+
+If you cannot change router settings and need immediate offline access on a specific computer, you can manually map standard `olares.com` domains in your hosts file.
 
 1. Locate your hosts file:
    - **Windows**: `C:\Windows\System32\drivers\etc\hosts`

--- a/docs/manual/best-practices/local-access.md
+++ b/docs/manual/best-practices/local-access.md
@@ -16,7 +16,7 @@ By the end of this tutorial, you will learn how to:
 
 - Establish a secure, high-speed local connection using the LarePass VPN.
 - Access Olares services using `.local` domains.
-- Configure local DNS to allow standard URLs to resolve locally across your entire network.
+- Configure local DNS so standard `olares.com` URLs resolve locally across your entire network.
 - Manually map hosts files to ensure access on specific machines without internet.
 
 ## Choose a connection method
@@ -27,7 +27,7 @@ There are four ways to establish a local connection:
 * **[Method 2: Use `.local` domain](#method-2-use-local-domain)**<br/>
   Access the device via a specific local URL format. No installation required.
 * **[Method 3: Configure local DNS](#method-3-configure-local-dns)**<br/>
-  Updates your router or computer's DNS settings to map the standard Olares URL to the local IP address.
+  Updates your router or computer's DNS settings to map standard `olares.com` URLs to the local IP address.
 * **[Method 4: Modify hosts files](#method-4-modify-hosts-files)**<br/>
   Manually maps the standard Olares URL to the local IP on a single computer.
 
@@ -79,7 +79,11 @@ Therefore, no extra setup is needed. You can directly use local URL in your brow
 <!--@include: ../../reusables/local-domain.md#windows-local-domain-->
 
 ## Method 3: Configure local DNS
-For a seamless experience where standard URLs resolve to your local IP address automatically, you can configure your network DNS. This configuration ensures consistent access across all devices on the network without requiring individual client setup.
+Method 3 is for standard Olares URLs that use the `olares.com` domain. These are the same URLs you normally use from outside your local network. By making your DNS resolver answer these `olares.com` names with your Olares device's internal IP address, traffic stays on your LAN while the URL stays unchanged.
+
+:::info `.local` URLs do not need DNS configuration
+Skip this method if you use `.local` URLs from [Method 2](#method-2-use-local-domain). These local domains use local name resolution and do not depend on `olares.com` DNS records.
+:::
 
 ### Find the internal IP for Olares device
 To configure DNS, first you need to find the internal IP for your Olares device.
@@ -122,7 +126,7 @@ Control Hub provides a built-in terminal that allows you to run system commands 
 </tabs>
 
 ### Configure DNS
-With the internal IP address identified, you must now configure your DNS settings to route traffic correctly. You can apply this configuration to a single computer for individual access, or update your router to enable seamless local resolution for all devices on your network.
+With the internal IP address identified, configure DNS for your standard `olares.com` URLs. You can apply this configuration to a single computer for individual access, or update your router to enable seamless local resolution for all devices on your network.
 <tabs>
 <template #Configure-for-local-device>
 
@@ -151,7 +155,7 @@ Update the DNS on your router to apply changes to every device in your network.
 </template>
 </tabs>
 
-Once configured, you can access Olares using both your standard public address and your local address.
+Once configured, open your standard `olares.com` URLs as usual. They will resolve to the Olares device's internal IP when you are on the same network.
 :::tip
 You can install AdGuard Home from the Olares Market to monitor traffic and manage DNS mappings graphically.
 :::

--- a/docs/manual/best-practices/local-access.md
+++ b/docs/manual/best-practices/local-access.md
@@ -160,9 +160,11 @@ Once configured, open your standard `olares.com` URLs as usual. They will resolv
 You can install AdGuard Home from the Olares Market to monitor traffic and manage DNS mappings graphically.
 :::
 ## Method 4: Modify hosts files
-Method 4 is for standard `olares.com` URLs only. If you use `.local` URLs from [Method 2](#method-2-use-local-domain), you do not need to edit hosts files manually.
+:::info `.local` URLs do not need manual hosts changes
+If you use `.local` URLs from [Method 2](#method-2-use-local-domain), skip this method. These local domains use local name resolution and do not require manually editing the hosts file.
+:::
 
-If you cannot change router settings and need immediate offline access on a specific computer, you can manually map standard `olares.com` domains in your hosts file.
+Method 4 is for standard `olares.com` URLs only. If you cannot change router settings and need immediate offline access on a specific computer, you can manually map standard `olares.com` domains in your hosts file.
 
 1. Locate your hosts file:
    - **Windows**: `C:\Windows\System32\drivers\etc\hosts`

--- a/docs/zh/manual/best-practices/local-access.md
+++ b/docs/zh/manual/best-practices/local-access.md
@@ -160,9 +160,11 @@ Apple devices support local service discovery via [Bonjour](https://developer.ap
 你可以从 Olares 应用市场安装 AdGuard Home，以图形化方式监控流量并管理 DNS 映射。
 :::
 ## 方法 4：修改 hosts 文件
-方法 4 仅适用于标准 `olares.com` 地址。若使用[方法 2](#方法-2-使用-local-域名) 中的 `.local` 地址，无需手动修改 hosts 文件。
+:::info `.local` 地址无需手动修改 hosts 文件
+若使用[方法 2](#方法-2-使用-local-域名) 中的 `.local` 地址，可跳过本方法。此类本地域名使用本地域名解析，无需手动编辑 hosts 文件。
+:::
 
-如果无法更改路由器设置，且需要在特定电脑上立即离线访问，可以在 hosts 文件中手动映射标准 `olares.com` 域名。
+方法 4 仅适用于标准 `olares.com` 地址。如果无法更改路由器设置，且需要在特定电脑上立即离线访问，可以在 hosts 文件中手动映射标准 `olares.com` 域名。
 
 1. 找到 hosts 文件：
    - **Windows**：`C:\Windows\System32\drivers\etc\hosts`

--- a/docs/zh/manual/best-practices/local-access.md
+++ b/docs/zh/manual/best-practices/local-access.md
@@ -160,7 +160,9 @@ Apple devices support local service discovery via [Bonjour](https://developer.ap
 你可以从 Olares 应用市场安装 AdGuard Home，以图形化方式监控流量并管理 DNS 映射。
 :::
 ## 方法 4：修改 hosts 文件
-如果无法更改路由器设置且需要在特定电脑上立即离线访问，可以在 hosts 文件中手动映射域名。
+方法 4 仅适用于标准 `olares.com` 地址。若使用[方法 2](#方法-2-使用-local-域名) 中的 `.local` 地址，无需手动修改 hosts 文件。
+
+如果无法更改路由器设置，且需要在特定电脑上立即离线访问，可以在 hosts 文件中手动映射标准 `olares.com` 域名。
 
 1. 找到 hosts 文件：
    - **Windows**：`C:\Windows\System32\drivers\etc\hosts`

--- a/docs/zh/manual/best-practices/local-access.md
+++ b/docs/zh/manual/best-practices/local-access.md
@@ -16,7 +16,7 @@ Olares 的设计初衷是让你随时随地都能无缝访问自己的服务。
 
 - 使用 LarePass 专用网络建立安全、高速的本地连接。
 - 使用 `.local` 域名访问 Olares 服务。
-- 配置本地 DNS，使全网设备可通过标准 URL 进行本地访问。
+- 配置本地 DNS，让基于 `olares.com` 的标准地址在局域网内解析到 Olares。
 - 手动修改 Hosts 文件，确保特定计算机在无外网环境下也能访问。
 
 ## 选择连接方式
@@ -25,11 +25,11 @@ Olares 的设计初衷是让你随时随地都能无缝访问自己的服务。
 * **[方法 1：启用 LarePass 专用网络](#方法-1-启用-larepass-专用网络)**<br/>
   利用 LarePass 专用网络自动检测本地网络并优化连接速度，无需更改任何设置。
 * **[方法 2：使用 `.local` 域名](#方法-2-使用-local-域名)**<br/>
-  通过特定的本地 URL 格式访问设备。无需安装任何软件。
+  通过特定的本地地址格式访问设备。无需安装任何软件。
 * **[方法 3：配置本地 DNS](#方法-3-配置本地-dns)**<br/>
-  更新路由器或计算机的 DNS 设置，将标准 Olares URL 映射到本地 IP 地址。
+  更新路由器或计算机的 DNS 设置，将基于 `olares.com` 的标准 Olares 地址映射到本地 IP 地址。
 * **[方法 4：修改 Hosts 文件](#方法-4-修改-hosts-文件)**<br/>
-  在单台计算机上手动将标准 Olares URL 映射到本地 IP。
+  在单台计算机上手动将标准 Olares 地址映射到本地 IP。
 
 ## 方法 1：启用 LarePass 专用网络
 LarePass 专用网络旨在兼顾连接安全与性能优化。启用后，LarePass 会自动检测设备是否处于同一网络，并切换至**内网**模式。
@@ -48,22 +48,22 @@ LarePass 专用网络旨在兼顾连接安全与性能优化。启用后，LareP
 
 ### 单级域名（所有操作系统适用）
 :::warning 仅支持社区应用
-Desktop 和文件管理器等 Olares 系统应用不支持此 URL 格式，因此无法正确加载。
+Desktop 和文件管理器等 Olares 系统应用不支持此地址格式，因此无法正确加载。
 :::
 此格式通过连字符（`-`）连接入口 ID 和用户名来使用单级主机名。
 
-**标准 URL**
+**标准地址**
 ```plain
 https://<entrance_id>.<username>.olares.cn
 ```
-**本地访问 URL**
+**本地访问地址**
 ```plain
 http://<entrance_id>-<username>-olares.local
 ```
 
 ### 多级域名
 
-The multi-level format below matches the structure of your standard Olares URL. Use it as shown.
+下方的多级域名格式与标准 Olares 地址结构一致。按示例使用即可。
 
 <!--@include: ../../reusables/local-domain.md#local-domain-overview-->
 
@@ -72,14 +72,18 @@ The multi-level format below matches the structure of your standard Olares URL. 
 #### macOS and iOS
 Apple devices support local service discovery via [Bonjour](https://developer.apple.com/bonjour/) (zero‑configuration networking), which can resolve multi‑label domains under `.local` on macOS and iOS.
 
-Therefore, no extra setup is needed. You can directly use local URL in your browser.
+因此无需额外设置。你可以直接在浏览器中使用本地地址。
 
 #### Windows
 
 <!--@include: ../../reusables/local-domain.md#windows-local-domain-->
 
 ## 方法 3：配置本地 DNS
-为了获得无缝体验（即标准 URL 自动解析为你的本地 IP 地址），你可以配置网络 DNS。此配置确保网络上所有设备的访问一致，无需单独设置客户端。
+方法 3 适用于基于 `olares.com` 域名的标准 Olares 地址，即外网访问时使用的常规地址。通过配置 DNS 解析器，将此类 `olares.com` 域名解析为 Olares 设备的内网 IP，即可在不改变访问地址的前提下，使网络流量仅在局域网内传输。
+
+:::info `.local` 地址无需配置 DNS
+若使用[方法 2](#方法-2-使用-local-域名) 中的 `.local` 地址，可跳过此步骤。此类本地域名采用局域网内的名称解析机制，不依赖 `olares.com` 的 DNS 记录。
+:::
 
 ### 查找 Olares 设备的内网 IP
 要配置 DNS，首先需要找到 Olares 设备的内网 IP。
@@ -122,7 +126,7 @@ Therefore, no extra setup is needed. You can directly use local URL in your brow
 </tabs>
 
 ### 配置 DNS
-确定内网 IP 地址后，现在必须配置 DNS 设置以正确路由流量。你可以将此配置应用于单台电脑以供个人访问，或者更新路由器以实现网络上所有设备的无缝本地解析。
+确定内网 IP 地址后，为标准 `olares.com` 地址配置 DNS。你可以将此配置应用于单台电脑以供个人访问，或者更新路由器以实现网络上所有设备的无缝本地解析。
 <tabs>
 <template #设置单台设备>
 
@@ -151,7 +155,7 @@ Therefore, no extra setup is needed. You can directly use local URL in your brow
 </template>
 </tabs>
 
-配置完成后，可以使用标准公网地址和本地地址访问 Olares。
+配置完成后，像往常一样打开标准 `olares.com` 地址即可。在同一局域网内，它会解析到 Olares 设备的内网 IP。
 :::tip
 你可以从 Olares 应用市场安装 AdGuard Home，以图形化方式监控流量并管理 DNS 映射。
 :::
@@ -180,7 +184,7 @@ Therefore, no extra setup is needed. You can directly use local URL in your brow
     ```
 4. 保存文件以应用更改。这能确保即使在断网情况下，你也能进行本地访问。
 
-你可以通过检查 URL 加载速度或使用终端来验证更改。例如：
+你可以通过检查地址加载速度或使用终端来验证更改。例如：
 ```bash
 ping desktop.<username>.olares.cn
 ```


### PR DESCRIPTION
* **Background**
See title.

* **Target Version for Merge**

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to user-facing guides; no application, auth, or infrastructure code changes.
> 
> **Overview**
> The **local access** guides (English and Chinese) now spell out which access paths need **`olares.com`** DNS or hosts work versus **`.local`** name resolution.
> 
> Learning objectives and the method overview call out **`olares.com`** for local DNS and hosts mapping. **Method 3** opens with when it applies and adds an info box: users on **Method 2** `.local` URLs should skip DNS setup. **Method 4** gets the same skip guidance for hosts, plus text that manual hosts edits are for standard **`olares.com`** domains only. Post-setup wording now says normal **`olares.com`** URLs resolve to the device on-LAN. The Chinese page mirrors these clarifications and tightens some “URL” wording to “address.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32af609f5f91865363c17f32733c864eea89a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->