### PR TITLE
fix: Cloud files paste reliability fix

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.171
+          image: beclab/files-server:v0.2.172
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: Cloud paste against a missing source no longer crashes the request handler with a corrupted HTTP 200 response.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/328

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm manifest change that only updates the `files-server` image version; risk is limited to behavioral changes introduced by the new image build.
> 
> **Overview**
> Updates the `files` DaemonSet deployment to run `beclab/files-server:v0.2.172` instead of `v0.2.171`, picking up the latest server-side fixes via the container image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe97eeda266611752e9f91459d3a5a636dbee2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->