### PR TITLE
olares-app: bump system-frontend image to v1.10.35 in helm chart

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.34
+          image: beclab/system-frontend:v1.10.35
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Fix desktop bugs and Optimize ControlHub Pod operation prompts

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1145


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm value change that only updates a container image tag; any risk is limited to behavior changes inside the new `system-frontend` image.
> 
> **Overview**
> Updates the `system-apps` Helm template (`olares-app.yaml`) to pull `beclab/system-frontend:v1.10.35` for the `olares-app-init` initContainer (was `v1.10.34`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ac791171950730fbc14b4df7d95179998ce1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->