### PR TITLE
feat(app-service): inject macvlan reply-via-eth0 init container via mutating webhook

### DIFF
--- a/framework/app-service/pkg/apiserver/filters.go
+++ b/framework/app-service/pkg/apiserver/filters.go
@@ -95,6 +95,7 @@ func (h *Handler) authenticate(req *restful.Request, resp *restful.Response, cha
 		"/app-service/v1/runasuser/inject",
 		"/app-service/v1/terminus/version",
 		"/app-service/v1/app-label/inject",
+		"/app-service/v1/macvlan-init/inject",
 		"/app-service/v1/apps/image-info",
 		"/app-service/v1/all/apps",
 		"/app-service/v1/apps/oamvalues",

--- a/framework/app-service/pkg/apiserver/handler.go
+++ b/framework/app-service/pkg/apiserver/handler.go
@@ -129,6 +129,10 @@ func (b *handlerBuilder) Build() (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = wh.CreateOrUpdateMacvlanInitMutatingWebhook()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Handler{
 		kubeHost:         b.ksHost,

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -1461,3 +1461,84 @@ func (h *Handler) upgradeOpValidate(ctx context.Context, appConfig *appcfg.Appli
 	}
 	return nil
 }
+
+// macvlanInitInject is the HTTP entrypoint for the macvlan-init mutating webhook.
+// It deserializes the AdmissionReview, runs macvlanInitMutate and writes the response.
+func (h *Handler) macvlanInitInject(req *restful.Request, resp *restful.Response) {
+	klog.Infof("Received mutating webhook[macvlan-init inject] request: Method=%v, URL=%v", req.Request.Method, req.Request.URL)
+	admissionRequestBody, ok := h.sidecarWebhook.GetAdmissionRequestBody(req, resp)
+	if !ok {
+		return
+	}
+	var admissionReq, admissionResp admissionv1.AdmissionReview
+	proxyUUID := uuid.New()
+	if _, _, err := webhook.Deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
+		klog.Errorf("Failed to decode admission request body err=%v", err)
+		admissionResp.Response = h.sidecarWebhook.AdmissionError("", err)
+	} else {
+		admissionResp.Response = h.macvlanInitMutate(req.Request.Context(), admissionReq.Request, proxyUUID)
+	}
+	admissionResp.TypeMeta = admissionReq.TypeMeta
+	admissionResp.Kind = admissionReq.Kind
+
+	requestForNamespace := "unknown"
+	if admissionReq.Request != nil {
+		requestForNamespace = admissionReq.Request.Namespace
+	}
+	err := resp.WriteAsJson(&admissionResp)
+	if err != nil {
+		klog.Errorf("Failed to write response[macvlan-init inject] admin review in namespace=%s err=%v", requestForNamespace, err)
+		return
+	}
+	klog.Infof("Done[macvlan-init inject] with uuid=%s in namespace=%s", proxyUUID, requestForNamespace)
+}
+
+// macvlanInitMutate is the core mutation logic for the macvlan-init webhook.
+// It is a no-op for pods without the macvlan-init label or whose owning
+// Application does not opt into enableOverlayGateway.
+func (h *Handler) macvlanInitMutate(ctx context.Context, req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) *admissionv1.AdmissionResponse {
+	if req == nil {
+		klog.Error("Failed to get admission request err=admission request is nil")
+		return h.sidecarWebhook.AdmissionError("", errNilAdmissionRequest)
+	}
+	resp := &admissionv1.AdmissionResponse{
+		Allowed: true,
+		UID:     req.UID,
+	}
+
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		klog.Errorf("Failed to unmarshal request object raw to pod with uuid=%s namespace=%s err=%v", proxyUUID, req.Namespace, err)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+
+	// Defense-in-depth: ObjectSelector already filters by this label, but
+	// re-check here in case the webhook is invoked from a misconfigured caller.
+	if pod.Labels[constants.ApplicationMacvlanInitLabel] != "true" {
+		return resp
+	}
+	ns := req.Namespace
+
+	shouldInject, err := h.sidecarWebhook.ShouldInjectMacvlanInit(ctx, &pod, ns)
+	if err != nil {
+		klog.Errorf("Failed to evaluate macvlan-init injection for pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+		// FailurePolicy is Ignore at the webhook-config level; here we
+		// still report an error so the API server records it, but the
+		// pod will be allowed.
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	if !shouldInject {
+		return resp
+	}
+
+	patchBytes, err := h.sidecarWebhook.CreateMacvlanInitPatch(req, &pod)
+	if err != nil {
+		klog.Errorf("Failed to create macvlan-init patch for pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	if len(patchBytes) > 0 {
+		h.sidecarWebhook.PatchAdmissionResponse(resp, patchBytes)
+	}
+	klog.Infof("macvlan-init: injected init container for pod=%s/%s uuid=%s", req.Namespace, pod.Name, proxyUUID)
+	return resp
+}

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -319,6 +319,13 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Returns(http.StatusOK, "add limit success", nil)).
 		Consumes(restful.MIME_JSON)
 
+	ws.Route(ws.POST("/macvlan-init/inject").
+		To(handler.macvlanInitInject).
+		Doc("mutating webhook to inject macvlan reply-via-eth0 init container").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Returns(http.StatusOK, "Success to inject", nil)).
+		Consumes(restful.MIME_JSON)
+
 	ws.Route(ws.POST("/provider-registry/validate").
 		To(handler.providerRegistryValidate).
 		Doc("validating webhook for validate app install namespace").

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -11,6 +11,7 @@ const (
 	KubeSphereAPIScheme                = "http"
 	ApplicationDefaultThirdLevelDomain = "applications.app.bytetrade.io/default-thirdlevel-domains"
 	ApplicationNameLabel               = "applications.app.bytetrade.io/name"
+	ApplicationMacvlanInitLabel        = "applications.app.bytetrade.io/macvlan-init"
 	ApplicationRawAppNameLabel         = "applications.app.bytetrade.io/raw-app-name"
 	ApplicationAppGroupLabel           = "applications.app.bytetrade.io/group"
 	ApplicationAuthorLabel             = "applications.app.bytetrade.io/author"

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -36,6 +36,9 @@ const (
 	evictionWebhookName                   = "kubelet-eviction-webhook"
 	evictionValidatingWebhookName         = "kubelet-eviction-webhook.bytetrade.io"
 
+	macvlanInitWebhookName         = "macvlan-init-webhook"
+	mutatingWebhookMacvlanInitName = "macvlan-init-inject-webhook.bytetrade.io"
+
 	applicationManagerMutatingWebhookName   = "applicationmanager-mutating-webhook"
 	applicationManagerValidatingWebhookName = "applicationmanager-validating-webhook"
 	argoResourceValidatingWebhookName       = "argo-resource-validating-webhook"
@@ -1085,5 +1088,120 @@ func (wh *Webhook) CreateOrUpdateArgoResourceValidatingWebhook() error {
 	}
 	klog.Infof("Finished creating Argo Resource ValidatingWebhookConfiguration")
 
+	return nil
+}
+
+// CreateOrUpdateMacvlanInitMutatingWebhook creates or updates the macvlan init container mutating webhook.
+// It only fires for pods labeled applications.app.bytetrade.io/macvlan-init=true on Create.
+// FailurePolicy is Ignore so that a transient webhook outage never blocks pod creation,
+// because the macvlan-init container is an additive networking concern.
+func (wh *Webhook) CreateOrUpdateMacvlanInitMutatingWebhook() error {
+	webhookPath := "/app-service/v1/macvlan-init/inject"
+	port, err := strconv.Atoi(strings.Split(constants.WebhookServerListenAddress, ":")[1])
+	if err != nil {
+		return err
+	}
+	webhookPort := int32(port)
+	failurePolicy := admissionregv1.Ignore
+	matchPolicy := admissionregv1.Exact
+	webhookTimeout := int32(30)
+
+	mwhLabels := map[string]string{"velero.io/exclude-from-backup": "true"}
+	caBundle, err := ioutil.ReadFile(defaultCaPath)
+	if err != nil {
+		return err
+	}
+	mwh := admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   macvlanInitWebhookName,
+			Labels: mwhLabels,
+		},
+		Webhooks: []admissionregv1.MutatingWebhook{
+			{
+				Name: mutatingWebhookMacvlanInitName,
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &admissionregv1.ServiceReference{
+						Namespace: webhookServiceNamespace,
+						Name:      webhookServiceName,
+						Path:      &webhookPath,
+						Port:      &webhookPort,
+					},
+				},
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.UnderLayerNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSNetworkNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSProtectedNamespaces,
+						},
+					},
+				},
+				ObjectSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constants.ApplicationMacvlanInitLabel: "true",
+					},
+				},
+				Rules: []admissionregv1.RuleWithOperations{
+					{
+						Operations: []admissionregv1.OperationType{admissionregv1.Create},
+						Rule: admissionregv1.Rule{
+							APIGroups:   []string{"*"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				TimeoutSeconds:          &webhookTimeout,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+	if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), &mwh, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing, err := wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), mwh.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("Failed to get MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+				return err
+			}
+			mwh.ObjectMeta.ResourceVersion = existing.ObjectMeta.ResourceVersion
+			if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.Background(), &mwh, metav1.UpdateOptions{}); err != nil {
+				if !apierrors.IsConflict(err) {
+					klog.Errorf("Failed to update MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+					return err
+				}
+			}
+		} else {
+			klog.Errorf("Failed to create MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+			return err
+		}
+	}
+	klog.Infof("Finished creating MutatingWebhookConfiguration %s", macvlanInitWebhookName)
 	return nil
 }

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -831,6 +831,11 @@ func (wh *Webhook) ShouldInjectMacvlanInit(ctx context.Context, pod *corev1.Pod,
 // present) and returns the JSON merge patch to send back in the admission
 // response.
 func (wh *Webhook) CreateMacvlanInitPatch(req *admissionv1.AdmissionRequest, pod *corev1.Pod) ([]byte, error) {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations["k8s.v1.cni.cncf.io/networks"] = "kube-system/underlay-macvlan"
+
 	for _, c := range pod.Spec.InitContainers {
 		if c.Name == MacvlanInitContainerName {
 			klog.Infof("macvlan-init: container already present in pod=%s/%s, skip", pod.Namespace, pod.Name)

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -732,3 +732,114 @@ func (wh *Webhook) isSelected(podSelectors []metav1.LabelSelector, pod *corev1.P
 	}
 	return false
 }
+
+// MacvlanInitContainerName is the name of the init container injected for pods
+// that need to reply via eth0 in macvlan setups.
+const MacvlanInitContainerName = "macvlan-reply-via-eth0"
+
+// macvlanInitScript is the shell script run inside the macvlan-init container.
+// It waits for an IPv4 address on eth0, then creates a dedicated routing table
+// and a `from <pod-ip>` rule so that reply traffic is sent out via eth0
+// instead of the default pod gateway.
+const macvlanInitScript = `set -eu
+TABLE=100
+PRI=100
+POD_IP=""
+i=0
+while [ "$i" -lt 30 ]; do
+  POD_IP=$(ip -4 addr show dev eth0 2>/dev/null | awk '/inet /{print $2}' | cut -d/ -f1 | head -1)
+  test -n "$POD_IP" && break
+  i=$((i + 1))
+  sleep 1
+done
+test -n "$POD_IP" || { echo "no eth0 address after wait"; exit 1; }
+GW=$(ip -4 route show dev eth0 | awk '/^default/{print $3; exit}')
+test -n "${GW:-}" || GW=169.254.1.1
+ip -4 route replace default via "$GW" dev eth0 table "$TABLE"
+if ip -4 rule list | grep -Fq "from $POD_IP lookup $TABLE"; then exit 0; fi
+ip -4 rule add from "$POD_IP/32" lookup "$TABLE" priority "$PRI"
+`
+
+// GetMacvlanInitContainer returns the init container spec used to set up
+// a dedicated routing table so that reply traffic flows back via eth0 for
+// pods participating in a macvlan / overlay-gateway setup.
+func GetMacvlanInitContainer() corev1.Container {
+	runAsNonRoot := false
+	allowPrivilegeEscalation := false
+	runAsUser := int64(0)
+	return corev1.Container{
+		Name:            MacvlanInitContainerName,
+		Image:           "docker.io/beclab/aboveos-busybox:1.37.0",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &runAsUser,
+			RunAsNonRoot:             &runAsNonRoot,
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN"},
+			},
+		},
+		Command:                  []string{"sh", "-c", macvlanInitScript},
+		Resources:                corev1.ResourceRequirements{},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+// ShouldInjectMacvlanInit reports whether the macvlan init container should be
+// injected for the given pod. It returns true only when the owning Application
+// can be resolved from the pod's app name/owner labels and has
+// `spec.settings.enableOverlayGateway == "true"`.
+func (wh *Webhook) ShouldInjectMacvlanInit(ctx context.Context, pod *corev1.Pod, ns string) (bool, error) {
+	if pod == nil || pod.Labels == nil {
+		return false, nil
+	}
+	if pod.Labels[constants.ApplicationMacvlanInitLabel] != "true" {
+		return false, nil
+	}
+	appName := pod.Labels[constants.ApplicationNameLabel]
+	owner := pod.Labels[constants.ApplicationOwnerLabel]
+	if appName == "" {
+		klog.Infof("macvlan-init: skip pod=%s/%s missing app labels", ns, pod.Name)
+		return false, nil
+	}
+	klog.Infof("ShouldInjectMacvlanInit: pod.Namespace: %s", ns)
+	applicationName, err := apputils.FmtAppMgrName(appName, owner, ns)
+	if err != nil {
+		klog.Errorf("macvlan-init: failed to format application name app=%s owner=%s ns=%s err=%v", appName, owner, ns, err)
+		return false, err
+	}
+	app, err := wh.dynamicClient.AppV1alpha1().Applications().Get(ctx, applicationName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("macvlan-init: application=%s not found for pod=%s/%s", applicationName, ns, pod.Name)
+			return false, nil
+		}
+		klog.Errorf("macvlan-init: failed to get application=%s err=%v", applicationName, err)
+		return false, err
+	}
+	enabled := app.Spec.Settings["enableOverlayGateway"] == "true"
+	if !enabled {
+		klog.Infof("macvlan-init: application=%s enableOverlayGateway is not true, skip pod=%s/%s", applicationName, ns, pod.Name)
+	}
+	return enabled, nil
+}
+
+// CreateMacvlanInitPatch appends the macvlan init container to the pod's
+// init containers (idempotent — does nothing if the container is already
+// present) and returns the JSON merge patch to send back in the admission
+// response.
+func (wh *Webhook) CreateMacvlanInitPatch(req *admissionv1.AdmissionRequest, pod *corev1.Pod) ([]byte, error) {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == MacvlanInitContainerName {
+			klog.Infof("macvlan-init: container already present in pod=%s/%s, skip", pod.Namespace, pod.Name)
+			return makePatches(req, pod)
+		}
+	}
+	// Append after any existing init containers (e.g. sidecar wait-for /
+	// render-envoy-config) so we run after them but still before the main
+	// app containers.
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, GetMacvlanInitContainer())
+	return makePatches(req, pod)
+}


### PR DESCRIPTION
## Summary

Add a new `MutatingAdmissionWebhook` (`macvlan-init-webhook`) that, on Pod **Create**, injects a `macvlan-reply-via-eth0` init container for pods labeled `applications.app.bytetrade.io/macvlan-init=true` whose owning Application has `spec.settings.enableOverlayGateway=="true"`.

The init container waits for an IPv4 address on `eth0`, then sets up a dedicated routing table and a `from <pod-ip>` rule so that reply traffic egresses via `eth0` in macvlan / overlay-gateway setups.

### Why a webhook instead of a controller

A Pod's `spec.initContainers` is immutable after creation, so the mutation must happen at admission time. The new webhook follows the same pattern as the existing `sandbox-webhook`, `app-label-webhook`, `gpu-limit-webhook` and `run-as-user-webhook`.

### Key design choices

- **Tightly scoped** via `ObjectSelector` on `applications.app.bytetrade.io/macvlan-init=true` — the API server only invokes the webhook for the (very small) set of pods that opt in.
- **`FailurePolicy: Ignore`** — a transient webhook outage never blocks pod scheduling; the macvlan reply-routing setup is additive and safely re-tried on next pod create.
- **Idempotent** — the mutation short-circuits when a container named `macvlan-reply-via-eth0` is already present, so re-admission and replay are safe.
- **Append** ordering — the init container is appended after any existing init containers (e.g. envoy/sandbox `wait-for` / `render-envoy-config`) so it runs after them but still before the main app containers.

### Files changed

- ` pkg/constants/constants.go ` — new label constant `ApplicationMacvlanInitLabel`.
- ` pkg/webhook/setup.go ` — new `CreateOrUpdateMacvlanInitMutatingWebhook` registers the MutatingWebhookConfiguration.
- ` pkg/webhook/webhook.go ` — `GetMacvlanInitContainer`, `ShouldInjectMacvlanInit`, `CreateMacvlanInitPatch` helpers.
- ` pkg/apiserver/handler_webhook.go ` — `macvlanInitInject` / `macvlanInitMutate` HTTP handler + mutation logic.
- ` pkg/apiserver/webservice.go ` — registers `POST /app-service/v1/macvlan-init/inject`.
- ` pkg/apiserver/filters.go ` — adds the new path to `trustPaths` (auth bypass for the API server callback, matching every other webhook path).
- ` pkg/apiserver/handler.go ` — wires the new webhook registration in `Build()` next to the existing webhooks.

## Test plan

- [ ] Deploy the new app-service image and verify the `macvlan-init-webhook` MutatingWebhookConfiguration is created on startup.
- [ ] Install/upgrade an app and set `spec.settings.enableOverlayGateway="true"`.
- [ ] Create a pod with `applications.app.bytetrade.io/macvlan-init=true` and the matching `name`/`owner` labels; confirm the `macvlan-reply-via-eth0` init container is present in the resulting pod and exits successfully.
- [ ] Create the same pod with `enableOverlayGateway` unset or `"false"`; confirm no init container is injected.
- [ ] Create a pod without the `macvlan-init` label; confirm the webhook is not invoked (no log entries).
- [ ] Re-admit / restart a pod that already has the init container; confirm no duplicate is appended.
- [ ] Simulate webhook downtime (scale app-service to 0) and verify regular pod creation still succeeds (FailurePolicy: Ignore).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates pod networking at admission (NET_ADMIN init, routing rules) but is label-scoped, gated on Application settings, idempotent, and uses FailurePolicy Ignore so outages do not block scheduling.
> 
> **Overview**
> Adds a **macvlan-init** mutating admission path on Pod **Create** so overlay-gateway apps can get reply traffic routed via **eth0** at admission time (init containers are immutable afterward).
> 
> On startup, **app-service** registers `macvlan-init-webhook` (scoped by `applications.app.bytetrade.io/macvlan-init=true`, **`FailurePolicy: Ignore`**) and exposes `POST /app-service/v1/macvlan-init/inject` on the same trust-path pattern as other webhooks. Injection runs only when the owning **Application** has `spec.settings.enableOverlayGateway == "true"`: the patch sets the `kube-system/underlay-macvlan` CNI annotation and appends an idempotent **`macvlan-reply-via-eth0`** init container (busybox + **NET_ADMIN**) that waits for an **eth0** IPv4 address and installs a dedicated routing table / `from <pod-ip>` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff471a8c5ac3ff672a5a821d27008b107a2d207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->