### PR TITLE
fix(cli/profile): update profile status message to remove duration from logged-in state

### DIFF
--- a/cli/cmd/ctl/profile/list.go
+++ b/cli/cmd/ctl/profile/list.go
@@ -19,7 +19,7 @@ import (
 // marking the current profile. STATUS reflects only what the local token
 // store can prove without making a network call:
 //
-//	logged-in (23h59m)  — token present, JWT exp claim still in the future
+//	logged-in           — token present, JWT exp claim still in the future
 //	expired             — token present, exp claim in the past
 //	invalidated         — token present but explicitly marked unusable
 //	                      (Phase 2 sets this when /api/refresh returns 401/403);
@@ -99,7 +99,7 @@ func profileStatus(store auth.TokenStore, p *cliconfig.ProfileConfig, now time.T
 	if !now.Before(exp) {
 		return "expired"
 	}
-	return fmt.Sprintf("logged-in (%s)", humanizeDuration(exp.Sub(now)))
+	return "logged-in"
 }
 
 // humanizeDuration prints a coarse "23h59m" / "12m34s" / "5s" representation.


### PR DESCRIPTION
* **Background**
cli/profile: update profile status message to remove duration from logged-in state

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to profile list output; no auth or token handling logic modified.
> 
> **Overview**
> **`olares-cli profile list`** no longer appends remaining JWT lifetime to the STATUS column for valid tokens (e.g. `logged-in (23h59m)` → **`logged-in`**). The command comment describing STATUS values is updated to match.
> 
> Token validity logic is unchanged; only the displayed label is simplified for a narrower, stable table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379df787a42e2f61de122467b5cb4778e751ddb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->