### PR TITLE
fix(l4):  normalize Access-Control-Allow-Origin to a single "*" at the vhost

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -142,7 +142,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.19"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.20"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.19
+          value: v0.3.20
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.19
+      name: beclab/l4-bfl-proxy:v0.3.20
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -638,6 +638,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -660,7 +667,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -726,6 +733,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -748,7 +762,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -814,6 +828,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -836,7 +857,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -902,6 +923,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -924,7 +952,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1095,6 +1123,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1117,7 +1152,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1183,6 +1218,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1205,7 +1247,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1271,6 +1313,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1293,7 +1342,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1359,6 +1408,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1381,7 +1437,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -665,6 +665,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -721,6 +728,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -781,6 +795,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -839,6 +860,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -895,6 +923,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1060,6 +1095,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1116,6 +1158,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1176,6 +1225,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1234,6 +1290,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1290,6 +1353,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -1248,6 +1248,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1304,6 +1311,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1364,6 +1378,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1420,6 +1441,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1585,6 +1613,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1607,7 +1642,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1673,6 +1708,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1695,7 +1737,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1761,6 +1803,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1783,7 +1832,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1849,6 +1898,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1871,7 +1927,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -1937,6 +1993,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1959,7 +2022,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2025,6 +2088,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2047,7 +2117,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2218,6 +2288,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2274,6 +2351,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2334,6 +2418,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2390,6 +2481,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2555,6 +2653,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2577,7 +2682,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2643,6 +2748,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2665,7 +2777,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2731,6 +2843,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2753,7 +2872,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2819,6 +2938,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2841,7 +2967,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2907,6 +3033,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2929,7 +3062,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {
@@ -2995,6 +3128,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3017,7 +3157,7 @@
                         {
                           "remoteIp": {
                             "addressPrefix": "100.64.0.0",
-                            "prefixLen": 24
+                            "prefixLen": 16
                           }
                         },
                         {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -1701,6 +1701,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1757,6 +1764,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1817,6 +1831,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1875,6 +1896,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1931,6 +1959,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2096,6 +2131,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2152,6 +2194,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2212,6 +2261,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2270,6 +2326,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2326,6 +2389,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2491,6 +2561,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2547,6 +2624,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2607,6 +2691,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2665,6 +2756,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2721,6 +2819,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -2886,6 +2991,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2942,6 +3054,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -3002,6 +3121,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3060,6 +3186,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3116,6 +3249,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -3281,6 +3421,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3337,6 +3484,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -3397,6 +3551,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3455,6 +3616,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3511,6 +3679,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -3676,6 +3851,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3732,6 +3914,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -3792,6 +3981,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3850,6 +4046,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3906,6 +4109,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -730,6 +730,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -786,6 +793,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -846,6 +860,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -904,6 +925,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -960,6 +988,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1125,6 +1160,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1181,6 +1223,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1241,6 +1290,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1299,6 +1355,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1355,6 +1418,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -713,6 +713,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -769,6 +776,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -829,6 +843,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -887,6 +908,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -943,6 +971,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1108,6 +1143,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1164,6 +1206,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
@@ -1224,6 +1273,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1282,6 +1338,13 @@
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1338,6 +1401,13 @@
               "header": {
                 "key": "access-control-allow-methods",
                 "value": "PUT, GET, DELETE, POST, OPTIONS"
+              },
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+            },
+            {
+              "header": {
+                "key": "access-control-allow-origin",
+                "value": "*"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -645,6 +645,13 @@ func translateVirtualHost(vhIR *ir.VirtualHostIR) *routev3.VirtualHost {
 		})
 	}
 
+	// CORS response headers are normalized at the vhost level using
+	// OVERWRITE_IF_EXISTS_OR_ADD so that any duplicates emitted by upstream
+	// services (e.g. BFL's filter that calls AddHeader instead of Set, or an
+	// intermediate Node.js proxy that reflects the request Origin) collapse
+	// into a single deterministic value. Without this, the browser would
+	// receive headers like "Access-Control-Allow-Origin: *,http://localhost"
+	// which is invalid per the Fetch spec.
 	vh.ResponseHeadersToAdd = append(vh.ResponseHeadersToAdd,
 		&corev3.HeaderValueOption{
 			Header:       &corev3.HeaderValue{Key: "access-control-allow-headers", Value: "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"},
@@ -652,6 +659,10 @@ func translateVirtualHost(vhIR *ir.VirtualHostIR) *routev3.VirtualHost {
 		},
 		&corev3.HeaderValueOption{
 			Header:       &corev3.HeaderValue{Key: "access-control-allow-methods", Value: "PUT, GET, DELETE, POST, OPTIONS"},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		},
+		&corev3.HeaderValueOption{
+			Header:       &corev3.HeaderValue{Key: "access-control-allow-origin", Value: "*"},
 			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 		},
 	)


### PR DESCRIPTION
* **Background**
    Upstream services in the request chain (BFL's CORS filter uses AddHeader
    instead of Set, and intermediate Node.js proxies sometimes reflect the
    request Origin) can each append their own Access-Control-Allow-Origin,
    leaving the client with a merged value like "*,http://localhost". The
    Fetch spec requires a single origin or "*", so browsers reject the
    response and CORS preflights fail.
    
    Add access-control-allow-origin: * to the vhost-level responseHeadersToAdd
    with OVERWRITE_IF_EXISTS_OR_ADD so Envoy collapses any duplicate or
    conflicting values from upstream into one deterministic header. This
    mirrors the existing handling of access-control-allow-headers and
    access-control-allow-methods and acts as a bottom-line guard regardless
    of upstream behavior.


* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edge-proxy response CORS policy (global `*`) and deployment version; regenerated RBAC snapshots widen the allowed `100.64.0.0` prefix in some routes—verify that matches intended network access rules.
> 
> **Overview**
> Releases **l4-bfl-proxy** `v0.3.20` by bumping the image tag in the CLI upgrade task, BFL launcher `L4_PROXY_IMAGE_VERSION`, and `Olares.yaml` prebuilt output.
> 
> The proxy’s XDS translator now adds **`access-control-allow-origin: *`** on every virtual host with `OVERWRITE_IF_EXISTS_OR_ADD`, matching the existing CORS header/method normalization so duplicate upstream `Access-Control-Allow-Origin` values collapse to a single `*` and browsers stop rejecting preflights.
> 
> E2E golden Envoy JSON was regenerated across scenarios to include that header; RBAC fixtures that allow `100.64.0.0` now use **`prefixLen` 16** instead of 24 where those policies appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c06acc60e943a446bc5656d0dae9a8087520138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->