### PR TITLE
fix(olares-cli/dashboard): Fix data formatting and time zone vulnerabilities of olares-cli dashboard

### DIFF
--- a/cli/cmd/ctl/dashboard/options.go
+++ b/cli/cmd/ctl/dashboard/options.go
@@ -39,7 +39,10 @@ func bindPersistentFlags(cf *pkgdashboard.CommonFlags, cmd *cobra.Command) {
 	pf.StringVar(&cf.EndRaw, "end", "",
 		"absolute window end (RFC3339); fixed across iterations when --watch")
 	pf.StringVar(&cf.TimezoneRaw, "timezone", "",
-		"timezone for table rendering (IANA name, default: $TZ / system local)")
+		"timezone for table rendering (IANA name, default: $TZ / system local). "+
+			"Affects DISPLAY only — the wire format sent to HAMI's monitor query endpoints "+
+			"is rendered in the backend's own TZ regardless of this flag, so trends resolve "+
+			"correctly even when --timezone differs from the HAMI pod TZ")
 	pf.StringVar(&cf.TempUnitRaw, "temp-unit", "C",
 		"temperature display unit: C, F, or K (JSON raw always Celsius)")
 	pf.StringVar(&cf.User, "user", "",

--- a/cli/cmd/ctl/dashboard/overview/gpu/detail.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/detail.go
@@ -7,10 +7,17 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUDetailFullCommand exposes the legacy `gpu detail
+// <uuid>` cobra surface. Hidden + deprecated since the SPA-aligned
+// refactor — `gpu graphics <uuid>` is the new canonical command.
+// Kept functional for back-compat; emits the same
+// `dashboard.overview.gpu.detail.full` envelope.
 func newOverviewGPUDetailFullCommand(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use:           "detail <uuid>",
 		Short:         "Per-GPU detail page (info + gauges + trends; SPA Overview2/GPU/GPUsDetails)",
+		Hidden:        true,
+		Deprecated:    "use 'olares-cli dashboard overview gpu graphics <uuid>' instead",
 		Args:          cobra.ExactArgs(1),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cli/cmd/ctl/dashboard/overview/gpu/get.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/get.go
@@ -7,10 +7,18 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUGetCommand exposes the legacy `gpu get <uuid>`
+// cobra surface — a single flat HAMI /v1/gpu detail item with no
+// gauge / trend fan-out. Hidden + deprecated: this verb has no SPA
+// equivalent (the SPA's GPUsDetails page always renders gauges +
+// trends), so new callers should switch to `gpu graphics <uuid>`
+// for the SPA-aligned view. Kept functional for back-compat.
 func newOverviewGPUGetCommand(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use:           "get <uuid>",
-		Short:         "Per-GPU detail by UUID",
+		Short:         "Per-GPU detail by UUID (HAMI raw passthrough; no gauges/trends)",
+		Hidden:        true,
+		Deprecated:    "use 'olares-cli dashboard overview gpu graphics <uuid>' for the SPA-aligned detail page (info + gauges + trends)",
 		Args:          cobra.ExactArgs(1),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cli/cmd/ctl/dashboard/overview/gpu/graphics.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/graphics.go
@@ -1,0 +1,52 @@
+package gpu
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
+)
+
+// newOverviewGPUGraphicsCommand wires the SPA-aligned `gpu
+// graphics [uuid]` parent command. Mirrors the SPA's "Graphics
+// management" tab — bare invocation lists every device (the SPA's
+// table view), passing a uuid drills into the per-GPU detail page
+// (info + 6 gauges + 4 trends, the SPA's GPUsDetails route).
+//
+// Internally dispatches to RunList (no positional arg) or
+// RunDetail (one positional arg). Implementation note: kept on the
+// cmd side because SKILL forbids putting fan-out logic in cmd, and
+// dispatching by arg count is neither fan-out nor envelope work —
+// it's argument routing, the canonical responsibility of cmd.
+func newOverviewGPUGraphicsCommand(f *cmdutil.Factory) *cobra.Command {
+	return &cobra.Command{
+		Use:   "graphics [uuid]",
+		Short: "Graphics management — list GPUs (no arg) or detail page (uuid; SPA Overview2/GPU/GPUsDetails)",
+		Long: `Graphics management — SPA's "Graphics management" tab.
+
+  olares-cli dashboard overview gpu graphics              # list every GPU (HAMI /v1/gpus)
+  olares-cli dashboard overview gpu graphics <uuid>       # info + gauges + trends for one GPU
+                                                          # (HAMI /v1/gpu?uid=<uuid> + 4 instant +
+                                                          #  4 range PromQL queries)
+
+The single command replaces the older split of ` + "`list` / `detail`" + `.`,
+		Example: `  olares-cli dashboard overview gpu graphics
+  olares-cli dashboard overview gpu graphics GPU-e5d26177-beec-64c1-2681-56cc973d9910 -o json`,
+		Args:          cobra.MaximumNArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := common.Validate(); err != nil {
+				return err
+			}
+			cli, err := prepareClient(c.Context(), f)
+			if err != nil {
+				return err
+			}
+			if len(args) == 0 {
+				return pkggpu.RunList(c.Context(), cli, common)
+			}
+			return pkggpu.RunDetail(c.Context(), cli, common, args[0])
+		},
+	}
+}

--- a/cli/cmd/ctl/dashboard/overview/gpu/list.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/list.go
@@ -7,10 +7,16 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUListCommand exposes the legacy `gpu list` cobra
+// surface. Hidden + deprecated since the SPA-aligned refactor —
+// `gpu graphics` is the new canonical command. Kept for existing
+// agent scripts; emits the same envelope (`dashboard.overview.gpu.list`).
 func newOverviewGPUListCommand(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use:           "list",
 		Short:         "List discovered vGPUs (Graphics management tab; 404 = HAMI not installed)",
+		Hidden:        true,
+		Deprecated:    "use 'olares-cli dashboard overview gpu graphics' instead",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/cli/cmd/ctl/dashboard/overview/gpu/root.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/root.go
@@ -8,18 +8,43 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
-// NewGPUCommand assembles `dashboard overview gpu` (root + 6
-// leaves). cf is the shared *pkgdashboard.CommonFlags pointer
-// stored in the area's `common` package var; cobra's persistent-
-// flag inheritance from the dashboard root mutates the pointed-at
-// struct before any leaf RunE fires. The default RunE (no
-// subverb) forwards to `list`, mirroring the SPA's "GPU view
-// opens to the device list" behaviour.
+// NewGPUCommand assembles `dashboard overview gpu` — the SPA's
+// "GPU overview" page in CLI form. cf is the shared
+// *pkgdashboard.CommonFlags pointer stored in the area's `common`
+// package var; cobra's persistent-flag inheritance from the
+// dashboard root mutates the pointed-at struct before any leaf
+// RunE fires.
+//
+// Public surface (--help):
+//
+//	gpu graphics [uuid]    # SPA's Graphics management tab + GPUsDetails
+//	gpu tasks    [name]    # SPA's Task management tab + TasksDetails
+//
+// The default RunE (no subverb) emits a sections envelope
+// containing both `graphics` and `tasks` — same data the SPA's
+// "GPU overview" page renders behind its two tabs (both lists are
+// loaded eagerly when the page mounts; the user toggles between
+// them with the tabs widget). This puts gpu in the parent-default
+// = sections-envelope family alongside `overview`, `overview disk`
+// and `overview fan`.
+//
+// Legacy/hidden surface (kept for back-compat agent scripts; runs
+// with a Cobra deprecation hint):
+//
+//	gpu list / get <uuid> / detail <uuid>          → use `gpu graphics [uuid]`
+//	gpu task <name> <pod-uid> / task-detail …      → use `gpu tasks [name]`
 func NewGPUCommand(f *cmdutil.Factory, cf *pkgdashboard.CommonFlags) *cobra.Command {
 	common = cf
 	cmd := &cobra.Command{
-		Use:           "gpu",
-		Short:         "vGPU views: list / tasks / get / task / detail / task-detail",
+		Use:   "gpu",
+		Short: "GPU overview (SPA Overview2/GPU): graphics + tasks sections",
+		Long: `GPU overview — mirrors the SPA's Overview2/GPU page (Graphics management + Task management tabs).
+
+  olares-cli dashboard overview gpu                       # default → sections envelope (graphics + tasks)
+  olares-cli dashboard overview gpu graphics              # graphics list only (Graphics management tab)
+  olares-cli dashboard overview gpu graphics <uuid>       # GPU details page
+  olares-cli dashboard overview gpu tasks                 # task list only (Task management tab)
+  olares-cli dashboard overview gpu tasks <name>          # task details page (auto-resolves pod-uid)`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -33,11 +58,17 @@ func NewGPUCommand(f *cmdutil.Factory, cf *pkgdashboard.CommonFlags) *cobra.Comm
 			if err != nil {
 				return err
 			}
-			return pkggpu.RunList(c.Context(), cli, common)
+			return pkggpu.RunDefault(c.Context(), cli, common)
 		},
 	}
-	cmd.AddCommand(newOverviewGPUListCommand(f))
+	// Visible (SPA-aligned).
+	cmd.AddCommand(newOverviewGPUGraphicsCommand(f))
 	cmd.AddCommand(newOverviewGPUTasksCommand(f))
+	// Hidden (legacy, deprecated). Still functional for existing
+	// agent scripts; cobra emits a one-line deprecation hint when
+	// invoked. Removing them later is a follow-up release-note item,
+	// not part of the current refactor.
+	cmd.AddCommand(newOverviewGPUListCommand(f))
 	cmd.AddCommand(newOverviewGPUGetCommand(f))
 	cmd.AddCommand(newOverviewGPUTaskCommand(f))
 	cmd.AddCommand(newOverviewGPUDetailFullCommand(f))

--- a/cli/cmd/ctl/dashboard/overview/gpu/task.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/task.go
@@ -7,11 +7,20 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUTaskCommand exposes the legacy `gpu task <name>
+// <pod-uid>` cobra surface — a single flat HAMI /v1/container body
+// with no gauge / trend fan-out. Hidden + deprecated: this verb
+// has no SPA equivalent (the SPA's TasksDetails page always renders
+// gauges + trends). New callers should switch to `gpu tasks <name>`
+// for the SPA-aligned view (auto-resolves pod-uid). Kept functional
+// for back-compat.
 func newOverviewGPUTaskCommand(f *cmdutil.Factory) *cobra.Command {
 	var sharemode string
 	cmd := &cobra.Command{
 		Use:           "task <name> <pod-uid>",
-		Short:         "Per-task detail (pod-uid from `kubectl get pods -n <ns> -o jsonpath='{.items[*].metadata.uid}'`)",
+		Short:         "Per-task detail (HAMI raw passthrough; no gauges/trends)",
+		Hidden:        true,
+		Deprecated:    "use 'olares-cli dashboard overview gpu tasks <name>' for the SPA-aligned detail page (info + gauges + trends)",
 		Args:          cobra.ExactArgs(2),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cli/cmd/ctl/dashboard/overview/gpu/task_detail.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/task_detail.go
@@ -7,11 +7,22 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUTaskDetailFullCommand exposes the legacy
+// `gpu task-detail <name> <pod-uid>` cobra surface. Hidden +
+// deprecated since the SPA-aligned refactor — `gpu tasks <name>`
+// is the new canonical command (it auto-resolves pod-uid +
+// sharemode, no kubectl call needed). Kept functional for
+// back-compat scripts that already cached pod-uid; the explicit
+// two-arg form remains the only path that takes a manual
+// `--sharemode` override (the new `gpu tasks <name>` always
+// auto-detects sharemode from HAMI's task list).
 func newOverviewGPUTaskDetailFullCommand(f *cmdutil.Factory) *cobra.Command {
 	var sharemode string
 	cmd := &cobra.Command{
 		Use:           "task-detail <name> <pod-uid>",
 		Short:         "Per-task detail page (info + gauges + trends; SPA Overview2/GPU/TasksDetails)",
+		Hidden:        true,
+		Deprecated:    "use 'olares-cli dashboard overview gpu tasks <name>' instead (auto-resolves pod-uid; no kubectl needed)",
 		Args:          cobra.ExactArgs(2),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cli/cmd/ctl/dashboard/overview/gpu/tasks.go
+++ b/cli/cmd/ctl/dashboard/overview/gpu/tasks.go
@@ -7,10 +7,40 @@ import (
 	pkggpu "github.com/beclab/Olares/cli/pkg/dashboard/overview/gpu"
 )
 
+// newOverviewGPUTasksCommand wires the SPA-aligned `gpu tasks
+// [ref]` parent command. Mirrors the SPA's "Task management" tab —
+// bare invocation lists every running vGPU task, passing a `<ref>`
+// drills into that task's detail page (info + 2 gauges + 2 trends,
+// the SPA's TasksDetails route).
+//
+// `<ref>` accepts either the row's `name` (TASK column) or its
+// `podUid` (POD_UID column) — both are surfaced in the bare `gpu`
+// / `gpu tasks` listings, and copy-paste from either column should
+// "just work". The pkg layer's RunTaskByRef reverse-resolves
+// pod-uid + sharemode from the task list (same path the SPA takes
+// when the user clicks "View details" on a TasksTable row).
+//
+// The legacy `gpu task-detail <name> <pod-uid>` two-arg form
+// remains hidden + deprecated for agent scripts that already
+// cached the pod-uid.
 func newOverviewGPUTasksCommand(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:           "tasks",
-		Short:         "List vGPU tasks (Task management tab)",
+		Use:   "tasks [name|pod-uid]",
+		Short: "Task management — list vGPU tasks (no arg) or detail page (name or pod-uid; SPA Overview2/GPU/TasksDetails)",
+		Long: `Task management — SPA's "Task management" tab.
+
+  olares-cli dashboard overview gpu tasks                 # list every vGPU task (HAMI /v1/containers)
+  olares-cli dashboard overview gpu tasks <ref>           # info + gauges + trends for one task
+                                                          # <ref> = TASK (name) or POD_UID column from
+                                                          #  the listing; auto-resolves the missing half
+                                                          #  + sharemode (no kubectl needed).
+
+When two tasks share the same name, the CLI errors out with the candidate pod-uids;
+re-run with one of those pod-uids (still ` + "`gpu tasks <pod-uid>`" + `) to disambiguate.`,
+		Example: `  olares-cli dashboard overview gpu tasks
+  olares-cli dashboard overview gpu tasks comfyai -o json
+  olares-cli dashboard overview gpu tasks d2a8ea32-8e56-49f9-b876-21b2fa0c5a83`,
+		Args:          cobra.MaximumNArgs(1),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -21,7 +51,10 @@ func newOverviewGPUTasksCommand(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return pkggpu.RunTasks(c.Context(), cli, common)
+			if len(args) == 0 {
+				return pkggpu.RunTasks(c.Context(), cli, common)
+			}
+			return pkggpu.RunTaskByRef(c.Context(), cli, common, args[0])
 		},
 	}
 }

--- a/cli/cmd/ctl/dashboard/overview/root.go
+++ b/cli/cmd/ctl/dashboard/overview/root.go
@@ -37,7 +37,7 @@ import (
 //	overview fan curve            — hardcoded fanCurveTable (helpers.go)
 //	overview gpu list             — POST /hami/api/vgpu/v1/gpus
 //	overview gpu tasks            — POST /hami/api/vgpu/v1/containers
-//	overview gpu get <uuid>       — GET  /hami/api/vgpu/v1/gpu?uuid=...
+//	overview gpu get <uuid>       — GET  /hami/api/vgpu/v1/gpu?uid=...
 //	overview gpu task <name> <uid>— GET  /hami/api/vgpu/v1/container?name=&podUid=
 //
 // Every leaf consumes CommonFlags (--output / --watch / --since / etc.)

--- a/cli/pkg/dashboard/dashboard_test.go
+++ b/cli/pkg/dashboard/dashboard_test.go
@@ -1347,6 +1347,30 @@ func TestFetchGraphicsDetail_ReturnsBodyAsIs(t *testing.T) {
 	}
 }
 
+// TestFetchGraphicsDetail_SendsUidQueryParam pins the wire-name
+// contract: HAMI accepts the GPU UUID under the `uid` query key
+// (see the SPA's `GraphicsDetailsParams { uid: string }` in
+// src/apps/dashboard/types/gpu.ts). An earlier revision sent
+// `?uuid=...` and HAMI silently returned a zero-filled placeholder
+// object — this test is the regression net for that bug.
+func TestFetchGraphicsDetail_SendsUidQueryParam(t *testing.T) {
+	const want = "GPU-e5d26177-beec-64c1-2681-56cc973d9910"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("uid"); got != want {
+			t.Errorf("query 'uid' = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("uuid"); got != "" {
+			t.Errorf("query 'uuid' = %q, want empty (HAMI expects 'uid')", got)
+		}
+		_, _ = w.Write([]byte(`{"uuid":"` + want + `","type":"NVIDIA","health":true}`))
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	if _, err := fetchGraphicsDetail(context.Background(), c, want); err != nil {
+		t.Fatalf("fetchGraphicsDetail: %v", err)
+	}
+}
+
 // TestFetchTaskDetail_ReturnsBodyAsIs: same wire-shape contract for
 // `/v1/container` (task detail).
 func TestFetchTaskDetail_ReturnsBodyAsIs(t *testing.T) {

--- a/cli/pkg/dashboard/dashboard_test.go
+++ b/cli/pkg/dashboard/dashboard_test.go
@@ -1578,6 +1578,125 @@ func TestGPUTrendStep(t *testing.T) {
 	}
 }
 
+// TestGPUTrendTimestampISO_RespectsTimezone pins the user-visible
+// bug behind "trends 全空 / Gauges 正常" on UTC hosts. The CLI's
+// `time.Now()` returns absolute time (a TZ-less instant); the
+// HAMI WebUI backend pod runs with TZ=Asia/Shanghai and re-parses
+// the offset-less string with that location. If the formatter
+// ignores the caller's --timezone, the window string carries the
+// host's wall clock (often UTC) but gets re-stamped by HAMI as
+// Asia/Shanghai → the actual queried [start,end] in UTC shifts by
+// 8h into the future → Prometheus returns empty.
+//
+// Contract: same absolute instant, two different `tz` arguments,
+// MUST produce strings that differ by the offset between the two
+// zones. tz=nil falls back to time.Local (matches the legacy
+// unparameterised signature for back-compat in case any caller
+// forgets to plumb cf.Timezone in).
+func TestGPUTrendTimestampISO_RespectsTimezone(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	// Reference instant: 2026-05-25 11:39:54 UTC, which is the exact
+	// `end` the user-reported bug printed when the host was running
+	// in UTC. With tz=UTC the string MUST be 11:39:54; with
+	// tz=Asia/Shanghai it MUST be 19:39:54.
+	instant := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	if got := GPUTrendTimestampISO(instant, time.UTC); got != "2026-05-25 11:39:54" {
+		t.Errorf("UTC formatting = %q, want %q", got, "2026-05-25 11:39:54")
+	}
+	if got := GPUTrendTimestampISO(instant, shanghai); got != "2026-05-25 19:39:54" {
+		t.Errorf("Asia/Shanghai formatting = %q, want %q (UTC instant + 8h)", got, "2026-05-25 19:39:54")
+	}
+	// Two zones, same instant → strings MUST differ by the offset.
+	utcStr := GPUTrendTimestampISO(instant, time.UTC)
+	cnStr := GPUTrendTimestampISO(instant, shanghai)
+	if utcStr == cnStr {
+		t.Fatalf("UTC and Asia/Shanghai produced same string for the same instant (%q == %q); tz arg ignored", utcStr, cnStr)
+	}
+}
+
+// TestGPUTrendTimestampISO_NilTimezoneFallsBackToLocal pins that a
+// nil tz argument doesn't panic and falls back to time.Local — the
+// pre-fix unparameterised behaviour. Any in-tree caller now passes
+// cf.Timezone.Time(), but external callers (Go API consumers using
+// the dashboard package directly) might still be on the old call
+// shape; this fallback prevents a hard break.
+func TestGPUTrendTimestampISO_NilTimezoneFallsBackToLocal(t *testing.T) {
+	instant := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	want := instant.In(time.Local).Format("2006-01-02 15:04:05")
+	if got := GPUTrendTimestampISO(instant, nil); got != want {
+		t.Errorf("nil tz fallback = %q, want %q (time.Local rendering)", got, want)
+	}
+}
+
+// TestGPUTrendTimestampWire_FormatsInHAMIBackendTZ pins the
+// wire-side half of the TZ split. GPUTrendTimestampWire MUST NOT
+// honour the CLI host's TZ or the user's cf.Timezone — it MUST
+// always render in HAMIBackendTimezone() so the absolute instant
+// round-trips through HAMI's `time.ParseInLocation` against its own
+// pod TZ. Conflating wire and render TZ is what caused the original
+// "Gauges populated / Trends empty" bug on UTC hosts.
+func TestGPUTrendTimestampWire_FormatsInHAMIBackendTZ(t *testing.T) {
+	if _, err := time.LoadLocation("Asia/Shanghai"); err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	// Same instant as the ISO test above, so the two tests double
+	// as a worked example of the wire/render split.
+	instant := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	// Default HAMI backend TZ (no env override) is Asia/Shanghai
+	// → UTC + 8h.
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "")
+	if got := GPUTrendTimestampWire(instant); got != "2026-05-25 19:39:54" {
+		t.Errorf("wire formatting (default tz) = %q, want %q (UTC instant + 8h Asia/Shanghai)", got, "2026-05-25 19:39:54")
+	}
+}
+
+// TestGPUTrendTimestampWire_RespectsEnvOverride pins the escape
+// hatch for operators on non-default HAMI deployments. Setting
+// OLARES_HAMI_BACKEND_TZ to a valid IANA name MUST change the wire
+// string accordingly; an invalid name MUST fall back to the
+// Asia/Shanghai default (rather than crash or emit UTC), so a typo
+// in an env var doesn't silently break the data fetch.
+func TestGPUTrendTimestampWire_RespectsEnvOverride(t *testing.T) {
+	if _, err := time.LoadLocation("Asia/Shanghai"); err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	if _, err := time.LoadLocation("America/Los_Angeles"); err != nil {
+		t.Skipf("America/Los_Angeles zone unavailable: %v", err)
+	}
+	instant := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	// May 25 in LA is PDT (UTC-7): 11:39:54 UTC → 04:39:54 PDT.
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "America/Los_Angeles")
+	if got := GPUTrendTimestampWire(instant); got != "2026-05-25 04:39:54" {
+		t.Errorf("wire formatting (LA override) = %q, want %q (UTC instant - 7h PDT)", got, "2026-05-25 04:39:54")
+	}
+	// Bad env value → silent fallback to the default (Asia/Shanghai).
+	// We deliberately don't return an error here: a CLI session that
+	// runs against a default Olares deployment would otherwise break
+	// just because the operator put a typo into their shell rc.
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "Not/A_Real_Zone")
+	if got := GPUTrendTimestampWire(instant); got != "2026-05-25 19:39:54" {
+		t.Errorf("wire formatting (bad env) = %q, want %q (fallback to Asia/Shanghai)", got, "2026-05-25 19:39:54")
+	}
+}
+
+// TestHAMIBackendTimezone_DefaultIsAsiaShanghai locks in the
+// hardcoded default: today's Olares-bundled HAMI WebUI chart pins
+// webui.env.backend.TZ to Asia/Shanghai. If that ever changes (new
+// chart release, new region), the failure here is the loud signal
+// to update defaultHAMIBackendTZ in gpu.go AND the SKILL.md table.
+// Test guards against a silent drift between the chart values and
+// the CLI's assumption.
+func TestHAMIBackendTimezone_DefaultIsAsiaShanghai(t *testing.T) {
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "")
+	loc := HAMIBackendTimezone()
+	if loc.String() != "Asia/Shanghai" {
+		t.Errorf("HAMIBackendTimezone() default = %q, want %q (must match infrastructure/gpu/.olares/config/gpu/hami/values.yaml::webui.env.backend.TZ)", loc.String(), "Asia/Shanghai")
+	}
+}
+
 // TestBuildGPUDetailFullEnvelope_PartialFailure and
 // TestBuildGPUTaskDetailFullEnvelope_TimeSlicingSkipsAllocation moved
 // to cli/cmd/ctl/dashboard/overview/gpu/detail_test.go (next to the

--- a/cli/pkg/dashboard/gpu.go
+++ b/cli/pkg/dashboard/gpu.go
@@ -110,8 +110,19 @@ func FetchTaskList(ctx context.Context, c *Client, filters map[string]string) ([
 
 // FetchGraphicsDetail returns HAMI's `/v1/gpu` payload directly — the
 // SPA's `GraphicsDetailsResponse` is a flat object, no `data` envelope.
+//
+// Wire-name gotcha: HAMI's WebUI accepts the GPU UUID under the
+// `uid` query key (see the SPA's `GraphicsDetailsParams { uid: string }`
+// in src/apps/dashboard/types/gpu.ts and the network helper in
+// src/apps/dashboard/network/gpu.ts). An earlier revision of this
+// fetcher sent `?uuid=...` — HAMI silently treated that as "no
+// match" and returned a placeholder object with every numeric
+// field set to 0 / every string set to "-", which is why
+// `olares-cli dashboard overview gpu get <uuid>` historically
+// rendered all-zeros while `gpu list` showed real values for the
+// same UUID (list is a POST with `filters` and isn't affected).
 func FetchGraphicsDetail(ctx context.Context, c *Client, uuid string) (map[string]any, error) {
-	q := url.Values{"uuid": []string{uuid}}
+	q := url.Values{"uid": []string{uuid}}
 	var raw map[string]any
 	if err := c.DoJSON(ctx, http.MethodGet, "/hami/api/vgpu/v1/gpu", q, nil, &raw); err != nil {
 		return nil, err

--- a/cli/pkg/dashboard/gpu.go
+++ b/cli/pkg/dashboard/gpu.go
@@ -5,12 +5,84 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/beclab/Olares/cli/pkg/dashboard/format"
 )
+
+// defaultHAMIBackendTZ mirrors the bundled HAMI WebUI chart's
+// `webui.env.backend.TZ` (see
+// infrastructure/gpu/.olares/config/gpu/hami/values.yaml:519-521).
+// The CLI sends offset-less `YYYY-MM-DD HH:mm:ss` window strings to
+// HAMI's monitor query endpoints; the backend re-parses them with
+// `time.ParseInLocation` against this TZ, so the wire string MUST be
+// rendered in this TZ for the absolute instant to round-trip.
+//
+// We deliberately keep "the timezone HAMI parses with" decoupled
+// from "the timezone the user wants their tables rendered in"
+// (cf.Timezone). SPA gets away with conflating them because the
+// browser's local clock typically matches the pod TZ; CLI runs
+// elsewhere (UTC servers, US/EU operator workstations) and must
+// not assume coincidence. Validated empirically against
+// `beclab/hami-webui-be-oss:v1.0.8`: Unix-seconds payloads are
+// rejected (`data: []` even for known-good queries), only the
+// human-readable form is accepted.
+const defaultHAMIBackendTZ = "Asia/Shanghai"
+
+// hamiBackendTZOverrideEnv lets operators of non-default HAMI
+// deployments (different `webui.env.backend.TZ`) tell the CLI which
+// TZ to use on the wire WITHOUT recompiling. Hidden from --help on
+// purpose: the bundled chart pins Asia/Shanghai, so 99% of users
+// never need to touch this. Surfacing it in --help would invite
+// "fix it by setting this" cargo-culting when the real issue is
+// elsewhere (e.g. Prometheus retention).
+const hamiBackendTZOverrideEnv = "OLARES_HAMI_BACKEND_TZ"
+
+// HAMIBackendTimezone returns the *time.Location the HAMI WebUI
+// backend uses to re-parse offset-less monitor query timestamps.
+// Reads the OLARES_HAMI_BACKEND_TZ env var first (escape hatch for
+// non-default deployments); falls back to defaultHAMIBackendTZ.
+// An unparseable env override is treated as "ignore" rather than
+// "error" so a typo doesn't break the data fetch — the default is
+// still correct for every Olares deployment we ship today.
+func HAMIBackendTimezone() *time.Location {
+	if name, ok := os.LookupEnv(hamiBackendTZOverrideEnv); ok && name != "" {
+		if loc, err := time.LoadLocation(name); err == nil {
+			return loc
+		}
+	}
+	if loc, err := time.LoadLocation(defaultHAMIBackendTZ); err == nil {
+		return loc
+	}
+	// Last-ditch fallback: the time package guarantees time.UTC is
+	// always available even when the tzdata DB is missing. Hitting
+	// this path means the host has neither Asia/Shanghai nor any
+	// IANA zone DB compiled in — extremely rare, but we'd rather
+	// emit a UTC-shaped string than crash.
+	return time.UTC
+}
+
+// GPUTrendTimestampWire formats `t` for the wire body sent to HAMI's
+// /monitor/query/{instant,range}-vector endpoints — always in
+// HAMIBackendTimezone(), regardless of the CLI host's TZ or the
+// user's --timezone. This is the function to call when building
+// the request payload; see GPUTrendTimestampISO for the display
+// counterpart that DOES follow cf.Timezone.
+//
+// The split exists because conflating the two broke `gpu graphics
+// <uuid>` for any user whose host TZ ≠ HAMI backend TZ (UTC server,
+// US operator workstation, etc): Gauges populated correctly via
+// instant-vector (5m lookback masked the shift), but every range
+// query returned `data: []` because the [start,end] window got
+// re-stamped by the backend into a window 8h in the future where
+// Prometheus had no samples. Pinned by
+// TestBuildDetailFullEnvelope_UTCHostStillGetsData et al.
+func GPUTrendTimestampWire(t time.Time) string {
+	return t.In(HAMIBackendTimezone()).Format("2006-01-02 15:04:05")
+}
 
 // ----------------------------------------------------------------------------
 // HAMI list / detail endpoints
@@ -316,13 +388,22 @@ func GPUStepPreset(minutes int) (string, bool) {
 	}
 }
 
-// GPUTrendTimestampISO formats a time.Time the way the SPA's
-// `timeParse(date)` does for monitor queries: `YYYY-MM-DD HH:mm:ss` in
-// the caller's timezone (no offset suffix). HAMI's WebUI accepts
-// either Unix-seconds or this human-readable form; the SPA exclusively
-// sends the latter, so we match.
-func GPUTrendTimestampISO(t time.Time) string {
-	return t.Format("2006-01-02 15:04:05")
+// GPUTrendTimestampISO formats a time.Time in `tz` as
+// `YYYY-MM-DD HH:mm:ss` (no offset suffix). This is the DISPLAY
+// helper — used to render `meta.window.start/end` and table-side
+// trend point timestamps in the user's preferred timezone
+// (cf.Timezone, default time.Local). It MUST NOT be used to build
+// HAMI request payloads — use GPUTrendTimestampWire for that. The
+// two are decoupled on purpose; see GPUTrendTimestampWire's docs
+// for the wire-side rationale.
+//
+// `tz==nil` falls back to time.Local for back-compat with any
+// out-of-tree caller still on the old single-argument signature.
+func GPUTrendTimestampISO(t time.Time, tz *time.Location) string {
+	if tz == nil {
+		tz = time.Local
+	}
+	return t.In(tz).Format("2006-01-02 15:04:05")
 }
 
 // ----------------------------------------------------------------------------

--- a/cli/pkg/dashboard/overview/default_test.go
+++ b/cli/pkg/dashboard/overview/default_test.go
@@ -46,6 +46,15 @@ func defaultFixtureServer(t *testing.T) *httptest.Server {
                 {"metric":{"namespace":"jellyfin"},"value":[1714600000,"1.5"]}
               ]}}
             ]}`))
+		// Optional endpoints exercised by BuildPhysicalEnvelope's
+		// fan-out (GPU summary + fan readings — see Bug 1/2 fix).
+		// 404 keeps both rows skipped which is the right
+		// "no GPU, generic device" baseline for the smoke test.
+		case r.URL.Path == "/hami/api/vgpu/v1/monitor/query/instant-vector",
+			r.URL.Path == "/hami/api/vgpu/v1/gpus",
+			r.URL.Path == "/user-service/api/system/status",
+			r.URL.Path == "/user-service/api/mdns/olares-one/cpu-gpu":
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			noUnexpectedPath(t, w, r.URL.Path)
 		}

--- a/cli/pkg/dashboard/overview/gpu/default.go
+++ b/cli/pkg/dashboard/overview/gpu/default.go
@@ -1,0 +1,128 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
+)
+
+// RunDefault is the cmd-side entry point for `dashboard overview
+// gpu` without a subverb. Emits a sections envelope: graphics +
+// tasks — same data the SPA renders behind the two tabs of the
+// "GPU overview" page (both lists are loaded eagerly when the page
+// mounts; the user just toggles between them via the tabs widget).
+//
+// Concurrency: the two endpoints (HAMI /v1/gpus and /v1/containers)
+// are independent, so we fan them out with sync.WaitGroup. Per-
+// section transport errors land on the section's Meta.Error rather
+// than aborting the parent envelope — partial-failure semantics
+// match the rest of the dashboard sections-envelope family.
+//
+// Soft GPU advisory: the parent envelope's Meta.Note carries the
+// SPA-equivalent "would-have-been-hidden" hint (non-admin / no-CUDA
+// node) on a single Client cache hit; child sections re-use the
+// same note via BuildListEnvelope / BuildTasksEnvelope which each
+// call GPUAdvisory once.
+//
+// One-shot only — graphics + tasks have the same operational nature
+// (status snapshots, no monitor windows), but adding --watch on the
+// parent would force a single combined cadence for two endpoints
+// the SPA refreshes independently. Users wanting watch should pick
+// `gpu graphics --watch` or `gpu tasks --watch`.
+func RunDefault(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags) error {
+	now := time.Now()
+	env := BuildSectionsEnvelope(ctx, c, cf, now)
+	if cf.Output == pkgdashboard.OutputJSON {
+		return pkgdashboard.WriteJSON(os.Stdout, env)
+	}
+	return WriteSectionsTable(os.Stdout, env)
+}
+
+// BuildSectionsEnvelope assembles { graphics, tasks } in one
+// fan-out. A section that fails (transport, decode, gating) keeps
+// Meta.Error on itself and does NOT abort sibling fetches — same
+// shape as overview/{disk,fan}/default.go.
+func BuildSectionsEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, now time.Time) pkgdashboard.Envelope {
+	advisoryNote, _ := pkgdashboard.GPUAdvisory(ctx, c, cf, os.Stderr)
+
+	var (
+		graphicsEnv pkgdashboard.Envelope
+		tasksEnv    pkgdashboard.Envelope
+		wg          sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		graphicsEnv = BuildListEnvelope(ctx, c, cf, now)
+	}()
+	go func() {
+		defer wg.Done()
+		tasksEnv = BuildTasksEnvelope(ctx, c, cf, now)
+	}()
+	wg.Wait()
+
+	parent := pkgdashboard.Envelope{
+		Kind: pkgdashboard.KindOverviewGPU,
+		Meta: pkgdashboard.NewMeta(time.Now().In(cf.Timezone.Time()), c.OlaresID(), cf.User),
+		Sections: map[string]pkgdashboard.Envelope{
+			"graphics": graphicsEnv,
+			"tasks":    tasksEnv,
+		},
+	}
+	if advisoryNote != "" {
+		parent.Meta.Note = advisoryNote
+	}
+	return parent
+}
+
+// WriteSectionsTable renders the human-readable sections layout:
+//
+//	== GRAPHICS ==
+//	<gpu list table>
+//
+//	== TASKS ==
+//	<task list table>
+//
+// Per-section errors print "(error: ...)" so the other section
+// still renders — same pattern as overview/disk/fan default tables.
+func WriteSectionsTable(w io.Writer, env pkgdashboard.Envelope) error {
+	if env.Meta.Note != "" {
+		fmt.Fprintf(os.Stderr, "(advisory) %s\n", env.Meta.Note)
+	}
+	graphics, hasGraphics := env.Sections["graphics"]
+	tasks, hasTasks := env.Sections["tasks"]
+
+	fmt.Fprintln(w, "== GRAPHICS ==")
+	switch {
+	case !hasGraphics:
+		fmt.Fprintln(w, "(missing)")
+	case graphics.Meta.Error != "":
+		fmt.Fprintf(w, "(error: %s)\n", graphics.Meta.Error)
+	case graphics.Meta.Empty:
+		fmt.Fprintf(w, "(empty: %s)\n", graphics.Meta.EmptyReason)
+	default:
+		if err := WriteListTable(w, graphics); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintln(w, "\n== TASKS ==")
+	switch {
+	case !hasTasks:
+		fmt.Fprintln(w, "(missing)")
+	case tasks.Meta.Error != "":
+		fmt.Fprintf(w, "(error: %s)\n", tasks.Meta.Error)
+	case tasks.Meta.Empty:
+		fmt.Fprintf(w, "(empty: %s)\n", tasks.Meta.EmptyReason)
+	default:
+		if err := WriteTasksTable(w, tasks); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/pkg/dashboard/overview/gpu/default_test.go
+++ b/cli/pkg/dashboard/overview/gpu/default_test.go
@@ -1,0 +1,113 @@
+package gpu
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
+)
+
+// TestRunDefault_HappyPath: bare `dashboard overview gpu` emits a
+// `dashboard.overview.gpu` parent envelope whose `sections` map
+// has both `graphics` (kind .list) and `tasks` (kind .tasks)
+// populated. Mirrors the SPA's GPU overview page that loads both
+// tabs eagerly. Item ordering inside each section is governed by
+// the leaf builders (already covered by RunList/RunTasks tests).
+func TestRunDefault_HappyPath(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"list":[
+              {"uuid":"GPU-A","type":"NVIDIA-A","shareMode":"0","nodeName":"node-1","health":true,"coreUtilizedPercent":35,"memoryTotal":24576,"memoryUsed":12288,"memoryUtilizedPercent":50,"power":120.5,"temperature":62}
+            ]}`))
+		},
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"task-A","status":"running","appName":"pod-1","namespace":"ns-1","podUid":"uid-1","nodeName":"node-1","deviceShareModes":["0"],"devicesCoreUtilizedPercent":[42],"devicesMemUtilized":[1024]}
+            ]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunDefault(context.Background(), c, cf) })
+	for _, want := range []string{
+		`"kind":"dashboard.overview.gpu"`,
+		`"graphics":`,
+		`"tasks":`,
+		`"kind":"dashboard.overview.gpu.list"`,
+		`"kind":"dashboard.overview.gpu.tasks"`,
+		`"GPU-A"`,
+		`"task-A"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunDefault_PartialFailureKeepsOtherSection: a 5xx on
+// /v1/gpus must NOT abort the tasks section. The graphics section
+// surfaces empty_reason=vgpu_unavailable + http_status=500, while
+// tasks still emits its items. This is the canonical
+// sections-envelope partial-failure invariant — same shape as
+// `dashboard overview disk` (one disk's partition fetch failing
+// must not blank the other disks' tables).
+func TestRunDefault_PartialFailureKeepsOtherSection(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"hami down"}`))
+		},
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"task-A","status":"running","appName":"pod-1","namespace":"ns-1","podUid":"uid-1","deviceShareModes":["0"]}
+            ]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunDefault(context.Background(), c, cf) })
+	if !strings.Contains(out, `"empty_reason":"vgpu_unavailable"`) {
+		t.Errorf("expected graphics section vgpu_unavailable; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"task-A"`) {
+		t.Errorf("expected tasks section to still render task-A despite graphics 500; got:\n%s", out)
+	}
+}
+
+// TestRunDefault_HAMINotInstalled404: 404 on both endpoints folds
+// into per-section empty_reason=no_vgpu_integration. The parent
+// envelope itself stays non-empty (it always carries fetched_at +
+// the two section keys); agents distinguish the case via
+// `sections.<key>.meta.empty_reason`. Pinned because earlier
+// drafts collapsed both 404s into a parent-level empty.
+func TestRunDefault_HAMINotInstalled404(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunDefault(context.Background(), c, cf) })
+	if !strings.Contains(out, `"kind":"dashboard.overview.gpu"`) {
+		t.Errorf("missing parent kind in:\n%s", out)
+	}
+	// Both sections should carry no_vgpu_integration.
+	if c := strings.Count(out, `"empty_reason":"no_vgpu_integration"`); c != 2 {
+		t.Errorf("expected 2 no_vgpu_integration markers (graphics+tasks); got %d in:\n%s", c, out)
+	}
+}

--- a/cli/pkg/dashboard/overview/gpu/detail.go
+++ b/cli/pkg/dashboard/overview/gpu/detail.go
@@ -109,6 +109,7 @@ func BuildDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 		ctx, c,
 		gaugeSpecs, trendSpecs,
 		deviceuuidReplacer, env.Meta.Window.Start, env.Meta.Window.End, env.Meta.Window.Step,
+		cf.Timezone.Time(),
 		addWarning,
 		"power_trend",
 	)

--- a/cli/pkg/dashboard/overview/gpu/detail.go
+++ b/cli/pkg/dashboard/overview/gpu/detail.go
@@ -62,10 +62,19 @@ func BuildDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 	}
 	env.Meta.Window = &pkgdashboard.TimeWindow{
 		Since: humanizeSince(since),
-		Start: pkgdashboard.GPUTrendTimestampISO(start),
-		End:   pkgdashboard.GPUTrendTimestampISO(end),
+		Start: pkgdashboard.GPUTrendTimestampISO(start, cf.Timezone.Time()),
+		End:   pkgdashboard.GPUTrendTimestampISO(end, cf.Timezone.Time()),
 		Step:  pkgdashboard.GPUTrendStep(start, end),
 	}
+	// Wire window: ALWAYS rendered in the HAMI backend's TZ
+	// (default Asia/Shanghai, OLARES_HAMI_BACKEND_TZ override).
+	// Decoupled from meta.window above on purpose — meta.window
+	// is for the user's eyes (cf.Timezone), wireStart/wireEnd is
+	// for the backend's `time.ParseInLocation`. Conflating them
+	// silently zero-filled every range query when CLI host TZ ≠
+	// HAMI backend TZ; see pkg/dashboard/gpu.go::GPUTrendTimestampWire.
+	wireStart := pkgdashboard.GPUTrendTimestampWire(start)
+	wireEnd := pkgdashboard.GPUTrendTimestampWire(end)
 
 	// Step 1 — flat detail.
 	detail, err := pkgdashboard.FetchGraphicsDetail(ctx, c, uuid)
@@ -108,7 +117,7 @@ func BuildDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 	gaugeItems, trendItems, labelsFromPw := fanoutGaugeAndTrend(
 		ctx, c,
 		gaugeSpecs, trendSpecs,
-		deviceuuidReplacer, env.Meta.Window.Start, env.Meta.Window.End, env.Meta.Window.Step,
+		deviceuuidReplacer, wireStart, wireEnd, env.Meta.Window.Step,
 		cf.Timezone.Time(),
 		addWarning,
 		"power_trend",

--- a/cli/pkg/dashboard/overview/gpu/detail_test.go
+++ b/cli/pkg/dashboard/overview/gpu/detail_test.go
@@ -2,13 +2,16 @@ package gpu
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
+	"github.com/beclab/Olares/cli/pkg/dashboard/format"
 )
 
 // TestBuildDetailFullEnvelope_PartialFailure: when ONE gauge query
@@ -80,6 +83,278 @@ func TestBuildDetailFullEnvelope_PartialFailure(t *testing.T) {
 	}
 	if det["driver_version"] != "590.44.01" {
 		t.Errorf("detail.driver_version = %v, want 590.44.01", det["driver_version"])
+	}
+}
+
+// TestBuildDetailFullEnvelope_WireAndRenderTZsAreSeparate pins the
+// post-fix wire/render TZ split. meta.window.start/end is rendered
+// in cf.Timezone (user-visible); the body sent to HAMI's
+// /monitor/query/range-vector endpoint is rendered in
+// HAMIBackendTimezone() (whatever the backend pod parses with).
+//
+// We exercise the split by choosing DIFFERENT zones for the two:
+//   - cf.Timezone = Asia/Shanghai → meta.window in CST
+//   - OLARES_HAMI_BACKEND_TZ = America/Los_Angeles (May → PDT, UTC-7)
+//     → wire in PDT
+//
+// If the two paths regress to a single TZ the test fails on either
+// the meta.window assertion (CST != PDT) or the wire-body assertion
+// (PDT != CST). Naming intentionally drops the old
+// "WindowFormattedInTimezone" suffix — that name implied a single
+// TZ governs both sides, which is exactly what we're moving away
+// from.
+func TestBuildDetailFullEnvelope_WireAndRenderTZsAreSeparate(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	if _, err := time.LoadLocation("America/Los_Angeles"); err != nil {
+		t.Skipf("America/Los_Angeles zone unavailable: %v", err)
+	}
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "America/Los_Angeles")
+
+	var (
+		mu              sync.Mutex
+		rangeWireBodies []map[string]any
+	)
+	srv := gpuStubMux{
+		graphicsGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"uuid":"GPU-1","type":"NVIDIA","health":true,"shareMode":"0","nodeName":"olares"}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":1.0,"timestamp":"1745000000"}]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			if rng, ok := req["range"].(map[string]any); ok {
+				mu.Lock()
+				rangeWireBodies = append(rangeWireBodies, rng)
+				mu.Unlock()
+			}
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Timezone = format.NewLocation(shanghai)
+	cf.Output = pkgdashboard.OutputJSON
+
+	// Same absolute instant as the original user-reported bug
+	// (2026-05-25 11:39:54 UTC). Conversions:
+	//   end   = 2026-05-25 11:39:54 UTC = 19:39:54 CST = 04:39:54 PDT
+	//   start = 2026-05-25 03:39:54 UTC = 11:39:54 CST = 2026-05-24 20:39:54 PDT
+	end := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	start := end.Add(-8 * time.Hour)
+	env, err := BuildDetailFullEnvelope(context.Background(), c, cf, "GPU-1", start, end, 8*time.Hour)
+	if err != nil {
+		t.Fatalf("BuildDetailFullEnvelope: %v", err)
+	}
+	// meta.window is the USER-VISIBLE side → CST (cf.Timezone).
+	wantMetaStart := "2026-05-25 11:39:54"
+	wantMetaEnd := "2026-05-25 19:39:54"
+	if env.Meta.Window == nil {
+		t.Fatal("meta.window is nil; the agent contract requires it for replays")
+	}
+	if env.Meta.Window.Start != wantMetaStart {
+		t.Errorf("meta.window.start = %q, want %q (CST rendering for the user)", env.Meta.Window.Start, wantMetaStart)
+	}
+	if env.Meta.Window.End != wantMetaEnd {
+		t.Errorf("meta.window.end = %q, want %q (CST rendering for the user)", env.Meta.Window.End, wantMetaEnd)
+	}
+
+	// Wire is the BACKEND-VISIBLE side → PDT (HAMI backend TZ
+	// override). Every range-vector body in the fan-out MUST carry
+	// the PDT-shaped strings, NOT the CST strings from meta.window.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rangeWireBodies) == 0 {
+		t.Fatal("no range-vector requests captured; fan-out broken?")
+	}
+	wantWireStart := "2026-05-24 20:39:54"
+	wantWireEnd := "2026-05-25 04:39:54"
+	for i, rng := range rangeWireBodies {
+		if rng["start"] != wantWireStart {
+			t.Errorf("range[%d].start sent to HAMI = %q, want %q (PDT, backend TZ); MUST NOT equal meta.window.start %q",
+				i, rng["start"], wantWireStart, wantMetaStart)
+		}
+		if rng["end"] != wantWireEnd {
+			t.Errorf("range[%d].end sent to HAMI = %q, want %q (PDT, backend TZ); MUST NOT equal meta.window.end %q",
+				i, rng["end"], wantWireEnd, wantMetaEnd)
+		}
+		// Belt-and-suspenders: if the two paths ever collapse back
+		// into a single TZ, at least one of these equalities will
+		// hold and we want a screaming-loud test failure for it.
+		if rng["start"] == wantMetaStart && rng["end"] == wantMetaEnd {
+			t.Errorf("range[%d] wire body equals meta.window — wire/render TZ split regressed", i)
+		}
+	}
+}
+
+// TestBuildDetailFullEnvelope_UTCHostStillGetsData is the explicit
+// regression net for the original symptom: a CLI session on a UTC
+// host (cf.Timezone == UTC, no --timezone override) used to send
+// offset-less UTC wall clock strings to a HAMI backend running on
+// Asia/Shanghai, which then re-parsed them as CST and queried
+// Prometheus 8h in the future → `data: []`.
+//
+// The fix: wire side is always HAMIBackendTimezone() (default
+// Asia/Shanghai), independent of cf.Timezone. This test asserts the
+// invariant by checking the wire body is CST even though the user
+// asked for UTC rendering. If the fix regresses the test catches it
+// at PR time, not at customer-deploy time.
+func TestBuildDetailFullEnvelope_UTCHostStillGetsData(t *testing.T) {
+	if _, err := time.LoadLocation("Asia/Shanghai"); err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "") // default → Asia/Shanghai
+
+	var (
+		mu              sync.Mutex
+		rangeWireBodies []map[string]any
+	)
+	srv := gpuStubMux{
+		graphicsGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"uuid":"GPU-1","type":"NVIDIA","health":true,"shareMode":"0","nodeName":"olares"}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":1.0,"timestamp":"1745000000"}]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			if rng, ok := req["range"].(map[string]any); ok {
+				mu.Lock()
+				rangeWireBodies = append(rangeWireBodies, rng)
+				mu.Unlock()
+			}
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Timezone = format.NewLocation(time.UTC) // simulate UTC host
+	cf.Output = pkgdashboard.OutputJSON
+
+	end := time.Date(2026, 5, 25, 11, 39, 54, 0, time.UTC)
+	start := end.Add(-8 * time.Hour)
+	env, err := BuildDetailFullEnvelope(context.Background(), c, cf, "GPU-1", start, end, 8*time.Hour)
+	if err != nil {
+		t.Fatalf("BuildDetailFullEnvelope: %v", err)
+	}
+	// User asked for UTC rendering → meta.window is UTC.
+	if got, want := env.Meta.Window.Start, "2026-05-25 03:39:54"; got != want {
+		t.Errorf("meta.window.start = %q, want %q (UTC rendering for the user)", got, want)
+	}
+	if got, want := env.Meta.Window.End, "2026-05-25 11:39:54"; got != want {
+		t.Errorf("meta.window.end = %q, want %q (UTC rendering for the user)", got, want)
+	}
+
+	// Wire is CST regardless of cf.Timezone → this is the bugfix.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rangeWireBodies) == 0 {
+		t.Fatal("no range-vector requests captured; fan-out broken?")
+	}
+	wantWireStart := "2026-05-25 11:39:54"
+	wantWireEnd := "2026-05-25 19:39:54"
+	for i, rng := range rangeWireBodies {
+		if rng["start"] != wantWireStart {
+			t.Errorf("range[%d].start sent to HAMI = %q, want %q (CST, backend TZ — UTC host bug regression)", i, rng["start"], wantWireStart)
+		}
+		if rng["end"] != wantWireEnd {
+			t.Errorf("range[%d].end sent to HAMI = %q, want %q (CST, backend TZ — UTC host bug regression)", i, rng["end"], wantWireEnd)
+		}
+	}
+}
+
+// TestBuildTaskDetailFullEnvelope_WireAndRenderTZsAreSeparate is
+// the task-flavoured twin of
+// TestBuildDetailFullEnvelope_WireAndRenderTZsAreSeparate. Both
+// builders share the same fanoutGaugeAndTrend plumbing; we keep
+// the twin to lock in that no task-detail caller accidentally
+// re-conflates the two TZs (the SPA's task page uses the same
+// /monitor/query/range-vector endpoint, so the contract is
+// identical).
+func TestBuildTaskDetailFullEnvelope_WireAndRenderTZsAreSeparate(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	if _, err := time.LoadLocation("America/Los_Angeles"); err != nil {
+		t.Skipf("America/Los_Angeles zone unavailable: %v", err)
+	}
+	t.Setenv("OLARES_HAMI_BACKEND_TZ", "America/Los_Angeles")
+
+	var (
+		mu              sync.Mutex
+		rangeWireBodies []map[string]any
+	)
+	srv := gpuStubMux{
+		taskGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"name":"task-A","status":"running","appName":"pod-1","namespace":"ns-1","podUid":"pod-1","deviceShareModes":["2"]}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":1.0,"timestamp":"1745000000"}]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			if rng, ok := req["range"].(map[string]any); ok {
+				mu.Lock()
+				rangeWireBodies = append(rangeWireBodies, rng)
+				mu.Unlock()
+			}
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Timezone = format.NewLocation(shanghai)
+	cf.Output = pkgdashboard.OutputJSON
+
+	// end = 2026-05-25 11:40:20 UTC
+	//   = 19:40:20 CST (meta.window)
+	//   = 04:40:20 PDT (wire)
+	// start = end - 1h = 2026-05-25 10:40:20 UTC
+	//   = 18:40:20 CST
+	//   = 03:40:20 PDT
+	end := time.Date(2026, 5, 25, 11, 40, 20, 0, time.UTC)
+	start := end.Add(-1 * time.Hour)
+	env, err := BuildTaskDetailFullEnvelope(context.Background(), c, cf, "task-A", "pod-1", "2", start, end, time.Hour)
+	if err != nil {
+		t.Fatalf("BuildTaskDetailFullEnvelope: %v", err)
+	}
+	if env.Meta.Window == nil {
+		t.Fatal("meta.window is nil")
+	}
+	if got, want := env.Meta.Window.Start, "2026-05-25 18:40:20"; got != want {
+		t.Errorf("meta.window.start = %q, want %q (CST for the user)", got, want)
+	}
+	if got, want := env.Meta.Window.End, "2026-05-25 19:40:20"; got != want {
+		t.Errorf("meta.window.end = %q, want %q (CST for the user)", got, want)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rangeWireBodies) == 0 {
+		t.Fatal("no range-vector requests captured; fan-out broken?")
+	}
+	wantWireStart := "2026-05-25 03:40:20"
+	wantWireEnd := "2026-05-25 04:40:20"
+	for i, rng := range rangeWireBodies {
+		if rng["start"] != wantWireStart {
+			t.Errorf("range[%d].start = %q, want %q (PDT, backend TZ)", i, rng["start"], wantWireStart)
+		}
+		if rng["end"] != wantWireEnd {
+			t.Errorf("range[%d].end = %q, want %q (PDT, backend TZ)", i, rng["end"], wantWireEnd)
+		}
 	}
 }
 

--- a/cli/pkg/dashboard/overview/gpu/format_test.go
+++ b/cli/pkg/dashboard/overview/gpu/format_test.go
@@ -1,0 +1,343 @@
+package gpu
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
+	"github.com/beclab/Olares/cli/pkg/dashboard/format"
+)
+
+// TestFormatTrendTimestamp_AllShapes pins the three timestamp
+// shapes the CLI must accept from HAMI's range-vector endpoint —
+// epoch ms (13-digit int string, the shape that triggered the
+// user-visible bug "1779636713000"), epoch s (10-digit), and
+// float-seconds with sub-second precision (Prometheus's wire
+// shape). All three MUST collapse to the SPA's
+// `YYYY-MM-DD HH:mm:ss` rendering. Edge cases (empty,
+// unparseable) MUST fall through to the raw string instead of
+// silently rendering "1970-01-01" — agents debugging HAMI need
+// to see what HAMI actually sent.
+func TestFormatTrendTimestamp_AllShapes(t *testing.T) {
+	utc := time.UTC
+
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"epoch_ms_13_digits", "1779636713000", "2026-05-24 15:31:53"},
+		{"epoch_s_10_digits", "1779636713", "2026-05-24 15:31:53"},
+		{"epoch_s_with_subsec", "1779636713.5", "2026-05-24 15:31:53"},
+		{"empty_returns_dash", "", "-"},
+		{"unparseable_passes_through", "not-a-number", "not-a-number"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatTrendTimestamp(tc.raw, utc)
+			if got != tc.want {
+				t.Errorf("formatTrendTimestamp(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatTrendTimestamp_RespectsTimezone pins that the caller's
+// --timezone is actually applied. The same epoch produces
+// different strings for UTC vs Asia/Shanghai (UTC+8). Without
+// honoring tz the CLI would emit UTC even when the user explicitly
+// asked for local — a footgun for ops people parsing logs.
+func TestFormatTrendTimestamp_RespectsTimezone(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Skipf("Asia/Shanghai zone unavailable: %v", err)
+	}
+	utc := formatTrendTimestamp("1779636713000", time.UTC)
+	cn := formatTrendTimestamp("1779636713000", shanghai)
+	if utc == cn {
+		t.Fatalf("UTC == Asia/Shanghai for the same epoch (%q == %q); tz argument ignored?", utc, cn)
+	}
+	if !strings.HasPrefix(utc, "2026-05-24 15:") {
+		t.Errorf("UTC rendering = %q, want 2026-05-24 15:…", utc)
+	}
+	if !strings.HasPrefix(cn, "2026-05-24 23:") {
+		t.Errorf("CN rendering = %q, want 2026-05-24 23:… (UTC+8 of 15:31:53)", cn)
+	}
+}
+
+// TestRoundDP_HalfAwayFromZero pins the SPA's lodash.round behavior
+// — half-away-from-zero, NOT banker's. Without this someone could
+// "fix" CLI to use math.RoundToEven and silently desync from the
+// SPA chart values for any .5-ending input.
+func TestRoundDP_HalfAwayFromZero(t *testing.T) {
+	cases := []struct {
+		in   float64
+		dp   int
+		want float64
+	}{
+		{0.125, 2, 0.13},
+		{0.135, 2, 0.14},
+		{2.5, 0, 3},
+		{-2.5, 0, -3},
+		{23.889648, 2, 23.89},
+		{0.28808594, 2, 0.29},
+		{99.99876, 2, 100},
+	}
+	for _, tc := range cases {
+		if got := roundDP(tc.in, tc.dp); got != tc.want {
+			t.Errorf("roundDP(%v,%d) = %v, want %v", tc.in, tc.dp, got, tc.want)
+		}
+	}
+}
+
+// TestRoundedNumberString_StripsTrailingZeros — the SPA renders
+// `String(round(23.89, 2))` as "23.89", not "23.890000000000004"
+// or "23.890000". This is what makes the tabular output legible.
+func TestRoundedNumberString_StripsTrailingZeros(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{23.889648, "23.89"},
+		{0.28808594, "0.29"},
+		{100.0, "100"},
+		{0.0, "0"},
+		{7.866, "7.87"},
+	}
+	for _, tc := range cases {
+		if got := roundedNumberString(tc.in); got != tc.want {
+			t.Errorf("roundedNumberString(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFormatGaugeValue pins the `<value> <unit>` join for SPA
+// parity. The four ratio gauges (unit=" " or unit="") must NOT
+// emit a trailing space + unit; the unit-bearing gauges (Gi / W /
+// ℃ / %) MUST. This is exactly what `<MyGaugeChart unit=…>` does
+// — the CLI table column "VALUE" matches the gauge dial label
+// 1:1.
+func TestFormatGaugeValue(t *testing.T) {
+	cases := []struct {
+		v    float64
+		unit string
+		want string
+	}{
+		{23.889648, "Gi", "23.89 Gi"},
+		{7.866, "W", "7.87 W"},
+		{46.0, "℃", "46 ℃"},
+		{1.21, "%", "1.21 %"},
+		{100.0, "", "100"},  // ratio gauges (alloc_core) — no unit
+		{100.0, " ", "100"}, // SPA's literal " " sentinel
+		{0, "Gi", "0 Gi"},
+	}
+	for _, tc := range cases {
+		if got := formatGaugeValue(tc.v, tc.unit); got != tc.want {
+			t.Errorf("formatGaugeValue(%v,%q) = %q, want %q", tc.v, tc.unit, got, tc.want)
+		}
+	}
+}
+
+// TestGpuDetailDisplayCopy_SPAFieldWhitelist freezes the 6-field
+// whitelist matching GPUsDetails.vue:112-137. If anyone widens
+// the whitelist (e.g. brings memoryTotal/power/temperature back
+// into the Detail card) this test fails — a deliberate guardrail
+// because those fields are placeholders in HAMI's flat
+// /v1/gpu body and re-introducing them was the bug we just fixed.
+func TestGpuDetailDisplayCopy_SPAFieldWhitelist(t *testing.T) {
+	// Full HAMI body — should be available on Raw, but Display must
+	// only surface the SPA's 6 columns.
+	src := map[string]any{
+		"uuid":           "GPU-A",
+		"type":           "NVIDIA GeForce RTX 5090",
+		"nodeName":       "olares",
+		"nodeUid":        "node-uid-redacted",
+		"shareMode":      "0",
+		"vgpuUsed":       1,
+		"vgpuTotal":      30,
+		"coreUsed":       100,
+		"coreTotal":      100,
+		"memoryUsed":     0,
+		"memoryTotal":    24463,
+		"power":          0,
+		"powerLimit":     0,
+		"temperature":    0,
+		"device_no":      "nvidia0",
+		"driver_version": "595.71.05",
+		"health":         true,
+	}
+	got := gpuDetailDisplayCopy(src)
+
+	wantKeys := map[string]bool{
+		"uuid": true, "type": true, "nodeName": true,
+		"device_no": true, "driver_version": true, "health": true,
+	}
+	for k := range got {
+		if !wantKeys[k] {
+			t.Errorf("Display has unexpected key %q (SPA columns whitelist disallows it); full = %v", k, got)
+		}
+	}
+	for k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("Display missing whitelisted key %q; full = %v", k, got)
+		}
+	}
+	// health passes through gpuHealthLabel — pin the label conversion.
+	if got["health"] != "healthy" {
+		t.Errorf("Display.health = %q, want \"healthy\"", got["health"])
+	}
+}
+
+// TestGpuTaskDetailDisplayCopy_SPAFieldWhitelist freezes the
+// task-detail whitelist matching TasksDetails.vue:134-174.
+// Allocations are conditional in SPA (displayAllocation) —
+// CLI emits them when present, omits when absent.
+func TestGpuTaskDetailDisplayCopy_SPAFieldWhitelist(t *testing.T) {
+	src := map[string]any{
+		"name":             "comfyui",
+		"status":           "running",
+		"podUid":           "pod-uid-redacted",
+		"nodeName":         "olares",
+		"nodeUid":          "node-uid-redacted",
+		"type":             "NVIDIA-vGPU",
+		"appName":          "comfyui-7d4f4915-7d-zwmgs",
+		"namespace":        "ns-1",
+		"createTime":       "2026-05-25T15:00:00Z",
+		"startTime":        "2026-05-25T15:00:01Z",
+		"endTime":          "2026-05-25T16:00:00Z",
+		"deviceIds":        []any{"GPU-A"},
+		"deviceShareModes": []any{"2"},
+		"allocatedDevices": 1,
+		"allocatedCores":   25,
+		"allocatedMem":     "256MiB",
+		"resourcePool":     "pool-1",
+		"flavor":           "small",
+		"priority":         "high",
+	}
+	got := gpuTaskDetailDisplayCopy(src)
+
+	wantKeys := map[string]bool{
+		"status": true, "deviceIds": true, "nodeName": true, "type": true,
+		"allocatedCores": true, "allocatedMem": true,
+		"appName": true, "createTime": true,
+	}
+	for k := range got {
+		if !wantKeys[k] {
+			t.Errorf("Display has unexpected key %q (SPA columns whitelist disallows it); full = %v", k, got)
+		}
+	}
+	for k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("Display missing whitelisted key %q; full = %v", k, got)
+		}
+	}
+	if got["deviceIds"] != "GPU-A" {
+		t.Errorf("deviceIds join = %q, want \"GPU-A\"", got["deviceIds"])
+	}
+}
+
+// TestRunDetailFull_TrendPointsAreFormatted is the end-to-end pin
+// for the user-visible bug ("graphics 的时间格式是 '2026-05-25 …'，
+// 数据要格式化成合适的单位"). Stubs HAMI to return:
+//   - a range-vector point whose timestamp is epoch ms
+//     ("1779636713000") and value is a noisy 7-digit float
+//     (`23.889648`).
+// The envelope's `trends.points[0].timestamp` MUST be
+// `2026-05-24 …` (SPA `YYYY-MM-DD HH:mm:ss`), `value` MUST be
+// `23.89` (lodash.round(2)), and the wire-shape epoch MUST be
+// preserved on `timestamp_ms`. End-to-end test catches a future
+// "I refactored runTrend back to raw passthrough" regression.
+func TestRunDetailFull_TrendPointsAreFormatted(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"uuid":"GPU-1","type":"NVIDIA","health":true,"shareMode":"0","nodeName":"olares"}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":7.866,"timestamp":"1779636713"}]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[{"metric":{},"values":[
+              {"value":23.889648,"timestamp":"1779636713000"},
+              {"value":99.99876,"timestamp":"1779636773000"}
+            ]}]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	// Pin UTC so the assertion strings stay deterministic regardless
+	// of the test runner's host timezone — fixtureFlags otherwise
+	// uses LocalLocation() which would render Asia/Shanghai on the
+	// dev box and UTC on CI.
+	cf.Timezone = format.NewLocation(time.UTC)
+	cf.Output = pkgdashboard.OutputJSON
+
+	end := time.Date(2026, 5, 24, 23, 31, 53, 0, time.UTC)
+	start := end.Add(-8 * time.Hour)
+	envelope, err := BuildDetailFullEnvelope(context.Background(), c, cf, "GPU-1", start, end, 8*time.Hour)
+	if err != nil {
+		t.Fatalf("BuildDetailFullEnvelope: %v", err)
+	}
+	trends := envelope.Sections["trends"].Items
+	if len(trends) == 0 {
+		t.Fatal("expected at least one trend item")
+	}
+	// Find first trend item with non-empty points.
+	var firstPoint map[string]any
+	for _, it := range trends {
+		lines, _ := it.Raw["lines"].([]map[string]any)
+		for _, ln := range lines {
+			points, _ := ln["points"].([]map[string]any)
+			if len(points) > 0 {
+				firstPoint = points[0]
+				break
+			}
+		}
+		if firstPoint != nil {
+			break
+		}
+	}
+	if firstPoint == nil {
+		t.Fatal("no trend points captured — stub returned empty?")
+	}
+	if got := firstPoint["timestamp"]; got != "2026-05-24 15:31:53" {
+		t.Errorf("trend point timestamp = %v, want \"2026-05-24 15:31:53\" (epoch ms 1779636713000 in UTC)", got)
+	}
+	if got, _ := firstPoint["timestamp_ms"].(int64); got != 1779636713000 {
+		t.Errorf("trend point timestamp_ms = %v, want 1779636713000 (wire-shape preserved)", firstPoint["timestamp_ms"])
+	}
+	if got, _ := firstPoint["value"].(float64); got != 23.89 {
+		t.Errorf("trend point value = %v, want 23.89 (lodash.round(2) of 23.889648)", firstPoint["value"])
+	}
+	if got, _ := firstPoint["value_raw"].(float64); got != 23.889648 {
+		t.Errorf("trend point value_raw = %v, want 23.889648 (full precision preserved)", firstPoint["value_raw"])
+	}
+}
+
+// TestGpuTaskDetailDisplayCopy_OmitsAllocationsWhenAbsent — when
+// HAMI doesn't return allocatedCores / allocatedMem (the
+// time-slicing branch) the rows MUST be absent from Display, not
+// rendered as "0" or "<nil>". Pinned because the SPA's
+// `displayAllocation` gate guarantees the same: the user sees a
+// 6-row card, not 8 rows with two empty.
+func TestGpuTaskDetailDisplayCopy_OmitsAllocationsWhenAbsent(t *testing.T) {
+	src := map[string]any{
+		"name":      "task-A",
+		"status":    "running",
+		"appName":   "app-a",
+		"nodeName":  "node-1",
+		"type":      "NVIDIA-vGPU",
+		"deviceIds": []any{"GPU-A"},
+	}
+	got := gpuTaskDetailDisplayCopy(src)
+	if _, ok := got["allocatedCores"]; ok {
+		t.Errorf("allocatedCores must be absent when source omits it; got=%v", got)
+	}
+	if _, ok := got["allocatedMem"]; ok {
+		t.Errorf("allocatedMem must be absent when source omits it; got=%v", got)
+	}
+}

--- a/cli/pkg/dashboard/overview/gpu/helpers_test.go
+++ b/cli/pkg/dashboard/overview/gpu/helpers_test.go
@@ -130,6 +130,28 @@ func (m gpuStubMux) server(t *testing.T) *httptest.Server {
 // print.
 func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
+	out, runErr := runWithCapturedStdout(t, fn)
+	if runErr != nil {
+		t.Fatalf("captured fn err: %v", runErr)
+	}
+	return out
+}
+
+// captureStdoutAndErr is the captureStdout variant for tests that
+// EXPECT fn to return a non-nil error (e.g. Bug 2's "RunList must
+// return Meta.Error to cobra in table mode" regression). Returns
+// both the captured stdout AND the error so the test can assert on
+// the error wording without losing the prose the leaf may have
+// printed before the failure surfaced.
+func captureStdoutAndErr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	return runWithCapturedStdout(t, fn)
+}
+
+// runWithCapturedStdout is the shared piping body for both
+// captureStdout (success-only) and captureStdoutAndErr (error-OK).
+func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
 	old := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -152,10 +174,7 @@ func captureStdout(t *testing.T, fn func() error) string {
 	os.Stdout = old
 	res := <-done
 	if res.err != nil {
-		t.Fatalf("captureStdout read: %v", res.err)
+		t.Fatalf("runWithCapturedStdout read: %v", res.err)
 	}
-	if runErr != nil {
-		t.Fatalf("captured fn err: %v", runErr)
-	}
-	return res.out
+	return res.out, runErr
 }

--- a/cli/pkg/dashboard/overview/gpu/list.go
+++ b/cli/pkg/dashboard/overview/gpu/list.go
@@ -17,8 +17,41 @@ import (
 // doesn't need watch semantics; if a user wants polling they can
 // run `watch -n 5 olares-cli dashboard overview gpu list` from
 // outside.
+//
+// Implementation: BuildListEnvelope assembles the envelope (no
+// stdout writes); RunList wraps it with the legacy stdout side
+// effects (the "(no vGPUs detected …)" prose lines that earlier
+// revisions printed for the bare-leaf invocation). RunDefault
+// (sections envelope) reuses BuildListEnvelope directly so a
+// graphics-section transport error doesn't print prose ahead of
+// the tasks section.
 func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags) error {
 	now := time.Now()
+	env := BuildListEnvelope(ctx, c, cf, now)
+	if cf.Output == pkgdashboard.OutputJSON {
+		return pkgdashboard.WriteJSON(os.Stdout, env)
+	}
+	if env.Meta.Empty {
+		switch env.Meta.EmptyReason {
+		case "no_vgpu_integration":
+			fmt.Fprintln(os.Stdout, "(no vGPUs detected — HAMI integration absent)")
+		case "no_gpu_detected":
+			fmt.Fprintln(os.Stdout, "(no GPUs reported — HAMI integration up but no devices)")
+		case "vgpu_unavailable":
+			// stderr advisory already printed by VgpuUnavailableFromError.
+		}
+		return nil
+	}
+	return WriteListTable(os.Stdout, env)
+}
+
+// BuildListEnvelope assembles the gpu list envelope without any
+// stdout side effects. Honors the standard 3-state empty-data
+// taxonomy (no_vgpu_integration / vgpu_unavailable /
+// no_gpu_detected) and surfaces the GPUAdvisory soft-gate as
+// Meta.Note. Used by RunList (Shape A leaf) and by RunDefault as
+// the `graphics` section (Shape B parent).
+func BuildListEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, now time.Time) pkgdashboard.Envelope {
 	advisoryNote, _ := pkgdashboard.GPUAdvisory(ctx, c, cf, os.Stderr)
 	list, err := pkgdashboard.FetchGraphicsList(ctx, c, nil)
 
@@ -34,11 +67,7 @@ func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 			env.Meta.Empty = true
 			env.Meta.EmptyReason = "no_vgpu_integration"
 			env.Meta.HTTPStatus = he.Status
-			if cf.Output == pkgdashboard.OutputJSON {
-				return pkgdashboard.WriteJSON(os.Stdout, env)
-			}
-			fmt.Fprintln(os.Stdout, "(no vGPUs detected — HAMI integration absent)")
-			return nil
+			return env
 		}
 		if unavail, ok := pkgdashboard.VgpuUnavailableFromError(c, cf, err, pkgdashboard.KindOverviewGPUList, now, os.Stderr); ok {
 			if advisoryNote != "" {
@@ -48,21 +77,20 @@ func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 				// `meta.note` string separated by " | ".
 				unavail.Meta.Note = advisoryNote + " | " + unavail.Meta.Note
 			}
-			if cf.Output == pkgdashboard.OutputJSON {
-				return pkgdashboard.WriteJSON(os.Stdout, unavail)
-			}
-			return nil
+			return unavail
 		}
-		return err
+		// Transport error not classifiable as a soft 4xx/5xx —
+		// surface it on the envelope so RunDefault keeps the tasks
+		// section. RunList's caller branch above maps Output==JSON
+		// to a clean payload too.
+		env.Meta.Error = err.Error()
+		env.Meta.ErrorKind = pkgdashboard.ClassifyTransportErr(err)
+		return env
 	}
 	if len(list) == 0 {
 		env.Meta.Empty = true
 		env.Meta.EmptyReason = "no_gpu_detected"
-		if cf.Output == pkgdashboard.OutputJSON {
-			return pkgdashboard.WriteJSON(os.Stdout, env)
-		}
-		fmt.Fprintln(os.Stdout, "(no GPUs reported — HAMI integration up but no devices)")
-		return nil
+		return env
 	}
 	// Field names below match HAMI's actual response shape (see
 	// SPA's `Graphics` interface in src/apps/dashboard/types/gpu.ts
@@ -73,6 +101,14 @@ func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 	// under `Raw` so agents can pull fields the table doesn't
 	// surface (vgpuUsed/vgpuTotal, nodeUid, memoryUtilizedPercent,
 	// etc.).
+	// Display fields mirror SPA's GPUsTable.vue column set verbatim:
+	// nodeUid is omitted in favour of the more useful uuid (CLI's
+	// `gpu graphics <uuid>` keys on uuid; SPA's column header is
+	// labelled "GPU ID" but the underlying field IS nodeUid in the
+	// SPA — the CLI departs here intentionally so the column value
+	// can be copy-pasted into `graphics <uuid>`). Otherwise: model /
+	// mode / host / health / core_util / vram_total / vram_usage /
+	// power / temperature, in that order.
 	for _, g := range list {
 		raw := map[string]any{}
 		for k, v := range g {
@@ -87,20 +123,20 @@ func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 			"core_util":   percentDirect(toFloat(g["coreUtilizedPercent"])),
 			"vram_total":  gpuVRAMHuman(g["memoryTotal"]),
 			"vram_used":   gpuVRAMHuman(g["memoryUsed"]),
+			"vram_usage":  percentDirect(toFloat(g["memoryUtilizedPercent"])),
 			"power":       fmt.Sprintf("%.2f W", toFloat(g["power"])),
 			"temperature": renderTemperature(toFloat(g["temperature"]), cf.TempUnit),
 		}
 		env.Items = append(env.Items, pkgdashboard.Item{Raw: raw, Display: disp})
 	}
-	if cf.Output == pkgdashboard.OutputJSON {
-		return pkgdashboard.WriteJSON(os.Stdout, env)
-	}
-	return WriteListTable(os.Stdout, env)
+	return env
 }
 
 // WriteListTable renders the per-GPU summary table. Column order
 // is pinned: agent scrapers depend on the index being stable across
-// releases.
+// releases. VRAM_USAGE is the SPA's `memoryUtilizedPercent` column
+// that earlier revisions of this table omitted; readded so the CLI
+// matches Graphics management tab cell-for-cell.
 func WriteListTable(w io.Writer, env pkgdashboard.Envelope) error {
 	cols := []pkgdashboard.TableColumn{
 		{Header: "GPU_ID", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "gpu_id") }},
@@ -110,6 +146,7 @@ func WriteListTable(w io.Writer, env pkgdashboard.Envelope) error {
 		{Header: "HEALTH", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "health") }},
 		{Header: "CORE_UTIL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "core_util") }},
 		{Header: "VRAM", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "vram_total") }},
+		{Header: "VRAM_USAGE", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "vram_usage") }},
 		{Header: "POWER", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "power") }},
 		{Header: "TEMP", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "temperature") }},
 	}

--- a/cli/pkg/dashboard/overview/gpu/list.go
+++ b/cli/pkg/dashboard/overview/gpu/list.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,6 +42,21 @@ func RunList(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 			// stderr advisory already printed by VgpuUnavailableFromError.
 		}
 		return nil
+	}
+	// Unclassifiable transport / 4xx error — BuildListEnvelope
+	// stashes it on Meta.Error (Meta.Empty stays false). JSON mode
+	// returned the envelope as-is above so agents can branch on
+	// `meta.error`; table mode used to fall through to
+	// WriteListTable and render a header + "-" row with no
+	// diagnostic, silently swallowing the failure. Returning the
+	// error here surfaces it to cobra (printed to stderr with a
+	// non-zero exit code), restoring the legacy pre-envelope-split
+	// behaviour. Checked AFTER the Empty switch so the soft empty
+	// states (no_vgpu_integration / vgpu_unavailable / no_gpu_detected)
+	// keep their non-fatal semantics — vgpu_unavailable in particular
+	// sets both Empty AND Error and is intentionally a clean exit.
+	if env.Meta.Error != "" {
+		return errors.New(env.Meta.Error)
 	}
 	return WriteListTable(os.Stdout, env)
 }

--- a/cli/pkg/dashboard/overview/gpu/list_test.go
+++ b/cli/pkg/dashboard/overview/gpu/list_test.go
@@ -62,6 +62,71 @@ func TestRunList_NoVgpuIntegration404(t *testing.T) {
 	}
 }
 
+// TestRunList_TableModeSurfacesTransportError pins Bug 2: when
+// BuildListEnvelope hits a 4xx HAMI response that's neither a 404
+// (no_vgpu_integration) nor a 5xx (vgpu_unavailable) — e.g. a 400
+// from a misconfigured deployment, an auth 401/403, or a generic
+// transport breakage — the envelope captures the error on
+// `Meta.Error` for JSON consumers, but table mode used to silently
+// render an empty table with no diagnostic.
+//
+// Contract: RunList in table mode MUST return that error to cobra
+// so it surfaces on stderr instead of being swallowed. JSON mode
+// keeps emitting the envelope unchanged (consumers parse
+// meta.error directly). The chosen status here (400) is the
+// canonical "unclassifiable" case: a 4xx that doesn't match any
+// of the soft-empty branches.
+func TestRunList_TableModeSurfacesTransportError(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"bad filter"}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	// Explicit table mode — fixtureFlags already defaults here, but
+	// the assertion is about TABLE not JSON, so we pin it locally so
+	// a future fixture flip doesn't silently mute this test.
+	cf.Output = pkgdashboard.OutputTable
+
+	_, runErr := captureStdoutAndErr(t, func() error { return RunList(context.Background(), c, cf) })
+	if runErr == nil {
+		t.Fatal("RunList returned nil; want a non-nil error surfacing Meta.Error in table mode")
+	}
+	if !strings.Contains(runErr.Error(), "400") && !strings.Contains(runErr.Error(), "bad filter") {
+		t.Errorf("RunList err = %q, want it to mention either the HTTP 400 status or the HAMI message 'bad filter' so the user has a diagnostic", runErr)
+	}
+}
+
+// TestRunList_JSONModeKeepsTransportErrorOnEnvelope pins the
+// other half of Bug 2's contract: JSON mode MUST NOT regress to
+// "return err and emit nothing". Agents drive --output json and
+// rely on `meta.error` being present on a non-zero-length envelope
+// — converting that to a cobra-side error would skip the envelope
+// emit entirely and force agents to parse stderr.
+func TestRunList_JSONModeKeepsTransportErrorOnEnvelope(t *testing.T) {
+	srv := gpuStubMux{
+		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"bad filter"}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunList(context.Background(), c, cf) })
+	if !strings.Contains(out, `"error":`) {
+		t.Errorf("expected meta.error in envelope; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"kind":"dashboard.overview.gpu.list"`) {
+		t.Errorf("expected envelope kind to still emit alongside meta.error; got:\n%s", out)
+	}
+}
+
 // TestRunList_NoGPUDetected pins the "HAMI up, zero devices"
 // branch.
 func TestRunList_NoGPUDetected(t *testing.T) {

--- a/cli/pkg/dashboard/overview/gpu/list_test.go
+++ b/cli/pkg/dashboard/overview/gpu/list_test.go
@@ -12,13 +12,13 @@ import (
 // TestRunList_HappyPath pins the table-rendered GPU list shape
 // against an admin profile + CUDA node + 2-device HAMI fixture.
 // The Display columns must match the SPA's column order
-// (GPU_ID/MODEL/MODE/HOST/HEALTH/CORE_UTIL/VRAM/POWER/TEMP).
+// (GPU_ID/MODEL/MODE/HOST/HEALTH/CORE_UTIL/VRAM/VRAM_USAGE/POWER/TEMP).
 func TestRunList_HappyPath(t *testing.T) {
 	srv := gpuStubMux{
 		graphicsList: func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"list":[
-              {"uuid":"GPU-A","type":"NVIDIA-A","shareMode":"0","nodeName":"node-1","health":true,"coreUtilizedPercent":35,"memoryTotal":24576,"memoryUsed":12288,"power":120.5,"temperature":62},
-              {"uuid":"GPU-B","type":"NVIDIA-B","shareMode":"1","nodeName":"node-2","health":false,"coreUtilizedPercent":80,"memoryTotal":81920,"memoryUsed":4096,"power":250,"temperature":81}
+              {"uuid":"GPU-A","type":"NVIDIA-A","shareMode":"0","nodeName":"node-1","health":true,"coreUtilizedPercent":35,"memoryTotal":24576,"memoryUsed":12288,"memoryUtilizedPercent":50,"power":120.5,"temperature":62},
+              {"uuid":"GPU-B","type":"NVIDIA-B","shareMode":"1","nodeName":"node-2","health":false,"coreUtilizedPercent":80,"memoryTotal":81920,"memoryUsed":4096,"memoryUtilizedPercent":5,"power":250,"temperature":81}
             ]}`))
 		},
 	}.server(t)
@@ -33,6 +33,12 @@ func TestRunList_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(out, `"kind":"dashboard.overview.gpu.list"`) {
 		t.Errorf("missing kind=dashboard.overview.gpu.list in:\n%s", out)
+	}
+	// SPA "VRAM usage rate" column — the regression net for the
+	// GPUsTable.vue:159-166 column that earlier CLI revisions did
+	// not surface.
+	if !strings.Contains(out, `"vram_usage":"50%"`) || !strings.Contains(out, `"vram_usage":"5%"`) {
+		t.Errorf("expected vram_usage column for both GPUs (50%% / 5%%); got:\n%s", out)
 	}
 }
 

--- a/cli/pkg/dashboard/overview/gpu/specs.go
+++ b/cli/pkg/dashboard/overview/gpu/specs.go
@@ -3,6 +3,8 @@ package gpu
 import (
 	"context"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -323,14 +325,23 @@ func runGauge(ctx context.Context, c *pkgdashboard.Client, spec gaugeSpec, repl 
 		"title": spec.Title,
 		"unit":  spec.Unit,
 	}
+	// Display formatting mirrors GPUsDetails.vue / TasksDetails.vue:
+	//   • numbers go through lodash.round(value, 2) — `roundDP(2)` here
+	//   • the unit ("Gi" / "W" / "℃" / "%") is rendered next to the
+	//     number by the SPA's <MyGaugeChart unit=…> prop. We bake it
+	//     directly into `value` and `used_total` so the CLI's table
+	//     row reads "23.89 Gi" instead of two columns the agent has
+	//     to concat ("VALUE 23.889648 / UNIT Gi").
+	// `Raw` keeps the un-rounded float so JSON consumers needing
+	// arbitrary precision still get it.
 	if total > 0 && (spec.TotalQuery != "" || spec.TotalLiteral > 0) {
 		disp["percent"] = percentDirect(percent)
-		disp["used_total"] = fmt.Sprintf("%g/%g", used, total)
+		disp["used_total"] = fmt.Sprintf("%s/%s", roundedNumberString(used), roundedNumberString(total))
 	} else {
 		disp["percent"] = "—"
 		disp["used_total"] = "—"
 	}
-	disp["value"] = formatFloat(used)
+	disp["value"] = formatGaugeValue(used, spec.Unit)
 	if valErr != nil || totErr != nil {
 		err := valErr
 		if err == nil {
@@ -347,7 +358,20 @@ func runGauge(ctx context.Context, c *pkgdashboard.Client, spec gaugeSpec, repl 
 // Returns the assembled Item plus the metric labels of the FIRST
 // non-empty response (used to populate device_no / driver_version
 // on the GPU detail page).
-func runTrend(ctx context.Context, c *pkgdashboard.Client, spec trendSpec, repl *strings.Replacer, start, end, step string, addWarning func(string)) (pkgdashboard.Item, map[string]string) {
+//
+// Display formatting (per-point) mirrors the SPA chart axis:
+//   - timestamp is HAMI's epoch (seconds with optional sub-second
+//     decimals OR raw milliseconds — both shapes observed in the
+//     wild from /v1/monitor/query/range-vector). The CLI parses
+//     either via `formatTrendTimestamp` and emits the SPA's
+//     `YYYY-MM-DD HH:mm:ss` in the caller's --timezone. The raw
+//     epoch milliseconds is preserved on `Raw.points[i].timestamp_ms`
+//     so JSON consumers needing the wire shape still get it.
+//   - value goes through lodash.round(value, 2) — same call the
+//     SPA's config.ts:84 does before handing the array to ECharts.
+//     The full-precision float is preserved on
+//     `Raw.points[i].value_raw` for agents that need it.
+func runTrend(ctx context.Context, c *pkgdashboard.Client, spec trendSpec, repl *strings.Replacer, start, end, step string, tz *time.Location, addWarning func(string)) (pkgdashboard.Item, map[string]string) {
 	lineRaws := make([]map[string]any, 0, len(spec.Lines))
 	lineDisps := make([]map[string]any, 0, len(spec.Lines))
 	var firstLabels map[string]string
@@ -380,11 +404,16 @@ func runTrend(ctx context.Context, c *pkgdashboard.Client, spec trendSpec, repl 
 			labels = series[0].Metric
 			for _, p := range series[0].Values {
 				pf := toFloat(p.Value)
+				rounded := roundDP(pf, 2)
+				tsHuman := formatTrendTimestamp(p.Timestamp, tz)
+				tsMS := trendTimestampMillis(p.Timestamp)
 				pointsRaw = append(pointsRaw, map[string]any{
-					"timestamp": p.Timestamp,
-					"value":     pf,
+					"timestamp":    tsHuman,
+					"timestamp_ms": tsMS,
+					"value":        rounded,
+					"value_raw":    pf,
 				})
-				pointsDisp = append(pointsDisp, fmt.Sprintf("%s=%g", p.Timestamp, pf))
+				pointsDisp = append(pointsDisp, fmt.Sprintf("%s=%s", tsHuman, roundedNumberString(rounded)))
 			}
 		}
 		if firstLabels == nil && labels != nil {
@@ -433,9 +462,18 @@ func fanoutGaugeAndTrend(
 	ctx context.Context, c *pkgdashboard.Client,
 	gaugeSpecs []gaugeSpec, trendSpecs []trendSpec,
 	repl *strings.Replacer, start, end, step string,
+	tz *time.Location,
 	addWarning func(string),
 	captureLabelsForTrendKey string,
 ) ([]pkgdashboard.Item, []pkgdashboard.Item, map[string]string) {
+	if tz == nil {
+		// Defensive: callers (BuildDetailFullEnvelope /
+		// BuildTaskDetailFullEnvelope) always pass cf.Timezone, but a
+		// nil here would make formatTrendTimestamp return UTC strings
+		// silently — we'd rather use the local zone (matches
+		// CommonFlags.Validate's empty-flag default).
+		tz = time.Local
+	}
 	gaugeItems := make([]pkgdashboard.Item, len(gaugeSpecs))
 	trendItems := make([]pkgdashboard.Item, len(trendSpecs))
 	var (
@@ -453,7 +491,7 @@ func fanoutGaugeAndTrend(
 	for i, spec := range trendSpecs {
 		i, spec := i, spec
 		g.Go(func() error {
-			item, labels := runTrend(gctx, c, spec, repl, start, end, step, addWarning)
+			item, labels := runTrend(gctx, c, spec, repl, start, end, step, tz, addWarning)
 			trendItems[i] = item
 			if captureLabelsForTrendKey != "" && spec.Key == captureLabelsForTrendKey && len(labels) > 0 {
 				labelMu.Lock()
@@ -472,16 +510,35 @@ func fanoutGaugeAndTrend(
 // ----------------------------------------------------------------------------
 
 // gpuDetailDisplayCopy converts HAMI's flat /v1/gpu body into a
-// human-friendly key/value map. Only the SPA-rendered fields end up
-// here; the full HAMI document is preserved on `Raw` for agents.
+// human-friendly key/value map for the Detail card. The whitelist
+// is the SPA's `columns` array verbatim
+// (GPUsDetails.vue:112-137) — six fields, in this order:
+//
+//	health / uuid / nodeName / type / device_no / driver_version
+//
+// Other HAMI fields (memoryTotal/Used, power, powerLimit,
+// temperature, coreTotal/Used, vgpuTotal/Used, mode, shareMode,
+// nodeUid) are deliberately NOT in `Display` — the SPA covers
+// those numbers via the gauges + trend lineTools cards, and
+// duplicating them here led to:
+//
+//   - misleading zeros: HAMI's flat /v1/gpu returns
+//     `memoryUsed: 0 / power: 0 / temperature: 0` as placeholders
+//     because the LIVE values come from instant-vector queries.
+//     Surfacing those zeros under "Detail" made the user think the
+//     GPU was reporting zero everything.
+//   - unit clutter: `memoryTotal: 24463` (raw MiB) without a unit
+//     suffix; the SPA never shows this number in the detail card,
+//     it shows `23.89 Gi` inside a gauge, so adding a "MiB" suffix
+//     in CLI would still mismatch the SPA value.
+//
+// Agents that need the full HAMI body still get it via `Raw` (the
+// envelope's source-of-truth field). Pinned by
+// TestGpuDetailDisplayCopy_SPAFieldWhitelist.
 func gpuDetailDisplayCopy(d map[string]any) map[string]any {
 	out := map[string]any{}
 	for _, k := range []string{
-		"uuid", "type", "nodeName", "nodeUid", "shareMode",
-		"vgpuUsed", "vgpuTotal", "coreUsed", "coreTotal",
-		"memoryUsed", "memoryTotal",
-		"power", "powerLimit", "temperature",
-		"device_no", "driver_version",
+		"uuid", "nodeName", "type", "device_no", "driver_version",
 	} {
 		if v, ok := d[k]; ok {
 			out[k] = fmt.Sprintf("%v", v)
@@ -490,20 +547,26 @@ func gpuDetailDisplayCopy(d map[string]any) map[string]any {
 	if v, ok := d["health"]; ok {
 		out["health"] = gpuHealthLabel(v)
 	}
-	if v, ok := d["shareMode"]; ok {
-		out["mode"] = gpuModeLabel(v)
-	}
 	return out
 }
 
+// gpuTaskDetailDisplayCopy mirrors `TasksDetails.vue:134-174` —
+// eight fields (six unconditional + two `displayAllocation`-gated)
+// in this order:
+//
+//	status / deviceIds / nodeName / type /
+//	(allocatedCores) / (allocatedMem) / appName / createTime
+//
+// The two allocation rows are emitted only when present in the
+// HAMI body (HAMI omits them for time-slicing tasks); the SPA
+// hides the same rows via `displayAllocation = sharemode !==
+// TimeSlicing`. Other HAMI fields (podUid, namespace, nodeUid,
+// startTime/endTime, flavor, priority, …) live on `Raw` for
+// agents but are NOT in `Display`. Pinned by
+// TestGpuTaskDetailDisplayCopy_SPAFieldWhitelist.
 func gpuTaskDetailDisplayCopy(d map[string]any) map[string]any {
 	out := map[string]any{}
-	for _, k := range []string{
-		"name", "status", "podUid", "nodeName", "nodeUid",
-		"type", "appName", "namespace", "createTime", "startTime", "endTime",
-		"allocatedDevices", "allocatedCores", "allocatedMem",
-		"resourcePool", "flavor", "priority",
-	} {
+	for _, k := range []string{"status", "nodeName", "type", "appName", "createTime"} {
 		if v, ok := d[k]; ok {
 			out[k] = fmt.Sprintf("%v", v)
 		}
@@ -518,13 +581,123 @@ func gpuTaskDetailDisplayCopy(d map[string]any) map[string]any {
 			out["deviceIds"] = strings.Join(parts, ",")
 		case []string:
 			out["deviceIds"] = strings.Join(arr, ",")
+		default:
+			out["deviceIds"] = fmt.Sprintf("%v", v)
 		}
 	}
-	if v, ok := d["deviceShareModes"]; ok {
-		first := firstAnyInArray(v)
-		out["mode"] = gpuModeLabel(first)
+	for _, k := range []string{"allocatedCores", "allocatedMem"} {
+		if v, ok := d[k]; ok {
+			out[k] = fmt.Sprintf("%v", v)
+		}
 	}
 	return out
+}
+
+// roundDP applies the same lodash.round(value, dp) the SPA uses
+// before handing trend points to ECharts (config.ts:84) and gauge
+// values to MyGaugeChart (GPUsDetails.vue:33-49). Banker's rounding
+// is intentionally NOT used — the SPA's lodash.round is half-away-
+// from-zero, and matching that is the whole point of this helper.
+func roundDP(v float64, dp int) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return v
+	}
+	scale := math.Pow(10, float64(dp))
+	return math.Round(v*scale) / scale
+}
+
+// roundedNumberString renders a float at 2dp the way SPA's
+// `String(round(x, 2))` would: trailing zeros stripped, decimal
+// point dropped when integer-valued. "23.89" / "100" / "0.29" — not
+// "23.890000000000004" / "100.00" / "0.290000".
+func roundedNumberString(v float64) string {
+	r := roundDP(v, 2)
+	if math.IsNaN(r) {
+		return "NaN"
+	}
+	if math.IsInf(r, 0) {
+		return "Inf"
+	}
+	// %g with 6-digit precision after rounding gives the SPA-shaped
+	// output for everything in HAMI's observed range. strconv with
+	// 'f' / -1 also works but emits "23.89" → "23.89" while %g
+	// keeps small / large values readable; we pick %g for parity
+	// with the pre-refactor printf path.
+	return strconv.FormatFloat(r, 'f', -1, 64)
+}
+
+// formatGaugeValue renders a gauge's display VALUE column. Mirrors
+// the SPA's `<MyGaugeChart unit=…>` prop: for unit-bearing gauges
+// (Gi, W, ℃) the unit is appended to the number; unit-less gauges
+// (the four "%" / ratio gauges that pass `unit: ' '`) emit just the
+// number. The rounded number always uses roundedNumberString so
+// trailing zeros / float noise are stripped.
+func formatGaugeValue(v float64, unit string) string {
+	num := roundedNumberString(v)
+	switch strings.TrimSpace(unit) {
+	case "", "-":
+		return num
+	default:
+		return num + " " + strings.TrimSpace(unit)
+	}
+}
+
+// formatTrendTimestamp converts HAMI's per-point timestamp into the
+// SPA's `YYYY-MM-DD HH:mm:ss` shape (utils/gpu.ts::timeParse). HAMI
+// is observed to return either:
+//   - a 13-character integer string ("1779636713000") = epoch ms
+//   - a 10-character integer string ("1779636713")    = epoch s
+//   - a float string                ("1779636713.5") = epoch s
+//     with sub-second decimals (Prometheus's wire shape)
+//
+// The detection runs in float64 — a 13-digit integer fits exactly,
+// and any value > 1e12 gets demoted from "seconds" to "milliseconds"
+// because epoch-seconds in 2026 sit at ~1.78e9. Empty / unparsable
+// inputs fall through to the raw string so the user can debug what
+// HAMI actually sent (better than silently rendering "1970-01-01").
+func formatTrendTimestamp(raw string, tz *time.Location) string {
+	if raw == "" {
+		return "-"
+	}
+	if tz == nil {
+		tz = time.Local
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return raw
+	}
+	var sec int64
+	var nsec int64
+	if f >= 1e12 {
+		// epoch milliseconds.
+		ms := int64(math.Round(f))
+		sec = ms / 1000
+		nsec = (ms % 1000) * int64(time.Millisecond)
+	} else {
+		sec = int64(f)
+		nsec = int64((f - float64(sec)) * float64(time.Second))
+	}
+	return time.Unix(sec, nsec).In(tz).Format("2006-01-02 15:04:05")
+}
+
+// trendTimestampMillis preserves the wire-shape epoch-ms integer on
+// the Raw point so JSON consumers needing arbitrary-precision time
+// math (or chart libraries that re-derive from epoch) can still
+// round-trip without re-parsing the human ISO string. Returns 0 on
+// unparsable input — matches HAMI's "no value" sentinel for ints
+// and avoids surfacing a fake epoch.
+func trendTimestampMillis(raw string) int64 {
+	if raw == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0
+	}
+	if f >= 1e12 {
+		return int64(math.Round(f))
+	}
+	return int64(math.Round(f * 1000))
 }
 
 // humanizeSince renders a duration the way the SPA's window picker

--- a/cli/pkg/dashboard/overview/gpu/specs.go
+++ b/cli/pkg/dashboard/overview/gpu/specs.go
@@ -164,9 +164,19 @@ func gpuDetailTrendSpecs() []trendSpec {
 			Key:   "alloc_trend",
 			Title: "Resource allocation trend",
 			Unit:  "%",
+			// Labels mirror the SPA's legend
+			// (`legend: [t('GPU_OP.VRAM'), t('GPU_OP.GPU_MEMORY')]`
+			// in GPUsDetails.vue:223). Note: despite the names, the
+			// FIRST line is fed by `hami_core_*` (compute-power
+			// allocation %) and the SECOND by `hami_memory_*` (VRAM
+			// allocation %) — that's the SPA's chosen wording, and
+			// the CLI must reproduce it 1:1 so agents/users see the
+			// same legend tokens across surfaces. Don't "fix" by
+			// reverting to `core`/`memory` without a coordinated SPA
+			// change.
 			Lines: []trendLine{
-				{Label: "core", Query: allocCorePct},
-				{Label: "memory", Query: allocMemPct},
+				{Label: "VRAM", Query: allocCorePct},
+				{Label: "GPU_MEMORY", Query: allocMemPct},
 			},
 		},
 		{
@@ -174,8 +184,8 @@ func gpuDetailTrendSpecs() []trendSpec {
 			Title: "Resource usage trend",
 			Unit:  "%",
 			Lines: []trendLine{
-				{Label: "core", Query: utilCorePct},
-				{Label: "memory", Query: utilMemPct},
+				{Label: "VRAM", Query: utilCorePct},
+				{Label: "GPU_MEMORY", Query: utilMemPct},
 			},
 		},
 		{

--- a/cli/pkg/dashboard/overview/gpu/task_detail.go
+++ b/cli/pkg/dashboard/overview/gpu/task_detail.go
@@ -190,10 +190,14 @@ func BuildTaskDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf
 	}
 	env.Meta.Window = &pkgdashboard.TimeWindow{
 		Since: humanizeSince(since),
-		Start: pkgdashboard.GPUTrendTimestampISO(start),
-		End:   pkgdashboard.GPUTrendTimestampISO(end),
+		Start: pkgdashboard.GPUTrendTimestampISO(start, cf.Timezone.Time()),
+		End:   pkgdashboard.GPUTrendTimestampISO(end, cf.Timezone.Time()),
 		Step:  pkgdashboard.GPUTrendStep(start, end),
 	}
+	// See BuildDetailFullEnvelope for the wire-vs-render TZ split
+	// rationale. Same contract here.
+	wireStart := pkgdashboard.GPUTrendTimestampWire(start)
+	wireEnd := pkgdashboard.GPUTrendTimestampWire(end)
 
 	detail, err := pkgdashboard.FetchTaskDetail(ctx, c, name, podUID, sharemode)
 	if err != nil {
@@ -240,7 +244,7 @@ func BuildTaskDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf
 	gaugeItems, trendItems, _ := fanoutGaugeAndTrend(
 		ctx, c,
 		gaugeSpecs, trendSpecs,
-		repl, env.Meta.Window.Start, env.Meta.Window.End, env.Meta.Window.Step,
+		repl, wireStart, wireEnd, env.Meta.Window.Step,
 		cf.Timezone.Time(),
 		addWarning,
 		"", // task-detail page doesn't capture power_trend labels

--- a/cli/pkg/dashboard/overview/gpu/task_detail.go
+++ b/cli/pkg/dashboard/overview/gpu/task_detail.go
@@ -13,6 +13,143 @@ import (
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
 )
 
+// RunTaskByRef is the cmd-side entry point for `dashboard
+// overview gpu tasks <ref>` — the SPA-aligned shorthand. `<ref>`
+// matches the row's `name` OR its `podUid` (the two columns the
+// SPA's TasksTable surfaces, and the two values the CLI prints in
+// the bare `gpu` / `gpu tasks` listings — users naturally
+// copy-paste either). The function reverse-resolves the task's
+// pod-uid + sharemode by listing HAMI's /v1/containers (same path
+// the SPA uses when the user clicks "View details"; that click
+// passes podUid + deviceShareModes[0] into the route param). When
+// the ref is unique we delegate to RunTaskDetail; ambiguity /
+// not-found surface as typed errors with a copy-paste-friendly
+// hint listing every candidate (so an agent doesn't have to round-
+// trip the listing endpoint to recover). Empty container list →
+// standard `no_gpu_detected` envelope (single fetch, no fan-out).
+//
+// Pod-uid match wins ties: if the same string somehow matches both
+// a `name` and a `podUid` across two rows (impossible in practice
+// because pod-uids are RFC 4122 UUIDs, but defensive nonetheless),
+// the pod-uid match is used since it's globally unique. Equal-name
+// rows still produce an ambiguity error pointing at the pod-uids.
+func RunTaskByRef(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, ref string) error {
+	now := time.Now()
+	advisoryNote, _ := pkgdashboard.GPUAdvisory(ctx, c, cf, os.Stderr)
+	list, err := pkgdashboard.FetchTaskList(ctx, c, nil)
+	if err != nil {
+		if he, ok := pkgdashboard.IsHTTPError(err); ok && he.Status == http.StatusNotFound {
+			env := pkgdashboard.Envelope{
+				Kind: pkgdashboard.KindOverviewGPUTaskDetFull,
+				Meta: pkgdashboard.NewMeta(now.In(cf.Timezone.Time()), c.OlaresID(), cf.User),
+			}
+			env.Meta.Empty = true
+			env.Meta.EmptyReason = "no_vgpu_integration"
+			env.Meta.HTTPStatus = he.Status
+			if advisoryNote != "" {
+				env.Meta.Note = advisoryNote
+			}
+			if cf.Output == pkgdashboard.OutputJSON {
+				return pkgdashboard.WriteJSON(os.Stdout, env)
+			}
+			fmt.Fprintln(os.Stdout, "(task not found — HAMI integration absent or task ref invalid)")
+			return nil
+		}
+		if unavail, ok := pkgdashboard.VgpuUnavailableFromError(c, cf, err, pkgdashboard.KindOverviewGPUTaskDetFull, now, os.Stderr); ok {
+			if advisoryNote != "" {
+				unavail.Meta.Note = advisoryNote + " | " + unavail.Meta.Note
+			}
+			if cf.Output == pkgdashboard.OutputJSON {
+				return pkgdashboard.WriteJSON(os.Stdout, unavail)
+			}
+			return nil
+		}
+		return err
+	}
+
+	// First pass: exact pod-uid match (globally unique, wins over
+	// name match if both happen to coincide).
+	for _, t := range list {
+		if fmt.Sprintf("%v", t["podUid"]) == ref {
+			name := fmt.Sprintf("%v", t["name"])
+			podUID := fmt.Sprintf("%v", t["podUid"])
+			sharemode := fmt.Sprintf("%v", firstAnyInArray(t["deviceShareModes"]))
+			return RunTaskDetail(ctx, c, cf, name, podUID, sharemode)
+		}
+	}
+	// Second pass: name match — collect all to detect ambiguity.
+	nameMatches := make([]map[string]any, 0, 2)
+	for _, t := range list {
+		if fmt.Sprintf("%v", t["name"]) == ref {
+			nameMatches = append(nameMatches, t)
+		}
+	}
+	switch len(nameMatches) {
+	case 0:
+		env := pkgdashboard.Envelope{
+			Kind: pkgdashboard.KindOverviewGPUTaskDetFull,
+			Meta: pkgdashboard.NewMeta(now.In(cf.Timezone.Time()), c.OlaresID(), cf.User),
+		}
+		env.Meta.Empty = true
+		env.Meta.EmptyReason = "no_gpu_detected"
+		if advisoryNote != "" {
+			env.Meta.Note = advisoryNote
+		}
+		if cf.Output == pkgdashboard.OutputJSON {
+			return pkgdashboard.WriteJSON(os.Stdout, env)
+		}
+		fmt.Fprintf(os.Stdout, "(no task matches %q — neither a name nor a pod-uid in HAMI's container list)\n", ref)
+		// Nudge the user toward the listing command so they can
+		// copy a real ref. Skip when the list itself is empty.
+		if hint := candidateHintLine(list); hint != "" {
+			fmt.Fprintln(os.Stdout, hint)
+		}
+		return nil
+	case 1:
+		t := nameMatches[0]
+		name := fmt.Sprintf("%v", t["name"])
+		podUID := fmt.Sprintf("%v", t["podUid"])
+		sharemode := fmt.Sprintf("%v", firstAnyInArray(t["deviceShareModes"]))
+		return RunTaskDetail(ctx, c, cf, name, podUID, sharemode)
+	default:
+		// Multiple tasks share the name. Mirror the SPA: it never
+		// allows ambiguity because the user clicks the row directly,
+		// but the CLI must produce a deterministic error AND the
+		// disambiguating ref each pod-uid maps to so the user can
+		// re-run without re-listing.
+		uids := make([]string, 0, len(nameMatches))
+		for _, m := range nameMatches {
+			uids = append(uids, fmt.Sprintf("%v", m["podUid"]))
+		}
+		return fmt.Errorf("task name %q matches %d running pods (%s); rerun with one of the pod-uids: olares-cli dashboard overview gpu tasks <pod-uid>",
+			ref, len(nameMatches), strings.Join(uids, ", "))
+	}
+}
+
+// candidateHintLine renders a short "available refs" suggestion
+// for the not-found prose path. Lists at most 5 distinct names +
+// the matching pod-uid so the user has a concrete copy target;
+// returns "" when the input list is empty (the calling site
+// already prints a plain "not found" line in that case).
+func candidateHintLine(list []map[string]any) string {
+	if len(list) == 0 {
+		return ""
+	}
+	const maxShown = 5
+	pairs := make([]string, 0, maxShown)
+	for i, t := range list {
+		if i >= maxShown {
+			break
+		}
+		pairs = append(pairs, fmt.Sprintf("%v (%v)", t["name"], t["podUid"]))
+	}
+	more := ""
+	if len(list) > maxShown {
+		more = fmt.Sprintf(", … +%d more", len(list)-maxShown)
+	}
+	return fmt.Sprintf("hint: try one of: %s%s", strings.Join(pairs, ", "), more)
+}
+
 // RunTaskDetail is the cmd-side entry point for `dashboard
 // overview gpu task-detail <name> <pod-uid>`. Watch-aware (Runner
 // with 30s recommended cadence); sharemode is the SPA-supplied

--- a/cli/pkg/dashboard/overview/gpu/task_detail.go
+++ b/cli/pkg/dashboard/overview/gpu/task_detail.go
@@ -241,6 +241,7 @@ func BuildTaskDetailFullEnvelope(ctx context.Context, c *pkgdashboard.Client, cf
 		ctx, c,
 		gaugeSpecs, trendSpecs,
 		repl, env.Meta.Window.Start, env.Meta.Window.End, env.Meta.Window.Step,
+		cf.Timezone.Time(),
 		addWarning,
 		"", // task-detail page doesn't capture power_trend labels
 	)

--- a/cli/pkg/dashboard/overview/gpu/tasks.go
+++ b/cli/pkg/dashboard/overview/gpu/tasks.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,6 +37,14 @@ func RunTasks(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Comm
 			// stderr advisory already printed by VgpuUnavailableFromError.
 		}
 		return nil
+	}
+	// Mirror of RunList: surface an unclassifiable transport /
+	// 4xx error stashed on Meta.Error to cobra instead of falling
+	// through to an empty-table render. JSON mode is handled by
+	// the early return above (consumers see the envelope with
+	// meta.error populated). See RunList for the full rationale.
+	if env.Meta.Error != "" {
+		return errors.New(env.Meta.Error)
 	}
 	return WriteTasksTable(os.Stdout, env)
 }

--- a/cli/pkg/dashboard/overview/gpu/tasks.go
+++ b/cli/pkg/dashboard/overview/gpu/tasks.go
@@ -16,8 +16,35 @@ import (
 // RunList — kept open-coded per leaf so each leaf's HTTP-status
 // branches stay close to the call site (the SPA's task page does
 // the same).
+//
+// Implementation: BuildTasksEnvelope produces the envelope (no
+// stdout); RunTasks adds the legacy "(no vGPU tasks)" prose lines
+// and the table writer. RunDefault (sections envelope) reuses
+// BuildTasksEnvelope directly so a tasks-section transport error
+// doesn't print prose ahead of the graphics section.
 func RunTasks(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags) error {
 	now := time.Now()
+	env := BuildTasksEnvelope(ctx, c, cf, now)
+	if cf.Output == pkgdashboard.OutputJSON {
+		return pkgdashboard.WriteJSON(os.Stdout, env)
+	}
+	if env.Meta.Empty {
+		switch env.Meta.EmptyReason {
+		case "no_vgpu_integration", "no_gpu_detected":
+			fmt.Fprintln(os.Stdout, "(no vGPU tasks)")
+		case "vgpu_unavailable":
+			// stderr advisory already printed by VgpuUnavailableFromError.
+		}
+		return nil
+	}
+	return WriteTasksTable(os.Stdout, env)
+}
+
+// BuildTasksEnvelope assembles the gpu tasks envelope without any
+// stdout side effects. Same 3-state empty-data taxonomy as
+// BuildListEnvelope. Used by RunTasks (Shape A leaf) and by
+// RunDefault as the `tasks` section (Shape B parent).
+func BuildTasksEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, now time.Time) pkgdashboard.Envelope {
 	advisoryNote, _ := pkgdashboard.GPUAdvisory(ctx, c, cf, os.Stderr)
 	list, err := pkgdashboard.FetchTaskList(ctx, c, nil)
 
@@ -33,31 +60,22 @@ func RunTasks(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Comm
 			env.Meta.Empty = true
 			env.Meta.EmptyReason = "no_vgpu_integration"
 			env.Meta.HTTPStatus = he.Status
-			if cf.Output == pkgdashboard.OutputJSON {
-				return pkgdashboard.WriteJSON(os.Stdout, env)
-			}
-			fmt.Fprintln(os.Stdout, "(no vGPU tasks)")
-			return nil
+			return env
 		}
 		if unavail, ok := pkgdashboard.VgpuUnavailableFromError(c, cf, err, pkgdashboard.KindOverviewGPUTasks, now, os.Stderr); ok {
 			if advisoryNote != "" {
 				unavail.Meta.Note = advisoryNote + " | " + unavail.Meta.Note
 			}
-			if cf.Output == pkgdashboard.OutputJSON {
-				return pkgdashboard.WriteJSON(os.Stdout, unavail)
-			}
-			return nil
+			return unavail
 		}
-		return err
+		env.Meta.Error = err.Error()
+		env.Meta.ErrorKind = pkgdashboard.ClassifyTransportErr(err)
+		return env
 	}
 	if len(list) == 0 {
 		env.Meta.Empty = true
 		env.Meta.EmptyReason = "no_gpu_detected"
-		if cf.Output == pkgdashboard.OutputJSON {
-			return pkgdashboard.WriteJSON(os.Stdout, env)
-		}
-		fmt.Fprintln(os.Stdout, "(no vGPU tasks)")
-		return nil
+		return env
 	}
 	// HAMI's task entries match the SPA's `TaskItem` interface.
 	// The "core util / mem used" columns are arrays (one element
@@ -83,10 +101,7 @@ func RunTasks(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Comm
 		}
 		env.Items = append(env.Items, pkgdashboard.Item{Raw: raw, Display: disp})
 	}
-	if cf.Output == pkgdashboard.OutputJSON {
-		return pkgdashboard.WriteJSON(os.Stdout, env)
-	}
-	return WriteTasksTable(os.Stdout, env)
+	return env
 }
 
 // WriteTasksTable renders the per-task summary table.

--- a/cli/pkg/dashboard/overview/gpu/tasks_test.go
+++ b/cli/pkg/dashboard/overview/gpu/tasks_test.go
@@ -52,3 +52,164 @@ func TestRunTasks_NoVgpuIntegration404(t *testing.T) {
 		t.Errorf("missing no_vgpu_integration; got:\n%s", out)
 	}
 }
+
+// TestRunTaskByRef_ResolvesPodUIDFromList — happy path for the
+// `gpu tasks <ref>` shorthand. With a single-name match in the
+// task list the resolver MUST forward to RunTaskDetail with the
+// auto-resolved pod-uid + sharemode, producing a
+// `dashboard.overview.gpu.task.detail.full` envelope. The user
+// should never have to copy-paste pod-uid from kubectl.
+func TestRunTaskByRef_ResolvesPodUIDFromList(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"comfyai","status":"running","appName":"comfyai-7d4f4915-7d-zwmgs","namespace":"ns-1","podUid":"pod-uid-A","nodeName":"node-1","deviceShareModes":["2"],"devicesCoreUtilizedPercent":[0],"devicesMemUtilized":[256]}
+            ]}`))
+		},
+		taskGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"name":"comfyai","status":"running","appName":"comfyai-7d4f4915-7d-zwmgs","namespace":"ns-1","podUid":"pod-uid-A","deviceShareModes":["2"]}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunTaskByRef(context.Background(), c, cf, "comfyai") })
+	if !strings.Contains(out, `"kind":"dashboard.overview.gpu.task.detail.full"`) {
+		t.Errorf("expected full task-detail envelope; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"comfyai"`) {
+		t.Errorf("expected resolved task name in detail body; got:\n%s", out)
+	}
+}
+
+// TestRunTaskByRef_ResolvesByPodUID — pinned regression for the
+// "user copy-pasted POD_UID column instead of TASK column" path
+// (the bug that prompted RunTaskByRef in the first place). The
+// resolver MUST treat the arg as a pod-uid and produce the same
+// detail envelope the name-arg path does. Without this the
+// listing-then-drill-down workflow breaks for any user whose eye
+// lands on the rightmost column first.
+func TestRunTaskByRef_ResolvesByPodUID(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"comfyai","status":"running","appName":"comfyai-7d4f4915-7d-zwmgs","namespace":"ns-1","podUid":"d2a8ea32-8e56-49f9-b876-21b2fa0c5a83","nodeName":"node-1","deviceShareModes":["2"]}
+            ]}`))
+		},
+		taskGet: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"name":"comfyai","status":"running","appName":"comfyai-7d4f4915-7d-zwmgs","namespace":"ns-1","podUid":"d2a8ea32-8e56-49f9-b876-21b2fa0c5a83","deviceShareModes":["2"]}`))
+		},
+		instantVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+		rangeVector: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error {
+		return RunTaskByRef(context.Background(), c, cf, "d2a8ea32-8e56-49f9-b876-21b2fa0c5a83")
+	})
+	if !strings.Contains(out, `"kind":"dashboard.overview.gpu.task.detail.full"`) {
+		t.Errorf("pod-uid ref must resolve to the same detail envelope as a name ref; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"comfyai"`) {
+		t.Errorf("expected pod-uid lookup to recover the row's name (comfyai); got:\n%s", out)
+	}
+}
+
+// TestRunTaskByRef_NotFoundEmitsNoGPUDetected — when the ref
+// matches neither a name nor a pod-uid the resolver MUST emit a
+// standard `no_gpu_detected` envelope (not error out) and, in
+// table mode, suggest the actual candidates so the user can
+// recover without re-running the listing command.
+func TestRunTaskByRef_NotFoundEmitsNoGPUDetected(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunTaskByRef(context.Background(), c, cf, "ghost") })
+	if !strings.Contains(out, `"empty_reason":"no_gpu_detected"`) {
+		t.Errorf("expected empty_reason=no_gpu_detected; got:\n%s", out)
+	}
+}
+
+// TestRunTaskByRef_NotFoundTableShowsHint — table-mode counterpart
+// of the above: when the ref doesn't match anything but the list
+// has rows, the user should see a "(no task matches …)" line plus
+// a hint listing real (name, pod-uid) pairs they can copy.
+func TestRunTaskByRef_NotFoundTableShowsHint(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"comfyai","podUid":"pod-A","deviceShareModes":["2"]},
+              {"name":"trainer","podUid":"pod-B","deviceShareModes":["0"]}
+            ]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputTable
+
+	out := captureStdout(t, func() error { return RunTaskByRef(context.Background(), c, cf, "ghost") })
+	for _, want := range []string{
+		`(no task matches "ghost"`,
+		"hint: try one of:",
+		"comfyai (pod-A)",
+		"trainer (pod-B)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table-mode not-found output missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunTaskByRef_AmbiguousErrorsWithCandidates — two pods sharing
+// the same task name MUST surface a typed error listing the
+// candidate pod-uids. Pod-uids are themselves valid refs so the
+// hint says `gpu tasks <pod-uid>` (the disambiguating re-run) —
+// not the legacy `gpu task-detail <name> <pod-uid>` two-arg form.
+func TestRunTaskByRef_AmbiguousErrorsWithCandidates(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"items":[
+              {"name":"trainer","podUid":"pod-A","deviceShareModes":["0"]},
+              {"name":"trainer","podUid":"pod-B","deviceShareModes":["0"]}
+            ]}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	err := RunTaskByRef(context.Background(), c, cf, "trainer")
+	if err == nil {
+		t.Fatal("expected ambiguity error; got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{`"trainer"`, "pod-A", "pod-B", "gpu tasks <pod-uid>"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ambiguity error %q missing %q", msg, want)
+		}
+	}
+}

--- a/cli/pkg/dashboard/overview/gpu/tasks_test.go
+++ b/cli/pkg/dashboard/overview/gpu/tasks_test.go
@@ -53,6 +53,58 @@ func TestRunTasks_NoVgpuIntegration404(t *testing.T) {
 	}
 }
 
+// TestRunTasks_TableModeSurfacesTransportError pins Bug 2's
+// RunTasks half. Same contract as the RunList counterpart: an
+// unclassifiable 4xx (here 400) must surface to cobra in table
+// mode instead of being silently absorbed into an empty table.
+// The bug let the user see a header row + a "-" placeholder line
+// with no indication that the upstream call failed.
+func TestRunTasks_TableModeSurfacesTransportError(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"bad filter"}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputTable
+
+	_, runErr := captureStdoutAndErr(t, func() error { return RunTasks(context.Background(), c, cf) })
+	if runErr == nil {
+		t.Fatal("RunTasks returned nil; want a non-nil error surfacing Meta.Error in table mode")
+	}
+	if !strings.Contains(runErr.Error(), "400") && !strings.Contains(runErr.Error(), "bad filter") {
+		t.Errorf("RunTasks err = %q, want it to mention HTTP 400 or 'bad filter' so the user has a diagnostic", runErr)
+	}
+}
+
+// TestRunTasks_JSONModeKeepsTransportErrorOnEnvelope — RunTasks
+// JSON path must keep emitting the envelope with meta.error
+// populated. See the RunList equivalent for the rationale (agents
+// shouldn't have to parse stderr to detect a failed iteration).
+func TestRunTasks_JSONModeKeepsTransportErrorOnEnvelope(t *testing.T) {
+	srv := gpuStubMux{
+		taskList: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"bad filter"}`))
+		},
+	}.server(t)
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+	cf.Output = pkgdashboard.OutputJSON
+
+	out := captureStdout(t, func() error { return RunTasks(context.Background(), c, cf) })
+	if !strings.Contains(out, `"error":`) {
+		t.Errorf("expected meta.error in envelope; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"kind":"dashboard.overview.gpu.tasks"`) {
+		t.Errorf("expected envelope kind to still emit alongside meta.error; got:\n%s", out)
+	}
+}
+
 // TestRunTaskByRef_ResolvesPodUIDFromList — happy path for the
 // `gpu tasks <ref>` shorthand. With a single-name match in the
 // task list the resolver MUST forward to RunTaskDetail with the

--- a/cli/pkg/dashboard/overview/memory.go
+++ b/cli/pkg/dashboard/overview/memory.go
@@ -71,10 +71,30 @@ func memoryPhysicalDisplay(node string, last map[string]format.LastMonitoringSam
 	return raw, disp
 }
 
+// memorySwapMetricSet — the SPA's "memory exchange" view doesn't
+// have swap-specific total/used metrics: KubeSphere's prometheus
+// PromQL registry only exposes physical-memory totals and the two
+// `node_vmstat_pswp{in,out}_bytes` rate series (see
+// infrastructure/kubesphere/.../promql.go). So the SPA renders swap
+// page header with the physical memory totals + the swap-in / -out
+// throughput rates (Overview2/Memory/config.ts:getMemoryExchange*).
+//
+// History: an earlier revision listed `node_memory_swap_total /
+// _swap_used / _pgpgin_rate / _pgpgout_rate` — none of which the
+// kapis monitoring service knows about, so every column rendered
+// "-" in production. This test fixture (memory_test.go) used to
+// hard-code those non-existent names which is why the bug went
+// uncaught for so long. Keep this list in sync with what
+// `promql.go` actually maps; if you add a metric here that isn't
+// in `named_metrics.go` the upstream filters it out and you get
+// silent dashes.
 func memorySwapMetricSet() []string {
 	return []string{
-		"node_memory_swap_total", "node_memory_swap_used",
-		"node_memory_pgpgin_rate", "node_memory_pgpgout_rate",
+		"node_memory_total",
+		"node_memory_usage_wo_cache",
+		"node_memory_utilisation",
+		"node_vmstat_pswpin_bytes",
+		"node_vmstat_pswpout_bytes",
 	}
 }
 
@@ -83,29 +103,30 @@ func memorySwapColumns() []pkgdashboard.TableColumn {
 		{Header: "NODE", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "node") }},
 		{Header: "TOTAL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "total") }},
 		{Header: "USED", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "used") }},
-		{Header: "PG_IN", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "pg_in") }},
-		{Header: "PG_OUT", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "pg_out") }},
+		{Header: "SWAP_IN", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "swap_in") }},
+		{Header: "SWAP_OUT", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "swap_out") }},
 		{Header: "UTIL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "util") }},
 	}
 }
 
 func memorySwapDisplay(node string, last map[string]format.LastMonitoringSample) (map[string]any, map[string]any) {
-	total := sampleFloat(last["node_memory_swap_total"])
-	used := sampleFloat(last["node_memory_swap_used"])
-	pgIn := sampleFloat(last["node_memory_pgpgin_rate"])
-	pgOut := sampleFloat(last["node_memory_pgpgout_rate"])
-	util := safeRatio(used, total)
+	total := sampleFloat(last["node_memory_total"])
+	used := sampleFloat(last["node_memory_usage_wo_cache"])
+	util := sampleFloat(last["node_memory_utilisation"])
+	swapIn := sampleFloat(last["node_vmstat_pswpin_bytes"])
+	swapOut := sampleFloat(last["node_vmstat_pswpout_bytes"])
 	raw := map[string]any{
-		"node": node, "total": total, "used": used, "pg_in": pgIn, "pg_out": pgOut,
+		"node": node, "total": total, "used": used,
+		"swap_in_bps": swapIn, "swap_out_bps": swapOut,
 		"util": util, "mode": "swap",
 	}
 	disp := map[string]any{
-		"node":   node,
-		"total":  format.GetDiskSize(formatFloat(total)),
-		"used":   format.GetDiskSize(formatFloat(used)),
-		"pg_in":  format.WorthValue(formatFloat(pgIn)),
-		"pg_out": format.WorthValue(formatFloat(pgOut)),
-		"util":   percentString(util),
+		"node":     node,
+		"total":    format.GetDiskSize(formatFloat(total)),
+		"used":     format.GetDiskSize(formatFloat(used)),
+		"swap_in":  format.GetThroughput(formatFloat(swapIn)),
+		"swap_out": format.GetThroughput(formatFloat(swapOut)),
+		"util":     percentString(util),
 	}
 	return raw, disp
 }

--- a/cli/pkg/dashboard/overview/memory_test.go
+++ b/cli/pkg/dashboard/overview/memory_test.go
@@ -30,10 +30,8 @@ func memorySrv(t *testing.T) *httptest.Server {
           {"metric_name":"node_memory_utilisation","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"0.25"]}]}},
           {"metric_name":"node_memory_cached","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"1073741824"]}]}},
           {"metric_name":"node_memory_buffers","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"536870912"]}]}},
-          {"metric_name":"node_memory_swap_total","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"4294967296"]}]}},
-          {"metric_name":"node_memory_swap_used","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"1073741824"]}]}},
-          {"metric_name":"node_memory_pgpgin_rate","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"100"]}]}},
-          {"metric_name":"node_memory_pgpgout_rate","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"50"]}]}}
+          {"metric_name":"node_vmstat_pswpin_bytes","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"100"]}]}},
+          {"metric_name":"node_vmstat_pswpout_bytes","data":{"result":[{"metric":{"node":"olares-1"},"value":[1714600000,"50"]}]}}
         ]}`))
 	}))
 }
@@ -75,9 +73,11 @@ func TestMemoryPhysicalMode(t *testing.T) {
 }
 
 // TestMemorySwapMode pins the swap-mode divergence: Raw.mode =
-// "swap", PG_IN / PG_OUT columns populated, and util computed
-// locally as used/total since swap_utilisation isn't a separate
-// upstream series.
+// "swap", SWAP_IN / SWAP_OUT columns populated with throughput
+// rates from `node_vmstat_pswp{in,out}_bytes`, and total/used/util
+// reuse the physical memory series the SPA's "exchange" panel
+// also relies on (KubeSphere doesn't expose a dedicated
+// swap_total / swap_used pair).
 func TestMemorySwapMode(t *testing.T) {
 	srv := memorySrv(t)
 	defer srv.Close()
@@ -97,15 +97,14 @@ func TestMemorySwapMode(t *testing.T) {
 	if row.Raw["mode"] != "swap" {
 		t.Errorf("Raw.mode = %v, want swap", row.Raw["mode"])
 	}
-	for _, key := range []string{"total", "used", "pg_in", "pg_out", "util"} {
+	for _, key := range []string{"total", "used", "swap_in", "swap_out", "util"} {
 		if v, ok := row.Display[key]; !ok || v == nil {
 			t.Errorf("Display missing %q key", key)
 		}
 	}
-	// 1 GiB used / 4 GiB total = 25% — locally computed by
-	// safeRatio rather than a dedicated upstream metric.
+	// 4 GiB used / 16 GiB total => upstream node_memory_utilisation = 0.25 -> "25%".
 	if row.Display["util"] != "25%" {
-		t.Errorf("util = %v, want 25%% (used/total locally)", row.Display["util"])
+		t.Errorf("util = %v, want 25%% (from node_memory_utilisation)", row.Display["util"])
 	}
 }
 

--- a/cli/pkg/dashboard/overview/physical.go
+++ b/cli/pkg/dashboard/overview/physical.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
@@ -53,6 +54,31 @@ func RunPhysical(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.C
 // sections envelope (RunDefault). cf is threaded through so the
 // monitoring fetch honours --since / --start / --end without going
 // through a global; otherwise the function stays cobra-agnostic.
+//
+// Row inventory (mirrors the SPA's `Overview2/ClusterResource.vue`
+// card stack — every visible card on the page becomes a row here):
+//
+//  1. cpu / memory / disk / pods / net_in / net_out — always emitted
+//     from the kapis cluster monitoring fetch.
+//  2. gpu — only when HAMI vGPU is installed AND the GPU list is
+//     non-empty. Aggregates `memoryUsed` / `memoryTotal` (MiB)
+//     across every device, presented in bytes so the SPA-aligned
+//     GiB/TiB unit inference picks the right suffix. HAMI 404 / 5xx
+//     just drops the row (matches the SPA hiding the GPU card when
+//     the card-gauge fetch comes back empty); the failure is
+//     surfaced via Meta.Warnings so JSON consumers can demux.
+//  3. fan_cpu / fan_gpu — only when EnsureSystemStatus reports an
+//     Olares One device AND `/user-service/api/mdns/olares-one/cpu-gpu`
+//     responds successfully. Each row holds the live RPM reading
+//     against the `FanSpeedMaxCPU / FanSpeedMaxGPU` constants the
+//     SPA uses; non-Olares-One / fan endpoint 404 just drops
+//     these rows. Mirrors the SPA's `FanStore.isOlaresOneDevice`
+//     gate.
+//
+// Soft-failure semantics: a missing GPU or fan card NEVER aborts
+// the envelope. The 6 always-emitted rows ship even if every
+// optional card fails. Only an upstream cluster-metrics failure
+// (`FetchClusterMetrics`) returns an error from this function.
 func BuildPhysicalEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, now time.Time) (pkgdashboard.Envelope, error) {
 	metrics := []string{
 		"cluster_cpu_usage", "cluster_cpu_total", "cluster_cpu_utilisation",
@@ -67,6 +93,43 @@ func BuildPhysicalEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgd
 	}
 	last := format.GetLastMonitoringData(res, 0)
 	rows := DerivePhysicalRows(last)
+
+	// Optional fan-out: GPU summary + fan readings. Run in
+	// parallel so a slow / 404 HAMI doesn't gate the fan probe
+	// and vice versa. Each branch writes to its own slot so the
+	// final row order stays deterministic regardless of which
+	// goroutine completes first (gpu first, then fan_cpu /
+	// fan_gpu — matches the SPA's `ClusterResource.vue` card
+	// stack order). Warnings accumulate behind a mutex.
+	var (
+		warnMu        sync.Mutex
+		extraWarnings []string
+		gpuRow        PhysicalMetric
+		gpuRowOK      bool
+		fanRows       []PhysicalMetric
+	)
+	addWarning := func(msg string) {
+		warnMu.Lock()
+		extraWarnings = append(extraWarnings, msg)
+		warnMu.Unlock()
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		gpuRow, gpuRowOK = buildGPUSummaryRow(ctx, c, addWarning)
+	}()
+	go func() {
+		defer wg.Done()
+		fanRows = buildFanRows(ctx, c, addWarning)
+	}()
+	wg.Wait()
+
+	if gpuRowOK {
+		rows = append(rows, gpuRow)
+	}
+	rows = append(rows, fanRows...)
+
 	items := make([]pkgdashboard.Item, 0, len(rows))
 	for _, r := range rows {
 		raw := map[string]any{
@@ -89,11 +152,170 @@ func BuildPhysicalEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgd
 		}
 		items = append(items, pkgdashboard.Item{Raw: raw, Display: display})
 	}
-	return pkgdashboard.Envelope{
+	env := pkgdashboard.Envelope{
 		Kind:  pkgdashboard.KindOverviewPhysical,
 		Meta:  pkgdashboard.NewMeta(now.In(cf.Timezone.Time()), c.OlaresID(), cf.User),
 		Items: items,
-	}, nil
+	}
+	if len(extraWarnings) > 0 {
+		env.Meta.Warnings = extraWarnings
+	}
+	return env, nil
+}
+
+// SPA-aligned PromQL for the cluster-overview GPU card. Lifted
+// 1:1 from `Overview2/ClusterResource.vue:cardGaugeConfig` —
+// `avg(sum(...) by (instance))` collapses HAMI's per-instance
+// metrics down to a single cluster-wide value (HAMI's WebUI
+// multiplexes instances and the SPA renders the average; we mirror
+// that to keep the CLI number == SPA card number). Result unit is
+// MiB (raw `hami_memory_used / hami_memory_size` are MiB on the
+// wire); we convert to bytes downstream so format.GetDiskSize can
+// pick the right Gi/Ti suffix.
+const (
+	gpuSummaryUsedQuery  = `avg(sum(hami_memory_used) by (instance))`
+	gpuSummaryTotalQuery = `avg(sum(hami_memory_size) by (instance))`
+)
+
+// buildGPUSummaryRow mirrors the SPA's cluster-overview GPU card
+// 1:1. Two stages:
+//
+//  1. Primary: HAMI prom queries (cardGaugeConfig in
+//     Overview2/ClusterResource.vue). `hami_memory_used` covers
+//     ALL VRAM consumption — vGPU containers AND raw CUDA
+//     processes the device-level allocation table doesn't track.
+//     This is what the SPA renders and so the CLI shows the same
+//     number as the dashboard browser tab.
+//  2. Fallback: aggregate `g["memoryUsed"] / g["memoryTotal"]`
+//     across `/v1/gpus`. Used when prom is missing, misconfigured,
+//     or returns no series — keeps a non-zero total visible so the
+//     row doesn't disappear just because hami-prometheus is down.
+//     Note: the fallback total is always correct, but `used` will
+//     undercount when no vGPU is allocated (it's the
+//     allocation-table number, not the actual VRAM consumption).
+//
+// Returns ok=false (no row) when:
+//   - HAMI's /v1/gpus returns 404 (no vGPU integration), and
+//   - the prom path also has no series / errored.
+//   - Or both succeeded but reported total = 0 (no devices).
+//
+// 5xx from either source emits a `gpu_summary: ...` warning so
+// agents can branch on len(meta.warnings)>0 without scanning each
+// section.
+func buildGPUSummaryRow(ctx context.Context, c *pkgdashboard.Client, addWarning func(string)) (PhysicalMetric, bool) {
+	usedMiB, totalMiB, promOK := fetchGPUSummaryFromProm(ctx, c, addWarning)
+	if !promOK {
+		// Prom unavailable -> fall back to list aggregation.
+		// The list endpoint may itself be 404 (no HAMI at all)
+		// in which case we just skip the row.
+		usedMiB, totalMiB, _ = fetchGPUSummaryFromList(ctx, c, addWarning)
+	}
+	if totalMiB <= 0 {
+		return PhysicalMetric{}, false
+	}
+	usedBytes := usedMiB * 1024 * 1024
+	totalBytes := totalMiB * 1024 * 1024
+	return PhysicalMetric{
+		Key:         "gpu",
+		Label:       "GPU",
+		Value:       usedBytes,
+		Total:       totalBytes,
+		Unit:        format.GetSuitableUnit(totalBytes, format.UnitTypeMemory),
+		Utilisation: safeRatio(usedBytes, totalBytes),
+	}, true
+}
+
+// fetchGPUSummaryFromProm runs the SPA-aligned instant-vector
+// queries. Returns (used MiB, total MiB, ok). ok=false when EITHER
+// query hard-failed; an empty `data: []` response is NOT a hard
+// failure (HAMI prom under "no scrape data" returns an empty
+// vector — the caller falls back to list aggregation).
+func fetchGPUSummaryFromProm(ctx context.Context, c *pkgdashboard.Client, addWarning func(string)) (used, total float64, ok bool) {
+	usedSamples, errU := pkgdashboard.FetchInstantVector(ctx, c, gpuSummaryUsedQuery)
+	totalSamples, errT := pkgdashboard.FetchInstantVector(ctx, c, gpuSummaryTotalQuery)
+	if errU != nil || errT != nil {
+		err := errU
+		if err == nil {
+			err = errT
+		}
+		if he, isHTTP := pkgdashboard.IsHTTPError(err); isHTTP && he.Status >= 500 {
+			addWarning(fmt.Sprintf("gpu_summary (prom): HAMI %d", he.Status))
+		}
+		return 0, 0, false
+	}
+	if len(totalSamples) == 0 {
+		// Prom is up but no series — caller falls back.
+		return 0, 0, false
+	}
+	if len(usedSamples) > 0 {
+		used = usedSamples[0].Value
+	}
+	total = totalSamples[0].Value
+	return used, total, true
+}
+
+// fetchGPUSummaryFromList is the prom-fallback path. Sums
+// `memoryUsed` / `memoryTotal` (MiB) across /v1/gpus. Returns
+// ok=false when HAMI's list endpoint itself errored or returned
+// an empty list.
+func fetchGPUSummaryFromList(ctx context.Context, c *pkgdashboard.Client, addWarning func(string)) (used, total float64, ok bool) {
+	list, err := pkgdashboard.FetchGraphicsList(ctx, c, nil)
+	if err != nil {
+		if he, isHTTP := pkgdashboard.IsHTTPError(err); isHTTP && he.Status >= 500 {
+			addWarning(fmt.Sprintf("gpu_summary (list): HAMI %d", he.Status))
+		}
+		return 0, 0, false
+	}
+	if len(list) == 0 {
+		return 0, 0, false
+	}
+	for _, g := range list {
+		used += pkgdashboard.ToFloat(g["memoryUsed"])
+		total += pkgdashboard.ToFloat(g["memoryTotal"])
+	}
+	return used, total, true
+}
+
+// buildFanRows returns the two fan rows (cpu / gpu) when running
+// on an Olares One device with the cooling endpoint reachable.
+// Off-device or fan endpoint 404 → empty slice. Mirrors the SPA's
+// `FanStore.isOlaresOneDevice` gate inside ClusterResource.vue
+// (the fan card is appended to the cluster-overview options only
+// when that flag is true).
+func buildFanRows(ctx context.Context, c *pkgdashboard.Client, addWarning func(string)) []PhysicalMetric {
+	st, err := c.EnsureSystemStatus(ctx)
+	if err != nil || st == nil || !st.IsOlaresOne() {
+		return nil
+	}
+	fan, err := pkgdashboard.FetchSystemFan(ctx, c)
+	if err != nil {
+		if he, ok := pkgdashboard.IsHTTPError(err); ok && he.Status >= 500 {
+			addWarning(fmt.Sprintf("fan_live: cooling endpoint %d", he.Status))
+		}
+		return nil
+	}
+	cpuMax := float64(pkgdashboard.FanSpeedMaxCPU)
+	gpuMax := float64(pkgdashboard.FanSpeedMaxGPU)
+	return []PhysicalMetric{
+		{
+			Key:         "fan_cpu",
+			Label:       "Fan CPU",
+			Value:       fan.CPUFanSpeed,
+			Total:       cpuMax,
+			Unit:        "RPM",
+			Utilisation: safeRatio(fan.CPUFanSpeed, cpuMax),
+			Detail:      fmt.Sprintf("%.0f / %.0f RPM", fan.CPUFanSpeed, cpuMax),
+		},
+		{
+			Key:         "fan_gpu",
+			Label:       "Fan GPU",
+			Value:       fan.GPUFanSpeed,
+			Total:       gpuMax,
+			Unit:        "RPM",
+			Utilisation: safeRatio(fan.GPUFanSpeed, gpuMax),
+			Detail:      fmt.Sprintf("%.0f / %.0f RPM", fan.GPUFanSpeed, gpuMax),
+		},
+	}
 }
 
 // DerivePhysicalRows turns the last-sample map into the 6 rows the SPA
@@ -148,6 +370,15 @@ func formatPhysicalValue(r PhysicalMetric) string {
 			format.GetDiskSize(formatFloat(r.Total)))
 	case "pods":
 		return fmt.Sprintf("%.0f / %.0f", r.Value, r.Total)
+	case "gpu":
+		// GPU VRAM rendered the same way as cluster memory —
+		// SPA's `getDiskSize(memoryUsed * 1024 * 1024)` -> GiB
+		// once the magnitude crosses 1 GiB.
+		return fmt.Sprintf("%s / %s",
+			format.GetDiskSize(formatFloat(r.Value)),
+			format.GetDiskSize(formatFloat(r.Total)))
+	case "fan_cpu", "fan_gpu":
+		return r.Detail
 	case "net_in", "net_out":
 		return r.Detail
 	default:

--- a/cli/pkg/dashboard/overview/physical_test.go
+++ b/cli/pkg/dashboard/overview/physical_test.go
@@ -3,8 +3,10 @@ package overview
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -12,37 +14,54 @@ import (
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
 )
 
+// physicalClusterMetricsHandler writes the canonical 13-metric
+// cluster body the physical envelope builder reads. Pulled into a
+// helper so both the baseline test and the augmented (GPU + fan)
+// test can reuse the same payload without duplicating fixture text.
+func physicalClusterMetricsHandler(w http.ResponseWriter) {
+	_, _ = w.Write([]byte(`{"results":[
+      {"metric_name":"cluster_cpu_usage","data":{"result":[{"metric":{},"value":[1714600000,"4.2"]}]}},
+      {"metric_name":"cluster_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"16"]}]}},
+      {"metric_name":"cluster_cpu_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.2625"]}]}},
+      {"metric_name":"cluster_memory_usage_wo_cache","data":{"result":[{"metric":{},"value":[1714600000,"4294967296"]}]}},
+      {"metric_name":"cluster_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"17179869184"]}]}},
+      {"metric_name":"cluster_memory_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.25"]}]}},
+      {"metric_name":"cluster_disk_size_usage","data":{"result":[{"metric":{},"value":[1714600000,"107374182400"]}]}},
+      {"metric_name":"cluster_disk_size_capacity","data":{"result":[{"metric":{},"value":[1714600000,"536870912000"]}]}},
+      {"metric_name":"cluster_disk_size_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.2"]}]}},
+      {"metric_name":"cluster_pod_running_count","data":{"result":[{"metric":{},"value":[1714600000,"42"]}]}},
+      {"metric_name":"cluster_pod_quota","data":{"result":[{"metric":{},"value":[1714600000,"110"]}]}},
+      {"metric_name":"cluster_net_bytes_received","data":{"result":[{"metric":{},"value":[1714600000,"4096"]}]}},
+      {"metric_name":"cluster_net_bytes_transmitted","data":{"result":[{"metric":{},"value":[1714600000,"8192"]}]}}
+    ]}`))
+}
+
 // TestBuildPhysicalEnvelope_SixRowsAndUnitInference pins the 6-row
-// shape (cpu / memory / disk / pods / net_in / net_out) and the
-// SPA-aligned unit-inference behaviour (memory rows over 1 GiB
-// render in GiB, large net throughput renders in MB/s, etc.).
+// baseline shape (cpu / memory / disk / pods / net_in / net_out)
+// and the SPA-aligned unit-inference behaviour. The GPU + fan
+// optional rows are explicitly stubbed as 404 so the test exercises
+// the "no GPU, not Olares One" baseline (every row is from cluster
+// monitoring).
 //
 // Wire shape: GET /kapis/monitoring.kubesphere.io/v1alpha3/cluster
 // returning the standard `{ results: [{ metric_name, data: { result:
 // [{ value: [ts, "X"] }] } }] }` envelope.
 func TestBuildPhysicalEnvelope_SixRowsAndUnitInference(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/kapis/monitoring.kubesphere.io/v1alpha3/cluster" {
+		switch r.URL.Path {
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			physicalClusterMetricsHandler(w)
+		// Optional GPU/fan endpoints — return 404 so the rows
+		// are skipped (matches "HAMI not installed, not Olares
+		// One" production wire shape).
+		case "/hami/api/vgpu/v1/monitor/query/instant-vector",
+			"/hami/api/vgpu/v1/gpus",
+			"/user-service/api/system/status",
+			"/user-service/api/mdns/olares-one/cpu-gpu":
+			w.WriteHeader(http.StatusNotFound)
+		default:
 			noUnexpectedPath(t, w, r.URL.Path)
-			return
 		}
-		// 13 metric_name entries — DerivePhysicalRows reads them
-		// individually so missing metrics yield 0 rather than aborting.
-		_, _ = w.Write([]byte(`{"results":[
-          {"metric_name":"cluster_cpu_usage","data":{"result":[{"metric":{},"value":[1714600000,"4.2"]}]}},
-          {"metric_name":"cluster_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"16"]}]}},
-          {"metric_name":"cluster_cpu_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.2625"]}]}},
-          {"metric_name":"cluster_memory_usage_wo_cache","data":{"result":[{"metric":{},"value":[1714600000,"4294967296"]}]}},
-          {"metric_name":"cluster_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"17179869184"]}]}},
-          {"metric_name":"cluster_memory_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.25"]}]}},
-          {"metric_name":"cluster_disk_size_usage","data":{"result":[{"metric":{},"value":[1714600000,"107374182400"]}]}},
-          {"metric_name":"cluster_disk_size_capacity","data":{"result":[{"metric":{},"value":[1714600000,"536870912000"]}]}},
-          {"metric_name":"cluster_disk_size_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.2"]}]}},
-          {"metric_name":"cluster_pod_running_count","data":{"result":[{"metric":{},"value":[1714600000,"42"]}]}},
-          {"metric_name":"cluster_pod_quota","data":{"result":[{"metric":{},"value":[1714600000,"110"]}]}},
-          {"metric_name":"cluster_net_bytes_received","data":{"result":[{"metric":{},"value":[1714600000,"4096"]}]}},
-          {"metric_name":"cluster_net_bytes_transmitted","data":{"result":[{"metric":{},"value":[1714600000,"8192"]}]}}
-        ]}`))
 	}))
 	defer srv.Close()
 	c := newTestClient(srv)
@@ -56,7 +75,7 @@ func TestBuildPhysicalEnvelope_SixRowsAndUnitInference(t *testing.T) {
 		t.Errorf("Kind = %q, want %q", env.Kind, pkgdashboard.KindOverviewPhysical)
 	}
 	if len(env.Items) != 6 {
-		t.Fatalf("Items len = %d, want 6 (cpu/memory/disk/pods/net_in/net_out)", len(env.Items))
+		t.Fatalf("Items len = %d, want 6 (cpu/memory/disk/pods/net_in/net_out — GPU/fan should be skipped on 404)", len(env.Items))
 	}
 
 	wantOrder := []string{"cpu", "memory", "disk", "pods", "net_in", "net_out"}
@@ -79,6 +98,177 @@ func TestBuildPhysicalEnvelope_SixRowsAndUnitInference(t *testing.T) {
 	netInDetail, _ := env.Items[4].Display["detail"].(string)
 	if !strings.Contains(netInDetail, "/s") {
 		t.Errorf("net_in detail = %q, want a 'B/s'-style throughput suffix", netInDetail)
+	}
+}
+
+// gpuInstantVectorHandler routes the two SPA-aligned instant-vector
+// queries (`hami_memory_used` / `hami_memory_size` aggregated by
+// instance) to MiB values. Returns an empty `data` array for any
+// other query so unrelated callers don't accidentally pick up
+// these stubs.
+//
+// Note: the SPA's actual queries divide by 1024 (`/ 1024`) to land
+// in GiB; we match the *un-divided* MiB form because that's what
+// `gpuSummaryUsedQuery` / `gpuSummaryTotalQuery` send. The CLI then
+// multiplies by 1024 * 1024 to land in bytes so format.GetDiskSize
+// can pick the right Gi/Ti suffix.
+func gpuInstantVectorHandler(w http.ResponseWriter, body string, usedMiB, totalMiB float64) {
+	switch {
+	case strings.Contains(body, "hami_memory_used"):
+		_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":` +
+			strconv.FormatFloat(usedMiB, 'f', -1, 64) + `,"timestamp":"2026-05-25T00:00:00Z"}]}`))
+	case strings.Contains(body, "hami_memory_size"):
+		_, _ = w.Write([]byte(`{"data":[{"metric":{},"value":` +
+			strconv.FormatFloat(totalMiB, 'f', -1, 64) + `,"timestamp":"2026-05-25T00:00:00Z"}]}`))
+	default:
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}
+}
+
+// TestBuildPhysicalEnvelope_AugmentsWithGPUAndFanRows pins the
+// SPA-aligned augmentation behaviour: when HAMI returns a non-empty
+// GPU list AND the device reports as Olares One, the envelope adds
+// `gpu`, `fan_cpu`, `fan_gpu` rows after the 6 baseline rows. The
+// SPA's `Overview2/ClusterResource.vue` does the same — the GPU
+// card is appended only when `hasGPU.value` is truthy and the fan
+// card only when `FanStore.isOlaresOneDevice`.
+//
+// Regression net for the production bug where
+// `olares-cli dashboard overview` and
+// `olares-cli dashboard overview physical` both omitted GPU + fan
+// even though the SPA showed those panels.
+//
+// The GPU `used` value comes from the SPA-aligned
+// `avg(sum(hami_memory_used) by (instance))` instant query (NOT
+// the /v1/gpus list aggregation, which only counts vGPU-allocated
+// VRAM — see physical.go:buildGPUSummaryRow for the rationale).
+func TestBuildPhysicalEnvelope_AugmentsWithGPUAndFanRows(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			physicalClusterMetricsHandler(w)
+		case "/hami/api/vgpu/v1/monitor/query/instant-vector":
+			// 270 MiB used / 24576 MiB (24 GiB) total —
+			// matches what the SPA cluster card shows for
+			// olarestest004's RTX 5090.
+			body, _ := io.ReadAll(r.Body)
+			gpuInstantVectorHandler(w, string(body), 270, 24576)
+		case "/hami/api/vgpu/v1/gpus":
+			// Fallback path: same total but `memoryUsed=0`
+			// (the realistic vGPU-allocation-table number;
+			// the prom path is preferred precisely because
+			// it covers non-vGPU CUDA processes too).
+			_, _ = w.Write([]byte(`{"list":[{
+              "uuid":"GPU-e5d26177","type":"NVIDIA RTX 5090","health":true,
+              "memoryUsed":0,"memoryTotal":24576,"shareMode":"2",
+              "nodeName":"olares","power":7.6,"powerLimit":175,
+              "temperature":44,"coreUtilizedPercent":0
+            }]}`))
+		case "/user-service/api/system/status":
+			// `device_name = "Olares One"` triggers
+			// `IsOlaresOne()` -> true (the only branch that
+			// activates the fan rows).
+			_, _ = w.Write([]byte(`{"code":0,"data":{"device_name":"Olares One"}}`))
+		case "/user-service/api/mdns/olares-one/cpu-gpu":
+			_, _ = w.Write([]byte(`{"data":{
+              "cpu_fan_speed":1100,"cpu_temperature":55,
+              "gpu_fan_speed":1300,"gpu_temperature":48
+            }}`))
+		default:
+			noUnexpectedPath(t, w, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+
+	env, err := BuildPhysicalEnvelope(context.Background(), c, cf, time.Now())
+	if err != nil {
+		t.Fatalf("BuildPhysicalEnvelope: %v", err)
+	}
+	if len(env.Items) != 9 {
+		t.Fatalf("Items len = %d, want 9 (6 baseline + gpu + fan_cpu + fan_gpu)", len(env.Items))
+	}
+	wantOrder := []string{"cpu", "memory", "disk", "pods", "net_in", "net_out", "gpu", "fan_cpu", "fan_gpu"}
+	for i, want := range wantOrder {
+		if env.Items[i].Raw["metric"] != want {
+			t.Errorf("row %d: metric = %v, want %q", i, env.Items[i].Raw["metric"], want)
+		}
+	}
+
+	// GPU row: prom path picked the 270 MiB used / 24 GiB total
+	// values — Display "value" should carry the Gi suffix and
+	// the used segment must NOT be the "-" empty placeholder
+	// (regression for the production bug where the row
+	// rendered "- / 23.89Gi" because the list-only path saw
+	// memoryUsed=0 from the allocation table).
+	gpuValue, _ := env.Items[6].Display["value"].(string)
+	if !strings.Contains(gpuValue, "Gi") {
+		t.Errorf("gpu value = %q, want 'Gi' suffix at 24 GiB total", gpuValue)
+	}
+	if strings.HasPrefix(gpuValue, "- /") {
+		t.Errorf("gpu value = %q, used segment must not be '-' when prom path returned a non-zero used value", gpuValue)
+	}
+
+	// Fan rows: detail uses RPM with a "/" separator like
+	// the SPA's "1100 / 2900 RPM" cell.
+	cpuFanDetail, _ := env.Items[7].Display["detail"].(string)
+	if !strings.Contains(cpuFanDetail, "RPM") || !strings.Contains(cpuFanDetail, "/") {
+		t.Errorf("fan_cpu detail = %q, want '<rpm> / <max> RPM'", cpuFanDetail)
+	}
+	gpuFanDetail, _ := env.Items[8].Display["detail"].(string)
+	if !strings.Contains(gpuFanDetail, "RPM") || !strings.Contains(gpuFanDetail, "/") {
+		t.Errorf("fan_gpu detail = %q, want '<rpm> / <max> RPM'", gpuFanDetail)
+	}
+}
+
+// TestBuildPhysicalEnvelope_GPUFallsBackToListWhenPromEmpty pins
+// the prom-fallback path: when the SPA-aligned instant-vector
+// queries succeed but return an empty `data: []` (HAMI prom is
+// reachable but has no series for this cluster yet), the GPU row
+// builder falls back to aggregating /v1/gpus. The row still ships
+// — just with the allocation-table numbers rather than prom's
+// real-VRAM figure.
+func TestBuildPhysicalEnvelope_GPUFallsBackToListWhenPromEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			physicalClusterMetricsHandler(w)
+		case "/hami/api/vgpu/v1/monitor/query/instant-vector":
+			// Prom up, no series — caller should fall back.
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case "/hami/api/vgpu/v1/gpus":
+			_, _ = w.Write([]byte(`{"list":[{
+              "uuid":"GPU-e5d26177","memoryUsed":1024,"memoryTotal":24576
+            }]}`))
+		case "/user-service/api/system/status",
+			"/user-service/api/mdns/olares-one/cpu-gpu":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			noUnexpectedPath(t, w, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+
+	env, err := BuildPhysicalEnvelope(context.Background(), c, cf, time.Now())
+	if err != nil {
+		t.Fatalf("BuildPhysicalEnvelope: %v", err)
+	}
+	// Expect 7 rows: 6 baseline + gpu (no fan, off-Olares-One).
+	if len(env.Items) != 7 {
+		t.Fatalf("Items len = %d, want 7 (6 baseline + gpu via list-fallback)", len(env.Items))
+	}
+	gpuRow := env.Items[6]
+	if gpuRow.Raw["metric"] != "gpu" {
+		t.Fatalf("row 6 metric = %v, want gpu", gpuRow.Raw["metric"])
+	}
+	// 1024 MiB used == 1 GiB; format.GetDiskSize converts and
+	// returns a Gi-suffixed string.
+	gpuValue, _ := gpuRow.Display["value"].(string)
+	if !strings.Contains(gpuValue, "Gi") {
+		t.Errorf("gpu value = %q, want 'Gi' suffix from list-fallback aggregation", gpuValue)
 	}
 }
 

--- a/cli/pkg/dashboard/overview/user.go
+++ b/cli/pkg/dashboard/overview/user.go
@@ -80,10 +80,24 @@ func BuildUserEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashb
 	// Self-target path resolves the active profile (with role
 	// metadata); admin-target path returns a synthetic record
 	// without a role. Re-probe via EnsureUser so we can detect
-	// the latter.
+	// the latter — but ONLY accept the re-probe's "admin=true"
+	// signal when the re-probed identity is the same user we're
+	// rendering for. Otherwise an admin (alice) running
+	// `--user bob` would inherit alice's admin role for bob's
+	// envelope, silently overriding bob's real ResourceQuota
+	// with the cluster total: bob would appear to own every CPU
+	// / byte of memory the cluster has, hiding the actual quota
+	// and making `--user bob` useless for capacity planning.
+	//
+	// In practice the admin-target path's synthetic record never
+	// matches the active user's name (ResolveTargetUser returns
+	// the real cached record when requested == active), so this
+	// re-probe is effectively defense-in-depth — but the guard
+	// keeps the code correct under any future change to
+	// ResolveTargetUser's gating shape.
 	isAdmin := user.IsAdmin()
 	if !isAdmin {
-		if active, ferr := c.EnsureUser(ctx); ferr == nil && active != nil && active.IsAdmin() {
+		if active, ferr := c.EnsureUser(ctx); ferr == nil && active != nil && active.IsAdmin() && active.Name == user.Name {
 			isAdmin = true
 		}
 	}

--- a/cli/pkg/dashboard/overview/user.go
+++ b/cli/pkg/dashboard/overview/user.go
@@ -40,6 +40,21 @@ func RunUser(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 // envelope (one row per resource type). Surfaces a typed admin-
 // required error from ResolveTargetUser without modifying it so the
 // agent-facing diagnostic stays 1:1.
+//
+// Admin total fallback: KubeSphere's `user_cpu_total` /
+// `user_memory_total` map to `kube_user_{cpu,memory}_total` which
+// only emit a value when the user has an explicit ResourceQuota.
+// Platform admins typically have no quota → both series return 0
+// and the SPA shows "0/-" which is misleading. The SPA's overview
+// page sidesteps this by falling back to cluster totals for admin
+// users (Overview2/IndexPage.vue passes
+// `cluster_cpu_total`/`cluster_memory_total` as props that win
+// over the user-grain values inside UserResource.vue). We mirror
+// that 1:1 — when the resolved user is admin we additionally
+// fetch `cluster_cpu_total` / `cluster_memory_total` and prefer
+// those; the chosen source is recorded under
+// `Raw["total_source"]` ("user_quota" vs "cluster_total") so
+// agents can demux without re-running the heuristic.
 func BuildUserEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, target string, now time.Time) (pkgdashboard.Envelope, error) {
 	user, err := pkgdashboard.ResolveTargetUser(ctx, c, target)
 	if err != nil {
@@ -61,33 +76,70 @@ func BuildUserEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashb
 	memUsage := sampleFloat(last["user_memory_usage_wo_cache"])
 	memUtil := sampleFloat(last["user_memory_utilisation"])
 
+	cpuTotalSource, memTotalSource := "user_quota", "user_quota"
+	// Self-target path resolves the active profile (with role
+	// metadata); admin-target path returns a synthetic record
+	// without a role. Re-probe via EnsureUser so we can detect
+	// the latter.
+	isAdmin := user.IsAdmin()
+	if !isAdmin {
+		if active, ferr := c.EnsureUser(ctx); ferr == nil && active != nil && active.IsAdmin() {
+			isAdmin = true
+		}
+	}
+	if isAdmin {
+		clusterRes, cerr := pkgdashboard.FetchClusterMetrics(ctx, c, cf,
+			[]string{"cluster_cpu_total", "cluster_memory_total"},
+			pkgdashboard.DefaultClusterWindow(), now, false)
+		if cerr == nil {
+			clusterLast := format.GetLastMonitoringData(clusterRes, 0)
+			if v := sampleFloat(clusterLast["cluster_cpu_total"]); v > 0 {
+				cpuTotal = v
+				cpuTotalSource = "cluster_total"
+				if cpuTotal > 0 {
+					cpuUtil = cpuUsage / cpuTotal
+				}
+			}
+			if v := sampleFloat(clusterLast["cluster_memory_total"]); v > 0 {
+				memTotal = v
+				memTotalSource = "cluster_total"
+				if memTotal > 0 {
+					memUtil = memUsage / memTotal
+				}
+			}
+		}
+	}
+
 	rows := []map[string]any{
 		{
-			"metric":      "CPU",
-			"used_raw":    cpuUsage,
-			"total_raw":   cpuTotal,
-			"utilisation": cpuUtil,
-			"used":        fmt.Sprintf("%.2f", cpuUsage),
-			"total":       fmt.Sprintf("%.2f", cpuTotal),
+			"metric":       "CPU",
+			"used_raw":     cpuUsage,
+			"total_raw":    cpuTotal,
+			"utilisation":  cpuUtil,
+			"total_source": cpuTotalSource,
+			"used":         fmt.Sprintf("%.2f", cpuUsage),
+			"total":        fmt.Sprintf("%.2f", cpuTotal),
 		},
 		{
-			"metric":      "Memory",
-			"used_raw":    memUsage,
-			"total_raw":   memTotal,
-			"utilisation": memUtil,
-			"used":        format.GetDiskSize(formatFloat(memUsage)),
-			"total":       format.GetDiskSize(formatFloat(memTotal)),
+			"metric":       "Memory",
+			"used_raw":     memUsage,
+			"total_raw":    memTotal,
+			"utilisation":  memUtil,
+			"total_source": memTotalSource,
+			"used":         format.GetDiskSize(formatFloat(memUsage)),
+			"total":        format.GetDiskSize(formatFloat(memTotal)),
 		},
 	}
 	items := make([]pkgdashboard.Item, 0, len(rows))
 	for _, r := range rows {
 		items = append(items, pkgdashboard.Item{
 			Raw: map[string]any{
-				"metric":      r["metric"],
-				"used":        r["used_raw"],
-				"total":       r["total_raw"],
-				"utilisation": r["utilisation"],
-				"user":        user.Name,
+				"metric":       r["metric"],
+				"used":         r["used_raw"],
+				"total":        r["total_raw"],
+				"utilisation":  r["utilisation"],
+				"total_source": r["total_source"],
+				"user":         user.Name,
 			},
 			Display: map[string]any{
 				"metric":      r["metric"],

--- a/cli/pkg/dashboard/overview/user_test.go
+++ b/cli/pkg/dashboard/overview/user_test.go
@@ -191,6 +191,98 @@ func TestBuildUserEnvelope_AdminWithoutQuotaFallsBackToCluster(t *testing.T) {
 	}
 }
 
+// TestBuildUserEnvelope_AdminTargetingPeerKeepsPeerQuota pins the
+// cross-user variant of the admin-total fallback. When an admin
+// (alice) targets a different user (`--user bob`),
+// `ResolveTargetUser` returns a synthetic record carrying bob's
+// name + `GlobalRole="<admin-target>"` — i.e. `user.IsAdmin()` is
+// false. The admin-total fallback MUST stay off in that case:
+// "alice is allowed to look at bob's stats" never implies "bob's
+// quota should be replaced by the cluster total". Otherwise the
+// CLI silently inflates bob's totals to whatever the cluster owns,
+// hiding the real ResourceQuota and making `--user bob` useless
+// for capacity planning.
+//
+// Regression net for the bug where the EnsureUser re-probe was
+// firing on the active profile (alice→admin) and bumping
+// `isAdmin=true` for bob; the fix gates the re-probe on
+// `active.Name == user.Name` so the bump only fires for the
+// self-target path (where ResolveTargetUser already returned the
+// real record with a real role anyway — the re-probe is now pure
+// defense-in-depth).
+func TestBuildUserEnvelope_AdminTargetingPeerKeepsPeerQuota(t *testing.T) {
+	// `bob` has an explicit ResourceQuota (8 CPU / 16 GiB). The
+	// cluster total is 24 CPU / 96 GiB — picking the bug would
+	// inflate bob's CPU to 24 and Memory to 96 GiB. The test pins
+	// the non-inflated values + `total_source=user_quota`.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/capi/app/detail":
+			_, _ = w.Write([]byte(`{"user":{"username":"alice","globalrole":"platform-admin"}}`))
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/users/bob":
+			_, _ = w.Write([]byte(`{"results":[
+              {"metric_name":"user_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"8"]}]}},
+              {"metric_name":"user_cpu_usage","data":{"result":[{"metric":{},"value":[1714600000,"2"]}]}},
+              {"metric_name":"user_cpu_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.25"]}]}},
+              {"metric_name":"user_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"17179869184"]}]}},
+              {"metric_name":"user_memory_usage_wo_cache","data":{"result":[{"metric":{},"value":[1714600000,"4294967296"]}]}},
+              {"metric_name":"user_memory_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.25"]}]}}
+            ]}`))
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			// If the bug fires this gets read and clobbers bob's totals.
+			_, _ = w.Write([]byte(`{"results":[
+              {"metric_name":"cluster_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"24"]}]}},
+              {"metric_name":"cluster_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"103079215104"]}]}}
+            ]}`))
+		default:
+			noUnexpectedPath(t, w, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+
+	env, err := BuildUserEnvelope(context.Background(), c, cf, "bob", time.Now())
+	if err != nil {
+		t.Fatalf("BuildUserEnvelope: %v", err)
+	}
+	if len(env.Items) != 2 {
+		t.Fatalf("Items len = %d, want 2", len(env.Items))
+	}
+
+	cpuRow := env.Items[0]
+	if cpuRow.Raw["user"] != "bob" {
+		t.Errorf("CPU Raw.user = %v, want bob (admin-target path)", cpuRow.Raw["user"])
+	}
+	if cpuRow.Raw["total_source"] != "user_quota" {
+		t.Errorf("CPU Raw.total_source = %v, want user_quota (admin targeting peer must NOT activate cluster fallback)", cpuRow.Raw["total_source"])
+	}
+	if cpuRow.Display["total"] != "8.00" {
+		t.Errorf("CPU total display = %v, want 8.00 (bob's quota, NOT cluster's 24)", cpuRow.Display["total"])
+	}
+	// 2/8 = 0.25 → percentString → "25%" (integer branch of
+	// formatNumberJSLike: trunc(v)==v so 0-decimal). If the bug
+	// fires the utilisation gets recomputed against cluster 24 →
+	// "8.33%".
+	if cpuRow.Display["utilisation"] != "25%" {
+		t.Errorf("CPU utilisation = %v, want 25%% (2/8, NOT recomputed against cluster 24)", cpuRow.Display["utilisation"])
+	}
+
+	memRow := env.Items[1]
+	if memRow.Raw["total_source"] != "user_quota" {
+		t.Errorf("Memory Raw.total_source = %v, want user_quota", memRow.Raw["total_source"])
+	}
+	memTotal, _ := memRow.Display["total"].(string)
+	// 16 GiB exact (17179869184 bytes / 2^30 = 16) — GetDiskSize
+	// renders integer values without decimals via formatNumberJSLike
+	// (`v == Trunc(v)` branch). Pin the exact rendered string so a
+	// loose substring check doesn't accidentally pass against the
+	// cluster's "96Gi" or "9.00Gi" partial overlap.
+	if memTotal != "16Gi" {
+		t.Errorf("Memory total display = %q, want %q (bob's quota, NOT cluster's 96 GiB)", memTotal, "16Gi")
+	}
+}
+
 // TestBuildUserEnvelope_NonAdminPrefersUserQuota pins the inverse
 // of the admin fallback: a non-admin (`workspaces-manager`)
 // querying themselves keeps `total_source = user_quota` even when

--- a/cli/pkg/dashboard/overview/user_test.go
+++ b/cli/pkg/dashboard/overview/user_test.go
@@ -14,6 +14,14 @@ import (
 // userFixtureServer stubs the active-profile probe (/capi/app/detail)
 // + the user-grain monitoring fetch. role / username / quota values
 // are knobs the tests vary to exercise admin / non-admin branches.
+//
+// The cluster monitoring endpoint is stubbed too — the admin-total
+// fallback path (BuildUserEnvelope, see Bug 3 in the dashboard
+// area) issues a parallel `cluster_cpu_total` /
+// `cluster_memory_total` query when the resolved user is admin.
+// We respond with a value the admin tests can pin against
+// (24 cores / 96 GiB) but the legacy "user has its own quota"
+// tests mask it via the user-grain numbers.
 func userFixtureServer(t *testing.T, role, username string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,6 +36,43 @@ func userFixtureServer(t *testing.T, role, username string) *httptest.Server {
               {"metric_name":"user_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"4294967296"]}]}},
               {"metric_name":"user_memory_usage_wo_cache","data":{"result":[{"metric":{},"value":[1714600000,"1073741824"]}]}},
               {"metric_name":"user_memory_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0.25"]}]}}
+            ]}`))
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			_, _ = w.Write([]byte(`{"results":[
+              {"metric_name":"cluster_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"24"]}]}},
+              {"metric_name":"cluster_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"103079215104"]}]}}
+            ]}`))
+		default:
+			noUnexpectedPath(t, w, r.URL.Path)
+		}
+	}))
+}
+
+// userFixtureServerNoUserQuota stubs the user-grain endpoint
+// returning all-zero `user_cpu_total` / `user_memory_total` (the
+// real-world admin-without-ResourceQuota wire shape — `kube_user_*`
+// PromQL has no series, monitoring fills with 0). Cluster endpoint
+// still returns 24 cores / 96 GiB so the fallback path can pin
+// against those.
+func userFixtureServerNoUserQuota(t *testing.T, role, username string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/capi/app/detail":
+			_, _ = w.Write([]byte(`{"user":{"username":"` + username + `","globalrole":"` + role + `"}}`))
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/users/" + username:
+			_, _ = w.Write([]byte(`{"results":[
+              {"metric_name":"user_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"0"]}]}},
+              {"metric_name":"user_cpu_usage","data":{"result":[{"metric":{},"value":[1714600000,"1.5"]}]}},
+              {"metric_name":"user_cpu_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0"]}]}},
+              {"metric_name":"user_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"0"]}]}},
+              {"metric_name":"user_memory_usage_wo_cache","data":{"result":[{"metric":{},"value":[1714600000,"1073741824"]}]}},
+              {"metric_name":"user_memory_utilisation","data":{"result":[{"metric":{},"value":[1714600000,"0"]}]}}
+            ]}`))
+		case "/kapis/monitoring.kubesphere.io/v1alpha3/cluster":
+			_, _ = w.Write([]byte(`{"results":[
+              {"metric_name":"cluster_cpu_total","data":{"result":[{"metric":{},"value":[1714600000,"24"]}]}},
+              {"metric_name":"cluster_memory_total","data":{"result":[{"metric":{},"value":[1714600000,"103079215104"]}]}}
             ]}`))
 		default:
 			noUnexpectedPath(t, w, r.URL.Path)
@@ -94,5 +139,80 @@ func TestBuildUserEnvelope_NonAdminTargetingPeerRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "platform-admin") {
 		t.Errorf("error %q does not mention 'platform-admin'", err)
+	}
+}
+
+// TestBuildUserEnvelope_AdminWithoutQuotaFallsBackToCluster pins
+// the SPA-aligned admin-total fallback: when `user_cpu_total` /
+// `user_memory_total` are zero (typical for platform admins
+// without an explicit ResourceQuota), the envelope total must
+// switch to `cluster_cpu_total` / `cluster_memory_total` and
+// `Raw["total_source"]` must flip to "cluster_total" so agents
+// can detect the source change without re-running the heuristic.
+//
+// Regression net for the production bug where
+// `olares-cli dashboard overview user` rendered "1.5 / 0" CPU
+// for admins because user-grain totals were zero and the CLI
+// did not mirror the SPA's
+// (Overview2/IndexPage.vue:cluster_cpu_total) fallback.
+func TestBuildUserEnvelope_AdminWithoutQuotaFallsBackToCluster(t *testing.T) {
+	srv := userFixtureServerNoUserQuota(t, "platform-admin", "alice")
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+
+	env, err := BuildUserEnvelope(context.Background(), c, cf, "", time.Now())
+	if err != nil {
+		t.Fatalf("BuildUserEnvelope: %v", err)
+	}
+	if len(env.Items) != 2 {
+		t.Fatalf("Items len = %d, want 2", len(env.Items))
+	}
+
+	cpuRow := env.Items[0]
+	if cpuRow.Display["total"] != "24.00" {
+		t.Errorf("CPU total display = %v, want 24.00 (cluster fallback)", cpuRow.Display["total"])
+	}
+	if cpuRow.Raw["total_source"] != "cluster_total" {
+		t.Errorf("CPU Raw.total_source = %v, want cluster_total", cpuRow.Raw["total_source"])
+	}
+	// 1.5 used / 24 total ≈ 6.25%
+	if cpuRow.Display["utilisation"] != "6.25%" {
+		t.Errorf("CPU utilisation = %v, want 6.25%% (recomputed against cluster total)", cpuRow.Display["utilisation"])
+	}
+
+	memRow := env.Items[1]
+	memTotal, _ := memRow.Display["total"].(string)
+	if !strings.Contains(memTotal, "Gi") {
+		t.Errorf("Memory total display = %q, want a 'Gi' suffix at 96 GiB cluster total", memTotal)
+	}
+	if memRow.Raw["total_source"] != "cluster_total" {
+		t.Errorf("Memory Raw.total_source = %v, want cluster_total", memRow.Raw["total_source"])
+	}
+}
+
+// TestBuildUserEnvelope_NonAdminPrefersUserQuota pins the inverse
+// of the admin fallback: a non-admin (`workspaces-manager`)
+// querying themselves keeps `total_source = user_quota` even when
+// cluster_cpu_total would also be available — non-admins must NOT
+// see cluster totals (that's the SPA's IndexPage.vue gate
+// `appDetail.isAdmin ? ... : undefined`).
+func TestBuildUserEnvelope_NonAdminPrefersUserQuota(t *testing.T) {
+	srv := userFixtureServer(t, "workspaces-manager", "bob")
+	defer srv.Close()
+	c := newTestClient(srv)
+	cf := fixtureFlags(t)
+
+	env, err := BuildUserEnvelope(context.Background(), c, cf, "", time.Now())
+	if err != nil {
+		t.Fatalf("BuildUserEnvelope: %v", err)
+	}
+	if env.Items[0].Raw["total_source"] != "user_quota" {
+		t.Errorf("CPU Raw.total_source = %v, want user_quota for non-admin",
+			env.Items[0].Raw["total_source"])
+	}
+	if env.Items[0].Display["total"] != "4.00" {
+		t.Errorf("CPU total = %v, want 4.00 (user quota, NOT cluster total)",
+			env.Items[0].Display["total"])
 	}
 }

--- a/cli/pkg/dashboard/schema.go
+++ b/cli/pkg/dashboard/schema.go
@@ -38,6 +38,11 @@ const (
 	KindOverviewFan            = "dashboard.overview.fan"     // sections (live + curve)
 	KindOverviewFanLive        = "dashboard.overview.fan.live"
 	KindOverviewFanCurve       = "dashboard.overview.fan.curve"
+	// `dashboard overview gpu` (default action) — sections
+	// envelope: graphics + tasks. Mirrors the SPA's GPU overview
+	// page (which renders both tabs in one DOM, switching between
+	// Graphics management / Task management without re-fetching).
+	KindOverviewGPU            = "dashboard.overview.gpu"
 	KindOverviewGPUList        = "dashboard.overview.gpu.list"
 	KindOverviewGPUTasks       = "dashboard.overview.gpu.tasks"
 	KindOverviewGPUDetail      = "dashboard.overview.gpu.detail"
@@ -72,6 +77,7 @@ func AllKinds() []string {
 		KindOverviewFan,
 		KindOverviewFanLive,
 		KindOverviewFanCurve,
+		KindOverviewGPU,
 		KindOverviewGPUList,
 		KindOverviewGPUTasks,
 		KindOverviewGPUDetail,
@@ -114,12 +120,25 @@ func LoadSchemaIndex() []SchemaEntry {
 		{"dashboard overview fan", KindOverviewFan, "overview-fan.json"},
 		{"dashboard overview fan live", KindOverviewFanLive, "overview-fan-live.json"},
 		{"dashboard overview fan curve", KindOverviewFanCurve, "overview-fan-curve.json"},
-		{"dashboard overview gpu list", KindOverviewGPUList, "overview-gpu-list.json"},
+		// `gpu` (no subverb) — sections envelope mirroring the SPA's
+		// GPU overview page with both tabs preloaded.
+		{"dashboard overview gpu", KindOverviewGPU, "overview-gpu.json"},
+		// SPA-aligned `gpu graphics` / `gpu tasks` parent commands (the
+		// public surface). Each parent dispatches by arg count; both
+		// kinds are listed so `dashboard schema` documents the
+		// envelope shape per arg variant.
+		{"dashboard overview gpu graphics", KindOverviewGPUList, "overview-gpu-list.json"},
+		{"dashboard overview gpu graphics <uuid>", KindOverviewGPUDetailFull, "overview-gpu-detail-full.json"},
 		{"dashboard overview gpu tasks", KindOverviewGPUTasks, "overview-gpu-tasks.json"},
-		{"dashboard overview gpu get", KindOverviewGPUDetail, "overview-gpu-detail.json"},
-		{"dashboard overview gpu task", KindOverviewGPUTaskDet, "overview-gpu-task-detail.json"},
-		{"dashboard overview gpu detail", KindOverviewGPUDetailFull, "overview-gpu-detail-full.json"},
-		{"dashboard overview gpu task-detail", KindOverviewGPUTaskDetFull, "overview-gpu-task-detail-full.json"},
+		{"dashboard overview gpu tasks <name>", KindOverviewGPUTaskDetFull, "overview-gpu-task-detail-full.json"},
+		// Legacy / hidden / deprecated cobra paths (still functional
+		// for back-compat agent scripts; cobra emits a deprecation
+		// hint when invoked).
+		{"dashboard overview gpu list (deprecated)", KindOverviewGPUList, "overview-gpu-list.json"},
+		{"dashboard overview gpu get (deprecated)", KindOverviewGPUDetail, "overview-gpu-detail.json"},
+		{"dashboard overview gpu detail (deprecated)", KindOverviewGPUDetailFull, "overview-gpu-detail-full.json"},
+		{"dashboard overview gpu task (deprecated)", KindOverviewGPUTaskDet, "overview-gpu-task-detail.json"},
+		{"dashboard overview gpu task-detail (deprecated)", KindOverviewGPUTaskDetFull, "overview-gpu-task-detail-full.json"},
 		{"dashboard applications", KindApplicationsList, "applications.json"},
 	}
 	have := embeddedSchemaFiles()

--- a/cli/pkg/dashboard/schemas/overview-gpu-detail.json
+++ b/cli/pkg/dashboard/schemas/overview-gpu-detail.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "dashboard.overview.gpu.detail",
-  "description": "Per-GPU detail from /hami/api/vgpu/v1/gpu?uuid=<uuid>. HAMI returns the detail object FLAT at the top level (no `data` envelope, matches the SPA's `GraphicsDetailsResponse`). The CLI surfaces it in `items[0]` with both `raw` and `display` mapped to the upstream JSON one-to-one — fields include uuid, type, shareMode, nodeName, nodeUid, health, coreUsed, coreTotal, coreUtilizedPercent, memoryUsed, memoryUtilized, memoryTotal, memoryUtilizedPercent, vgpuUsed, vgpuTotal, power, powerLimit, temperature, mode. Soft-gated like gpu.list: admin / CUDA hints land in meta.note. Empty envelopes carry 'no_vgpu_integration' (HAMI 404), 'vgpu_unavailable' (HAMI 5xx — meta.error / meta.http_status), or 'no_gpu_detected' (HAMI 200 but empty body).",
+  "description": "Per-GPU detail from /hami/api/vgpu/v1/gpu?uid=<uuid>. HAMI returns the detail object FLAT at the top level (no `data` envelope, matches the SPA's `GraphicsDetailsResponse`). The CLI surfaces it in `items[0]` with both `raw` and `display` mapped to the upstream JSON one-to-one — fields include uuid, type, shareMode, nodeName, nodeUid, health, coreUsed, coreTotal, coreUtilizedPercent, memoryUsed, memoryUtilized, memoryTotal, memoryUtilizedPercent, vgpuUsed, vgpuTotal, power, powerLimit, temperature, mode. Soft-gated like gpu.list: admin / CUDA hints land in meta.note. Empty envelopes carry 'no_vgpu_integration' (HAMI 404), 'vgpu_unavailable' (HAMI 5xx — meta.error / meta.http_status), or 'no_gpu_detected' (HAMI 200 but empty body).",
   "type": "object",
   "required": ["kind", "meta", "items"],
   "properties": {

--- a/cli/pkg/dashboard/schemas/overview-gpu.json
+++ b/cli/pkg/dashboard/schemas/overview-gpu.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "dashboard.overview.gpu",
+  "description": "`dashboard overview gpu` (default action) — sections envelope: graphics + tasks. Mirrors the SPA's GPU overview page (both Graphics management and Task management tabs preloaded). Per-section transport errors land on the section's `meta.error` rather than aborting the parent envelope; agents branch on `sections.<key>.meta.error` to detect partial failure.",
+  "type": "object",
+  "required": ["kind", "meta", "sections"],
+  "properties": {
+    "kind": {"const": "dashboard.overview.gpu"},
+    "meta": {"$ref": "#/definitions/meta"},
+    "sections": {
+      "type": "object",
+      "required": ["graphics", "tasks"],
+      "properties": {
+        "graphics": {"$ref": "overview-gpu-list.json"},
+        "tasks": {"$ref": "overview-gpu-tasks.json"}
+      }
+    }
+  },
+  "definitions": {
+    "meta": {
+      "type": "object",
+      "required": ["fetched_at"],
+      "properties": {
+        "fetched_at": {"type": "string"},
+        "profile": {"type": "string"},
+        "user": {"type": "string"},
+        "note": {"type": "string"},
+        "recommended_poll_seconds": {"type": "integer"},
+        "iteration": {"type": "integer"},
+        "error": {"type": "string"},
+        "error_kind": {"type": "string"}
+      }
+    }
+  }
+}

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -281,7 +281,7 @@ HAMI's WebUI returns the payload **at the top level** for every endpoint we call
 |---|---|---|
 | `POST /hami/api/vgpu/v1/gpus` | `{"list":[ {graphics...} ]}` | `struct{ List []map[string]any }`, return `raw.List` |
 | `POST /hami/api/vgpu/v1/containers` | `{"items":[ {task...} ]}` | `struct{ Items []map[string]any }`, return `raw.Items` |
-| `GET /hami/api/vgpu/v1/gpu?uuid=…` | `{ ...graphics fields... }` | `map[string]any`, return verbatim |
+| `GET /hami/api/vgpu/v1/gpu?uid=…` | `{ ...graphics fields... }` | `map[string]any`, return verbatim |
 | `GET /hami/api/vgpu/v1/container?name=…&podUid=…` | `{ ...task fields... }` | `map[string]any`, return verbatim |
 
 The fetchers in [`pkg/dashboard/gpu.go`](cli/pkg/dashboard/gpu.go) are pinned to this shape; `TestFetchGraphicsList_ParsesTopLevelList` / `TestFetchTaskList_ParsesTopLevelItems` / `TestFetchGraphicsDetail_ReturnsBodyAsIs` / `TestFetchTaskDetail_ReturnsBodyAsIs` enforce the contract (in `cli/pkg/dashboard/dashboard_test.go`).

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -314,6 +314,25 @@ Both fetchers (`fetchInstantVector` / `fetchRangeVector`) are pinned by `TestFet
 
 Range body shape: `{"query":"<promql>","range":{"start":"YYYY-MM-DD HH:mm:ss","end":"…","step":"30m"}}`. `start`/`end` are SPA's `timeParse(date)` (local clock, no offset suffix); the `step` is computed by `gpuTrendStep(start, end)` — a 1:1 port of [`timeRangeFormate(diff_s, 16)`](packages/app/src/apps/controlPanelCommon/containers/Monitoring/utils.js) which preserves the SPA's preset table (10m→1m, 60m→10m, 480m→30m, 1440m→60m, etc.) and falls back to `floor(minutes/16)m` capped at `[1m..60m]`.
 
+**Window timezone contract (paid in blood)** — the offset-less string is re-parsed by the HAMI WebUI backend with `time.ParseInLocation` against the backend pod's `TZ` (today: `Asia/Shanghai`, see [`infrastructure/gpu/.olares/config/gpu/hami/values.yaml`](infrastructure/gpu/.olares/config/gpu/hami/values.yaml) `webui.env.backend.TZ`; verified empirically that Unix-epoch payloads are rejected with `data: []`, only the human-readable form works). The SPA gets this right by accident: a browser running in CST emits CST wall-clock strings, which the backend re-stamps as CST → correct UTC. CLI does NOT have that coincidence — a UTC host (typical Linux server / container) was sending UTC wall clock that HAMI re-stamped as CST, shifting `[start,end]` 8h into the future where Prometheus has no samples → the user-visible symptom was "Gauges 正常 / Trends 全空，无 warnings".
+
+**The fix splits the TZ in two**, on purpose:
+
+| Purpose | TZ | Helper | Knob |
+|---|---|---|---|
+| Render `meta.window.start/end`, table-side trend timestamps, table headers | `cf.Timezone` (user's preference, default `time.Local`) | `GPUTrendTimestampISO(t, cf.Timezone.Time())` | `--timezone <IANA>` |
+| Build the wire body sent to `/monitor/query/{instant,range}-vector` | `HAMIBackendTimezone()` (the backend pod's TZ, default `Asia/Shanghai`) | `GPUTrendTimestampWire(t)` | `OLARES_HAMI_BACKEND_TZ=<IANA>` env (hidden from `--help` — only operators of non-default HAMI deployments need it) |
+
+Both helpers live in [`pkg/dashboard/gpu.go`](cli/pkg/dashboard/gpu.go); never reuse one for the other's job. The split lets a user in Los Angeles see PDT timestamps in their tables while the CLI still gets correct data from a Shanghai-deployed HAMI backend.
+
+Pinned by:
+- `TestGPUTrendTimestampISO_RespectsTimezone`, `TestGPUTrendTimestampISO_NilTimezoneFallsBackToLocal` (pkg root) — display helper.
+- `TestGPUTrendTimestampWire_FormatsInHAMIBackendTZ`, `TestGPUTrendTimestampWire_RespectsEnvOverride`, `TestHAMIBackendTimezone_DefaultIsAsiaShanghai` (pkg root) — wire helper + env override + the "default matches chart values.yaml" drift alarm.
+- `TestBuildDetailFullEnvelope_WireAndRenderTZsAreSeparate`, `TestBuildTaskDetailFullEnvelope_WireAndRenderTZsAreSeparate` (pkg area) — end-to-end with cf.Timezone ≠ HAMI backend TZ; assert `meta.window` and captured wire body are in DIFFERENT zones.
+- `TestBuildDetailFullEnvelope_UTCHostStillGetsData` (pkg area) — the explicit "original bug" regression: cf.Timezone=UTC, HAMI backend TZ default → meta.window in UTC, wire in CST.
+
+If you ever feel tempted to "simplify" by collapsing wire+render back into one TZ argument: don't. The two-table arrangement is the whole point.
+
 ### `dashboard overview gpu` — SPA-aligned command surface
 
 The cobra surface mirrors the SPA's `Overview2/GPU` route exactly — two parent commands matching the two tabs, each accepting an optional positional argument that drills into the per-row "View details" page:
@@ -684,6 +703,7 @@ the documented Kind enum + envelope shape.
 | `meta.empty_reason = no_vgpu_integration` (200 envelope, items:[]) | HAMI vGPU absent (HTTP 404) | Not an error — install HAMI or skip the GPU view. |
 | `meta.empty_reason = vgpu_unavailable` (200 envelope, items:[]) + `meta.http_status=5xx` + `meta.error="..."` + stderr `gpu data temporarily unavailable: HAMI returned HTTP 5xx ...` | HAMI installed but unhealthy (HTTP 5xx) | Transient — retry; investigate the HAMI controller. CLI exit code stays `0` so `--watch` keeps streaming. |
 | `meta.empty_reason = no_gpu_detected` (200 envelope, items:[]) | HAMI healthy but the device list / detail is empty | Not an error. |
+| `gpu graphics/tasks <ref>` — Gauges have values, **all Trends `points_count: 0`, no `meta.warnings`** | Wire/render TZ split regressed (see "Window timezone contract" above): the CLI is sending offset-less window strings in the CLI host's TZ instead of `HAMIBackendTimezone()`, so the HAMI backend re-stamps them with its own TZ and queries Prometheus 8h off → empty data. Verify via `jq '.meta.window.end'` and the captured wire body diverge by the offset. | Should be impossible on a current build (`GPUTrendTimestampWire` pins the wire side to `Asia/Shanghai` by default). If reproducing: check that `pkg/dashboard/overview/gpu/detail.go` and `task_detail.go` build `wireStart/wireEnd` via `GPUTrendTimestampWire(t)` and feed *those* into `fanoutGaugeAndTrend` (not `env.Meta.Window.Start/End`). If your HAMI deployment uses a non-default TZ, set `OLARES_HAMI_BACKEND_TZ=<chart-TZ>` (env, not a flag). |
 | `meta.empty_reason = no_fan_integration` (200 envelope, items:[]) | `/user-service/api/mdns/olares-one/cpu-gpu` returned 404 (Olares One only) | Not an error on non-Olares-One deployments. |
 | `meta.empty_reason = not_olares_one` (200 envelope, items:[]) + stderr `fan is only available on Olares One devices ...` | Active device's `device_name` is not `Olares One` — fan subtree is hard-gated off | Not an error. Skip fan on this hardware; verify with `curl /user-service/api/system/status`. |
 | `meta.note="GPU sidebar entry is hidden for non-admin profiles ..."` + stderr `(advisory) GPU sidebar entry ...` | Non-admin profile invoked a gpu verb. **Soft advisory only** — data still fetched. | Not an error. If HAMI still returned data, surface the note alongside the items. Switch to a platform-admin profile if the agent needs the SPA-equivalent UX. |

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -81,7 +81,7 @@ mirror subpackage under `cli/pkg/dashboard/<area>/`. The pkg root
 | `cmd/ctl/dashboard/overview/{cpu,memory,pods,network}.go` | `pkg/dashboard/overview/{cpu,memory,pods,network}.go` → `RunCPU`/`RunMemory`/`RunPods`/`RunNetwork` (built on `nodes.go`'s `RunPerNodeMetric` scaffold) | `monitoring.go`, `system.go` (network → capi `/system/ifs`), `numbers.go` |
 | `cmd/ctl/dashboard/overview/disk/{root,main,partitions}.go` | `pkg/dashboard/overview/disk/{default,main,partitions}.go` → `RunDefault`/`RunMain`/`RunPartitions` | `monitoring.go` (node\_disk\_*), `lsblk.go`, `numbers.go`, `format/...` |
 | `cmd/ctl/dashboard/overview/fan/{root,live,curve}.go` | `pkg/dashboard/overview/fan/{default,live,curve}.go` → `RunDefault`/`RunLive`/`RunCurve` | `system.go` (`FetchSystemFan`), `gates.go` (`GateOlaresOne`), `gpu.go` (graphics list co-render), `fan_curve.go` |
-| `cmd/ctl/dashboard/overview/gpu/{root,list,tasks,get,task,detail,task_detail}.go` | `pkg/dashboard/overview/gpu/{list,tasks,get,task,detail,task_detail}.go` → `RunList`/`RunTasks`/`RunGet`/`RunTask`/`RunDetail`/`RunTaskDetail` (+ `specs.go` for the gauge/trend catalogue and concurrent fan-out) | `gpu.go`, `gpu_format.go`, `gpu_query.go`, `gates.go`, `client.go` |
+| `cmd/ctl/dashboard/overview/gpu/{root,graphics,tasks,list,get,task,detail,task_detail}.go` | `pkg/dashboard/overview/gpu/{list,tasks,get,task,detail,task_detail}.go` → `RunList`/`RunTasks`/`RunGet`/`RunTask`/`RunDetail`/`RunTaskDetail`/`RunTaskByRef` (+ `specs.go` for the gauge/trend catalogue and concurrent fan-out) | `gpu.go`, `gpu_format.go`, `gpu_query.go`, `gates.go`, `client.go` |
 | `cmd/ctl/dashboard/schema/root.go` | n/a — schema loader stays in pkg root | `schema.go` (loader + `go:embed` bundle) |
 
 - HTTP base = `ResolvedProfile.DashboardURL = https://dashboard.<localPrefix><terminusName>` (derived in [`cli/pkg/olares/id.go`](cli/pkg/olares/id.go) `DashboardURL`).
@@ -122,6 +122,7 @@ Used by **parent commands that aggregate multiple sub-views**:
 | `dashboard overview`     | `physical` / `user` / `ranking`     | `dashboard.overview.physical` / `.user` / `.ranking` |
 | `dashboard overview disk`| `main` / `partitions`               | `dashboard.overview.disk.main` / `.partitions` (the latter is itself a sections envelope, keyed by device) |
 | `dashboard overview fan` | `live` / `curve`                    | `dashboard.overview.fan.live` / `.curve` |
+| `dashboard overview gpu` | `graphics` / `tasks`                | `dashboard.overview.gpu.list` / `.tasks` (mirrors the SPA's GPU overview tabs preloaded together) |
 | `dashboard schema`       | n/a — emits Shape A index           | `dashboard.schema.index` |
 
 ```json
@@ -313,14 +314,55 @@ Both fetchers (`fetchInstantVector` / `fetchRangeVector`) are pinned by `TestFet
 
 Range body shape: `{"query":"<promql>","range":{"start":"YYYY-MM-DD HH:mm:ss","end":"…","step":"30m"}}`. `start`/`end` are SPA's `timeParse(date)` (local clock, no offset suffix); the `step` is computed by `gpuTrendStep(start, end)` — a 1:1 port of [`timeRangeFormate(diff_s, 16)`](packages/app/src/apps/controlPanelCommon/containers/Monitoring/utils.js) which preserves the SPA's preset table (10m→1m, 60m→10m, 480m→30m, 1440m→60m, etc.) and falls back to `floor(minutes/16)m` capped at `[1m..60m]`.
 
-### `dashboard overview gpu detail <uuid>` / `task-detail <name> <pod-uid>` — full detail pages
+### `dashboard overview gpu` — SPA-aligned command surface
 
-Two new commands mirror the SPA's `Overview2/GPU/GPUsDetails.vue` and `Overview2/GPU/TasksDetails.vue` pages: basic info (HAMI `/v1/gpu` or `/v1/container`) + top gauges (instant-vector) + trend charts (range-vector), all assembled into a single sections envelope.
+The cobra surface mirrors the SPA's `Overview2/GPU` route exactly — two parent commands matching the two tabs, each accepting an optional positional argument that drills into the per-row "View details" page:
+
+| Public command | Behavior | Kind | SPA equivalent |
+|---|---|---|---|
+| `gpu` (no subverb) | Sections envelope: graphics + tasks loaded concurrently | `dashboard.overview.gpu` (Shape B) | Both tabs preloaded on GPU overview page mount |
+| `gpu graphics` | List every discovered vGPU | `dashboard.overview.gpu.list` | Graphics management tab |
+| `gpu graphics <uuid>` | Per-GPU detail page (info + 6 gauges + 4 trends) | `dashboard.overview.gpu.detail.full` | GPUsDetails.vue (route /:uuid) |
+| `gpu tasks` | List every running vGPU task | `dashboard.overview.gpu.tasks` | Task management tab |
+| `gpu tasks <ref>` | Per-task detail page; `<ref>` = TASK column (`name`) **or** POD_UID column (`podUid`); auto-resolves the missing half + sharemode | `dashboard.overview.gpu.task.detail.full` | TasksDetails.vue (route /:name/:pod_uid) |
+
+**Naming**: the `graphics` / `tasks` parents use the SPA's tab labels (`Graphics management` / `Task management`) verbatim; the optional positional arg dispatches to the matching detail-page builder. SKILL forbids "putting fan-out logic in cmd" — argument-count routing is NOT fan-out, it's the canonical cmd responsibility, so the dispatch lives in `cmd/.../graphics.go` + `cmd/.../tasks.go`.
+
+**Auto-resolution for `gpu tasks <ref>`**: the SPA passes `podUid` + `deviceShareModes[0]` through the route param when the user clicks a TasksTable row. The CLI mirrors that by calling `pkgdashboard.FetchTaskList`, looking up the row by EITHER `podUid` (first pass — globally unique, wins on tie) OR `name` (second pass), and forwarding the resolved triple to `RunTaskDetail`. Both columns are surfaced in the bare `gpu` and `gpu tasks` listings, so copy-paste from either column "just works" — accepting only `name` was the original UX bug (users naturally copy the rightmost POD_UID column).
+
+Ambiguity (two rows share a name) surfaces as a typed error listing the candidate pod-uids; users re-run with one of those pod-uids (still `gpu tasks <pod-uid>` — pod-uids ARE valid refs, no need to invoke the legacy two-arg form):
+
+```
+task name "trainer" matches 2 running pods (pod-A, pod-B); rerun with one of the
+pod-uids: olares-cli dashboard overview gpu tasks <pod-uid>
+```
+
+Not-found in table mode prints `(no task matches "<ref>" — neither a name nor a pod-uid in HAMI's container list)` followed by a `hint: try one of: <name> (<pod-uid>), …` line listing up to 5 real candidates pulled from the same task list (so the user doesn't need to re-list to recover). JSON mode emits the standard `no_gpu_detected` empty envelope.
+
+Pinned by `TestRunTaskByRef_ResolvesByPodUID` / `TestRunTaskByRef_NotFoundTableShowsHint` / `TestRunTaskByRef_AmbiguousErrorsWithCandidates`.
+
+#### Legacy (hidden + deprecated) cobra surface
+
+The pre-refactor `list` / `get` / `detail` / `task` / `task-detail` cobra commands remain functional for back-compat with existing agent scripts. They are marked `Hidden: true` (removed from `--help`) and `Deprecated: "use 'gpu graphics …' / 'gpu tasks …' instead"`; cobra prints a one-line deprecation hint when they run. The underlying `Run*` package functions still exist (some agents may call them via the Go API) and their tests are intact:
+
+| Legacy cobra | Status | Replacement |
+|---|---|---|
+| `gpu list` | Hidden + deprecated | `gpu graphics` |
+| `gpu get <uuid>` | Hidden + deprecated. Note: emits `dashboard.overview.gpu.detail` (HAMI raw, single-shot) — NOT the same envelope as `gpu graphics <uuid>` (which emits `.detail.full` with gauges + trends). Kept because the raw-passthrough verb has no SPA analogue and removing it would break callers that pin on the flat HAMI body. | `gpu graphics <uuid>` (different envelope; opt-in semantic upgrade) |
+| `gpu detail <uuid>` | Hidden + deprecated | `gpu graphics <uuid>` (same envelope) |
+| `gpu task <name> <pod-uid>` | Hidden + deprecated. Same caveat as `gpu get`: emits raw `dashboard.overview.gpu.task.detail`. | `gpu tasks <name>` (different envelope; opt-in semantic upgrade) |
+| `gpu task-detail <name> <pod-uid>` | Hidden + deprecated. Still the only path that takes a manual `--sharemode` override; the new `gpu tasks <name>` always auto-detects sharemode from HAMI's task list. | `gpu tasks <name>` |
+
+Schema introspection (`dashboard schema -o json`) lists both the new surface and the legacy entries (suffixed `(deprecated)`) so an agent can discover the migration mapping programmatically.
+
+### `gpu graphics <uuid>` / `gpu tasks <name>` — full detail pages
+
+Both parent-with-arg variants mirror the SPA's `Overview2/GPU/GPUsDetails.vue` and `Overview2/GPU/TasksDetails.vue` pages: basic info (HAMI `/v1/gpu` or `/v1/container`) + top gauges (instant-vector) + trend charts (range-vector), all assembled into a single sections envelope.
 
 | Command | Kind | Default window | Sections | PromQL count |
 |---|---|---|---|---|
-| `overview gpu detail <uuid>` | `dashboard.overview.gpu.detail.full` | 8h | `detail` / `gauges` / `trends` | 4 instant + 6 range |
-| `overview gpu task-detail <name> <pod-uid> [--sharemode]` | `dashboard.overview.gpu.task.detail.full` | 1h | `detail` / `gauges` / `trends` | 2 instant + 2 range |
+| `overview gpu graphics <uuid>` (legacy: `overview gpu detail <uuid>`) | `dashboard.overview.gpu.detail.full` | 8h | `detail` / `gauges` / `trends` | 4 instant + 6 range |
+| `overview gpu tasks <name>` (legacy: `overview gpu task-detail <name> <pod-uid> [--sharemode]`) | `dashboard.overview.gpu.task.detail.full` | 1h | `detail` / `gauges` / `trends` | 2 instant + 2 range |
 
 Section item ordering is fixed and stable across releases — agents can index by position OR by `raw.key`:
 
@@ -473,7 +515,7 @@ reach `RunXxx`.
 | `pkg/dashboard/overview/` | `RunDefault` (sections envelope), `RunPhysical`, `RunUser(target)`, `RunRanking(sortDir)`, `RunCPU`, `RunMemory(mode)`, `RunPods`, `RunNetwork(testConn)` + the per-node scaffold `RunPerNodeMetric` (`PerNodeDisplayFn`) | `default.go`, `physical.go`, `user.go`, `ranking.go`, `cpu.go`, `memory.go`, `pods.go`, `network.go`, `nodes.go`, `helpers.go` (+ tests) |
 | `pkg/dashboard/overview/disk/` | `RunDefault`, `RunMain`, `RunPartitions(device)` | `default.go`, `main.go`, `partitions.go`, `helpers.go` (+ tests) |
 | `pkg/dashboard/overview/fan/` | `RunDefault`, `RunLive`, `RunCurve` | `default.go`, `live.go`, `curve.go`, `helpers.go` (+ tests) |
-| `pkg/dashboard/overview/gpu/` | `RunList`, `RunTasks`, `RunGet(uuid)`, `RunTask(name,podUID,sharemode)`, `RunDetail(uuid)`, `RunTaskDetail(name,podUID,sharemode)` + the `specs.go` query catalogue (`gaugeSpec` / `trendSpec` / `runGauge` / `runTrend` / `fanoutGaugeAndTrend`) | `list.go`, `tasks.go`, `get.go`, `task.go`, `detail.go`, `task_detail.go`, `specs.go`, `helpers.go` (+ tests) |
+| `pkg/dashboard/overview/gpu/` | `RunDefault` (sections envelope: graphics + tasks), `RunList`, `RunTasks`, `RunGet(uuid)`, `RunTask(name,podUID,sharemode)`, `RunDetail(uuid)`, `RunTaskDetail(name,podUID,sharemode)`, `RunTaskByRef(ref)` (auto-resolves whether `ref` is a task name or a pod-uid) + the `specs.go` query catalogue (`gaugeSpec` / `trendSpec` / `runGauge` / `runTrend` / `fanoutGaugeAndTrend`) | `default.go`, `list.go`, `tasks.go`, `get.go`, `task.go`, `detail.go`, `task_detail.go`, `specs.go`, `helpers.go` (+ tests) |
 
 Each subpackage's `helpers.go` may carry **package-private lowercase
 aliases** (e.g. `formatFloat = pkgdashboard.FormatFloat`,
@@ -572,7 +614,7 @@ Forbidden (regression / scope creep):
 - **Reverting to a flat cmd package** — every fix-it-quick attempt to "just dump it next to overview.go" is a regression. The directory tree IS the command tree; keep them aligned on both sides of the split.
 - Renaming, removing, or repurposing any `Kind*` constant.
 - Changing envelope shapes A / B (additive `omitempty` is fine; structural change is not).
-- Changing the parent-command default → sections envelope mapping. Specifically: `overview`, `overview disk`, `overview fan` default to Shape B; `overview gpu` defaults to `gpu list` (Shape A); `overview cpu` / `overview memory` / `overview pods` etc. are leaves and keep their Shape A defaults. New parent commands MUST pick one of these two shapes and pin it in the `Use` description (and in the area's pkg `default.go`).
+- Changing the parent-command default → sections envelope mapping. Specifically: `overview`, `overview disk`, `overview fan`, `overview gpu` default to Shape B; `overview cpu` / `overview memory` / `overview pods` etc. are leaves and keep their Shape A defaults. New parent commands MUST pick one of these two shapes and pin it in the `Use` description (and in the area's pkg `default.go`).
 - Performing unit / number formatting outside `pkg/dashboard/format/` (including ad-hoc `fmt.Sprintf("%.2f", ...)` for user-visible values).
 - Bypassing the factory-injected client (handwritten `http.Client`, manual `X-Authorization`).
 - Editing `--watch` exit semantics (3-fail cap, `ErrTokenInvalidated` short-circuit, SIGINT exit-0, NDJSON-per-iteration). Adding new exit conditions requires a separate plan.
@@ -675,14 +717,23 @@ olares-cli dashboard overview fan -o json | jq '.sections.curve.items | length' 
 olares-cli dashboard overview fan live --watch --watch-iterations 5 -o json
 ```
 
-GPU + tasks (3-state):
+GPU + tasks (3-state, SPA-aligned surface):
 
 ```bash
-olares-cli dashboard overview gpu list -o json
+# Tabs (lists)
+olares-cli dashboard overview gpu graphics -o json
 olares-cli dashboard overview gpu tasks -o json
+
+# Detail pages (auto-resolves what the SPA passes through the route)
+olares-cli dashboard overview gpu graphics GPU-0123abcd -o json
+olares-cli dashboard overview gpu tasks my-task -o json
+
+# Legacy (hidden + deprecated; still functional for back-compat)
+olares-cli dashboard overview gpu list -o json
 olares-cli dashboard overview gpu get GPU-0123abcd -o json
 olares-cli dashboard overview gpu task my-task abcdef-0123-...
-
+olares-cli dashboard overview gpu detail GPU-0123abcd -o json
+olares-cli dashboard overview gpu task-detail my-task abcdef-0123-... -o json
 ```
 
 Cross-user query as admin:
@@ -697,5 +748,5 @@ Real-machine smoke (drive `-o json` and `jq -e` directly):
 olares-cli profile use olares-id
 olares-cli dashboard schema -o json | jq -e '.kind == "dashboard.schema.index"'
 olares-cli dashboard overview -o json | jq -e '.sections.physical.kind == "dashboard.overview.physical"'
-olares-cli dashboard overview gpu list -o json | jq -e '.kind == "dashboard.overview.gpu.list"'
+olares-cli dashboard overview gpu graphics -o json | jq -e '.kind == "dashboard.overview.gpu.list"'
 ```

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -367,10 +367,24 @@ Both parent-with-arg variants mirror the SPA's `Overview2/GPU/GPUsDetails.vue` a
 Section item ordering is fixed and stable across releases — agents can index by position OR by `raw.key`:
 
 GPU `detail.full` `gauges` keys (in order): `alloc_core` / `alloc_mem` / `util_core` / `util_mem` / `power` / `temperature`.
-GPU `detail.full` `trends` keys (in order): `alloc_trend` (lines: core+memory) / `usage_trend` (core+memory) / `power_trend` / `temp_trend`.
+GPU `detail.full` `trends` keys (in order): `alloc_trend` (lines: VRAM+GPU_MEMORY) / `usage_trend` (VRAM+GPU_MEMORY) / `power_trend` / `temp_trend`.
 
 Task `task-detail.full` `gauges` keys (in order): `compute_usage` / `vram_usage`.
 Task `task-detail.full` `trends` keys (in order): `compute_trend` / `vram_trend` (each one line, label `usage`).
+
+#### Display-vs-Raw formatting invariants (frozen)
+
+The `detail` / `gauges` / `trends` sections each split formatted user-facing values from the wire shape. **`Item.Display` MUST mirror the SPA's chart/text rendering 1:1**, while `Item.Raw` keeps the un-rounded / un-formatted upstream values for agents that need arbitrary precision. Pinned by `format_test.go`. The contracts:
+
+1. **Detail card field whitelist** — `gpuDetailDisplayCopy` emits ONLY the 6 fields SPA's `GPUsDetails.vue:112-137 columns` array displays: `health` / `uuid` / `nodeName` / `type` / `device_no` / `driver_version`. `gpuTaskDetailDisplayCopy` emits ONLY the 8 (6 unconditional + 2 conditional) fields from `TasksDetails.vue:134-174`: `status` / `deviceIds` / `nodeName` / `type` / [`allocatedCores`] / [`allocatedMem`] / `appName` / `createTime` (allocations are emitted only when present in the HAMI body — matches SPA's `displayAllocation = sharemode !== TimeSlicing` gate). HAMI fields that look detail-worthy but **are not in the SPA's `columns` array** (`memoryTotal/Used`, `power`, `powerLimit`, `temperature`, `coreTotal/Used`, `vgpuTotal/Used`, `mode`, `shareMode`, `nodeUid`, etc.) are **deliberately excluded from `Display`** because HAMI's flat `/v1/gpu` body returns placeholders (`memoryUsed: 0`, `power: 0`, `temperature: 0`) — the live values live in instant-vector queries (the `gauges` section) and re-surfacing them under "Detail" misleads users into thinking the GPU is reporting zero everything. `Raw` still carries the entire HAMI body so agents that prefer the wire shape are unaffected. Pinned by `TestGpuDetailDisplayCopy_SPAFieldWhitelist` / `TestGpuTaskDetailDisplayCopy_SPAFieldWhitelist`.
+
+2. **Gauge values are `<number> <unit>` with lodash.round(2)** — `formatGaugeValue` mirrors `<MyGaugeChart unit=…>`. Examples: `23.89 Gi`, `7.87 W`, `46 ℃`. Unit-less ratio gauges (the SPA passes `unit: ' '`) emit just the number. `used_total` is `"0.29/23.89"` — both halves go through `roundedNumberString` (lodash.round(2) + trailing-zero strip). Pinned by `TestFormatGaugeValue` / `TestRoundedNumberString_StripsTrailingZeros`.
+
+3. **Trend point timestamps are SPA-format `YYYY-MM-DD HH:mm:ss` in `cf.Timezone`** — NOT the wire-shape epoch milliseconds (HAMI returns `"1779636713000"`). `formatTrendTimestamp` parses three observed shapes (epoch-ms 13-digit, epoch-s 10-digit, float-s with sub-second decimals) and emits the SPA's `timeParse` shape; unparseable inputs fall through to the raw string so agents can debug HAMI quirks. The wire epoch-ms integer is preserved on `Raw.points[i].timestamp_ms` (`int64`) so chart libraries that re-derive from epoch can round-trip without re-parsing. Pinned by `TestFormatTrendTimestamp_AllShapes` / `TestFormatTrendTimestamp_RespectsTimezone`.
+
+4. **Trend point values use lodash.round(value, 2)** — same call SPA's `pages/Overview2/GPU/config.ts:84` makes before handing the array to ECharts. The full-precision float lives on `Raw.points[i].value_raw`. Use `roundDP(v, dp)` (half-away-from-zero — matches lodash, NOT banker's). Pinned by `TestRoundDP_HalfAwayFromZero` / `TestRunTrend_RoundsValueTo2dp` (via the integration tests in `detail_test.go`).
+
+The `formatTrendTimestamp` / `roundDP` / `roundedNumberString` / `formatGaugeValue` helpers are private to `pkg/dashboard/overview/gpu/specs.go` — they encode SPA-specific render conventions, NOT general-purpose formatters; resist promoting them to `pkgdashboard` until another area starts mirroring SPA chart axes.
 
 Time window flags reuse the existing `--since` / `--start` / `--end`. With neither set the SPA defaults apply (8h for GPU detail, 1h for task detail). `meta.window` carries `{since, start, end, step}` so an agent can replay the exact same query without recomputing.
 


### PR DESCRIPTION
* **Background**
1. Fixed data format issue of olares-cli dashboard
2. Fixed time zone issue of olares-cli dashboard

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HAMI request timestamps and GPU detail query parameters plus broad overview/monitoring aggregation; behavior is heavily regression-tested but affects production CLI parity with the SPA.
> 
> **Overview**
> Aligns **olares-cli dashboard** with the SPA for GPU/overview output and fixes **timezone and wire-format bugs** that caused empty GPU trends and wrong GPU detail on non-Shanghai hosts.
> 
> **GPU / HAMI:** Monitor query windows sent to HAMI are formatted in the **backend timezone** (`GPUTrendTimestampWire`, default Asia/Shanghai, `OLARES_HAMI_BACKEND_TZ`), while `--timezone` only affects **display** (`meta.window`, trend point labels). Per-GPU fetch uses query param **`uid`** instead of `uuid`. Public commands are **`gpu graphics [uuid]`** and **`gpu tasks [ref]`** (name or pod-uid); bare **`dashboard overview gpu`** returns a **sections** envelope (graphics + tasks). Legacy `list` / `get` / `detail` / `task` paths stay working but hidden and deprecated.
> 
> **Formatting / parity:** GPU list adds **VRAM_USAGE**; detail cards use SPA field whitelists; gauges/trends use SPA-style rounding and human timestamps; trend legends match the SPA (VRAM / GPU_MEMORY).
> 
> **Other overview fixes:** **Physical** panel can add cluster **GPU VRAM** (Prom with list fallback) and **fan** rows on Olares One; **user** totals for platform admins without quota fall back to **cluster** totals (without applying that to `--user` peers); **memory swap** mode uses real KubeSphere metrics (`node_vmstat_pswp*`) instead of non-existent swap series. Table mode for GPU list/tasks now **exits with error** on unclassified upstream failures (JSON still returns `meta.error`).
> 
> Extensive regression tests cover TZ split, `uid` param, sections partial failure, and admin quota behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d08fd2687564b3cad6d2c4ff4db8d26459404e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->