### PR TITLE
fix: files paste/delete: missing dirents, unwritable destinations, and incomplete moves

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.172
+          image: beclab/files-server:v0.2.173
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: DELETE /api/resources no longer silently returns 200 when the target dirent does not exist.
- fix: PATCH /api/paste returns a synchronous 403 Permission denied when the destination is not writable, instead of returning 200 followed by an async task failure.
- fix: Cloud-to-sync move and cross-node POSIX move now drop the source file after the copy completes, instead of leaving it behind.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/329

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy; behavior changes come from the upstream files-server release, not local config edits.
> 
> **Overview**
> Bumps the **`files`** DaemonSet container image from `beclab/files-server:v0.2.172` to **`v0.2.173`** in `files_deploy.yaml`, rolling out the files-server build that fixes paste/delete/move behavior (per linked `beclab/files` PR).
> 
> No other manifest, env, or nginx changes in this diff—only the image tag on the `files` container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062ef4feae28686096422748f354dd70c5547620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->