### PR TITLE
feat: inject macvlan reply-via-eth0 init container via mutating webhook

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.23
+        image: beclab/app-service:0.5.24
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260522131110-3a5366610d57
-	github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca
+	github.com/beclab/Olares/framework/oac v0.0.0-20260524144521-bca08c6cf3e3
+	github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29
 	github.com/containers/image/v5 v5.36.1

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -114,10 +114,14 @@ github.com/beclab/Olares/framework/oac v0.0.0-20260515145456-498af91fbbf3 h1:Hwc
 github.com/beclab/Olares/framework/oac v0.0.0-20260515145456-498af91fbbf3/go.mod h1:RvlUQohWvYWZomd85NXtJqctSDQihFZXIYXUwS9743A=
 github.com/beclab/Olares/framework/oac v0.0.0-20260522131110-3a5366610d57 h1:AmHutDaJtjxcHiE0uvJdAMZYUgAme+L8PgJR86BzbHw=
 github.com/beclab/Olares/framework/oac v0.0.0-20260522131110-3a5366610d57/go.mod h1:/G2D7ESXWhMW9NlHv0H/Y9ZaSkRYUpPCv/645L7e9No=
+github.com/beclab/Olares/framework/oac v0.0.0-20260524144521-bca08c6cf3e3 h1:Wtj4Dd4vhL0k1vUEG9JimJFz6KDtbpH85a7kQqXguVE=
+github.com/beclab/Olares/framework/oac v0.0.0-20260524144521-bca08c6cf3e3/go.mod h1:Iff3u03XgyRWM+Xg+4Acx0qe2SjVwTFgchTEHkhOCjA=
 github.com/beclab/api v0.0.7 h1:lpeJHgWNDUv2GG1iP/kv40Ub6fKSHTNfdk4l0/8vxUM=
 github.com/beclab/api v0.0.7/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca h1:dXFvtsmf8uounNwUnE8Cyto08+HUwNHsQYllFR0ViCo=
 github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000 h1:KoS6+k9h+LQfkhex0UHeoOzK1VT59x7rTBVTL6P0T94=
+github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=
 github.com/beclab/lldap-client v0.0.11/go.mod h1:Y74tcKzyNL73a9pFAvImwXgzqp7S7Jb8RY1mMY90e/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/framework/app-service/pkg/apiserver/api/types.go
+++ b/framework/app-service/pkg/apiserver/api/types.go
@@ -21,15 +21,7 @@ const (
 )
 
 const (
-	CodeSuccess                    int32 = 200
-	CodeComputeBindingRequired     int32 = 4601
-	CodeComputeBindingUnavailable  int32 = 4602
-	CodeComputeDeviceSwitchBlocked int32 = 4603
-	// CodeComputeAmbiguousMode is returned by the install endpoint when
-	// the caller did not pick a selectedGpuType and more than one mode in
-	// the manifest is runnable on this cluster. The body carries the
-	// install compute plan so the client can let the user pick.
-	CodeComputeAmbiguousMode int32 = 4604
+	CodeSuccess int32 = 200
 )
 
 // Response represents the code for response.
@@ -224,8 +216,12 @@ type ImageInfoV2 struct {
 }
 
 var (
-	CheckTypeAppEnv      = "appenv"
-	CheckTypeAppEntrance = "appEntrance"
+	CheckTypeAppEnv                     = "appenv"
+	CheckTypeAppEntrance                = "appEntrance"
+	CheckTypeComputeModeSelect          = "computeModeSelect"
+	CheckTypeComputeBindingRequired     = "computeBindingRequired"
+	CheckTypeComputeBindingUnavailable  = "computeBindingUnavailable"
+	CheckTypeComputeDeviceSwitchBlocked = "computeDeviceSwitchBlocked"
 )
 
 type FailedCheckResponse struct {

--- a/framework/app-service/pkg/apiserver/api/utils.go
+++ b/framework/app-service/pkg/apiserver/api/utils.go
@@ -48,8 +48,8 @@ func HandleConflict(response *restful.Response, req *restful.Request, err error)
 	handle(http.StatusConflict, response, req, err)
 }
 
-func HandleFailedCheck(response *restful.Response, checkType string, checkResult any, code int) {
-	response.WriteHeaderAndEntity(http.StatusUnprocessableEntity, FailedCheckResponse{Code: code, Data: FailedCheckResponseData{Type: checkType, Data: checkResult}})
+func HandleFailedCheck(response *restful.Response, checkType string, checkResult any) {
+	response.WriteHeaderAndEntity(http.StatusOK, FailedCheckResponse{Code: http.StatusUnprocessableEntity, Data: FailedCheckResponseData{Type: checkType, Data: checkResult}})
 }
 
 // HandleError handles the given error by determining the appropriate HTTP status code and performing error handling logic.

--- a/framework/app-service/pkg/apiserver/filters.go
+++ b/framework/app-service/pkg/apiserver/filters.go
@@ -95,6 +95,7 @@ func (h *Handler) authenticate(req *restful.Request, resp *restful.Response, cha
 		"/app-service/v1/runasuser/inject",
 		"/app-service/v1/terminus/version",
 		"/app-service/v1/app-label/inject",
+		"/app-service/v1/macvlan-init/inject",
 		"/app-service/v1/apps/image-info",
 		"/app-service/v1/all/apps",
 		"/app-service/v1/apps/oamvalues",

--- a/framework/app-service/pkg/apiserver/handler.go
+++ b/framework/app-service/pkg/apiserver/handler.go
@@ -129,6 +129,10 @@ func (b *handlerBuilder) Build() (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = wh.CreateOrUpdateMacvlanInitMutatingWebhook()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Handler{
 		kubeHost:         b.ksHost,

--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -25,25 +25,20 @@ type ComputeResourcesResponse struct {
 	Data         []compute.Node `json:"data"`
 }
 
-type ComputeAvailabilityResponse struct {
-	api.Response `json:",inline"`
-	Data         *compute.AvailabilityResult      `json:"data"`
-	Validation   *compute.BindingValidationResult `json:"validation,omitempty"`
-}
-
 type ComputeBindingResponse struct {
 	api.Response `json:",inline"`
 	Data         []compute.Allocation `json:"data"`
 }
 
-// InstallComputePlanResponse is returned by the install endpoint
-// (POST /apps/{name}/install) when the caller did not pick a
-// selectedGpuType and more than one mode in the manifest is runnable on
-// this cluster. Code is api.CodeComputeAmbiguousMode and Data lists the
-// per-mode install plan so the client can let the user choose.
-type InstallComputePlanResponse struct {
-	api.Response `json:",inline"`
-	Data         []compute.ModePlanResult `json:"data"`
+// ComputeBindingFailedCheck is the payload returned by the resume endpoint
+// under FailedCheckResponse when the caller needs to (re)select a compute
+// binding before the resume can proceed. CheckTypeComputeBindingRequired
+// signals a binding is required and Validation is nil;
+// CheckTypeComputeBindingUnavailable signals the caller-supplied binding
+// could not be satisfied and Validation explains why.
+type ComputeBindingFailedCheck struct {
+	Availability *compute.AvailabilityResult      `json:"availability"`
+	Validation   *compute.BindingValidationResult `json:"validation,omitempty"`
 }
 
 type UpdateDeviceSupportTypeRequest struct {
@@ -133,13 +128,10 @@ func (h *Handler) updateDeviceSupportType(req *restful.Request, resp *restful.Re
 		return
 	}
 	if len(plan.blocked) > 0 {
-		resp.WriteAsJson(DeviceSupportTypeSwitchResponse{
-			Response: api.Response{Code: api.CodeComputeDeviceSwitchBlocked},
-			Data: DeviceSupportTypeSwitchResult{
-				Status:      "bound-apps-stop-blocked",
-				Device:      device,
-				BlockedApps: plan.blocked,
-			},
+		api.HandleFailedCheck(resp, api.CheckTypeComputeDeviceSwitchBlocked, DeviceSupportTypeSwitchResult{
+			Status:      "bound-apps-stop-blocked",
+			Device:      device,
+			BlockedApps: plan.blocked,
 		})
 		return
 	}

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -244,10 +244,7 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 				api.HandleError(resp, req, planErr)
 				return
 			}
-			resp.WriteAsJson(InstallComputePlanResponse{
-				Response: api.Response{Code: api.CodeComputeAmbiguousMode},
-				Data:     plan,
-			})
+			api.HandleFailedCheck(resp, api.CheckTypeComputeModeSelect, plan)
 			return
 		}
 		if err != nil {
@@ -361,7 +358,7 @@ func (h *installHandlerHelper) validate(isAdmin bool, installedApps []*v1alpha1.
 		return err
 	}
 	if result != nil {
-		api.HandleFailedCheck(h.resp, api.CheckTypeAppEntrance, result, 104222)
+		api.HandleFailedCheck(h.resp, api.CheckTypeAppEntrance, result)
 		return fmt.Errorf("invalid entrance config, check result: %#v", result)
 	}
 
@@ -477,7 +474,7 @@ func (h *installHandlerHelper) validate(isAdmin bool, installedApps []*v1alpha1.
 		return
 	}
 	if ret != nil {
-		api.HandleFailedCheck(h.resp, api.CheckTypeAppEnv, ret, http.StatusUnprocessableEntity)
+		api.HandleFailedCheck(h.resp, api.CheckTypeAppEnv, ret)
 		return fmt.Errorf("Invalid appenv config, check result: %#v", ret)
 	}
 

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -158,10 +158,16 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 	}
 	switch bindingResult.Status {
 	case compute.BindingApplyStatusRequired:
-		writeComputeAvailability(resp, api.CodeComputeBindingRequired, bindingResult.Availability, bindingResult.Validation)
+		api.HandleFailedCheck(resp, api.CheckTypeComputeBindingRequired, ComputeBindingFailedCheck{
+			Availability: bindingResult.Availability,
+			Validation:   bindingResult.Validation,
+		})
 		return
 	case compute.BindingApplyStatusUnavailable:
-		writeComputeAvailability(resp, api.CodeComputeBindingUnavailable, bindingResult.Availability, bindingResult.Validation)
+		api.HandleFailedCheck(resp, api.CheckTypeComputeBindingUnavailable, ComputeBindingFailedCheck{
+			Availability: bindingResult.Availability,
+			Validation:   bindingResult.Validation,
+		})
 		return
 	case compute.BindingApplyStatusApplied:
 	case compute.BindingApplyStatusNotRequired:
@@ -224,16 +230,4 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 
 type ResumeRequest struct {
 	ComputeBinding []compute.BindingSelection `json:"computeBinding,omitempty"`
-}
-
-func writeComputeAvailability(resp *restful.Response, code int32, availability *compute.AvailabilityResult, validation ...*compute.BindingValidationResult) {
-	var bindingValidation *compute.BindingValidationResult
-	if len(validation) > 0 {
-		bindingValidation = validation[0]
-	}
-	resp.WriteAsJson(ComputeAvailabilityResponse{
-		Response:   api.Response{Code: code},
-		Data:       availability,
-		Validation: bindingValidation,
-	})
 }

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -1461,3 +1461,84 @@ func (h *Handler) upgradeOpValidate(ctx context.Context, appConfig *appcfg.Appli
 	}
 	return nil
 }
+
+// macvlanInitInject is the HTTP entrypoint for the macvlan-init mutating webhook.
+// It deserializes the AdmissionReview, runs macvlanInitMutate and writes the response.
+func (h *Handler) macvlanInitInject(req *restful.Request, resp *restful.Response) {
+	klog.Infof("Received mutating webhook[macvlan-init inject] request: Method=%v, URL=%v", req.Request.Method, req.Request.URL)
+	admissionRequestBody, ok := h.sidecarWebhook.GetAdmissionRequestBody(req, resp)
+	if !ok {
+		return
+	}
+	var admissionReq, admissionResp admissionv1.AdmissionReview
+	proxyUUID := uuid.New()
+	if _, _, err := webhook.Deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
+		klog.Errorf("Failed to decode admission request body err=%v", err)
+		admissionResp.Response = h.sidecarWebhook.AdmissionError("", err)
+	} else {
+		admissionResp.Response = h.macvlanInitMutate(req.Request.Context(), admissionReq.Request, proxyUUID)
+	}
+	admissionResp.TypeMeta = admissionReq.TypeMeta
+	admissionResp.Kind = admissionReq.Kind
+
+	requestForNamespace := "unknown"
+	if admissionReq.Request != nil {
+		requestForNamespace = admissionReq.Request.Namespace
+	}
+	err := resp.WriteAsJson(&admissionResp)
+	if err != nil {
+		klog.Errorf("Failed to write response[macvlan-init inject] admin review in namespace=%s err=%v", requestForNamespace, err)
+		return
+	}
+	klog.Infof("Done[macvlan-init inject] with uuid=%s in namespace=%s", proxyUUID, requestForNamespace)
+}
+
+// macvlanInitMutate is the core mutation logic for the macvlan-init webhook.
+// It is a no-op for pods without the macvlan-init label or whose owning
+// Application does not opt into enableOverlayGateway.
+func (h *Handler) macvlanInitMutate(ctx context.Context, req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) *admissionv1.AdmissionResponse {
+	if req == nil {
+		klog.Error("Failed to get admission request err=admission request is nil")
+		return h.sidecarWebhook.AdmissionError("", errNilAdmissionRequest)
+	}
+	resp := &admissionv1.AdmissionResponse{
+		Allowed: true,
+		UID:     req.UID,
+	}
+
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		klog.Errorf("Failed to unmarshal request object raw to pod with uuid=%s namespace=%s err=%v", proxyUUID, req.Namespace, err)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+
+	// Defense-in-depth: ObjectSelector already filters by this label, but
+	// re-check here in case the webhook is invoked from a misconfigured caller.
+	if pod.Labels[constants.ApplicationMacvlanInitLabel] != "true" {
+		return resp
+	}
+	ns := req.Namespace
+
+	shouldInject, err := h.sidecarWebhook.ShouldInjectMacvlanInit(ctx, &pod, ns)
+	if err != nil {
+		klog.Errorf("Failed to evaluate macvlan-init injection for pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+		// FailurePolicy is Ignore at the webhook-config level; here we
+		// still report an error so the API server records it, but the
+		// pod will be allowed.
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	if !shouldInject {
+		return resp
+	}
+
+	patchBytes, err := h.sidecarWebhook.CreateMacvlanInitPatch(req, &pod)
+	if err != nil {
+		klog.Errorf("Failed to create macvlan-init patch for pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	if len(patchBytes) > 0 {
+		h.sidecarWebhook.PatchAdmissionResponse(resp, patchBytes)
+	}
+	klog.Infof("macvlan-init: injected init container for pod=%s/%s uuid=%s", req.Namespace, pod.Name, proxyUUID)
+	return resp
+}

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -319,6 +319,13 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Returns(http.StatusOK, "add limit success", nil)).
 		Consumes(restful.MIME_JSON)
 
+	ws.Route(ws.POST("/macvlan-init/inject").
+		To(handler.macvlanInitInject).
+		Doc("mutating webhook to inject macvlan reply-via-eth0 init container").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Returns(http.StatusOK, "Success to inject", nil)).
+		Consumes(restful.MIME_JSON)
+
 	ws.Route(ws.POST("/provider-registry/validate").
 		To(handler.providerRegistryValidate).
 		Doc("validating webhook for validate app install namespace").

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -103,7 +103,7 @@ type ApplicationConfig struct {
 	HardwareRequirement  Hardware
 	SharedEntrances      []Entrance
 	SelectedGpuType      string
-	Resources            []ResourceMode
+	Accelerator          []ResourceMode
 	// NeedsSharedAccess signals that the app needs cross-namespace access to a
 	// v3 app's services (e.g. for service-mesh sidecar injection).
 	// Force-set to true for v3 apps in toApplicationConfig regardless of
@@ -178,7 +178,7 @@ func (c *ApplicationConfig) GenSharedEntranceURL(ctx context.Context) ([]Entranc
 
 func (c *ApplicationConfig) SelectedResourceMode() (ResourceMode, bool) {
 	modes := c.ComputeResourceModes()
-	if len(modes) == 1 && len(c.Resources) == 0 {
+	if len(modes) == 1 && len(c.Accelerator) == 0 {
 		return modes[0], true
 	}
 	mode := findResourceMode(modes, c.SelectedGpuType)
@@ -195,8 +195,8 @@ func (c *ApplicationConfig) SelectedResourceMode() (ResourceMode, bool) {
 // derived from c.SelectedGpuType / c.Requirement.GPU — see
 // legacyComputeMode for the exact rules.
 func (c *ApplicationConfig) ComputeResourceModes() []ResourceMode {
-	if len(c.Resources) > 0 {
-		return c.Resources
+	if len(c.Accelerator) > 0 {
+		return c.Accelerator
 	}
 	mode := legacyComputeMode(c)
 	return []ResourceMode{{
@@ -387,7 +387,7 @@ func (c *ApplicationConfig) ResolveRequirement(selectedGpu string) (*AppRequirem
 	if len(modes) == 0 {
 		return nil, fmt.Errorf("empty compute resources")
 	}
-	if len(c.Resources) == 0 && len(modes) == 1 {
+	if len(c.Accelerator) == 0 && len(modes) == 1 {
 		req, err := ParseResourceRequirement(&modes[0].ResourceRequirement)
 		if err != nil {
 			return nil, fmt.Errorf("resolve requirement for mode %s: %w", modes[0].Mode, err)

--- a/framework/app-service/pkg/appcfg/application_test.go
+++ b/framework/app-service/pkg/appcfg/application_test.go
@@ -25,7 +25,7 @@ import (
 func TestResolveRequirementSelectedGpuFallbackSemantics(t *testing.T) {
 	nvidiaCpuApp := &ApplicationConfig{
 		AppName: "new-format-multi-mode",
-		Resources: []ResourceMode{
+		Accelerator: []ResourceMode{
 			{
 				Mode: utils.NvidiaCardType,
 				ResourceRequirement: ResourceRequirement{
@@ -43,7 +43,7 @@ func TestResolveRequirementSelectedGpuFallbackSemantics(t *testing.T) {
 	}
 	nvidiaOnlyApp := &ApplicationConfig{
 		AppName: "new-format-nvidia-only",
-		Resources: []ResourceMode{
+		Accelerator: []ResourceMode{
 			{
 				Mode: utils.NvidiaCardType,
 				ResourceRequirement: ResourceRequirement{

--- a/framework/app-service/pkg/compute/auto_select_test.go
+++ b/framework/app-service/pkg/compute/auto_select_test.go
@@ -24,7 +24,7 @@ func TestAppSupportedModes(t *testing.T) {
 		{
 			name: "new format returns spec.resources verbatim in declared order",
 			cfg: &appcfg.ApplicationConfig{
-				Resources: []appcfg.ResourceMode{
+				Accelerator: []appcfg.ResourceMode{
 					{Mode: utils.NvidiaCardType},
 					{Mode: utils.CPUType},
 				},
@@ -324,7 +324,7 @@ func TestAutoSelectModeOnNvidiaOnlyNewFormatApp(t *testing.T) {
 	cfg := &appcfg.ApplicationConfig{
 		AppName:   "nvidia-only-new-format",
 		OwnerName: "alice",
-		Resources: []appcfg.ResourceMode{
+		Accelerator: []appcfg.ResourceMode{
 			{
 				Mode: utils.NvidiaCardType,
 				ResourceRequirement: appcfg.ResourceRequirement{

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -14,7 +14,7 @@ const gi = int64(1024 * 1024 * 1024)
 func TestCalculateInstallComputePlanUsesPureInputs(t *testing.T) {
 	app := &appcfg.ApplicationConfig{
 		AppName: "ollama",
-		Resources: []appcfg.ResourceMode{
+		Accelerator: []appcfg.ResourceMode{
 			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
 			resourceMode(utils.AppleMChipType, "", "1Gi"),
 			resourceMode(utils.StrixHaloChipType, "", "8Gi"),
@@ -34,7 +34,7 @@ func TestCalculateInstallComputePlanUsesPureInputs(t *testing.T) {
 func TestInstallComputePlanIgnoresCurrentBindings(t *testing.T) {
 	app := &appcfg.ApplicationConfig{
 		AppName: "llm",
-		Resources: []appcfg.ResourceMode{
+		Accelerator: []appcfg.ResourceMode{
 			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
 		},
 	}

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -11,6 +11,7 @@ const (
 	KubeSphereAPIScheme                = "http"
 	ApplicationDefaultThirdLevelDomain = "applications.app.bytetrade.io/default-thirdlevel-domains"
 	ApplicationNameLabel               = "applications.app.bytetrade.io/name"
+	ApplicationMacvlanInitLabel        = "applications.app.bytetrade.io/macvlan-init"
 	ApplicationRawAppNameLabel         = "applications.app.bytetrade.io/raw-app-name"
 	ApplicationAppGroupLabel           = "applications.app.bytetrade.io/group"
 	ApplicationAuthorLabel             = "applications.app.bytetrade.io/author"

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -1083,7 +1083,7 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		HardwareRequirement:     cfg.Spec.Hardware,
 		SharedEntrances:         cfg.SharedEntrances,
 		SelectedGpuType:         opt.SelectedGpu,
-		Resources:               cfg.Spec.AcceleratedResources,
+		Accelerator:             cfg.Spec.Accelerator,
 		NeedsSharedAccess:       cfg.Options.NeedsSharedAccess,
 		OverlayGatewaySupported: cfg.Options.OverlayGatewaySupported,
 		LLMGatewaySupported:     cfg.Options.LLMGatewaySupported,

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -36,6 +36,9 @@ const (
 	evictionWebhookName                   = "kubelet-eviction-webhook"
 	evictionValidatingWebhookName         = "kubelet-eviction-webhook.bytetrade.io"
 
+	macvlanInitWebhookName         = "macvlan-init-webhook"
+	mutatingWebhookMacvlanInitName = "macvlan-init-inject-webhook.bytetrade.io"
+
 	applicationManagerMutatingWebhookName   = "applicationmanager-mutating-webhook"
 	applicationManagerValidatingWebhookName = "applicationmanager-validating-webhook"
 	argoResourceValidatingWebhookName       = "argo-resource-validating-webhook"
@@ -1085,5 +1088,120 @@ func (wh *Webhook) CreateOrUpdateArgoResourceValidatingWebhook() error {
 	}
 	klog.Infof("Finished creating Argo Resource ValidatingWebhookConfiguration")
 
+	return nil
+}
+
+// CreateOrUpdateMacvlanInitMutatingWebhook creates or updates the macvlan init container mutating webhook.
+// It only fires for pods labeled applications.app.bytetrade.io/macvlan-init=true on Create.
+// FailurePolicy is Ignore so that a transient webhook outage never blocks pod creation,
+// because the macvlan-init container is an additive networking concern.
+func (wh *Webhook) CreateOrUpdateMacvlanInitMutatingWebhook() error {
+	webhookPath := "/app-service/v1/macvlan-init/inject"
+	port, err := strconv.Atoi(strings.Split(constants.WebhookServerListenAddress, ":")[1])
+	if err != nil {
+		return err
+	}
+	webhookPort := int32(port)
+	failurePolicy := admissionregv1.Ignore
+	matchPolicy := admissionregv1.Exact
+	webhookTimeout := int32(30)
+
+	mwhLabels := map[string]string{"velero.io/exclude-from-backup": "true"}
+	caBundle, err := ioutil.ReadFile(defaultCaPath)
+	if err != nil {
+		return err
+	}
+	mwh := admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   macvlanInitWebhookName,
+			Labels: mwhLabels,
+		},
+		Webhooks: []admissionregv1.MutatingWebhook{
+			{
+				Name: mutatingWebhookMacvlanInitName,
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &admissionregv1.ServiceReference{
+						Namespace: webhookServiceNamespace,
+						Name:      webhookServiceName,
+						Path:      &webhookPath,
+						Port:      &webhookPort,
+					},
+				},
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.UnderLayerNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSNetworkNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSProtectedNamespaces,
+						},
+					},
+				},
+				ObjectSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constants.ApplicationMacvlanInitLabel: "true",
+					},
+				},
+				Rules: []admissionregv1.RuleWithOperations{
+					{
+						Operations: []admissionregv1.OperationType{admissionregv1.Create},
+						Rule: admissionregv1.Rule{
+							APIGroups:   []string{"*"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				TimeoutSeconds:          &webhookTimeout,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+	if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), &mwh, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing, err := wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), mwh.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("Failed to get MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+				return err
+			}
+			mwh.ObjectMeta.ResourceVersion = existing.ObjectMeta.ResourceVersion
+			if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.Background(), &mwh, metav1.UpdateOptions{}); err != nil {
+				if !apierrors.IsConflict(err) {
+					klog.Errorf("Failed to update MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+					return err
+				}
+			}
+		} else {
+			klog.Errorf("Failed to create MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+			return err
+		}
+	}
+	klog.Infof("Finished creating MutatingWebhookConfiguration %s", macvlanInitWebhookName)
 	return nil
 }

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -831,6 +831,11 @@ func (wh *Webhook) ShouldInjectMacvlanInit(ctx context.Context, pod *corev1.Pod,
 // present) and returns the JSON merge patch to send back in the admission
 // response.
 func (wh *Webhook) CreateMacvlanInitPatch(req *admissionv1.AdmissionRequest, pod *corev1.Pod) ([]byte, error) {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations["k8s.v1.cni.cncf.io/networks"] = "kube-system/underlay-macvlan"
+
 	for _, c := range pod.Spec.InitContainers {
 		if c.Name == MacvlanInitContainerName {
 			klog.Infof("macvlan-init: container already present in pod=%s/%s, skip", pod.Namespace, pod.Name)

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -732,3 +732,114 @@ func (wh *Webhook) isSelected(podSelectors []metav1.LabelSelector, pod *corev1.P
 	}
 	return false
 }
+
+// MacvlanInitContainerName is the name of the init container injected for pods
+// that need to reply via eth0 in macvlan setups.
+const MacvlanInitContainerName = "macvlan-reply-via-eth0"
+
+// macvlanInitScript is the shell script run inside the macvlan-init container.
+// It waits for an IPv4 address on eth0, then creates a dedicated routing table
+// and a `from <pod-ip>` rule so that reply traffic is sent out via eth0
+// instead of the default pod gateway.
+const macvlanInitScript = `set -eu
+TABLE=100
+PRI=100
+POD_IP=""
+i=0
+while [ "$i" -lt 30 ]; do
+  POD_IP=$(ip -4 addr show dev eth0 2>/dev/null | awk '/inet /{print $2}' | cut -d/ -f1 | head -1)
+  test -n "$POD_IP" && break
+  i=$((i + 1))
+  sleep 1
+done
+test -n "$POD_IP" || { echo "no eth0 address after wait"; exit 1; }
+GW=$(ip -4 route show dev eth0 | awk '/^default/{print $3; exit}')
+test -n "${GW:-}" || GW=169.254.1.1
+ip -4 route replace default via "$GW" dev eth0 table "$TABLE"
+if ip -4 rule list | grep -Fq "from $POD_IP lookup $TABLE"; then exit 0; fi
+ip -4 rule add from "$POD_IP/32" lookup "$TABLE" priority "$PRI"
+`
+
+// GetMacvlanInitContainer returns the init container spec used to set up
+// a dedicated routing table so that reply traffic flows back via eth0 for
+// pods participating in a macvlan / overlay-gateway setup.
+func GetMacvlanInitContainer() corev1.Container {
+	runAsNonRoot := false
+	allowPrivilegeEscalation := false
+	runAsUser := int64(0)
+	return corev1.Container{
+		Name:            MacvlanInitContainerName,
+		Image:           "docker.io/beclab/aboveos-busybox:1.37.0",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &runAsUser,
+			RunAsNonRoot:             &runAsNonRoot,
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN"},
+			},
+		},
+		Command:                  []string{"sh", "-c", macvlanInitScript},
+		Resources:                corev1.ResourceRequirements{},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+// ShouldInjectMacvlanInit reports whether the macvlan init container should be
+// injected for the given pod. It returns true only when the owning Application
+// can be resolved from the pod's app name/owner labels and has
+// `spec.settings.enableOverlayGateway == "true"`.
+func (wh *Webhook) ShouldInjectMacvlanInit(ctx context.Context, pod *corev1.Pod, ns string) (bool, error) {
+	if pod == nil || pod.Labels == nil {
+		return false, nil
+	}
+	if pod.Labels[constants.ApplicationMacvlanInitLabel] != "true" {
+		return false, nil
+	}
+	appName := pod.Labels[constants.ApplicationNameLabel]
+	owner := pod.Labels[constants.ApplicationOwnerLabel]
+	if appName == "" {
+		klog.Infof("macvlan-init: skip pod=%s/%s missing app labels", ns, pod.Name)
+		return false, nil
+	}
+	klog.Infof("ShouldInjectMacvlanInit: pod.Namespace: %s", ns)
+	applicationName, err := apputils.FmtAppMgrName(appName, owner, ns)
+	if err != nil {
+		klog.Errorf("macvlan-init: failed to format application name app=%s owner=%s ns=%s err=%v", appName, owner, ns, err)
+		return false, err
+	}
+	app, err := wh.dynamicClient.AppV1alpha1().Applications().Get(ctx, applicationName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("macvlan-init: application=%s not found for pod=%s/%s", applicationName, ns, pod.Name)
+			return false, nil
+		}
+		klog.Errorf("macvlan-init: failed to get application=%s err=%v", applicationName, err)
+		return false, err
+	}
+	enabled := app.Spec.Settings["enableOverlayGateway"] == "true"
+	if !enabled {
+		klog.Infof("macvlan-init: application=%s enableOverlayGateway is not true, skip pod=%s/%s", applicationName, ns, pod.Name)
+	}
+	return enabled, nil
+}
+
+// CreateMacvlanInitPatch appends the macvlan init container to the pod's
+// init containers (idempotent — does nothing if the container is already
+// present) and returns the JSON merge patch to send back in the admission
+// response.
+func (wh *Webhook) CreateMacvlanInitPatch(req *admissionv1.AdmissionRequest, pod *corev1.Pod) ([]byte, error) {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == MacvlanInitContainerName {
+			klog.Infof("macvlan-init: container already present in pod=%s/%s, skip", pod.Namespace, pod.Name)
+			return makePatches(req, pod)
+		}
+	}
+	// Append after any existing init containers (e.g. sidecar wait-for /
+	// render-envoy-config) so we run after them but still before the main
+	// app containers.
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, GetMacvlanInitContainer())
+	return makePatches(req, pod)
+}


### PR DESCRIPTION


* **Background**
    Add a new MutatingAdmissionWebhook (macvlan-init-webhook) that, on Pod
    Create, injects a macvlan-reply-via-eth0 init container for pods
    labeled applications.app.bytetrade.io/macvlan-init=true whose owning
    Application has spec.settings.enableOverlayGateway="true". The init
    container sets up a dedicated routing table and a from-<pod-ip> rule so
    that reply traffic egresses via eth0 in macvlan / overlay-gateway
    setups.
    
    The webhook is tightly scoped via ObjectSelector on the macvlan-init
    label and uses FailurePolicy: Ignore so a transient webhook outage
    never blocks pod scheduling. Injection is idempotent: it short-circuits
    when a container named macvlan-reply-via-eth0 is already present.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pod networking is mutated via NET_ADMIN init containers and admission webhooks; API clients must adapt to the new FailedCheck shape for compute flows.
> 
> **Overview**
> Adds a **macvlan-init** mutating admission path for pods labeled `applications.app.bytetrade.io/macvlan-init=true` when the owning Application has `enableOverlayGateway=true`. On create, it can append a `macvlan-reply-via-eth0` init container (dedicated routing table / reply via **eth0**), set the underlay macvlan CNI annotation, register the webhook at startup, expose `POST /app-service/v1/macvlan-init/inject`, and bump the deployed **app-service** image to **0.5.24** with newer **oac** / **api** deps.
> 
> Separately, **install / resume / compute device switch** no longer return bespoke numeric codes (e.g. ambiguous GPU mode, binding required). Those cases now use a unified **`FailedCheckResponse`** (HTTP **200**, body `code` **422**) with typed `checkType` values such as `computeModeSelect`, `computeBindingRequired`, and `computeDeviceSwitchBlocked`. Manifest-side accelerated modes are renamed in config from **`Resources`** to **`Accelerator`** (wired from `spec.accelerator`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b875318c039326949a77329df4338c95e1d1e70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->