### PR TITLE
olares-app: bump system-frontend image to v1.10.36 in helm chart

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.35
+          image: beclab/system-frontend:v1.10.36
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
  - feat(android): accessibility prominent disclosure and copy updates
  - feat(market): GPU compute mode selection and binding for install/clone/resume

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1147
  https://github.com/beclab/TermiPass/pull/1149

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.36
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.35...v1.10.36

## Test plan
- [ ] Verify `olares-app.yaml` initContainer image is `beclab/system-frontend:v1.10.36`
- [ ] Deploy/upgrade system-apps and confirm olares-app init completes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on an init container that stages static assets; no auth, API, or chart logic changes.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image from **`beclab/system-frontend:v1.10.35`** to **`v1.10.36`** in the system-apps Helm chart so deploys/upgrade pull the newer TermiPass/system-frontend bundle into the shared **`www`** volume (same **`cp -r /apps/* /www/`** step).
> 
> This is the only change in the diff; it ships frontend fixes/features from the **v1.10.36** release (e.g. Android accessibility disclosure copy, Market GPU compute mode for install/clone/resume) without altering chart structure or other images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d198799f988b103263e64006dbb7235963547b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->