### PR TITLE
settings users: escape get user path consistently

### DIFF
--- a/cli/cmd/ctl/settings/users/get.go
+++ b/cli/cmd/ctl/settings/users/get.go
@@ -81,7 +81,7 @@ func runGet(ctx context.Context, f *cmdutil.Factory, username, outputRaw string)
 	}
 
 	var u userInfo
-	path := "/api/users/" + username
+	path := userRecordPath(username)
 	if err := decodeObjectResult(ctx, pc.Doer, path, &u); err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func runGet(ctx context.Context, f *cmdutil.Factory, username, outputRaw string)
 	// polls during create.
 	wizardLookupErr := ""
 	if !u.WizardComplete && !strings.EqualFold(strings.TrimSpace(u.State), "Failed") {
-		statusPath := "/api/users/" + url.PathEscape(username) + "/status"
+		statusPath := userStatusPath(username)
 		var st accountModifyStatus
 		if err := decodeObjectResult(ctx, pc.Doer, statusPath, &st); err != nil {
 			// Non-fatal: keep printing the user record. Surface the reason
@@ -115,6 +115,14 @@ func runGet(ctx context.Context, f *cmdutil.Factory, username, outputRaw string)
 		}
 		return renderUserDetail(os.Stdout, u)
 	}
+}
+
+func userRecordPath(username string) string {
+	return "/api/users/" + url.PathEscape(username)
+}
+
+func userStatusPath(username string) string {
+	return userRecordPath(username) + "/status"
 }
 
 // renderUserDetail prints a 2-column "Field: Value" view rather than the

--- a/cli/cmd/ctl/settings/users/get_test.go
+++ b/cli/cmd/ctl/settings/users/get_test.go
@@ -1,0 +1,14 @@
+package users
+
+import "testing"
+
+func TestUserGetPathsEscapeUsernameConsistently(t *testing.T) {
+	username := "alice/team one@olares.com"
+
+	if got, want := userRecordPath(username), "/api/users/alice%2Fteam%20one@olares.com"; got != want {
+		t.Fatalf("userRecordPath() = %q, want %q", got, want)
+	}
+	if got, want := userStatusPath(username), "/api/users/alice%2Fteam%20one@olares.com/status"; got != want {
+		t.Fatalf("userStatusPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
* **Background**
The `settings users get` command built `/api/users/<username>` with the raw username while using `url.PathEscape(username)` for the wizard status lookup. Usernames containing path-sensitive characters could therefore hit different endpoint shapes for the main record and wizard status request.

* **Target Version for Merge**
Not specified.

* **Related Issues**
Fixes inconsistent username escaping in `cli/cmd/ctl/settings/users/get.go`.

* **PRs Involving Sub-Systems**
N/A

* **Other information**:
- Reuses a shared path helper for the main record and status lookup.
- Adds unit coverage for usernames requiring path escaping.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a01ba8b-b05f-48e8-9f88-55dbe8260c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a01ba8b-b05f-48e8-9f88-55dbe8260c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

