### PR TITLE
fix(tapr): shared app shared entrance

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -79,7 +79,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.20
+        image: beclab/sys-event:0.2.21
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -237,10 +237,18 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 				refAppName := ns.Labels["applications.app.bytetrade.io/name"]
 				sharedNamespace := ns.Labels["bytetrade.io/ns-shared"]
 				installedUser := ns.Labels["applications.app.bytetrade.io/install_user"]
-				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner {
+				isV3 := ns.Labels["app.bytetrade.io/api-version"] == "v3"
+				namespaceV3 := ns.Labels["bytetrade.io/namespace"]
+				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner || (isV3 && app.Spec.Namespace == namespaceV3) {
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
+			klog.Infof("appName: %s", app.Spec.Name)
+			nss := make([]string, 0)
+			for _, n := range sharedNs {
+				nss = append(nss, n.Name)
+			}
+			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -243,12 +243,6 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
-			klog.Infof("appName: %s", app.Spec.Name)
-			nss := make([]string, 0)
-			for _, n := range sharedNs {
-				nss = append(nss, n.Name)
-			}
-			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {


### PR DESCRIPTION
* **Background**
shared app shared entrance
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster DNS template generation for shared entrances; incorrect namespace matching could misroute in-cluster resolution for shared apps.
> 
> **Overview**
> Bumps the **tapr-sysevent** deployment image from `beclab/sys-event:0.2.20` to `0.2.21`.
> 
> In **CoreDNS corefile regeneration**, shared-app **shared entrance** DNS records now resolve namespaces for **v3** apps as well as the legacy shared-namespace path. Namespace selection adds checks for `app.bytetrade.io/api-version` == `v3` and `bytetrade.io/namespace` matching the application’s `Spec.Namespace`, alongside the existing shared NS labels (`bytetrade.io/ns-shared`, install user, and app name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a50b21f58f596c2fa96422f7f87b110d442d56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->