### PR TITLE
fix(app-service): webhook prevent owner role user be deleted

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.24
+        image: beclab/app-service:0.5.25
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -651,6 +651,8 @@ func (r *ApplicationReconciler) getAppSettings(ctx context.Context, appName, app
 				}
 
 				sharedEntrances = appCfg.SharedEntrances
+			} else if appCfg.IsV3() {
+				sharedEntrances = appCfg.SharedEntrances
 			}
 			if appCfg.MobileSupported {
 				settings["mobileSupported"] = "true"

--- a/framework/app-service/pkg/apiserver/api/utils.go
+++ b/framework/app-service/pkg/apiserver/api/utils.go
@@ -69,5 +69,8 @@ func HandleError(response *restful.Response, req *restful.Request, err error) {
 func handle(statusCode int, response *restful.Response, req *restful.Request, err error) {
 	_, fn, line, _ := runtime.Caller(2)
 	ctrl.Log.Error(err, "response error", "func", fn, "line", line)
-	http.Error(response, sanitizer.Replace(err.Error()), statusCode)
+	response.WriteHeaderAndJson(statusCode, ResponseWithMsg{
+		Response: Response{Code: int32(statusCode)},
+		Message:  sanitizer.Replace(err.Error()),
+	}, restful.MIME_JSON)
 }

--- a/framework/app-service/pkg/apiserver/handler_user.go
+++ b/framework/app-service/pkg/apiserver/handler_user.go
@@ -212,6 +212,11 @@ func (h *Handler) deleteUser(req *restful.Request, resp *restful.Response) {
 		api.HandleBadRequest(resp, req, fmt.Errorf("user %s not found", username))
 		return
 	}
+	if user.Annotations[users.UserAnnotationOwnerRole] == "owner" {
+		api.HandleForbidden(resp, req, fmt.Errorf("user %s with role[owner] can not be deleted", user.Name))
+		return
+	}
+
 	user.Annotations[users.AnnotationUserDeleter] = owner
 	err = h.ctrlClient.Update(req.Request.Context(), &user)
 	if err != nil {

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -1007,10 +1007,24 @@ func (h *Handler) validateUser(ctx context.Context, req *admissionv1.AdmissionRe
 	// Decode the User spec from the request.
 	var user iamv1alpha2.User
 	raw := req.Object.Raw
+	if req.Operation == admissionv1.Delete {
+		raw = req.OldObject.Raw
+	}
 	err := json.Unmarshal(raw, &user)
 	if err != nil {
 		klog.Errorf("Failed to unmarshal request object raw to user with uuid=%s namespace=%s", proxyUUID, req.Namespace)
 		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+
+	if req.Operation == admissionv1.Delete {
+		if user.Annotations[users.UserAnnotationOwnerRole] == "owner" {
+			resp.Allowed = false
+			resp.Result = &metav1.Status{
+				Message: fmt.Sprintf("user %s with role[owner] can not be deleted", user.Name),
+			}
+			return resp
+		}
+		return resp
 	}
 
 	// Check if user already exists

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -121,7 +121,7 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest,
 		return h.sidecarWebhook.AdmissionError(req.UID, err)
 	}
 	klog.Infof("injectPolicy=%v, injectWs=%v, injectUpload=%v, injectSharedPod=%v, perms=%v", injectPolicy, injectWs, injectUpload, injectSharedPod, perms)
-	if !injectPolicy && !injectWs && !injectUpload && injectSharedPod == nil && len(perms) == 0 {
+	if !injectPolicy && !injectWs && !injectUpload && injectSharedPod == nil && len(perms) == 0 || (appCfg != nil && appCfg.IsV3()) {
 		klog.Infof("Skipping sidecar injection for pod with uuid=%s namespace=%s", proxyUUID, req.Namespace)
 		return resp
 	}

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -796,7 +796,10 @@ func (wh *Webhook) CreateOrUpdateUserValidatingWebhook() error {
 				MatchPolicy:   &matchPolicy,
 				Rules: []admissionregv1.RuleWithOperations{
 					{
-						Operations: []admissionregv1.OperationType{admissionregv1.Create},
+						Operations: []admissionregv1.OperationType{
+							admissionregv1.Create,
+							admissionregv1.Delete,
+						},
 						Rule: admissionregv1.Rule{
 							APIGroups:   []string{"iam.kubesphere.io"},
 							APIVersions: []string{"v1alpha2"},


### PR DESCRIPTION
* **Background**
- api error response with json
- webhook prevent owner role user be deleted
- omit envoy inject for shared app

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IAM delete paths and admission webhooks (owner lockout) plus pod mutation for v3 apps; mistakes could block legitimate deletes or alter networking for shared/v3 workloads.
> 
> **Overview**
> Bumps **app-service** to `0.5.25` and tightens user lifecycle, API errors, and v3/shared-app behavior.
> 
> **Owner protection:** Users with `bytetrade.io/owner-role` = `owner` cannot be removed via the delete-user API (403) or through direct Kubernetes deletes—the user validating webhook now handles **Delete** (using `OldObject`) and rejects the same case.
> 
> **API errors:** Shared error handling now returns **JSON** (`code` + sanitized `message`) instead of a plain HTTP error body.
> 
> **Apps:** **v3** app configs skip sandbox/sidecar injection in the mutating webhook. **Shared entrances** are copied from install config for v3 apps even when they are not cluster-scoped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87e404a5913c7f91d6a103098f15ba931160f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->