### PR TITLE
cli: add CreateAppCommonDir task

### DIFF
--- a/cli/pkg/storage/constants.go
+++ b/cli/pkg/storage/constants.go
@@ -41,4 +41,6 @@ var (
 	MinioConfigFile  = path.Join(Root, "etc", "default", "minio")
 
 	MinioOperatorFile = path.Join(Root, "usr", "local", "bin", "minio-operator")
+
+	AppCommonDir = path.Join(OlaresJuiceFSRootDir, "Common")
 )

--- a/cli/pkg/storage/tasks.go
+++ b/cli/pkg/storage/tasks.go
@@ -410,3 +410,17 @@ func (t *CreateSharedLibDir) Execute(runtime connector.Runtime) error {
 	}
 	return nil
 }
+
+type CreateAppCommonDir struct {
+	common.KubeAction
+}
+
+func (t *CreateAppCommonDir) Execute(runtime connector.Runtime) error {
+	if runtime.GetSystemInfo().IsDarwin() {
+		return nil
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", AppCommonDir, AppCommonDir), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create app common dir")
+	}
+	return nil
+}

--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -342,6 +342,11 @@ func (m *InstallOsSystemModule) Init() {
 		Action: &storage.CreateSharedLibDir{},
 	}
 
+	createAppCommonDir := &task.LocalTask{
+		Name:   "CreateAppCommonDir",
+		Action: &storage.CreateAppCommonDir{},
+	}
+
 	installOsSystem := &task.LocalTask{
 		Name:   "InstallOsSystem",
 		Action: &InstallOsSystem{},
@@ -375,6 +380,7 @@ func (m *InstallOsSystemModule) Init() {
 		applySystemEnv,
 		createUserEnvConfigMap,
 		createSharedLibDir,
+		createAppCommonDir,
 		installOsSystem,
 		createBackupConfigMap,
 		checkSystemService,

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -40,6 +40,7 @@ func (u upgrader_1_12_6) PrepareForUpgrade() []task.Interface {
 	tasks = append(tasks, upgradeNodeExporterServiceMonitor()...)
 	tasks = append(tasks, upgradeNodeExporter()...)
 	tasks = append(tasks, upgradeMultus()...)
+	tasks = append(tasks, createAppCommonDir()...)
 
 	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
 	return tasks

--- a/cli/pkg/upgrade/1_12_7_20260527.go
+++ b/cli/pkg/upgrade/1_12_7_20260527.go
@@ -1,0 +1,26 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_7_20260527 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260527) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260527")
+}
+
+func (u upgrader_1_12_7_20260527) PrepareForUpgrade() []task.Interface {
+	tasks := make([]task.Interface, 0)
+	tasks = append(tasks, createAppCommonDir()...)
+
+	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260527{})
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -33,6 +33,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/plugins/network"
 	"github.com/beclab/Olares/cli/pkg/plugins/network/templates"
+	"github.com/beclab/Olares/cli/pkg/storage"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 	"github.com/beclab/Olares/cli/pkg/utils"
 	appv1alpha1 "github.com/beclab/Olares/framework/app-service/api/app.bytetrade.io/v1alpha1"
@@ -713,4 +714,13 @@ func (a *generateMultusConfigAction) Execute(runtime connector.Runtime) error {
 	}
 
 	return a.Template.Execute(runtime)
+}
+
+func createAppCommonDir() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "CreateAppCommonDir",
+			Action: &storage.CreateAppCommonDir{},
+		},
+	}
 }


### PR DESCRIPTION
* **Background**
Create the application common directory for the LLM model cache sharing in multi-apps and multi-nodes

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to host filesystem setup under the existing JuiceFS root; no auth or API changes, with the same sudo/chown pattern as shared lib dir creation.
> 
> **Overview**
> Adds a **`CreateAppCommonDir`** install/upgrade step that creates **`AppCommonDir`** (`<OlaresJuiceFS rootfs>/Common`) with `mkdir -p` and **`chown 1000:1000`**, mirroring **`CreateSharedLibDir`** and skipping macOS.
> 
> Fresh installs run the task in **`InstallOsSystemModule`** before **`InstallOsSystem`**. Upgrades run it via shared **`createAppCommonDir()`** in **`1.12.6`** `PrepareForUpgrade` and a new daily upgrader **`1.12.7-20260527`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84929ed83ad4ed23f7680b7566bdb387de7fbbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->