### PR TITLE
fix(oac): rename acceleratedResources to accelerator ,api to v0.0.8

### DIFF
--- a/framework/oac/appconfig_types_test.go
+++ b/framework/oac/appconfig_types_test.go
@@ -46,7 +46,7 @@ func TestAppConfiguration_Constructible(t *testing.T) {
 			SubCharts: []manifest.Chart{
 				{Name: "extra", Shared: true},
 			},
-			AcceleratedResources: []manifest.ResourceMode{
+			Accelerator: []manifest.ResourceMode{
 				{
 					Mode: "cpu",
 					ResourceRequirement: manifest.ResourceRequirement{
@@ -69,8 +69,8 @@ func TestAppConfiguration_Constructible(t *testing.T) {
 	if cfg.Metadata.Name != "demo" {
 		t.Fatalf("metadata round-trip broken: %+v", cfg.Metadata)
 	}
-	if cfg.Spec.AcceleratedResources[0].LimitedCPU != "200m" {
-		t.Fatalf("inline ResourceRequirement round-trip broken: %+v", cfg.Spec.AcceleratedResources[0])
+	if cfg.Spec.Accelerator[0].LimitedCPU != "200m" {
+		t.Fatalf("inline ResourceRequirement round-trip broken: %+v", cfg.Spec.Accelerator[0])
 	}
 	if cfg.Options.Upload.Dest != "/tmp" {
 		t.Fatalf("options.upload round-trip broken: %+v", cfg.Options.Upload)

--- a/framework/oac/appconfig_types_test.go
+++ b/framework/oac/appconfig_types_test.go
@@ -46,7 +46,7 @@ func TestAppConfiguration_Constructible(t *testing.T) {
 			SubCharts: []manifest.Chart{
 				{Name: "extra", Shared: true},
 			},
-			Resources: []manifest.ResourceMode{
+			AcceleratedResources: []manifest.ResourceMode{
 				{
 					Mode: "cpu",
 					ResourceRequirement: manifest.ResourceRequirement{
@@ -69,8 +69,8 @@ func TestAppConfiguration_Constructible(t *testing.T) {
 	if cfg.Metadata.Name != "demo" {
 		t.Fatalf("metadata round-trip broken: %+v", cfg.Metadata)
 	}
-	if cfg.Spec.Resources[0].LimitedCPU != "200m" {
-		t.Fatalf("inline ResourceRequirement round-trip broken: %+v", cfg.Spec.Resources[0])
+	if cfg.Spec.AcceleratedResources[0].LimitedCPU != "200m" {
+		t.Fatalf("inline ResourceRequirement round-trip broken: %+v", cfg.Spec.AcceleratedResources[0])
 	}
 	if cfg.Options.Upload.Dest != "/tmp" {
 		t.Fatalf("options.upload round-trip broken: %+v", cfg.Options.Upload)

--- a/framework/oac/apps_report_test.go
+++ b/framework/oac/apps_report_test.go
@@ -741,7 +741,7 @@ func manifestLimitLines(cfg *manifest.AppConfiguration) []string {
 		))
 		return lines
 	}
-	for _, rm := range cfg.Spec.Resources {
+	for _, rm := range cfg.Spec.AcceleratedResources {
 		lines = append(lines, fmt.Sprintf(
 			"mode=%s: requiredCpu=%s, limitedCpu=%s, requiredMemory=%s, limitedMemory=%s",
 			rm.Mode,

--- a/framework/oac/apps_report_test.go
+++ b/framework/oac/apps_report_test.go
@@ -741,7 +741,7 @@ func manifestLimitLines(cfg *manifest.AppConfiguration) []string {
 		))
 		return lines
 	}
-	for _, rm := range cfg.Spec.AcceleratedResources {
+	for _, rm := range cfg.Spec.Accelerator {
 		lines = append(lines, fmt.Sprintf(
 			"mode=%s: requiredCpu=%s, limitedCpu=%s, requiredMemory=%s, limitedMemory=%s",
 			rm.Mode,

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -396,11 +396,11 @@ func (c *OAC) checkResourceLimits(oacPath string, m Manifest, sc ownerScenario, 
 			LimitedMemory:  cfg.Spec.LimitedMemory,
 		})
 	}
-	if len(cfg.Spec.AcceleratedResources) == 0 {
+	if len(cfg.Spec.Accelerator) == 0 {
 		return nil
 	}
 	var errs []error
-	for _, rm := range cfg.Spec.AcceleratedResources {
+	for _, rm := range cfg.Spec.Accelerator {
 		values := c.buildRenderValues(m, sc)
 		helmrender.SetGPUType(values, rm.Mode)
 		list, err := helmrender.Render(oacPath, values, m.AppName())

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -396,11 +396,11 @@ func (c *OAC) checkResourceLimits(oacPath string, m Manifest, sc ownerScenario, 
 			LimitedMemory:  cfg.Spec.LimitedMemory,
 		})
 	}
-	if len(cfg.Spec.Resources) == 0 {
+	if len(cfg.Spec.AcceleratedResources) == 0 {
 		return nil
 	}
 	var errs []error
-	for _, rm := range cfg.Spec.Resources {
+	for _, rm := range cfg.Spec.AcceleratedResources {
 		values := c.buildRenderValues(m, sc)
 		helmrender.SetGPUType(values, rm.Mode)
 		list, err := helmrender.Render(oacPath, values, m.AppName())

--- a/framework/oac/chart_limits_test.go
+++ b/framework/oac/chart_limits_test.go
@@ -86,7 +86,7 @@ func TestCheckResourceLimits_V2_SkipsRegardlessOfManifestVersion(t *testing.T) {
 	}
 
 	cfg.ConfigVersion = "0.11.0"
-	cfg.Spec.Resources = nil
+	cfg.Spec.AcceleratedResources = nil
 	if err := c.checkResourceLimits(dir, m, sc, nil); err != nil {
 		t.Fatalf("v2 + legacy must skip the limit check, got: %v", err)
 	}

--- a/framework/oac/chart_limits_test.go
+++ b/framework/oac/chart_limits_test.go
@@ -86,7 +86,7 @@ func TestCheckResourceLimits_V2_SkipsRegardlessOfManifestVersion(t *testing.T) {
 	}
 
 	cfg.ConfigVersion = "0.11.0"
-	cfg.Spec.AcceleratedResources = nil
+	cfg.Spec.Accelerator = nil
 	if err := c.checkResourceLimits(dir, m, sc, nil); err != nil {
 		t.Fatalf("v2 + legacy must skip the limit check, got: %v", err)
 	}

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca
+	github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	helm.sh/helm/v3 v3.19.5

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.7
+	github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	helm.sh/helm/v3 v3.19.5

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000
+	github.com/beclab/api v0.0.8
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	helm.sh/helm/v3 v3.19.5

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -27,6 +27,10 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/api v0.0.7 h1:lpeJHgWNDUv2GG1iP/kv40Ub6fKSHTNfdk4l0/8vxUM=
 github.com/beclab/api v0.0.7/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.8-0.20260522121624-41c892fa293b h1:/cQTpOmLIO/0/t/UPrOBm6Itls7VtuQ4lTTWdGoJz4I=
+github.com/beclab/api v0.0.8-0.20260522121624-41c892fa293b/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca h1:dXFvtsmf8uounNwUnE8Cyto08+HUwNHsQYllFR0ViCo=
+github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -31,6 +31,8 @@ github.com/beclab/api v0.0.8-0.20260522121624-41c892fa293b h1:/cQTpOmLIO/0/t/UPr
 github.com/beclab/api v0.0.8-0.20260522121624-41c892fa293b/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca h1:dXFvtsmf8uounNwUnE8Cyto08+HUwNHsQYllFR0ViCo=
 github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000 h1:KoS6+k9h+LQfkhex0UHeoOzK1VT59x7rTBVTL6P0T94=
+github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -33,6 +33,8 @@ github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca h1:dXFvtsmf8uounNwUnE
 github.com/beclab/api v0.0.8-0.20260522125754-f2fb68d230ca/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000 h1:KoS6+k9h+LQfkhex0UHeoOzK1VT59x7rTBVTL6P0T94=
 github.com/beclab/api v0.0.8-0.20260524143612-0ae07f657000/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.8 h1:7d15aTwZh+Bgv6EgoUT0WmPUKE5tANtBT9oAlq4x6/w=
+github.com/beclab/api v0.0.8/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -88,8 +88,9 @@ func ValidateResourceMode(r ResourceMode) error {
 //   - mutual exclusion (Rule 7): runs at every version. Legacy flat
 //     spec.required*/spec.limited* fields cannot coexist with
 //     spec.resources[] -- they are alternative expressions of the same
-//     envelope, not complementary fields, so emitting this rule on legacy
-//     manifests warns users who try to straddle both shapes.
+//     envelope, not complementary fields, so emitting this rule on
+//     legacy / v2 / modern manifests alike warns any user who tries to
+//     straddle both shapes.
 //   - per-entry validation (mode -> supportArch and empty-envelope
 //     completeness): only runs when olaresManifest.version >= 0.12.0 and
 //     apiVersion is not v2 (v2 forbids spec.resources[] entirely).
@@ -112,7 +113,7 @@ func specResourceCrossFieldRules(configVersion, apiVersion string, spec *AppSpec
 		supportArch[a] = struct{}{}
 	}
 
-	for i, rm := range spec.Resources {
+	for i, rm := range spec.AcceleratedResources {
 		path := fmt.Sprintf("spec.resources[%d]", i)
 
 		if required, ok := modeArchRequirement[rm.Mode]; ok {
@@ -188,10 +189,10 @@ var legacySpecResourceFields = [...]struct {
 // disk and spec.required*/limited*Gpu are not part of the must-fill set
 // at legacy versions and are intentionally excluded from the check.
 func isLegacyEnvelopeMissing(spec *AppSpec) bool {
-	return spec.RequiredCPU == "" &&
-		spec.LimitedCPU == "" &&
-		spec.RequiredMemory == "" &&
-		spec.LimitedMemory == "" &&
+	return spec.RequiredCPU == "" ||
+		spec.LimitedCPU == "" ||
+		spec.RequiredMemory == "" ||
+		spec.LimitedMemory == "" ||
 		spec.RequiredDisk == ""
 }
 
@@ -203,7 +204,7 @@ func isLegacyEnvelopeMissing(spec *AppSpec) bool {
 // fields are unconstrained here -- callers (validateAppSpec) decide
 // whether they are required or simply optional for the version in play.
 func ensureLegacyAndResourcesAreMutuallyExclusive(spec *AppSpec) error {
-	if len(spec.Resources) == 0 {
+	if len(spec.AcceleratedResources) == 0 {
 		return nil
 	}
 	var errs []error

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -24,7 +24,7 @@ const (
 
 var validResourceModes = []any{
 	ResourceModeCPU,
-	ResourceModeAMDAPU,
+	ResourceModeStrixHalo,
 	ResourceModeAMDGPU,
 	ResourceModeAppleM,
 	ResourceModeNvidia,

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -113,7 +113,7 @@ func specResourceCrossFieldRules(configVersion, apiVersion string, spec *AppSpec
 		supportArch[a] = struct{}{}
 	}
 
-	for i, rm := range spec.AcceleratedResources {
+	for i, rm := range spec.Accelerator {
 		path := fmt.Sprintf("spec.resources[%d]", i)
 
 		if required, ok := modeArchRequirement[rm.Mode]; ok {
@@ -204,7 +204,7 @@ func isLegacyEnvelopeMissing(spec *AppSpec) bool {
 // fields are unconstrained here -- callers (validateAppSpec) decide
 // whether they are required or simply optional for the version in play.
 func ensureLegacyAndResourcesAreMutuallyExclusive(spec *AppSpec) error {
-	if len(spec.AcceleratedResources) == 0 {
+	if len(spec.Accelerator) == 0 {
 		return nil
 	}
 	var errs []error

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -16,7 +16,7 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c.ConfigVersion = "0.13.0" // >= 0.12.0 -> rules apply
 	c.APIVersion = APIVersionV1
 	c.Spec.SupportArch = []string{"amd64", "arm64"}
-	c.Spec.AcceleratedResources = modes
+	c.Spec.Accelerator = modes
 	c.Spec.RequiredCPU = ""
 	c.Spec.LimitedCPU = ""
 	c.Spec.RequiredMemory = ""

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -16,7 +16,7 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c.ConfigVersion = "0.13.0" // >= 0.12.0 -> rules apply
 	c.APIVersion = APIVersionV1
 	c.Spec.SupportArch = []string{"amd64", "arm64"}
-	c.Spec.Resources = modes
+	c.Spec.AcceleratedResources = modes
 	c.Spec.RequiredCPU = ""
 	c.Spec.LimitedCPU = ""
 	c.Spec.RequiredMemory = ""

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -247,7 +247,7 @@ func TestRule2_InlineMissingFieldRejected(t *testing.T) {
 // relaxation of the old "cpu+memory only" constraint.
 func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	for _, mode := range []string{
-		ResourceModeCPU, ResourceModeAMDAPU, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMThreadsM1000,
+		ResourceModeCPU, ResourceModeStrixHalo, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMThreadsM1000,
 	} {
 		mode := mode
 		t.Run(mode+"_disk_allowed", func(t *testing.T) {

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -243,7 +243,7 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 
 	api := normalizeAPIVersion(apiVersion)
 	var v2ResourcesErr error
-	if api == APIVersionV2 && len(s.Resources) > 0 {
+	if api == APIVersionV2 && len(s.AcceleratedResources) > 0 {
 		v2ResourcesErr = fmt.Errorf(
 			"spec.resources is not supported for apiVersion=v2 (including when olaresManifest.version >= 0.12.0); use spec.requiredCpu, spec.limitedCpu, spec.requiredMemory, spec.limitedMemory, and spec.requiredDisk instead",
 		)
@@ -262,11 +262,8 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 	switch {
 	case modern:
 		fields = append(fields,
-			validation.Field(&s.Resources,
-				validation.Required.Error(
-					"spec.resources is required for olaresManifest.version >= 0.12.0; declare at least one entry",
-				),
-				validation.Each(validation.By(validateResourceModeValue)),
+			validation.Field(&s.AcceleratedResources,
+				validation.By(validateResourceModeValueFor(&s)),
 			),
 		)
 	case isLegacyEnvelopeMissing(&s):
@@ -277,36 +274,144 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 			validation.Field(&s.LimitedDisk, optionalLimitedDiskQuantity),
 		)
 	default:
-		fields = append(fields,
-			validation.Field(&s.RequiredMemory,
-				validation.Required.Error("spec.requiredMemory is required for olaresManifest.version < 0.12.0"),
-				quantityRule),
-			validation.Field(&s.RequiredDisk,
-				validation.Required.Error("spec.requiredDisk is required for olaresManifest.version < 0.12.0"),
-				quantityRule),
-			validation.Field(&s.RequiredCPU,
-				validation.Required.Error("spec.requiredCpu is required for olaresManifest.version < 0.12.0"),
-				quantityRule),
-			validation.Field(&s.LimitedMemory,
-				validation.Required.Error("spec.limitedMemory is required for olaresManifest.version < 0.12.0"),
-				quantityRule),
-			validation.Field(&s.LimitedCPU,
-				validation.Required.Error("spec.limitedCpu is required for olaresManifest.version < 0.12.0"),
-				quantityRule),
-			validation.Field(&s.LimitedDisk, optionalLimitedDiskQuantity),
-		)
+		fields = append(fields, legacyEnvelopeFieldRules(&s, quantityRule, optionalLimitedDiskQuantity)...)
 	}
 
 	structErr := validation.ValidateStruct(&s, fields...)
 	return errors.Join(v2ResourcesErr, supportedGpuModernErr, structErr, versionGuidance, specResourceCrossFieldRules(configVersion, apiVersion, &s))
 }
 
-func validateResourceModeValue(v interface{}) error {
-	rm, ok := v.(ResourceMode)
-	if !ok {
-		return fmt.Errorf("resources: unexpected type %T", v)
+// legacyEnvelopeFieldRules builds the FieldRules for the legacy flat
+// resource envelope: requiredCpu / limitedCpu / requiredMemory /
+// limitedMemory / requiredDisk are all required (with quantity validation)
+// while limitedDisk stays optional but still quantity-checked when set.
+//
+// Factored out of validateAppSpec so the legacy branch can install it with
+// a single append, and so any future caller (or test) that wants the same
+// shape doesn't have to redeclare every Field rule.
+func legacyEnvelopeFieldRules(s *AppSpec, quantityRule, optionalLimitedDiskQuantity validation.Rule) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&s.RequiredMemory,
+			validation.Required.Error("spec.requiredMemory is required for olaresManifest.version < 0.12.0"),
+			quantityRule),
+		validation.Field(&s.RequiredDisk,
+			validation.Required.Error("spec.requiredDisk is required for olaresManifest.version < 0.12.0"),
+			quantityRule),
+		validation.Field(&s.RequiredCPU,
+			validation.Required.Error("spec.requiredCpu is required for olaresManifest.version < 0.12.0"),
+			quantityRule),
+		validation.Field(&s.LimitedMemory,
+			validation.Required.Error("spec.limitedMemory is required for olaresManifest.version < 0.12.0"),
+			quantityRule),
+		validation.Field(&s.LimitedCPU,
+			validation.Required.Error("spec.limitedCpu is required for olaresManifest.version < 0.12.0"),
+			quantityRule),
+		validation.Field(&s.LimitedDisk, optionalLimitedDiskQuantity),
 	}
-	return ValidateResourceMode(rm)
+}
+
+// validateResourceModeValueFor binds spec so the modern (>= 0.12.0,
+// apiVersion != v2) branch can dispatch validation onto whichever shape
+// the manifest actually uses, from a single validation.By rule wired onto
+// spec.Resources:
+//
+//  1. spec.resources[] is non-empty: iterate every entry and apply
+//     per-element validation (ValidateResourceMode -- mode enum, quantity
+//     validity, section completeness, gpu-section gate, limit >= required).
+//  2. spec.resources[] is empty AND at least one flat field is set: the
+//     manifest opted into the legacy envelope on a modern version, so
+//     format-validate every populated spec.required* / spec.limited*
+//     flat field via validateFlatResourceQuantities. Required-ness of
+//     individual flat fields is deliberately not enforced here -- users
+//     who fill out only part of the envelope still get format feedback
+//     plus the Rule 5 limit >= required pairing applied to whatever they
+//     wrote down.
+//  3. spec.resources[] is empty AND no flat field is set: emit a single
+//     consolidated guidance message listing both shapes; the manifest
+//     must declare at least one.
+//
+// Rule 7 mutex (spec.resources[] cannot coexist with the eight flat
+// fields) is still enforced by ensureLegacyAndResourcesAreMutuallyExclusive
+// from specResourceCrossFieldRules, which runs for every version, so this
+// closure does not need to repeat it.
+func validateResourceModeValueFor(spec *AppSpec) validation.RuleFunc {
+	return func(v interface{}) error {
+		var errs []error
+		for i, rm := range spec.AcceleratedResources {
+			if err := ValidateResourceMode(rm); err != nil {
+				errs = append(errs, fmt.Errorf("spec.resources[%d]: %w", i, err))
+			}
+		}
+		if len(spec.AcceleratedResources) == 0 {
+			if err := validateFlatResourceQuantities(spec); err != nil {
+				errs = append(errs, err)
+			}
+			if !hasAnyFlatResourceQuantity(spec) {
+				errs = append(errs, fmt.Errorf(
+					"either spec.resources[] or the legacy envelope (spec.requiredCpu / spec.limitedCpu / spec.requiredMemory / spec.limitedMemory / spec.requiredDisk) is required for olaresManifest.version >= 0.12.0",
+				))
+			}
+		}
+
+		return errors.Join(errs...)
+	}
+}
+
+// hasAnyFlatResourceQuantity reports whether any of the eight legacy
+// spec.required* / spec.limited* flat fields carries a value. Used by
+// the modern-branch closure to decide whether an empty spec.resources[]
+// means "the manifest opted into the flat envelope" (some flat field is
+// set) or "the manifest forgot to declare a resource envelope at all"
+// (nothing is set).
+func hasAnyFlatResourceQuantity(spec *AppSpec) bool {
+	return spec.RequiredCPU != "" ||
+		spec.LimitedCPU != "" ||
+		spec.RequiredMemory != "" ||
+		spec.LimitedMemory != "" ||
+		spec.RequiredDisk != "" ||
+		spec.LimitedDisk != ""
+}
+
+// validateFlatResourceQuantities reports each populated
+// spec.required* / spec.limited* flat field whose value does not parse
+// as a Kubernetes quantity. Empty fields are skipped: this helper only
+// answers "is the value I wrote down legal?", not "did I write down
+// enough fields?". Required-ness is a separate concern owned by the
+// caller (legacyEnvelopeFieldRules for the legacy branch; the modern
+// branch currently accepts any subset since the user can also opt into
+// spec.resources[] instead).
+//
+// The eight fields covered match the legacy envelope plus the two GPU
+// quantities, so a manifest that mixes any of them will get format
+// feedback before Rule 7 weighs in on whether they were allowed to be
+// set at all.
+func validateFlatResourceQuantities(spec *AppSpec) error {
+	pairs := []struct {
+		name  string
+		value string
+	}{
+		{"spec.requiredCpu", spec.RequiredCPU},
+		{"spec.limitedCpu", spec.LimitedCPU},
+		{"spec.requiredMemory", spec.RequiredMemory},
+		{"spec.limitedMemory", spec.LimitedMemory},
+		{"spec.requiredDisk", spec.RequiredDisk},
+		{"spec.limitedDisk", spec.LimitedDisk},
+		{"spec.requiredGpu", spec.RequiredGPU},
+		{"spec.limitedGpu", spec.LimitedGPU},
+	}
+	var errs []error
+	for _, p := range pairs {
+		if p.value == "" {
+			continue
+		}
+		if !k8sQuantity.MatchString(p.value) {
+			errs = append(errs, fmt.Errorf(
+				"%s must be a valid Kubernetes quantity (got %q)",
+				p.name, p.value,
+			))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func validateOptions(v interface{}) error {

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -243,7 +243,7 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 
 	api := normalizeAPIVersion(apiVersion)
 	var v2ResourcesErr error
-	if api == APIVersionV2 && len(s.AcceleratedResources) > 0 {
+	if api == APIVersionV2 && len(s.Accelerator) > 0 {
 		v2ResourcesErr = fmt.Errorf(
 			"spec.resources is not supported for apiVersion=v2 (including when olaresManifest.version >= 0.12.0); use spec.requiredCpu, spec.limitedCpu, spec.requiredMemory, spec.limitedMemory, and spec.requiredDisk instead",
 		)
@@ -262,7 +262,7 @@ func validateAppSpec(configVersion, apiVersion string, s AppSpec) error {
 	switch {
 	case modern:
 		fields = append(fields,
-			validation.Field(&s.AcceleratedResources,
+			validation.Field(&s.Accelerator,
 				validation.By(validateResourceModeValueFor(&s)),
 			),
 		)
@@ -337,12 +337,12 @@ func legacyEnvelopeFieldRules(s *AppSpec, quantityRule, optionalLimitedDiskQuant
 func validateResourceModeValueFor(spec *AppSpec) validation.RuleFunc {
 	return func(v interface{}) error {
 		var errs []error
-		for i, rm := range spec.AcceleratedResources {
+		for i, rm := range spec.Accelerator {
 			if err := ValidateResourceMode(rm); err != nil {
 				errs = append(errs, fmt.Errorf("spec.resources[%d]: %w", i, err))
 			}
 		}
-		if len(spec.AcceleratedResources) == 0 {
+		if len(spec.Accelerator) == 0 {
 			if err := validateFlatResourceQuantities(spec); err != nil {
 				errs = append(errs, err)
 			}

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -360,7 +360,7 @@ func TestValidateAppSpec_LegacyRequiredFieldsBelowGate(t *testing.T) {
 		c.Spec.LimitedDisk = ""
 		c.Spec.RequiredGPU = ""
 		c.Spec.LimitedGPU = ""
-		c.Spec.AcceleratedResources = nil
+		c.Spec.Accelerator = nil
 
 		err := ValidateAppConfiguration(c)
 		if err == nil {
@@ -683,7 +683,7 @@ func TestValidateAppSpec_ModernAcceptsLegacyFlatEnvelope(t *testing.T) {
 	// must still be caught by Rule 7.
 	t.Run("flat_envelope_plus_resources_triggers_mutex", func(t *testing.T) {
 		c := populated()
-		c.Spec.AcceleratedResources = []ResourceMode{{
+		c.Spec.Accelerator = []ResourceMode{{
 			Mode: ResourceModeCPU,
 			ResourceRequirement: ResourceRequirement{
 				RequiredCPU:    "100m",

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -253,46 +253,30 @@ func TestAppSpec_QuantityFields(t *testing.T) {
 // < 0.12.0:
 //
 //   - requiredMemory, requiredDisk, requiredCpu, limitedMemory, limitedCpu
-//     are required (one error per missing field).
+//     are required. Because isLegacyEnvelopeMissing flips to true the
+//     moment any one of the five is empty, a partial fill produces the
+//     consolidated guidance message rather than a per-field cascade --
+//     the subtests assert on that consolidated message.
 //   - requiredGpu, limitedGpu are optional (the manifest still validates
 //     when both are absent).
 //
 // Each subtest blanks out exactly one legacy field on a fully-populated
-// fixture and expects the corresponding error message; the tail subtests
-// pin the optional GPU contract (omitted is fine, set must parse).
+// fixture and expects the consolidated guidance to fire; the tail
+// subtests pin the optional GPU contract (omitted is fine, set must
+// parse).
 func TestValidateAppSpec_LegacyRequiredFieldsBelowGate(t *testing.T) {
 	const legacyVersion = "0.11.0"
+	const consolidatedGuidance = "spec.requiredCpu / spec.limitedCpu / spec.requiredMemory / spec.limitedMemory / spec.requiredDisk are required for olaresManifest.version < 0.12.0; populate the legacy resource envelope"
 
 	required := []struct {
-		name      string
-		clear     func(*AppSpec)
-		errSuffix string
+		name  string
+		clear func(*AppSpec)
 	}{
-		{
-			name:      "requiredMemory",
-			clear:     func(s *AppSpec) { s.RequiredMemory = "" },
-			errSuffix: "spec.requiredMemory is required for olaresManifest.version < 0.12.0",
-		},
-		{
-			name:      "requiredDisk",
-			clear:     func(s *AppSpec) { s.RequiredDisk = "" },
-			errSuffix: "spec.requiredDisk is required for olaresManifest.version < 0.12.0",
-		},
-		{
-			name:      "requiredCpu",
-			clear:     func(s *AppSpec) { s.RequiredCPU = "" },
-			errSuffix: "spec.requiredCpu is required for olaresManifest.version < 0.12.0",
-		},
-		{
-			name:      "limitedMemory",
-			clear:     func(s *AppSpec) { s.LimitedMemory = "" },
-			errSuffix: "spec.limitedMemory is required for olaresManifest.version < 0.12.0",
-		},
-		{
-			name:      "limitedCpu",
-			clear:     func(s *AppSpec) { s.LimitedCPU = "" },
-			errSuffix: "spec.limitedCpu is required for olaresManifest.version < 0.12.0",
-		},
+		{name: "requiredMemory", clear: func(s *AppSpec) { s.RequiredMemory = "" }},
+		{name: "requiredDisk", clear: func(s *AppSpec) { s.RequiredDisk = "" }},
+		{name: "requiredCpu", clear: func(s *AppSpec) { s.RequiredCPU = "" }},
+		{name: "limitedMemory", clear: func(s *AppSpec) { s.LimitedMemory = "" }},
+		{name: "limitedCpu", clear: func(s *AppSpec) { s.LimitedCPU = "" }},
 	}
 	for _, tc := range required {
 		tc := tc
@@ -304,8 +288,8 @@ func TestValidateAppSpec_LegacyRequiredFieldsBelowGate(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error: %s missing should fail at olaresManifest.version=%s", tc.name, legacyVersion)
 			}
-			if !strings.Contains(err.Error(), tc.errSuffix) {
-				t.Fatalf("error should mention %q, got: %v", tc.errSuffix, err)
+			if !strings.Contains(err.Error(), consolidatedGuidance) {
+				t.Fatalf("error should mention the consolidated guidance message, got: %v", err)
 			}
 		})
 	}
@@ -376,7 +360,7 @@ func TestValidateAppSpec_LegacyRequiredFieldsBelowGate(t *testing.T) {
 		c.Spec.LimitedDisk = ""
 		c.Spec.RequiredGPU = ""
 		c.Spec.LimitedGPU = ""
-		c.Spec.Resources = nil
+		c.Spec.AcceleratedResources = nil
 
 		err := ValidateAppConfiguration(c)
 		if err == nil {
@@ -402,24 +386,28 @@ func TestValidateAppSpec_LegacyRequiredFieldsBelowGate(t *testing.T) {
 
 // Modern manifests (olaresManifest.version >= 0.12.0):
 //
-//   - spec.resources is required (missing/empty rejected).
-//   - Each declared spec.resources[] entry must populate every standard
-//     field (cpu/memory/disk pair, plus the gpu pair on gpu-capable modes).
-//   - The legacy flat spec.required*/spec.limited* fields must be empty
-//     (Rule 7 -- already covered in resources_test.go but pinned here for
-//     completeness so a regression on the modern branch lights up locally).
+//   - EITHER spec.resources[] OR the legacy flat envelope is required.
+//     If neither is declared, the modern-branch closure emits a single
+//     consolidated guidance line listing both options.
+//   - When spec.resources[] is declared, each entry must populate every
+//     standard field (cpu/memory/disk pair, plus the gpu pair on
+//     gpu-capable modes).
+//   - The two shapes are mutually exclusive (Rule 7 -- already covered
+//     in resources_test.go but pinned here for completeness so a
+//     regression on the modern branch lights up locally).
 //   - spec.requiredGpu and spec.limitedGpu remain optional at the spec
-//     level (gpu fields belong inside spec.resources[] entries instead).
+//     level (with spec.resources[] declared, gpu fields belong inside an
+//     entry; with the flat envelope they live at the spec level).
 func TestValidateAppSpec_ModernResourcesRequiredAtOrAboveGate(t *testing.T) {
-	t.Run("missing_resources_rejected", func(t *testing.T) {
-		c := newResourcesConfig() // no modes -> Resources is empty
+	t.Run("missing_both_shapes_emits_dual_guidance", func(t *testing.T) {
+		c := newResourcesConfig() // no modes AND newResourcesConfig clears every flat field
 		err := ValidateAppConfiguration(c)
 		if err == nil {
-			t.Fatal("expected error: spec.resources is required for olaresManifest.version >= 0.12.0")
+			t.Fatal("expected error: at least one resource envelope shape must be declared on a modern manifest")
 		}
-		want := "spec.resources is required for olaresManifest.version >= 0.12.0; declare at least one entry"
+		want := "either spec.resources[] or the legacy envelope (spec.requiredCpu / spec.limitedCpu / spec.requiredMemory / spec.limitedMemory / spec.requiredDisk) is required for olaresManifest.version >= 0.12.0"
 		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error should mention modern consolidated guidance, got: %v", err)
+			t.Fatalf("error should mention modern dual-shape guidance, got: %v", err)
 		}
 	})
 
@@ -576,6 +564,261 @@ func TestValidateAppSpec_ModernResourcesRequiredAtOrAboveGate(t *testing.T) {
 		})
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern manifest without spec-level gpu fields must validate: %v", err)
+		}
+	})
+}
+
+// validateAppSpec contract at the 0.12.0 boundary when the manifest opts
+// into the legacy flat envelope (spec.requiredCpu / spec.limitedCpu /
+// spec.requiredMemory / spec.limitedMemory / spec.requiredDisk + optional
+// limitedDisk / requiredGpu / limitedGpu) instead of spec.resources[].
+//
+// 0.12.0 is the boundary at which the modern code path activates
+// (resourcesCheckApplies is inclusive), so this is the case where the
+// modern-branch closure (validateResourceModeValueFor) must accept the
+// flat shape and route every populated field through
+// validateFlatResourceQuantities for K8s-quantity format checking.
+// Required-ness of individual flat fields is intentionally not enforced
+// here -- a partial envelope still passes format validation, mirroring
+// the loose modern semantics the closure documents.
+func TestValidateAppSpec_ModernAcceptsLegacyFlatEnvelope(t *testing.T) {
+	const modernBoundary = "0.12.0"
+
+	// populated builds a modern (0.12.0) manifest that declares the
+	// legacy flat envelope and leaves spec.resources[] empty.
+	// newResourcesConfig clears every flat field; we re-populate the
+	// five mandatory quantities here.
+	populated := func() *AppConfiguration {
+		c := newResourcesConfig() // no modes, ConfigVersion=0.13.0, every flat field cleared
+		c.ConfigVersion = modernBoundary
+		c.APIVersion = APIVersionV1
+		c.Spec.RequiredCPU = "100m"
+		c.Spec.LimitedCPU = "200m"
+		c.Spec.RequiredMemory = "128Mi"
+		c.Spec.LimitedMemory = "256Mi"
+		c.Spec.RequiredDisk = "1Gi"
+		return c
+	}
+
+	t.Run("complete_flat_envelope_valid_at_boundary", func(t *testing.T) {
+		c := populated()
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest at %s using the legacy flat envelope must validate: %v", modernBoundary, err)
+		}
+	})
+
+	t.Run("complete_flat_envelope_valid_above_boundary", func(t *testing.T) {
+		// 0.13.0 sits well above the gate. The closure must take the
+		// same branch as the 0.12.0 boundary and accept the flat shape.
+		c := populated()
+		c.ConfigVersion = "0.13.0"
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest at 0.13.0 using the legacy flat envelope must validate: %v", err)
+		}
+	})
+
+	t.Run("flat_envelope_with_optional_disk_and_gpu_valid", func(t *testing.T) {
+		c := populated()
+		c.Spec.LimitedDisk = "2Gi"
+		c.Spec.RequiredGPU = "1"
+		c.Spec.LimitedGPU = "2"
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest with optional disk/gpu fields must validate: %v", err)
+		}
+	})
+
+	// Each populated flat field must parse as a Kubernetes quantity --
+	// the closure's validateFlatResourceQuantities walks every non-empty
+	// flat field and reports the first that fails the k8sQuantity regex.
+	t.Run("invalid_required_quantity_rejected", func(t *testing.T) {
+		c := populated()
+		c.Spec.RequiredMemory = "totally-not-a-quantity"
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: invalid quantity on the flat envelope must be rejected")
+		}
+		want := "spec.requiredMemory must be a valid Kubernetes quantity"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention %q, got: %v", want, err)
+		}
+	})
+
+	t.Run("invalid_limited_disk_quantity_rejected", func(t *testing.T) {
+		// limitedDisk is optional but still quantity-checked when set:
+		// confirm the optional fields go through validateFlatResourceQuantities
+		// rather than getting silently accepted.
+		c := populated()
+		c.Spec.LimitedDisk = "not-a-quantity"
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: invalid limitedDisk quantity must be rejected")
+		}
+		want := "spec.limitedDisk must be a valid Kubernetes quantity"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention %q, got: %v", want, err)
+		}
+	})
+
+	// Modern-with-flat must not accidentally trip the modern-with-resources
+	// guidance ("either spec.resources[] or the legacy envelope ...") --
+	// once any flat field is set, hasAnyFlatResourceQuantity flips to true
+	// and the dual-shape guard stays quiet.
+	t.Run("no_dual_shape_guidance_when_flat_envelope_set", func(t *testing.T) {
+		c := populated()
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("baseline must pass: %v", err)
+		}
+		// Even a single set flat field should be enough.
+		c = newResourcesConfig()
+		c.ConfigVersion = modernBoundary
+		c.Spec.RequiredCPU = "100m"
+		err := ValidateAppConfiguration(c)
+		if err != nil && strings.Contains(err.Error(), "either spec.resources[] or the legacy envelope") {
+			t.Fatalf("dual-shape guidance must not fire once any flat field is set, got: %v", err)
+		}
+	})
+
+	// Sanity-check the symmetric mutex contract: a modern manifest that
+	// declared the flat envelope but later also adds spec.resources[]
+	// must still be caught by Rule 7.
+	t.Run("flat_envelope_plus_resources_triggers_mutex", func(t *testing.T) {
+		c := populated()
+		c.Spec.AcceleratedResources = []ResourceMode{{
+			Mode: ResourceModeCPU,
+			ResourceRequirement: ResourceRequirement{
+				RequiredCPU:    "100m",
+				LimitedCPU:     "200m",
+				RequiredMemory: "128Mi",
+				LimitedMemory:  "256Mi",
+				RequiredDisk:   "1Gi",
+				LimitedDisk:    "2Gi",
+			},
+		}}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected Rule 7 mutex error when both shapes coexist")
+		}
+		if !strings.Contains(err.Error(), "spec.requiredCpu must be empty when spec.resources[] is set") {
+			t.Fatalf("error should mention mutex violation, got: %v", err)
+		}
+	})
+}
+
+// validateAppSpec contract under olaresManifest.version >= 0.12.0 (apiVersion
+// != v2) when both shapes coexist on the same manifest:
+//
+//   - Setting any one of the eight legacy flat fields alongside a populated
+//     spec.resources[] entry must trip Rule 7 and report
+//     "<field> must be empty when spec.resources[] is set" for exactly that
+//     field. The subtests cycle through cpu / memory / disk / gpu pairs so a
+//     regression that drops one column lights up locally rather than only
+//     showing up in the aggregated TestRule7_* tests over in
+//     resources_test.go.
+//   - Setting all eight at once must produce all eight errors in a single
+//     errors.Join'd return so callers see the full picture without having
+//     to fix-and-rerun.
+//   - The per-entry validation of spec.resources[] continues to fire
+//     alongside the mutex errors -- a malformed resources entry must not
+//     mask the mutex violation and vice versa.
+func TestValidateAppSpec_ModernRejectsBothShapesCoexisting(t *testing.T) {
+	completeFields := func() ResourceRequirement {
+		return ResourceRequirement{
+			RequiredCPU:    "100m",
+			LimitedCPU:     "200m",
+			RequiredMemory: "128Mi",
+			LimitedMemory:  "256Mi",
+			RequiredDisk:   "1Gi",
+			LimitedDisk:    "2Gi",
+		}
+	}
+
+	perFieldCases := []struct {
+		name  string
+		apply func(*AppSpec)
+		field string
+	}{
+		{"requiredCpu", func(s *AppSpec) { s.RequiredCPU = "100m" }, "spec.requiredCpu"},
+		{"limitedCpu", func(s *AppSpec) { s.LimitedCPU = "200m" }, "spec.limitedCpu"},
+		{"requiredMemory", func(s *AppSpec) { s.RequiredMemory = "256Mi" }, "spec.requiredMemory"},
+		{"limitedMemory", func(s *AppSpec) { s.LimitedMemory = "512Mi" }, "spec.limitedMemory"},
+		{"requiredDisk", func(s *AppSpec) { s.RequiredDisk = "1Gi" }, "spec.requiredDisk"},
+		{"limitedDisk", func(s *AppSpec) { s.LimitedDisk = "2Gi" }, "spec.limitedDisk"},
+		{"requiredGpu", func(s *AppSpec) { s.RequiredGPU = "1" }, "spec.requiredGpu"},
+		{"limitedGpu", func(s *AppSpec) { s.LimitedGPU = "2" }, "spec.limitedGpu"},
+	}
+	for _, tc := range perFieldCases {
+		tc := tc
+		t.Run("single_field_"+tc.name, func(t *testing.T) {
+			c := newResourcesConfig(ResourceMode{
+				Mode:                ResourceModeCPU,
+				ResourceRequirement: completeFields(),
+			})
+			tc.apply(&c.Spec)
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("expected Rule 7 violation: %s cannot coexist with spec.resources[]", tc.field)
+			}
+			want := tc.field + " must be empty when spec.resources[] is set"
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error should mention %q, got: %v", want, err)
+			}
+		})
+	}
+
+	t.Run("all_eight_flat_fields_aggregated", func(t *testing.T) {
+		c := newResourcesConfig(ResourceMode{
+			Mode:                ResourceModeCPU,
+			ResourceRequirement: completeFields(),
+		})
+		c.Spec.RequiredCPU = "100m"
+		c.Spec.LimitedCPU = "200m"
+		c.Spec.RequiredMemory = "256Mi"
+		c.Spec.LimitedMemory = "512Mi"
+		c.Spec.RequiredDisk = "1Gi"
+		c.Spec.LimitedDisk = "2Gi"
+		c.Spec.RequiredGPU = "1"
+		c.Spec.LimitedGPU = "2"
+
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected aggregated Rule 7 violations for every coexisting flat field")
+		}
+		msg := err.Error()
+		for _, field := range []string{
+			"spec.requiredCpu", "spec.limitedCpu",
+			"spec.requiredMemory", "spec.limitedMemory",
+			"spec.requiredDisk", "spec.limitedDisk",
+			"spec.requiredGpu", "spec.limitedGpu",
+		} {
+			want := field + " must be empty when spec.resources[] is set"
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error should mention %s mutual-exclusion violation, got: %v", field, err)
+			}
+		}
+	})
+
+	// Per-entry validation must still surface even when Rule 7 has plenty
+	// to say. A malformed resources entry (missing limitedCpu) coexists
+	// with a populated spec.requiredCpu -- the user should see both the
+	// envelope-completeness error AND the mutex error in one shot.
+	t.Run("entry_validation_runs_alongside_mutex_errors", func(t *testing.T) {
+		rr := completeFields()
+		rr.LimitedCPU = "" // breaks the per-entry envelope
+		c := newResourcesConfig(ResourceMode{
+			Mode:                ResourceModeCPU,
+			ResourceRequirement: rr,
+		})
+		c.Spec.RequiredCPU = "100m" // trips Rule 7
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected aggregated error covering both mutex and entry validation")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "spec.requiredCpu must be empty when spec.resources[] is set") {
+			t.Fatalf("error should report Rule 7 mutex violation, got: %v", err)
+		}
+		if !strings.Contains(msg, "limitedCpu is required to declare a complete resource envelope") {
+			t.Fatalf("error should also report per-entry completeness violation, got: %v", err)
 		}
 	})
 }

--- a/framework/oac/resource_limits.go
+++ b/framework/oac/resource_limits.go
@@ -19,8 +19,8 @@ func ResourceLimitsForResourceMode(cfg *AppConfiguration, mode string) (Manifest
 	if cfg == nil {
 		return ManifestResourceLimits{}, fmt.Errorf("oac: AppConfiguration is nil")
 	}
-	for i := range cfg.Spec.AcceleratedResources {
-		rm := &cfg.Spec.AcceleratedResources[i]
+	for i := range cfg.Spec.Accelerator {
+		rm := &cfg.Spec.Accelerator[i]
 		if strings.EqualFold(rm.Mode, mode) {
 			return manifest.ResourceRequirementToLimits(rm.ResourceRequirement), nil
 		}

--- a/framework/oac/resource_limits.go
+++ b/framework/oac/resource_limits.go
@@ -19,8 +19,8 @@ func ResourceLimitsForResourceMode(cfg *AppConfiguration, mode string) (Manifest
 	if cfg == nil {
 		return ManifestResourceLimits{}, fmt.Errorf("oac: AppConfiguration is nil")
 	}
-	for i := range cfg.Spec.Resources {
-		rm := &cfg.Spec.Resources[i]
+	for i := range cfg.Spec.AcceleratedResources {
+		rm := &cfg.Spec.AcceleratedResources[i]
 		if strings.EqualFold(rm.Mode, mode) {
 			return manifest.ResourceRequirementToLimits(rm.ResourceRequirement), nil
 		}

--- a/framework/oac/resource_limits_test.go
+++ b/framework/oac/resource_limits_test.go
@@ -18,7 +18,7 @@ func TestResourceLimitsForResourceMode(t *testing.T) {
 		Entrances:     []appv1.Entrance{{Name: "w", Host: "d", Port: 80}},
 		Spec: manifest.AppSpec{
 			SupportArch: []string{"amd64"},
-			Resources: []manifest.ResourceMode{{
+			AcceleratedResources: []manifest.ResourceMode{{
 				Mode: olm.ResourceModeNvidia,
 				ResourceRequirement: manifest.ResourceRequirement{
 					RequiredCPU: "150m", LimitedCPU: "300m",

--- a/framework/oac/resource_limits_test.go
+++ b/framework/oac/resource_limits_test.go
@@ -18,7 +18,7 @@ func TestResourceLimitsForResourceMode(t *testing.T) {
 		Entrances:     []appv1.Entrance{{Name: "w", Host: "d", Port: 80}},
 		Spec: manifest.AppSpec{
 			SupportArch: []string{"amd64"},
-			AcceleratedResources: []manifest.ResourceMode{{
+			Accelerator: []manifest.ResourceMode{{
 				Mode: olm.ResourceModeNvidia,
 				ResourceRequirement: manifest.ResourceRequirement{
 					RequiredCPU: "150m", LimitedCPU: "300m",

--- a/framework/oac/testdata/full_manifest/OlaresManifest.yaml
+++ b/framework/oac/testdata/full_manifest/OlaresManifest.yaml
@@ -84,7 +84,7 @@ spec:
         - cuda
       singleMemory: 8Gi
       totalMemory: 16Gi
-  acceleratedResources:
+  accelerator:
     - mode: cpu
       supportMultiCard: true
       supportMultiNodes: true

--- a/framework/oac/testdata/full_manifest/OlaresManifest.yaml
+++ b/framework/oac/testdata/full_manifest/OlaresManifest.yaml
@@ -84,7 +84,7 @@ spec:
         - cuda
       singleMemory: 8Gi
       totalMemory: 16Gi
-  resources:
+  acceleratedResources:
     - mode: cpu
       supportMultiCard: true
       supportMultiNodes: true
@@ -96,6 +96,14 @@ spec:
       limitedDisk: 2Gi
       requiredGPUMemory: 1Gi
       limitedGPUMemory: 2Gi
+  requiredCpu: 100m
+  limitedCpu: 200m
+  requiredMemory: 128Mi
+  limitedMemory: 256Mi
+  requiredDisk: 1Gi
+  limitedDisk: 2Gi
+  requiredGpu: 1Gi
+  limitedGpu: 2Gi
   supportArch:
     - amd64
   website: https://example.com


### PR DESCRIPTION
* **Background**
rename acceleratedResources to accelerator
spec.required and spec.resources exclusive
fix resource mode strix-halo
bump api version to v0.0.8

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manifest validation rules and field names that app authors and installers depend on; incorrect adoption could reject or mis-validate existing OlaresManifest YAML until manifests are updated.
> 
> **Overview**
> Aligns **OAC** with **`github.com/beclab/api` v0.0.8** by renaming the modern per-mode resource list from **`spec.resources`** to **`spec.accelerator`** everywhere (chart limits, reports, limit lookup, tests, sample manifest).
> 
> **Modern manifest validation (`olaresManifest.version` ≥ 0.12.0, non-v2)** no longer requires a non-empty **`accelerator`** array only: manifests may declare **either** `accelerator[]` **or** the legacy flat **`requiredCpu` / `limitedCpu` / …** envelope, with format checks on populated flat fields and a single error if neither shape is present. **Rule 7** still forbids mixing flat fields with `accelerator[]`.
> 
> **Legacy (&lt; 0.12.0)** treats the five mandatory flat fields as missing if **any** one is empty (`isLegacyEnvelopeMissing`), so partial fills get one consolidated guidance message instead of per-field required errors.
> 
> **Resource modes:** **`amd-apu`** is dropped from the allowed set in favor of **`strix-halo`** (with **`strix-halo`** also mapped to **`amd64`** in arch requirements). Tests and fixtures are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eac5d1102a03f32830c62e76340e57b49a6c2cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->