### PR TITLE
files: add drive/Common, archive compress

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -407,7 +407,7 @@ spec:
             type: DirectoryOrCreate
         - name: common-data
           hostPath:
-            type: Directory
+            type: DirectoryOrCreate
             path: '{{ .Values.rootPath }}/rootfs/Common'
         
 {{ if .Values.sharedlib }}        

--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.173
+          image: beclab/files-server:v0.2.174
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -223,6 +223,8 @@ spec:
               mountPath: /data
             - name: upload-appdata
               mountPath: /appcache/
+            - name: common-data
+              mountPath: /appcommon/
             - name: seafile-data
               mountPath: /root/dev/seafile-data
 {{ if .Values.sharedlib }}        
@@ -399,11 +401,14 @@ spec:
           hostPath:
             path: '{{ .Values.rootPath }}/userdata/Cache'
             type: Directory
-
         - name: seafile-data
           hostPath:
             path: '{{ .Values.rootPath }}/rootfs/Application/seafile/data'
             type: DirectoryOrCreate
+        - name: common-data
+          hostPath:
+            type: Directory
+            path: '{{ .Values.rootPath }}/rootfs/Common'
         
 {{ if .Values.sharedlib }}        
         - name: shared-lib


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
add drive/Common, archive compress

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/files/pull/330
https://github.com/beclab/files/pull/331
https://github.com/beclab/files/pull/332


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kubernetes manifest and image tag only; adds a hostPath mount to an already privileged files pod with no auth or data-model changes in this diff.
> 
> **Overview**
> Bumps the **files** container image from `beclab/files-server:v0.2.173` to **v0.2.174** (carries drive/Common and archive-compress behavior from the linked application PRs).
> 
> Adds a **`common-data`** hostPath volume pointing at `{{ .Values.rootPath }}/rootfs/Common` (`DirectoryOrCreate`) and mounts it into the files container at **`/appcommon/`**, exposing the cluster **Common** location to the files service alongside existing userdata and Seafile mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c757a5fafe4086e2bc706ecb83744f40195065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->