### PR TITLE
market: improve shared-app state push, permissions

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.42
+        image: beclab/market-backend:v0.6.44
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
improve shared-app state fan-out, permissions, and related stability fixes

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/265


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in deployment config; no manifest or permission changes in this PR.
> 
> **Overview**
> Bumps the **market** `appstore-backend` container image from `beclab/market-backend:v0.6.42` to **`v0.6.44`** in `market_deploy.yaml`. No other manifest, env, or RBAC changes in this diff.
> 
> This wires the cluster to the newer backend build (aligned with the linked **market** PR for shared-app state fan-out, permissions, and related fixes); behavior lives in the image, not in these YAML edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39341b5e8090131993c5dc826e84bdcdf515d93e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->