### PR TITLE
feat: upgrade headscale to v0.28.0

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -51,7 +51,7 @@ spec:
           key: pg_password
           name: headscale-secrets
     databases:
-    - name: headscale
+    - name: headscale_v2
 
 ---
 apiVersion: v1
@@ -178,7 +178,7 @@ spec:
         - |
           chown -R 1000:1000 /headscale 
       - name: init
-        image: beclab/headscale-init:v0.1.13
+        image: beclab/headscale-init:v0.1.15
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -196,7 +196,7 @@ spec:
         - name: PG_PASS
           value: "{{ $pg_password | b64dec }}"
         - name: PG_DB
-          value: user_space_{{ .Values.bfl.username }}_headscale
+          value: user_space_{{ .Values.bfl.username }}_headscale_v2
         - name: USER_SUBNET
           value: {{ .Values.tailscaleUserSubnet | default "100.64.0.0/20" }}
         volumeMounts:
@@ -220,11 +220,11 @@ spec:
         - name: PGPASSWORD
           value: "{{ $pg_password | b64dec }}"
         - name: PGDB
-          value: user_space_{{ .Values.bfl.username }}_headscale
+          value: user_space_{{ .Values.bfl.username }}_headscale_v2
         imagePullPolicy: IfNotPresent
       containers:
       - name: headscale
-        image: headscale/headscale:0.22.3
+        image: headscale/headscale:0.28.0-debug
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false
@@ -238,7 +238,27 @@ spec:
               command:
                 - "sh"
                 - "-xc"
-                - "(date; for i in `seq 1 600`; do if ! test -S /var/run/headscale.sock; then echo wait-headscale.sock-1s; sleep 1; else break; fi; done; headscale apikeys create -e 3650d > /etc/headscale/apikey; headscale users create default; headscale preauthkeys create -e 3650d --reusable -u default > /etc/headscale/preauthkey; if ! test -s /etc/headscale/apikey; then echo apikey-empty; exit 1; fi; if ! test -s /etc/headscale/preauthkey; then echo preauthkey-empty; exit 1; fi) >> /tmp/headscale.log 2>&1"
+                - |
+                  (
+                      export NO_COLOR=1
+                      date
+                      for i in $(seq 1 300); do
+                          if ! test -S /var/run/headscale/headscale.sock; then
+                              echo wait-headscale.sock-1s
+                              sleep 1
+                          else
+                              break
+                          fi
+                      done
+                      headscale apikeys create -e 3650d > /etc/headscale/apikey
+                      headscale users create default
+                      USER_ID=$(headscale users list | awk '/default/ {print $1; exit}')
+                      [ -n "$USER_ID" ] || { echo "user default not found"; exit 1; }
+                      headscale preauthkeys create -e 3650d --reusable -u "$USER_ID" \
+                          > /etc/headscale/preauthkey
+                      if ! test -s /etc/headscale/apikey; then echo apikey-empty; exit 1; fi
+                      if ! test -s /etc/headscale/preauthkey; then echo preauthkey-empty; exit 1; fi
+                  ) > /etc/headscale/.headscale.log 2>&1
         volumeMounts:
         - name: config
           mountPath: /etc/headscale
@@ -271,7 +291,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        image: beclab/headscale-api-wrapper:v0.1.7
+        image: beclab/headscale-api-wrapper:v0.1.8
         imagePullPolicy: IfNotPresent
         name: headscale-api-wrapper
         securityContext:
@@ -403,10 +423,15 @@ spec:
             --tun=tailscale0{{ if and .Values.tailscaleUserIndex (ne .Values.tailscaleUserIndex  "0") }}$(USER_INDEX){{ end }}
         - name: TS_ROUTES
           value: $(COREDNS_SVC)/32
+        {{- if eq $role "owner" }}
+        - name: ADVERTISE_EXIT_NODE
+          value: "false"
+        {{- end }}
         - name: TS_EXTRA_ARGS
           value: >-
             --login-server https://headscale-server-svc
-            --netfilter-mode {{ if eq $role "owner" }}on{{ else }}off{{ end }}
+            --netfilter-mode {{ if eq $role "owner" }}on{{ else }}off{{ end }}{{ if eq $role "owner" }}
+            --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset{{ end }}
         - name: TS_USERSPACE
           value: "false"
 
@@ -479,15 +504,16 @@ data:
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:80"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:443"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:18088"] },
-        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] }
+        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] },
+        { "action": "accept", "src": ["*"], "dst": ["autogroup:internet:*"] }
       ],
       "autoApprovers": {
         "routes": {
-          "10.0.0.0/8": ["default"],
-          "172.16.0.0/12": ["default"],
-          "192.168.0.0/16": ["default"]
+          "10.0.0.0/8": ["default@"],
+          "172.16.0.0/12": ["default@"],
+          "192.168.0.0/16": ["default@"]
         },
-        "exitNode": []
+        "exitNode": ["default@"]
       }
     }
 kind: ConfigMap

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/provider.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/provider.yaml
@@ -42,10 +42,8 @@ metadata:
     provider-service-ref: headscale-server-svc.{{ .Release.Namespace }}:8000
 rules:
 - nonResourceURLs: 
-  - "/headscale/machine"
-  - "/headscale/machine/rename"
-  - "/headscale/machine/routes"
-  - "/headscale/routes/enable"
-  - "/headscale/routes/disable"
-  - "/headscale/machine/tags"
+  - "/headscale/node"
+  - "/headscale/node/rename"
+  - "/headscale/node/approve_routes"
+  - "/headscale/node/tags"
   verbs: ["*"]


### PR DESCRIPTION

* **Background**
Upgrade Headscale to v0.28.0 and add exit-node support for the Olares owner role

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major control-plane version jump, new database name (fresh DB / no in-diff migration), and networking policy changes (ACLs, exit-node advertisement, API path renames) affect VPN connectivity for all users.
> 
> **Overview**
> Upgrades the user-space **Headscale** Helm deployment from **0.22.3** to **0.28.0-debug** and points Postgres at a new **`headscale_v2`** database (middleware, init, and wait-for-postgres env).
> 
> Bumps **`beclab/headscale-init`** and **`beclab/headscale-api-wrapper`** images. The **postStart** bootstrap is rewritten for v0.28: Unix socket under **`/var/run/headscale/headscale.sock`**, resolves the **`default`** user by ID for reusable preauth keys, and logs to **`/etc/headscale/.headscale.log`**.
> 
> For **owner** Olares roles, the Tailscale sidecar gains **`ADVERTISE_EXIT_NODE`** (default **`false`**) and passes **`--advertise-exit-node`** with **`--reset`** in **`TS_EXTRA_ARGS`**. **ACL** policy adopts v0.28-style identities (**`default@`**), allows **`autogroup:internet:*`**, and auto-approves **`default@`** as an exit node.
> 
> **Provider** ClusterRole non-resource URLs switch from **`/headscale/machine*`** and legacy route enable/disable paths to **`/headscale/node*`** (rename, approve_routes, tags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de5f87c978753e25c28c0c9c1e81d4b2f1fb71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->