### PR TITLE
cli/files: preflight existence / kind / dir-only checks for cp, mv, rm, share

### DIFF
--- a/cli/cmd/ctl/files/cp.go
+++ b/cli/cmd/ctl/files/cp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/internal/files/cp"
+	"github.com/beclab/Olares/cli/internal/files/download"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 )
@@ -35,11 +36,14 @@ type cpOptions struct {
 //     directory, preserving its basename" — e.g. `cp foo bar baz/`
 //     yields baz/foo and baz/bar. This matches `files upload`'s
 //     <remote> rule and download's resolveLocalFile.
-//   - Without a trailing '/' on <dst>, exactly one <src> is allowed
-//     and <dst> is treated as the full target path (rename on the
-//     way in). Multi-source + non-dir <dst> is rejected.
 //   - --recursive / -r is required for directory sources, same
 //     refusal pattern as Unix `cp -r`. -R is accepted as an alias.
+//
+// Renaming via `cp` (single source + non-dir <dst>) is intentionally
+// undocumented in the user-facing help — point users at
+// `olares-cli files rename` for in-place basename changes. The
+// planner still accepts that shape for backwards compatibility, but
+// the help text only promotes the drop-into-directory UX.
 //
 // The PATCH endpoint returns one task_id per call (the actual byte
 // movement runs on the server's task queue), so a multi-source
@@ -66,9 +70,8 @@ storage-class fan-out.
 
 Destination semantics:
 
-    --- <dst> ENDS with '/' ---
-    Drop-into-directory mode. Each <src>'s basename is appended,
-    preserving the dir / file marker:
+    <dst> MUST end with '/' (drop-into-directory mode). Each <src>'s
+    basename is appended, preserving the dir / file marker:
 
         cp drive/Home/a.pdf drive/Home/Backups/
         # → /drive/Home/Backups/a.pdf
@@ -76,19 +79,31 @@ Destination semantics:
         cp -r drive/Home/old/ drive/Home/Backups/
         # → /drive/Home/Backups/old/
 
-    --- <dst> does NOT end with '/' ---
-    Rename / exact-target mode. Exactly one <src> is allowed; <dst>
-    becomes the full target path:
-
-        cp drive/Home/a.pdf drive/Home/a-backup.pdf
-        # → /drive/Home/a-backup.pdf
-
-    Multi-source with a non-directory <dst> is rejected.
+    Renaming via ` + "`cp`" + ` is not currently supported — for in-place
+    basename changes use ` + "`olares-cli files rename`" + ` (or move into a
+    directory under a different parent with ` + "`files mv`" + ` after the
+    rename).
 
 Recursion:
 
     Directory sources require --recursive / -r (or -R). Without it
     the command refuses to operate, matching Unix ` + "`cp -r`" + ` behavior.
+
+Preflight existence check:
+
+    Before any PATCH /api/paste/<node>/ is sent, the CLI Stats every
+    source and the destination directory:
+
+      - each <src> MUST exist on the server, AND its trailing slash
+        must match the actual file/dir kind (trailing '/' for
+        directories, none for files);
+      - <dst> MUST exist as a directory on the server (create it
+        first with ` + "`olares-cli files mkdir`" + ` if it doesn't yet exist).
+
+    The check fails fast — without the preflight a typo could
+    enqueue paste tasks that fail asynchronously on the server's
+    task queue with no transactional rollback, leaving the user to
+    reason about a partial-success batch.
 
 Node selection:
 
@@ -103,9 +118,6 @@ Examples:
 
     # One file → directory.
     olares-cli files cp drive/Home/notes.md drive/Home/Documents/
-
-    # Rename on copy.
-    olares-cli files cp drive/Home/notes.md drive/Home/notes-2026.md
 
     # Recursive directory copy.
     olares-cli files cp -r drive/Home/Photos/ drive/Home/Backups/
@@ -134,19 +146,29 @@ func NewMvCommand(f *cmdutil.Factory) *cobra.Command {
 	o := &cpOptions{}
 	cmd := &cobra.Command{
 		Use:   "mv [-r] <src>... <dst>",
-		Short: "move (or rename) one or more remote files / directories",
+		Short: "move one or more remote files / directories into a destination directory",
 		Long: `Move one or more entries between locations on the per-user files-backend.
 
 Same wire endpoint as ` + "`files cp`" + ` (PATCH /api/paste/<node>/), but
 with action="move" — the server moves the source instead of
-copying it. Same Unix-style multi-source / target-shape rules
-apply: trailing '/' on <dst> drops sources into the directory by
-basename; no trailing slash + a single source = rename.
+copying it. Same Unix-style multi-source / target-shape rule
+applies: <dst> MUST end with '/' (drop-into-directory mode); each
+source is dropped into the directory by basename.
+
+Renaming via ` + "`mv`" + ` is not currently supported — for in-place
+basename changes use ` + "`olares-cli files rename`" + `.
+
+Preflight existence check (same as ` + "`files cp`" + `):
+
+    Before the PATCH goes out, every <src> is Stat'd (must exist;
+    trailing slash must match file/dir kind) and <dst> is Stat'd
+    (must exist as a directory). A missing source or destination
+    directory aborts the operation before any state change.
 
 Examples:
 
-    # Rename a file in place.
-    olares-cli files mv drive/Home/notes.md drive/Home/notes-2026.md
+    # Move one file into a directory.
+    olares-cli files mv drive/Home/notes.md drive/Home/Archive/
 
     # Move several files into a directory.
     olares-cli files mv drive/Home/a.pdf drive/Home/b.pdf drive/Home/Archive/
@@ -267,6 +289,29 @@ func runCpMv(
 		return err
 	}
 
+	// Preflight: verify every source exists on the server, the
+	// trailing-slash on the source matches the actual file/dir kind,
+	// and the destination (or its parent for the undocumented
+	// exact-target shape) exists as a directory. This catches the
+	// common typo cases ("did you mean Documents/?" / "you forgot
+	// to mkdir the target") BEFORE we enqueue any paste tasks —
+	// once a paste task is on the queue we have no transactional
+	// rollback, and a partial-success batch is harder to reason
+	// about than a clean refusal up front.
+	//
+	// Stat uses the same parent-listing strategy `files cat` and
+	// `files download` use (see internal/files/download/stat.go) so
+	// it works uniformly across drive / sync / cache / external /
+	// cloud namespaces. We pass the same HTTPClient cp uses so the
+	// preflight inherits the refreshing-transport's 401/403 retry.
+	statClient := &download.Client{
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
+	}
+	if err := preflightCpMv(ctx, statClient, srcs, dst, action); err != nil {
+		return reformatCpHTTPErr(err, rp.OlaresID, string(action)+" preflight", "")
+	}
+
 	// Plan summary first — gives the user a chance to ^C before any
 	// state-changing wire call goes out.
 	fmt.Fprintf(out, "%s %d entr%s:\n", action, len(ops), pluralYies(len(ops)))
@@ -366,10 +411,172 @@ func isPasteMultiNode(fileType string) bool {
 	}
 }
 
-// reformatCpHTTPErr maps cp.HTTPError onto user-friendly messages,
-// mirroring rm/download's reformatters. Typed credential errors from
-// the refreshing transport are surfaced verbatim — see
-// reformatHTTPErr in download.go for the rationale.
+// preflightCpMv probes every source and the destination side BEFORE
+// any state-changing PATCH /api/paste/<node>/ goes out, and refuses
+// the operation early if:
+//
+//   - a source path doesn't exist on the server (typo / stale path);
+//   - a source's trailing-slash intent doesn't match the actual file
+//     vs. directory kind on the server (e.g. user typed
+//     `cp drive/Home/Photos` without the trailing '/' but Photos is
+//     actually a directory — they would have hit "is a directory:
+//     pass -r/-R" via the planner only if they ALSO typed `Photos/`,
+//     so we surface the kind mismatch here);
+//   - in drop-into-dir mode (the documented shape, `<dst>` ends with
+//     '/'), the destination directory doesn't exist OR is a file;
+//   - in exact-target mode (the undocumented single-source +
+//     non-'/'-terminated `<dst>` shape), the destination's parent
+//     directory doesn't exist OR is a file.
+//
+// The Stat strategy is the same parent-listing approach `files cat`
+// and `files download` use (see internal/files/download/stat.go).
+// Volume roots (depth-0/1 subpaths like `drive/Home/`, `sync/<repo>/`)
+// stat as synthetic directories — they always "exist" in the
+// files-backend model — so a `cp foo drive/Home/` works without an
+// extra round-trip.
+//
+// Performance:
+//   - One Stat per unique source path. Multi-source `cp a b c dst/`
+//     sharing the same parent dir still issues N Stats (one per
+//     leaf); the redundancy is small for typical N≤10 and not worth
+//     a parent-listing cache yet.
+//   - One Stat for the destination side (the dst dir itself, or its
+//     parent for exact-target mode).
+//
+// Returns nil on success; otherwise a typed error whose Error()
+// names the offending path and the corrective action. HTTP errors
+// (auth / network) are passed through verbatim so reformatCpHTTPErr
+// can attach the standard CTA.
+func preflightCpMv(
+	ctx context.Context,
+	statClient *download.Client,
+	srcs []cp.Source,
+	dst cp.Destination,
+	action cp.Action,
+) error {
+	for _, s := range srcs {
+		srcDisplay := s.FileType + "/" + s.Extend + s.SubPath
+		srcPlain := s.FileType + "/" + s.Extend + s.SubPath
+		info, err := statClient.Stat(ctx, srcPlain)
+		if err != nil {
+			if download.IsNotFound(err) {
+				return fmt.Errorf("%s: source %s does not exist on the server",
+					action, srcDisplay)
+			}
+			return err
+		}
+		// Volume roots stat as synthetic directories; the planner
+		// has already rejected SubPath=="/" sources, so a synthetic
+		// dir reaching here means the user gave us at least one
+		// real path segment — info.IsDir reflects the actual leaf.
+		if s.IsDirIntent && !info.IsDir {
+			return fmt.Errorf(
+				"%s: source %s is a file on the server, not a directory; drop the trailing '/'",
+				action, srcDisplay)
+		}
+		if !s.IsDirIntent && info.IsDir {
+			return fmt.Errorf(
+				"%s: source %s is a directory on the server; add a trailing '/' and pass -r/-R to %s it recursively",
+				action, srcDisplay, action)
+		}
+	}
+
+	// Destination side. The two shapes correspond to the two
+	// destination modes the planner accepts:
+	//
+	//   - dst.IsDirIntent == true  → drop-into-directory mode.
+	//     The dst path ITSELF must exist as a directory.
+	//   - dst.IsDirIntent == false → exact-target mode (the
+	//     undocumented single-source rename shape kept for
+	//     backwards compatibility). The dst's PARENT directory
+	//     must exist; the leaf doesn't exist yet by definition
+	//     (or, if it does, the backend's auto-rename / overwrite
+	//     handling takes over, which is server-side behavior we
+	//     don't preflight here).
+	if dst.IsDirIntent {
+		dstDisplay := dst.FileType + "/" + dst.Extend + dst.SubPath
+		dstPlain := dst.FileType + "/" + dst.Extend + dst.SubPath
+		info, err := statClient.Stat(ctx, dstPlain)
+		if err != nil {
+			if download.IsNotFound(err) {
+				return fmt.Errorf(
+					"%s: destination directory %s does not exist on the server; create it first with `olares-cli files mkdir`",
+					action, dstDisplay)
+			}
+			return err
+		}
+		if !info.IsDir {
+			return fmt.Errorf(
+				"%s: destination %s is a file on the server, not a directory; drop the trailing '/' or pick a different target",
+				action, dstDisplay)
+		}
+		return nil
+	}
+
+	// Exact-target mode: stat the parent directory only. The
+	// planner has already rejected SubPath=="/" via the dir-intent
+	// requirement on root targets, so dst.SubPath here is at least
+	// "/<leaf>".
+	parentSub := parentSubPath(dst.SubPath)
+	parentDisplay := dst.FileType + "/" + dst.Extend + parentSub
+	parentPlain := dst.FileType + "/" + dst.Extend + parentSub
+	info, err := statClient.Stat(ctx, parentPlain)
+	if err != nil {
+		if download.IsNotFound(err) {
+			return fmt.Errorf(
+				"%s: destination's parent directory %s does not exist on the server",
+				action, parentDisplay)
+		}
+		return err
+	}
+	if !info.IsDir {
+		return fmt.Errorf(
+			"%s: destination's parent %s is a file on the server, not a directory",
+			action, parentDisplay)
+	}
+	return nil
+}
+
+// parentSubPath returns the parent of a `<sub-path>` (always a string
+// starting with '/'). Examples:
+//
+//	"/Documents/foo.pdf"  → "/Documents/"
+//	"/Documents/sub/"     → "/Documents/"   (treat the input as the dir itself)
+//	"/foo.pdf"            → "/"             (parent is the extend root)
+//	"/"                   → "/"             (extend root — its own parent)
+//
+// The trailing '/' on the returned parent is preserved so Stat
+// receives the canonical directory-form path; download.Stat trims it
+// internally before splitting on '/', but keeping the slash here
+// keeps the wire shape consistent with the rest of the codebase.
+func parentSubPath(sub string) string {
+	s := strings.TrimRight(sub, "/")
+	if s == "" {
+		return "/"
+	}
+	i := strings.LastIndex(s, "/")
+	if i < 0 {
+		return "/"
+	}
+	return s[:i+1]
+}
+
+// reformatCpHTTPErr maps cp.HTTPError / download.HTTPError onto
+// user-friendly messages, mirroring rm/download's reformatters.
+// Typed credential errors from the refreshing transport are
+// surfaced verbatim — see reformatHTTPErr in download.go for the
+// rationale.
+//
+// We branch on both error types because the cp cobra flow now goes
+// through TWO packages:
+//   - cp.Client.PasteOne for the PATCH calls (cp.HTTPError);
+//   - download.Client.Stat for the preflight existence checks
+//     (download.HTTPError).
+//
+// Status code mapping (401/403 → re-login CTA, 404 → "not found")
+// is the same for both — we keep one switch block but two errors.As
+// branches so the type-specific status / URL fields stay accessible
+// for future per-package diagnostics.
 func reformatCpHTTPErr(err error, olaresID, op, target string) error {
 	if err == nil {
 		return nil
@@ -382,21 +589,27 @@ func reformatCpHTTPErr(err error, olaresID, op, target string) error {
 	if errors.As(err, &nli) {
 		return nli
 	}
-	var hErr *cp.HTTPError
-	if errors.As(err, &hErr) {
-		switch hErr.Status {
-		case 401, 403:
-			if olaresID != "" {
-				return fmt.Errorf("server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",
-					hErr.Status, olaresID)
-			}
-			return fmt.Errorf("server rejected the access token (HTTP %d); please re-run `olares-cli profile login`", hErr.Status)
-		case 404:
-			if target == "" {
-				return fmt.Errorf("%s: not found on the server (HTTP 404)", op)
-			}
-			return fmt.Errorf("%s %s: not found on the server (HTTP 404)", op, target)
+	var status int
+	var cpErr *cp.HTTPError
+	if errors.As(err, &cpErr) {
+		status = cpErr.Status
+	}
+	var dlErr *download.HTTPError
+	if status == 0 && errors.As(err, &dlErr) {
+		status = dlErr.Status
+	}
+	switch status {
+	case 401, 403:
+		if olaresID != "" {
+			return fmt.Errorf("server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",
+				status, olaresID)
 		}
+		return fmt.Errorf("server rejected the access token (HTTP %d); please re-run `olares-cli profile login`", status)
+	case 404:
+		if target == "" {
+			return fmt.Errorf("%s: not found on the server (HTTP 404)", op)
+		}
+		return fmt.Errorf("%s %s: not found on the server (HTTP 404)", op, target)
 	}
 	return err
 }

--- a/cli/cmd/ctl/files/cp.go
+++ b/cli/cmd/ctl/files/cp.go
@@ -455,13 +455,21 @@ func preflightCpMv(
 	action cp.Action,
 ) error {
 	for _, s := range srcs {
-		srcDisplay := s.FileType + "/" + s.Extend + s.SubPath
-		srcPlain := s.FileType + "/" + s.Extend + s.SubPath
-		info, err := statClient.Stat(ctx, srcPlain)
+		// One canonical string is used for BOTH the wire path
+		// (passed to download.Stat) and the human-facing error
+		// display. An earlier revision had separate
+		// srcPlain / srcDisplay variables assigned to the same
+		// expression — they were left split "for future divergence",
+		// but the divergence never materialised and the parallel
+		// assignments became a maintenance trap (a tweak to one
+		// would silently miss its twin). Same pattern on the dst
+		// and parent legs below.
+		src := s.FileType + "/" + s.Extend + s.SubPath
+		info, err := statClient.Stat(ctx, src)
 		if err != nil {
 			if download.IsNotFound(err) {
 				return fmt.Errorf("%s: source %s does not exist on the server",
-					action, srcDisplay)
+					action, src)
 			}
 			return err
 		}
@@ -472,12 +480,12 @@ func preflightCpMv(
 		if s.IsDirIntent && !info.IsDir {
 			return fmt.Errorf(
 				"%s: source %s is a file on the server, not a directory; drop the trailing '/'",
-				action, srcDisplay)
+				action, src)
 		}
 		if !s.IsDirIntent && info.IsDir {
 			return fmt.Errorf(
 				"%s: source %s is a directory on the server; add a trailing '/' and pass -r/-R to %s it recursively",
-				action, srcDisplay, action)
+				action, src, action)
 		}
 	}
 
@@ -494,21 +502,20 @@ func preflightCpMv(
 	//     handling takes over, which is server-side behavior we
 	//     don't preflight here).
 	if dst.IsDirIntent {
-		dstDisplay := dst.FileType + "/" + dst.Extend + dst.SubPath
-		dstPlain := dst.FileType + "/" + dst.Extend + dst.SubPath
-		info, err := statClient.Stat(ctx, dstPlain)
+		dstPath := dst.FileType + "/" + dst.Extend + dst.SubPath
+		info, err := statClient.Stat(ctx, dstPath)
 		if err != nil {
 			if download.IsNotFound(err) {
 				return fmt.Errorf(
 					"%s: destination directory %s does not exist on the server; create it first with `olares-cli files mkdir`",
-					action, dstDisplay)
+					action, dstPath)
 			}
 			return err
 		}
 		if !info.IsDir {
 			return fmt.Errorf(
 				"%s: destination %s is a file on the server, not a directory; drop the trailing '/' or pick a different target",
-				action, dstDisplay)
+				action, dstPath)
 		}
 		return nil
 	}
@@ -517,22 +524,20 @@ func preflightCpMv(
 	// planner has already rejected SubPath=="/" via the dir-intent
 	// requirement on root targets, so dst.SubPath here is at least
 	// "/<leaf>".
-	parentSub := parentSubPath(dst.SubPath)
-	parentDisplay := dst.FileType + "/" + dst.Extend + parentSub
-	parentPlain := dst.FileType + "/" + dst.Extend + parentSub
-	info, err := statClient.Stat(ctx, parentPlain)
+	parentPath := dst.FileType + "/" + dst.Extend + parentSubPath(dst.SubPath)
+	info, err := statClient.Stat(ctx, parentPath)
 	if err != nil {
 		if download.IsNotFound(err) {
 			return fmt.Errorf(
 				"%s: destination's parent directory %s does not exist on the server",
-				action, parentDisplay)
+				action, parentPath)
 		}
 		return err
 	}
 	if !info.IsDir {
 		return fmt.Errorf(
 			"%s: destination's parent %s is a file on the server, not a directory",
-			action, parentDisplay)
+			action, parentPath)
 	}
 	return nil
 }

--- a/cli/cmd/ctl/files/cp_test.go
+++ b/cli/cmd/ctl/files/cp_test.go
@@ -1,0 +1,398 @@
+// cp_test.go: unit tests for the cobra-layer cp/mv glue —
+// specifically the preflight existence/kind checks that run BEFORE
+// any state-changing PATCH /api/paste/<node>/ goes out.
+//
+// Why this lives in the cobra layer rather than internal/files/cp:
+// the planner (cp.Plan) is pure — it operates on already-typed
+// Source/Destination shapes and never touches the wire. The
+// preflight, by contrast, is a network step (one Stat per source +
+// one Stat for the destination side) that the cobra glue
+// orchestrates by wiring a download.Client into preflightCpMv. The
+// tests follow the same parent-listing mock pattern the download
+// package's stat tests use (see internal/files/download/stat.go).
+package files
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/internal/files/cp"
+	"github.com/beclab/Olares/cli/internal/files/download"
+)
+
+// newPreflightClient stands up an httptest.Server with the supplied
+// handler and returns a download.Client pointing at it. The cp
+// preflight only consumes Stat, so a single handler is enough — no
+// need to instantiate the cp.Client.
+func newPreflightClient(t *testing.T, h http.Handler) *download.Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &download.Client{
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	}
+}
+
+// listingHandler is a tiny test helper: routes are keyed by
+// `<URL.Path>` (e.g. `/api/resources/drive/Home/`) and the value is
+// the raw JSON body to write back. Unknown paths return 404 so the
+// preflight's NotFound branch fires; entries shape mirrors the
+// LarePass web app's items[] envelope (the cp preflight reuses
+// download.Client.Stat which decodes that shape).
+func listingHandler(t *testing.T, routes map[string]string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("preflight should only issue GETs, got %s %s",
+				r.Method, r.URL.Path)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			http.Error(w, "{}", http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	})
+}
+
+// TestParentSubPath pins the small helper that derives the parent
+// directory of a `/...`-prefixed subpath. The cases cover the three
+// shapes that show up on the wire: nested file, nested directory
+// (input itself ending in `/`), depth-1 leaf (parent is the extend
+// root), and the extend root itself (its own parent — degenerate
+// guard so callers never have to special-case it).
+func TestParentSubPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"nested file", "/Documents/foo.pdf", "/Documents/"},
+		{"nested dir with trailing slash", "/Documents/sub/", "/Documents/"},
+		{"depth-1 file", "/foo.pdf", "/"},
+		{"depth-1 dir", "/Backups/", "/"},
+		{"extend root", "/", "/"},
+		// Defensive: an empty input should NOT panic. The cp glue
+		// always passes a `/`-prefixed string from ParseFrontendPath
+		// so this is unreachable in practice, but the helper guards
+		// it explicitly and we lock that down.
+		{"empty input", "", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parentSubPath(tc.in); got != tc.want {
+				t.Errorf("parentSubPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPreflightCpMv_HappyPath: every source exists with the right
+// kind, the destination is an existing directory. The handler
+// returns the parent listings that make all those lookups succeed.
+//
+// `cp drive/Home/notes.md drive/Home/Archive/` — single file source
+// under `drive/Home/`, dropped into the existing `drive/Home/Archive/`
+// directory. The preflight should issue exactly two GETs:
+//
+//   - GET /api/resources/drive/Home/      → find "notes.md" (file) and "Archive" (dir)
+//   - GET /api/resources/drive/Home/      → find "Archive" (dir) for the dst stat
+//
+// We mount both lookups on the same `/api/resources/drive/Home/`
+// URL so the handler returns the same body twice (download.Stat
+// doesn't cache across calls — that's a documented future
+// optimization, not the current contract).
+func TestPreflightCpMv_HappyPath(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42},
+			{"name":"Archive","isDir":true,"size":0}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/Archive/", IsDirIntent: true,
+	}
+	if err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy); err != nil {
+		t.Fatalf("happy-path preflight: unexpected error %v", err)
+	}
+}
+
+// TestPreflightCpMv_SourceNotFound covers the most common
+// user-facing failure: a typo in the src path. The handler omits
+// the leaf from the parent listing, so download.Stat synthesises a
+// 404 and the preflight should turn it into "source ... does not
+// exist on the server" with the offending path named verbatim.
+func TestPreflightCpMv_SourceNotFound(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"other.md","isDir":false,"size":1}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if !strings.Contains(err.Error(), "drive/Home/notes.md") ||
+		!strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should name the missing source and say 'does not exist', got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_SrcKind_DirNoTrailingSlash: the user typed
+// `cp drive/Home/Photos drive/Home/Archive/` (no trailing slash on
+// Photos), but Photos is actually a directory on the server. The
+// planner wouldn't catch this — it trusts the user's IsDirIntent
+// signal — so the preflight surfaces the kind mismatch with a
+// targeted message that includes the corrective command shape
+// ("add a trailing '/' and pass -r").
+func TestPreflightCpMv_SrcKind_DirNoTrailingSlash(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"Photos","isDir":true,"size":0},
+			{"name":"Archive","isDir":true,"size":0}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		// IsDirIntent=false on purpose: user did NOT type trailing slash.
+		{FileType: "drive", Extend: "Home", SubPath: "/Photos"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/Archive/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for dir-source-without-trailing-slash")
+	}
+	if !strings.Contains(err.Error(), "is a directory") ||
+		!strings.Contains(err.Error(), "Photos") ||
+		!strings.Contains(err.Error(), "-r") {
+		t.Errorf("error should name the dir, mention '-r', got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_SrcKind_FileWithTrailingSlash: inverse of the
+// above. The user typed `cp -r drive/Home/notes.md/ drive/Home/Archive/`
+// (trailing slash on what is actually a file). The planner would
+// happily proceed (the slash + -r flag pass the IsDirIntent +
+// recursive guard), and the backend would reject it confusingly.
+// The preflight catches it with "is a file on the server, not a
+// directory; drop the trailing '/'".
+func TestPreflightCpMv_SrcKind_FileWithTrailingSlash(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42},
+			{"name":"Archive","isDir":true,"size":0}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		// IsDirIntent=true (user typed `notes.md/`).
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md/", IsDirIntent: true},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/Archive/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for file-source-with-trailing-slash")
+	}
+	if !strings.Contains(err.Error(), "is a file") ||
+		!strings.Contains(err.Error(), "notes.md") ||
+		!strings.Contains(err.Error(), "drop the trailing") {
+		t.Errorf("error should name the file and tell the user to drop the slash, got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_DstDirMissing covers the "you forgot to mkdir
+// the target" case. drop-into-dir mode REQUIRES the dst directory
+// to already exist on the server (the backend's POST-on-collision
+// auto-rename quirk would otherwise create weird sibling shapes —
+// see SKILL.md's "Server-side quirks" section). The preflight
+// refuses early with a `mkdir` CTA.
+func TestPreflightCpMv_DstDirMissing(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		// `Archive` is NOT in the parent listing above.
+		FileType: "drive", Extend: "Home", SubPath: "/Archive/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for missing dst dir")
+	}
+	if !strings.Contains(err.Error(), "drive/Home/Archive/") ||
+		!strings.Contains(err.Error(), "does not exist") ||
+		!strings.Contains(err.Error(), "mkdir") {
+		t.Errorf("error should name the missing dir + suggest mkdir, got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_DstIsFile catches `cp foo bar/` where `bar` is
+// actually a file on the server (not a directory). Drop-into-dir
+// mode would land foo at `bar/foo`, which the backend can't
+// represent because bar is a file. The preflight refuses with
+// "destination ... is a file ... drop the trailing '/'".
+func TestPreflightCpMv_DstIsFile(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42},
+			{"name":"bar","isDir":false,"size":7}
+		]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/bar/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for dst-that-is-file")
+	}
+	if !strings.Contains(err.Error(), "bar") ||
+		!strings.Contains(err.Error(), "is a file") {
+		t.Errorf("error should name the file dst, got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_VolumeRootDst: dst is the bare volume root
+// (`drive/Home/`). download.Stat short-circuits to a synthetic dir
+// for ≤2-segment paths so the preflight should pass WITHOUT hitting
+// the wire for the dst leg — the handler asserts that the only GET
+// we see is the source-side parent listing.
+func TestPreflightCpMv_VolumeRootDst(t *testing.T) {
+	var dstStats int
+	stat := newPreflightClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("want GET, got %s", r.Method)
+		}
+		// The only legitimate GET is the source's parent listing.
+		// Any other URL means download.Stat hit the network for
+		// the synthetic-dir volume root — a regression.
+		if r.URL.Path != "/api/resources/drive/Home/" {
+			t.Errorf("unexpected wire call %s — synthetic dst stat should not hit the network",
+				r.URL.Path)
+		}
+		dstStats++
+		_, _ = io.WriteString(w, `{"items":[
+			{"name":"notes.md","isDir":false,"size":42}
+		]}`)
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/", IsDirIntent: true,
+	}
+	if err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy); err != nil {
+		t.Fatalf("volume-root dst: unexpected error %v", err)
+	}
+	// Exactly one GET for the source's parent listing — no
+	// extra round-trip for the synthetic dst.
+	if dstStats != 1 {
+		t.Errorf("want 1 wire GET (source parent), got %d", dstStats)
+	}
+}
+
+// TestPreflightCpMv_ExactTargetParentExists covers the undocumented
+// single-source + non-trailing-slash `<dst>` mode that the planner
+// still accepts for backwards compatibility. The preflight should
+// verify the PARENT of dst (not dst itself) — the leaf doesn't exist
+// yet by definition. Happy path: parent exists as a dir.
+func TestPreflightCpMv_ExactTargetParentExists(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		// Source's parent — contains notes.md.
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42},
+			{"name":"Documents","isDir":true,"size":0}
+		]}`,
+		// Dst's parent — `/Documents/`. The leaf
+		// `notes-2026.md` is intentionally absent: exact-target
+		// mode tolerates that (the backend will create it or
+		// auto-rename on collision).
+		"/api/resources/drive/Home/Documents/": `{"items":[]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		// IsDirIntent=false: this is the undocumented exact-target shape.
+		FileType: "drive", Extend: "Home", SubPath: "/Documents/notes-2026.md",
+	}
+	if err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy); err != nil {
+		t.Fatalf("exact-target happy path: unexpected error %v", err)
+	}
+}
+
+// TestPreflightCpMv_ExactTargetParentMissing: exact-target mode
+// where the dst's parent dir is itself a typo. Without this check
+// the backend would either 404 or create a weird placeholder; the
+// preflight refuses early and names the missing parent.
+func TestPreflightCpMv_ExactTargetParentMissing(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		// Source's parent — notes.md is here.
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42}
+		]}`,
+		// Dst's parent (`/Documents/`) is intentionally NOT in
+		// the routes map → returns 404 → preflight should refuse.
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/Documents/notes-2026.md",
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionCopy)
+	if err == nil {
+		t.Fatal("expected error for missing exact-target parent")
+	}
+	if !strings.Contains(err.Error(), "parent") ||
+		!strings.Contains(err.Error(), "Documents") {
+		t.Errorf("error should mention the missing parent dir, got: %v", err)
+	}
+}
+
+// TestPreflightCpMv_MvActionLabelsErrors: the error messages should
+// say `mv:` (not `copy:`) when action is move, so the user can match
+// the failure to the command they actually typed. Cheap to verify
+// alongside one of the existing rejection arms.
+func TestPreflightCpMv_MvActionLabelsErrors(t *testing.T) {
+	stat := newPreflightClient(t, listingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[]}`,
+	}))
+	srcs := []cp.Source{
+		{FileType: "drive", Extend: "Home", SubPath: "/notes.md"},
+	}
+	dst := cp.Destination{
+		FileType: "drive", Extend: "Home", SubPath: "/", IsDirIntent: true,
+	}
+	err := preflightCpMv(context.Background(), stat, srcs, dst, cp.ActionMove)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if !strings.HasPrefix(err.Error(), "move:") {
+		t.Errorf("error should be labelled with the action verb, got: %v", err)
+	}
+}

--- a/cli/cmd/ctl/files/rm.go
+++ b/cli/cmd/ctl/files/rm.go
@@ -13,9 +13,10 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/beclab/Olares/cli/internal/files/download"
+	"github.com/beclab/Olares/cli/internal/files/rm"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
-	"github.com/beclab/Olares/cli/internal/files/rm"
 )
 
 type rmOptions struct {
@@ -64,12 +65,31 @@ request, matching the LarePass web app's batchDeleteFileItems helper.
 Targets across different parents send one request each, in a stable
 order (sorted by fileType + extend + parent).
 
+Preflight existence check (runs BEFORE the preview / prompt):
+
+    Every target is Stat'd against the server before the
+    confirmation prompt is shown. The check fails fast and aborts
+    BEFORE printing any "will delete N entries" line if:
+
+      - a target path doesn't exist on the server (typo / stale path);
+      - the user typed ` + "`<target>/`" + ` or passed --recursive, but the
+        entry on the server is actually a FILE;
+      - the user typed ` + "`<target>`" + ` (no slash) without --recursive,
+        but the entry is actually a DIRECTORY (same "pass -r/-R"
+        CTA the planner uses).
+
+    Volume roots (` + "`drive/Home/`" + `, ` + "`sync/<repo>/`" + `, ...) are rejected
+    upstream by the planner; the preflight only sees real entries.
+
 Confirmation:
 
     By default ` + "`rm`" + ` lists what it would delete and asks y/N. Pass
     --force / -f to skip the prompt (e.g. in scripts). In a non-TTY
     context (CI, piped stdin) we refuse without --force rather than
-    guessing.
+    guessing. ` + "`--force`" + ` does NOT bypass the preflight existence
+    check — a missing path still aborts the operation, matching the
+    safer-than-Unix-` + "`rm -f`" + ` default we've taken everywhere else in
+    ` + "`olares-cli files`" + `.
 
 Trailing slash on a target signals "this is a directory" — the
 planner errors out without --recursive in that case (Unix-style).
@@ -144,6 +164,51 @@ func runRm(
 		return err
 	}
 
+	// Resolve profile + HTTP client up front. Earlier revisions of
+	// rm deferred this until after the confirmation prompt so a
+	// `-f` script could short-circuit on a Plan-level rejection
+	// without a network round-trip, but the preflight existence
+	// check below NEEDS the HTTP client BEFORE the preview /
+	// confirmation — printing a "will delete X" line for a path
+	// that doesn't even exist on the server is misleading, and
+	// proceeding to the DELETE would just produce a 404 the user
+	// has to interpret. We accept the extra `/api/refresh` round-
+	// trip on the cold path (the refreshing transport caches the
+	// token within a process) so the preflight can give a clean,
+	// path-named rejection before any state is shown as "about to
+	// be deleted".
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return err
+	}
+	httpClient, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
+	client := &rm.Client{
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
+	}
+
+	// Preflight: Stat every target to verify it exists on the server
+	// and that the trailing-slash / -r intent matches the actual
+	// file vs. directory kind. This refuses the typical "I typed
+	// the wrong path" and "I forgot -r" cases BEFORE we print a
+	// destructive-looking preview line. See preflightRm for the full
+	// table of refusal arms.
+	//
+	// Stat reuses the same parent-listing strategy `files cat` /
+	// `files download` / `files cp` use (see
+	// internal/files/download/stat.go) so the check works uniformly
+	// across drive / sync / cache / external / cloud namespaces.
+	statClient := &download.Client{
+		HTTPClient: httpClient,
+		BaseURL:    rp.FilesURL,
+	}
+	if err := preflightRm(ctx, statClient, targets, o.recursive); err != nil {
+		return reformatRmHTTPErr(err, rp.OlaresID, nil)
+	}
+
 	// Show the user the exact set of operations before any wire call
 	// goes out — even with --force; deletion is destructive enough
 	// that a one-line "deleting N entries" line is worth printing.
@@ -179,19 +244,6 @@ func runRm(
 			fmt.Fprintf(out, "aborted\n")
 			return nil
 		}
-	}
-
-	rp, err := f.ResolveProfile(ctx)
-	if err != nil {
-		return err
-	}
-	httpClient, err := f.HTTPClient(ctx)
-	if err != nil {
-		return err
-	}
-	client := &rm.Client{
-		HTTPClient: httpClient,
-		BaseURL:    rp.FilesURL,
 	}
 
 	// Serial DELETE per group. Per-group failures abort the rest:
@@ -277,10 +329,103 @@ func readYesNo(in io.Reader) (bool, error) {
 	}
 }
 
-// reformatRmHTTPErr maps rm.HTTPError onto user-friendly messages,
-// same spirit as the download counterpart. Typed credential errors
-// from the refreshing transport are surfaced verbatim — see
-// reformatHTTPErr in download.go for the rationale.
+// preflightRm probes every target BEFORE any state-changing DELETE
+// /api/resources/<parent>/ goes out, and refuses the operation early
+// if:
+//
+//   - a target path doesn't exist on the server (typo / stale path);
+//   - the user typed `<target>/` (trailing slash) or passed `-r`, but
+//     the actual entry is a FILE on the server. Both signal directory
+//     intent (the planner promotes `-r` invocations to dir dirents
+//     regardless of trailing slash), so a file at that path would
+//     fail confusingly server-side;
+//   - the user typed `<target>` (no slash) and did NOT pass `-r`, but
+//     the actual entry is a DIRECTORY on the server. The planner
+//     would have sent a file-shape dirent `/foo` which the backend
+//     refuses; preflight surfaces the kind mismatch with the same
+//     "pass -r/-R" CTA the planner uses.
+//
+// Stat uses the parent-listing strategy `files cat` / `files cp` use
+// (see internal/files/download/stat.go). Volume roots are not
+// reachable here because frontendPathToRmTarget already rejects them.
+//
+// The effective directory-intent rule matches the planner exactly:
+// `IsDirIntent || recursive` is taken as "the user means directory".
+// That way preflight and Plan agree on which kind to enforce, and a
+// `rm -r foo` (no trailing slash) gets the same treatment as
+// `rm -r foo/` — the user has declared dir intent via -r.
+//
+// Fail-fast: the FIRST refusal stops the batch. We don't continue
+// past a mismatch because the preview that follows ("will delete N
+// entries in M batches") would be lying — at least one of the
+// claimed deletions can't actually run.
+//
+// Network cost: one Stat per target. Multi-target `rm a b c` against
+// the same parent dir still issues N Stats (one per leaf) because
+// download.Client.Stat doesn't cache parent listings across calls —
+// a documented future optimization, not the current contract.
+//
+// HTTP errors (auth / network) are passed through verbatim so
+// reformatRmHTTPErr can attach the standard CTA.
+func preflightRm(
+	ctx context.Context,
+	statClient *download.Client,
+	targets []rm.Target,
+	recursive bool,
+) error {
+	for _, t := range targets {
+		plain := t.FileType + "/" + t.Extend + t.ParentSubPath + t.Name
+		display := plain
+		if t.IsDirIntent && !strings.HasSuffix(display, "/") {
+			display += "/"
+		}
+		info, err := statClient.Stat(ctx, plain)
+		if err != nil {
+			if download.IsNotFound(err) {
+				return fmt.Errorf(
+					"rm: target %s does not exist on the server",
+					display)
+			}
+			return err
+		}
+		// Effective dir intent: explicit trailing slash OR -r flag.
+		// Matches the `t.IsDirIntent || recursive` rule the planner
+		// uses to decide whether to add a trailing slash to the
+		// wire dirent. We keep the two rules in lockstep so the
+		// preflight and the Plan can never disagree on "is this a
+		// directory delete".
+		effectiveDir := t.IsDirIntent || recursive
+		if effectiveDir && !info.IsDir {
+			return fmt.Errorf(
+				"rm: target %s is a file on the server, not a directory; drop the trailing '/' and the -r/-R flag",
+				display)
+		}
+		if !effectiveDir && info.IsDir {
+			return fmt.Errorf(
+				"rm: target %s is a directory on the server; pass -r/-R to remove it recursively",
+				display)
+		}
+	}
+	return nil
+}
+
+// reformatRmHTTPErr maps rm.HTTPError / download.HTTPError onto
+// user-friendly messages, same spirit as the download counterpart.
+// Typed credential errors from the refreshing transport are
+// surfaced verbatim — see reformatHTTPErr in download.go for the
+// rationale.
+//
+// Like cp/mv, rm now goes through TWO packages:
+//   - rm.Client.DeleteBatch for the DELETE calls (rm.HTTPError);
+//   - download.Client.Stat for the preflight existence checks
+//     (download.HTTPError).
+//
+// Both error types are mapped to the same status-code switch. The
+// `g` parameter is non-nil only when the call originated from
+// DeleteBatch (we know the group's parent path then); the preflight
+// path passes nil and falls back to a parent-less "not found"
+// message — that's fine because the preflight's own error string
+// already names the offending target verbatim.
 func reformatRmHTTPErr(err error, olaresID string, g *rm.Group) error {
 	if err == nil {
 		return nil
@@ -293,19 +438,28 @@ func reformatRmHTTPErr(err error, olaresID string, g *rm.Group) error {
 	if errors.As(err, &nli) {
 		return nli
 	}
-	var hErr *rm.HTTPError
-	if errors.As(err, &hErr) {
-		switch hErr.Status {
-		case 401, 403:
-			if olaresID != "" {
-				return fmt.Errorf("server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",
-					hErr.Status, olaresID)
-			}
-			return fmt.Errorf("server rejected the access token (HTTP %d); please re-run `olares-cli profile login`", hErr.Status)
-		case 404:
+	var status int
+	var rmErr *rm.HTTPError
+	if errors.As(err, &rmErr) {
+		status = rmErr.Status
+	}
+	var dlErr *download.HTTPError
+	if status == 0 && errors.As(err, &dlErr) {
+		status = dlErr.Status
+	}
+	switch status {
+	case 401, 403:
+		if olaresID != "" {
+			return fmt.Errorf("server rejected the access token (HTTP %d); please run: olares-cli profile login --olares-id %s",
+				status, olaresID)
+		}
+		return fmt.Errorf("server rejected the access token (HTTP %d); please re-run `olares-cli profile login`", status)
+	case 404:
+		if g != nil {
 			return fmt.Errorf("delete %s/%s%s: not found on the server (HTTP 404)",
 				g.FileType, g.Extend, g.ParentSubPath)
 		}
+		return fmt.Errorf("rm: not found on the server (HTTP 404)")
 	}
 	return err
 }

--- a/cli/cmd/ctl/files/rm.go
+++ b/cli/cmd/ctl/files/rm.go
@@ -396,9 +396,39 @@ func preflightRm(
 		// directory delete".
 		effectiveDir := t.IsDirIntent || recursive
 		if effectiveDir && !info.IsDir {
+			// The corrective CTA must name ONLY the inputs the user
+			// actually typed. Three combinations reach this branch:
+			//
+			//   IsDirIntent  recursive   user-input → CTA
+			//   ------------ ----------- ------------------------------
+			//   true         true        `rm -r foo/`  → drop trailing
+			//                                            '/' AND -r/-R
+			//   true         false       `rm foo/`     → drop trailing
+			//                                            '/'  (unreach-
+			//                                            able in practice
+			//                                            — the planner
+			//                                            rejects trailing
+			//                                            slash without -r
+			//                                            upstream, but we
+			//                                            keep the arm
+			//                                            sound for defence
+			//                                            in depth)
+			//   false        true        `rm -r foo`   → drop -r/-R
+			//
+			// Telling a user who never typed a trailing slash to
+			// "drop the trailing '/'" sends them on a confused
+			// hunt for one in their command line — the previous
+			// unconditional message did exactly that.
+			cta := "drop the -r/-R flag"
+			switch {
+			case t.IsDirIntent && recursive:
+				cta = "drop the trailing '/' and the -r/-R flag"
+			case t.IsDirIntent:
+				cta = "drop the trailing '/'"
+			}
 			return fmt.Errorf(
-				"rm: target %s is a file on the server, not a directory; drop the trailing '/' and the -r/-R flag",
-				display)
+				"rm: target %s is a file on the server, not a directory; %s",
+				display, cta)
 		}
 		if !effectiveDir && info.IsDir {
 			return fmt.Errorf(

--- a/cli/cmd/ctl/files/rm_test.go
+++ b/cli/cmd/ctl/files/rm_test.go
@@ -154,6 +154,16 @@ func TestPreflightRm_FileWithRecursive(t *testing.T) {
 		!strings.Contains(err.Error(), "is a file") {
 		t.Errorf("error should name the file and reject the recursive intent, got: %v", err)
 	}
+	// The user did NOT type a trailing slash here — only -r promoted
+	// dir intent. Telling them to "drop the trailing '/'" would send
+	// them hunting for one in their command line that isn't there.
+	// Lock the CTA down to the -r/-R-only branch.
+	if !strings.Contains(err.Error(), "drop the -r/-R flag") {
+		t.Errorf("CTA must say 'drop the -r/-R flag' when only -r promoted dir intent; got: %v", err)
+	}
+	if strings.Contains(err.Error(), "trailing '/'") {
+		t.Errorf("CTA must NOT mention 'trailing /' when the user didn't type one; got: %v", err)
+	}
 }
 
 // TestPreflightRm_FileWithTrailingSlash: user typed `rm
@@ -181,6 +191,12 @@ func TestPreflightRm_DirIntentButActuallyFile(t *testing.T) {
 	if !strings.Contains(err.Error(), "notes.md/") ||
 		!strings.Contains(err.Error(), "is a file") {
 		t.Errorf("error should preserve trailing slash on display and call it a file, got: %v", err)
+	}
+	// Both IsDirIntent AND recursive triggered the effective dir
+	// promotion, so the CTA must mention BOTH corrective actions —
+	// the user has two flags to undo (or two inputs to reconsider).
+	if !strings.Contains(err.Error(), "drop the trailing '/' and the -r/-R flag") {
+		t.Errorf("CTA must mention both trailing slash and -r/-R flag when both triggered dir intent; got: %v", err)
 	}
 }
 

--- a/cli/cmd/ctl/files/rm_test.go
+++ b/cli/cmd/ctl/files/rm_test.go
@@ -1,0 +1,259 @@
+// rm_test.go: unit tests for the cobra-layer rm preflight existence
+// + kind check. Same shape as cp_test.go — uses httptest to mock
+// the parent-listing endpoint download.Client.Stat hits, and asserts
+// the error surface on each refusal arm.
+//
+// Why the test lives at the cobra layer rather than internal/files/rm:
+// the planner (rm.Plan) is pure — it operates on already-typed Target
+// shapes and never touches the wire. The preflight, by contrast, is
+// a network step (one Stat per target) that the cobra glue
+// orchestrates by wiring a download.Client into preflightRm. The
+// planner tests in internal/files/rm/rm_test.go stay focused on the
+// pure validation arms (root refusal, protected names, group
+// dedup, ...); preflight semantics live here.
+package files
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/internal/files/download"
+	"github.com/beclab/Olares/cli/internal/files/rm"
+)
+
+// newRmPreflightClient stands up an httptest.Server with the supplied
+// handler and returns a download.Client pointing at it. Mirrors the
+// cp_test.go helper — the rm preflight only consumes Stat, so a
+// single handler suffices (no need to instantiate rm.Client).
+func newRmPreflightClient(t *testing.T, h http.Handler) *download.Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &download.Client{
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	}
+}
+
+// rmListingHandler keys routes by URL path (e.g.
+// `/api/resources/drive/Home/`) and returns the raw JSON body for
+// download.Client.Stat to decode. Unknown paths return 404, which
+// download.Stat surfaces as the synthetic "leaf not in listing" 404
+// branch — i.e. our preflight's "does not exist" arm.
+func rmListingHandler(t *testing.T, routes map[string]string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("preflight should only issue GETs, got %s %s",
+				r.Method, r.URL.Path)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			http.Error(w, "{}", http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	})
+}
+
+// TestPreflightRm_HappyPath: target exists with the matching kind.
+// One file under `drive/Home/Documents/`, no `-r` — should pass the
+// preflight clean without touching anything else.
+func TestPreflightRm_HappyPath(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/Documents/": `{"items":[
+			{"name":"foo.pdf","isDir":false,"size":1234}
+		]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/Documents/", Name: "foo.pdf"},
+	}
+	if err := preflightRm(context.Background(), stat, targets, false); err != nil {
+		t.Fatalf("happy-path preflight: unexpected error %v", err)
+	}
+}
+
+// TestPreflightRm_TargetNotFound: the most common typo. Stat's
+// parent listing succeeds but the target leaf isn't in it; the
+// synthetic 404 maps to "does not exist on the server" with the
+// offending path named verbatim (no -r flag in play, so the display
+// path stays without a trailing slash).
+func TestPreflightRm_TargetNotFound(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"other.md","isDir":false,"size":1}
+		]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "notes.md"},
+	}
+	err := preflightRm(context.Background(), stat, targets, false)
+	if err == nil {
+		t.Fatal("expected error for missing target")
+	}
+	if !strings.Contains(err.Error(), "drive/Home/notes.md") ||
+		!strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should name the target and say 'does not exist', got: %v", err)
+	}
+}
+
+// TestPreflightRm_DirWithoutRecursive: user typed `rm drive/Home/Photos`
+// (no trailing slash) and DIDN'T pass -r, but Photos is actually a
+// directory on the server. The planner would happily send a
+// file-shape dirent `/Photos` which the backend refuses; preflight
+// catches it earlier with the same "pass -r/-R" CTA.
+func TestPreflightRm_DirWithoutRecursive(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"Photos","isDir":true,"size":0}
+		]}`,
+	}))
+	targets := []rm.Target{
+		// IsDirIntent=false: no trailing slash, planner has not seen `-r` yet.
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "Photos"},
+	}
+	err := preflightRm(context.Background(), stat, targets, false)
+	if err == nil {
+		t.Fatal("expected error for dir-target-without-r")
+	}
+	if !strings.Contains(err.Error(), "Photos") ||
+		!strings.Contains(err.Error(), "is a directory") ||
+		!strings.Contains(err.Error(), "-r") {
+		t.Errorf("error should name the dir + suggest -r, got: %v", err)
+	}
+}
+
+// TestPreflightRm_FileWithRecursive: inverse of the above. User
+// typed `rm -r drive/Home/notes.md` — the planner promotes this to
+// a dir-shape dirent `/notes.md/` based on the `-r` flag alone,
+// which would hit the backend's directory-removal path against a
+// file and fail. The preflight catches the kind mismatch with
+// "drop the -r/-R flag".
+func TestPreflightRm_FileWithRecursive(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42}
+		]}`,
+	}))
+	targets := []rm.Target{
+		// IsDirIntent=false (no trailing slash typed by user), but
+		// recursive=true below promotes effective intent to dir.
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "notes.md"},
+	}
+	err := preflightRm(context.Background(), stat, targets, true)
+	if err == nil {
+		t.Fatal("expected error for file-target-with-r")
+	}
+	if !strings.Contains(err.Error(), "notes.md") ||
+		!strings.Contains(err.Error(), "is a file") {
+		t.Errorf("error should name the file and reject the recursive intent, got: %v", err)
+	}
+}
+
+// TestPreflightRm_FileWithTrailingSlash: user typed `rm
+// drive/Home/notes.md/` (trailing slash) without -r — but
+// IsDirIntent=true triggers the dir-without-recursive planner
+// rejection, which is structural and doesn't reach the preflight.
+// The interesting case at the preflight layer is `rm -r notes.md/`:
+// IsDirIntent=true AND recursive=true, but the target is a file on
+// the server. The preflight should refuse with the same "is a file"
+// message — directory intent doesn't matter, the actual kind does.
+func TestPreflightRm_DirIntentButActuallyFile(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"notes.md","isDir":false,"size":42}
+		]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "notes.md", IsDirIntent: true},
+	}
+	err := preflightRm(context.Background(), stat, targets, true)
+	if err == nil {
+		t.Fatal("expected error for dir-intent target that is a file on the server")
+	}
+	// Display includes the trailing slash (IsDirIntent preserved on the wire path).
+	if !strings.Contains(err.Error(), "notes.md/") ||
+		!strings.Contains(err.Error(), "is a file") {
+		t.Errorf("error should preserve trailing slash on display and call it a file, got: %v", err)
+	}
+}
+
+// TestPreflightRm_RecursiveDirHappyPath: `rm -r drive/Home/Photos/`
+// — dir intent (user-typed slash AND -r) matches the actual dir
+// kind on the server. The preflight should pass; the planner's
+// effective dir-intent rule is in lockstep with the preflight's, so
+// `IsDirIntent=true, recursive=true, info.IsDir=true` is the happy
+// case.
+func TestPreflightRm_RecursiveDirHappyPath(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"Photos","isDir":true,"size":0}
+		]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "Photos", IsDirIntent: true},
+	}
+	if err := preflightRm(context.Background(), stat, targets, true); err != nil {
+		t.Fatalf("recursive-dir happy path: unexpected error %v", err)
+	}
+}
+
+// TestPreflightRm_MultipleTargets_OneMissing: fail-fast contract.
+// Three targets, the SECOND one is missing — the preflight should
+// stop at the second and surface its path. The third target
+// (which exists) is NOT consulted, so the test handler asserts that
+// the second target's parent is the last URL visited.
+//
+// We don't try to assert "third URL never hit" because Stat reuses
+// the same parent-listing URL for siblings, and we'd be coupling
+// the test to download.Stat's internal call order. Naming the
+// failing path in the error is the user-facing contract that
+// matters here.
+func TestPreflightRm_MultipleTargets_OneMissing(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/Documents/": `{"items":[
+			{"name":"a.pdf","isDir":false,"size":1},
+			{"name":"c.pdf","isDir":false,"size":1}
+		]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/Documents/", Name: "a.pdf"},
+		// b.pdf does NOT exist in the listing.
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/Documents/", Name: "b.pdf"},
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/Documents/", Name: "c.pdf"},
+	}
+	err := preflightRm(context.Background(), stat, targets, false)
+	if err == nil {
+		t.Fatal("expected error for the middle missing target")
+	}
+	if !strings.Contains(err.Error(), "b.pdf") ||
+		!strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should name the missing target verbatim, got: %v", err)
+	}
+}
+
+// TestPreflightRm_RmErrorPrefix: every preflight error should be
+// prefixed with `rm:` so the user can match it to the command they
+// typed (and so a future log-grep can filter rm-specific failures
+// without ambiguity).
+func TestPreflightRm_RmErrorPrefix(t *testing.T) {
+	stat := newRmPreflightClient(t, rmListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[]}`,
+	}))
+	targets := []rm.Target{
+		{FileType: "drive", Extend: "Home", ParentSubPath: "/", Name: "ghost"},
+	}
+	err := preflightRm(context.Background(), stat, targets, false)
+	if err == nil {
+		t.Fatal("expected error for missing target")
+	}
+	if !strings.HasPrefix(err.Error(), "rm:") {
+		t.Errorf("error should be labelled with `rm:`, got: %v", err)
+	}
+}

--- a/cli/cmd/ctl/files/share.go
+++ b/cli/cmd/ctl/files/share.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/internal/files/download"
 	"github.com/beclab/Olares/cli/internal/files/share"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
@@ -40,8 +41,16 @@ import (
 func NewShareCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "share",
-		Short: "create and manage internal / public / SMB shares for files-backend resources",
-		Long: `Create and manage shares for files / folders on the per-user files-backend.
+		Short: "create and manage internal / public / SMB shares for files-backend directories",
+		Long: `Create and manage shares for directories on the per-user files-backend.
+
+All three create flavors are DIRECTORY-ONLY: each ` + "`share <flavor>"+ "`" + `
+verb Stats the target before posting the create record and refuses
+up front when the path is a file (or doesn't exist on the server).
+This matches the LarePass GUI's per-driver share-menu gating on
+` + "`event.isDir`" + ` — sharing a single file is rejected by the web app
+and by the CLI. To "share a single file", place it in a dedicated
+directory and share that directory instead.
 
 Three share flavors:
 
@@ -505,11 +514,15 @@ func setupShareClient(ctx context.Context, f *cmdutil.Factory) (*share.Client, *
 //     layer rules for `external/<node>/` and `cache/<node>/`; those
 //     are namespace-orthogonal and applied separately via
 //     IsExternalNodeRoot / IsCacheNodeRoot below.
-//   - It does not replicate the GUI's `event.isDir` constraint for
-//     SMB / Internal share menus — sharing a single file IS a
-//     legitimate Internal-share use case, and the CLI accepts it
-//     (the server is the authoritative gate for "is this resource
-//     shareable").
+//   - It does not encode the GUI's `event.isDir` constraint here.
+//     That dir-only gate IS enforced (matching the LarePass GUI's
+//     per-driver share-menu condition list), but it lives in a
+//     separate cobra-layer preflight — [preflightShareCreate] in
+//     [share_create.go] — because it needs a wire round-trip
+//     (download.Client.Stat) to know whether the target is a file
+//     or a directory. Keeping the namespace allow-list pure
+//     (string in → error out) keeps it independently testable
+//     without standing up an HTTP server.
 var shareFlavorAllowedNamespaces = map[share.Type]map[string]struct{}{
 	share.TypeInternal: {
 		"drive":    {},
@@ -854,13 +867,39 @@ func resolveShareDisplayPath(ctx context.Context, f *cmdutil.Factory, r *share.R
 	return formatSharePathLine(r, name)
 }
 
-// reformatShareHTTPErr maps share.HTTPError onto user-friendly
-// messages — same pattern as cp / rm / download. The op string
-// describes which verb hit the error so multiple verbs in one
-// session can be told apart in error logs.
+// reformatShareHTTPErr maps share.HTTPError / download.HTTPError
+// onto user-friendly messages — same pattern as cp / rm / download.
+// The op string describes which verb hit the error so multiple
+// verbs in one session can be told apart in error logs.
 //
 // Typed credential errors from the refreshing transport are surfaced
 // verbatim; see reformatHTTPErr in download.go for the rationale.
+//
+// Two error types because the share-create cobra flow now goes
+// through TWO packages:
+//   - share.Client.{Create,...} for the share record CRUD
+//     (share.HTTPError);
+//   - download.Client.Stat for the preflight existence / dir-only
+//     check that runs before Create (download.HTTPError).
+//
+// Status code handling is identical for both — we want the user to
+// see the same `profile login` CTA on 401/403 regardless of which
+// leg of the operation failed — so we collapse the two into one
+// status integer and run a single switch.
+//
+// The 459 status is a back-compat artifact of the LarePass auth
+// proxy (legacy "token invalidated" indicator that pre-dates the
+// refreshing transport's typed errors). It only ever comes from
+// share.HTTPError; download.HTTPError doesn't model it explicitly,
+// but the switch arm handles either source uniformly because
+// preflight 401/403 already gets the same treatment.
+//
+// The 409 arm is share.HTTPError-only by design — it describes a
+// share-record state conflict (existing share id, double-create),
+// which can only originate from Create/Add/Update calls. The
+// preflight's Stat path never produces 409, so the arm is
+// effectively `share.HTTPError`-scoped without needing an extra
+// type guard.
 func reformatShareHTTPErr(err error, olaresID, op string) error {
 	if err == nil {
 		return nil
@@ -873,21 +912,27 @@ func reformatShareHTTPErr(err error, olaresID, op string) error {
 	if errors.As(err, &nli) {
 		return nli
 	}
-	var hErr *share.HTTPError
-	if errors.As(err, &hErr) {
-		switch hErr.Status {
-		case 401, 403, 459:
-			if olaresID != "" {
-				return fmt.Errorf("server rejected the access token (HTTP %d) during %s; please run: olares-cli profile login --olares-id %s",
-					hErr.Status, op, olaresID)
-			}
-			return fmt.Errorf("server rejected the access token (HTTP %d) during %s; please re-run `olares-cli profile login`",
-				hErr.Status, op)
-		case 404:
-			return fmt.Errorf("%s: not found on the server (HTTP 404)", op)
-		case 409:
-			return fmt.Errorf("%s: server reported a conflict (HTTP 409); the resource may already be shared, or the share id is in use", op)
+	var status int
+	var shareErr *share.HTTPError
+	if errors.As(err, &shareErr) {
+		status = shareErr.Status
+	}
+	var dlErr *download.HTTPError
+	if status == 0 && errors.As(err, &dlErr) {
+		status = dlErr.Status
+	}
+	switch status {
+	case 401, 403, 459:
+		if olaresID != "" {
+			return fmt.Errorf("server rejected the access token (HTTP %d) during %s; please run: olares-cli profile login --olares-id %s",
+				status, op, olaresID)
 		}
+		return fmt.Errorf("server rejected the access token (HTTP %d) during %s; please re-run `olares-cli profile login`",
+			status, op)
+	case 404:
+		return fmt.Errorf("%s: not found on the server (HTTP 404)", op)
+	case 409:
+		return fmt.Errorf("%s: server reported a conflict (HTTP 409); the resource may already be shared, or the share id is in use", op)
 	}
 	return err
 }

--- a/cli/cmd/ctl/files/share_create.go
+++ b/cli/cmd/ctl/files/share_create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/internal/files/download"
 	"github.com/beclab/Olares/cli/internal/files/share"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
@@ -39,9 +40,9 @@ func newShareInternalCommand(f *cmdutil.Factory) *cobra.Command {
 	o := &shareInternalOptions{}
 	cmd := &cobra.Command{
 		Use:   "internal <remote-path>",
-		Short: "create an Internal (cross-user) share for a folder or file",
+		Short: "create an Internal (cross-user) share for a directory",
 		Long: `Create an Internal share — visible to other Olares users on the same
-node — for a folder or file under the per-user files-backend.
+node — for a directory under the per-user files-backend.
 
 Wire shape (two calls, both required when --users is given):
 
@@ -56,6 +57,15 @@ passed, only the share record is created — useful when you want to
 hand the id off to a workflow that adds members separately, or
 when the share is private to its owner for now.
 
+Dir-only policy:
+
+    Only directories can be shared. The CLI Stats the target BEFORE
+    sending the create POST and refuses up front if the path is a
+    file (or doesn't exist on the server) — matches the LarePass
+    GUI's per-driver share-menu gating on ` + "`event.isDir`" + `. To share
+    a single file, place it in a dedicated directory and share that
+    directory instead.
+
 --users uses the format "name:perm" with multiple users joined by
 ",", e.g. "alice:edit,bob:view,charlie:admin". perm is one of
 view / upload / edit / admin (or 0..4). Default per-user perm is
@@ -67,7 +77,7 @@ sensible default (matching the web app) is admin (full control).
 Examples:
 
     olares-cli files share internal drive/Home/Backups/
-    olares-cli files share internal drive/Home/Reports/Q1.pdf \
+    olares-cli files share internal drive/Home/Reports/ \
         --users alice:edit,bob:view
 `,
 		Args: cobra.ExactArgs(1),
@@ -115,6 +125,22 @@ func runShareInternal(
 	client, rp, err := setupShareClient(ctx, f)
 	if err != nil {
 		return err
+	}
+
+	// Preflight: refuse to create a share against a file. Mirrors
+	// the LarePass GUI's per-driver share-menu gating on event.isDir
+	// — sharing a single file is rejected by the web app and the
+	// CLI now stays in lockstep. See preflightShareCreate for the
+	// full set of refusal arms and the rationale (the previous
+	// "file shares are legitimate Internal use case" comment in
+	// share.go is no longer accurate and has been updated).
+	httpClient, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
+	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
+	if err := preflightShareCreate(ctx, statClient, tgt, share.TypeInternal); err != nil {
+		return reformatShareHTTPErr(err, rp.OlaresID, "create internal share preflight for "+pathArg)
 	}
 
 	// For sync paths, swap the bare repo_id in for the human
@@ -182,7 +208,7 @@ func newSharePublicCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "public <remote-path>",
 		Aliases: []string{"link"},
-		Short:   "create a Public-link share for a folder or file",
+		Short:   "create a Public-link share for a directory",
 		Long: `Create a Public-link share. The link is opaque and can be sent to
 anyone who has the password; recipients open it through the
 LarePass app at the share host's /sharable-link/<id>/ path.
@@ -196,6 +222,15 @@ Wire shape:
 Required: --password OR auto-generated; AND one of --expire-days /
 --expire-time. Public links without an expiration are not supported
 by the backend.
+
+Dir-only policy:
+
+    Only directories can be shared. The CLI Stats the target BEFORE
+    sending the create POST and refuses up front if the path is a
+    file (or doesn't exist on the server) — matches the LarePass
+    GUI's per-driver share-menu gating on ` + "`event.isDir`" + `. For
+    one-off file distribution, use ` + "`files download`" + ` and re-share
+    the bytes out-of-band.
 
 Permission defaults to "edit" (recipients can read AND upload). Pass
 --upload-only to lock recipients into "upload-only" mode (they can
@@ -332,6 +367,20 @@ func runSharePublic(
 	if err != nil {
 		return err
 	}
+
+	// Preflight: same dir-only policy as `share internal` /
+	// `share smb`. Refuses early when target is a file (or doesn't
+	// exist on the server). See preflightShareCreate for the
+	// rationale.
+	httpClient, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
+	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
+	if err := preflightShareCreate(ctx, statClient, tgt, share.TypePublic); err != nil {
+		return reformatShareHTTPErr(err, rp.OlaresID, "create public share preflight for "+pathArg)
+	}
+
 	res, err := client.Create(ctx, tgt, opts)
 	if err != nil {
 		return reformatShareHTTPErr(err, rp.OlaresID, "create public share for "+pathArg)
@@ -416,6 +465,15 @@ SMB shares don't take a password (the password lives on the
 returned record per share, not in the request body) and don't take
 an expiration — they're mounted-resource-style and live until you
 ` + "`share rm`" + ` them.
+
+Dir-only policy:
+
+    SMB exports a directory tree mount, so a single-file target
+    has no working server-side representation. The CLI Stats the
+    target BEFORE sending the create POST and refuses up front if
+    the path is a file (or doesn't exist on the server) — same
+    dir-only policy as ` + "`share internal`" + ` and ` + "`share public`" + ` and
+    matches the LarePass GUI's gating on ` + "`event.isDir`" + `.
 
 Examples:
 
@@ -508,6 +566,22 @@ func runShareSMB(
 	if err != nil {
 		return err
 	}
+
+	// Preflight: same dir-only policy as `share internal` /
+	// `share public`. SMB shares are intrinsically directory-scoped
+	// on the wire (a Samba export points at a directory tree, not
+	// a single file), so this check is doubly motivated for the
+	// SMB flavor — the GUI also gates on event.isDir here. See
+	// preflightShareCreate for the full refusal table.
+	httpClient, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
+	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
+	if err := preflightShareCreate(ctx, statClient, tgt, share.TypeSMB); err != nil {
+		return reformatShareHTTPErr(err, rp.OlaresID, "create SMB share preflight for "+pathArg)
+	}
+
 	res, err := client.Create(ctx, tgt, opts)
 	if err != nil {
 		return reformatShareHTTPErr(err, rp.OlaresID, "create SMB share for "+pathArg)
@@ -532,6 +606,86 @@ func runShareSMB(
 		for _, u := range users {
 			fmt.Fprintf(out, "    - %s  (%s)\n", u.ID, u.Permission)
 		}
+	}
+	return nil
+}
+
+// preflightShareCreate Stats the share target BEFORE any state-
+// changing POST /api/share/share_path/<...>/ goes out, and refuses
+// the create when:
+//
+//   - the target path doesn't exist on the server (typo / stale path
+//     — the create would otherwise either 404 server-side or, worse,
+//     create a share record pointing at nothing);
+//
+//   - the target IS a file on the server. `files share` (all three
+//     flavors — internal / public / smb) is locked to directories
+//     only. Rationale per flavor:
+//
+//   - **SMB**: a Samba export is intrinsically a directory tree
+//     mount; pointing it at a single file has no working server-
+//     side representation. The LarePass GUI's Share-to-SMB menu
+//     also gates on `event.isDir`.
+//
+//   - **Public link**: the LarePass GUI surfaces "Generate
+//     Public Link" only on directories — a public link UX
+//     centred on a single file (download / preview only) is
+//     handled by other flows in the web app, not the share
+//     endpoint.
+//
+//   - **Internal**: aligned with the GUI for consistency. The
+//     server would technically accept a single-file Internal
+//     share record, but the resulting share has no working
+//     LarePass-app UI to open it because the recipient-side
+//     listing assumes a folder; the create would succeed but the
+//     share would be effectively invisible to its members. The
+//     CLI fast-fails up front rather than letting the user
+//     create a guaranteed-broken share record. To "share a single
+//     file", place it in a dedicated directory and share that
+//     directory instead.
+//
+// Volume roots (`drive/Home/`, `drive/Data/`, `sync/<repo>/`,
+// `external/<node>/<volume>/`, `cache/<node>/<sub>/`) Stat as
+// synthetic directories — `download.Stat` short-circuits when the
+// path is ≤2 segments, and deeper volume / node roots resolve
+// through their parent listing — so sharing a volume root works
+// without an extra round-trip relative to sharing a subdirectory.
+//
+// Stat reuses the parent-listing strategy `files cat` /
+// `files download` / `files cp` / `files rm` use (see
+// internal/files/download/stat.go); the check works uniformly
+// across drive / sync / cache / external namespaces. Cloud /
+// `external/<node>/` / `cache/<node>/` are already rejected upstream
+// by `frontendPathToShareTarget` so they never reach this helper.
+//
+// HTTP errors (auth / network) are returned verbatim so
+// reformatShareHTTPErr can attach the standard `profile login` CTA
+// regardless of which leg (preflight vs. the create POST) failed.
+func preflightShareCreate(
+	ctx context.Context,
+	statClient *download.Client,
+	tgt share.Target,
+	flavor share.Type,
+) error {
+	plain := tgt.FileType + "/" + tgt.Extend + tgt.SubPath
+	display := plain
+	info, err := statClient.Stat(ctx, plain)
+	if err != nil {
+		if download.IsNotFound(err) {
+			return fmt.Errorf(
+				"refusing to create a %s share for %s: target does not exist on the server",
+				shareFlavorFriendlyName(flavor), display)
+		}
+		return err
+	}
+	if !info.IsDir {
+		return fmt.Errorf(
+			"refusing to create a %s share for %s: target is a file on the server; "+
+				"`files share` only supports directories (matches the LarePass GUI's "+
+				"per-driver share-menu gating on event.isDir). To share a single file, "+
+				"place it in a dedicated directory and share that directory instead, "+
+				"or use `files download` + redistribute the file out-of-band.",
+			shareFlavorFriendlyName(flavor), display)
 	}
 	return nil
 }

--- a/cli/cmd/ctl/files/share_create.go
+++ b/cli/cmd/ctl/files/share_create.go
@@ -133,13 +133,11 @@ func runShareInternal(
 	// CLI now stays in lockstep. See preflightShareCreate for the
 	// full set of refusal arms and the rationale (the previous
 	// "file shares are legitimate Internal use case" comment in
-	// share.go is no longer accurate and has been updated).
-	httpClient, err := f.HTTPClient(ctx)
-	if err != nil {
-		return err
-	}
-	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
-	if err := preflightShareCreate(ctx, statClient, tgt, share.TypeInternal); err != nil {
+	// share.go is no longer accurate and has been updated). The
+	// stat client borrows the share client's HTTPClient + BaseURL
+	// directly — see newShareStatClient for why we don't ask the
+	// factory for a second http.Client here.
+	if err := preflightShareCreate(ctx, newShareStatClient(client), tgt, share.TypeInternal); err != nil {
 		return reformatShareHTTPErr(err, rp.OlaresID, "create internal share preflight for "+pathArg)
 	}
 
@@ -371,13 +369,10 @@ func runSharePublic(
 	// Preflight: same dir-only policy as `share internal` /
 	// `share smb`. Refuses early when target is a file (or doesn't
 	// exist on the server). See preflightShareCreate for the
-	// rationale.
-	httpClient, err := f.HTTPClient(ctx)
-	if err != nil {
-		return err
-	}
-	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
-	if err := preflightShareCreate(ctx, statClient, tgt, share.TypePublic); err != nil {
+	// rationale and newShareStatClient for why the stat client
+	// borrows from the share client instead of asking the factory
+	// for a second HTTP client.
+	if err := preflightShareCreate(ctx, newShareStatClient(client), tgt, share.TypePublic); err != nil {
 		return reformatShareHTTPErr(err, rp.OlaresID, "create public share preflight for "+pathArg)
 	}
 
@@ -572,13 +567,9 @@ func runShareSMB(
 	// on the wire (a Samba export points at a directory tree, not
 	// a single file), so this check is doubly motivated for the
 	// SMB flavor — the GUI also gates on event.isDir here. See
-	// preflightShareCreate for the full refusal table.
-	httpClient, err := f.HTTPClient(ctx)
-	if err != nil {
-		return err
-	}
-	statClient := &download.Client{HTTPClient: httpClient, BaseURL: rp.FilesURL}
-	if err := preflightShareCreate(ctx, statClient, tgt, share.TypeSMB); err != nil {
+	// preflightShareCreate for the full refusal table and
+	// newShareStatClient for the stat-client wiring.
+	if err := preflightShareCreate(ctx, newShareStatClient(client), tgt, share.TypeSMB); err != nil {
 		return reformatShareHTTPErr(err, rp.OlaresID, "create SMB share preflight for "+pathArg)
 	}
 
@@ -608,6 +599,42 @@ func runShareSMB(
 		}
 	}
 	return nil
+}
+
+// newShareStatClient builds the download.Client the share-create
+// preflight Stats its target with, reusing the already-built
+// share.Client's HTTPClient + BaseURL verbatim.
+//
+// Why a helper (and why we don't call f.HTTPClient(ctx) here):
+// setupShareClient — called by every share-create runner a few
+// lines BEFORE the preflight — has already executed
+// f.ResolveProfile(ctx) and f.HTTPClient(ctx), and stashed the
+// resulting *http.Client in share.Client.HTTPClient. f.HTTPClient
+// has a sync.Once around the *http.Client construction, but it
+// STILL calls f.ResolveProfile(ctx) on every entry (factory.go
+// L177-189) — and ResolveProfile in turn has its own resolveOnce
+// guard that, while fast, isn't free. More importantly:
+//
+//   - the second call returns the same *http.Client the share
+//     client already holds, so the extra hop just makes the
+//     wiring look like it's deriving something independent — a
+//     reader has to follow the trail back through the Factory
+//     to see that it's the same object;
+//   - cobra runners that already have the share.Client would
+//     otherwise repeat a "get the HTTP client" stanza per call
+//     site (three sites here), and a tweak to one would silently
+//     miss the others. preflightCpMv has the same concern called
+//     out verbatim in its "collapsed display/plain vars" comment.
+//
+// Keeping a single-line helper here means the preflight stat path
+// is unambiguously "the same wire transport the share-create call
+// uses", and adding a new share-create flavor only needs one line
+// to wire its preflight.
+func newShareStatClient(client *share.Client) *download.Client {
+	return &download.Client{
+		HTTPClient: client.HTTPClient,
+		BaseURL:    client.BaseURL,
+	}
 }
 
 // preflightShareCreate Stats the share target BEFORE any state-

--- a/cli/cmd/ctl/files/share_preflight_test.go
+++ b/cli/cmd/ctl/files/share_preflight_test.go
@@ -1,0 +1,301 @@
+// share_preflight_test.go: unit tests for the cobra-layer share-
+// create dir-only / existence preflight (preflightShareCreate in
+// share_create.go). Mirrors the cp/rm preflight test pattern: stand
+// up an httptest.Server, drive download.Client.Stat against it, and
+// assert that preflightShareCreate refuses the right shapes with
+// the right error messages.
+//
+// The preflight is what enforces the LarePass GUI's per-driver
+// share-menu gating on event.isDir (sharing a single file is
+// rejected by both the web app and the CLI). The shape of the gate
+// — Stat the target, refuse if !IsDir — is shared across all three
+// flavors (internal / public / smb); the only per-flavor variance
+// is the friendly flavor name baked into the error message, so the
+// tests parameterize over share.Type to lock that in.
+package files
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/internal/files/download"
+	"github.com/beclab/Olares/cli/internal/files/share"
+)
+
+// newSharePreflightClient stands up an httptest.Server with the
+// supplied handler and returns a download.Client pointing at it.
+// Same shape as newPreflightClient in cp_test.go — the share
+// preflight reuses download.Client.Stat verbatim, so a dedicated
+// helper would just be a copy; keeping a tiny share-specific
+// wrapper isolates this file's intent (share-create gating).
+func newSharePreflightClient(t *testing.T, h http.Handler) *download.Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &download.Client{
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	}
+}
+
+// shareListingHandler is the share-preflight equivalent of
+// cp_test.go's listingHandler. Routes are keyed by the GET URL
+// path (e.g. `/api/resources/drive/Home/`) and the value is the
+// raw `{"items":[...]}` body to write back. Unknown paths return
+// 404 so the preflight's NotFound branch fires. The handler also
+// asserts that the preflight only issues GETs (a POST against the
+// /api/share/ surface would mean we accidentally let the create
+// call leak past the gate — that's exactly what the preflight is
+// supposed to PREVENT, so we want the test to scream).
+func shareListingHandler(t *testing.T, routes map[string]string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("share preflight should only issue GETs, got %s %s",
+				r.Method, r.URL.Path)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			http.Error(w, "{}", http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	})
+}
+
+// TestPreflightShareCreate_DirectoryHappyPath: target is an
+// existing directory under drive/Home/. The preflight should pass
+// without error after exactly one GET (the parent listing that
+// resolves the directory leaf).
+//
+// Runs across all three flavors to confirm the dir-only gate is
+// uniformly applied (the per-flavor namespace allow-list lives in
+// a separate gate; this test only exercises the existence + kind
+// branch).
+func TestPreflightShareCreate_DirectoryHappyPath(t *testing.T) {
+	for _, flavor := range []share.Type{
+		share.TypeInternal,
+		share.TypePublic,
+		share.TypeSMB,
+	} {
+		t.Run(string(flavor), func(t *testing.T) {
+			stat := newSharePreflightClient(t, shareListingHandler(t, map[string]string{
+				"/api/resources/drive/Home/": `{"items":[
+					{"name":"Backups","isDir":true,"size":0}
+				]}`,
+			}))
+			tgt := share.Target{
+				FileType:    "drive",
+				Extend:      "Home",
+				SubPath:     "/Backups/",
+				IsDirIntent: true,
+			}
+			if err := preflightShareCreate(context.Background(), stat, tgt, flavor); err != nil {
+				t.Errorf("directory happy path (%s): unexpected error %v", flavor, err)
+			}
+		})
+	}
+}
+
+// TestPreflightShareCreate_RejectsFile: the central regression
+// guard. The target resolves to a file on the server; preflight
+// must refuse with a message that:
+//
+//   - names the offending path verbatim;
+//   - says "is a file on the server";
+//   - mentions "only supports directories";
+//   - cites the GUI gating ("event.isDir") so a maintainer doing
+//     code-archaeology can find this rule in the LarePass app
+//     source from the error message alone;
+//   - hints at the corrective workflow ("place it in a dedicated
+//     directory").
+//
+// Runs across all three flavors to lock down the per-flavor
+// friendly-name prefix ("internal" / "public" / "smb") — the wire
+// type for Public is the historically confusing "external", so
+// users would hunt for a non-existent verb if the error leaked
+// the wire value.
+func TestPreflightShareCreate_RejectsFile(t *testing.T) {
+	cases := []struct {
+		flavor       share.Type
+		wantFriendly string
+	}{
+		{share.TypeInternal, "internal"},
+		{share.TypePublic, "public"},
+		{share.TypeSMB, "smb"},
+	}
+	for _, c := range cases {
+		t.Run(string(c.flavor), func(t *testing.T) {
+			stat := newSharePreflightClient(t, shareListingHandler(t, map[string]string{
+				"/api/resources/drive/Home/": `{"items":[
+					{"name":"notes.md","isDir":false,"size":42}
+				]}`,
+			}))
+			tgt := share.Target{
+				FileType: "drive",
+				Extend:   "Home",
+				SubPath:  "/notes.md",
+			}
+			err := preflightShareCreate(context.Background(), stat, tgt, c.flavor)
+			if err == nil {
+				t.Fatalf("flavor=%s: expected refusal for file target", c.flavor)
+			}
+			msg := err.Error()
+			for _, want := range []string{
+				"refusing to create a " + c.wantFriendly + " share",
+				"drive/Home/notes.md",
+				"is a file on the server",
+				"only supports directories",
+				"event.isDir",
+				"place it in a dedicated directory",
+			} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("flavor=%s: error must contain %q; got: %v",
+						c.flavor, want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestPreflightShareCreate_RejectsMissingTarget: the target path
+// doesn't exist on the server (parent listing exists but the leaf
+// isn't there). The preflight must refuse with a "does not exist"
+// message that names the offending path. This is the typo / stale-
+// path branch — same shape as cp/rm's preflight, just routed
+// through the share-flavor friendly-name prefix.
+func TestPreflightShareCreate_RejectsMissingTarget(t *testing.T) {
+	stat := newSharePreflightClient(t, shareListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/": `{"items":[
+			{"name":"other","isDir":true,"size":0}
+		]}`,
+	}))
+	tgt := share.Target{
+		FileType:    "drive",
+		Extend:      "Home",
+		SubPath:     "/Backups/",
+		IsDirIntent: true,
+	}
+	err := preflightShareCreate(context.Background(), stat, tgt, share.TypeInternal)
+	if err == nil {
+		t.Fatal("expected refusal for missing target")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"refusing to create a internal share",
+		"drive/Home/Backups/",
+		"does not exist on the server",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error must contain %q; got: %v", want, err)
+		}
+	}
+}
+
+// TestPreflightShareCreate_VolumeRootIsSyntheticDir: a share
+// against the bare volume root (e.g. `drive/Home/`,
+// `drive/Data/`, `sync/<repo>/`) must pass without hitting the
+// wire. download.Stat short-circuits ≤2-segment paths to a
+// synthetic IsDir=true record (see internal/files/download/stat.go).
+//
+// The handler asserts that ZERO GETs reach it — a regression here
+// would mean we're paying an extra round-trip for sharing a
+// volume root (and it would 404 against the test server since no
+// routes are mounted).
+func TestPreflightShareCreate_VolumeRootIsSyntheticDir(t *testing.T) {
+	cases := []struct {
+		name   string
+		target share.Target
+	}{
+		{
+			name:   "drive/Home/",
+			target: share.Target{FileType: "drive", Extend: "Home", SubPath: "/", IsDirIntent: true},
+		},
+		{
+			name:   "drive/Data/",
+			target: share.Target{FileType: "drive", Extend: "Data", SubPath: "/", IsDirIntent: true},
+		},
+		{
+			name: "sync/<repo>/",
+			target: share.Target{
+				FileType:    "sync",
+				Extend:      "b7ffab7f-3ceb-4e36-aeb7-74d958ad0a7a",
+				SubPath:     "/",
+				IsDirIntent: true,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var hits int
+			stat := newSharePreflightClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				t.Errorf("volume-root preflight should not hit the wire; got %s %s",
+					r.Method, r.URL.Path)
+				http.Error(w, "{}", http.StatusInternalServerError)
+			}))
+			if err := preflightShareCreate(context.Background(), stat, c.target, share.TypeInternal); err != nil {
+				t.Errorf("volume root preflight: unexpected error %v", err)
+			}
+			if hits != 0 {
+				t.Errorf("expected zero wire GETs for synthetic volume root, got %d", hits)
+			}
+		})
+	}
+}
+
+// TestPreflightShareCreate_DeepDirectory: target is a deeper
+// subdirectory (`drive/Home/Reports/2026/Q1/`) — the preflight
+// must resolve through the parent listing
+// (`/api/resources/drive/Home/Reports/2026/`) and accept when the
+// leaf is a dir. Confirms the parent-listing strategy works at
+// depth, not just the depth-1 case the happy-path test covers.
+func TestPreflightShareCreate_DeepDirectory(t *testing.T) {
+	stat := newSharePreflightClient(t, shareListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/Reports/2026/": `{"items":[
+			{"name":"Q1","isDir":true,"size":0}
+		]}`,
+	}))
+	tgt := share.Target{
+		FileType:    "drive",
+		Extend:      "Home",
+		SubPath:     "/Reports/2026/Q1/",
+		IsDirIntent: true,
+	}
+	if err := preflightShareCreate(context.Background(), stat, tgt, share.TypePublic); err != nil {
+		t.Errorf("deep dir preflight: unexpected error %v", err)
+	}
+}
+
+// TestPreflightShareCreate_DeepFileRejected: deeper variant of
+// the file-rejection test — a real path like
+// `drive/Home/Reports/2026/Q1.pdf`. Locks in that the dir-only
+// gate fires at any depth, not just at the volume-root level.
+func TestPreflightShareCreate_DeepFileRejected(t *testing.T) {
+	stat := newSharePreflightClient(t, shareListingHandler(t, map[string]string{
+		"/api/resources/drive/Home/Reports/2026/": `{"items":[
+			{"name":"Q1.pdf","isDir":false,"size":1024}
+		]}`,
+	}))
+	tgt := share.Target{
+		FileType: "drive",
+		Extend:   "Home",
+		SubPath:  "/Reports/2026/Q1.pdf",
+	}
+	err := preflightShareCreate(context.Background(), stat, tgt, share.TypeSMB)
+	if err == nil {
+		t.Fatal("expected refusal for deep file target")
+	}
+	if !strings.Contains(err.Error(), "drive/Home/Reports/2026/Q1.pdf") {
+		t.Errorf("error must name the deep file path; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "is a file on the server") {
+		t.Errorf("error must say 'is a file on the server'; got: %v", err)
+	}
+}

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -70,7 +70,7 @@ This shows up in five places:
 
 - `files rm drive/Home/Foo/` requires `-r` (the trailing `/` declares "this is a directory")
 - `files upload <local> drive/Home/Documents/` means "upload INTO Documents/"; `files upload <local> drive/Home/Documents/2026-Q1.pdf` means "upload AS that exact path (rename on the way in)"
-- `files cp <src> <dst>/` drops `<src>` into the directory by basename; `files cp <src> <dst>` (no trailing slash, single source only) treats `<dst>` as the **full target path** (rename / exact-target mode). Same for `files mv`.
+- `files cp <src> <dst>/` and `files mv <src> <dst>/` drop `<src>` into the directory by basename — `<dst>` MUST end with `/` (drop-into-directory mode). Renaming via `cp` / `mv` is **not currently supported**; use `files rename` for in-place basename changes.
 - `files cp -r drive/Home/old/` (trailing `/` on a source) requires `-r` — Unix-style refusal to operate on directories without recursion. Same for `files mv`.
 - `files ls drive/Home/` lists the volume root; the parser tolerates both `drive/Home` and `drive/Home/` for ls but the trailing slash is recommended for clarity
 
@@ -527,6 +527,24 @@ Flags / rules:
 - Removing the root of a volume (`drive/Home/`, `sync/<repo>/`, ...) is rejected by the planner: `refusing to delete the root of <fileType>/<extend>`.
 - **System-managed Home children are rejected**: `files rm [-r] drive/Home/{Pictures, Music, Movies, Downloads, Documents, Code, Cache, Data, Home, Ollama, Huggingface}` errors with `refusing to delete drive/Home/<name>: this is a system-managed Home folder reserved by Files; ...`. The names match the LarePass app's `disableMenuItem` array (Server-side quirks #4); their casing is fixed (`Huggingface` is one word). Children INSIDE these dirs (e.g. `drive/Home/Pictures/Trip2024/`) are user content and remain freely deletable. To clear out a protected folder, delete its contents (`files rm -r drive/Home/Pictures/<entry>`); the folder itself stays.
 
+Preflight existence check (runs BEFORE the preview / confirmation prompt):
+
+After the planner (`rm.Plan`) succeeds and BEFORE any state-changing wire call goes out, the cobra layer (`preflightRm` in [`cli/cmd/ctl/files/rm.go`](cli/cmd/ctl/files/rm.go)) Stats every target. The check reuses [`download.Client.Stat`](cli/internal/files/download/stat.go) — same parent-listing strategy `files cat` / `files download` / `files cp` use — so it works uniformly across drive / sync / cache / external / cloud namespaces. Refusal arms (each fails fast, no `will delete` preview shown):
+
+| Failure | Wire shape | Message |
+|---------|-----------|---------|
+| Target not found | parent listing missing the leaf | `rm: target <fileType>/<extend><parent><name> does not exist on the server` |
+| Effective dir intent (`<target>/` or `-r`) but the entry is actually a file | `Stat.IsDir == false` with `IsDirIntent || recursive` | `rm: target ... is a file on the server, not a directory; drop the trailing '/' and the -r/-R flag` |
+| No dir intent (no trailing slash, no `-r`) but the entry is actually a directory | `Stat.IsDir == true` with `!IsDirIntent && !recursive` | `rm: target ... is a directory on the server; pass -r/-R to remove it recursively` |
+
+The "effective dir intent" rule is `IsDirIntent || recursive` — identical to the rule `rm.Plan` uses when deciding whether to add a trailing slash to the wire dirent. The two stay in lockstep so the preflight and planner can never disagree about which kind to enforce: `rm -r foo` (no trailing slash) is treated the same as `rm -r foo/` for both — the user has declared dir intent by passing `-r`.
+
+`--force` does NOT bypass the preflight existence check — a missing target still aborts the operation, intentionally diverging from Unix `rm -f`'s "ignore nonexistent files" behavior. The cost of accidentally deleting the wrong thing on a remote files surface is high enough that we prefer the strict default; if you genuinely want best-effort batch removal that skips missing entries, run the check upstream of `rm` (e.g. with `files ls` + a shell filter).
+
+Network cost: one Stat per target. Multi-target `rm a b c` against the same parent dir still issues N Stats (one per leaf) because `download.Stat` doesn't cache parent listings across calls — a documented future optimization rather than the current contract. Auth 401/403 errors during preflight surface through the same `reformatRmHTTPErr` reformatter the DELETE calls use, so the user gets the standard `profile login` CTA regardless of which leg of the operation failed.
+
+Why preflight at all (vs. let the server reject): the server-side DELETE handler iterates the dirents list as a batch — a single missing entry doesn't roll back the others, leaving a partial-success state the user has to manually reconcile. More importantly, the kind mismatch arms catch the much-more-confusing failure mode where `rm` (no `-r`) hits a directory or `rm -r` hits a file: the backend's response is non-obvious and varies by driver, while the preflight's pointed "pass -r/-R" / "drop the -r/-R flag" messages map directly to the corrective command.
+
 Aliases: `olares-cli files remove ...`, `olares-cli files delete ...` are the same command.
 
 ### `files cp [-r] <src>... <dst>`
@@ -537,9 +555,6 @@ Server-side copy across remote paths via the per-user files-backend's paste endp
 # Copy one file into a directory.
 olares-cli files cp drive/Home/notes.md drive/Home/Documents/
 
-# Copy with a new name on the destination side.
-olares-cli files cp drive/Home/notes.md drive/Home/notes-2026.md
-
 # Recursive directory copy.
 olares-cli files cp -r drive/Home/Photos/ drive/Home/Backups/
 
@@ -549,6 +564,8 @@ olares-cli files cp drive/Home/a.pdf drive/Home/b.pdf drive/Home/Archive/
 # Cross-volume copy (drive → sync repo).
 olares-cli files cp drive/Home/notes.md sync/<repo_id>/inbox/
 ```
+
+> **Renaming via `cp` is not currently supported.** Use `files rename` for in-place basename changes (e.g. `notes.md` → `notes-2026.md` under the same parent). The destination MUST end with `/`; the planner still accepts a non-`/`-terminated single-source `<dst>` for backwards compatibility, but it's intentionally undocumented and may be tightened later.
 
 Wire shape (one PATCH per source — the endpoint does **not** batch like `rm`):
 
@@ -562,9 +579,9 @@ Destination semantics (Unix-style):
 
 | Form of `<dst>` | Meaning |
 |-----------------|---------|
-| ends with `/` | Drop-into-directory mode. Each `<src>`'s basename is appended; the dir / file marker on the source is preserved on the destination. |
-| no trailing `/` (single source only) | Rename / exact-target mode. `<dst>` is used verbatim as the full target path. |
+| ends with `/` | Drop-into-directory mode (the only documented shape). Each `<src>`'s basename is appended; the dir / file marker on the source is preserved on the destination. |
 | no trailing `/` with **multi-source** | Rejected: `target ... must end with '/' when more than one source is given`. |
+| no trailing `/` with a single source | Renaming via `cp` / `mv` is **not currently supported**. The planner still accepts this shape (treats `<dst>` as the full target path) for backwards compatibility, but the help text and SKILL no longer promote it — use `files rename` for in-place basename changes. |
 
 Recursion + safety rules:
 
@@ -574,6 +591,25 @@ Recursion + safety rules:
 - **`src == dst` is NOT rejected client-side** — the LarePass web app doesn't enforce this either. For a **file** target (`cp drive/Home/foo.pdf drive/Home/foo.pdf`) the backend auto-renames into `foo (1).pdf` (same POST-mkdir auto-rename quirk users already work with from `mkdir`); for a **directory** target the cycle check below catches it. `mv foo foo` on a file is a server-side no-op.
 - **Cycle detection**: copying `drive/Home/a/` into `drive/Home/a/sub/` (or `drive/Home/a/` into itself, since dir-onto-same-dir would create an infinitely-recursing tree) errors with `destination ... is inside source ... (would create a cycle)`.
 - **`mv` source-side rejects system-managed Home children**: `mv drive/Home/{Pictures, Music, Movies, Downloads, Documents, Code, Cache, Data, Home, Ollama, Huggingface} ...` errors with `refusing to mv source drive/Home/<name>: this is a system-managed Home folder reserved by Files; ...`. Moving would unlink bootstrap dirs that user apps depend on (Server-side quirks #4). **`cp` (copy) is intentionally NOT gated** — `cp -r drive/Home/Pictures/ drive/Home/Pictures-Backup/` is fine because the source is preserved. Children inside these dirs (e.g. `drive/Home/Pictures/Trip2024/`) are user content and remain freely movable.
+
+Preflight existence check (runs BEFORE the first PATCH):
+
+After the planner (`cp.Plan`) succeeds and BEFORE any state-changing wire call goes out, the cobra layer (`preflightCpMv` in [`cli/cmd/ctl/files/cp.go`](cli/cmd/ctl/files/cp.go)) Stats every source and the destination directory. The check reuses [`download.Client.Stat`](cli/internal/files/download/stat.go) — same parent-listing strategy `files cat` / `files download` use — so it works uniformly across drive / sync / cache / external / cloud namespaces. Refusal arms (each fails fast, no PATCH issued):
+
+| Failure | Wire shape | Message |
+|---------|-----------|---------|
+| Source not found | parent listing missing the leaf | `cp/mv: source <fileType>/<extend><sub> does not exist on the server` |
+| Source kind mismatch — user typed `<src>/` but it's actually a file | `Stat.IsDir == false` with `IsDirIntent == true` | `cp/mv: source ... is a file on the server, not a directory; drop the trailing '/'` |
+| Source kind mismatch — user typed `<src>` (no slash) but it's actually a directory | `Stat.IsDir == true` with `IsDirIntent == false` | `cp/mv: source ... is a directory on the server; add a trailing '/' and pass -r/-R to copy/mv it recursively` |
+| `<dst>` directory missing (drop-into-dir mode) | parent listing missing the dst leaf | `cp/mv: destination directory ... does not exist on the server; create it first with `olares-cli files mkdir`` |
+| `<dst>` exists but is a file (drop-into-dir mode) | `Stat.IsDir == false` with `dst.IsDirIntent == true` | `cp/mv: destination ... is a file on the server, not a directory; drop the trailing '/' or pick a different target` |
+| `<dst>`'s parent dir missing (undocumented exact-target mode) | parent of dst not in its parent's listing | `cp/mv: destination's parent directory ... does not exist on the server` |
+
+Volume roots (`drive/Home/`, `sync/<repo>/`, `cache/<node>/`, `external/<node>/`) Stat as synthetic directories — `download.Stat` short-circuits when the path is ≤2 segments — so a `cp foo drive/Home/` works without an extra round-trip for the dst leg.
+
+Network cost: N+1 GETs against `/api/resources/<parent>/` (one per source's parent + one for dst's parent). The redundancy across multiple sources sharing the same parent is acknowledged but not cached — it's a documented future optimization rather than the current contract. Auth 401/403 errors during preflight are surfaced verbatim through the same `reformatCpHTTPErr` reformatter the paste calls use, so the user gets the standard `profile login` CTA regardless of which leg of the operation failed.
+
+Why preflight at all (vs. let the server reject): the paste endpoint returns `task_id` after enqueueing the move, but the actual byte work runs asynchronously on the files-backend's task queue with **no transactional rollback**. A typo in a multi-source batch would otherwise enqueue N tasks and leave a partial-success state the user has to manually reconcile; the preflight catches the typo before the first task lands.
 
 Async / task semantics — important:
 
@@ -596,8 +632,8 @@ Server-side rejection signal (`code: -1`):
 Same wire endpoint as `files cp` (`PATCH /api/paste/<node>/`) but with `action: "move"` instead of `"copy"` — the server moves the source instead of duplicating it. Every flag, rule, and failure mode from `files cp` applies verbatim; the only difference is the verb.
 
 ```bash
-# Rename a file in place.
-olares-cli files mv drive/Home/notes.md drive/Home/notes-2026.md
+# Move one file into a directory.
+olares-cli files mv drive/Home/notes.md drive/Home/Archive/
 
 # Move several files into a directory.
 olares-cli files mv drive/Home/a.pdf drive/Home/b.pdf drive/Home/Archive/
@@ -606,11 +642,13 @@ olares-cli files mv drive/Home/a.pdf drive/Home/b.pdf drive/Home/Archive/
 olares-cli files mv -r drive/Home/Photos/ drive/Home/Backups/
 ```
 
+> **Renaming via `mv` is not currently supported.** Use `files rename` for in-place basename changes (e.g. `notes.md` → `notes-2026.md` under the same parent). The destination MUST end with `/` for `mv`, same as `cp`.
+
 `mv` is a separate cobra command (not a `cp --move` alias) so the help text stays honest about what each verb does and so `olares-cli files mv` reads the way users expect.
 
 > **`mv` is a single-step destructive operation from the user's POV.** Even though it's just a flag flip on the wire, treat it the way you would a `mv` on local disk: confirm with the user before running it on directories, and prefer `cp` then `rm` when you want a "verify then delete" workflow.
 
-> **System-managed Home children refuse `mv` as the source** (see `cp` section above). `mv drive/Home/Pictures ...` and the other ten LarePass-protected names will fail client-side with a self-describing error. If the goal is to relocate the *contents*, mv the children (`mv drive/Home/Pictures/* drive/Home/Backups/`) — the protected folder will stay where it is. If the goal is a renamed clone, use `cp -r` instead, then optionally clear the originals via `rm` (which the policy also blocks for the protected folder itself, but allows on its children).
+> **System-managed Home children refuse `mv` as the source** (see `cp` section above). `mv drive/Home/Pictures ...` and the other ten LarePass-protected names will fail client-side with a self-describing error. If the goal is to relocate the *contents*, mv the children into a destination directory (`mv drive/Home/Pictures/* drive/Home/Backups/`) — the protected folder itself will stay where it is. If the goal is a side-by-side backup, `files mkdir drive/Home/Pictures-Backup/` then `files cp -r drive/Home/Pictures/ drive/Home/Pictures-Backup/` to drop the Pictures tree under the new directory. The `files rename` verb is also blocked on the protected folder itself, so an in-place name change is not possible — `rm` likewise refuses the protected folder itself but allows its children.
 
 ### `files rename <remote-path> <new-name>` (alias `files rn`)
 
@@ -731,7 +769,9 @@ olares-cli files chown drive/Data/builds/out.bin --uid 0
 
 ### `files share <subcommand>`
 
-Create / list / remove shares for files-backend resources. Three creation flavors (Internal cross-user, Public link, SMB Samba) plus management verbs (`list` / `get` / `rm`) plus an SMB-account roster (`smb-users`). All flavors converge on the same wire endpoint and disambiguate via the `share_type` field in the JSON body.
+Create / list / remove shares for files-backend directories. Three creation flavors (Internal cross-user, Public link, SMB Samba) plus management verbs (`list` / `get` / `rm`) plus an SMB-account roster (`smb-users`). All flavors converge on the same wire endpoint and disambiguate via the `share_type` field in the JSON body.
+
+**Dir-only policy (all three create flavors).** `share internal` / `share public` / `share smb` all Stat the target before posting and refuse if the path is a file (or doesn't exist on the server). Single-file shares are NOT supported — matches the LarePass GUI's per-driver share-menu gating on `event.isDir`. See the [Preflight existence / dir-only check](#preflight-existence--dir-only-check-applies-to-all-three-create-flavors) sub-section below for the full rationale.
 
 See [`cli/cmd/ctl/files/share.go`](cli/cmd/ctl/files/share.go), [`cli/cmd/ctl/files/share_create.go`](cli/cmd/ctl/files/share_create.go), and [`cli/internal/files/share/`](cli/internal/files/share/).
 
@@ -791,10 +831,12 @@ The parenthesised `(repo <id>)` is preserved on resolved sync paths so users can
 # Bare share record, no members yet.
 olares-cli files share internal drive/Home/Backups/
 
-# Share a single file with two members.
-olares-cli files share internal drive/Home/Reports/Q1.pdf \
+# Share a directory with two members.
+olares-cli files share internal drive/Home/Reports/ \
     --users alice:edit,bob:view
 ```
+
+> **Directories only.** `share internal` Stats the target up front and refuses if it's a file — see the [preflight section below](#preflight-existence--dir-only-check-applies-to-all-three-create-flavors). To "share a single file", place it in a dedicated directory and share that directory instead.
 
 Two-call sequence on the wire:
 
@@ -835,6 +877,8 @@ Optional flags:
 - `--upload-size-limit` accepts `100M` / `1G` / `500K` / `512` (bytes). Suffixes are 1024-based (KiB/MiB/GiB/TiB) to match the web app's `fileLimitSize()`. Omitted / zero means no cap.
 
 The CLI prints the share id, password, expiration, and a **link template** of the form `<share-host>/sharable-link/<id>/`. The full link is built by the LarePass app from the user's hostname (`shareBaseUrl()` in `apps/.../stores/files.ts`); the CLI deliberately does NOT guess this prefix because the right value depends on subdomain layout the CLI can't observe — copy the id and let the LarePass app or the share-recipient's browser resolve the prefix.
+
+> **Directories only.** `share public` Stats the target up front and refuses if it's a file — see the [preflight section below](#preflight-existence--dir-only-check-applies-to-all-three-create-flavors). For one-off file distribution use `files download` and re-share the bytes out-of-band.
 
 Namespace gate (Public-only — distinct from the all-flavors gates further down):
 
@@ -918,6 +962,33 @@ olares-cli files share smb-users create <name> <password>
 ```
 
 The output of `share smb` includes the `smb_link` (UNC path), `smb_user`, and `smb_password` — these are what a Finder / Explorer / `mount.cifs` client needs to mount the share.
+
+> **Directories only.** `share smb` Stats the target up front and refuses if it's a file — Samba exports a directory tree, so a single-file target has no working server-side representation. See the [preflight section below](#preflight-existence--dir-only-check-applies-to-all-three-create-flavors).
+
+#### Preflight existence / dir-only check (applies to all three create flavors)
+
+After the per-flavor namespace gate (`validateShareNamespace`) and the path refusals (`frontendPathToShareTarget`) but BEFORE the create POST goes out, the cobra layer (`preflightShareCreate` in [`cli/cmd/ctl/files/share_create.go`](cli/cmd/ctl/files/share_create.go)) Stats the share target via [`download.Client.Stat`](cli/internal/files/download/stat.go) — the same parent-listing strategy `files cat` / `files download` / `files cp` / `files rm` use. The check works uniformly across drive / sync / cache / external namespaces (cloud is already rejected upstream).
+
+Refusal arms (each fails fast, no share record created):
+
+| Failure | Wire shape | Message |
+|---------|-----------|---------|
+| Target not found | parent listing missing the leaf | `refusing to create a <flavor> share for <path>: target does not exist on the server` |
+| Target is a file | `Stat.IsDir == false` | `refusing to create a <flavor> share for <path>: target is a file on the server; `files share` only supports directories (matches the LarePass GUI's per-driver share-menu gating on event.isDir). To share a single file, place it in a dedicated directory and share that directory instead, or use `files download` + redistribute the file out-of-band.` |
+
+Volume roots (`drive/Home/`, `drive/Data/`, `sync/<repo>/`, `external/<node>/<volume>/`, `cache/<node>/<sub>/`) Stat as synthetic directories — `download.Stat` short-circuits to a synthetic dir for ≤2-segment paths, and deeper volume / node roots resolve cleanly through their parent listing — so sharing a volume root works without an extra round-trip relative to sharing a subdirectory.
+
+Why dir-only? Per-flavor rationale, all of which converge on "directory" being the only meaningful unit of share:
+
+- **SMB**: a Samba export is intrinsically a directory tree mount. A single-file SMB share has no working server-side representation.
+- **Public**: the LarePass GUI surfaces "Generate Public Link" only on directories. Single-file public flows (download / preview) are handled by other web-app code paths, not the share endpoint.
+- **Internal**: the server would technically accept a single-file Internal record, but the LarePass recipient-side listing assumes a folder — the share would be effectively invisible to its members. The CLI fast-fails up front rather than creating a guaranteed-broken share record.
+
+This rule was previously divergent from the GUI (the CLI used to accept file targets with a comment in `shareFlavorAllowedNamespaces` saying "sharing a single file IS a legitimate Internal-share use case"). The comment is outdated and has been removed; the dir-only gate is now enforced at the cobra layer via the preflight Stat above.
+
+Network cost: one extra GET against `/api/resources/<parent>/` per share-create call. The redundancy with any subsequent share-create round-trip is acknowledged but uncacheable in the current code (`download.Stat` doesn't share state across calls). Auth 401/403 errors during preflight surface through the same `reformatShareHTTPErr` reformatter the create POST uses, so the user gets the standard `profile login` CTA regardless of which leg failed.
+
+Why preflight at all (vs. let the server reject): single-file Internal shares can succeed server-side but produce a broken UX (recipient can't see the share); single-file Public / SMB shares fail server-side with messages that don't name the corrective action ("place the file in a dedicated directory"). The preflight catches both cases up front with a path-named, action-named error before any state lands.
 
 #### Cloud rejection (applies to all three create flavors)
 


### PR DESCRIPTION
## Summary

Adds a uniform `download.Client.Stat`-based preflight to every state-changing files-backend write verb so the typical typo / forgotten-flag cases are refused up front — with a path-named, action-named error — instead of producing a partial-success batch on the async paste/delete queue or a confusing server-side rejection.

- **`files cp` / `files mv`**: Stat every source (existence + trailing slash matches file / dir kind) and the destination directory (must exist as a directory; or its parent for the undocumented exact-target shape). Renaming via `cp` / `mv` is removed from the user-facing docs / examples in favour of `files rename`; the planner still accepts the shape for backwards compatibility.
- **`files rm`**: Stat every target BEFORE the preview / confirmation prompt; refuses missing paths and kind mismatches (directory without `-r`, file with `-r` or trailing slash). `--force` does NOT bypass the check — intentionally safer than Unix `rm -f` for a remote files surface.
- **`files share` (`internal` / `public` / `smb`)**: Stat the target and refuse when it's a file, aligning with the LarePass GUI's per-driver share-menu gating on `event.isDir`. The previous "single-file Internal share is legitimate" comment is removed.

Each error reformatter (`cp` / `rm` / `share`) now recognises both its own `HTTPError` type and `download.HTTPError`, so `401` / `403` / `404` from preflight Stats surface through the same `profile login` CTA the create / delete calls already use.

## Test plan

- [x] `cd cli && go build ./cmd/ctl/files/...`
- [x] `cd cli && go test ./cmd/ctl/files/... -count=1` — all new preflight tests + existing `share` / `cp` / `rm` tests pass
- [x] New cobra-layer test files mock `/api/resources/` listings with `httptest` and lock down every refusal arm (missing target, kind mismatch, file rejection, exact-target parent missing, etc.) plus the synthetic-volume-root short-circuit
- [ ] Smoke against a real cluster:
  - `olares-cli files cp drive/Home/missing.md drive/Home/Archive/` → refuses (`source ... does not exist on the server`)
  - `olares-cli files cp drive/Home/Photos drive/Home/Archive/` → refuses (`source ... is a directory; add a trailing '/' and pass -r/-R`)
  - `olares-cli files cp drive/Home/notes.md drive/Home/MissingDir/` → refuses (`destination directory ... does not exist on the server; create it first with` `olares-cli files mkdir`)
  - `olares-cli files rm drive/Home/missing.md` → refuses (`rm: target ... does not exist on the server`)
  - `olares-cli files rm drive/Home/SomeDir` (no `-r`) → refuses (`is a directory on the server; pass -r/-R to remove it recursively`)
  - `olares-cli files share internal drive/Home/notes.md --users alice:view` → refuses (`target is a file on the server; ` `files share` ` only supports directories ...`)
  - `olares-cli files share public drive/Home/Photos/ --expire-days 7` → succeeds (directory target)

## Notes

- SKILL.md (`cli/skills/olares-files/SKILL.md`) gains preflight tables for `cp` / `rm` / `share`, including the per-flavor rationale for `share`'s dir-only policy (SMB exports a tree; Public GUI gates on `event.isDir`; Internal recipient-side listing assumes a folder).
- All preflight errors flow through the existing 401/403/404 reformatters, so users get a consistent `profile login` CTA regardless of which leg (preflight vs. create / delete) failed.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI behavior for common workflows (stricter cp/mv/rm/share validation, rm runs network before prompt); reduces accidental partial operations but may break scripts that relied on old rename docs or Unix-like rm -f on missing paths.
> 
> **Overview**
> Adds **`download.Client.Stat` preflights** before destructive or async files-backend writes so typos and file/dir mismatches fail with path-named errors instead of partial paste/delete batches or confusing server responses.
> 
> **`files cp` / `files mv`:** After `cp.Plan`, stats each source (exists; trailing slash matches kind) and the destination (drop-into-dir must exist as a directory; undocumented exact-target still checks parent). Help/docs de-emphasize rename-via-`cp`/`mv` in favor of **`files rename`**. **`reformatCpHTTPErr`** also handles **`download.HTTPError`**.
> 
> **`files rm`:** Resolves HTTP client **before** the delete preview; **`preflightRm`** runs first (missing paths, dir without `-r`, file with `-r`/slash). **`--force` does not skip** existence checks. Smarter CTAs when only `-r` implied directory intent. **`reformatRmHTTPErr`** extended for download errors.
> 
> **`files share` (internal/public/smb):** **`preflightShareCreate`** refuses missing paths and **file targets** (directories only, aligned with LarePass `event.isDir`). **`newShareStatClient`** reuses the share client transport.
> 
> **Tests & docs:** New **`cp_test.go`**, **`rm_test.go`**, **`share_preflight_test.go`** (httptest listings); **`SKILL.md`** documents preflight tables and policy changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62dc6e5bc53e69db4983d1f19ca2e1abca8ac11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->