### PR TITLE
chore(helm): update system-frontend image tag to v1.10.37 in olares-app.yaml

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.36
+          image: beclab/system-frontend:v1.10.37
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
market:  app-operation policy layer + drop deprecated chart fields

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1152


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single init-container image tag bump with no chart or runtime config changes; rollout risk is limited to whatever is in the new frontend image build.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image in `olares-app.yaml` from **`beclab/system-frontend:v1.10.36`** to **`v1.10.37`**, so deployed Olares app pods copy the newer bundled static assets into the shared `www` volume before nginx starts.
> 
> Per the PR notes, **`v1.10.37`** is intended to ship **Market** changes (app-operation policy layer and removal of deprecated chart fields); this diff only pins that release in Helm—no template logic or other images change here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e6de6d25137d89925b3c10e7ba502116ad3e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->