### PR TITLE
fix: common volume type

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -407,7 +407,7 @@ spec:
             type: DirectoryOrCreate
         - name: common-data
           hostPath:
-            type: DirectoryOrCreate
+            type: Directory
             path: '{{ .Values.rootPath }}/rootfs/Common'
         
 {{ if .Values.sharedlib }}        


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
change appCommon volume type

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pods may fail to start on nodes where `rootfs/Common` is absent, whereas DirectoryOrCreate previously created it automatically.
> 
> **Overview**
> Updates the **files** DaemonSet so the `common-data` hostPath volume (mounted at `/appcommon/` in the files container) uses **`Directory`** instead of **`DirectoryOrCreate`**.
> 
> Kubernetes will no longer create `{{ .Values.rootPath }}/rootfs/Common` on the node if it is missing; that path must already exist, aligning this volume with other host paths that require a pre-provisioned directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661c3cea8a3ffe806c2070591df818247e608cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->