### PR TITLE
files feat(external): NFS support and mount reliability; fix(permission,md5): drive/Common 404

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.174
+          image: beclab/files-server:v0.2.175
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat(external): add NFS mount/unmount via terminusd mount-nfs / umount-nfs-incluster, reusing smbPath as server:sharedPath.
- feat(external): make SMB user/password optional in IDL and validate them only when external_type=smb.
- feat(external): split mounted state into polled / reported / merged views and add field-level patch merge so reported updates no longer wipe unspecified fields.
- feat(external): expose /api/mounted_states for mounted-state reporting and clear stale reported overlays after mount/unmount.
- feat(external): add posix mount guard with probe timeout, cooldown and in-flight protection, returning a unified "temporarily unavailable" error.
- feat(external): fast-path external root listing to avoid blocking on problematic mount points.
- fix(permission): resolve /api/permission/drive/Common/* (and cache/*) 404 by switching to absolute paths via files.CleanResourcePath instead of DefaultFs.
- fix(md5): resolve /api/md5/drive/Common/* (and cache/*) 404 with the same path-handling cleanup and drop common.Md5File's RootPrefix re-prefix.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/333
- https://github.com/beclab/files/pull/334

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling out a new files-server image affects external mounts, APIs, and path handling cluster-wide; the YAML change itself is a one-line tag bump.
> 
> **Overview**
> This change **bumps the `files` DaemonSet container** from `beclab/files-server:v0.2.174` to **`v0.2.175`** in `framework/files/.olares/config/cluster/deploy/files_deploy.yaml`, so clusters pull the newer server image on rollout.
> 
> The application behavior described in the PR (NFS external mounts, mounted-state APIs, permission/MD5 path fixes, and related fixes) lives in that image release; **this repo diff only updates the deploy pin**, with no other manifest or config edits in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18bcdf5d02bdf6bf12afaad338e2d81a56bcbb4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->