### PR TITLE
daemon: enhance overlay gateway app structure

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/beclab/Olares/cli v0.0.0-20251230161135-5264df60cc33
-	github.com/beclab/Olares/framework/app-service v0.0.0-20260522162612-61734f52ff96
-	github.com/beclab/api v0.0.8
+	github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82
+	github.com/beclab/api v0.0.10
 	github.com/containerd/containerd v1.7.29
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
@@ -33,6 +33,7 @@ require (
 	github.com/jaypipes/ghw v0.13.0
 	github.com/jochenvg/go-udev v0.0.0-20171110120927-d6b62d56d37b
 	github.com/joho/godotenv v1.5.1
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/labstack/echo/v4 v4.0.0-00010101000000-000000000000
 	github.com/libp2p/go-netroute v0.2.2
@@ -103,6 +104,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
+	github.com/containernetworking/cni v1.2.0-rc1 // indirect
 	github.com/containers/image/v5 v5.36.1 // indirect
 	github.com/containers/storage v1.59.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -46,10 +46,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/Olares/framework/app-service v0.0.0-20260522162612-61734f52ff96 h1:1KFEq7tsGYMk6Z9Kn9f0QNF0v+LoCtAkvA7Kd6+WhFU=
-github.com/beclab/Olares/framework/app-service v0.0.0-20260522162612-61734f52ff96/go.mod h1:f745c4hwUjRRmQfRKWEqahSTQrZ44NTa5KJry28Hn4Q=
-github.com/beclab/api v0.0.8 h1:7d15aTwZh+Bgv6EgoUT0WmPUKE5tANtBT9oAlq4x6/w=
-github.com/beclab/api v0.0.8/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82 h1:BE/T9N2OyH0ZKMTzK7RY/EvKy8pfr0dokDBINJHLE8g=
+github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82/go.mod h1:LYHBxvVI3cDiRa116LbDQ09Uiphi3i3tWX2Cjeoyi9w=
+github.com/beclab/api v0.0.10 h1:+r+XRuW3fkQdt2elqpOK6Kt7g/s9RFpSELkV/XajJ7o=
+github.com/beclab/api v0.0.10/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/bfl v0.3.36 h1:PgeSPGc+XoONiwFsKq9xX8rqcL4kVM1G/ut0lYYj/js=
 github.com/beclab/bfl v0.3.36/go.mod h1:A82u38MxYk1C3Lqnm4iUUK4hBeY9HHIs+xU4V93OnJk=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
@@ -95,6 +95,8 @@ github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRq
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
+github.com/containernetworking/cni v1.2.0-rc1 h1:AKI3+pXtgY4PDLN9+50o9IaywWVuey0Jkw3Lvzp0HCY=
+github.com/containernetworking/cni v1.2.0-rc1/go.mod h1:Lt0TQcZQVDju64fYxUhDziTgXCDe3Olzi9I4zZJLWHg=
 github.com/containers/image/v5 v5.36.1 h1:6zpXBqR59UcAzoKpa/By5XekeqFV+htWYfr65+Cgjqo=
 github.com/containers/image/v5 v5.36.1/go.mod h1:b4GMKH2z/5t6/09utbse2ZiLK/c72GuGLFdp7K69eA4=
 github.com/containers/storage v1.59.1 h1:11Zu68MXsEQGBBd+GadPrHPpWeqjKS8hJDGiAHgIqDs=
@@ -198,6 +200,7 @@ github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptd
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe h1:zn8tqiUbec4wR94o7Qj3LZCAT6uGobhEgnDRg6isG5U=
@@ -283,7 +286,6 @@ github.com/hirochachacha/go-smb2 v1.1.0 h1:b6hs9qKIql9eVXAiN0M2wSFY5xnhbHAQoCwRK
 github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4FtcxjBfsY8TZE=
 github.com/hodgesds/perf-utils v0.7.0 h1:7KlHGMuig4FRH5fNw68PV6xLmgTe7jKs9hgAcEAbioU=
 github.com/hodgesds/perf-utils v0.7.0/go.mod h1:LAklqfDadNKpkxoAJNHpD5tkY0rkZEVdnCEWN5k4QJY=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -314,6 +316,8 @@ github.com/jsimonetti/rtnetlink/v2 v2.2.0 h1:/KfZ310gOAFrXXol5VwnFEt+ucldD/0dsSR
 github.com/jsimonetti/rtnetlink/v2 v2.2.0/go.mod h1:lbjDHxC+5RJ08lzPeA90Ls2pEoId3F08MoEMlhfHxeI=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -428,8 +432,9 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.25.2 h1:hepmgwx1D+llZleKQDMEvy8vIlCxMGt7W5ZxDjIEhsw=
 github.com/onsi/ginkgo/v2 v2.25.2/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -767,7 +772,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_status.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_status.go
@@ -25,10 +25,11 @@ var enableOverlayGatewayError string = ""
 var operateOverlayGatewayMutex sync.Mutex
 
 type OverlayGatewaySupportedApp struct {
-	AppName   string `json:"app_name"`
-	Enabled   bool   `json:"enabled"`
-	SharedApp bool   `json:"shared_app"`
-	AppID     string `json:"app_id"`
+	AppName          string                  `json:"app_name"`
+	Enabled          bool                    `json:"enabled"`
+	SharedApp        bool                    `json:"shared_app"`
+	AppID            string                  `json:"app_id"`
+	UnderlayNetworks []utils.UnderlayNetwork `json:"underlay_networks"`
 }
 
 type OverlayGatewayStatus struct {
@@ -91,10 +92,11 @@ func (h *Handlers) getOverlayGatewaySupportedApps(ctx context.Context, user stri
 	var apps []OverlayGatewaySupportedApp
 	for _, app := range supportedApps {
 		apps = append(apps, OverlayGatewaySupportedApp{
-			AppName:   app.AppName,
-			Enabled:   app.Enabled,
-			SharedApp: app.SharedApp,
-			AppID:     app.AppID,
+			AppName:          app.AppName,
+			Enabled:          app.Enabled,
+			SharedApp:        app.SharedApp,
+			AppID:            app.AppID,
+			UnderlayNetworks: app.UnderlayNetworks,
 		})
 	}
 

--- a/daemon/pkg/utils/drivers_linux.go
+++ b/daemon/pkg/utils/drivers_linux.go
@@ -457,10 +457,11 @@ func UmountOrRecordBrokenMounts(ctx context.Context, baseDir string) error {
 
 	updatedBrokenMounts := slices.Clone(currentBrokenMounts)
 	brokenMountsMu.Lock()
+	brokenMountsChanged := !slices.Equal(brokenMounts, updatedBrokenMounts)
 	brokenMounts = updatedBrokenMounts
 	brokenMountsMu.Unlock()
 
-	if len(updatedBrokenMounts) > 0 {
+	if len(updatedBrokenMounts) > 0 || brokenMountsChanged {
 		klog.Infof("current broken mounts: %v", updatedBrokenMounts)
 		// notify broken mounts
 		NotifyBrokenMounts(ctx)
@@ -805,7 +806,8 @@ func MountNfsDriver(ctx context.Context, mountBaseDir, mountPath string, nfsServ
 	}
 
 	nfsMountPath := fmt.Sprintf("%s:%s", nfsServer, nfsPath)
-	opts = append(opts, "uid=1000", "gid=1000")
+	// unsuppoted nfs v4
+	// opts = append(opts, "uid=1000", "gid=1000")
 	err = mounter.Mount(nfsMountPath, mntPath, "nfs", opts)
 	if err != nil {
 		klog.Error("mount path as rw error, ", err)

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -29,7 +30,9 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	sysv1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+	"github.com/beclab/api/manifest"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
+	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -606,6 +609,12 @@ func GetOverlayGatewaySupportedApps(ctx context.Context, user string) ([]Overlay
 		return nil, err
 	}
 
+	kubeClient, err := GetKubeClient()
+	if err != nil {
+		klog.Error("get kube client error, ", err)
+		return nil, err
+	}
+
 	appMgrs, err := clientset.AppV1alpha1().ApplicationManagers().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		klog.Error("list applications error, ", err)
@@ -627,7 +636,7 @@ func GetOverlayGatewaySupportedApps(ctx context.Context, user string) ([]Overlay
 		}
 
 		// check if the app is supported by the overlay gateway
-		if appConfig.OverlayGatewaySupported {
+		if appConfig.OverlayGateway.Enable {
 			// check if the app is enabled
 			app, err := clientset.AppV1alpha1().Applications().Get(ctx, appMgr.Name, metav1.GetOptions{})
 			if err != nil {
@@ -642,16 +651,56 @@ func GetOverlayGatewaySupportedApps(ctx context.Context, user string) ([]Overlay
 				}
 			}
 
-			enabled := app.Spec.Settings["enableOverlayGateway"]
-			supportedApps = append(supportedApps, OverlayGatewaySupportedApp{
+			enabled := strings.ToLower(app.Spec.Settings["enableOverlayGateway"]) == "true"
+			sa := OverlayGatewaySupportedApp{
 				AppResourceName: app.Name,
 				AppName:         app.Spec.Name,
-				Enabled:         strings.ToLower(enabled) == "true",
+				Enabled:         enabled,
 				Owner:           app.Spec.Owner,
 				SharedApp:       sharedApp,
 				Namespace:       app.Spec.Namespace,
 				AppID:           app.Spec.Appid,
-			})
+			}
+			if enabled {
+				pods, err := kubeClient.CoreV1().Pods(app.Spec.Namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					klog.Error("list pods error, ", err)
+				} else {
+					for _, pod := range pods.Items {
+						if pod.Labels["applications.app.bytetrade.io/macvlan-init"] == "true" {
+							statuses, err := nadutils.GetNetworkStatus(&pod)
+							if err != nil {
+								klog.Error("get network status error, ", err)
+								continue
+							}
+
+							for _, status := range statuses {
+								if status.Interface == "net1" {
+									if len(status.IPs) == 0 {
+										klog.Warningf("pod %s has no ip in net1, skip", pod.Name)
+										continue
+									}
+									un := UnderlayNetwork{
+										IP: status.IPs[0],
+									}
+
+									var entrances []manifest.OverlayEntrance
+									for _, e := range appConfig.OverlayGateway.Entrances {
+										if e.Workload == GetWorkloadNameFromPod(&pod) {
+											entrances = append(entrances, e)
+										}
+									}
+									un.Ports = entrances
+									sa.UnderlayNetworks = append(sa.UnderlayNetworks, un)
+									break
+								}
+							}
+
+						}
+					}
+				}
+			}
+			supportedApps = append(supportedApps, sa)
 		}
 
 	}
@@ -716,4 +765,10 @@ func RestartOverlayGatewaySupportedApps(ctx context.Context, apps []OverlayGatew
 	}
 
 	return nil
+}
+
+func GetWorkloadNameFromPod(pod *corev1.Pod) string {
+	podTemplateHash := pod.Labels["pod-template-hash"]
+	podNameTokens := strings.Split(pod.Name, fmt.Sprintf("-%s-", podTemplateHash))
+	return podNameTokens[0]
 }

--- a/daemon/pkg/utils/k8s_types.go
+++ b/daemon/pkg/utils/k8s_types.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	clistate "github.com/beclab/Olares/cli/pkg/daemon/state"
+	"github.com/beclab/api/manifest"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -21,13 +22,18 @@ var (
 // uses a string anyway and the cli module avoids depending on
 // k8s.io/api/core/v1.
 type NodePressure = clistate.NodePressure
+type UnderlayNetwork struct {
+	IP    string                     `json:"ip"`
+	Ports []manifest.OverlayEntrance `json:"ports"`
+}
 
 type OverlayGatewaySupportedApp struct {
-	AppResourceName string `json:"app_resource_name"`
-	AppName         string `json:"app_name"`
-	Enabled         bool   `json:"enabled"`
-	Owner           string `json:"owner"`
-	SharedApp       bool   `json:"shared_app"`
-	Namespace       string `json:"namespace"`
-	AppID           string `json:"app_id"`
+	AppResourceName  string            `json:"app_resource_name"`
+	AppName          string            `json:"app_name"`
+	Enabled          bool              `json:"enabled"`
+	Owner            string            `json:"owner"`
+	SharedApp        bool              `json:"shared_app"`
+	Namespace        string            `json:"namespace"`
+	AppID            string            `json:"app_id"`
+	UnderlayNetworks []UnderlayNetwork `json:"underlay_networks"`
 }


### PR DESCRIPTION
* **Background**
1. Enhance overlay gateway app structure
2. Send a notification to Files server when the broken SMB connection is recovered
3. Remove NFS mounting options of UID/GID, it's unsupported in NFS v4

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches overlay gateway discovery (K8s pod/NAD reads) and mount/notification paths for SMB/NFS; dependency upgrades may affect runtime behavior.
> 
> **Overview**
> The overlay gateway path is aligned with the newer app manifest shape (`OverlayGateway.Enable` / `Entrances`) and, for apps with overlay enabled, enriches status with **underlay** IPs and entrance ports read from macvlan-init pods via the network-attachment-definition client. The overlay gateway HTTP response now includes `underlay_networks` on each supported app.
> 
> **Storage/mount behavior:** CIFS/NFS broken-mount tracking notifies the Files service when the broken-mount set **changes**, including when SMB/NFS connections recover and the list clears. NFS mounts no longer pass `uid=1000`/`gid=1000` mount options (noted as unsupported on NFS v4).
> 
> Daemon dependencies are bumped (`app-service`, `beclab/api`) and `network-attachment-definition-client` is added for pod network status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80c166b45999cd73e585d951a89947b91c943eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->