### PR TITLE
market: add allowMultipleInstall to app_simple_info options

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.44
+        image: beclab/market-backend:v0.6.45
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
- add allowMultipleInstall to app_simple_info options
- improve datawatcher cursor safety and fetch resilience

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/267


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest, env, or RBAC changes in this diff.
> 
> **Overview**
> Bumps the **appstore-backend** container image in `market_deploy.yaml` from `beclab/market-backend:v0.6.44` to **`v0.6.45`**, so cluster deploys pick up the newer market backend build (aligned with the linked market changes such as `allowMultipleInstall` on app simple info and datawatcher hardening described in the PR text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0708269de30a9a050f7c7fa2e96d47835984bf1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->