### PR TITLE
helm: bump system-frontend to v1.10.38 and user-service to v0.0.94

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.37
+          image: beclab/system-frontend:v1.10.38
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.93
+          image: beclab/user-service:v0.0.94
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

Sync the helm chart `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml` to the latest released images of two sub-systems:

- `beclab/system-frontend`: `v1.10.37` → `v1.10.38`
- `beclab/user-service`: `v0.0.93` → `v0.0.94`

Highlights pulled in by these tags:

system-frontend (TermiPass v1.10.38):
- desktop window/dock UX, iframe routing sync, docker build cleanup
- consolidate user stores, push `apiVersion` to simple info, restructure app-operation pipeline
- new Common drive type, split-pane markdown editor, unsaved-changes guard
- headscale client upgrade
- version bump + `vpnAbility` flag

user-service (v0.0.94):
- upgrade headscale in user-service
- align API routes with headscale node endpoints

No code in this repo is changed besides the two image tags.

* **Target Version for Merge**

1.12.6 1.12.7

* **Related Issues**

None

* **PRs Involving Sub-Systems**

system-frontend (beclab/TermiPass v1.10.38):
- beclab/TermiPass#1154 — fix(desktop): window/dock UX, iframe routing sync, and docker build cleanup
- beclab/TermiPass#1155 — refactor(app): consolidate user stores, push apiVersion to simple info, restructure app-operation pipeline
- beclab/TermiPass#1153 — feat(files): Common drive type, split-pane markdown editor, unsaved-changes guard
- beclab/TermiPass#1043 — feat: headscale upgrade
- beclab/TermiPass#1156 — chore(app): bump version to 1.10.37 and add vpnAbility flag

user-service (beclab/user-service v0.0.94):
- beclab/user-service#71 — feat: upgrade headscale in userservice
- beclab/user-service#79 — fix(headscale): align API routes with headscale node endpoints

* **Other information**:

None

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tag-only change, but both images include headscale/VPN and user-service API updates that affect core Olares desktop and networking behavior after deploy.
> 
> **Overview**
> This PR only updates container image tags in `olares-app.yaml` for the Olares app deployment—no application logic changes in this repository.
> 
> The **olares-app-init** init container moves from `beclab/system-frontend:v1.10.37` to **v1.10.38**, which refreshes the static assets copied into the nginx `www` volume (desktop/files UX, app pipeline, headscale client, and related TermiPass fixes ship in that image). The **user-service** sidecar container moves from `beclab/user-service:v0.0.93` to **v0.0.94**, picking up headscale upgrades and API route alignment in the backend service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4081b492cb1758d5b1d8b3639dc46fad6314bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->