### PR TITLE
fix(cli/npm): hide host-side verbs and add 'npx @olares/cli install' wizard

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -88,6 +88,7 @@ jobs:
       version: ${{ needs.test-version.outputs.version }}
       ref: ${{ github.event.pull_request.head.ref }}
       repository: ${{ github.event.pull_request.head.repo.full_name }}
+      publish-npm: false
 
   upload-daemon:
     needs: test-version

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -12,6 +12,9 @@ on:
         type: string
       release-id:
         type: string
+      publish-npm:
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
@@ -23,6 +26,9 @@ on:
         type: string
       release-id:
         type: string
+      publish-npm:
+        type: boolean
+        default: true
 jobs:
   goreleaser:
     runs-on: ubuntu-22.04
@@ -109,6 +115,7 @@ jobs:
 
   publish-npm:
     needs: [goreleaser]
+    if: ${{ inputs.publish-npm }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
       version: ${{ github.event.inputs.tags }}
       release-id: ${{ needs.release-id.outputs.id }}
       ref: ${{ github.event.inputs.tags }}
+      publish-npm: false
 
   release-daemon:
     needs: [release-id]

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,28 +17,38 @@ The product surface this CLI mirrors:
 - **Agent-native** — every command tree ships a maintained `SKILL.md` so any agent (Cursor, Claude Code, Codex, OpenClaw, ...) can discover verbs, flags, and recovery flows
 - **Wide coverage** — Olares OS install/upgrade plus the full identity, files, market, dashboard, settings, and ControlHub surface from one binary
 - **Olares-native auth** — refresh tokens live in the OS keychain; access tokens auto-refresh on 401/403; profile model maps cleanly to multi-instance / multi-ID setups
-- **Distributed three ways** — one-line `npx ... install` bootstrap; persistent `npm install -g`; or zero-install `npx <verb>` for one-offs
+- **Distributed two ways** — persistent `npm install -g @olares/cli` client on macOS / Windows / Linux; or zero-install `npx @olares/cli <verb>` for one-offs. A first-run wizard, `npx @olares/cli install`, does both `npm install -g` and skill installation in one shot.
 
 ## Install — which path fits you?
 
 | Your situation | Use this | Why |
 | --- | --- | --- |
-| I want to turn a fresh Linux server into an Olares instance | `npx @olares/cli@latest install` <br>([Scenario A](#bootstrap-an-olares-host-scenario-a)) | One-line bootstrap; after `install` completes, `olares-cli` lives at `/usr/local/bin/` and is managed by Olares OS upgrades |
-| I'm already on an Olares host and want to use its CLI | Use `/usr/local/bin/olares-cli` directly | It's the OS-bundled copy, kept in sync via `olares-cli upgrade`. No need to install via npm. |
-| I want to control a remote Olares from my dev box, CI, macOS, or Windows | `npm install -g @olares/cli@latest` <br>([Scenario B](#client-on-a-non-olares-machine-scenario-b)) | Persistent install; `olares-cli` on PATH. Safe even if you already have an OS bundle — postinstall auto-skips the alias on conflict. |
+| I'm already on an Olares host and want to use its CLI | Use `/usr/local/bin/olares-cli` directly (and see ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) if you need the agent verbs the OS bundle doesn't ship) | It's the OS-bundled copy, kept in sync via `olares-cli upgrade`. |
+| I'm a first-time user and want one command to set up the CLI + skills | `npx @olares/cli@latest install` <br>([Scenario A](#first-run-wizard-scenario-a-recommended)) | Runs `npm install -g` and `skills add beclab/Olares` for you. Does not install Olares OS. |
+| I want to control a remote Olares from my dev box, CI, macOS, or Windows | `npm install -g @olares/cli@latest` <br>([Scenario B](#client-on-a-non-olares-machine-scenario-b)) | Persistent install; `olares-cli` on PATH. |
 | I just want to run one command quickly without installing | `npx @olares/cli@latest <verb>` <br>([Scenario C](#one-off-ops-scenario-c)) | No persistent files; ~1-2 s cold-start per invocation. Keychain/token caches persist per-user. |
 
-### Bootstrap an Olares host (Scenario A)
+### First-run wizard (Scenario A, recommended)
 
 ```bash
-# On a fresh Linux server you want to turn into an Olares instance:
 npx @olares/cli@latest install
-
-# After install completes, olares-cli is at /usr/local/bin/olares-cli (on PATH).
-# The npm-cached copy is no longer needed.
-olares-cli profile login <your-olares-id>
-olares-cli dashboard overview
 ```
+
+The `install` verb is handled entirely by the Node shim, never by the Go binary. It runs two steps for you:
+
+1. `npm install -g @olares/cli` (or upgrade if you already have it).
+2. `npx skills add beclab/Olares -y -g` to install the six `olares-*` agent skills.
+
+After it prints `You are all set!`, do the auth step yourself — it's interactive and ties to your Olares ID:
+
+```bash
+olares-cli profile login --olares-id <your-olares-id>
+olares-cli profile current
+```
+
+> **What this command does NOT do:** install Olares OS. The Linux host bootstrap stays `curl -fsSL https://olares.sh | bash` (see [docs/manual/get-started](https://docs.olares.com/manual/get-started/install-olares/linux.html)). It also does not configure any app credentials — Olares uses the Olares ID directly, so no `config init` step is needed.
+>
+> **On a Linux Olares host (`/usr/local/bin/olares-cli` already present):** the wizard detects the resulting `EEXIST` and prints two safe workarounds (`--prefix` side-by-side install, or stay on `npx`). It will not overwrite the OS bundle. See ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle).
 
 ### Client on a non-Olares machine (Scenario B)
 
@@ -48,9 +58,9 @@ npm install -g @olares/cli@latest
 
 # The package's only PATH-exposed bin is `olares-cli`, managed by npm itself.
 # If an existing `olares-cli` is already at npm's target path (i.e. you're on
-# an Olares host where the OS bundle owns /usr/local/bin/olares-cli), npm
+# a Linux Olares host where the OS bundle owns /usr/local/bin/olares-cli), npm
 # refuses the install with EEXIST — your existing binary is never overwritten.
-# See "On an Olares host" below for the --prefix workaround in that case.
+# See "On a Linux Olares host" below for the side-by-side workaround.
 
 olares-cli profile login <your-olares-id>
 olares-cli files ls /drive/Home
@@ -59,20 +69,24 @@ olares-cli files ls /drive/Home
 ### One-off ops (Scenario C)
 
 ```bash
-# No persistent install; each invocation re-uses the npm cache:
+# No persistent install; each invocation re-uses the npm cache. The OS keychain
+# persists across invocations, so log in once — subsequent commands re-use it.
+npx @olares/cli@latest profile login <your-olares-id>
 npx @olares/cli@latest profile current
 npx @olares/cli@latest files ls /drive/Home
 ```
 
 ### Capabilities & limits of each install method
 
-| Method | What it gives you | What it can't / won't do |
-| --- | --- | --- |
-| **A — `npx @olares/cli@latest install`** | Turns a Linux host into an Olares instance (downloads payload, installs k8s, lays `olares-cli` at `/usr/local/bin/`). Subsequent invocations are direct `olares-cli <verb>` on that host. | Requires Linux + root (or sudo) + ~50 GB free + 30-60 min runtime. Not usable on macOS / Windows / non-Linux. Doesn't help "I just want to control a remote Olares". |
-| **B — `npm install -g @olares/cli@latest`** | Persistent `olares-cli` CLI on PATH (macOS / Windows / Linux). Use to talk to a *remote* Olares (login, files, market, dashboard, cluster, settings). | Doesn't install Olares OS itself — `olares-cli install` from this client targets `localhost` and will fail on a non-Linux machine. If `olares-cli` already exists at npm's target path (e.g. on an Olares host where the OS bundle owns `/usr/local/bin/olares-cli`), npm aborts with `EEXIST` — see ["On an Olares host"](#on-an-olares-host-install-into-a-separate-prefix) for the workaround. |
-| **C — `npx @olares/cli@latest <verb>`** | Zero-install, runs any verb without touching PATH. Great for CI one-shots, ephemeral containers, "just try it". | Each invocation pays a ~1-2 s npx cold-start. Long watches (`olares-cli market list --watch`, `olares-cli cluster pod logs -f`) work but pay the cost up front. Keychain/token caches persist across npx invocations. |
+| Method | What it gives you | Binary path | What it can't / won't do |
+| --- | --- | --- | --- |
+| **A — `npx @olares/cli@latest install`** | Superset of B: runs `npm install -g @olares/cli` (or upgrade) and `npx skills add beclab/Olares -y -g` in one shot. End state is the same as B, plus the six `olares-*` skills pre-installed. | Same as B once the wizard finishes. The wizard itself is the Node shim from the npx cache. | Does not install Olares OS (still `curl -fsSL https://olares.sh \| bash`). Does not run `profile login` for you (interactive + needs your Olares ID). On a Linux Olares host with `/usr/local/bin/olares-cli` present, npm hits `EEXIST` — the wizard detects this and prints the [`--prefix` / `npx`](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) workarounds instead of failing silently. |
+| **B — `npm install -g @olares/cli@latest`** | Persistent `olares-cli` CLI on PATH (macOS / Windows / Linux). Use to talk to a *remote* Olares (login, files, market, dashboard, cluster, settings). | `<npm prefix>/bin/olares-cli` (symlink managed by npm itself). On a Linux Olares host where `/usr/local/bin/olares-cli` already exists, npm aborts with `EEXIST` — see ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) for the side-by-side workaround. | The npm wrapper auto-sets `OLARES_CLI_REMOTE_ONLY=1`, so host-side verbs (`uninstall`, `upgrade`, `node`, `os`, `gpu`, `disk`, `wizard`, `user`, `osinfo`, `amdgpu`) are hidden from `--help` and return `unknown command`. The `install` verb is intercepted by the Node shim and runs the Scenario A wizard. All of these are reachable only on an Olares host through the OS-bundled `/usr/local/bin/olares-cli`. |
+| **C — `npx @olares/cli@latest <verb>`** | Zero-install, runs any *remote/identity* verb without touching PATH. Great for CI one-shots, ephemeral containers, "just try it". | `~/.npm/_npx/<hash>/.../vendor/olares-cli` (only during the npx subprocess; cleared after) | Same host-side-verbs restriction as B (same Node shim). Each invocation pays a ~1-2 s npx cold-start. Long watches (`olares-cli market list --watch`, `olares-cli cluster pod logs -f`) work but pay the cost up front. Keychain/token caches persist across npx invocations. |
 
 ### Install AI agent skills
+
+The Scenario A wizard runs this for you. If you went the Scenario B / C route, run it manually:
 
 ```bash
 npx skills add beclab/Olares -y -g
@@ -82,27 +96,7 @@ Installs the 6 `olares-*` skill bundles via [vercel-labs/skills](https://github.
 
 > Note: the `@olares` npm scope and the `beclab` GitHub org are independent naming spaces. The canonical source repo is `github.com/beclab/Olares`, so the `skills add` command (which fetches via GitHub) uses `beclab/Olares`, while the npm package is published as `@olares/cli`.
 
-## Quick start (AI agent)
-
-If you are an AI coding agent reading this README to bootstrap an environment:
-
-```bash
-# 1. Install the CLI (pick one based on the target machine):
-npx @olares/cli@latest install            # fresh Linux host → full Olares install
-npm install -g @olares/cli@latest         # dev box / CI / macOS / Win → client only
-
-# 2. Install the agent skills into your own runtime:
-npx skills add beclab/Olares -y -g
-
-# 3. Ask the human to log in (interactive — browser + OS keychain):
-#    olares-cli profile login <their-olares-id>
-
-# 4. Verify identity + reach:
-olares-cli profile current
-olares-cli dashboard overview
-```
-
-Then load the appropriate skill (`olares-shared` is the foundation; load it first before any of the others) and follow its instructions.
+> **For AI agents:** the human must run `olares-cli profile login <their-olares-id>` themselves — auth opens a browser. Verify with `olares-cli profile current` + `olares-cli dashboard overview`. Load `olares-shared` first; it documents the auth model for the other skills.
 
 ## Agent skills
 
@@ -125,8 +119,8 @@ Skills are also published on [ClawHub](https://clawhub.io) (search "olares"); bo
 olares-cli <area> [<noun>] <verb> [flags]
 ```
 
-- **System layer** (root-level, no `<area>` prefix): `install`, `uninstall`, `upgrade`, `start`, `stop`, `status`, `backup`, `precheck`, `prepare`, `download`, `change-ip`, `release`, `printinfo`, `logs`, `node`, `gpu`, `amdgpu`, `disk`, `osinfo`, `wizard`. These manage the host running Olares OS itself and require root / kubeconfig access — they are not driven by an Olares ID.
-- **Identity-bound layer** (`<area>` = `profile` / `files` / `market` / `settings` / `dashboard` / `cluster`): act on behalf of the currently-selected Olares ID against a running Olares HTTP API. Pick the identity once with `olares-cli profile use <name>`, then every verb in this layer uses it.
+- **System layer** (root-level, no `<area>` prefix): `install`, `uninstall`, `upgrade`, `start`, `stop`, `status`, `backup`, `precheck`, `prepare`, `download`, `change-ip`, `release`, `printinfo`, `logs`, `node`, `gpu`, `amdgpu`, `disk`, `osinfo`, `wizard`. These manage the host running Olares OS itself and require root / kubeconfig access — they are not driven by an Olares ID. *Channel availability*: the Go binary only registers them when `OLARES_CLI_REMOTE_ONLY` is unset, i.e. only when invoked from an Olares host's OS-bundled `/usr/local/bin/olares-cli`. Through `npm install -g @olares/cli` or `npx @olares/cli`, the Node shim sets `OLARES_CLI_REMOTE_ONLY=1` and they are hidden. The lone exception is `install`, which the Node shim itself intercepts and routes to the [first-run wizard](#first-run-wizard-scenario-a-recommended) — it never reaches the Go binary on the npm channel.
+- **Identity-bound layer** (`<area>` = `profile` / `files` / `market` / `settings` / `dashboard` / `cluster`): act on behalf of the currently-selected Olares ID against a running Olares HTTP API. Pick the identity once with `olares-cli profile use <name>`, then every verb in this layer uses it. Reachable through both `npm install -g` and `npx`.
 
 For every command, `--help` is the source of truth for flags and wire shapes:
 
@@ -145,20 +139,11 @@ olares-cli files ls /drive/Home --output json
 olares-cli market list --output json | jq '.items[] | {name, version, status}'
 ```
 
-## Where is olares-cli after install?
-
-| Scenario | `olares-cli` resolves to |
-| --- | --- |
-| **A** — `npx ... install` on a fresh host | `/usr/local/bin/olares-cli` (OS bundle, on PATH after install completes) |
-| **B** — `npm install -g` on a host without an existing `olares-cli` | `<npm prefix>/bin/olares-cli` (symlink managed by npm itself) |
-| **B-conflict** — `npm install -g` on a host that already has `olares-cli` at npm's target path | npm aborts with `EEXIST`; nothing is installed. The pre-existing binary stays put. Use the [`--prefix` workaround](#on-an-olares-host-install-into-a-separate-prefix) to coexist. |
-| **C** — `npx @olares/cli@latest <verb>` | `~/.npm/_npx/<hash>/.../vendor/olares-cli` (only during the npx subprocess) |
-
 ## Uninstall
 
 Pick the reverse operation that matches how you installed.
 
-### Remove the CLI client (Scenario B)
+### Remove the CLI client
 
 ```bash
 npm uninstall -g @olares/cli
@@ -166,7 +151,7 @@ npm uninstall -g @olares/cli
 # there is no extra cleanup step.
 ```
 
-### Clear the npx cache (Scenario C)
+### Clear the npx cache
 
 ```bash
 # npx auto-evicts the cache after a few days. To force-clear sooner:
@@ -176,22 +161,13 @@ ls ~/.npm/_npx/                            # find the hash dir for @olares/cli
 rm -rf ~/.npm/_npx/<hash>/
 ```
 
-### Remove Olares OS from a host (Scenario A — destructive!)
-
-```bash
-olares-cli uninstall                       # revert the most recent install phase
-olares-cli uninstall --all                 # complete removal (Olares + k8s + data)
-```
-
-> **Warning**: `olares-cli uninstall --all` deletes **all** Olares data (user files, installed apps, profiles, k8s state). Back up first via `olares-cli backup` or the Olares dashboard. The `/usr/local/bin/olares-cli` binary itself stays (you may still want it for re-install); to drop it too: `sudo rm /usr/local/bin/olares-cli`.
-
 ### Remove agent skills
 
 ```bash
 npx skills remove beclab/Olares -y -g     # mirror of `skills add`
 ```
 
-### Wipe stored credentials (any scenario)
+### Wipe stored credentials
 
 ```bash
 olares-cli profile list                    # see what's stored
@@ -200,18 +176,40 @@ olares-cli profile remove <name>           # delete one profile + its keychain t
 
 Credentials live in the OS-native keychain (macOS Keychain / Windows DPAPI / Linux secret-service or filesystem fallback at `~/.olares/credentials/`). `profile remove` is always the right cleaning verb — don't hand-edit those files.
 
-## On an Olares host: install into a separate prefix
+## On a Linux Olares host: install side-by-side with the OS bundle
 
-If you are on an Olares host (where `/usr/local/bin/olares-cli` already exists from `olares-cli install`), a plain `npm install -g @olares/cli` aborts with `EEXIST`. To install the npm copy side-by-side without touching the OS bundle, use a separate prefix:
+This section applies **only to Linux hosts that have Olares OS installed** (where `/usr/local/bin/olares-cli` already exists). macOS / Windows / non-Olares Linux dev boxes never hit this scenario.
+
+### Why you might want this
+
+The OS-bundled `olares-cli` is pinned to the version that shipped with your Olares OS release (e.g. **1.12.5**). Older bundles do **not** include the agent / identity verbs (`profile`, `files`, `market`, `dashboard`, `settings`, `cluster`) — those land in newer npm releases first. If you want to drive a remote (or your own) Olares from the same Linux host, install the latest npm copy alongside the OS bundle. Two ways:
+
+### Option 1 — Install under a separate prefix
+
+A plain `npm install -g @olares/cli` aborts with `EEXIST` because `/usr/local/bin/olares-cli` already exists. Use a separate prefix to coexist:
 
 ```bash
 npm install -g @olares/cli@latest --prefix ~/.olares-cli-npm
 export PATH="$HOME/.olares-cli-npm/bin:$PATH"   # PATH order decides which copy wins
-olares-cli --version                            # resolves to the npm copy
+olares-cli --version                            # now resolves to the npm copy
 # Revert: reorder PATH or `rm -rf ~/.olares-cli-npm/`
 ```
 
-> Do **not** use `npm install -g --force` to bypass `EEXIST` on an Olares host — that would clobber the OS-managed binary. The OS bundle is the canonical CLI on an Olares host and is upgraded via `olares-cli upgrade`.
+Both binaries are then on disk:
+
+- `/usr/local/bin/olares-cli` — OS bundle. System layer (`install`, `uninstall`, `upgrade`, `start`, `stop`, ...).
+- `~/.olares-cli-npm/bin/olares-cli` — npm copy. Identity layer (`profile`, `files`, `market`, `dashboard`, `settings`, `cluster`); system layer is hidden by `OLARES_CLI_REMOTE_ONLY=1`.
+
+### Option 2 — Use `npx` for one-offs
+
+No persistent install, no PATH gymnastics:
+
+```bash
+npx @olares/cli@latest profile current
+npx @olares/cli@latest files ls /drive/Home
+```
+
+> Do **not** `npm install -g @olares/cli --force` on an Olares host — that would clobber the OS-managed `/usr/local/bin/olares-cli`. The OS bundle is canonical for system-layer verbs on that host and is upgraded via `olares-cli upgrade`. Without `--force`, npm already aborts safely with `EEXIST`.
 
 ## Build from source
 

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -2,6 +2,7 @@ package ctl
 
 import (
 	"fmt"
+	goOS "os"
 
 	"github.com/beclab/Olares/cli/cmd/config"
 	"github.com/beclab/Olares/cli/cmd/ctl/amdgpu"
@@ -65,14 +66,28 @@ func NewDefaultCommand() *cobra.Command {
 	// identities mid-pipeline. To target a different profile, run
 	// `olares-cli profile use <name>` first.
 
-	cmds.AddCommand(osinfo.NewCmdInfo())
-	cmds.AddCommand(os.NewOSCommands()...)
-	cmds.AddCommand(node.NewNodeCommand())
-	cmds.AddCommand(gpu.NewCmdGpu())
-	cmds.AddCommand(amdgpu.NewCmdAmdGpu())
-	cmds.AddCommand(user.NewUserCommand())
-	cmds.AddCommand(wizard.NewWizardCommand())
-	cmds.AddCommand(disk.NewDiskCommand())
+	// OLARES_CLI_REMOTE_ONLY=1 hides host-side verbs (install, upgrade, node,
+	// os, gpu, disk, wizard, user, osinfo, amdgpu) that require an Olares host
+	// filesystem (~/.olares/versions/<v>/...) laid down by the install wizard.
+	// The npm distribution sets this from its Node shim (cli/npm/bin/olares-cli.js)
+	// so `npx @olares/cli` never exposes those verbs to remote/agent users.
+	// The host-bundled binary at /usr/local/bin/olares-cli leaves the env unset
+	// and behaves as before — all verbs registered.
+	remoteOnly := goOS.Getenv("OLARES_CLI_REMOTE_ONLY") == "1"
+
+	if !remoteOnly {
+		cmds.AddCommand(osinfo.NewCmdInfo())
+		cmds.AddCommand(os.NewOSCommands()...)
+		cmds.AddCommand(node.NewNodeCommand())
+		cmds.AddCommand(gpu.NewCmdGpu())
+		cmds.AddCommand(amdgpu.NewCmdAmdGpu())
+		cmds.AddCommand(user.NewUserCommand())
+		cmds.AddCommand(wizard.NewWizardCommand())
+		cmds.AddCommand(disk.NewDiskCommand())
+	}
+
+	// Always-on: developer utilities (chart) + remote/agent verbs that go
+	// through control-hub.<terminus> via the active profile's token.
 	cmds.AddCommand(chart.NewChartCommand())
 	cmds.AddCommand(market.NewMarketCommand(factory))
 	cmds.AddCommand(profile.NewProfileCommand(factory))

--- a/cli/npm/README.md
+++ b/cli/npm/README.md
@@ -7,28 +7,32 @@ This package downloads the platform-specific Go binary on `postinstall` and expo
 ## Quick start
 
 ```bash
+# First-run wizard (recommended): does `npm install -g @olares/cli` and
+# `npx skills add beclab/Olares -y -g` for you, in that order.
+npx @olares/cli@latest install
+
+# Or do it yourself, step by step:
+npm install -g @olares/cli@latest                # persistent global install
+npx skills add beclab/Olares -y -g               # six olares-* agent skills
+
 # One-off — no install:
 npx @olares/cli@latest <verb>
-
-# Persistent global install (recommended for dev boxes, CI, macOS, Windows):
-npm install -g @olares/cli@latest
-olares-cli <verb>
-
-# Bootstrap a fresh Linux server into a full Olares instance:
-npx @olares/cli@latest install
 ```
 
-After install, your AI coding agent can also pull the matching skill bundles:
+After any of those, authenticate (interactive, prompts for password + optional TOTP):
 
 ```bash
-npx skills add beclab/Olares -y -g
+olares-cli profile login --olares-id <your-olares-id>
+olares-cli profile current      # verify
 ```
+
+> This package distributes the `olares-cli` binary as a **client** only. The Node wrapper auto-sets `OLARES_CLI_REMOTE_ONLY=1`, which hides the Go binary's host-side verbs (`uninstall`, `upgrade`, `node`, `os`, `gpu`, `disk`, `wizard`, `user`, `osinfo`, `amdgpu`); these are reachable only on an Olares host through `/usr/local/bin/olares-cli`. The `install` verb is intercepted by the Node shim itself and routed to the first-run wizard (it never reaches the Go binary). Installing Olares OS itself is out of scope for this package — on a Linux host run `curl -fsSL https://olares.sh | bash`.
 
 ## Where the binary lives
 
 | You ran | Binary ends up at |
 | --- | --- |
-| `npx @olares/cli@latest install` | `/usr/local/bin/olares-cli` (laid by Olares OS bootstrap) |
+| On a Linux Olares host (OS bundle already there) | `/usr/local/bin/olares-cli` (managed by Olares OS upgrades) |
 | `npm install -g @olares/cli` (no existing `olares-cli` on PATH) | `<npm prefix>/bin/olares-cli` (symlink managed by npm) |
 | `npm install -g @olares/cli` (with existing `olares-cli` already at the target path) | npm aborts with `EEXIST`. Your existing binary is **never overwritten**. Use `--prefix` (see below) to side-step. |
 | `npx @olares/cli@latest <verb>` | `~/.npm/_npx/<hash>/.../vendor/olares-cli` (temporary) |
@@ -41,13 +45,19 @@ npm uninstall -g @olares/cli
 
 npm cleans the symlink and the package files itself. There is no extra cleanup step.
 
-## On an Olares host: install into a separate prefix
+## On a Linux Olares host: install side-by-side with the OS bundle
 
-If you are already on an Olares host (where `/usr/local/bin/olares-cli` exists), `npm install -g` will refuse with `EEXIST`. To install the npm copy side-by-side without touching the OS bundle:
+Linux-only: macOS / Windows / non-Olares Linux never hit this.
+
+The OS-bundled `olares-cli` is pinned to whatever shipped with your Olares OS release (e.g. **1.12.5**). Older bundles don't include the agent / identity verbs (`profile`, `files`, `market`, `dashboard`, `settings`, `cluster`) — those land in newer npm releases first. To get them on the same Linux host as the OS bundle, install the npm copy under a separate prefix, or use `npx` for one-offs:
 
 ```bash
+# Option 1 — separate prefix (npm aborts with EEXIST otherwise):
 npm install -g @olares/cli@latest --prefix ~/.olares-cli-npm
 export PATH="$HOME/.olares-cli-npm/bin:$PATH"   # PATH order decides which copy wins
+
+# Option 2 — npx, no install:
+npx @olares/cli@latest profile current
 ```
 
 Don't use `npm install -g --force` on an Olares host — it would clobber the OS-managed binary.

--- a/cli/npm/bin/olares-cli.js
+++ b/cli/npm/bin/olares-cli.js
@@ -5,6 +5,18 @@ const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
+// `npx @olares/cli install` is a first-run wizard implemented purely in JS:
+// it promotes the npx invocation to a global `npm install -g @olares/cli`
+// and then installs the agent skills via `npx skills add beclab/Olares`. It
+// does NOT install Olares OS (use `curl -fsSL https://olares.sh | bash` for
+// that on a Linux host) and does NOT touch the Go binary. Intercept the verb
+// here so it works even when the vendor binary failed to download.
+const args = process.argv.slice(2);
+if (args[0] === 'install') {
+  require('../scripts/install-wizard.js');
+  return;
+}
+
 const isWindows = process.platform === 'win32';
 const binName = isWindows ? 'olares-cli.exe' : 'olares-cli';
 const bin = path.join(__dirname, '..', 'vendor', binName);
@@ -18,13 +30,14 @@ if (!fs.existsSync(bin)) {
 }
 
 // OLARES_CLI_REMOTE_ONLY=1 tells the Go binary's root command tree to skip
-// registering host-side verbs (install, upgrade, node, os, gpu, disk, wizard,
-// user, osinfo, amdgpu) that require an Olares host filesystem laid down by
-// the install wizard. See cli/cmd/ctl/root.go. npx users never run the
-// wizard, so exposing those verbs would just produce confusing manifest-
-// not-found errors. The host-bundled binary at /usr/local/bin/olares-cli is
-// invoked by install.sh without this env var and keeps the full verb set.
-const res = spawnSync(bin, process.argv.slice(2), {
+// registering host-side verbs (uninstall, upgrade, node, os, gpu, disk,
+// wizard, user, osinfo, amdgpu) that require an Olares host filesystem laid
+// down by the install wizard. See cli/cmd/ctl/root.go. npx users never run
+// that wizard, so exposing those verbs would just produce confusing
+// manifest-not-found errors. The host-bundled binary at
+// /usr/local/bin/olares-cli is invoked by install.sh without this env var
+// and keeps the full verb set.
+const res = spawnSync(bin, args, {
   stdio: 'inherit',
   windowsHide: true,
   env: { ...process.env, OLARES_CLI_REMOTE_ONLY: '1' },

--- a/cli/npm/bin/olares-cli.js
+++ b/cli/npm/bin/olares-cli.js
@@ -17,9 +17,17 @@ if (!fs.existsSync(bin)) {
   process.exit(1);
 }
 
+// OLARES_CLI_REMOTE_ONLY=1 tells the Go binary's root command tree to skip
+// registering host-side verbs (install, upgrade, node, os, gpu, disk, wizard,
+// user, osinfo, amdgpu) that require an Olares host filesystem laid down by
+// the install wizard. See cli/cmd/ctl/root.go. npx users never run the
+// wizard, so exposing those verbs would just produce confusing manifest-
+// not-found errors. The host-bundled binary at /usr/local/bin/olares-cli is
+// invoked by install.sh without this env var and keeps the full verb set.
 const res = spawnSync(bin, process.argv.slice(2), {
   stdio: 'inherit',
   windowsHide: true,
+  env: { ...process.env, OLARES_CLI_REMOTE_ONLY: '1' },
 });
 
 if (res.error) {

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -28,6 +28,7 @@
     "README.md"
   ],
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "tar": "^7.4.3"
   },
   "license": "AGPL-3.0-or-later",

--- a/cli/npm/scripts/install-wizard.js
+++ b/cli/npm/scripts/install-wizard.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync, execFile } = require('node:child_process');
+const p = require('@clack/prompts');
+
+const PKG = '@olares/cli';
+const SKILLS_REPO = 'beclab/Olares';
+const isWindows = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
+
+// ---------------------------------------------------------------------------
+// Messages (English only for now; --lang/zh planned as a follow-up)
+// ---------------------------------------------------------------------------
+
+const msg = {
+  setup:           'Setting up Olares CLI...',
+  step1:           'Installing %s globally...',
+  step1Upgrade:    'Upgrading %s (v%s -> v%s)...',
+  step1Skip:       'Already installed (v%s). Skipped',
+  step1Done:       'Installed globally',
+  step1Upgraded:   'Upgraded to v%s',
+  step1Fail:       'Failed to install globally. Run manually: npm install -g %s',
+  step1Eexist:
+    'Detected an existing olares-cli at /usr/local/bin/olares-cli (likely the OS bundle on a Linux Olares host).\n' +
+    'npm refuses to overwrite it. Two safe workarounds:\n' +
+    '  1) Side-by-side install:  npm install -g %s --prefix=$HOME/.olares-cli-npm\n' +
+    '                            then add $HOME/.olares-cli-npm/bin to your PATH (before /usr/local/bin).\n' +
+    '  2) One-off ops via npx:   npx %s@latest <verb>\n' +
+    'See cli/README.md "On a Linux Olares host" for details.',
+  step2Spinner:    'Installing AI skills...',
+  step2Skip:       'Skills already installed. Skipped',
+  step2Done:       'Skills installed',
+  step2Fail:       'Failed to install skills. Run manually: npx skills add %s -y -g',
+  done:
+    'You are all set!\n\n' +
+    'Next:\n' +
+    '  olares-cli profile login --olares-id <your-olares-id>   # authenticate (browser/password + optional TOTP)\n' +
+    '  olares-cli profile current                              # verify\n\n' +
+    'Then tell your AI agent: "Load the olares-shared skill, then use olares-cli to ..."',
+  nonTtyHint:
+    'To finish setup, run:\n' +
+    '  olares-cli profile login --olares-id <your-olares-id>\n' +
+    '  olares-cli profile current',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmt(template, ...values) {
+  let i = 0;
+  return template.replace(/%s/g, () => values[i++] ?? '');
+}
+
+function execCmd(cmd, args, opts) {
+  if (isWindows) {
+    return execFileSync('cmd.exe', ['/c', cmd, ...args], opts);
+  }
+  return execFileSync(cmd, args, opts);
+}
+
+function runSilent(cmd, args, opts = {}) {
+  return execCmd(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...opts,
+  });
+}
+
+function runSilentAsync(cmd, args, opts = {}) {
+  const actualCmd = isWindows ? 'cmd.exe' : cmd;
+  const actualArgs = isWindows ? ['/c', cmd, ...args] : args;
+  return new Promise((resolve, reject) => {
+    execFile(actualCmd, actualArgs, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...opts,
+    }, (err, stdout, stderr) => {
+      if (err) {
+        err.stderr = stderr;
+        err.stdout = stdout;
+        reject(err);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+function getLatestVersion() {
+  try {
+    const out = runSilent('npm', ['view', PKG, 'version'], { timeout: 15000 });
+    const ver = out.toString().trim();
+    return /^\d+\.\d+\.\d+/.test(ver) ? ver : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function semverLessThan(a, b) {
+  const pa = a.replace(/-.*$/, '').split('.').map(Number);
+  const pb = b.replace(/-.*$/, '').split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) < (pb[i] || 0)) return true;
+    if ((pa[i] || 0) > (pb[i] || 0)) return false;
+  }
+  return false;
+}
+
+function getGloballyInstalledVersion() {
+  try {
+    const out = runSilent('npm', ['list', '-g', PKG], { timeout: 15000 });
+    const match = out.toString().match(/@olares\/cli@(\d+\.\d+\.\d+[^\s]*)/);
+    return match ? match[1] : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+// Heuristic: did `npm install -g` fail because /usr/local/bin/olares-cli already exists?
+// On Linux Olares hosts the OS bundle owns that path and npm refuses to clobber it.
+function looksLikeEexistConflict(err) {
+  if (!isLinux) return false;
+  const blob = `${err.message || ''}\n${err.stderr || ''}`;
+  if (/EEXIST/i.test(blob) && /olares-cli/.test(blob)) return true;
+  try {
+    return fs.existsSync('/usr/local/bin/olares-cli');
+  } catch (_) {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Steps
+// ---------------------------------------------------------------------------
+
+async function stepInstallGlobally(interactive) {
+  const installedVer = getGloballyInstalledVersion();
+  const latestVer = getLatestVersion();
+  const needsUpgrade = installedVer && latestVer && semverLessThan(installedVer, latestVer);
+
+  if (installedVer && !needsUpgrade) {
+    const line = fmt(msg.step1Skip, installedVer);
+    if (interactive) p.log.info(line); else console.log(line);
+    return;
+  }
+
+  const startLine = needsUpgrade
+    ? fmt(msg.step1Upgrade, PKG, installedVer, latestVer)
+    : fmt(msg.step1, PKG);
+  const doneLine = needsUpgrade
+    ? fmt(msg.step1Upgraded, latestVer)
+    : msg.step1Done;
+
+  const s = interactive ? p.spinner() : null;
+  if (s) s.start(startLine); else console.log(startLine);
+
+  try {
+    await runSilentAsync('npm', ['install', '-g', PKG], { timeout: 120000 });
+    if (s) s.stop(doneLine); else console.log(doneLine);
+  } catch (err) {
+    if (looksLikeEexistConflict(err)) {
+      if (s) s.stop(fmt(msg.step1Fail, PKG)); else console.error(fmt(msg.step1Fail, PKG));
+      const hint = fmt(msg.step1Eexist, PKG, PKG);
+      if (interactive) p.log.warn(hint); else console.error(hint);
+    } else {
+      if (s) s.stop(fmt(msg.step1Fail, PKG)); else console.error(fmt(msg.step1Fail, PKG));
+    }
+    process.exit(1);
+  }
+}
+
+async function skillsAlreadyInstalled() {
+  try {
+    const out = await runSilentAsync('npx', ['-y', 'skills', 'ls', '-g'], { timeout: 120000 });
+    return /^olares-/m.test(out.toString());
+  } catch (_) {
+    return false;
+  }
+}
+
+async function stepInstallSkills(interactive) {
+  const s = interactive ? p.spinner() : null;
+  if (s) s.start(msg.step2Spinner); else console.log(msg.step2Spinner);
+
+  try {
+    if (await skillsAlreadyInstalled()) {
+      if (s) s.stop(msg.step2Skip); else console.log(msg.step2Skip);
+      return;
+    }
+    await runSilentAsync('npx', ['-y', 'skills', 'add', SKILLS_REPO, '-y', '-g'], { timeout: 120000 });
+    if (s) s.stop(msg.step2Done); else console.log(msg.step2Done);
+  } catch (_) {
+    const line = fmt(msg.step2Fail, SKILLS_REPO);
+    if (s) s.stop(line); else console.error(line);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const interactive = !!process.stdin.isTTY && !!process.stdout.isTTY;
+
+  if (interactive) {
+    p.intro(msg.setup);
+    await stepInstallGlobally(true);
+    await stepInstallSkills(true);
+    p.outro(msg.done);
+  } else {
+    console.log(msg.setup);
+    await stepInstallGlobally(false);
+    await stepInstallSkills(false);
+    console.log(msg.nonTtyHint);
+  }
+}
+
+main().catch((err) => {
+  const line = 'Unexpected error: ' + (err && err.message ? err.message : err);
+  try { p.cancel(line); } catch (_) { console.error(line); }
+  process.exit(1);
+});


### PR DESCRIPTION
## Background

Two things on the `@olares/cli` npm channel were broken / latent:

1. **`npx @olares/cli install` crashed mid-pipeline** with `installation.manifest not found`, because the Go binary's `install` verb (designed to bootstrap Olares OS onto a Linux host via the wizard) was reachable from any npm-distributed invocation. The other 21 host-side verbs (`uninstall`, `upgrade`, `osinfo`, `node`, `disk`, ...) had the same shape: they assume an Olares host filesystem under `~/.olares/versions/<v>/` and fail confusingly when invoked from a dev box.

2. **The reusable `release-cli.yaml` was published-by-default.** PR #3188 moved the `npm publish` step into `release-cli.yaml`, but both `release.yaml` (Olares OS install-wizard release) and `check.yaml` (every PR push touching `cli/**`) invoke that workflow, so every PR check would silently `npm publish --access public` -- clearly not the intent.

This PR makes `npx @olares/cli install` do something useful, hides every other host-only verb from the npm channel, and reins npm publishing back to an explicit manual action.

## Summary

### Runtime behavior (commits 1 + 2)

1. **Hide host-side verbs from the Go binary on the npm channel.** The Node shim at `cli/npm/bin/olares-cli.js` now sets `OLARES_CLI_REMOTE_ONLY=1` when it spawns the Go binary. `cli/cmd/ctl/root.go` gates every host-only `AddCommand` behind that env, so `npx @olares/cli upgrade` (etc.) returns Cobra's standard `unknown command` with suggestions instead of crashing inside `InstallSystemPhase`. The host-bundled `/usr/local/bin/olares-cli` is invoked without the env and keeps its full verb set.

2. **Add a JS-shim-level first-run wizard at `npx @olares/cli install`.** Mirroring [`larksuite/cli` 1.0.43](https://github.com/larksuite/cli/blob/main/scripts/run.js)'s pattern, the shim intercepts `argv[0] === 'install'` before spawning the Go binary and runs `cli/npm/scripts/install-wizard.js`. The wizard does two things in sequence:
   - `npm install -g @olares/cli` (or upgrade if a stale global copy is on disk; skip if at registry's `latest`).
   - `npx -y skills add beclab/Olares -y -g` to install the six `olares-*` agent skills.

   It then prints the next-step `profile login` command and exits. Auth is intentionally NOT in the wizard (it's interactive, ties to the user's Olares ID).

3. **Linux Olares host EEXIST handling.** If `/usr/local/bin/olares-cli` is already owned by the OS bundle, `npm install -g` fails with `EEXIST`. The wizard detects this and prints the two safe workarounds (`--prefix=$HOME/.olares-cli-npm` side-by-side install, or stay on `npx`) instead of dying with a raw npm trace.

### CI gate (commit 4)

`release-cli.yaml` gains a `publish-npm` boolean input gating the `publish-npm` job with `if: ${{ inputs.publish-npm }}`:

| Entry point | publish-npm | Effect |
|---|---|---|
| `check.yaml` (PR push to `cli/**`) | `false` (explicit) | Build/upload binary, **skip** npm publish |
| `release.yaml` (OS install-wizard dispatch) | `false` (explicit) | Build/upload binary, **skip** npm publish |
| `release-cli.yaml` direct `workflow_dispatch` | `true` (default, UI checkbox pre-checked) | Full pipeline, the only npm publish channel |
| Any other `workflow_call` | `false` (fail-safe default) | Skip npm publish unless caller opts in |

This makes npm publishing strictly manual without losing the atomic "build the binary and publish it as the same workflow run" guarantee that #3188 set up. To ship a new npm release, dispatch `release-cli.yaml` directly with the desired tag.

### Docs (commit 3)

Both `cli/README.md` and `cli/npm/README.md` are refocused on installing the CLI (not the OS), document the new Scenario A wizard, and call out which verbs are JS-shim-intercepted vs `OLARES_CLI_REMOTE_ONLY`-hidden.

## Commits

- `fix(cli): add OLARES_CLI_REMOTE_ONLY env to hide host-side verbs` -- Go binary gate + Node shim env injection.
- `feat(cli/npm): add 'npx @olares/cli install' first-run wizard` -- wizard script, shim interceptor, `@clack/prompts ^1.2.0` dep.
- `docs(cli): align READMEs with remote-only npm + install wizard` -- both READMEs.
- `fix(ci): gate release-cli npm publish behind an explicit input flag` -- 3 workflow files, 9 lines.

## Test plan

After merge, smoke-test the npm side once a fresh `@olares/cli` is published via `release-cli.yaml` dispatch:

- [ ] `npx @olares/cli@latest install` runs the wizard end-to-end on macOS (Step 1 + Step 2 + final hint), in both TTY and non-TTY (`< /dev/null`).
- [ ] On a Linux Olares host (or a container with `/usr/local/bin/olares-cli` pre-placed), the wizard prints the EEXIST workarounds instead of failing silently.
- [ ] `npx @olares/cli@latest upgrade` and the other host-only verbs return `unknown command for "olares-cli"` with Cobra's "Did you mean ...?" suggestions.
- [ ] `npx @olares/cli@latest profile login --olares-id <id>` still works (remote/identity verbs unaffected).
- [ ] `npx @olares/cli@latest --help` lists only agent-facing verbs (no `upgrade` / `node` / `disk` / etc.).
- [ ] OS-bundle `/usr/local/bin/olares-cli install ...` still works as before (no `OLARES_CLI_REMOTE_ONLY`, full verb set registered).

CI gate verification on this PR itself:

- [ ] The PR-triggered `check.yaml -> release-cli.yaml` run shows `goreleaser` green and `publish-npm` as `Skipped` (no NPM_OLARES_PUBLISH_TOKEN consumed, npm registry untouched).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how users discover CLI commands and when CI can publish to npm; mistaken manual dispatch could still publish, but PR/OS release paths no longer auto-publish.
> 
> **Overview**
> The npm channel no longer exposes Olares **host** verbs: the Node shim sets `OLARES_CLI_REMOTE_ONLY=1`, and the Go root command tree only registers `os` / `node` / `gpu` / `disk` / `wizard` / etc. when that env is unset (OS bundle at `/usr/local/bin/olares-cli` unchanged).
> 
> `npx @olares/cli install` is now a **JS first-run wizard** (not the Go OS installer): global `npm install -g @olares/cli`, then `npx skills add beclab/Olares`, with Linux **EEXIST** guidance when `/usr/local/bin/olares-cli` already exists.
> 
> **CI:** `release-cli.yaml` adds a `publish-npm` input; PR checks and the install-wizard release pass `publish-npm: false` so `@olares/cli` is only published on explicit `release-cli` dispatch (default `true` there).
> 
> Docs in `cli/README.md` and `cli/npm/README.md` describe client-only npm usage, remote-only verbs, and the new wizard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fabab30081a07da2071add7ee3b2c11f6c3fef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->