### PR TITLE
feat(cli): Makefile + smart system-binary detection for the install wizard

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,0 +1,23 @@
+BINARY  := olares-cli
+MODULE  := github.com/beclab/Olares/cli
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -s -w -X $(MODULE)/version.VERSION=$(VERSION)
+PREFIX  ?= /usr/local
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd
+
+install: build
+	install -d $(PREFIX)/bin
+	install -m755 $(BINARY) $(PREFIX)/bin/$(BINARY)
+	@echo "OK: $(PREFIX)/bin/$(BINARY) ($(VERSION))"
+
+uninstall:
+	rm -f $(PREFIX)/bin/$(BINARY)
+
+clean:
+	rm -f $(BINARY)

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,7 +48,9 @@ olares-cli profile current
 
 > **What this command does NOT do:** install Olares OS. The Linux host bootstrap stays `curl -fsSL https://olares.sh | bash` (see [docs/manual/get-started](https://docs.olares.com/manual/get-started/install-olares/linux.html)). It also does not configure any app credentials — Olares uses the Olares ID directly, so no `config init` step is needed.
 >
-> **On a Linux Olares host (`/usr/local/bin/olares-cli` already present):** the wizard detects the resulting `EEXIST` and prints two safe workarounds (`--prefix` side-by-side install, or stay on `npx`). It will not overwrite the OS bundle. See ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle).
+> **On a Linux host with an existing `olares-cli` in `/usr/local/bin` or `/usr/bin`:** the wizard reads its `--version` and decides keep-vs-replace.
+> - **Release-grade** (stable `1.12.7`, or pre-releases `-rc1` / `-beta.1` / `-alpha2`) → kept; npm hits `EEXIST` and prints the [`--prefix` / `npx`](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) workarounds rather than clobbering it. The OS bundle is canonical for system-layer verbs and only `olares-cli upgrade` is supposed to replace it.
+> - **Dev / test / dirty** (the Makefile placeholder `0.0.0-development`, `git describe` outputs like `1.12.7-3-gabc1234-dirty`, check.yaml's `1.12.7-12345678` PR builds, unparseable output) → removed so npm can install over the same path. If removal needs root, the wizard exits with a one-line sudo hint instead of silently failing.
 
 ### Or build from source
 
@@ -98,7 +100,7 @@ npx @olares/cli@latest files ls /drive/Home
 
 | Method | What it gives you | Binary path | What it can't / won't do |
 | --- | --- | --- | --- |
-| **A — `npx @olares/cli@latest install`** | Superset of B: runs `npm install -g @olares/cli` (or upgrade) and `npx skills add beclab/Olares -y -g` in one shot. End state is the same as B, plus the six `olares-*` skills pre-installed. | Same as B once the wizard finishes. The wizard itself is the Node shim from the npx cache. | Does not install Olares OS (still `curl -fsSL https://olares.sh \| bash`). Does not run `profile login` for you (interactive + needs your Olares ID). On a Linux Olares host with `/usr/local/bin/olares-cli` present, npm hits `EEXIST` — the wizard detects this and prints the [`--prefix` / `npx`](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) workarounds instead of failing silently. |
+| **A — `npx @olares/cli@latest install`** | Superset of B: runs `npm install -g @olares/cli` (or upgrade) and `npx skills add beclab/Olares -y -g` in one shot. End state is the same as B, plus the six `olares-*` skills pre-installed. | Same as B once the wizard finishes. The wizard itself is the Node shim from the npx cache. | Does not install Olares OS (still `curl -fsSL https://olares.sh \| bash`). Does not run `profile login` for you (interactive + needs your Olares ID). On a Linux host with an existing `/usr/local/bin/olares-cli` or `/usr/bin/olares-cli`, the wizard reads its `--version`: release-grade copies (stable / `rc` / `beta` / `alpha`) are kept and npm prints the [`--prefix` / `npx`](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) workarounds; dev / test / dirty / `0.0.0-development` builds are removed so the npm copy can take over (re-run with `sudo` if the wizard exits with a permission hint). |
 | **B — `npm install -g @olares/cli@latest`** | Persistent `olares-cli` CLI on PATH (macOS / Windows / Linux). Use to talk to a *remote* Olares (login, files, market, dashboard, cluster, settings). | `<npm prefix>/bin/olares-cli` (symlink managed by npm itself). On a Linux Olares host where `/usr/local/bin/olares-cli` already exists, npm aborts with `EEXIST` — see ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) for the side-by-side workaround. | The npm wrapper auto-sets `OLARES_CLI_REMOTE_ONLY=1`, so host-side verbs (`uninstall`, `upgrade`, `node`, `os`, `gpu`, `disk`, `wizard`, `user`, `osinfo`, `amdgpu`) are hidden from `--help` and return `unknown command`. The `install` verb is intercepted by the Node shim and runs the Scenario A wizard. All of these are reachable only on an Olares host through the OS-bundled `/usr/local/bin/olares-cli`. |
 | **C — `npx @olares/cli@latest <verb>`** | Zero-install, runs any *remote/identity* verb without touching PATH. Great for CI one-shots, ephemeral containers, "just try it". | `~/.npm/_npx/<hash>/.../vendor/olares-cli` (only during the npx subprocess; cleared after) | Same host-side-verbs restriction as B (same Node shim). Each invocation pays a ~1-2 s npx cold-start. Long watches (`olares-cli market list --watch`, `olares-cli cluster pod logs -f`) work but pay the cost up front. Keychain/token caches persist across npx invocations. |
 
@@ -228,6 +230,8 @@ npx @olares/cli@latest files ls /drive/Home
 ```
 
 > Do **not** `npm install -g @olares/cli --force` on an Olares host — that would clobber the OS-managed `/usr/local/bin/olares-cli`. The OS bundle is canonical for system-layer verbs on that host and is upgraded via `olares-cli upgrade`. Without `--force`, npm already aborts safely with `EEXIST`.
+
+> The Scenario A wizard automates this safety net: it reads the existing binary's `--version` and only refuses to replace it when the version is release-grade (stable / `rc` / `beta` / `alpha`). If you intentionally placed a `make install` dev build at `/usr/local/bin/olares-cli`, the wizard will remove it and let npm install over the path — re-run with `sudo` if removal needs root.
 
 ## Build from source
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,24 @@ olares-cli profile current
 >
 > **On a Linux Olares host (`/usr/local/bin/olares-cli` already present):** the wizard detects the resulting `EEXIST` and prints two safe workarounds (`--prefix` side-by-side install, or stay on `npx`). It will not overwrite the OS bundle. See ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle).
 
+### Or build from source
+
+For local development or pinning to a specific commit. Requires Go 1.24+ and the full Olares repo — the CLI's [`cli/go.mod`](go.mod) has a relative `replace` directive into `../framework/oac`, so a `cli/`-only clone won't build.
+
+```bash
+git clone https://github.com/beclab/Olares.git
+cd Olares/cli
+
+sudo make install                                    # → /usr/local/bin/olares-cli
+sudo make install PREFIX=$HOME/.local                # or pick your own prefix
+make uninstall                                       # remove the same binary
+
+# Install the agent skills (Scenario A does this for you; from-source doesn't):
+npx skills add beclab/Olares -y -g
+```
+
+The resulting binary reports `git describe --tags --always --dirty` as its version (e.g. `1.12.7-3-gabc1234-dirty`), distinguishable from official releases (stable / `rc` / `beta` / `alpha` semver) and from `npm install -g` copies.
+
 ### Client on a non-Olares machine (Scenario B)
 
 ```bash

--- a/cli/npm/README.md
+++ b/cli/npm/README.md
@@ -62,6 +62,13 @@ npx @olares/cli@latest profile current
 
 Don't use `npm install -g --force` on an Olares host — it would clobber the OS-managed binary.
 
+### What the `npx @olares/cli@latest install` wizard does on this path
+
+Before running `npm install -g`, the wizard reads `--version` on the existing `/usr/local/bin/olares-cli` (or `/usr/bin/olares-cli`):
+
+- **Release-grade** (stable `1.12.7`, or pre-releases `-rc1` / `-beta.1` / `-alpha2`) → left alone; npm hits `EEXIST` and the wizard prints the Option 1 / Option 2 workaround above instead of clobbering it.
+- **Dev / test / dirty** (`0.0.0-development` placeholder, `git describe` outputs like `1.12.7-3-gabc1234-dirty`, check.yaml's `1.12.7-12345678` PR builds, unparseable output) → removed so the npm copy can install over the same path. If `unlink` fails for permission reasons, the wizard exits with a one-line hint to re-run with `sudo` rather than silently failing.
+
 ## Environment
 
 - `OLARES_CLI_DOWNLOAD_MIRROR` — base URL for downloading the prebuilt binary if `https://github.com/beclab/Olares/releases/download/...` is unreachable (defaults to `https://cdn.olares.com`).

--- a/cli/npm/scripts/install-wizard.js
+++ b/cli/npm/scripts/install-wizard.js
@@ -11,6 +11,13 @@ const SKILLS_REPO = 'beclab/Olares';
 const isWindows = process.platform === 'win32';
 const isLinux = process.platform === 'linux';
 
+// Canonical system paths an Olares OS bundle or `make install` build ends up
+// at -- outside any npm prefix, so npm can't see/manage them.
+const SYSTEM_OLARES_CLI_PATHS = [
+  '/usr/local/bin/olares-cli',
+  '/usr/bin/olares-cli',
+];
+
 // ---------------------------------------------------------------------------
 // Messages (English only for now; --lang/zh planned as a follow-up)
 // ---------------------------------------------------------------------------
@@ -30,6 +37,17 @@ const msg = {
     '                            then add $HOME/.olares-cli-npm/bin to your PATH (before /usr/local/bin).\n' +
     '  2) One-off ops via npx:   npx %s@latest <verb>\n' +
     'See cli/README.md "On a Linux Olares host" for details.',
+  preflightKeepRelease:
+    'Detected release olares-cli at %s (%s); keeping it (npm copy will install side-by-side if paths differ).',
+  preflightReplaceDev:
+    'Detected non-release olares-cli at %s (%s); replacing.',
+  preflightNoPermission:
+    'Cannot remove %s (%s).\n' +
+    'Re-run the wizard with sudo so it can replace the dev build:\n' +
+    '  sudo $(command -v npx) -y %s@latest install\n' +
+    'Or remove it yourself:\n' +
+    '  sudo rm %s\n' +
+    'then re-run `npx %s@latest install`.',
   step2Spinner:    'Installing AI skills...',
   step2Skip:       'Skills already installed. Skipped',
   step2Done:       'Skills installed',
@@ -131,11 +149,99 @@ function looksLikeEexistConflict(err) {
   }
 }
 
+// Locate an OS-bundle or make-install copy at the canonical system paths.
+// These live outside any npm prefix; npm can neither see nor manage them.
+function detectSystemOlaresCli() {
+  for (const candidate of SYSTEM_OLARES_CLI_PATHS) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch (_) { /* fall through */ }
+  }
+  return null;
+}
+
+function readOlaresCliVersion(binPath) {
+  try {
+    const out = execFileSync(binPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return out.trim();
+  } catch (_) {
+    return null;
+  }
+}
+
+// Classify the version string from `olares-cli --version` (Cobra default
+// emits "olares-cli version X.Y.Z[-PRE]"). Returns true ONLY for what the
+// release pipeline can produce:
+//   - stable:     1.12.7
+//   - prerelease: 1.12.8-rc1, 1.13.0-beta.1, 1.14.0-alpha2
+// Returns false for everything else (treat as dev/test, safe to replace):
+//   - 0.0.0-development (placeholder default in cli/version/version.go)
+//   - 1.12.5-cli.2-3-gddae4ca9c, 1.12.7-rc1-3-gabc-dirty (git describe output)
+//   - 1.12.7-12345678 (check.yaml PR-test build; numeric suffix isn't a tag)
+//   - `dev` (Makefile no-git fallback) or any unparseable output
+function isReleaseGradeVersion(verStr) {
+  if (!verStr) return false;
+  // Capture core MAJOR.MINOR.PATCH plus an optional pre-release suffix
+  // (everything up to the next whitespace). Anchoring on whitespace/EOL
+  // ensures we keep `-3-gabc-dirty` inside `pre` instead of silently dropping
+  // it and mis-classifying the version as stable.
+  const m = verStr.match(/version\s+v?(\d+\.\d+\.\d+)(?:-(\S+))?(?:\s|$)/);
+  if (!m) return false;
+  const [, mmp, pre] = m;
+  if (mmp === '0.0.0') return false;
+  if (!pre) return true;
+  // Strictly `rc[N]`, `beta[.N]`, `alpha[.N]`, etc. Anything trailing -- a
+  // git-describe `-N-gHASH`, a `-dirty` marker, or check.yaml's bare
+  // `-12345678` -- makes this a dev/test build.
+  return /^(rc|beta|alpha)(?:\.?\d+)?$/i.test(pre);
+}
+
+function tryUnlink(filePath) {
+  try {
+    fs.unlinkSync(filePath);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, err };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Steps
 // ---------------------------------------------------------------------------
 
 async function stepInstallGlobally(interactive) {
+  // Preflight: if a system-path olares-cli is present (OS bundle or
+  // `make install` artifact), decide keep-vs-replace based on its version.
+  // Release-grade versions (stable/rc/beta/alpha) are left alone -- the
+  // npm copy will install side-by-side and `looksLikeEexistConflict` below
+  // gives the user the workaround if npm would otherwise clobber it.
+  // Dev / test / unparseable versions are removed so npm can install over
+  // them. If we can't remove (typical: not running as root), bail with a
+  // sudo hint so the user knows what to do next.
+  const sysCli = detectSystemOlaresCli();
+  if (sysCli) {
+    const verStr = readOlaresCliVersion(sysCli);
+    const verDisplay = verStr || 'unknown';
+    if (isReleaseGradeVersion(verStr)) {
+      const line = fmt(msg.preflightKeepRelease, sysCli, verDisplay);
+      if (interactive) p.log.info(line); else console.log(line);
+    } else {
+      const line = fmt(msg.preflightReplaceDev, sysCli, verDisplay);
+      if (interactive) p.log.warn(line); else console.warn(line);
+      const rm = tryUnlink(sysCli);
+      if (!rm.ok) {
+        const reason = rm.err.code || rm.err.message || 'unknown error';
+        const hint = fmt(msg.preflightNoPermission, sysCli, reason, PKG, sysCli, PKG);
+        if (interactive) p.log.error(hint); else console.error(hint);
+        process.exit(1);
+      }
+    }
+  }
+
   const installedVer = getGloballyInstalledVersion();
   const latestVer = getLatestVersion();
   const needsUpgrade = installedVer && latestVer && semverLessThan(installedVer, latestVer);


### PR DESCRIPTION
## Background

Follow-up to #3191. Two related gaps from that PR:

1. There was no documented from-source path -- a developer wanting to pin to a commit, test an in-flight branch locally, or just avoid touching npm had no first-class workflow. [`larksuite/cli`](https://github.com/larksuite/cli) ships a minimal Makefile + a "from source" README section; this PR adapts that pattern.
2. The `npx @olares/cli install` wizard's only guard against an existing `/usr/local/bin/olares-cli` was the post-`npm install -g` `EEXIST` heuristic -- harmless on a Linux Olares host (where the OS bundle is canonical and should NOT be replaced), but actively wrong if the user had a `make install` dev build there: npm would silently refuse to install and the user would be stuck.

This PR adds both pieces -- a Makefile, and the version-aware preflight that ties them together.

## Summary

### Part 1 -- `cli/Makefile` for from-source builds (commit 1)

- New [`cli/Makefile`](cli/Makefile) with `build` / `install` / `uninstall` / `clean` targets, 23 lines total.
  - `VERSION` is computed at make time from `git describe --tags --always --dirty`, with `dev` as the no-git fallback.
  - ldflags inject `version.VERSION` to match [`cli/.goreleaser.yaml`](cli/.goreleaser.yaml).
  - `PREFIX ?= /usr/local`; pass `PREFIX=\$HOME/.local` (or anywhere writable) to skip sudo.
  - The git-describe version intentionally does NOT match the `stable / rc / beta / alpha` semver shapes that signal a real release, so the wizard in Part 2 can tell a make-install build apart from an OS-bundle release.
- [`cli/README.md`](cli/README.md): new "Or build from source" subsection right below Scenario A. Calls out that `cli/go.mod` has a relative `replace ../framework/oac` directive, so a `cli/`-only clone won't build -- you need the full Olares repo on disk. Also points users at \`npx skills add beclab/Olares -y -g\` so the make-install flow ends with the same agent skills as Scenario A.

### Part 2 -- version-aware preflight in the install wizard (commit 2)

[`cli/npm/scripts/install-wizard.js`](cli/npm/scripts/install-wizard.js) now pre-flights `/usr/local/bin/olares-cli` and `/usr/bin/olares-cli` before calling `npm install -g`:

- Reads the binary's `--version` and classifies it via a tightened regex.
- **Release-grade** (stable `1.12.7`, `-rc1`, `-beta.1`, `-alpha2`) -> kept; npm aborts with `EEXIST` and the existing handler prints the `--prefix` / `npx` workarounds.
- **Dev / test / dirty** (`0.0.0-development` placeholder, git-describe outputs like `1.12.7-3-gabc1234-dirty`, check.yaml's `1.12.7-12345678` PR builds, unparseable output) -> removed so the npm copy can install over the same path.
- If `unlink` fails for permission reasons, the wizard exits with a one-line `sudo` hint rather than silently failing.

This pairs cleanly with Part 1: if the user runs \`sudo make install\` and later \`npx @olares/cli install\`, the wizard replaces the dev build instead of bouncing off it.

[`cli/README.md`](cli/README.md) and [`cli/npm/README.md`](cli/npm/README.md) both document the keep-vs-replace policy and the sudo hint.

## Test plan

### Part 1
Smoke-tested locally on macOS:

\`\`\`
\$ cd Olares/cli
\$ make build
CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/beclab/Olares/cli/version.VERSION=1.12.5-cli.2-3-gddae4ca9c" -o olares-cli ./cmd
\$ ./olares-cli --version
olares-cli version 1.12.5-cli.2-3-gddae4ca9c
\$ make clean
rm -f olares-cli
\`\`\`

- [ ] On a Linux dev box, \`sudo make install\` writes \`/usr/local/bin/olares-cli\` and the binary reports the git-describe version.
- [ ] \`make install PREFIX=\$HOME/.local\` writes \`\$HOME/.local/bin/olares-cli\` without sudo.
- [ ] \`make uninstall\` removes the binary.
- [ ] \`make clean\` removes the local build artifact.

### Part 2
\`isReleaseGradeVersion\` truth-table (15/15 cases pass; ran with \`node -e\`):

\`\`\`
ok    "olares-cli version 1.12.7" -> true
ok    "olares-cli version 1.12.8-rc1" -> true
ok    "olares-cli version 1.12.8-rc.1" -> true
ok    "olares-cli version 1.13.0-beta.1" -> true
ok    "olares-cli version 1.13.0-beta" -> true
ok    "olares-cli version 1.14.0-alpha2" -> true
ok    "olares-cli version v1.12.7" -> true
ok    "olares-cli version 0.0.0-development" -> false
ok    "olares-cli version 1.12.5-cli.2-3-gddae4ca9c" -> false
ok    "olares-cli version 1.12.7-12345678" -> false
ok    "olares-cli version 1.12.7-3-gabc1234-dirty" -> false
ok    "olares-cli version 1.12.7-rc1-3-gabc-dirty" -> false
ok    "olares-cli version dev" -> false
ok    "" -> false
ok    "random garbage" -> false
\`\`\`

End-to-end checks still pending on a Linux box:
- [ ] \`sudo make install\` then \`npx @olares/cli install\` (no sudo) -> wizard prints the sudo hint and exits 1.
- [ ] \`sudo make install\` then \`sudo \$(command -v npx) -y @olares/cli@latest install\` -> wizard removes the dev binary, runs \`npm install -g\`, then \`npx skills add\`.
- [ ] Linux Olares host with the OS bundle in place -> wizard detects release-grade version, leaves it alone, npm aborts with \`EEXIST\` and prints the existing \`--prefix\` workaround.

Made with [Cursor](https://cursor.com)