### PR TITLE
fix(cli/npm): bump install wizard timeouts to 10 min and surface skills-step errors

### DIFF
--- a/cli/npm/scripts/install-wizard.js
+++ b/cli/npm/scripts/install-wizard.js
@@ -305,7 +305,7 @@ async function stepInstallGlobally(interactive) {
   if (s) s.start(startLine); else console.log(startLine);
 
   try {
-    await runSilentAsync('npm', ['install', '-g', PKG], { timeout: 120000 });
+    await runSilentAsync('npm', ['install', '-g', PKG], { timeout: 600000 });
     if (s) s.stop(doneLine); else console.log(doneLine);
   } catch (err) {
     if (looksLikeEexistConflict(err)) {
@@ -321,7 +321,7 @@ async function stepInstallGlobally(interactive) {
 
 async function skillsAlreadyInstalled() {
   try {
-    const out = await runSilentAsync('npx', ['-y', 'skills', 'ls', '-g'], { timeout: 120000 });
+    const out = await runSilentAsync('npx', ['-y', 'skills', 'ls', '-g'], { timeout: 600000 });
     return /^olares-/m.test(out.toString());
   } catch (_) {
     return false;
@@ -337,11 +337,33 @@ async function stepInstallSkills(interactive) {
       if (s) s.stop(msg.step2Skip); else console.log(msg.step2Skip);
       return;
     }
-    await runSilentAsync('npx', ['-y', 'skills', 'add', SKILLS_REPO, '-y', '-g'], { timeout: 120000 });
+    await runSilentAsync('npx', ['-y', 'skills', 'add', SKILLS_REPO, '-y', '-g'], { timeout: 600000 });
     if (s) s.stop(msg.step2Done); else console.log(msg.step2Done);
-  } catch (_) {
+  } catch (err) {
     const line = fmt(msg.step2Fail, SKILLS_REPO);
     if (s) s.stop(line); else console.error(line);
+
+    const isTimeout = !!(err && (err.code === 'ETIMEDOUT' || err.killed));
+    const details = [];
+    if (err && err.code) {
+      details.push(`  code: ${err.code}`);
+    } else if (err && err.signal) {
+      details.push(`  signal: ${err.signal}${err.killed ? ' (killed)' : ''}`);
+    }
+    const stderrTail = err && err.stderr ? err.stderr.toString().trim().slice(-2048) : '';
+    const stdoutTail = err && err.stdout ? err.stdout.toString().trim().slice(-2048) : '';
+    if (stderrTail) details.push(`  stderr (tail):\n${stderrTail}`);
+    if (stdoutTail) details.push(`  stdout (tail):\n${stdoutTail}`);
+    if (details.length) {
+      const blob = details.join('\n');
+      if (interactive) p.log.error(blob); else console.error(blob);
+    }
+
+    if (isTimeout) {
+      const hint = `Timed out after 10 min. Likely cause: slow / proxied connection to github.com during git clone.\nRetry outside the wizard: npx skills add ${SKILLS_REPO} -y -g`;
+      if (interactive) p.log.warn(hint); else console.error(hint);
+    }
+
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Reported in chat: on Windows, `npx @olares/cli@latest install` consistently fails at the skills step with the unhelpful one-liner

```
Failed to install skills. Run manually: npx skills add beclab/Olares -y -g
```

Root cause: the three sub-process calls in `cli/npm/scripts/install-wizard.js` all carried `timeout: 120000` (2 min), but `npx skills add beclab/Olares -y -g` runs a full `git clone` of the Olares mono-repo and takes ~100 s on a healthy link (measured 105.7 s locally). Any wobble in network/proxy/CDN pushes it past the 2-min cliff, where the timer fires `SIGTERM`. The `catch (_)` block in `stepInstallSkills` then swallowed `err.code` / `err.signal` / `err.stderr` / `err.stdout`, leaving the user with zero diagnostic signal.

This PR:

- Bumps all three child-process timeouts from `120000` → `600000` (10 min) for a comfortable margin and consistency across the wizard:
  - `npm install -g @olares/cli` in `stepInstallGlobally`
  - `npx skills ls -g` in `skillsAlreadyInstalled`
  - `npx skills add beclab/Olares -y -g` in `stepInstallSkills`
- Replaces `catch (_)` in `stepInstallSkills` with `catch (err)` and prints, after the existing one-liner:
  - `err.code`, or `err.signal` plus `(killed)` when the timer SIGTERMs the child (Node 22's `execFile` timeout sets `code: null, killed: true, signal: 'SIGTERM'`, verified locally)
  - Last 2 KiB of `err.stderr` and `err.stdout`
  - A dedicated hint when the failure looks like a timeout, telling the user to retry `npx skills add beclab/Olares -y -g` outside the wizard so they can see live clone progress

No happy-path behaviour change. `stepInstallGlobally`'s existing `EEXIST` / generic catch branches are untouched. `skillsAlreadyInstalled` keeps its `catch (_) { return false; }` semantics (failure there is benign — the install path takes over).

## Test plan

- [x] `node --check cli/npm/scripts/install-wizard.js` — passes (no syntax error).
- [x] End-to-end on Windows 11 / PowerShell / Node 22.22.0: `npx -y skills add beclab/Olares -y -g` completes in 105.7 s and installs all 6 skills (copy mode, auto-detected `cursor-cli` agent). Confirms 10-min timeout is comfortable.
- [x] Forced-timeout harness on the same machine (separate script, deleted before commit): `execFile` with `timeout: 1000` on a 5-s sleep produced `code: null, killed: true, signal: 'SIGTERM'` and the catch block printed the full diagnostic blob (`signal: SIGTERM (killed)` + `stderr (tail): slow-step starting...` + the 10-min retry hint), instead of the bare "Failed to install skills" line.
- [ ] Smoke-run `npx @olares/cli@<next>-cli.<n> install` on a fresh Windows host once a release with this change is published.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI install-script only: longer timeouts and richer failure logging; no auth, security, or runtime API changes.
> 
> **Overview**
> The install wizard in `install-wizard.js` now allows **10 minutes** (was 2) for the three long-running child steps: global `npm install -g @olares/cli`, `npx skills ls -g`, and `npx skills add beclab/Olares -y -g`, so slow networks or a full repo clone are less likely to hit `SIGTERM` from the timer.
> 
> When the skills install step fails, the wizard no longer swallows the error: it prints **exit code or signal** (including killed-by-timeout), the **last 2 KiB** of stdout/stderr, and a **timeout-specific hint** to retry `npx skills add beclab/Olares -y -g` outside the wizard. Happy-path behavior and other catch paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebc809592278a668caf0a0ff9ef9fa10abcb01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->