### PR TITLE
fix(cli/npm): surface npm install errors and add EACCES user-prefix hint

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -51,6 +51,8 @@ olares-cli profile current
 > **On a Linux host with an existing `olares-cli` in `/usr/local/bin` or `/usr/bin`:** the wizard reads its `--version` and decides keep-vs-replace.
 > - **Release-grade** (stable `1.12.7`, or pre-releases `-rc1` / `-beta.1` / `-alpha2`) → kept; if `npm config get prefix` resolves to the same `bin` directory (typical Olares host: `/usr/local`), the wizard short-circuits the `npm install -g` attempt — no full install timeout — and exits with a side-by-side install block (`npm install -g ... --prefix=$HOME/.olares-cli-npm` + `PATH` export + `npx skills add beclab/Olares -y -g`) you can copy verbatim. The OS bundle is canonical for system-layer verbs and only `olares-cli upgrade` is supposed to replace it. See ["On a Linux Olares host"](#on-a-linux-olares-host-install-side-by-side-with-the-os-bundle) for the long-form reference.
 > - **Dev / test / dirty** (the Makefile placeholder `0.0.0-development`, `git describe` outputs like `1.12.7-3-gabc1234-dirty`, check.yaml's `1.12.7-12345678` PR builds, unparseable output) → removed so npm can install over the same path. If removal needs root, the wizard exits with a one-line sudo hint instead of silently failing.
+>
+> **Permission errors on Linux** (`EACCES` while npm writes to `/usr/lib/node_modules` or `/usr/local/lib/node_modules`): typical for distro-packaged Node (`apt install nodejs`) where the global prefix is root-owned. The wizard surfaces the offending npm `stderr` plus a one-time fix that switches npm to a user-owned prefix (`npm config set prefix ~/.npm-global` + `PATH`) so global installs no longer need `sudo` and `npx skills add -g` writes under your user (not `/root`).
 
 ### Or build from source
 

--- a/cli/npm/README.md
+++ b/cli/npm/README.md
@@ -28,6 +28,8 @@ olares-cli profile current      # verify
 
 > This package distributes the `olares-cli` binary as a **client** only. The Node wrapper auto-sets `OLARES_CLI_REMOTE_ONLY=1`, which hides the Go binary's host-side verbs (`uninstall`, `upgrade`, `node`, `os`, `gpu`, `disk`, `wizard`, `user`, `osinfo`, `amdgpu`); these are reachable only on an Olares host through `/usr/local/bin/olares-cli`. The `install` verb is intercepted by the Node shim itself and routed to the first-run wizard (it never reaches the Go binary). Installing Olares OS itself is out of scope for this package — on a Linux host run `curl -fsSL https://olares.sh | bash`.
 
+> **Permission errors on Linux** (`EACCES` while npm writes to `/usr/lib/node_modules` or `/usr/local/lib/node_modules`): typical for distro-packaged Node (`apt install nodejs`) where the global prefix is root-owned. The wizard surfaces the offending npm `stderr` plus a one-time fix that switches npm to a user-owned prefix (`npm config set prefix ~/.npm-global` + `PATH`) so global installs no longer need `sudo` and `npx skills add -g` writes under your user (not `/root`).
+
 ## Where the binary lives
 
 | You ran | Binary ends up at |

--- a/cli/npm/scripts/install-wizard.js
+++ b/cli/npm/scripts/install-wizard.js
@@ -38,6 +38,19 @@ const msg = {
     '  export PATH="$HOME/.olares-cli-npm/bin:$PATH"   # before /usr/local/bin\n' +
     '  npx skills add %s -y -g\n' +
     'See cli/README.md "On a Linux Olares host" for details.',
+  step1EaccesHint:
+    'npm install -g hit EACCES while writing to its global prefix.\n' +
+    'On distro-packaged Node (apt/dnf, e.g. Ubuntu / Debian) the prefix is typically /usr or /usr/local and needs root.\n' +
+    'Recommended one-time fix: switch npm to a user-owned prefix so global installs do not need sudo,\n' +
+    'and `npx skills add -g` ends up writing under your user (not /root):\n' +
+    '  mkdir -p ~/.npm-global\n' +
+    '  npm config set prefix ~/.npm-global\n' +
+    '  echo \'export PATH="$HOME/.npm-global/bin:$PATH"\' >> ~/.bashrc\n' +
+    '  export PATH="$HOME/.npm-global/bin:$PATH"\n' +
+    'then re-run:  npx -y @olares/cli@latest install',
+  step1TimeoutHint:
+    'Timed out after 10 min. Likely cause: slow / proxied connection while downloading the Go binary from github.com.\n' +
+    'Retry outside the wizard so you can watch progress: npm install -g %s',
   preflightKeepRelease:
     'Detected release olares-cli at %s (%s); keeping it.',
   preflightReplaceDev:
@@ -349,7 +362,38 @@ async function stepInstallGlobally(interactive) {
       const hint = fmt(msg.step1Eexist, PKG, SKILLS_REPO);
       if (interactive) p.log.warn(hint); else console.error(hint);
     } else {
-      if (s) s.stop(fmt(msg.step1Fail, PKG)); else console.error(fmt(msg.step1Fail, PKG));
+      const line = fmt(msg.step1Fail, PKG);
+      if (s) s.stop(line); else console.error(line);
+
+      // npm exits non-zero with a numeric `err.code`; the syscall-level
+      // 'EACCES' surfaces only in stderr text (e.g. "npm error code EACCES
+      // ... permission denied, mkdir '/usr/lib/node_modules/@olares'").
+      const stderrStr = err && err.stderr ? err.stderr.toString() : '';
+      const isEacces  = /EACCES|permission denied/i.test(stderrStr);
+      const isTimeout = !!(err && (err.code === 'ETIMEDOUT' || err.killed));
+
+      const details = [];
+      if (err && err.code) {
+        details.push(`  code: ${err.code}`);
+      } else if (err && err.signal) {
+        details.push(`  signal: ${err.signal}${err.killed ? ' (killed)' : ''}`);
+      }
+      const stderrTail = stderrStr ? stderrStr.trim().slice(-2048) : '';
+      const stdoutTail = err && err.stdout ? err.stdout.toString().trim().slice(-2048) : '';
+      if (stderrTail) details.push(`  stderr (tail):\n${stderrTail}`);
+      if (stdoutTail) details.push(`  stdout (tail):\n${stdoutTail}`);
+      if (details.length) {
+        const blob = details.join('\n');
+        if (interactive) p.log.error(blob); else console.error(blob);
+      }
+
+      if (isEacces) {
+        const hint = msg.step1EaccesHint;
+        if (interactive) p.log.warn(hint); else console.error(hint);
+      } else if (isTimeout) {
+        const hint = fmt(msg.step1TimeoutHint, PKG);
+        if (interactive) p.log.warn(hint); else console.error(hint);
+      }
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Background

Follow-up to #3194 (which fixed the same surface-error problem in `stepInstallSkills`). On a fresh Ubuntu host with distro-packaged Node:

```
olares@olares:~$ npx @olares/cli@latest install
|  Setting up Olares CLI...
o  Failed to install globally. Run manually: npm install -g @olares/cli
olares@olares:~$
```

Nothing else. The user has no signal at all. Running `npm install -g` by hand reveals the real cause:

```
npm error code EACCES
npm error syscall mkdir
npm error path /usr/lib/node_modules/@olares
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/lib/node_modules/@olares'
```

On distro-packaged Node (`apt install nodejs`) the npm prefix is `/usr` and the global modules directory is root-owned, so `npm install -g` from a regular user always EACCES.

The bug: `stepInstallGlobally`'s catch had two arms, EEXIST (well covered in #3193) and `else` -- and the `else` just printed the bare `step1Fail` line and `process.exit(1)`, dropping `err.code`, `err.signal`, `err.stderr`, `err.stdout` on the floor. Same hole #3194 closed for the skills step, just not propagated.

## Changes

[`cli/npm/scripts/install-wizard.js`](cli/npm/scripts/install-wizard.js) -- only the non-EEXIST arm of `stepInstallGlobally` is touched; EEXIST behavior unchanged from #3193:

- Print `err.code` (or `err.signal` + `(killed)` when timer-killed), then the last 2 KiB of stderr / stdout. Mirrors #3194 exactly.
- Detect EACCES via stderr regex (`/EACCES|permission denied/i`). `runSilentAsync` uses `execFile`, so npm's non-zero exit puts a numeric code in `err.code`; the syscall-level `EACCES` lives only in `err.stderr`. The hint walks the user through switching npm to a user-owned prefix:
  ```
  mkdir -p ~/.npm-global
  npm config set prefix ~/.npm-global
  echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> ~/.bashrc
  export PATH="$HOME/.npm-global/bin:$PATH"
  ```
  Deliberately **not** recommending `sudo $(command -v npx) install` -- that would let `npm install -g` succeed but the follow-up `npx skills add -g` would then write skills under `/root/.cursor/...` etc., where the user's agent (running as the non-root user) can't see them. The user-prefix fix keeps everything under `$HOME` and self-consistent.
- Detect timeout the same way #3194 does (`err.code === 'ETIMEDOUT'` || `err.killed`) and point at a retry of `npm install -g <pkg>` outside the wizard so the user can watch download progress live.
- For any other failure (network, postinstall binary download integrity check, disk full, ENOTFOUND), the stderr/stdout tail alone gives enough signal -- no extra hint printed.

[`cli/README.md`](cli/README.md) / [`cli/npm/README.md`](cli/npm/README.md) -- one-line note under the Scenario A block describing the EACCES surfacing and the user-prefix fix.

## Test plan

3-case stub harness mirroring the real failure shapes, all classifying correctly:

```
ok   EACCES (real npm output, user-reported)
    isEacces=true  isTimeout=false  details=2
ok   timeout (10-min SIGTERM)
    isEacces=false isTimeout=true   details=1
ok   other (network / postinstall download)
    isEacces=false isTimeout=false  details=2
```

End-to-end on a Linux host (pending):

- [ ] Ubuntu, distro-packaged Node, regular user (the exact reporter's setup) -> wizard now prints full npm stderr tail + EACCES hint with the four-line user-prefix workaround. Following the hint and re-running the wizard succeeds.
- [ ] Same host with `npm config set prefix ~/.npm-global` already applied -> wizard installs to `~/.npm-global/bin/olares-cli` without surfacing EACCES, skills step runs.
- [ ] macOS / a healthy Linux dev box -> happy path unchanged.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and install-wizard error messaging only; no auth, API, or install-engine behavior changes.
> 
> **Overview**
> When `npx @olares/cli install` fails on **`npm install -g`** (anything other than the existing **EEXIST** / OS-bundle path), the wizard no longer exits with only a generic failure line. It now prints **`err.code`** or kill **signal**, the last **2 KiB** of **npm stderr/stdout**, and targeted follow-ups.
> 
> **EACCES** (common on distro Node with a root-owned global prefix) is detected from stderr and gets a **user-owned npm prefix** workaround (`~/.npm-global` + **PATH**), explicitly **not** `sudo`, so a later **`npx skills add -g`** stays under the real user. **10-minute timeouts** get a retry hint to run **`npm install -g`** outside the wizard. **`cli/README.md`** and **`cli/npm/README.md`** document the same Linux permission case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22aab430bb3ace623ac22da69b574626190fe017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->