### PR TITLE
docs(use-cases/hermes): add Olares skills, OpenAI API, and restart command updates

### DIFF
--- a/docs/use-cases/hermes.md
+++ b/docs/use-cases/hermes.md
@@ -1,0 +1,335 @@
+---
+outline: [2,3]
+description: Learn how to install and configure Hermes Agent on Olares and connect it to Discord.
+head:
+  - - meta
+    - name: keywords
+      content: Olares, Hermes, Hermes Agent, autonomous AI, self-improving AI, Discord bot, self-hosted
+app_version: "1.3.2"
+doc_version: "1.0"
+doc_updated: "2026-05-15"
+---
+
+# Set up a self-directed AI agent with Hermes
+
+Hermes Agent is a self-directed AI assistant that connects to your local models to execute system tasks, generate code, and manage workflows. It retains memory across sessions and creates reusable skills based on your interactions. By integrating it with messaging platforms like Discord, you can interact with your local AI agent remotely.
+
+## Learning objectives
+
+In this guide, you will learn how to:
+- Install Hermes Agent on Olares.
+- Configure Hermes Agent to connect to a local model.
+- Interact with your agent directly via the terminal.
+- Integrate with Discord for remote chat.
+
+## Prerequisites
+
+- Local model: [Ollama is installed](./ollama.md) with at least one tool-capable model downloaded and running. This tutorial uses `qwen3.5:9b`.
+- Discord account: Required to create the bot application.
+- Discord server: A server where you have permissions to add bots.
+
+## Install Hermes Agent
+
+1. Open Market and search for "Hermes".
+
+   ![Install Hermes Agent](/images/manual/use-cases/hermes-agent.png#bordered)
+
+2. Click **Get**, and then click **Install**. When the installation finishes, two shortcuts appear in the Launchpad:
+
+    - Hermes CLI: The command line interface
+    - Dashboard: The graphical dashboard
+
+    ![Hermes entry points](/images/manual/use-cases/hermes-entry-points.png#bordered){width=50%}
+
+:::tip Run multiple Hermes agents
+Olares supports app cloning. If you want to run multiple independent AI agents for different tasks, you can clone the Hermes Agent app. For more information, see [Clone applications](../manual/olares/market/clone-apps.md).
+:::
+
+## Configure Hermes Agent
+
+Run a quick setup to connect Hermes Agent to your local model.
+
+### Step 1: Get model and endpoint details
+
+1. Open the Ollama app from the Launchpad.
+2. Check the installed models by running the following command:
+
+    ```bash
+    ollama list
+    ```
+3. Copy and save your model name exactly as shown in the **NAME** column. For example, `qwen3.5:9b`.
+4. Check the context window of the model by running the following command:
+
+    ```bash
+    ollama ps
+    ```
+
+5. Copy and save the value as shown in the **CONTEXT** column. For example, `32768`.
+6. Open Settings, go to **Applications** > **Ollama** > **Shared entrances** > **Ollama API**, and then copy the endpoint address. For example, `http://d54536a50.shared.olares.com`.
+
+    ![Obtain Ollama API](/images/manual/use-cases/ollama-endpoint1.png#bordered){width=65%}
+
+### Step 2: Run the setup wizard
+
+1. Open the Hermes CLI app from the Launchpad.
+2. Enter the following command to start the configuration wizard:
+
+   ```bash
+   hermes setup
+   ```
+
+3. The wizard guides you through a series of steps. Use the arrow keys to navigate and press **Enter** to confirm.
+
+    | Settings   | Option   |
+    |:-----------|:---------|
+    | How would you like to set up Hermes | Select **Quick setup - provider, model & messaging (recommended)**. |
+    | Select provider | Select **Custom endpoint (enter URL manually)**.  |
+    | API base URL  | Enter your model's API address and append `/v1` to the end.<br>For example, `http://d54536a50.shared.olares.com/v1`.  |
+    | API key  | Enter any text as a placeholder value, such as `ollama-local`.<br>The input remains hidden for security. |
+    | Available models | Enter the number corresponding to your target model<br> from the generated list. |
+    | Context length in tokens | <ul><li>If your model's context window is less than `65536`,<br>enter a value greater than `65536`.</li><li>If your model's context window is more than `65536`,<br>leave this field blank to auto-detect.</li></ul> |
+    | Display name |  Enter a name for easy identification, such as `ollama-local`.|
+    | Connect a messaging platform | Select **Skip - set up later with `hermes setup gateway`**. |
+
+4. Keep the Hermes CLI window open for the next step.
+
+## Interact with Hermes Agent
+
+### Option 1: Terminal chat
+
+The Terminal User Interface (TUI) runs directly in the Hermes CLI with no extra setup. It is ideal for quick tests.
+
+1. When the setup wizard completes, it prompts you to launch `hermes chat`. Type `y` and press **Enter** to start the TUI.
+
+   :::tip
+   If you exited the wizard, manually start the chat by entering `hermes chat` in the Hermes CLI.
+   :::
+
+    ![Hermes setup complete](/images/manual/use-cases/hermes-setup-complete.png#bordered)
+
+2. Send a message, such as `what can you do`, to verify that the agent responds correctly.
+
+    ![Hermes TUI chat](/images/manual/use-cases/hermes-tui.png#bordered)
+
+3. To close the TUI and return to the standard CLI, type `/exit`, and then press **Enter**.
+
+### Option 2: Remote chat via Discord
+
+To chat with your agent remotely, connect it to a Discord bot.
+
+#### Step 1: Create a Discord bot
+
+1. Log in to the [Discord Developer Portal](https://discord.com/developers/home) with your Discord account.
+2. Select **Applications** from the left sidebar, and then click **New Application**.
+
+    ![New application in Discord developer portal](/images/manual/use-cases/hermes-new-app.png#bordered)
+
+3. Enter a name for the new app, agree to the terms, and then click **Create**.
+
+    ![Create an application window](/images/manual/use-cases/hermes-create-app.png#bordered){width=40%}
+
+4. From the left sidebar, select **Bot**.
+5. Scroll down to the **Privileged Gateway Intents** section and enable the following settings:
+
+    - Presence Intent
+    - Server Members Intent
+    - Message Content Intent
+
+    ![Privileged gateway intents](/images/manual/use-cases/hermes-privileged-gateway-intents.png#bordered)
+
+6. Click **Save Changes**.
+7. Scroll up to the **Token** section, click **Reset Token**, and then copy the generated token for your Discord bot. You need the token for messaging platform configuration later in the Hermes CLI.
+
+    ![Reset token](/images/manual/use-cases/hermes-reset-token.png#bordered)
+
+#### Step 2: Invite the bot to your server
+
+1. From the left sidebar, select **OAuth2**, and then find the **OAuth2 URL Generator** section:
+
+    a. In **Scopes**, select **Bot** and **applications.commands**.
+
+    ![OAuth2 URL Generator](/images/manual/use-cases/hermes-oauth21.png#bordered)
+
+    b. Scroll down to **Bot Permissions**, set the permissions as shown in the following image. You can modify the settings later.
+
+    ![Bot permissions](/images/manual/use-cases/hermes-bot-permissions.png#bordered)
+
+2. Copy the **Generated URL** at the bottom.
+3. Paste the URL into a new browser tab, select your Discord server from **Add to server**, click **Continue**, and then click **Authorize**. 
+
+    ![Add Discord bot to server](/images/manual/use-cases/hermes-add-bot.png#bordered){width=50%}
+
+    The bot is authorized and added to your server.
+
+    ![Bot added to server](/images/manual/use-cases/hermes-bot-added.png#bordered)
+
+#### Step 3: Configure the messaging platform
+
+Connect Hermes Agent to your Discord bot by configuring and running the Hermes gateway.
+
+1. Open the Hermes CLI, and then enter the following command to start the configuration wizard:
+
+   ```bash
+   hermes gateway setup
+   ```
+
+2. Select **Discord** as your messaging platform.
+3. Follow the prompts to configure the bot integration:
+
+   - **Discord bot token**: Enter the bot token generated from your Discord Developer Portal. The input remains hidden.
+   - **Allowed user IDs or usernames**: Enter your Discord user ID to restrict access to yourself.
+   - (Optional) **Home channel ID**: Enter the ID of the Discord channel where the bot operates. 
+
+4. Select **Done**.
+5. When prompted to **Restart the gateway to pick up changes**, enter `y`.
+6. Check your bot status in Discord. A green status icon confirms the bot is online, which means the gateway restarted successfully and the configuration is correct.
+
+#### Step 4: Authorize your account
+
+For security, the bot does not talk to unauthorized users. You must pair your Discord account with the bot.
+
+1. Send a Direct Message to your new bot. The bot will reply with an error message containing a pairing code.
+2. Open the Hermes CLI and enter the following command:
+
+    ```bash
+    hermes pairing approve discord {Your-Pairing-Code}
+    ```
+
+3. Once approved, you can start chatting with your agent in Discord. If you are talking to it in a channel, mention it first.
+
+## Advanced configuration
+
+To manually adjust parameters, edit the configuration files directly, and then restart the Hermes CLI to apply the changes. 
+
+1. Open the Files app from the Launchpad.
+2. Go to **Data** > **hermesagent** > **home**, and locate the configuration files, such as `config.yaml` and `.env`. 
+
+The file structure and configuration options match the official defaults. For detailed parameter descriptions, see the [Hermes configuration guide](https://hermes-agent.nousresearch.com/docs/user-guide/configuration).
+
+## FAQs
+
+### How to manually restart the Hermes gateway?
+
+You can restart the gateway manually using one of the following methods:
+
+- **Use the Hermes CLI**
+
+    This is the fastest method. Open the Hermes CLI from the Launchpad, and then run the following command:
+
+    ```bash
+    hermes restart-gateway
+    ```
+- **Use the Hermes Dashboard**
+
+    This is the most intuitive method. Open the Hermes Dashboard from the Launchpad, and then select **Restart Gateway** in the left sidebar.
+
+- **Use Control Hub**
+
+    Open Control Hub, and then go to **Browse** > **{username}** > **hermesagent-{username}** > **Deployments** > **hermesagent**, and then click **Restart** in the upper-right corner. This method completely restarts the entire service, which takes slightly longer.
+
+## Next steps
+
+After you complete the basic setup, explore the official resources to expand your agent's capabilities:
+- For advanced terminal commands, see [CLI Interface](https://hermes-agent.nousresearch.com/docs/user-guide/cli).
+- For integration with Slack, Telegram, and other platforms, see [Messaging Platforms](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+- For installation of skills, see [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills).
+- For installation of tools, see [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools).
+- For information about best practices and optimization, see [Tips & Best Practices](https://hermes-agent.nousresearch.com/docs/guides/tips).
+
+:::info Note on sudo commands
+The Hermes CLI in the Olares environment does not support `sudo` commands. Ignore any steps in the official documentation that require `sudo` privileges.
+:::
+
+## Install Olares Skills
+
+Hermes Agent supports installing Olares skills to extend its capabilities. These skills provide integration with Olares applications such as Files, Settings, and Dashboard.
+
+To install Olares skills:
+
+1. Open the Hermes CLI from the Launchpad.
+2. Run the following command to install each skill:
+
+   ```bash
+   hermes skills install clawhub/olares-shared --yes
+   ```
+
+3. Repeat the command for each of the following skills:
+   - `clawhub/olares-market`
+   - `clawhub/olares-dashboard`
+   - `clawhub/olares-settings`
+   - `clawhub/olares-files`
+
+4. After installation, the skills can be used just like OpenClaw skills.
+
+## Call Hermes Agent via OpenAI-compatible API
+
+Hermes Agent supports being called by other applications through an OpenAI-compatible API, allowing you to integrate it with tools like OpenWebUI.
+
+### Step 1: Enable the Gateway API
+
+1. Open **Settings** > **Applications** > **Hermes Agent**.
+2. In the environment variables section, set **API_SERVER_ENABLED** to `true`.
+3. Set an **API_SERVER_KEY** value:
+   - The key must be at least 8 characters long.
+   - Allowed characters: letters, numbers, and `-_.`
+   - Avoid placeholder values like `your_api_key`.
+
+   ![Enable Gateway API](/images/manual/use-cases/hermes-api-settings.png#bordered)
+
+4. Wait for the application to restart.
+
+### Step 2: Find the Gateway API URL
+
+1. Go back to **Settings** > **Applications** > **Hermes Agent**.
+2. Find the **Hermes Gateway API** URL and copy it. For example:
+
+   ```
+   https://baf3d7172.olarestest003.olares.com
+   ```
+
+### Step 3: Verify the API is running
+
+Open your browser and navigate to:
+
+```
+https://<your-gateway-url>/health
+```
+
+If enabled successfully, you will see a response confirming the API is running.
+
+### Step 4: Connect from another application
+
+1. Open the application you want to connect (for example, OpenWebUI).
+2. Navigate to the admin panel and select **Connection** or **Models**.
+3. Add a new OpenAI-compatible model entry with the following settings:
+   - **Base URL**: Your Hermes Gateway API URL + `/v1`
+     - For example: `https://baf3d7172.olarestest003.olares.com/v1`
+   - **Auth**: Select **Bearer** and enter the `API_SERVER_KEY` you set in Step 1.
+4. Click the refresh button next to the toggle to check the connection.
+
+5. Once connected, the Hermes Agent model will appear in your application, and you can start chatting with it.
+
+![Connect OpenWebUI](/images/manual/use-cases/hermes-openwebui-connection.png#bordered)
+
+## FAQ: Gateway API fails to start
+
+**Symptom**
+- Gateway API access shows "Unable to connect".
+- Logs display: `[Api_Server] Refusing to start: API_SERVER_KEY is set to a placeholder value`
+
+**Cause**
+
+The API key does not meet Hermes security requirements.
+
+**Solution**
+
+Reset the API key in **Settings** > **Applications** > **Hermes Agent** with a value that:
+- Is at least 8 characters long.
+- Contains only letters, numbers, and `-_.`
+- Is not a common placeholder value like `your_api_key`.
+
+## Learn more
+
+- [How do I create a server in Discord](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server)
+- [How to find the Channel ID number](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID)
+- [OpenClaw](openclaw.md)


### PR DESCRIPTION
## Summary
- Simplify gateway restart: use `hermes restart-gateway` instead of touch command
- Add section on installing Olares skills (olares-shared, olares-market, olares-dashboard, olares-settings, olares-files)
- Add section on calling Hermes Agent via OpenAI-compatible API
- Add FAQ for Gateway API startup failures (API_SERVER_KEY placeholder issue)

## Changes

### FAQ restart command update
Changed from `touch /opt/data/.gateway-restart-requested` to `hermes restart-gateway` for simplicity.

### Olares Skills section
Added documentation for installing 5 Olares skills via ClawHub:
- olares-shared
- olares-market
- olares-dashboard
- olares-settings
- olares-files

### OpenAI-compatible API section
New section documenting how to:
1. Enable API_SERVER_ENABLED and set API_SERVER_KEY in Settings
2. Find the Hermes Gateway API URL
3. Verify API via /health endpoint
4. Connect from OpenWebUI or similar apps

### FAQ: Gateway API fails to start
Added troubleshooting for the common issue where API_SERVER_KEY is set to a placeholder value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application, auth, or infrastructure code modified.
> 
> **Overview**
> This PR **adds or extends** the Hermes use-case guide in `docs/use-cases/hermes.md` with Olares-specific workflows beyond the existing install, Ollama, terminal, and Discord setup.
> 
> The **gateway restart FAQ** now recommends `hermes restart-gateway` in the CLI instead of a manual touch-file workaround. New sections document **installing five ClawHub Olares skills** (`olares-shared`, `olares-market`, `olares-dashboard`, `olares-settings`, `olares-files`) via `hermes skills install`, and **exposing Hermes through an OpenAI-compatible Gateway API** (enable `API_SERVER_ENABLED`, set a valid `API_SERVER_KEY`, verify `/health`, connect clients such as OpenWebUI with Bearer auth). A **troubleshooting FAQ** covers Gateway API startup failures when `API_SERVER_KEY` is a rejected placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8bd0c4d3d1e525a1e0fc9cc7e1fa4ca006ac97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->