### PR TITLE
feat: add appcommon for search3monitor

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -187,7 +187,7 @@ metadata:
     applications.app.bytetrade.io/author: bytetrade.io
   annotations:
     applications.app.bytetrade.io/version: '0.0.1'
-spec:
+spec
   replicas: 1
   selector:
     matchLabels:
@@ -220,6 +220,10 @@ spec:
           hostPath:
             path: /olares/share
             type: Directory
+        - name: common-data
+          hostPath:
+            path: /olares/rootfs/Common
+            type: DirectoryOrCreate
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'
@@ -241,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.2
+        image: beclab/search3:v0.3.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -302,7 +306,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.2
+        image: beclab/search3monitor:v0.3.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081
@@ -356,6 +360,8 @@ spec:
           - name: shared-lib
             mountPath: /data/External
             mountPropagation: Bidirectional
+          - name: common-data
+            mountPath: /appcommon/
         securityContext:
           privileged: true
           runAsUser: 0
@@ -377,6 +383,10 @@ spec:
           hostPath:
             path: /olares/share
             type: Directory
+        - name: common-data
+          hostPath:
+            path: /olares/rootfs/Common
+            type: DirectoryOrCreate
 
 ---
 apiVersion: v1

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -187,7 +187,7 @@ metadata:
     applications.app.bytetrade.io/author: bytetrade.io
   annotations:
     applications.app.bytetrade.io/version: '0.0.1'
-spec
+spec:
   replicas: 1
   selector:
     matchLabels:

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.2
+        image: beclab/search3validation:v0.3.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: add appcommon for search3monitor
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
drive/Common is a cluster-wide RWX volume mounted at /appcommon. Unlike drive/Home and drive/Data, it is not scoped to a per-user PVC. Because monitor tasks can only run on one user/process per node, AppCommon monitoring is assigned to the owner user's FileName task on the master node only.


* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.6
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/201



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment/DaemonSet volume and image tag updates only; no auth or API surface changes in this repo.
> 
> **Overview**
> This PR wires **search3monitor** to the cluster-wide **AppCommon** store by adding a `common-data` hostPath volume (`/olares/rootfs/Common`) mounted at **`/appcommon/`**, matching the drive/Common RWX layout used for shared (non per-user) monitoring.
> 
> It also bumps **search3**, **search3monitor**, and **search3validation** container images from **v0.3.2** to **v0.3.3** (aligned with the upstream search3 change for AppCommon monitoring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2ae01966feea191f05a25b3c136bae5a80832c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->