### PR TITLE
opa: bump OPA and kube-mgmt images to v1.17.0 and v11.0.7 respectively

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -82,7 +82,7 @@ spec:
                     operator: Exists
       containers:
         - name: opa
-          image: openpolicyagent/opa:1.11.0
+          image: openpolicyagent/opa:1.17.0
           args:
             - "run"
             - "--server"
@@ -95,7 +95,7 @@ spec:
               mountPath: /etc/certs
               name: certs
         - name: kube-mgmt
-          image: openpolicyagent/kube-mgmt:9.3.0
+          image: openpolicyagent/kube-mgmt:11.0.7
           args:
             - --enable-policies=true
             - --namespaces={{ .Release.Namespace }}
@@ -166,6 +166,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     openpolicyagent.org/policy: rego
+  annotations:
+    openpolicyagent.org/kube-mgmt-retries: "30"
 data:
   main: |
     package system
@@ -200,6 +202,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     openpolicyagent.org/policy: rego
+  annotations:
+    openpolicyagent.org/kube-mgmt-retries: "30"
 data:
   main: |
     package kubernetes.admission


### PR DESCRIPTION
* **Background**
1. Bump OPA and kube-mgmt images to v1.17.0 and v11.0.7
2. Add kube-mgmt retries annotation

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the validating admission webhook stack (image major jumps); policy logic is unchanged but failed sync could briefly affect enforcement until retries succeed.
> 
> **Overview**
> Upgrades the cluster **OPA** deployment to **openpolicyagent/opa:1.17.0** and **kube-mgmt** to **openpolicyagent/kube-mgmt:11.0.7** in `deployment.yaml`.
> 
> Adds **`openpolicyagent.org/kube-mgmt-retries: "30"`** on the **`default-decision`** and **`untrusted-pod-check`** policy ConfigMaps so kube-mgmt retries policy sync to OPA more reliably after the sidecar upgrade. **Rego admission rules are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a3ae2e0671473bc469a86987ca62988c696622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->