### PR TITLE
feat(l4): xds honor client-supplied X-Forwarded-Proto

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -142,7 +142,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.20"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.21"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.20
+          value: v0.3.21
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.20
+      name: beclab/l4-bfl-proxy:v0.3.21
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -235,7 +235,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -342,6 +342,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -433,7 +434,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -540,6 +541,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1059,7 +1061,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -1544,7 +1546,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -262,7 +262,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -369,6 +369,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -460,7 +461,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -567,6 +568,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1031,7 +1033,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -1461,7 +1463,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -451,7 +451,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -558,6 +558,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -629,7 +630,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -736,6 +737,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -827,7 +829,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -934,6 +936,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1005,7 +1008,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -1112,6 +1115,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1549,7 +1553,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -2224,7 +2228,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -2589,7 +2593,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -3264,7 +3268,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -586,7 +586,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -693,6 +693,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -764,7 +765,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -871,6 +872,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -942,7 +944,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -1049,6 +1051,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1140,7 +1143,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -1247,6 +1250,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1318,7 +1322,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -1425,6 +1429,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1496,7 +1501,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -1603,6 +1608,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -2067,7 +2073,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -2497,7 +2503,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -2927,7 +2933,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -3357,7 +3363,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -3787,7 +3793,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -4217,7 +4223,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -289,7 +289,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -396,6 +396,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -487,7 +488,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -594,6 +595,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1096,7 +1098,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -1526,7 +1528,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -289,7 +289,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -396,6 +396,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -487,7 +488,7 @@
                           "headersToAdd": [
                             {
                               "key": "X-Forwarded-Proto",
-                              "value": "https"
+                              "value": "%REQ(x-forwarded-proto?:SCHEME)%"
                             },
                             {
                               "key": "X-BFL-USER",
@@ -594,6 +595,7 @@
                   }
                 ],
                 "useRemoteAddress": true,
+                "xffNumTrustedHops": 1,
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1079,7 +1081,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },
@@ -1509,7 +1511,7 @@
         {
           "header": {
             "key": "X-Forwarded-Proto",
-            "value": "https"
+            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         },

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -117,6 +117,14 @@ function envoy_on_response(response_handle)
 end
 `
 
+// xForwardedProtoValue mirrors nginx:
+//
+//	map $http_x_forwarded_proto $x_forwarded_proto {
+//	    ""      $scheme;
+//	    default $http_x_forwarded_proto;
+//	}
+const xForwardedProtoValue = "%REQ(x-forwarded-proto?:SCHEME)%"
+
 var (
 	tcpIdleTimeout        = time.Hour
 	httpStreamIdleTimeout = 30 * time.Minute
@@ -426,7 +434,7 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 			VirtualHosts: virtualHosts,
 			RequestHeadersToAdd: []*corev3.HeaderValueOption{
 				{Header: &corev3.HeaderValue{Key: "X-Forwarded-Host", Value: "%REQ(:AUTHORITY)%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
-				{Header: &corev3.HeaderValue{Key: "X-Forwarded-Proto", Value: "https"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
+				{Header: &corev3.HeaderValue{Key: "X-Forwarded-Proto", Value: xForwardedProtoValue}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 				{Header: &corev3.HeaderValue{Key: "X-Real-IP", Value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 				{Header: &corev3.HeaderValue{Key: "X-Original-Forwarded-For", Value: "%REQ(X-FORWARDED-FOR)%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 			},
@@ -492,8 +500,14 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 				{UpgradeType: "websocket"},
 				{UpgradeType: "tailscale-control-protocol"},
 			},
-			AccessLog:         []*accesslogv3.AccessLog{buildHTTPAccessLog()},
-			UseRemoteAddress:  wrapperspb.Bool(true),
+			AccessLog:        []*accesslogv3.AccessLog{buildHTTPAccessLog()},
+			UseRemoteAddress: wrapperspb.Bool(true),
+			// Trust one hop of downstream-supplied forwarding headers so that a
+			// client/proxy-set X-Forwarded-Proto is honored (mirrors nginx's
+			// `map $http_x_forwarded_proto`). With the default value of 0 Envoy
+			// would unconditionally overwrite x-forwarded-proto based on the
+			// downstream connection's TLS status.
+			XffNumTrustedHops: 1,
 			StreamIdleTimeout: durationpb.New(httpStreamIdleTimeout),
 			StripPortMode: &hcmv3.HttpConnectionManager_StripAnyHostPort{
 				StripAnyHostPort: true,
@@ -796,7 +810,7 @@ func buildExtAuthzFilter(autheliaClusterName string, clusterMap map[string]*ir.C
 				PathPrefix: "/api/authz/ext-authz/",
 				AuthorizationRequest: &extauthzv3.AuthorizationRequest{
 					HeadersToAdd: []*corev3.HeaderValue{
-						{Key: "X-Forwarded-Proto", Value: "https"},
+						{Key: "X-Forwarded-Proto", Value: xForwardedProtoValue},
 						{Key: "X-BFL-USER", Value: userName},
 					},
 				},


### PR DESCRIPTION
* **Background**
    - Set X-Forwarded-Proto (route header and ext_authz authz request) to
      `%REQ(x-forwarded-proto?:SCHEME)%`, falling back to the connection
      scheme when the header is absent, instead of hardcoding "https".
    - Set XffNumTrustedHops=1 on the HTTP connection manager so Envoy trusts
      the downstream-supplied x-forwarded-proto rather than overwriting it
      based on the downstream TLS status.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes forwarding headers and ext_authz inputs used by Authelia; mis-trusted hops could affect auth or redirect behavior, though the change intentionally aligns with nginx semantics.
> 
> **Overview**
> Bumps **l4-bfl-proxy** to **v0.3.21** in the upgrade task, BFL launcher env (`L4_PROXY_IMAGE_VERSION`), and Olares prebuilt image metadata.
> 
> The Envoy xDS translator now sets **`X-Forwarded-Proto`** (on routes and **ext_authz** requests) to `%REQ(x-forwarded-proto?:SCHEME)%` instead of a fixed `https`, and sets **`xffNumTrustedHops: 1`** on the HTTP connection manager so one hop of client/proxy forwarding headers is trusted—matching prior nginx behavior. E2E golden configs were refreshed for the same output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc338c99d59080b19af3fc55ac786fc000ec18f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->