### PR TITLE
daemon: implement network change notification and handling in DSR and mDNS servers

### DIFF
--- a/daemon/internel/intranet/dsr_linux.go
+++ b/daemon/internel/intranet/dsr_linux.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/beclab/Olares/daemon/pkg/utils"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 	"github.com/mdlayher/raw"
@@ -44,12 +45,15 @@ type DSRProxy struct {
 	stopCh chan struct{}
 
 	requestPortMap *sync.Map // map[uint16]uint16
+
+	isNetworkChanged func() bool
 }
 
 func NewDSRProxy() *DSRProxy {
 	return &DSRProxy{
-		stopCh:         make(chan struct{}),
-		requestPortMap: new(sync.Map),
+		stopCh:           make(chan struct{}),
+		requestPortMap:   new(sync.Map),
+		isNetworkChanged: utils.RegisterNetworkChangedNotify(),
 	}
 }
 
@@ -480,7 +484,7 @@ func (d *DSRProxy) handleResponse(data []byte, conn net.PacketConn) {
 func (d *DSRProxy) regonfigure() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if !d.configChanged {
+	if !d.configChanged && !d.isNetworkChanged() {
 		return nil
 	}
 

--- a/daemon/internel/mdns/server.go
+++ b/daemon/internel/mdns/server.go
@@ -26,11 +26,12 @@ type serverIntf interface {
 }
 
 type server struct {
-	server       *zeroconf.Server
-	port         int
-	name         string
-	registeredIP string
-	serviceName  string
+	server           *zeroconf.Server
+	port             int
+	name             string
+	registeredIP     string
+	serviceName      string
+	isNetworkChanged func() bool
 }
 
 type sunshineServer struct {
@@ -40,15 +41,24 @@ type sunshineServer struct {
 
 func NewServer(apiPort int) (serverIntf, error) {
 	s := &server{
-		port:        apiPort,
-		serviceName: SERVICE_NAME,
-		name:        INSTANCE_NAME + "-" + tools.RandomString(6),
+		port:             apiPort,
+		serviceName:      SERVICE_NAME,
+		name:             INSTANCE_NAME + "-" + tools.RandomString(6),
+		isNetworkChanged: utils.RegisterNetworkChangedNotify(),
 	}
 	return s, s.Restart()
 }
 
 func NewSunShineProxyWithoutStart(ctx context.Context) serverIntf {
-	s := &sunshineServer{server: server{port: 47989, name: "", serviceName: "_nvstream._tcp"}, ctx: ctx}
+	s := &sunshineServer{
+		server: server{
+			port:             47989,
+			name:             "",
+			serviceName:      "_nvstream._tcp",
+			isNetworkChanged: utils.RegisterNetworkChangedNotify(),
+		},
+		ctx: ctx,
+	}
 	return s
 }
 
@@ -102,7 +112,7 @@ func (s *server) Restart() error {
 		hostname = strings.Join([]string{hostname, iptoken[len(iptoken)-1]}, "-")
 	}
 
-	if s.registeredIP != ip {
+	if s.registeredIP != ip || s.isNetworkChanged() {
 		if s.server != nil {
 			s.Close()
 		}

--- a/daemon/pkg/commands/disable_overlay_gateway/cmd.go
+++ b/daemon/pkg/commands/disable_overlay_gateway/cmd.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
-	"k8s.io/klog/v2"
 )
 
 type disableOverlayGateway struct {
@@ -30,6 +29,8 @@ func (d *disableOverlayGateway) Execute(ctx context.Context, p any) (res any, er
 	if err != nil {
 		return nil, err
 	}
+
+	utils.NotifyNetworkChanged()
 
 	// turn off the CNI-DHCP service
 	cmd := exec.CommandContext(ctx, "systemctl", "disable", "--now", "cni-dhcp.service")
@@ -56,13 +57,13 @@ func (d *disableOverlayGateway) Execute(ctx context.Context, p any) (res any, er
 	}
 
 	// restart the overlay gateway supported apps
-	// restart in a separate goroutine, cause the restarting process may take a while
-	go func() {
-		err = utils.RestartOverlayGatewaySupportedApps(ctx, apps)
-		if err != nil {
-			klog.Error("restart overlay gateway supported apps error, ", err)
-		}
-	}()
+	// call restarting from the frontend
+	// go func() {
+	// 	err = utils.RestartOverlayGatewaySupportedApps(ctx, apps)
+	// 	if err != nil {
+	// 		klog.Error("restart overlay gateway supported apps error, ", err)
+	// 	}
+	// }()
 
 	return nil, nil
 }

--- a/daemon/pkg/commands/enable_overlay_gateway/cmd.go
+++ b/daemon/pkg/commands/enable_overlay_gateway/cmd.go
@@ -25,18 +25,19 @@ func New() commands.Interface {
 }
 
 func (e *enableOverlayGateway) Execute(ctx context.Context, p any) (res any, err error) {
-	// create the bridge connection
-	err = utils.CreateBridgeConnection(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// turn on the CNI-DHCP service
 	cmd := exec.CommandContext(ctx, "systemctl", "enable", "--now", "cni-dhcp.service")
 	cmd.Env = os.Environ()
 	_, err = cmd.Output()
 	if err != nil {
 		klog.Error("failed to enable and start the CNI-DHCP service: %w", err)
+		return nil, err
+	}
+
+	// create the bridge connection
+	err = utils.CreateBridgeConnection(ctx)
+	utils.NotifyNetworkChanged()
+	if err != nil {
 		return nil, err
 	}
 

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -572,10 +572,21 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 	}
 
 	for _, app := range apps.Items {
-		entrances, err := appcfg.GenEntranceURL(ctx, &app)
-		if err != nil {
-			klog.Error("generate application entrance url error, ", err, ", ", app.Name)
-			continue
+		var entrances []appcfg.Entrance
+		var err error
+		if isV3(&app) {
+			entrances, err = appcfg.GenEntranceURL(ctx, &app)
+			if err != nil {
+				klog.Error("generate application entrance url error, ", err, ", ", app.Name)
+				continue
+			}
+		} else {
+
+			entrances, err = BatchGenSharedAppEntranceURL(ctx, &app)
+			if err != nil {
+				klog.Error("generate shared application entrance url error, ", err, ", ", app.Name)
+				continue
+			}
 		}
 
 		for _, entrance := range entrances {
@@ -771,4 +782,44 @@ func GetWorkloadNameFromPod(pod *corev1.Pod) string {
 	podTemplateHash := pod.Labels["pod-template-hash"]
 	podNameTokens := strings.Split(pod.Name, fmt.Sprintf("-%s-", podTemplateHash))
 	return podNameTokens[0]
+}
+
+const (
+	AppApiVersionLabel = "app.bytetrade.io/api-version"
+	AppVersionV3       = "v3"
+)
+
+func isV3(a *appv1alpha1.Application) bool {
+	return a.Labels != nil && a.Labels[AppApiVersionLabel] == AppVersionV3
+}
+
+func BatchGenSharedAppEntranceURL(ctx context.Context, app *appv1alpha1.Application) ([]appcfg.Entrance, error) {
+	if !isV3(app) {
+		return nil, nil
+	}
+
+	client, err := GetDynamicClient()
+	if err != nil {
+		klog.Error("get dynamic client error, ", err)
+		return nil, err
+	}
+
+	users, err := ListUsers(ctx, client, func(u *unstructured.Unstructured) bool {
+		return true
+	})
+
+	var entrances []appcfg.Entrance
+	for _, u := range users {
+		a := app.DeepCopy()
+		a.Spec.Owner = u.GetName()
+		_, err := appcfg.GenEntranceURL(ctx, a)
+		if err != nil {
+			klog.Error("generate entrance url error, ", err)
+			continue
+		}
+
+		entrances = append(entrances, a.Spec.Entrances...)
+	}
+
+	return entrances, nil
 }

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -574,7 +574,7 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 	for _, app := range apps.Items {
 		var entrances []appcfg.Entrance
 		var err error
-		if isV3(&app) {
+		if !isV3(&app) {
 			entrances, err = appcfg.GenEntranceURL(ctx, &app)
 			if err != nil {
 				klog.Error("generate application entrance url error, ", err, ", ", app.Name)
@@ -807,6 +807,10 @@ func BatchGenSharedAppEntranceURL(ctx context.Context, app *appv1alpha1.Applicat
 	users, err := ListUsers(ctx, client, func(u *unstructured.Unstructured) bool {
 		return true
 	})
+	if err != nil {
+		klog.Error("list user error, ", err)
+		return nil, err
+	}
 
 	var entrances []appcfg.Entrance
 	for _, u := range users {

--- a/daemon/pkg/utils/network_common.go
+++ b/daemon/pkg/utils/network_common.go
@@ -5,9 +5,17 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"sync"
+
+	"github.com/google/uuid"
 )
 
 const CHECK_CONNECTIVITY_URL = "http://connectivity-check.ubuntu.com/"
+
+var (
+	networkChangedNotify map[string]bool
+	networkChangedMu     sync.Mutex
+)
 
 func CheckInterfaceIPv4Connectivity(ctx context.Context, interfaceName string) bool {
 	// try to connect to the CHECK_CONNECTIVITY_URL using the specified interface
@@ -35,4 +43,29 @@ func MaskFromCIDR(bits int) (string, error) {
 	}
 	mask := net.CIDRMask(bits, 32)
 	return fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3]), nil
+}
+
+func NotifyNetworkChanged() {
+	networkChangedMu.Lock()
+	defer networkChangedMu.Unlock()
+	for key := range networkChangedNotify {
+		networkChangedNotify[key] = true
+	}
+}
+
+func RegisterNetworkChangedNotify() func() bool {
+	networkChangedMu.Lock()
+	defer networkChangedMu.Unlock()
+	if networkChangedNotify == nil {
+		networkChangedNotify = make(map[string]bool)
+	}
+	notifyId := uuid.New().String()
+	networkChangedNotify[notifyId] = false
+	return func() bool {
+		networkChangedMu.Lock()
+		defer networkChangedMu.Unlock()
+		changed := networkChangedNotify[notifyId]
+		networkChangedNotify[notifyId] = false
+		return changed
+	}
 }


### PR DESCRIPTION
* **Background**
1. Send notification to DSR server and mDNS server to restart with the new network interface when the overlay-gateway enable/disable
2. Add the shared app domain of all users to the mDNS and local domain DNS.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
mDNS is not working after the overlay-gateway is enabled or disabled

* **PRs Involving Sub-Systems** 
none

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live networking (DSR, mDNS, overlay bridge) and DNS URL enumeration; enable path calls NotifyNetworkChanged before verifying bridge creation succeeded.
> 
> **Overview**
> Adds a **network-changed** signal in `daemon/pkg/utils` (`NotifyNetworkChanged` / `RegisterNetworkChangedNotify`) and wires overlay-gateway **enable** and **disable** commands to broadcast it after bridge setup/teardown.
> 
> **DSR** and **mDNS** register that signal and treat it like a config change: DSR `regonfigure` runs when the flag is set; mDNS `Restart` tears down and re-registers when the registered IP changes *or* the network changed.
> 
> **Application URL collection** for intranet DNS/mDNS now branches on v3 (`app.bytetrade.io/api-version`): shared apps get entrance URLs generated **per user** via `BatchGenSharedAppEntranceURL`, so local DNS/mDNS can include all users’ shared-app domains.
> 
> Overlay-gateway **disable** no longer restarts supported apps in a background goroutine (left to the frontend). **Enable** reorders work (CNI-DHCP before bridge creation) and notifies after `CreateBridgeConnection`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b2b2ee059f77af7764786d966154ad85b4203c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->