### PR TITLE
helm/system-apps: bump system-frontend to v1.10.39 and user-service to v0.0.95

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.38
+          image: beclab/system-frontend:v1.10.39
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.94
+          image: beclab/user-service:v0.0.95
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

Ship the Overlay Gateway feature by bumping platform image tags in `olares-app.yaml`:

- `beclab/system-frontend`: `v1.10.38` → `v1.10.39` — includes Settings → Network → Overlay Gateway UI (gateway toggle, per-app overlay management, underlay IP/port display with copy-to-clipboard, confirm dialogs, and i18n).
- `beclab/user-service`: `v0.0.94` → `v0.0.95` — includes overlay gateway API proxy to olaresd (status query, gateway/app enable-disable) and `underlay_networks` response types.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1130 
https://github.com/beclab/user-service/pull/80 
https://github.com/beclab/TermiPass/pull/1160 
https://github.com/beclab/TermiPass/pull/1157 

* **Other information**:
None

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Network gateway behavior changes via new frontend and user-service images; risk is limited to version bumps in a single template with no config edits.
> 
> **Overview**
> Bumps **system-apps** deployment images in `olares-app.yaml` so the platform ships **Overlay Gateway**: `beclab/system-frontend` **v1.10.38 → v1.10.39** on the `olares-app-init` init container (Settings → Network UI), and `beclab/user-service` **v0.0.94 → v0.0.95** on the `user-service` container (olaresd proxy and underlay network types). No chart structure, env, or routing changes—only image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3934ff781b448f7721918bba092bbb1dd18bac15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->