### PR TITLE
fix: files standardize path resolution and fix archive route registration & extract naming

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -208,7 +208,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.175
+          image: beclab/files-server:v0.2.176
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- Refactor: normalize path resolution in the permission, md5 and unmount handlers so non-/data mounts resolve correctly.
- Fix: md5 returns 404 instead of 400 when the target file is missing.
- Fix: unmount is correctly restricted to external storage.
- Fix: declare the archive entries/entry endpoints in thrift so they are no longer dropped from the built image.
- Fix: extract now names the output folder after the archive without its suffix, with rename on conflict.

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/335
- https://github.com/beclab/files/pull/336
- https://github.com/beclab/files/pull/337

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in deployment config; behavior change comes from the already-built server image, with no manifest logic or secret handling changes in this diff.
> 
> **Overview**
> This PR **bumps the `files` container image** in the cluster `files` DaemonSet deploy manifest from `beclab/files-server:v0.2.175` to **`v0.2.176`**, rolling out the files-server build that carries the path, md5, unmount, archive route, and extract naming fixes described for the release (target **1.12.6**).
> 
> No other deploy settings, env vars, or sidecar images change in this diff—only the pinned server image tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67bafadd96e69106c73e8b2df31da8b7779d1123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->