### PR TITLE
cli: add cache directories for HuggingFace, llama.cpp, and Ollama

### DIFF
--- a/cli/pkg/storage/constants.go
+++ b/cli/pkg/storage/constants.go
@@ -42,5 +42,8 @@ var (
 
 	MinioOperatorFile = path.Join(Root, "usr", "local", "bin", "minio-operator")
 
-	AppCommonDir = path.Join(OlaresJuiceFSRootDir, "Common")
+	AppCommonDir        = path.Join(OlaresJuiceFSRootDir, "Common")
+	HuggingFaceCacheDir = path.Join(AppCommonDir, "huggingface")
+	LLampCPPCacheDir    = path.Join(AppCommonDir, "llama.cpp")
+	OllamaCacheDir      = path.Join(AppCommonDir, "ollama")
 )

--- a/cli/pkg/storage/tasks.go
+++ b/cli/pkg/storage/tasks.go
@@ -422,5 +422,14 @@ func (t *CreateAppCommonDir) Execute(runtime connector.Runtime) error {
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", AppCommonDir, AppCommonDir), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "failed to create app common dir")
 	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", HuggingFaceCacheDir, HuggingFaceCacheDir), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create huggingface cache dir")
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", LLampCPPCacheDir, LLampCPPCacheDir), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create llama.cpp cache dir")
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", OllamaCacheDir, OllamaCacheDir), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create ollama cache dir")
+	}
 	return nil
 }

--- a/cli/pkg/upgrade/1_12_7_20260601.go
+++ b/cli/pkg/upgrade/1_12_7_20260601.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260601 struct {
+	upgrader_1_12_7_20260527
+}
+
+func (u upgrader_1_12_7_20260601) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260601")
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260601{})
+}


### PR DESCRIPTION
* **Background**
Add cache directories for HuggingFace, llama.cpp, and Ollama

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to filesystem provisioning under existing Common dir setup; no auth, data migration, or service logic changes.
> 
> **Overview**
> Adds shared **JuiceFS `Common` cache paths** for Hugging Face, **llama.cpp**, and **Ollama** under `AppCommonDir`, and extends **`CreateAppCommonDir`** so fresh installs and upgrades create those directories with the same `mkdir` + `chown 1000:1000` pattern as the parent common dir (still skipped on Darwin).
> 
> Registers daily upgrader **`1.12.7-20260601`**, embedding the prior **`20260527`** upgrader so upgrade runs still invoke **`createAppCommonDir()`** and pick up the new subdirectories on existing nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4699b09b28279797fa91fc74e88b55a377a01ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->