### PR TITLE
fix(app-service): don't mislabel a cancelled install as a startup failure

### DIFF
--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -311,19 +311,27 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				// startup polling for them.
 				if p.manager.Spec.Type != appsv1.Middleware {
 					if ok, waitErr := ops.WaitForStartUp(); !ok {
+						// A cancel (DELETE /apps/{name}/install) cancels opCtx,
+						// the only path on which WaitForStartUp returns (false, nil).
+						// That is NOT a startup failure: the InstallingCanceling
+						// state machine has already taken over this ApplicationManager
+						// and owns the terminal transition. Writing Stopping/InitFailed
+						// here would both mislabel a user cancel as an init failure and
+						// race the cancel path into a spurious installingCancelFailed.
+						// Bail out quietly and let the cancel handler drive the state.
+						if waitErr == nil || c.Err() != nil {
+							klog.Infof("install of app %s canceled while waiting for startup; leaving terminal state to the cancel handler", p.manager.Spec.AppName)
+							return
+						}
+
 						klog.Errorf("wait for app %s startup after scale-up failed %v", p.manager.Spec.AppName, waitErr)
 						reason := constants.AppStopDueToInitFailed
-						var wrappedWaitErr error
-						if waitErr != nil {
-							wrappedWaitErr = errors.Wrapf(waitErr, "wait for app %s startup after scale-up failed", p.manager.Spec.AppName)
-							if errors.Is(waitErr, errcode.ErrPodPending) || errors.Is(waitErr, errcode.ErrServerSidePodPending) {
-								reason = constants.AppUnschedulable
-								if errors.Is(waitErr, errcode.ErrHamiUnschedulable) {
-									reason = constants.AppHamiSchedulable
-								}
+						wrappedWaitErr := errors.Wrapf(waitErr, "wait for app %s startup after scale-up failed", p.manager.Spec.AppName)
+						if errors.Is(waitErr, errcode.ErrPodPending) || errors.Is(waitErr, errcode.ErrServerSidePodPending) {
+							reason = constants.AppUnschedulable
+							if errors.Is(waitErr, errcode.ErrHamiUnschedulable) {
+								reason = constants.AppHamiSchedulable
 							}
-						} else {
-							wrappedWaitErr = fmt.Errorf("wait for app %s startup after scale-up failed", p.manager.Spec.AppName)
 						}
 						msg := wrappedWaitErr.Error()
 						p.finally = func() {


### PR DESCRIPTION
## Summary

Cancelling an app install mid-flight (`DELETE /apps/{name}/install`, e.g. while the app is still in `Init:x/3`) intermittently surfaces a **spurious `installingCancelFailed` / `Stopping(InitFailed)`** terminal state with the misleading message `wait for app <x> startup after scale-up failed`, before the row finally settles at `uninstalled`. Any client that reacts to those transient events shows the user an "install failed".

### Root cause

`appFactory.cancelOperation` cancels the install's `opCtx`, which makes `HelmOps.WaitForStartUp` return `(false, nil)` — its **only** non-error, non-success return path (`ctx.Done()`):

```go
case <-h.ctx.Done():
    klog.Infof("Waiting for app startup canceled appName=%s", h.app.AppName)
    return false, nil
```

The installing state machine (`pkg/appstate/installing_app.go`) did not distinguish this cancellation from a genuine startup failure. With `waitErr == nil` it still:

1. logged at error level `wait for app <x> startup after scale-up failed <nil>`,
2. built that same misleading message + `reason=InitFailed`,
3. ran its `finally` to write `state=Stopping`.

That late `Stopping` write then **raced the cancel path** (which had already moved the manager to `InstallingCanceling`), tripping the factory mismatch `expected: stopping, actual: installingCanceling` → the cancel op died with `context canceled` → a transient **`installingCancelFailed`** before the controller reconciled to `uninstalled`.

### Fix

Detect the cancellation (`waitErr == nil || c.Err() != nil`) and bail out quietly, leaving the terminal transition to the `InstallingCanceling` handler. This removes both the misleading `InitFailed` status and the status-write race, so a cancelled install now settles cleanly via `installingCanceling -> uninstalled`. The genuine-failure path (pod pending / unschedulable / real `WaitForStartUp` error) is unchanged.

## Evidence (reproduced on a live cluster)

```
12:32:40.847 installing_canceling_app.go:59  execute installing cancel operation appName=owncast
12:32:40.847 helm_ops_install.go:635          Waiting for app startup canceled appName=owncast
12:32:40.847 installing_app.go:314 (E)        wait for app owncast startup after scale-up failed <nil>   <- waitErr is nil (cancel, not failure)
12:32:40.851 state=stopping  reason=InitFailed  msg="wait for app owncast startup after scale-up failed"
12:32:40.904 factory.go:46                     state is not match, expected: stopping, actual: installingCanceling
12:32:40.907 state=installingCancelFailed                                                                   <- spurious failure shown to user
12:32:46.975 state=uninstalled                                                                              <- eventually clean
```

A normal install that is **not** cancelled is unaffected (owncast reaches `running` in ~17s).

## Test plan

- [ ] `go build ./pkg/appstate/` passes (verified locally).
- [ ] Install an app, cancel while it is still in `Init:x/3`; confirm the state goes `installingCanceling -> uninstalled` with **no** `installingCancelFailed` / `InitFailed` event emitted.
- [ ] Trigger a genuine startup failure (e.g. unschedulable pod) and confirm it still lands in `Stopping` with the appropriate `AppUnschedulable` / `InitFailed` reason.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install state-machine terminal transitions during cancel vs failure, which affects user-visible status but is narrowly scoped to the WaitForStartUp branch.
> 
> **Overview**
> When an install is cancelled while the installing flow is blocked on **`WaitForStartUp`**, the handler now treats **`(false, nil)`** or a cancelled install context as a user cancel—not a startup failure. It logs at info and returns without scheduling **`Stopping` / `InitFailed`**, so **`InstallingCanceling`** can finish to **`uninstalled`** without racing the cancel path into **`installingCancelFailed`**.
> 
> Real startup failures (non-nil **`waitErr`**, including pending/unschedulable) still set **`Stopping`** with the same reason mapping; error wrapping for those cases is slightly simplified now that the nil-error cancel case is handled first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815786ef8f077e6d62502e1f081c10c670e7e5ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->