### PR TITLE
fix(app-service): prevent queued task panic from hanging request and crashing worker

### DIFF
--- a/framework/app-service/pkg/apiserver/queue.go
+++ b/framework/app-service/pkg/apiserver/queue.go
@@ -2,7 +2,11 @@ package apiserver
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 
 	"github.com/emicklei/go-restful/v3"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -27,8 +31,16 @@ func (h *Handler) queued(next func(req *restful.Request, resp *restful.Response)
 		done := make(chan struct{})
 		t := &Task{
 			exec: func() {
+				// always release the waiting HTTP goroutine, and never let a
+				// handler panic propagate up to crash the single queue worker.
+				defer close(done)
+				defer func() {
+					if r := recover(); r != nil {
+						klog.Errorf("recovered from panic in queued task for app %s: %v\n%s", app, r, debug.Stack())
+						api.HandleError(resp, req, fmt.Errorf("internal error processing %s: %v", app, r))
+					}
+				}()
 				next(req, resp)
-				close(done)
 			},
 		}
 		h.opController.enqueue(t)


### PR DESCRIPTION
## Summary
- `queued()` wraps mutating app-service endpoints (install/uninstall/suspend/resume/upgrade/applyEnv/cancel) and blocks the HTTP goroutine on `<-done`.
- `done` was only closed after `next()` returned successfully. If the handler panicked:
  - the HTTP goroutine blocked on `<-done` **forever** (goroutine leak / hung request), and
  - the panic propagated up through the single queue worker goroutine (`go wait.Until(op.worker, ...)`), which has no recover, crashing the process.
- Fix: inside the task, `defer close(done)` guarantees the waiting goroutine is always released, and a `recover()` converts a panic into a `500` response instead of taking down the worker.

The single-worker serial queue design is intentional and unchanged; this only hardens the failure path.

## Test plan
- [ ] `go build ./...` (verified locally for `pkg/apiserver/...`)
- [ ] Trigger a handler panic on a queued endpoint and confirm the request returns `500` instead of hanging, and the worker keeps processing subsequent tasks.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change to error handling in the existing serial queue; no change to auth, data paths, or queue semantics.
> 
> **Overview**
> Hardens the **`queued()`** wrapper used for serialized app lifecycle HTTP handlers (install, uninstall, suspend, resume, upgrade, apply env, cancel).
> 
> Previously **`close(done)`** ran only after the inner handler returned, so a **panic** left the client blocked on **`<-done`** and could kill the **single queue worker** with no recovery. The task now **`defer close(done)`** so the waiting HTTP goroutine always unblocks, and a **`recover()`** logs the stack and returns a **500** via **`api.HandleError`** instead of propagating the panic. The one-worker serial queue behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd626dedcfc66dea4ae576378c8103cb00d03bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->