### PR TITLE
fix(app-service): stop handlerBuilder from swallowing informer init error

### DIFF
--- a/framework/app-service/pkg/apiserver/handler.go
+++ b/framework/app-service/pkg/apiserver/handler.go
@@ -42,6 +42,7 @@ type handlerBuilder struct {
 	kubeConfig *rest.Config
 	ctrlClient client.Client
 	informer   externalversions.SharedInformerFactory
+	err        error
 }
 
 func (b *handlerBuilder) WithKubesphereConfig(ksHost string) *handlerBuilder {
@@ -65,17 +66,23 @@ func (b *handlerBuilder) WithCtrlClient(client client.Client) *handlerBuilder {
 }
 
 func (b *handlerBuilder) WithAppInformer() *handlerBuilder {
+	if b.err != nil {
+		return b
+	}
 	appClient, err := versioned.NewForConfig(b.kubeConfig)
 	if err != nil {
-		return nil
+		b.err = fmt.Errorf("create app clientset for informer: %w", err)
+		return b
 	}
 
-	informer := externalversions.NewSharedInformerFactory(appClient, 10*time.Minute)
-	b.informer = informer
+	b.informer = externalversions.NewSharedInformerFactory(appClient, 10*time.Minute)
 	return b
 }
 
 func (b *handlerBuilder) Build() (*Handler, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
 	wh, err := webhook.New(b.kubeConfig)
 	if err != nil {
 		return nil, err
@@ -147,7 +154,7 @@ func (b *handlerBuilder) Build() (*Handler, error) {
 		appSynced:        b.informer.App().V1alpha1().Applications().Informer().HasSynced,
 		appmgrSynced:     b.informer.App().V1alpha1().ApplicationManagers().Informer().HasSynced,
 		opController:     NewQueue(b.ctx),
-	}, err
+	}, nil
 
 }
 


### PR DESCRIPTION
## Summary
- `handlerBuilder.WithAppInformer()` returned `nil` and **dropped the error** when `versioned.NewForConfig` failed.
- In `PrepareRun` the chained builder result is discarded, so the `nil` return was never observed; instead `b.informer` stayed `nil`, the error was lost, and `Build()` later dereferenced the nil informer (`b.informer.App()...`) — a nil-pointer panic at startup rather than a clean error.
- Fix: accumulate the error on the builder (`b.err`) and surface it from `Build()`. Also return `nil` instead of the always-nil `err` at the successful `Build()` exit (every prior error path already returns early).

## Test plan
- [ ] `go build ./...` (verified locally for `pkg/apiserver/...`)
- [ ] Simulate a bad kubeconfig so `WithAppInformer` fails and confirm `New(...)`/`PrepareRun` returns an error instead of panicking.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup error-handling only; no change to runtime request handling or security paths.
> 
> **Overview**
> Fixes **app-service** API handler construction so a failed application clientset/informer setup fails startup with an error instead of a nil-pointer panic.
> 
> `handlerBuilder` now keeps an accumulated `err`. When `versioned.NewForConfig` fails in `WithAppInformer`, the error is stored and later returned from `Build()` (the method still returns `*handlerBuilder` so `PrepareRun`’s fluent chain works). `Build()` also bails out early if that error is set, and on success returns `nil` for the error instead of a stale `err` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55499d823b95f4c29390df42c5009e2355cf7752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->