### PR TITLE
chore(app-service): remove kubebuilder scaffold leftovers

### DIFF
--- a/framework/app-service/README.md
+++ b/framework/app-service/README.md
@@ -39,7 +39,7 @@ make undeploy
 ```
 
 ## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
+Issues and pull requests are welcome. Please open an issue to discuss substantial changes before submitting a PR.
 
 ### How it works
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)

--- a/framework/app-service/config/samples/app_v1alpha1_application.yaml
+++ b/framework/app-service/config/samples/app_v1alpha1_application.yaml
@@ -5,7 +5,6 @@ metadata:
   labels: 
     app.bytetrade.io/name: bfl
 spec:
-  # TODO(user): Add fields here
   name: bfl
   namespace: default
   owner: admin

--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -63,18 +62,7 @@ type ApplicationReconciler struct {
 //+kubebuilder:rbac:groups=app.bytetrade.io,resources=applications/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=app.bytetrade.io,resources=applications/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Application object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-
 	ctrl.Log.Info("reconcile request", "name", req.Name, "namespace", req.Namespace)
 
 	if req.Namespace == "" {

--- a/framework/app-service/controllers/entrancestatus_controller.go
+++ b/framework/app-service/controllers/entrancestatus_controller.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -82,7 +81,6 @@ func (r *EntranceStatusManagerController) SetUpWithManager(mgr ctrl.Manager) err
 }
 
 func (r *EntranceStatusManagerController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	klog.Infof("reconcile entrance-status-manager request name=%v", req.Name)
 	var pod corev1.Pod
 	err := r.Get(ctx, req.NamespacedName, &pod)

--- a/framework/app-service/controllers/eviction_controller.go
+++ b/framework/app-service/controllers/eviction_controller.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -66,7 +65,6 @@ func (r *EvictionManagerController) SetUpWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *EvictionManagerController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	klog.Infof("reconcile entrance-status-manager request name=%v", req.Name)
 	var pod corev1.Pod
 	err := r.Get(ctx, req.NamespacedName, &pod)

--- a/framework/app-service/controllers/image_controller.go
+++ b/framework/app-service/controllers/image_controller.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -82,7 +81,6 @@ var imageManager map[string]context.CancelFunc
 
 // Reconcile implements the reconciliation loop for the ImageManagerController
 func (r *ImageManagerController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	ctrl.Log.Info("reconcile image manager request", "name", req.Name)
 
 	var im appv1alpha1.ImageManager

--- a/framework/app-service/controllers/image_info_controller.go
+++ b/framework/app-service/controllers/image_info_controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -93,7 +92,6 @@ func (r *AppImageInfoController) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile implements the reconciliation loop for the ImageManagerController
 func (r *AppImageInfoController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	ctrl.Log.Info("reconcile app image request", "name", req.Name)
 
 	var am appv1alpha1.AppImage

--- a/framework/app-service/controllers/node_alert_controller.go
+++ b/framework/app-service/controllers/node_alert_controller.go
@@ -100,7 +100,6 @@ func (r *NodeAlertController) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop
 func (r *NodeAlertController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.Infof("start reconcile node %s", req.Name)
 

--- a/framework/app-service/controllers/tailscale_acl_configmap_controller.go
+++ b/framework/app-service/controllers/tailscale_acl_configmap_controller.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -61,7 +60,6 @@ func (r *TailScaleACLConfigMapController) SetUpWithManager(mgr ctrl.Manager) err
 }
 
 func (r *TailScaleACLConfigMapController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	klog.Infof("reconcile tailscale acls configmap request name=%v, owner=%v", req.Name, req.Namespace)
 
 	headScaleNamespace := req.Namespace

--- a/framework/app-service/controllers/tailscale_acl_controller.go
+++ b/framework/app-service/controllers/tailscale_acl_controller.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -137,7 +136,6 @@ func (r *TailScaleACLController) SetUpWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *TailScaleACLController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	klog.Infof("reconcile tailscale acls subroutes request name=%v, owner=%v", req.Name, req.Namespace)
 	owner := req.Namespace
 

--- a/framework/app-service/controllers/user_controller.go
+++ b/framework/app-service/controllers/user_controller.go
@@ -180,7 +180,6 @@ func (r *UserController) registerActiveUsersHandler(mgr ctrl.Manager) error {
 	return err
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop
 func (r *UserController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.Infof("start reconcile user %s", req.Name)
 


### PR DESCRIPTION
## Summary
- Remove generated kubebuilder `TODO(user)` scaffold comments: `README.md` Contributing section, `config/samples/app_v1alpha1_application.yaml`, and the `ApplicationReconciler.Reconcile` doc block.
- Drop the dead `_ = log.FromContext(ctx)` lines (the logger was fetched and immediately discarded) across 7 controllers, and remove the now-unused `sigs.k8s.io/controller-runtime/pkg/log` imports.
- Drop the truncated `// Reconcile is part of the main kubernetes reconciliation loop` boilerplate on `UserController`/`NodeAlertController`.

No behavior change; pure comment/dead-line removal. `go build ./controllers/...` and `gofmt -l` are clean.

## Test plan
- [ ] `go build ./...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and unused-import cleanup only; reconcile logic and runtime behavior are unchanged.
> 
> **Overview**
> Removes leftover **kubebuilder** scaffold text and dead logging lines across **app-service** with no functional changes.
> 
> **Docs/samples:** Replaces the Contributing `TODO(user)` in `README.md` with real contribution guidance, and drops the placeholder comment in `config/samples/app_v1alpha1_application.yaml`.
> 
> **Controllers:** Deletes the generated `ApplicationReconciler.Reconcile` doc block and truncated `Reconcile` boilerplate on `UserController` and `NodeAlertController`. In seven controllers, removes unused `_ = log.FromContext(ctx)` calls and the corresponding `controller-runtime/pkg/log` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8174a6f812b75c3da847bbe4142aeca4144b545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->