### PR TITLE
app-service: update github.com/beclab/api to v0.0.11 and remove deprecated entries

### DIFF
--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,16 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260527130026-7c3643a772ae h1:A3L9joHnT4tigu34skjajuxUM9Qileaxgkwt6N8JXSU=
-github.com/beclab/Olares/framework/oac v0.0.0-20260527130026-7c3643a772ae/go.mod h1:iaBf3RdcyrL5TMG9aBj8o1Alp0VGXPRt4M2chksZM6A=
-github.com/beclab/Olares/framework/oac v0.0.0-20260528064621-6972be3069ba h1:WJFVLR7jh8TnujuPNqYVDC2FrPufL7QZRU8gnTDw9Xg=
-github.com/beclab/Olares/framework/oac v0.0.0-20260528064621-6972be3069ba/go.mod h1:secYnd6xRFZgzCSoL90kjEGr9eoL2HjLqwnh8g5gSTs=
 github.com/beclab/Olares/framework/oac v0.0.0-20260601121600-b2b5bb20726e h1:J4P4b519QAF+halWQJoSfJIWcezhG/g74PW5DbFYgI8=
 github.com/beclab/Olares/framework/oac v0.0.0-20260601121600-b2b5bb20726e/go.mod h1:DiZ0SUoJ5iG5aimSjdboB/tEBol14gIyLYOzoxTBkQg=
-github.com/beclab/api v0.0.8 h1:7d15aTwZh+Bgv6EgoUT0WmPUKE5tANtBT9oAlq4x6/w=
-github.com/beclab/api v0.0.8/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
-github.com/beclab/api v0.0.10 h1:+r+XRuW3fkQdt2elqpOK6Kt7g/s9RFpSELkV/XajJ7o=
-github.com/beclab/api v0.0.10/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.11 h1:jNVX+hnZ4UJoF0S2wUEjepEULrhQcAs5Oh97IPbnBtA=
 github.com/beclab/api v0.0.11/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=


### PR DESCRIPTION
* **Background**
Update github.com/beclab/api to v0.0.11 and remove deprecated entries

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency alignment with no code changes; risk is limited to transitive API behavior from the newer beclab/api/oac versions at build/runtime.
> 
> **Overview**
> **app-service** dependency lockfile is refreshed so **`github.com/beclab/api`** resolves to **v0.0.11** and **`github.com/beclab/Olares/framework/oac`** to pseudo-version **`20260601121600-b2b5bb20726e`**.
> 
> The diff only touches **`go.sum`**: it drops checksum lines for superseded **`beclab/api`** (v0.0.8, v0.0.10) and older **`framework/oac`** pseudo-versions, leaving the current module versions. No application source files change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b214f7305db51a7a9a7dcf59089eae65737491b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->