### PR TITLE
test(app-service): L1 appstate unit tests (B)

### DIFF
--- a/framework/app-service/pkg/appstate/force_delete_app_test.go
+++ b/framework/app-service/pkg/appstate/force_delete_app_test.go
@@ -1,0 +1,97 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+)
+
+func TestForceDeleteAppSystemEmptyConfig(t *testing.T) {
+	am := testutil.NewAppManager("nginx",
+		testutil.WithSource("system"),
+		testutil.WithConfigJSON(""),
+		testutil.WithState(appsv1.Uninstalling),
+	)
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	if err := b.forceDeleteApp(context.TODO()); err != nil {
+		t.Fatalf("forceDeleteApp: %v", err)
+	}
+	got := getAM(t, b, "nginx")
+	if got.Status.State != appsv1.Uninstalled {
+		t.Errorf("state=%q want Uninstalled", got.Status.State)
+	}
+}
+
+func TestForceDeleteAppNormalUninstalls(t *testing.T) {
+	cfg := &appcfg.ApplicationConfig{AppName: "nginx", Namespace: "nginx-alice", OwnerName: "alice"}
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfg),
+		testutil.WithState(appsv1.Uninstalling),
+	)
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	if err := b.forceDeleteApp(context.TODO()); err != nil {
+		t.Fatalf("forceDeleteApp: %v", err)
+	}
+	if fake.CallCount("Uninstall") != 1 {
+		t.Errorf("Uninstall called %d times, want 1", fake.CallCount("Uninstall"))
+	}
+	if got := getAM(t, b, "nginx"); got.Status.State != appsv1.Uninstalled {
+		t.Errorf("state=%q want Uninstalled", got.Status.State)
+	}
+}
+
+func TestForceDeleteAppToleratesNotFound(t *testing.T) {
+	cfg := &appcfg.ApplicationConfig{AppName: "nginx", Namespace: "nginx-alice", OwnerName: "alice"}
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfg),
+		testutil.WithState(appsv1.Uninstalling),
+	)
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	fake := testutil.NewFakeHelmOps()
+	fake.UninstallErr = errors.New("release: not found")
+	injectHelmOps(t, fake)
+
+	if err := b.forceDeleteApp(context.TODO()); err != nil {
+		t.Fatalf("forceDeleteApp should tolerate not-found: %v", err)
+	}
+	if got := getAM(t, b, "nginx"); got.Status.State != appsv1.Uninstalled {
+		t.Errorf("state=%q want Uninstalled", got.Status.State)
+	}
+}
+
+func TestForceDeleteAppPropagatesHelmError(t *testing.T) {
+	cfg := &appcfg.ApplicationConfig{AppName: "nginx", Namespace: "nginx-alice", OwnerName: "alice"}
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfg),
+		testutil.WithState(appsv1.Uninstalling),
+	)
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	fake := testutil.NewFakeHelmOps()
+	fake.UninstallErr = errors.New("helm boom")
+	injectHelmOps(t, fake)
+
+	if err := b.forceDeleteApp(context.TODO()); err == nil {
+		t.Fatal("forceDeleteApp should propagate non-not-found helm error")
+	}
+	if got := getAM(t, b, "nginx"); got.Status.State == appsv1.Uninstalled {
+		t.Error("state should not be Uninstalled when uninstall failed")
+	}
+}

--- a/framework/app-service/pkg/appstate/is_startup_test.go
+++ b/framework/app-service/pkg/appstate/is_startup_test.go
@@ -1,0 +1,54 @@
+package appstate
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+)
+
+func TestIsStartUpReadyPod(t *testing.T) {
+	dep := testutil.NewDeployment("nginx", "nginx-alice", 1)
+	pod := testutil.NewReadyPod("nginx-abc", "nginx-alice", map[string]string{"app": "nginx"})
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	c := testutil.NewFakeClient(dep, pod, am)
+
+	ok, err := isStartUp(am, c)
+	if err != nil {
+		t.Fatalf("isStartUp: %v", err)
+	}
+	if !ok {
+		t.Error("expected started up = true for a ready pod")
+	}
+}
+
+func TestIsStartUpNoPods(t *testing.T) {
+	dep := testutil.NewDeployment("nginx", "nginx-alice", 1)
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	c := testutil.NewFakeClient(dep, am)
+
+	ok, err := isStartUp(am, c)
+	if err == nil {
+		t.Error("expected error when no pods are found")
+	}
+	if ok {
+		t.Error("expected started up = false when no pods are found")
+	}
+}
+
+func TestIsStartUpNotStarted(t *testing.T) {
+	dep := testutil.NewDeployment("nginx", "nginx-alice", 1)
+	pod := testutil.NewReadyPod("nginx-abc", "nginx-alice", map[string]string{"app": "nginx"})
+	notStarted := false
+	pod.Status.ContainerStatuses[0].Started = &notStarted
+	pod.Status.ContainerStatuses[0].Ready = false
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	c := testutil.NewFakeClient(dep, pod, am)
+
+	ok, err := isStartUp(am, c)
+	if err != nil {
+		t.Fatalf("isStartUp: %v", err)
+	}
+	if ok {
+		t.Error("expected started up = false for a not-started container")
+	}
+}

--- a/framework/app-service/pkg/appstate/seams_test_helper_test.go
+++ b/framework/app-service/pkg/appstate/seams_test_helper_test.go
@@ -1,0 +1,44 @@
+package appstate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+
+	"k8s.io/client-go/rest"
+)
+
+// injectHelmOps overrides the package-level newHelmOps/getKubeConfig seams to
+// return the supplied fake, restoring them when the test ends. Tests using it
+// must not run in parallel.
+func injectHelmOps(t *testing.T, f *testutil.FakeHelmOps) {
+	t.Helper()
+	origNew := newHelmOps
+	origCfg := getKubeConfig
+	newHelmOps = func(ctx context.Context, kubeConfig *rest.Config, app *appcfg.ApplicationConfig, token string, options appinstaller.Opt) (appinstaller.HelmOpsInterface, error) {
+		return f, nil
+	}
+	getKubeConfig = func() (*rest.Config, error) { return &rest.Config{}, nil }
+	t.Cleanup(func() {
+		newHelmOps = origNew
+		getKubeConfig = origCfg
+	})
+}
+
+// injectHelmOpsError makes the newHelmOps seam fail to construct.
+func injectHelmOpsError(t *testing.T, err error) {
+	t.Helper()
+	origNew := newHelmOps
+	origCfg := getKubeConfig
+	newHelmOps = func(ctx context.Context, kubeConfig *rest.Config, app *appcfg.ApplicationConfig, token string, options appinstaller.Opt) (appinstaller.HelmOpsInterface, error) {
+		return nil, err
+	}
+	getKubeConfig = func() (*rest.Config, error) { return &rest.Config{}, nil }
+	t.Cleanup(func() {
+		newHelmOps = origNew
+		getKubeConfig = origCfg
+	})
+}

--- a/framework/app-service/pkg/appstate/suspend_resume_test.go
+++ b/framework/app-service/pkg/appstate/suspend_resume_test.go
@@ -1,0 +1,112 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+
+	k8sappsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestSuspendThenResumeViaPatch(t *testing.T) {
+	dep := testutil.NewDeployment("nginx", "nginx-alice", 1)
+	sts := testutil.NewStatefulSet("nginx-sts", "nginx-alice", 2)
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	c := testutil.NewFakeClient(dep, sts, am)
+
+	if err := suspendV1AppOrV2Client(context.TODO(), c, am); err != nil {
+		t.Fatalf("suspend: %v", err)
+	}
+	var d k8sappsv1.Deployment
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "nginx", Namespace: "nginx-alice"}, &d); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if *d.Spec.Replicas != 0 {
+		t.Errorf("suspended replicas=%d want 0", *d.Spec.Replicas)
+	}
+	if d.Annotations[suspendAnnotation] != "app-service" {
+		t.Errorf("missing suspend annotation: %v", d.Annotations)
+	}
+	var s k8sappsv1.StatefulSet
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "nginx-sts", Namespace: "nginx-alice"}, &s); err != nil {
+		t.Fatalf("get sts: %v", err)
+	}
+	if *s.Spec.Replicas != 0 {
+		t.Errorf("suspended sts replicas=%d want 0", *s.Spec.Replicas)
+	}
+
+	if err := resumeV1AppOrV2AppClient(context.TODO(), c, am); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "nginx", Namespace: "nginx-alice"}, &d); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if *d.Spec.Replicas != 1 {
+		t.Errorf("resumed replicas=%d want 1", *d.Spec.Replicas)
+	}
+}
+
+// workloadReplicas config routes suspend/resume through helm Scale.
+func cfgWithReplicas() *appcfg.ApplicationConfig {
+	wr := appcfg.WorkloadReplicas{"nginx": 1}
+	return &appcfg.ApplicationConfig{AppName: "nginx", Namespace: "nginx-alice", OwnerName: "alice", WorkloadReplicas: &wr}
+}
+
+func TestScaleOrPatchResumeUsesHelmScaleUp(t *testing.T) {
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfgWithReplicas()),
+	)
+	c := testutil.NewFakeClient(am)
+	p := &ResumingApp{&baseOperationApp{baseStatefulApp: &baseStatefulApp{manager: am, client: c}}}
+
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	if err := p.scaleOrPatchResume(context.TODO(), false); err != nil {
+		t.Fatalf("scaleOrPatchResume: %v", err)
+	}
+	if got := fake.ScaleReplicas(); len(got) != 1 || got[0] != -1 {
+		t.Errorf("Scale args=%v want [-1]", got)
+	}
+}
+
+func TestScaleOrPatchSuspendUsesHelmScaleToZero(t *testing.T) {
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfgWithReplicas()),
+	)
+	c := testutil.NewFakeClient(am)
+	p := &SuspendingApp{&baseOperationApp{baseStatefulApp: &baseStatefulApp{manager: am, client: c}}}
+
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	if err := p.scaleOrPatchSuspend(context.TODO(), false); err != nil {
+		t.Fatalf("scaleOrPatchSuspend: %v", err)
+	}
+	if got := fake.ScaleReplicas(); len(got) != 1 || got[0] != 0 {
+		t.Errorf("Scale args=%v want [0]", got)
+	}
+}
+
+func TestScaleOrPatchResumePropagatesScaleError(t *testing.T) {
+	am := testutil.NewAppManager("nginx",
+		testutil.WithNamespace("nginx-alice"),
+		testutil.WithConfig(t, cfgWithReplicas()),
+	)
+	c := testutil.NewFakeClient(am)
+	p := &ResumingApp{&baseOperationApp{baseStatefulApp: &baseStatefulApp{manager: am, client: c}}}
+
+	fake := testutil.NewFakeHelmOps()
+	fake.ScaleErr = errors.New("scale boom")
+	injectHelmOps(t, fake)
+
+	if err := p.scaleOrPatchResume(context.TODO(), false); err == nil {
+		t.Fatal("expected scale error to propagate")
+	}
+}

--- a/framework/app-service/pkg/appstate/update_status_test.go
+++ b/framework/app-service/pkg/appstate/update_status_test.go
@@ -1,0 +1,94 @@
+package appstate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func getAM(t *testing.T, b *baseStatefulApp, name string) *appsv1.ApplicationManager {
+	t.Helper()
+	var am appsv1.ApplicationManager
+	if err := b.client.Get(context.TODO(), types.NamespacedName{Name: name}, &am); err != nil {
+		t.Fatalf("get AM %s: %v", name, err)
+	}
+	return &am
+}
+
+func TestUpdateStatusIncrementsGenerationAndPrependsRecord(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithState(appsv1.Installing))
+	am.Status.OpGeneration = 5
+	am.Status.OpRecords = []appsv1.OpRecord{{OpID: "old", Message: "old"}}
+
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	now := metav1.Now()
+	rec := &appsv1.OpRecord{OpID: "new", Message: "new", StateTime: &now}
+	if err := b.updateStatus(context.TODO(), am, appsv1.Running, rec, "done", "reason"); err != nil {
+		t.Fatalf("updateStatus: %v", err)
+	}
+
+	got := getAM(t, b, "nginx")
+	if got.Status.State != appsv1.Running {
+		t.Errorf("state=%q want Running", got.Status.State)
+	}
+	if got.Status.Message != "done" || got.Status.Reason != "reason" {
+		t.Errorf("message/reason=%q/%q", got.Status.Message, got.Status.Reason)
+	}
+	if got.Status.OpGeneration != 6 {
+		t.Errorf("OpGeneration=%d want 6", got.Status.OpGeneration)
+	}
+	if len(got.Status.OpRecords) != 2 {
+		t.Fatalf("OpRecords len=%d want 2", len(got.Status.OpRecords))
+	}
+	if got.Status.OpRecords[0].OpID != "new" {
+		t.Errorf("newest record not prepended: %q", got.Status.OpRecords[0].OpID)
+	}
+}
+
+func TestUpdateStatusCapsRecordsAt20(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithState(appsv1.Installing))
+	existing := make([]appsv1.OpRecord, 20)
+	for i := range existing {
+		existing[i] = appsv1.OpRecord{OpID: "old"}
+	}
+	am.Status.OpRecords = existing
+
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	now := metav1.Now()
+	rec := &appsv1.OpRecord{OpID: "new", StateTime: &now}
+	if err := b.updateStatus(context.TODO(), am, appsv1.Running, rec, "msg", ""); err != nil {
+		t.Fatalf("updateStatus: %v", err)
+	}
+
+	got := getAM(t, b, "nginx")
+	if len(got.Status.OpRecords) != 20 {
+		t.Fatalf("OpRecords len=%d want 20 (capped)", len(got.Status.OpRecords))
+	}
+	if got.Status.OpRecords[0].OpID != "new" {
+		t.Errorf("newest record should be first, got %q", got.Status.OpRecords[0].OpID)
+	}
+}
+
+func TestUpdateStatusNilRecordKeepsRecords(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithState(appsv1.Installing))
+	am.Status.OpRecords = []appsv1.OpRecord{{OpID: "old"}}
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	if err := b.updateStatus(context.TODO(), am, appsv1.Running, nil, "msg", ""); err != nil {
+		t.Fatalf("updateStatus: %v", err)
+	}
+	got := getAM(t, b, "nginx")
+	if len(got.Status.OpRecords) != 1 {
+		t.Errorf("OpRecords len=%d want 1 (unchanged)", len(got.Status.OpRecords))
+	}
+}

--- a/framework/app-service/pkg/testutil/client.go
+++ b/framework/app-service/pkg/testutil/client.go
@@ -8,12 +8,18 @@ import (
 )
 
 // NewFakeClient builds a fake controller-runtime client with the app-service
-// scheme and the status subresource enabled for ApplicationManager and
-// Application, which the appstate code patches via client.Status-style merges.
+// scheme.
+//
+// Only Application is registered as a status subresource: its CRD declares
+// subresources.status, so its status must be written via Status().Update/Patch.
+// ApplicationManager's CRD declares an empty subresources block (no /status),
+// so appstate.updateStatus persists status through a plain Patch; registering
+// it as a status subresource here would make the fake client silently drop
+// those status writes.
 func NewFakeClient(objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(NewScheme()).
-		WithStatusSubresource(&appv1alpha1.ApplicationManager{}, &appv1alpha1.Application{}).
+		WithStatusSubresource(&appv1alpha1.Application{}).
 		WithObjects(objs...).
 		Build()
 }


### PR DESCRIPTION
## Summary
L1 unit tests for the `appstate` state machine, using the fake client + `FakeHelmOps` from PR A.

- `updateStatus`: OpGeneration increment, newest-record prepend, 20-record cap, nil-record no-op.
- `forceDeleteApp`: system/empty-config short-circuit, helm uninstall via seam, `not found` tolerance, non-not-found error propagation.
- suspend/resume: direct-patch path (Deployment/StatefulSet replicas + suspend annotations) and helm `Scale(-1)`/`Scale(0)` routing, plus scale-error propagation.
- `isStartUp`: ready pod, no-pods error, not-started container.

## Stack
A → **B** → C → E → F. Base: `feat/as-tests-a-seams-l0`.

## Test plan
- [ ] `go test -race ./pkg/appstate/`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a test fake client fix; no production appstate or runtime behavior is modified.
> 
> **Overview**
> Adds **L1 unit tests** for `appstate` using the fake K8s client and injectable Helm seams (`injectHelmOps` / `injectHelmOpsError`).
> 
> Coverage includes **`updateStatus`** (OpGeneration bump, prepending op records, 20-record cap, nil record), **`forceDeleteApp`** (system/empty config, Helm uninstall, tolerating not-found, propagating other errors), **suspend/resume** (patch replicas/annotations on Deployment/StatefulSet vs Helm `Scale(0)` / `Scale(-1)` when `WorkloadReplicas` is set), and **`isStartUp`** (ready pod, no pods, container not started).
> 
> **`testutil.NewFakeClient`** now registers only **`Application`** as a status subresource so **`ApplicationManager`** status updates via plain `Patch` (matching the CRD) are not dropped by the fake client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e89834b8971c131da38f2b6e74f29285c72ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->