### PR TITLE
test(app-service): L1 apiserver tests (C)

### DIFF
--- a/framework/app-service/pkg/apiserver/apps_status_test.go
+++ b/framework/app-service/pkg/apiserver/apps_status_test.go
@@ -1,0 +1,148 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	appfake "github.com/beclab/api/pkg/generated/clientset/versioned/fake"
+	"github.com/beclab/api/pkg/generated/informers/externalversions"
+
+	"github.com/emicklei/go-restful/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func amObj(name, owner, appName string, state appv1alpha1.ApplicationManagerState, v3 bool) *appv1alpha1.ApplicationManager {
+	labels := map[string]string{}
+	if v3 {
+		labels[appv1alpha1.AppApiVersionLabel] = appv1alpha1.AppVersionV3
+	}
+	return &appv1alpha1.ApplicationManager{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec: appv1alpha1.ApplicationManagerSpec{
+			AppName:      appName,
+			AppNamespace: appName + "-" + owner,
+			AppOwner:     owner,
+			Source:       "market",
+			Type:         appv1alpha1.App,
+		},
+		Status: appv1alpha1.ApplicationManagerStatus{State: state},
+	}
+}
+
+func newHandlerWithAMs(t *testing.T, ams ...*appv1alpha1.ApplicationManager) *Handler {
+	t.Helper()
+	objs := make([]runtime.Object, 0, len(ams))
+	for _, am := range ams {
+		objs = append(objs, am)
+	}
+	client := appfake.NewSimpleClientset(objs...)
+	factory := externalversions.NewSharedInformerFactory(client, 0)
+	lister := factory.App().V1alpha1().ApplicationManagers().Lister()
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	synced := factory.WaitForCacheSync(stop)
+	for typ, ok := range synced {
+		if !ok {
+			t.Fatalf("informer cache for %v failed to sync", typ)
+		}
+	}
+	return &Handler{appmgrLister: lister}
+}
+
+type appsStatusResult struct {
+	Result []struct {
+		Name string `json:"name"`
+	} `json:"result"`
+}
+
+func callAppsStatus(t *testing.T, h *Handler, owner, query string) appsStatusResult {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodGet, "/apps?"+query, nil)
+	req := restful.NewRequest(httpReq)
+	req.SetAttribute(constants.UserContextAttribute, owner)
+	rec := httptest.NewRecorder()
+	resp := restful.NewResponse(rec)
+	resp.SetRequestAccepts(restful.MIME_JSON)
+
+	h.appsStatus(req, resp)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("appsStatus status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var out appsStatusResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rec.Body.String())
+	}
+	return out
+}
+
+func names(r appsStatusResult) map[string]bool {
+	m := map[string]bool{}
+	for _, a := range r.Result {
+		m[a.Name] = true
+	}
+	return m
+}
+
+func TestAppsStatusFiltersByOwnerAndV3(t *testing.T) {
+	h := newHandlerWithAMs(t,
+		amObj("a1", "alice", "nginx", appv1alpha1.Running, false),
+		amObj("a2", "bob", "mysql", appv1alpha1.Running, false),
+		amObj("a3", "bob", "shared", appv1alpha1.Running, true), // v3, visible to all
+	)
+	// wait until lister sees all three before asserting (List is eventually consistent).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got := names(callAppsStatus(t, h, "alice", ""))
+		if got["nginx"] && got["shared"] || time.Now().After(deadline) {
+			if got["mysql"] {
+				t.Errorf("alice should not see bob's non-v3 app, got %v", got)
+			}
+			if !got["nginx"] {
+				t.Errorf("alice should see her own app, got %v", got)
+			}
+			if !got["shared"] {
+				t.Errorf("alice should see the v3 app, got %v", got)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestAppsStatusFiltersByState(t *testing.T) {
+	h := newHandlerWithAMs(t,
+		amObj("a1", "alice", "nginx", appv1alpha1.Running, false),
+		amObj("a2", "alice", "redis", appv1alpha1.Stopped, false),
+	)
+	got := names(callAppsStatus(t, h, "alice", "state="+appv1alpha1.Running.String()))
+	if !got["nginx"] {
+		t.Errorf("running app nginx should be present, got %v", got)
+	}
+	if got["redis"] {
+		t.Errorf("stopped app redis should be filtered out, got %v", got)
+	}
+}
+
+func TestAppsStatusFiltersBySysApp(t *testing.T) {
+	t.Setenv("SYS_APPS", "settings")
+	h := newHandlerWithAMs(t,
+		amObj("a1", "alice", "settings", appv1alpha1.Running, false),
+		amObj("a2", "alice", "nginx", appv1alpha1.Running, false),
+	)
+	got := names(callAppsStatus(t, h, "alice", "issysapp=true"))
+	if !got["settings"] {
+		t.Errorf("system app settings should be present, got %v", got)
+	}
+	if got["nginx"] {
+		t.Errorf("non-system app nginx should be filtered out, got %v", got)
+	}
+}

--- a/framework/app-service/pkg/apiserver/handler_builder_test.go
+++ b/framework/app-service/pkg/apiserver/handler_builder_test.go
@@ -1,0 +1,33 @@
+package apiserver
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Regression for #3225: when WithAppInformer fails to build a clientset the
+// error must be carried into Build() and returned, not swallowed into a
+// nil-pointer panic.
+func TestHandlerBuilderPropagatesInformerError(t *testing.T) {
+	// exec and auth providers are mutually exclusive, so clientset
+	// construction fails deterministically without any cluster.
+	cfg := &rest.Config{
+		Host:         "http://localhost:8080",
+		ExecProvider: &clientcmdapi.ExecConfig{},
+		AuthProvider: &clientcmdapi.AuthProviderConfig{Name: "x"},
+	}
+	b := (&handlerBuilder{kubeConfig: cfg}).WithAppInformer()
+	if b.err == nil {
+		t.Fatal("WithAppInformer should record an error for conflicting exec/auth providers")
+	}
+
+	h, err := b.Build()
+	if err == nil {
+		t.Fatal("Build should return the accumulated informer error")
+	}
+	if h != nil {
+		t.Errorf("Build should return a nil handler on error, got %#v", h)
+	}
+}

--- a/framework/app-service/pkg/apiserver/queue_test.go
+++ b/framework/app-service/pkg/apiserver/queue_test.go
@@ -1,0 +1,117 @@
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/emicklei/go-restful/v3"
+)
+
+func startedQueue(t *testing.T) *OpController {
+	t.Helper()
+	op := NewQueue(context.Background())
+	go op.worker()
+	t.Cleanup(func() { op.wq.ShutDown() })
+	return op
+}
+
+func newRestful() (*restful.Request, *restful.Response, *httptest.ResponseRecorder) {
+	httpReq := httptest.NewRequest(http.MethodGet, "/apps/nginx/status", nil)
+	req := restful.NewRequest(httpReq)
+	rec := httptest.NewRecorder()
+	resp := restful.NewResponse(rec)
+	resp.SetRequestAccepts(restful.MIME_JSON)
+	return req, resp, rec
+}
+
+// Regression for #3224: a panic in the wrapped handler must not hang the
+// waiting HTTP goroutine, must surface a 500, and must not kill the worker.
+func TestQueuedRecoversPanicAndReleasesCaller(t *testing.T) {
+	op := startedQueue(t)
+	h := &Handler{opController: op}
+
+	req, resp, rec := newRestful()
+	wrapped := h.queued(func(_ *restful.Request, _ *restful.Response) {
+		panic("boom")
+	})
+
+	done := make(chan struct{})
+	go func() { wrapped(req, resp); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued handler hung after panic (caller not released)")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status after panic=%d want 500", rec.Code)
+	}
+
+	// The single worker must survive the panic and process a later task.
+	req2, resp2, _ := newRestful()
+	ran := false
+	wrapped2 := h.queued(func(_ *restful.Request, r *restful.Response) {
+		ran = true
+		r.WriteHeader(http.StatusOK)
+	})
+	done2 := make(chan struct{})
+	go func() { wrapped2(req2, resp2); close(done2) }()
+	select {
+	case <-done2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not survive the panic")
+	}
+	if !ran {
+		t.Error("subsequent task did not run after panic")
+	}
+}
+
+func TestQueuedPassesThroughNormally(t *testing.T) {
+	op := startedQueue(t)
+	h := &Handler{opController: op}
+	req, resp, rec := newRestful()
+	h.queued(func(_ *restful.Request, r *restful.Response) {
+		r.WriteHeader(http.StatusCreated)
+	})(req, resp)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status=%d want 201", rec.Code)
+	}
+}
+
+// The single worker must serialize all queued tasks: no two run concurrently.
+func TestQueuedSerializesTasks(t *testing.T) {
+	op := startedQueue(t)
+	h := &Handler{opController: op}
+
+	const n = 20
+	var mu sync.Mutex
+	concurrent, maxConcurrent := 0, 0
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, resp, _ := newRestful()
+			h.queued(func(_ *restful.Request, _ *restful.Response) {
+				mu.Lock()
+				concurrent++
+				if concurrent > maxConcurrent {
+					maxConcurrent = concurrent
+				}
+				mu.Unlock()
+				time.Sleep(time.Millisecond)
+				mu.Lock()
+				concurrent--
+				mu.Unlock()
+			})(req, resp)
+		}()
+	}
+	wg.Wait()
+	if maxConcurrent != 1 {
+		t.Errorf("max concurrent tasks=%d want 1 (single serial worker)", maxConcurrent)
+	}
+}


### PR DESCRIPTION
## Summary
L1 tests for the apiserver layer, protecting the two merged bug fixes and the status-listing filters.

- `queued`: panic recovery + caller release + worker survival (#3224 regression), normal pass-through, single-worker serialization.
- `handlerBuilder`: `WithAppInformer` error is carried into `Build()` rather than swallowed (#3225 regression).
- `appsStatus`: owner / v3-visibility / state / issysapp filtering via an informer-backed lister built on the fake clientset.

## Stack
A → B → **C** → E → F. Base: `feat/as-tests-b-appstate`.

## Test plan
- [ ] `go test -race ./pkg/apiserver/...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or API behavior changes.
> 
> **Overview**
> Adds **L1 apiserver tests** only (no production code changes): new `*_test.go` files under `pkg/apiserver` that lock in behavior for the request queue, handler builder, and app status listing.
> 
> **`queue_test.go`** covers `queued` handlers: panics return **500**, unblock the caller, keep the worker alive, normal status pass-through, and **single-worker serialization** (regression for #3224).
> 
> **`handler_builder_test.go`** asserts `WithAppInformer` clientset failures are stored on the builder and returned from `Build()` with a nil handler (regression for #3225).
> 
> **`apps_status_test.go`** drives `appsStatus` via a fake clientset + synced informer lister and checks filtering by **owner**, **v3 shared visibility**, **`state`**, and **`issysapp`** / `SYS_APPS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc2d5d79160385adb1e96f3a4d338f4f550b241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->