### PR TITLE
test(app-service): envtest controller harness + integration specs (E)

### DIFF
--- a/framework/app-service/controllers/application_controller_test.go
+++ b/framework/app-service/controllers/application_controller_test.go
@@ -1,0 +1,102 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// These specs run against a real API server (envtest) and validate the
+// status-subresource assumptions that the appstate / controller code relies
+// on, plus the optimistic-locking retry path.
+
+var _ = Describe("ApplicationManager status", func() {
+	It("persists status through a plain Patch (CRD has no /status subresource)", func() {
+		am := &appv1alpha1.ApplicationManager{
+			ObjectMeta: metav1.ObjectMeta{Name: "am-plain-patch"},
+			Spec: appv1alpha1.ApplicationManagerSpec{
+				AppName: "nginx", AppNamespace: "nginx-alice", AppOwner: "alice",
+				Source: "market", Type: appv1alpha1.App, OpType: appv1alpha1.InstallOp,
+			},
+		}
+		Expect(k8sClient.Create(suiteCtx, am)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(suiteCtx, am) })
+
+		base := am.DeepCopy()
+		am.Status.State = appv1alpha1.Running
+		am.Status.OpGeneration = 1
+		Expect(k8sClient.Patch(suiteCtx, am, client.MergeFrom(base))).To(Succeed())
+
+		var got appv1alpha1.ApplicationManager
+		Expect(k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(am), &got)).To(Succeed())
+		Expect(got.Status.State).To(Equal(appv1alpha1.Running))
+		Expect(got.Status.OpGeneration).To(Equal(int64(1)))
+	})
+
+	It("retries on conflict when two writers race (RetryOnConflict)", func() {
+		am := &appv1alpha1.ApplicationManager{
+			ObjectMeta: metav1.ObjectMeta{Name: "am-conflict"},
+			Spec: appv1alpha1.ApplicationManagerSpec{
+				AppName: "nginx", AppNamespace: "nginx-bob", AppOwner: "bob",
+				Source: "market", Type: appv1alpha1.App, OpType: appv1alpha1.InstallOp,
+			},
+		}
+		Expect(k8sClient.Create(suiteCtx, am)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(suiteCtx, am) })
+
+		// Two stale copies of the same generation. Patching the first bumps the
+		// resourceVersion; a stale Update from the second must conflict, and the
+		// retry helper must reload and succeed.
+		first := am.DeepCopy()
+		first.Status.Message = "first"
+		Expect(k8sClient.Patch(suiteCtx, first, client.MergeFrom(am))).To(Succeed())
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var latest appv1alpha1.ApplicationManager
+			if err := k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(am), &latest); err != nil {
+				return err
+			}
+			latest.Status.Message = "second"
+			return k8sClient.Update(suiteCtx, &latest)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got appv1alpha1.ApplicationManager
+		Expect(k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(am), &got)).To(Succeed())
+		Expect(got.Status.Message).To(Equal("second"))
+	})
+})
+
+var _ = Describe("Application status", func() {
+	It("ignores status on a plain object update but persists it via Status() (CRD has /status subresource)", func() {
+		app := &appv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-subresource"},
+			Spec:       appv1alpha1.ApplicationSpec{Name: "nginx", Namespace: "nginx-alice", Owner: "alice"},
+		}
+		Expect(k8sClient.Create(suiteCtx, app)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(suiteCtx, app) })
+
+		// A plain Update carrying a status change must NOT persist the status.
+		app.Status.State = "running"
+		Expect(k8sClient.Update(suiteCtx, app)).To(Succeed())
+		var afterPlain appv1alpha1.Application
+		Expect(k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(app), &afterPlain)).To(Succeed())
+		Expect(afterPlain.Status.State).To(BeEmpty())
+
+		// Status().Update must persist it. The CRD marks statusTime/updateTime
+		// as required, so set them too.
+		now := metav1.Now()
+		afterPlain.Status.State = "running"
+		afterPlain.Status.StatusTime = &now
+		afterPlain.Status.UpdateTime = &now
+		Expect(k8sClient.Status().Update(suiteCtx, &afterPlain)).To(Succeed())
+		var afterStatus appv1alpha1.Application
+		Expect(k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(app), &afterStatus)).To(Succeed())
+		Expect(afterStatus.Status.State).To(Equal("running"))
+	})
+})

--- a/framework/app-service/controllers/suite_test.go
+++ b/framework/app-service/controllers/suite_test.go
@@ -1,12 +1,65 @@
 package controllers
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"testing"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+	suiteCtx  context.Context
+	cancel    context.CancelFunc
 )
 
 func TestControllers(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; run `make test-unit-envtest` or setup-envtest to enable controller integration tests")
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "app manager controllers suite")
 }
+
+var _ = BeforeSuite(func() {
+	suiteCtx, cancel = context.WithCancel(context.TODO())
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", ".olares", "config", "cluster", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(appv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(sysv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	if cancel != nil {
+		cancel()
+	}
+	if testEnv != nil {
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+})


### PR DESCRIPTION
## Summary
Replaces the empty Ginkgo runner with a real envtest harness and adds integration specs that validate, against a real API server, the assumptions the code relies on.

- `controllers/suite_test.go`: boots `envtest.Environment` with CRDs from `.olares/config/cluster/crds`; skips cleanly when `KUBEBUILDER_ASSETS` is unset.
- Specs: `ApplicationManager` status persists via a plain `Patch` (no `/status` subresource) and survives a `RetryOnConflict` race; `Application` status only persists via `Status()` (has `/status`).

## Stack
A → B → C → **E** → F. Base: `feat/as-tests-c-apiserver`.

(No PR D: the plan's L1.5 layer — rapid/random/resource-limited — was not implemented.)

## Test plan
- [ ] `KUBEBUILDER_ASSETS=$(setup-envtest use 1.24.2 -p path) go test ./controllers/`
- [ ] `go test ./controllers/` with no assets → suite skips

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified; validates existing CRD/status assumptions for controllers.
> 
> **Overview**
> Adds a **controller-runtime envtest** harness for `app-service/controllers` and integration specs that lock in how **`ApplicationManager`** vs **`Application`** status must be written against the real API server.
> 
> The suite boots envtest with cluster CRDs from `.olares/config/cluster/crds`, registers app/sys schemes, and **skips** when `KUBEBUILDER_ASSETS` is unset (so plain `go test` stays lightweight). New specs assert **`ApplicationManager`** status persists via a plain **`Patch`** (no `/status` subresource) and that **`RetryOnConflict`** recovers when two writers race; **`Application`** status is **not** applied on a plain **`Update`** but **does** persist via **`Status().Update`** (with required status timestamps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ccfa3c43c10d4013eabb68f0dd25ae4aa6eb95b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->