### PR TITLE
fix(app-service): two compute-allocation bugs (own-claim re-allocation, lost first-create)

### DIFF
--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -266,7 +266,7 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		return nil, err
 	}
 	if len(selections) == 0 {
-		nodes, err := FetchNodeComputeAllocations(ctx, c)
+		nodes, err := FetchNodeComputeAllocationsExcludingApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
 		if err != nil {
 			return nil, err
 		}
@@ -281,6 +281,7 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 	var allocations []Allocation
 	var unavailable *BindingApplyResult
 	if _, err := mutateAllocations(ctx, c, func(nodes []Node, existing []Allocation) ([]Allocation, *Allocation, error) {
+		attachBindings(nodes, withoutAppAllocations(existing, appConfig.AppName, appConfig.OwnerName))
 		resolved, resolveErr := resolveSelection(selections, nodes)
 		if resolveErr != nil {
 			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error()))

--- a/framework/app-service/pkg/compute/reallocation_regression_test.go
+++ b/framework/app-service/pkg/compute/reallocation_regression_test.go
@@ -1,0 +1,99 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+// TestPickAllocationsExcludesOwnExistingClaim is a regression test for the
+// re-allocation bug: when an app already held an exclusive GPU, attaching its
+// own allocation as a binding made deviceAvailableMemory report zero free
+// memory, so PickAllocations could not re-place the app on the card it already
+// owned. A re-install or a manual re-bind therefore failed with "no available
+// compute resource" even though replaceAppAllocations is designed to support
+// re-allocation. AllocateForInstall and ApplyBindingSelection now attach the
+// node view with the app's own allocation excluded (withoutAppAllocations);
+// this test pins both the buggy precondition (own binding counted) and the
+// fixed behavior (own binding excluded) on the pure PickAllocations path.
+func TestPickAllocationsExcludesOwnExistingClaim(t *testing.T) {
+	const appName, owner = "stable-diffusion", "alice"
+	app := &appcfg.ApplicationConfig{
+		AppName:         appName,
+		OwnerName:       owner,
+		SelectedGpuType: utils.NvidiaCardType,
+		Accelerator: []appcfg.ResourceMode{
+			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
+		},
+	}
+	req, ok := SelectedRequirement(app)
+	if !ok {
+		t.Fatalf("expected a selected requirement for the nvidia app")
+	}
+
+	own := Allocation{
+		AppName:  appName,
+		Owner:    owner,
+		Mode:     utils.NvidiaCardType,
+		NodeName: "nvidia-a",
+		DeviceID: "gpu0",
+	}
+	newNodes := func() []Node {
+		return []Node{nvidiaNode("nvidia-a", Device{
+			ID:          "gpu0",
+			Memory:      16 * gi,
+			Health:      deviceHealthYes,
+			SupportType: SupportTypeExclusive,
+		})}
+	}
+
+	// Precondition (the bug): counting the app's own claim makes the single
+	// exclusive card look fully occupied, so no placement is found.
+	withOwn := newNodes()
+	attachBindings(withOwn, []Allocation{own})
+	if _, ok := PickAllocations(app, req, withOwn, PressureSnapshot{}); ok {
+		t.Fatalf("with the app's own binding attached the exclusive card should look occupied")
+	}
+
+	// The fix: excluding the app's own claim lets it re-take its own card.
+	withoutOwn := newNodes()
+	attachBindings(withoutOwn, withoutAppAllocations([]Allocation{own}, appName, owner))
+	picked, ok := PickAllocations(app, req, withoutOwn, PressureSnapshot{})
+	if !ok {
+		t.Fatalf("re-allocation must succeed once the app's own claim is excluded")
+	}
+	if len(picked) != 1 || picked[0].NodeName != "nvidia-a" || picked[0].DeviceID != "gpu0" {
+		t.Fatalf("expected the app to be re-placed on gpu0, got %#v", picked)
+	}
+
+	// A *different* app's exclusive binding must still block the card: the fix
+	// only drops the requesting app's own rows, not everyone else's.
+	otherNodes := newNodes()
+	other := Allocation{AppName: "other", Owner: "bob", NodeName: "nvidia-a", DeviceID: "gpu0"}
+	attachBindings(otherNodes, withoutAppAllocations([]Allocation{other}, appName, owner))
+	if _, ok := PickAllocations(app, req, otherNodes, PressureSnapshot{}); ok {
+		t.Fatalf("a different app's exclusive binding must keep the card occupied")
+	}
+}
+
+// TestWithoutAppAllocationsDropsOnlyMatchingOwner verifies the helper matches
+// on the full (appName, owner) key rather than appName alone, so it never
+// frees an unrelated app's or user's claim.
+func TestWithoutAppAllocationsDropsOnlyMatchingOwner(t *testing.T) {
+	const appName, owner = "stable-diffusion", "alice"
+	all := []Allocation{
+		{AppName: appName, Owner: owner, DeviceID: "gpu0"},
+		{AppName: appName, Owner: "someone-else", DeviceID: "gpu1"},
+		{AppName: "other", Owner: owner, DeviceID: "gpu2"},
+	}
+	kept := withoutAppAllocations(all, appName, owner)
+	if len(kept) != 2 {
+		t.Fatalf("expected to drop only rows owned by (%s,%s), kept=%#v", appName, owner, kept)
+	}
+	for _, allocation := range kept {
+		if allocation.AppName == appName && allocation.Owner == owner {
+			t.Fatalf("withoutAppAllocations leaked an owned row: %#v", allocation)
+		}
+	}
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -73,6 +73,7 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	}
 	var pickedAllocations []Allocation
 	allocation, err := mutateAllocations(ctx, c, func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
+		attachBindings(nodes, withoutAppAllocations(allocations, appConfig.AppName, appConfig.OwnerName))
 		picked, ok := PickAllocations(appConfig, req, nodes, pressure)
 		if !ok {
 			return nil, nil, fmt.Errorf("no available compute resource for type %s", req.Mode)

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -104,7 +104,16 @@ func FindAllocationsForApp(ctx context.Context, c client.Client, appName, owner 
 
 func mutateAllocations(ctx context.Context, c client.Client, mutation allocationMutation) (*Allocation, error) {
 	var selected *Allocation
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	// Retry on AlreadyExists in addition to Conflict: the first allocation on a
+	// fresh cluster creates the config map, and two concurrent first-time
+	// allocations both observe NotFound and both Create. The loser gets
+	// AlreadyExists; retrying re-reads the now-existing config map and falls
+	// through to the optimistic-locked Update path, so its allocation is merged
+	// instead of being silently dropped.
+	retriable := func(err error) bool {
+		return apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err)
+	}
+	err := retry.OnError(retry.DefaultRetry, retriable, func() error {
 		nodes, err := loadNodeResources(ctx, c)
 		if err != nil {
 			return err

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -34,6 +34,38 @@ func FetchNodeComputeAllocations(ctx context.Context, c client.Client) ([]Node, 
 	return nodes, nil
 }
 
+// FetchNodeComputeAllocationsExcludingApp returns the node view with the given
+// app's own allocation rows excluded, so a re-allocation / re-binding of that
+// app does not count its current claim against availability (an exclusive card
+// the app already holds would otherwise report zero free memory). Callers that
+// persist via replaceAppAllocations drop those rows anyway, so excluding them
+// here keeps the availability view consistent with the post-write state.
+func FetchNodeComputeAllocationsExcludingApp(ctx context.Context, c client.Client, appName, owner string) ([]Node, error) {
+	nodes, err := loadNodeResources(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	allocations, err := loadAllocations(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	attachBindings(nodes, withoutAppAllocations(allocations, appName, owner))
+	return nodes, nil
+}
+
+// withoutAppAllocations returns allocations excluding the rows owned by the
+// given (appName, owner) pair.
+func withoutAppAllocations(allocations []Allocation, appName, owner string) []Allocation {
+	out := make([]Allocation, 0, len(allocations))
+	for _, allocation := range allocations {
+		if allocation.AppName == appName && allocation.Owner == owner {
+			continue
+		}
+		out = append(out, allocation)
+	}
+	return out
+}
+
 func loadAllocations(ctx context.Context, c client.Client) ([]Allocation, error) {
 	_, allocations, err := loadAllocationConfigMap(ctx, c)
 	return allocations, err
@@ -81,7 +113,10 @@ func mutateAllocations(ctx context.Context, c client.Client, mutation allocation
 		if err != nil {
 			return err
 		}
-		attachBindings(nodes, allocations)
+		// Bindings are intentionally not attached here: app-specific mutations
+		// must decide whether to count an app's own existing allocation against
+		// availability (re-allocation excludes it), so they attach the node view
+		// themselves. Mutations that ignore nodes (e.g. delete) are unaffected.
 
 		next, allocation, err := mutation(nodes, allocations)
 		if err != nil {

--- a/framework/app-service/pkg/compute/store_concurrency_test.go
+++ b/framework/app-service/pkg/compute/store_concurrency_test.go
@@ -1,0 +1,101 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// TestMutateAllocationsRetriesLostFirstCreate is a regression test for the
+// first-allocation race: when the config map does not exist yet, two
+// concurrent allocations both observe NotFound and both Create. The loser used
+// to receive AlreadyExists, which RetryOnConflict did not retry, so its
+// allocation was silently dropped. mutateAllocations now retries AlreadyExists,
+// re-reads the winner's config map, and merges via the Update path.
+//
+// The race is reproduced deterministically: a Create interceptor persists a
+// "winner" config map out-of-band on the first Create and returns AlreadyExists
+// to the caller, exactly as a concurrent writer would.
+func TestMutateAllocationsRetriesLostFirstCreate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	winner := Allocation{AppName: "winner", Owner: "alice", NodeName: "nvidia-a", DeviceID: "gpu0"}
+	winnerData, err := json.Marshal([]Allocation{winner})
+	if err != nil {
+		t.Fatalf("marshal winner allocations: %v", err)
+	}
+
+	createCalls := 0
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				createCalls++
+				if createCalls == 1 {
+					// A concurrent writer wins the create with its own data.
+					winnerCM := &corev1.ConfigMap{}
+					winnerCM.Namespace = allocationConfigMapNamespace
+					winnerCM.Name = allocationConfigMapName
+					winnerCM.Data = map[string]string{allocationConfigMapKey: string(winnerData)}
+					if err := cl.Create(ctx, winnerCM); err != nil {
+						return err
+					}
+					return apierrors.NewAlreadyExists(
+						schema.GroupResource{Resource: "configmaps"},
+						allocationConfigMapName,
+					)
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	loser := Allocation{AppName: "loser", Owner: "bob", NodeName: "nvidia-a", DeviceID: "gpu0"}
+	selected, err := mutateAllocations(context.Background(), c, func(_ []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
+		next := append(append([]Allocation{}, allocations...), loser)
+		return next, &loser, nil
+	})
+	if err != nil {
+		t.Fatalf("mutateAllocations must retry the lost create instead of failing: %v", err)
+	}
+	if selected == nil || selected.AppName != loser.AppName {
+		t.Fatalf("expected the loser allocation to be selected, got %#v", selected)
+	}
+
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: allocationConfigMapNamespace,
+		Name:      allocationConfigMapName,
+	}, &cm); err != nil {
+		t.Fatalf("get allocation config map: %v", err)
+	}
+	var persisted []Allocation
+	if err := json.Unmarshal([]byte(cm.Data[allocationConfigMapKey]), &persisted); err != nil {
+		t.Fatalf("unmarshal persisted allocations: %v", err)
+	}
+
+	var haveWinner, haveLoser bool
+	for _, allocation := range persisted {
+		switch allocation.AppName {
+		case winner.AppName:
+			haveWinner = true
+		case loser.AppName:
+			haveLoser = true
+		}
+	}
+	if !haveWinner || !haveLoser {
+		t.Fatalf("both the winner's and the loser's allocations must survive the create race, got %#v", persisted)
+	}
+}


### PR DESCRIPTION
## Summary

A fresh bug-hunt over the `app-service` compute allocation / scheduling path (`pkg/compute`) turned up two latent defects. Each fix ships with a regression test.

### Bug 1 — re-allocation counts the app's own existing claim
`AllocateForInstall` and the user-facing `ApplyBindingSelection` computed availability via `mutateAllocations → attachBindings(nodes, allocations)`, where `allocations` still included the requesting app's **own** current allocation. For an Exclusive GPU the app already holds, `deviceAvailableMemory` then returns 0, so a re-install / manual re-bind fails with `no available compute resource` — even though `replaceAppAllocations` is explicitly designed to support re-allocation.

**Fix:** `mutateAllocations` no longer attaches bindings blindly. The two app-specific mutations (and the binding-apply preview) attach the node view with the requesting app's own rows excluded via `withoutAppAllocations`. Delete and the global read views are unchanged.

### Bug 2 — lost first-create when allocating compute concurrently
The allocation ConfigMap is created lazily on the first allocation. Two concurrent first-time allocations both observe `NotFound` and both `Create`; the loser got `AlreadyExists`, which `retry.RetryOnConflict` does **not** retry, so its allocation was silently dropped.

**Fix:** retry on `AlreadyExists` as well, so the loser re-reads the winner's ConfigMap and merges via the optimistic-locked `Update` path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/compute/...`
- [x] `go test -race ./pkg/compute/...` (all green)
- [x] `TestPickAllocationsExcludesOwnExistingClaim` pins both the buggy precondition and the fixed behavior
- [x] `TestMutateAllocationsRetriesLostFirstCreate` reproduces the create race deterministically via an interceptor; verified it fails without the fix

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compute scheduling and ConfigMap persistence; fixes are localized but incorrect availability or retry behavior could mis-assign GPUs or drop allocations.
> 
> **Overview**
> Fixes two bugs in **app-service** GPU/compute allocation so re-installs, re-binds, and concurrent first allocations behave correctly.
> 
> **Re-allocation:** Install and binding flows used to attach the requesting app’s **own** existing allocation when computing free capacity. On an exclusive GPU the app already holds, that made the card look fully occupied, so `PickAllocations` / binding preview failed with “no available compute resource” even though persistence was meant to replace the same claim. The node view now excludes only that app’s `(appName, owner)` rows via `withoutAppAllocations` / `FetchNodeComputeAllocationsExcludingApp`; `mutateAllocations` no longer attaches bindings globally—each mutation attaches the view it needs.
> 
> **First-create race:** When the allocation ConfigMap did not exist yet, two concurrent writers could both `Create`; the loser got `AlreadyExists`, which was not retried, so an allocation could be dropped. `mutateAllocations` now retries on `AlreadyExists` as well as conflict and merges on update.
> 
> Regression tests cover own-claim exclusion, owner-scoped filtering, and the lost-create path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff3cd06d34ef44d64ebdd30e5705ba51fbfb19e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->