### PR TITLE
feat: skip envoy redirect for macvlan net1 traffic when overlay-gateway is enable 

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.28
+        image: beclab/app-service:0.5.29
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/tailscale_acl_controller.go
+++ b/framework/app-service/controllers/tailscale_acl_controller.go
@@ -48,16 +48,23 @@ var defaultACLs = []v1alpha1.ACL{
 	{
 		Action: "accept",
 		Src:    []string{"*"},
-		Proto:  "",
+		Proto:  "udp",
 		Dst:    []string{"*:53"},
 	},
 	{
 		Action: "accept",
 		Src:    []string{"*"},
-		Proto:  "",
+		Proto:  "tcp",
 		Dst:    []string{"*:80"},
 	},
+	{
+		Action: "accept",
+		Src:    []string{"*"},
+		Proto:  "",
+		Dst:    []string{"autogroup:internet:*"},
+	},
 }
+
 var defaultSubRoutes = []string{"$(COREDNS_SVC)/32"}
 
 type ACLPolicy struct {
@@ -276,11 +283,11 @@ func makeACLPolicy(acls []v1alpha1.ACL) ([]byte, error) {
 		ACLs: acls,
 		AutoApprovers: AutoApprovers{
 			Routes: map[string][]string{
-				"10.0.0.0/8":     {"default"},
-				"172.16.0.0/12":  {"default"},
-				"192.168.0.0/16": {"default"},
+				"10.0.0.0/8":     {"default@"},
+				"172.16.0.0/12":  {"default@"},
+				"192.168.0.0/16": {"default@"},
 			},
-			ExitNode: []string{},
+			ExitNode: []string{"default@"},
 		},
 	}
 	aclPolicyByte, err := json.Marshal(aclPolicy)

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -19,6 +19,8 @@ type AppPermission interface{}
 type AppDataPermission string
 type AppCachePermission string
 type UserDataPermission string
+type AppCommonPermission string
+type ExternalDataPermission string
 
 type AppRequirement struct {
 	Memory        *resource.Quantity
@@ -40,9 +42,11 @@ type AppPolicy struct {
 }
 
 const (
-	AppDataRW  AppDataPermission  = "appdata-perm"
-	AppCacheRW AppCachePermission = "appcache-perm"
-	UserDataRW UserDataPermission = "userdata-perm"
+	AppDataRW      AppDataPermission      = "appdata-perm"
+	AppCacheRW     AppCachePermission     = "appcache-perm"
+	UserDataRW     UserDataPermission     = "userdata-perm"
+	AppCommonRW    AppCommonPermission    = "appCommon-perm"
+	ExternalDataRW ExternalDataPermission = "external-perm"
 )
 
 type APIVersion string

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -875,6 +875,10 @@ func ParseAppPermission(data []appcfg.AppPermission) []appcfg.AppPermission {
 			permissions = append(permissions, appcfg.AppCacheRW)
 		case appcfg.UserDataPermission:
 			permissions = append(permissions, appcfg.UserDataRW)
+		case appcfg.AppCommonPermission:
+			permissions = append(permissions, appcfg.AppCommonRW)
+		case appcfg.ExternalDataPermission:
+			permissions = append(permissions, appcfg.ExternalDataRW)
 		case []appcfg.ProviderPermission:
 			permissions = append(permissions, p)
 		case []interface{}:

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -862,6 +862,13 @@ func ParseAppPermission(data []appcfg.AppPermission) []appcfg.AppPermission {
 			if perm == "userdata-perm" {
 				permissions = append(permissions, appcfg.UserDataRW)
 			}
+			if perm == "appCommon-perm" {
+				permissions = append(permissions, appcfg.AppCommonRW)
+			}
+			if perm == "external-perm" {
+				permissions = append(permissions, appcfg.ExternalDataRW)
+			}
+
 		case appcfg.AppDataPermission:
 			permissions = append(permissions, appcfg.AppDataRW)
 		case appcfg.AppCachePermission:

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -284,6 +284,13 @@ func (h *HelmOps) SetValues(isInstallOp bool) (values map[string]interface{}, er
 				appData := fmt.Sprintf("%s/Data", userspacePath)
 				userspace["appData"] = filepath.Join(appData, h.app.AppName)
 			}
+			if perm == appcfg.AppCommonRW {
+				rootPath := userspacev1.DefaultRootPath
+				if os.Getenv(userspacev1.OlaresRootPath) != "" {
+					rootPath = os.Getenv(userspacev1.OlaresRootPath)
+				}
+				userspace["appCommon"] = fmt.Sprintf("%s/rootfs/Common", rootPath)
+			}
 
 		case []appcfg.ProviderPermission:
 			permCfgs, err := apputils.ProviderPermissionsConvertor(perm).ToPermissionCfg(h.ctx, h.app.OwnerName, h.options.MarketSource)

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -257,7 +257,7 @@ func (h *HelmOps) SetValues(isInstallOp bool) (values map[string]interface{}, er
 	h.app.Permission = ParseAppPermission(h.app.Permission)
 	for _, p := range h.app.Permission {
 		switch perm := p.(type) {
-		case appcfg.AppDataPermission, appcfg.AppCachePermission, appcfg.UserDataPermission:
+		case appcfg.AppDataPermission, appcfg.AppCachePermission, appcfg.UserDataPermission, appcfg.AppCommonPermission:
 
 			// app requests app data permission
 			// set .Values.schedule.nodeName and .Values.userspace.appCache to app

--- a/framework/app-service/pkg/sandbox/sidecar/envoy.go
+++ b/framework/app-service/pkg/sandbox/sidecar/envoy.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const defaultMacvlanIface = "net1"
+
 // GetEnvoySidecarContainerSpec returns the container specification for the envoy sidecar.
 func GetEnvoySidecarContainerSpec(clusterID string, envoyFilename string, appKey string, appSecret string) corev1.Container {
 	return corev1.Container{
@@ -278,9 +280,32 @@ func getEnvoyConfigOnlyForOutBound(appcfg *appcfg.ApplicationConfig, perms []app
 }
 
 // GetInitContainerSpec returns init container spec.
-func GetInitContainerSpec(appCfg *appcfg.ApplicationConfig) corev1.Container {
-	iptablesInitCommand := generateIptablesCommands(appCfg)
+//
+// When injectMacvlan is true the pod is expected to have a secondary macvlan
+// interface (net1) attached by multus because its owning Application has
+// `enableOverlayGateway=true`. In that case we install extra RETURN rules so
+// traffic entering/leaving via the macvlan NIC bypasses envoy interception.
+func GetInitContainerSpec(appCfg *appcfg.ApplicationConfig, injectMacvlan bool) corev1.Container {
+	iptablesInitCommand := generateIptablesCommands(appCfg, injectMacvlan)
 	enablePrivilegedInitContainer := true
+
+	env := []corev1.EnvVar{
+		{
+			Name: "POD_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.podIP",
+				},
+			},
+		},
+	}
+	if injectMacvlan {
+		env = append(env, corev1.EnvVar{
+			Name:  "MACVLAN_IFACE",
+			Value: defaultMacvlanIface,
+		})
+	}
 
 	return corev1.Container{
 		Name:            constants.SidecarInitContainerName,
@@ -302,21 +327,11 @@ func GetInitContainerSpec(appCfg *appcfg.ApplicationConfig) corev1.Container {
 			"-c",
 			iptablesInitCommand,
 		},
-		Env: []corev1.EnvVar{
-			{
-				Name: "POD_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "status.podIP",
-					},
-				},
-			},
-		},
+		Env: env,
 	}
 }
 
-func generateIptablesCommands(appCfg *appcfg.ApplicationConfig) string {
+func generateIptablesCommands(appCfg *appcfg.ApplicationConfig, injectMacvlan bool) string {
 	cmd := fmt.Sprintf(`iptables-restore --noflush <<EOF
 # sidecar interception rules
 *nat
@@ -339,12 +354,25 @@ func generateIptablesCommands(appCfg *appcfg.ApplicationConfig) string {
 		}
 	}
 
+	// Bypass envoy for traffic arriving on the macvlan NIC; must come before
+	// the catch-all redirect to PROXY_IN_REDIRECT.
+	if injectMacvlan {
+		cmd += "-A PROXY_INBOUND -i ${MACVLAN_IFACE} -j RETURN\n"
+	}
+
 	cmd += fmt.Sprintf(`-A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT
 -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port %d
 `, constants.EnvoyInboundListenerPort)
 
-	cmd += fmt.Sprintf(`-A PROXY_OUTBOUND -d ${POD_IP}/32 -j RETURN
--A PROXY_OUTBOUND -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1555 -j PROXY_IN_REDIRECT
+	cmd += `-A PROXY_OUTBOUND -d ${POD_IP}/32 -j RETURN
+`
+	// Bypass envoy for traffic leaving via the macvlan NIC; must come before
+	// the multiport / PROXY_OUT_REDIRECT rules.
+	if injectMacvlan {
+		cmd += "-A PROXY_OUTBOUND -o ${MACVLAN_IFACE} -j RETURN\n"
+	}
+
+	cmd += fmt.Sprintf(`-A PROXY_OUTBOUND -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1555 -j PROXY_IN_REDIRECT
 -A PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1555 -j RETURN
 -A PROXY_OUTBOUND -m owner --uid-owner 1555 -j RETURN
 -A PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -985,6 +985,14 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		permission = append(permission, appcfg.UserDataRW)
 	}
 
+	if cfg.Permission.AppCommon {
+		permission = append(permission, appcfg.AppCommonRW)
+	}
+
+	if cfg.Permission.ExternalData {
+		permission = append(permission, appcfg.ExternalDataRW)
+	}
+
 	if len(cfg.Permission.Provider) > 0 {
 		var perm []appcfg.ProviderPermission
 		for _, s := range cfg.Permission.Provider {

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -187,7 +187,16 @@ func (wh *Webhook) CreatePatch(
 		appKey, appSecret, _ := wh.getAppKeySecret(req.Namespace)
 
 		if injectPolicy || len(appConfig.PodsSelectors) == 0 || wh.isSelected(appConfig.PodsSelectors, pod) {
-			initContainer := sidecar.GetInitContainerSpec(appConfig)
+			// If the owning Application enables overlay-gateway, multus will
+			// attach a macvlan NIC (net1) to the pod. Tell the iptables init
+			// container to install bypass RETURN rules for that interface so
+			// north/south traffic on net1 doesn't get redirected to envoy.
+			injectMacvlan, err := wh.ShouldInjectMacvlanInit(ctx, pod, req.Namespace)
+			if err != nil {
+				klog.Errorf("Failed to evaluate macvlan-init for sidecar pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+				return nil, err
+			}
+			initContainer := sidecar.GetInitContainerSpec(appConfig, injectMacvlan)
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 			policySidecar := sidecar.GetEnvoySidecarContainerSpec(clusterID, envoyFilename, appKey, appSecret)
 			pod.Spec.Containers = append(pod.Spec.Containers, policySidecar)


### PR DESCRIPTION


* **Background**
- skip envoy redirect for macvlan net1 traffic when overlay-gateway is enable 
- update tailscale default acl policy
- add appCommon values

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes pod networking (iptables/Envoy bypass) and Tailscale ACL defaults, which can affect connectivity, routing approval, and east-west security boundaries.
> 
> **Overview**
> Bumps **app-service** to `0.5.29` and extends app install/permission handling for **`appCommon-perm`** and **`external-perm`**, including Helm **`userspace.appCommon`** (`{rootPath}/rootfs/Common`) when apps request shared common storage.
> 
> For apps with **overlay gateway** enabled, the admission webhook now passes **`injectMacvlan`** into the Envoy iptables init container so traffic on the multus macvlan interface **`net1`** gets **RETURN** rules and is **not** redirected through Envoy—fixing north/south connectivity on that NIC. The iptables template also corrects a broken **`PROXY_OUTBOUND`** line that previously used invalid shell comment syntax.
> 
> **Tailscale** default ACL policy is tightened and expanded: DNS/80 rules get explicit **udp/tcp** protocols, a new **`autogroup:internet:*`** accept rule is added, and route/exit-node auto-approvers use **`default@`** instead of bare **`default`** with exit nodes enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3333d3ac8b14b1605811d064f50b4a9a9f155a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->