### PR TITLE
authelia: enhance session handling by adding group

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.53
+        image: beclab/auth:0.2.54
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Using the user role instead of the user groups in LDAP when restoring the user session  on restarting

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/9e700a22f852f65cd92351b06daad143476085b7


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Single-tag rollout of the identity/session service; behavior changes on session restore affect authZ until pods roll out.
> 
> **Overview**
> This PR **bumps the Authelia backend container** in `auth_backend_deploy.yaml` from `beclab/auth:0.2.53` to **`beclab/auth:0.2.54`**. No Helm values, Authelia config, or other deployment fields change in this diff.
> 
> The new image tag is intended to ship **session-restore behavior that uses LDAP groups** (instead of role-only) on restart, per the linked Authelia commit and PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2334025b3932cae56c4fdda5299646c6d0d315a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->