### PR TITLE
feat: files unify permission checks (CheckAccess), refactor precheck into base.Execute, hydrate external root fast-list metadata

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -135,6 +135,8 @@ spec:
               name: userspace-dir
             - mountPath: /appcache/
               name: upload-appdata
+            - mountPath: /appcommon/
+              name: common-data
 {{ if .Values.sharedlib }}
             - mountPath: /data/External
               mountPropagation: Bidirectional
@@ -142,7 +144,7 @@ spec:
 {{ end }}
 
         - name: samba-server
-          image: beclab/samba-server:0.0.13
+          image: beclab/samba-server:0.0.14
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -208,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.176
+          image: beclab/files-server:v0.2.177
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat(access): unified Level/Action model behind a single CheckAccess entrypoint
- feat(api): add GET /api/permission to return the unified Level
- feat(security): share-proxy loopback now requires a random internal token (RNG failure → fail-closed)
- fix(security): enforce share expiry on search and chunked upload; unknown share type / Seafile perm / repo-enum / dir-share update errors are now fail-closed
- fix(sync): preview/cloud-edit/admin no longer collapse to mode 0; admin no longer rejected by hardcoded "rw" checks
- feat(external): hydrate fast-list of external root with mtime metadata; allow it under share listings
- refactor(drivers): replace pkg/drivers/precheck with CheckPermission + CheckPathExists on base.Execute; physical writable probes dropped, real I/O errors surface at task time

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/338
- https://github.com/beclab/files/pull/339
- https://github.com/beclab/files/pull/340

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling new files-server and samba images changes runtime behavior cluster-wide; the new rclone volume mount affects how shared Common paths are visible to sync.
> 
> **Overview**
> Updates the **files** cluster `DaemonSet` deploy manifest to roll out newer container images and wire shared storage into **rclone**.
> 
> The **rclone** sidecar now mounts host **`common-data`** at **`/appcommon/`**, matching the existing **`/appcommon/`** mount on the **files** container so rclone can see the Common tree. Container images are bumped to **`beclab/samba-server:0.0.14`** (from `0.0.13`) and **`beclab/files-server:v0.2.177`** (from `v0.2.176`), deploying the application changes described in the PR (unified access checks, permission API, security hardening, external fast-list) via image rollout rather than inline config in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5deed1752cd8834ea4d67ad80af3749e5870156c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->