### PR TITLE
market: multi-user shared clone app reconciliation

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.23
+        image: beclab/dynamic-chart-repository:v0.3.25
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.46
+        image: beclab/market-backend:v0.6.48
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
multi-user shared clone app reconciliation, oac update

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/272
https://github.com/beclab/market/pull/274
https://github.com/beclab/dynamic-chart-repository/pull/23


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical framework appstore/chart-repo workloads; behavior changes live in the new images, not in this repo’s YAML beyond the version pins.
> 
> **Overview**
> Rolls out newer **market** and **chart-repo** container images so clusters pick up multi-user shared clone app reconciliation and related OAC updates described in the linked upstream PRs.
> 
> `chart_repo_deploy.yaml` bumps `beclab/dynamic-chart-repository` from **v0.3.23** to **v0.3.25**. `market_deploy.yaml` bumps `beclab/market-backend` from **v0.6.46** to **v0.6.48**. No env, RBAC, or wiring changes in this diff—only image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff8866760dd5003c6c2c1981dda81479939ba9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->