### PR TITLE
helm-charts/system-apps: bump olares-app & user-service images for overlay gateway

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.39
+          image: beclab/system-frontend:v1.10.40
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.95
+          image: beclab/user-service:v0.0.96
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

Bumps the system-app container images (`olares-app` → v1.10.40, `user-service` → v0.0.96) to ship the per-app Overlay Gateway feature, delivered end-to-end across the user-service backend and the TermiPass frontend:

- **Backend (user-service#81)**: The overlay gateway proxy and olaresd client utilities are reworked so user-scoped requests authenticate with `X-Authorization` (from the request header, falling back to the `auth_token` cookie) instead of `X-Signature`. The olaresd client is unified into one credential family — `createOlaresInstance` (no auth), `createOlaresInstanceBySignature`, `createOlaresInstanceByAuthorization` — with shared response/error handling. Endpoints covered: `/system/overlay-gateway-status/:user` and `enable/disable[-app]-overlay-gateway`.
- **Frontend (TermiPass#1162)**: Overlay gateway status polling is driven reactively from store sync targets instead of fixed post-toggle loops. Enabling an app overlay only completes once it is `enabled` AND has an underlay IP; HTTP 530 during the activate/deactivate window is treated as a transient state (single soft tip, polling continues). The feature is gated behind the Olares version capability check.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/user-service/pull/81
https://github.com/beclab/TermiPass/pull/1162

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys new auth and overlay-gateway behavior via image bumps only; rollout risk is pod restarts and gateway/API regressions, not template edits in this diff.
> 
> **Overview**
> This PR only updates pinned container images in `olares-app.yaml` for the **olares-app** deployment: the `olares-app-init` init container moves from `beclab/system-frontend:v1.10.39` to **v1.10.40**, and the `user-service` sidecar moves from `beclab/user-service:v0.0.95` to **v0.0.96**. No chart logic, env vars, or service definitions change.
> 
> Together these tags roll out the **per-app Overlay Gateway** work shipped in the linked frontend and backend releases (overlay status/enable APIs, `X-Authorization`–based olaresd calls, and UI polling/gating).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5b3b0262b2627d21d748d6a694c45f1b09f90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->