### PR TITLE
feat: scoped, role-aware, multi-node collect-logs

### DIFF
--- a/cli/cmd/ctl/os/logs.go
+++ b/cli/cmd/ctl/os/logs.go
@@ -42,6 +42,17 @@ type LogCollectOptions struct {
 	IgnoreKubeErrors bool
 	// Skip retrieving logs from kube-apiserver
 	SkipKubeAPISserver bool
+	// PodNamespaces restricts /var/log/pods collection to the given
+	// namespaces. Nil/empty means collect all namespaces (backward
+	// compatible). Ignored when SkipPodLogs is set.
+	PodNamespaces []string
+	// Section switches. All default to false to preserve the original
+	// full-collection behavior when no flag is given.
+	SkipSystemd     bool
+	SkipDmesg       bool
+	SkipNetwork     bool
+	SkipClusterInfo bool
+	SkipPodLogs     bool
 }
 
 var servicesToCollectLogs = []string{"k3s", "containerd", "olaresd", "kubelet", "juicefs", "redis", "minio", "etcd", "NetworkManager"}
@@ -87,7 +98,7 @@ func collectLogs(options *LogCollectOptions) error {
 		return fmt.Errorf("os: please run as root")
 	}
 
-	if !options.SkipKubeAPISserver {
+	if !options.SkipClusterInfo && !options.SkipKubeAPISserver {
 		setSkipIfK8sNotReachable(options)
 	}
 
@@ -110,14 +121,17 @@ func collectLogs(options *LogCollectOptions) error {
 	tw := tar.NewWriter(gw)
 	defer tw.Close()
 
-	// collect systemd service logs
-	if err := collectSystemdLogs(tw, options); err != nil {
-		return fmt.Errorf("failed to collect systemd logs: %v", err)
+	if !options.SkipSystemd {
+		if err := collectSystemdLogs(tw, options); err != nil {
+			return fmt.Errorf("failed to collect systemd logs: %v", err)
+		}
 	}
 
-	fmt.Println("collecting dmesg logs ...")
-	if err := collectDmesgLogs(tw, options); err != nil {
-		return fmt.Errorf("failed to collect dmesg logs: %v", err)
+	if !options.SkipDmesg {
+		fmt.Println("collecting dmesg logs ...")
+		if err := collectDmesgLogs(tw, options); err != nil {
+			return fmt.Errorf("failed to collect dmesg logs: %v", err)
+		}
 	}
 
 	fmt.Println("collecting logs from kubernetes cluster...")
@@ -125,14 +139,20 @@ func collectLogs(options *LogCollectOptions) error {
 		return fmt.Errorf("failed to collect kubernetes logs: %v", err)
 	}
 
-	fmt.Println("collecting olares-cli logs...")
-	if err := collectOlaresCLILogs(tw, options); err != nil {
-		return fmt.Errorf("failed to collect OlaresCLI logs: %v", err)
+	// olares-cli's own logs are host-level Olares operational logs; tie
+	// them to cluster-info so a pods-only scoped collection excludes them.
+	if !options.SkipClusterInfo {
+		fmt.Println("collecting olares-cli logs...")
+		if err := collectOlaresCLILogs(tw, options); err != nil {
+			return fmt.Errorf("failed to collect OlaresCLI logs: %v", err)
+		}
 	}
 
-	fmt.Println("collecting network configs...")
-	if err := collectNetworkConfigs(tw, options); err != nil {
-		return fmt.Errorf("failed to collect network configs: %v", err)
+	if !options.SkipNetwork {
+		fmt.Println("collecting network configs...")
+		if err := collectNetworkConfigs(tw, options); err != nil {
+			return fmt.Errorf("failed to collect network configs: %v", err)
+		}
 	}
 
 	fmt.Printf("logs have been collected and archived in: %s\n", archiveName)
@@ -302,50 +322,83 @@ func collectDmesgLogs(tw *tar.Writer, options *LogCollectOptions) error {
 	return nil
 }
 
-func collectKubernetesLogs(tw *tar.Writer, options *LogCollectOptions) error {
+func collectPodLogs(tw *tar.Writer, options *LogCollectOptions) error {
+	if options.SkipPodLogs {
+		return nil
+	}
+
 	podsLogDir := "/var/log/pods"
 	if _, err := os.Stat(podsLogDir); err != nil {
 		fmt.Printf("warning: directory %s does not exist, skipping collecting pod logs\n", podsLogDir)
-	} else {
-		err := filepath.Walk(podsLogDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
+		return nil
+	}
 
-			if info.IsDir() {
-				return nil
-			}
+	var nsFilter map[string]struct{}
+	if len(options.PodNamespaces) > 0 {
+		nsFilter = make(map[string]struct{}, len(options.PodNamespaces))
+		for _, ns := range options.PodNamespaces {
+			nsFilter[ns] = struct{}{}
+		}
+	}
 
-			srcFile, err := os.Open(path)
-			if err != nil {
-				return fmt.Errorf("failed to open file %s: %v", path, err)
-			}
-			defer srcFile.Close()
+	err := filepath.Walk(podsLogDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 
-			relPath, err := filepath.Rel(podsLogDir, path)
-			if err != nil {
-				return fmt.Errorf("failed to get relative path: %v", err)
-			}
-
-			header := &tar.Header{
-				Name:    filepath.Join("pods", relPath),
-				Mode:    0644,
-				Size:    info.Size(),
-				ModTime: info.ModTime(),
-			}
-			if err := tw.WriteHeader(header); err != nil {
-				return fmt.Errorf("failed to write header for %s: %v", path, err)
-			}
-
-			// stream file contents to tar
-			if _, err := io.CopyN(tw, srcFile, header.Size); err != nil {
-				return fmt.Errorf("failed to write data for %s: %v", path, err)
+		if info.IsDir() {
+			// /var/log/pods/<namespace>_<pod>_<uid>: prune whole pod dirs
+			// whose namespace is not requested. namespace/pod names never
+			// contain '_', so the prefix is unambiguous.
+			if nsFilter != nil && filepath.Dir(path) == podsLogDir {
+				ns := strings.SplitN(info.Name(), "_", 2)[0]
+				if _, ok := nsFilter[ns]; !ok {
+					return filepath.SkipDir
+				}
 			}
 			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to collect pod logs from /var/log/pods: %v", err)
 		}
+
+		srcFile, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %v", path, err)
+		}
+		defer srcFile.Close()
+
+		relPath, err := filepath.Rel(podsLogDir, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %v", err)
+		}
+
+		header := &tar.Header{
+			Name:    filepath.Join("pods", relPath),
+			Mode:    0644,
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("failed to write header for %s: %v", path, err)
+		}
+
+		// stream file contents to tar
+		if _, err := io.CopyN(tw, srcFile, header.Size); err != nil {
+			return fmt.Errorf("failed to write data for %s: %v", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to collect pod logs from /var/log/pods: %v", err)
+	}
+	return nil
+}
+
+func collectKubernetesLogs(tw *tar.Writer, options *LogCollectOptions) error {
+	if err := collectPodLogs(tw, options); err != nil {
+		return err
+	}
+
+	if options.SkipClusterInfo {
+		return nil
 	}
 
 	if options.SkipKubeAPISserver {
@@ -627,6 +680,12 @@ func NewCmdLogs() *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.Components, "components", nil, "Specific components (systemd service) to collect logs from (comma-separated). If empty, collects from all Olares-related components that can be found")
 	cmd.Flags().BoolVar(&options.IgnoreKubeErrors, "ignore-kube-errors", options.IgnoreKubeErrors, "Continue collecting logs even if kubectl commands fail")
 	cmd.Flags().BoolVar(&options.SkipKubeAPISserver, "skip-kube-apiserver", options.SkipKubeAPISserver, "Skip retrieving logs from kube-apiserver, it's automatically set if apiserver is not reachable. To tolerate other cases, set the ignore-kube-errors")
+	cmd.Flags().StringSliceVar(&options.PodNamespaces, "pod-namespaces", nil, "Restrict /var/log/pods collection to these namespaces (comma-separated). If empty, collects pod logs from all namespaces")
+	cmd.Flags().BoolVar(&options.SkipSystemd, "skip-systemd", options.SkipSystemd, "Skip collecting systemd service logs")
+	cmd.Flags().BoolVar(&options.SkipDmesg, "skip-dmesg", options.SkipDmesg, "Skip collecting dmesg (kernel) logs")
+	cmd.Flags().BoolVar(&options.SkipNetwork, "skip-network", options.SkipNetwork, "Skip collecting network configs (ip/iptables/nft)")
+	cmd.Flags().BoolVar(&options.SkipClusterInfo, "skip-cluster-info", options.SkipClusterInfo, "Skip collecting cluster info (kubectl describe/pods-list, envoy config) and olares-cli logs")
+	cmd.Flags().BoolVar(&options.SkipPodLogs, "skip-pod-logs", options.SkipPodLogs, "Skip collecting pod logs from /var/log/pods")
 
 	return cmd
 }

--- a/daemon/internel/apiserver/handlers/command_group.go
+++ b/daemon/internel/apiserver/handlers/command_group.go
@@ -75,9 +75,15 @@ func init() {
 			handlers.WaitServerRunning(
 				handlers.RunCommand(handlers.PostUmountUsbInCluster, umountusb.New)))))
 
-	cmd.Post("/collect-logs", handlers.RequireLocal(
+	cmd.Post("/collect-logs", handlers.RequireMaster(
+		handlers.RequireSignature(
+			handlers.RequireOwnerOrAdmin(
+				handlers.WaitServerRunning(
+					handlers.RunCommand(handlers.PostCollectLogs, collectlogs.New))))))
+
+	cmd.Post("/collect-logs-node", handlers.RequireSignature(
 		handlers.WaitServerRunning(
-			handlers.RunCommand(handlers.PostCollectLogs, collectlogs.New))))
+			handlers.RunCommand(handlers.PostCollectLogsNode, collectlogs.NewNode))))
 
 	cmd.Post("/mount-samba", handlers.RequireMaster(
 		handlers.RequireLocal(

--- a/daemon/internel/apiserver/handlers/handler_collect_logs.go
+++ b/daemon/internel/apiserver/handlers/handler_collect_logs.go
@@ -1,19 +1,48 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/beclab/Olares/daemon/internel/client"
 	"github.com/beclab/Olares/daemon/pkg/commands"
+	collectlogs "github.com/beclab/Olares/daemon/pkg/commands/collect_logs"
 	"github.com/gofiber/fiber/v2"
 	"k8s.io/klog/v2"
 )
 
 func (h *Handlers) PostCollectLogs(ctx *fiber.Ctx, cmd commands.Interface) error {
-	_, err := cmd.Execute(ctx.Context(), nil)
-	if err != nil {
-		klog.Error("execute command error, ", err, ", ", cmd.OperationName().Stirng())
+	var param collectlogs.Param
+	if len(ctx.Body()) > 0 {
+		if err := h.ParseBody(ctx, &param); err != nil {
+			return h.ErrJSON(ctx, http.StatusBadRequest, err.Error())
+		}
+	}
 
-		return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
+	c, ok := ctx.Context().UserValue(client.ClIENT_CONTEXT).(client.Client)
+	if !ok {
+		return h.ErrJSON(ctx, http.StatusForbidden, "client not found")
+	}
+	// Inject the verified caller identity; never trust a body-supplied value.
+	param.CallerOlaresID = c.OlaresID()
+	// Forward the verified signature so the orchestrator can authenticate to
+	// each node's node-local endpoint as the same caller.
+	if sig, ok := ctx.GetReqHeaders()[SIGNATURE_HEADER]; ok && len(sig) > 0 {
+		param.CallerSignature = sig[0]
+	}
+
+	_, err := cmd.Execute(ctx.Context(), &param)
+	if err != nil {
+		var denied *collectlogs.ScopeDeniedError
+		switch {
+		case errors.As(err, &denied):
+			return h.ErrJSON(ctx, http.StatusForbidden, "requested scope exceeds caller permission", denied.Denied)
+		case errors.Is(err, collectlogs.ErrNothingRequested):
+			return h.ErrJSON(ctx, http.StatusBadRequest, err.Error())
+		default:
+			klog.Error("execute command error, ", err, ", ", cmd.OperationName().Stirng())
+			return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
+		}
 	}
 
 	return h.OkJSON(ctx, "success to exec command")

--- a/daemon/internel/apiserver/handlers/handler_collect_logs_node.go
+++ b/daemon/internel/apiserver/handlers/handler_collect_logs_node.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/beclab/Olares/daemon/internel/client"
+	"github.com/beclab/Olares/daemon/pkg/commands"
+	collectlogs "github.com/beclab/Olares/daemon/pkg/commands/collect_logs"
+	"github.com/gofiber/fiber/v2"
+	"k8s.io/klog/v2"
+)
+
+// PostCollectLogsNode is the node-local executor endpoint invoked by the master
+// orchestrator. It runs on every node (no RequireMaster) and collects only this
+// node's logs into the shared staging directory.
+func (h *Handlers) PostCollectLogsNode(ctx *fiber.Ctx, cmd commands.Interface) error {
+	var req collectlogs.NodeRequest
+	if err := h.ParseBody(ctx, &req); err != nil {
+		return h.ErrJSON(ctx, http.StatusBadRequest, err.Error())
+	}
+
+	c, ok := ctx.Context().UserValue(client.ClIENT_CONTEXT).(client.Client)
+	if !ok {
+		return h.ErrJSON(ctx, http.StatusForbidden, "client not found")
+	}
+	req.CallerOlaresID = c.OlaresID()
+
+	res, err := cmd.Execute(ctx.Context(), &req)
+	if err != nil {
+		var denied *collectlogs.ScopeDeniedError
+		switch {
+		case errors.As(err, &denied):
+			return h.ErrJSON(ctx, http.StatusForbidden, "requested scope exceeds caller permission", denied.Denied)
+		case errors.Is(err, collectlogs.ErrNothingRequested):
+			return h.ErrJSON(ctx, http.StatusBadRequest, err.Error())
+		default:
+			klog.Error("execute command error, ", err, ", ", cmd.OperationName().Stirng())
+			return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
+		}
+	}
+
+	return h.OkJSON(ctx, "success to collect node logs", res)
+}

--- a/daemon/internel/apiserver/handlers/middlewares.go
+++ b/daemon/internel/apiserver/handlers/middlewares.go
@@ -82,6 +82,33 @@ func (h *Handlers) RequireOwner(next func(ctx *fiber.Ctx) error) func(ctx *fiber
 	}
 }
 
+// RequireOwnerOrAdmin admits only callers whose Olares role is owner or admin.
+// It must run after RequireSignature, which puts the verified client in the
+// request context.
+func (h *Handlers) RequireOwnerOrAdmin(next func(ctx *fiber.Ctx) error) func(ctx *fiber.Ctx) error {
+	return func(ctx *fiber.Ctx) error {
+		c, ok := ctx.Context().UserValue(client.ClIENT_CONTEXT).(client.Client)
+		if !ok {
+			return h.ErrJSON(ctx, http.StatusForbidden, "client not found")
+		}
+
+		dynamicClient, err := utils.GetDynamicClient()
+		if err != nil {
+			return h.ErrJSON(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get dynamic client: %v", err))
+		}
+
+		_, role, err := utils.GetUserRoleByOlaresID(ctx.Context(), dynamicClient, c.OlaresID())
+		if err != nil {
+			return h.ErrJSON(ctx, http.StatusForbidden, err.Error())
+		}
+		if role != utils.RoleOwner && role != utils.RoleAdmin {
+			return h.ErrJSON(ctx, http.StatusForbidden, "operation requires owner or admin role")
+		}
+
+		return next(ctx)
+	}
+}
+
 func (h *Handlers) RunCommand(next func(ctx *fiber.Ctx, cmd commands.Interface) error,
 	cmdNew func() commands.Interface) func(ctx *fiber.Ctx) error {
 

--- a/daemon/pkg/cluster/fanout/fanout.go
+++ b/daemon/pkg/cluster/fanout/fanout.go
@@ -1,0 +1,224 @@
+// Package fanout is a generic mechanism for the master olaresd to dispatch the
+// same node-local action to every node's olaresd and aggregate the results per
+// node. It is intentionally decoupled from any specific command (collect-logs
+// is the first consumer): a node being unreachable is a first-class result, not
+// a silently dropped item.
+package fanout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/beclab/Olares/daemon/pkg/nets"
+	"github.com/beclab/Olares/daemon/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// OlaresdPort is the fixed port every node's olaresd listens on.
+	OlaresdPort = 18088
+
+	defaultTimeout  = 15 * time.Minute
+	defaultParallel = 4
+	signatureHeader = "X-Signature"
+)
+
+// NodeStatus classifies a per-node dispatch outcome.
+type NodeStatus string
+
+const (
+	StatusOK          NodeStatus = "ok"
+	StatusUnreachable NodeStatus = "unreachable"
+	StatusTimeout     NodeStatus = "timeout"
+	StatusError       NodeStatus = "error"
+)
+
+// NodeTarget identifies one node and how to reach its olaresd.
+type NodeTarget struct {
+	Name     string `json:"name"`
+	IP       string `json:"ip"`
+	IsSelf   bool   `json:"isSelf"`
+	IsMaster bool   `json:"isMaster"`
+}
+
+// NodeResult is the generic per-node outcome. Data carries the consumer's
+// node-local payload verbatim and is opaque to the fan-out layer.
+type NodeResult struct {
+	Node   NodeTarget      `json:"node"`
+	Status NodeStatus      `json:"status"`
+	Err    string          `json:"err,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+// Dispatcher fans a request out to a set of node-local olaresd endpoints.
+type Dispatcher struct {
+	// PeerPath is the node-local endpoint path, e.g. "/command/collect-logs-node".
+	PeerPath string
+	// Signature is forwarded as X-Signature so each node authenticates the
+	// same caller.
+	Signature string
+	// Timeout bounds each per-node call. Defaults to defaultTimeout.
+	Timeout time.Duration
+	// Parallel bounds concurrent calls. Defaults to defaultParallel.
+	Parallel int
+}
+
+// ListReadyNodes enumerates Ready nodes with an internal IP, tagging the local
+// node and master nodes.
+func ListReadyNodes(ctx context.Context) ([]NodeTarget, error) {
+	client, err := utils.GetKubeClient()
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	selfIPs := map[string]struct{}{}
+	if ips, err := nets.LookupHostIps(); err != nil {
+		klog.Warningf("fanout: lookup host ips error: %v", err)
+	} else {
+		for _, ip := range ips {
+			selfIPs[ip] = struct{}{}
+		}
+	}
+
+	var targets []NodeTarget
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		if !isNodeReady(n) {
+			continue
+		}
+		ip := internalIP(n)
+		if ip == "" {
+			continue
+		}
+		_, self := selfIPs[ip]
+		targets = append(targets, NodeTarget{
+			Name:     n.Name,
+			IP:       ip,
+			IsSelf:   self,
+			IsMaster: isMaster(n),
+		})
+	}
+	return targets, nil
+}
+
+// Run dispatches to every target concurrently and returns one result per
+// target. A failing node never aborts the others.
+func (d *Dispatcher) Run(ctx context.Context, targets []NodeTarget, payloadFor func(NodeTarget) any) []NodeResult {
+	timeout := d.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	parallel := d.Parallel
+	if parallel <= 0 {
+		parallel = defaultParallel
+	}
+
+	results := make([]NodeResult, len(targets))
+	sem := make(chan struct{}, parallel)
+	var wg sync.WaitGroup
+	for idx := range targets {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i] = d.call(ctx, targets[i], payloadFor(targets[i]), timeout)
+		}(idx)
+	}
+	wg.Wait()
+	return results
+}
+
+func (d *Dispatcher) call(ctx context.Context, t NodeTarget, payload any, timeout time.Duration) NodeResult {
+	res := NodeResult{Node: t}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		res.Status = StatusError
+		res.Err = fmt.Sprintf("marshal payload: %v", err)
+		return res
+	}
+
+	host := t.IP
+	if t.IsSelf {
+		host = "127.0.0.1"
+	}
+	url := fmt.Sprintf("http://%s:%d%s", host, OlaresdPort, d.PeerPath)
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		res.Status = StatusError
+		res.Err = err.Error()
+		return res
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if d.Signature != "" {
+		req.Header.Set(signatureHeader, d.Signature)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			res.Status = StatusTimeout
+		} else {
+			res.Status = StatusUnreachable
+		}
+		res.Err = err.Error()
+		return res
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		res.Status = StatusError
+		res.Err = fmt.Sprintf("node returned %d: %s", resp.StatusCode, string(respBody))
+		return res
+	}
+
+	res.Status = StatusOK
+	res.Data = respBody
+	return res
+}
+
+func isNodeReady(n *corev1.Node) bool {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func internalIP(n *corev1.Node) string {
+	for _, addr := range n.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
+}
+
+func isMaster(n *corev1.Node) bool {
+	if cp, ok := n.Labels["node-role.kubernetes.io/control-plane"]; ok && cp != "false" {
+		return true
+	}
+	if m, ok := n.Labels["node-role.kubernetes.io/master"]; ok && m != "false" {
+		return true
+	}
+	return false
+}

--- a/daemon/pkg/commands/collect_logs/archive.go
+++ b/daemon/pkg/commands/collect_logs/archive.go
@@ -1,0 +1,186 @@
+package collectlogs
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/daemon/pkg/cluster/fanout"
+	"github.com/beclab/Olares/daemon/pkg/commands"
+)
+
+func podLogsDir(home string) string {
+	return filepath.Join(home, commands.EXPORT_POD_LOGS_DIR)
+}
+
+func stagingRunDir(home, runID string) string {
+	return filepath.Join(podLogsDir(home), ".staging", sanitizeComponent(runID))
+}
+
+func nodeStagingDir(home, runID, node string) string {
+	return filepath.Join(stagingRunDir(home, runID), sanitizeComponent(node))
+}
+
+func finalArchivePath(home, runID string) string {
+	return filepath.Join(podLogsDir(home), fmt.Sprintf("olares-logs-%s.tar.gz", sanitizeComponent(runID)))
+}
+
+func newRunID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return time.Now().Format("20060102-150405")
+	}
+	return time.Now().Format("20060102-150405") + "-" + hex.EncodeToString(buf)
+}
+
+// sanitizeComponent keeps a value usable as a single path segment.
+func sanitizeComponent(s string) string {
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, "..", "_")
+	return s
+}
+
+type collectReport struct {
+	RunID      string            `json:"runID"`
+	Caller     string            `json:"caller"`
+	StartedAt  time.Time         `json:"startedAt"`
+	FinishedAt time.Time         `json:"finishedAt"`
+	Nodes      []nodeReportEntry `json:"nodes"`
+}
+
+type nodeReportEntry struct {
+	Name     string `json:"name"`
+	IP       string `json:"ip"`
+	IsSelf   bool   `json:"isSelf"`
+	IsMaster bool   `json:"isMaster"`
+	Status   string `json:"status"`
+	Err      string `json:"err,omitempty"`
+}
+
+// buildArchive merges each node's staging output into a single tar.gz. Per-node
+// content goes under nodes/<node>/; failed nodes get an error.txt so "this node
+// had no data / was unreachable" is visible after extraction. A
+// collect-report.json at the root records the authoritative per-node status.
+func buildArchive(archivePath, runDir, runID, caller string, startedAt time.Time, results []fanout.NodeResult) error {
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0755); err != nil {
+		return fmt.Errorf("mkdir archive dir: %w", err)
+	}
+	f, err := os.Create(archivePath)
+	if err != nil {
+		return fmt.Errorf("create archive: %w", err)
+	}
+	defer f.Close()
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	report := collectReport{
+		RunID:     runID,
+		Caller:    caller,
+		StartedAt: startedAt,
+	}
+
+	for _, r := range results {
+		report.Nodes = append(report.Nodes, nodeReportEntry{
+			Name:     r.Node.Name,
+			IP:       r.Node.IP,
+			IsSelf:   r.Node.IsSelf,
+			IsMaster: r.Node.IsMaster,
+			Status:   string(r.Status),
+			Err:      r.Err,
+		})
+
+		nodePrefix := filepath.Join("nodes", sanitizeComponent(r.Node.Name))
+		if r.Status != fanout.StatusOK {
+			msg := fmt.Sprintf("status: %s\nerror: %s\n", r.Status, r.Err)
+			if err := writeTarBytes(tw, filepath.Join(nodePrefix, "error.txt"), []byte(msg)); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := addDirToTar(tw, filepath.Join(runDir, sanitizeComponent(r.Node.Name)), nodePrefix); err != nil {
+			return err
+		}
+	}
+
+	report.FinishedAt = time.Now()
+	reportBytes, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if err := writeTarBytes(tw, "collect-report.json", reportBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addDirToTar(tw *tar.Writer, srcDir, destPrefix string) error {
+	info, err := os.Stat(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Node reported ok but produced nothing; leave a marker.
+			return writeTarBytes(tw, filepath.Join(destPrefix, "empty.txt"), []byte("node reported ok but produced no output\n"))
+		}
+		return fmt.Errorf("stat %s: %w", srcDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", srcDir)
+	}
+
+	return filepath.Walk(srcDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", path, err)
+		}
+		defer src.Close()
+		header := &tar.Header{
+			Name:    filepath.Join(destPrefix, rel),
+			Mode:    0644,
+			Size:    fi.Size(),
+			ModTime: fi.ModTime(),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("write header %s: %w", path, err)
+		}
+		if _, err := io.CopyN(tw, src, header.Size); err != nil {
+			return fmt.Errorf("write data %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func writeTarBytes(tw *tar.Writer, name string, data []byte) error {
+	header := &tar.Header{
+		Name:    name,
+		Mode:    0644,
+		Size:    int64(len(data)),
+		ModTime: time.Now(),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		return fmt.Errorf("write header %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("write data %s: %w", name, err)
+	}
+	return nil
+}

--- a/daemon/pkg/commands/collect_logs/authz.go
+++ b/daemon/pkg/commands/collect_logs/authz.go
@@ -1,0 +1,174 @@
+package collectlogs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/beclab/Olares/daemon/pkg/utils"
+	"github.com/beclab/Olares/framework/app-service/pkg/security"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	roleOwner  = "owner"
+	roleAdmin  = "admin"
+	roleNormal = "normal"
+)
+
+// ErrNothingRequested is returned when an authorized request would collect
+// nothing at all (caller asked for an empty scope).
+var ErrNothingRequested = errors.New("collect-logs: request selects nothing to collect")
+
+// ScopeDeniedError reports the parts of a request that the caller's role is
+// not allowed to collect. The handler maps this to HTTP 403.
+type ScopeDeniedError struct {
+	Denied []string
+}
+
+func (e *ScopeDeniedError) Error() string {
+	return fmt.Sprintf("requested scope exceeds caller permission, denied: %s", strings.Join(e.Denied, "; "))
+}
+
+// resolvedScope is the post-authz, post-wildcard-expansion collection plan
+// that translateFlags turns into olares-cli logs flags.
+type resolvedScope struct {
+	username string
+	role     string
+
+	collectSystemd    bool
+	systemdComponents []string // empty while collectSystemd => all known services
+	since             string
+	maxLines          int
+
+	collectDmesg       bool
+	collectNetwork     bool
+	collectClusterInfo bool
+
+	collectPods   bool
+	allNamespaces bool     // true => no --pod-namespaces filter (every namespace)
+	podNamespaces []string // concrete subset when !allNamespaces
+}
+
+// authorize resolves the caller's role, validates the requested scope against
+// it, and expands wildcards into a concrete plan. Privileged roles
+// (owner/admin) may collect anything; a normal user may only collect pod logs
+// from namespaces they own.
+func authorize(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, p *Param) (*resolvedScope, error) {
+	username, role, err := resolveCaller(ctx, dynamicClient, p.CallerOlaresID)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := &resolvedScope{username: username, role: role}
+	privileged := role == roleOwner || role == roleAdmin
+	var denied []string
+
+	if len(p.Systemd.Components) > 0 {
+		if !privileged {
+			denied = append(denied, "systemd (requires owner/admin)")
+		} else {
+			rs.collectSystemd = true
+			if !hasWildcard(p.Systemd.Components) {
+				rs.systemdComponents = p.Systemd.Components
+			}
+			rs.since = p.Systemd.Since
+			rs.maxLines = p.Systemd.MaxLines
+		}
+	}
+
+	if p.Host.Dmesg {
+		if !privileged {
+			denied = append(denied, "host.dmesg (requires owner/admin)")
+		} else {
+			rs.collectDmesg = true
+		}
+	}
+	if p.Host.Network {
+		if !privileged {
+			denied = append(denied, "host.network (requires owner/admin)")
+		} else {
+			rs.collectNetwork = true
+		}
+	}
+
+	if p.Cluster.Info {
+		if !privileged {
+			denied = append(denied, "cluster.info (requires owner/admin)")
+		} else {
+			rs.collectClusterInfo = true
+		}
+	}
+
+	if len(p.Namespaces.Names) > 0 {
+		rs.collectPods = true
+		if hasWildcard(p.Namespaces.Names) {
+			if privileged {
+				rs.allNamespaces = true
+			} else {
+				owned, err := listOwnedNamespaces(ctx, kubeClient, username)
+				if err != nil {
+					return nil, err
+				}
+				rs.podNamespaces = owned
+			}
+		} else if privileged {
+			rs.podNamespaces = p.Namespaces.Names
+		} else {
+			owned, err := listOwnedNamespaces(ctx, kubeClient, username)
+			if err != nil {
+				return nil, err
+			}
+			ownedSet := make(map[string]struct{}, len(owned))
+			for _, ns := range owned {
+				ownedSet[ns] = struct{}{}
+			}
+			for _, ns := range p.Namespaces.Names {
+				if _, ok := ownedSet[ns]; ok {
+					rs.podNamespaces = append(rs.podNamespaces, ns)
+				} else {
+					denied = append(denied, fmt.Sprintf("namespace %q (not owned by caller)", ns))
+				}
+			}
+		}
+	}
+
+	if len(denied) > 0 {
+		return nil, &ScopeDeniedError{Denied: denied}
+	}
+
+	// Guard against privilege escalation via the CLI's "empty filter = all"
+	// semantics: a normal user who owns nothing but asked for namespaces must
+	// not fall through to collecting every namespace.
+	if rs.collectPods && !rs.allNamespaces && len(rs.podNamespaces) == 0 {
+		rs.collectPods = false
+	}
+
+	if !rs.collectSystemd && !rs.collectDmesg && !rs.collectNetwork && !rs.collectClusterInfo && !rs.collectPods {
+		return nil, ErrNothingRequested
+	}
+
+	return rs, nil
+}
+
+// resolveCaller maps a verified Olares ID to its username and role.
+func resolveCaller(ctx context.Context, dynamicClient dynamic.Interface, olaresID string) (username, role string, err error) {
+	return utils.GetUserRoleByOlaresID(ctx, dynamicClient, olaresID)
+}
+
+func listOwnedNamespaces(ctx context.Context, kubeClient kubernetes.Interface, username string) ([]string, error) {
+	nss, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", security.NamespaceOwnerLabel, username),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list owned namespaces error: %w", err)
+	}
+	out := make([]string, 0, len(nss.Items))
+	for _, ns := range nss.Items {
+		out = append(out, ns.Name)
+	}
+	return out, nil
+}

--- a/daemon/pkg/commands/collect_logs/cmd.go
+++ b/daemon/pkg/commands/collect_logs/cmd.go
@@ -2,16 +2,24 @@ package collectlogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"time"
 
+	"github.com/beclab/Olares/daemon/pkg/cluster/fanout"
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	"github.com/beclab/Olares/daemon/pkg/commands"
 	"github.com/beclab/Olares/daemon/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
+// nodeLocalPath is the node-local endpoint the orchestrator fans out to.
+const nodeLocalPath = "/command/collect-logs-node"
+
+// collectLogs is the master-side orchestrator: it authorizes the request, then
+// fans the collection out to every node's node-local endpoint and merges the
+// per-node results into a single archive in the caller's Home.
 type collectLogs struct {
 	commands.Operation
 	*commands.BaseCommand
@@ -29,94 +37,112 @@ func New() commands.Interface {
 }
 
 func (i *collectLogs) Execute(ctx context.Context, p any) (res any, err error) {
+	param, ok := p.(*Param)
+	if !ok || param == nil {
+		return nil, fmt.Errorf("collect-logs: invalid param type %T", p)
+	}
+
+	kubeClient, err := utils.GetKubeClient()
+	if err != nil {
+		return nil, fmt.Errorf("create k8s client error: %w", err)
+	}
+	dynamicClient, err := utils.GetDynamicClient()
+	if err != nil {
+		return nil, fmt.Errorf("create dynamic client error: %w", err)
+	}
+
+	// Authorize synchronously so scope violations are reported to the caller
+	// (403) instead of being swallowed by the async orchestration.
+	rs, err := authorize(ctx, kubeClient, dynamicClient, param)
+	if err != nil {
+		return nil, err
+	}
+
+	// Results land in the requesting user's own Home (JuiceFS-backed, visible
+	// from every node), so any role can retrieve their result from Files.
+	home, err := utils.GetUserspacePvcHostPath(ctx, rs.username, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("get caller home path error: %w", err)
+	}
+
+	runID := newRunID()
+	signature := param.CallerSignature
+	// Forward the original (un-expanded) user scope; each node re-authorizes
+	// under the same identity and collects only its local portion.
+	nodeReqTemplate := *param
+
 	state.CurrentState.CollectingLogsState = state.InProgress
 	state.CurrentState.CollectingLogsError = ""
 
 	go func() {
+		startedAt := time.Now()
 		var (
 			errStr string
-			err    error
+			ferr   error
 		)
 		defer func() {
-			if err != nil {
+			if ferr != nil {
 				klog.Error(errStr)
 				state.CurrentState.CollectingLogsState = state.Failed
 				state.CurrentState.CollectingLogsError = errStr
 			}
 		}()
 
-		kubeClient, err := utils.GetKubeClient()
-		if err != nil {
-			errStr = fmt.Sprintf("create k8s / k3s client error, %v", err)
+		bgCtx := context.Background()
+		nodes, e := fanout.ListReadyNodes(bgCtx)
+		if e != nil {
+			ferr, errStr = e, fmt.Sprintf("list nodes error, %v", e)
+			return
+		}
+		if len(nodes) == 0 {
+			ferr = errors.New("no ready nodes found")
+			errStr = ferr.Error()
 			return
 		}
 
-		dynamicClient, err := utils.GetDynamicClient()
-		if err != nil {
-			errStr = fmt.Sprintf("create k8s / k3s client error, %v", err)
+		dispatcher := &fanout.Dispatcher{PeerPath: nodeLocalPath, Signature: signature}
+		results := dispatcher.Run(bgCtx, nodes, func(t fanout.NodeTarget) any {
+			req := &NodeRequest{Param: nodeReqTemplate, RunID: runID}
+			return req
+		})
+
+		archivePath := finalArchivePath(home, runID)
+		runDir := stagingRunDir(home, runID)
+		if e := buildArchive(archivePath, runDir, runID, rs.username, startedAt, results); e != nil {
+			ferr, errStr = e, fmt.Sprintf("build archive error, %v", e)
+			return
+		}
+		if e := os.Chown(archivePath, 1000, 1000); e != nil {
+			klog.Warningf("change archive owner error, %v", e)
+		}
+		if e := os.RemoveAll(runDir); e != nil {
+			klog.Warningf("cleanup staging dir error, %v", e)
+		}
+
+		var okCount int
+		var failed []string
+		for _, r := range results {
+			if r.Status == fanout.StatusOK {
+				okCount++
+			} else {
+				failed = append(failed, fmt.Sprintf("%s %s", r.Node.Name, r.Status))
+			}
+		}
+		if okCount == 0 {
+			ferr = errors.New("all nodes failed to collect logs")
+			errStr = ferr.Error()
 			return
 		}
 
-		adminUser, err := utils.GetAdminUser(ctx, dynamicClient)
-		if err != nil {
-			errStr = fmt.Sprintf("get admin user error, %v", err)
-			return
-		}
-
-		if adminUser == nil {
-			errStr = "admin user not found"
-			return
-		}
-
-		hostPath, err := utils.GetUserspacePvcHostPath(ctx, adminUser.GetName(), kubeClient)
-		if err != nil {
-			errStr = fmt.Sprintf("get admin user host path error, %v", err)
-			return
-		}
-
-		exportPodLogsDir := filepath.Join(hostPath, commands.EXPORT_POD_LOGS_DIR)
-
-		err = os.MkdirAll(exportPodLogsDir, 0755)
-		if err != nil {
-			errStr = fmt.Sprintf("mkdir error, %v", err)
-			return
-		}
-
-		err = os.Chown(exportPodLogsDir, 1000, 1000)
-		if err != nil {
-			errStr = fmt.Sprintf("change logs dir owner error, %v", err)
-			return
-		}
-
-		var cmds []string = []string{
-			"logs",
-			"--output-dir", exportPodLogsDir,
-			"--ignore-kube-errors", "true",
-		}
-
-		_, err = i.BaseCommand.Run_(ctx, "olares-cli", cmds...)
-		if err != nil {
-			state.CurrentState.CollectingLogsState = state.Failed
-			state.CurrentState.CollectingLogsError = err.Error()
-			errStr = fmt.Sprintf("collect logs error, %v", err)
-			return
-		}
-
-		// logTgz := fmt.Sprintf("%s/olares-logs-*.tar.gz", exportPodLogsDir)
-		// cmds = []string{
-		// 	"1000:1000",
-		// 	logTgz,
-		// }
-
-		// _, err = i.BaseCommand.Run_(ctx, "chown", cmds...)
-		// if err != nil {
-		// 	errStr = fmt.Sprintf("change logs file owner error, %v", err)
-		// 	return
-		// }
-
+		// Completed even with partial failures; see collect-report.json for
+		// the authoritative per-node status.
 		state.CurrentState.CollectingLogsState = state.Completed
-		state.CurrentState.CollectingLogsError = ""
-		klog.Info("collect log completed")
+		if len(failed) > 0 {
+			state.CurrentState.CollectingLogsError = fmt.Sprintf("partial: %v", failed)
+		} else {
+			state.CurrentState.CollectingLogsError = ""
+		}
+		klog.Infof("collect log completed, archive=%s, ok=%d/%d", archivePath, okCount, len(results))
 	}()
 
 	return nil, nil

--- a/daemon/pkg/commands/collect_logs/cmd_node.go
+++ b/daemon/pkg/commands/collect_logs/cmd_node.go
@@ -1,0 +1,130 @@
+package collectlogs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/beclab/Olares/daemon/pkg/commands"
+	"github.com/beclab/Olares/daemon/pkg/utils"
+)
+
+// nodeCollectLogs is the node-local executor invoked by the master
+// orchestrator on every node. It runs synchronously (the orchestrator waits on
+// the HTTP response) and collects only this node's logs into the shared staging
+// directory under the caller's Home.
+type nodeCollectLogs struct {
+	commands.Operation
+	*commands.BaseCommand
+}
+
+var _ commands.Interface = &nodeCollectLogs{}
+
+// NewNode builds the node-local executor. It reuses the CollectLogs operation
+// name so the state-machine validators admit it without changes.
+func NewNode() commands.Interface {
+	return &nodeCollectLogs{
+		Operation: commands.Operation{
+			Name: commands.CollectLogs,
+		},
+		BaseCommand: commands.NewBaseCommand(),
+	}
+}
+
+// NodeResultData is the payload a node returns to the orchestrator.
+type NodeResultData struct {
+	Node       string `json:"node"`
+	StagingDir string `json:"stagingDir"`
+}
+
+func (i *nodeCollectLogs) Execute(ctx context.Context, p any) (res any, err error) {
+	req, ok := p.(*NodeRequest)
+	if !ok || req == nil {
+		return nil, fmt.Errorf("collect-logs-node: invalid param type %T", p)
+	}
+	if req.RunID == "" {
+		return nil, fmt.Errorf("collect-logs-node: missing runID")
+	}
+
+	kubeClient, err := utils.GetKubeClient()
+	if err != nil {
+		return nil, fmt.Errorf("create k8s client error: %w", err)
+	}
+	dynamicClient, err := utils.GetDynamicClient()
+	if err != nil {
+		return nil, fmt.Errorf("create dynamic client error: %w", err)
+	}
+
+	// Defense in depth: re-authorize under the forwarded identity even though
+	// the master already did.
+	rs, err := authorize(ctx, kubeClient, dynamicClient, &req.Param)
+	if err != nil {
+		return nil, err
+	}
+
+	home, err := utils.GetUserspacePvcHostPath(ctx, rs.username, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("get caller home path error: %w", err)
+	}
+	nodeName, _, _, err := utils.GetThisNodeName(ctx, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("get this node name error: %w", err)
+	}
+
+	stagingDir := nodeStagingDir(home, req.RunID, nodeName)
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		return nil, fmt.Errorf("mkdir staging dir error: %w", err)
+	}
+
+	cmds := translateFlags(rs, stagingDir)
+	// Detached context: keep collecting even if the dispatch connection drops.
+	if _, err := i.BaseCommand.Run_(context.Background(), "olares-cli", cmds...); err != nil {
+		return nil, fmt.Errorf("collect logs error: %w", err)
+	}
+
+	return &NodeResultData{Node: nodeName, StagingDir: stagingDir}, nil
+}
+
+// translateFlags turns the resolved scope into olares-cli logs flags. Wildcards
+// are already expanded, so the CLI only ever sees concrete values.
+func translateFlags(rs *resolvedScope, outputDir string) []string {
+	cmds := []string{
+		"logs",
+		"--output-dir", outputDir,
+		"--ignore-kube-errors", "true",
+	}
+
+	if rs.collectSystemd {
+		if len(rs.systemdComponents) > 0 {
+			cmds = append(cmds, "--components", strings.Join(rs.systemdComponents, ","))
+		}
+		if rs.since != "" {
+			cmds = append(cmds, "--since", rs.since)
+		}
+		if rs.maxLines > 0 {
+			cmds = append(cmds, "--max-lines", strconv.Itoa(rs.maxLines))
+		}
+	} else {
+		cmds = append(cmds, "--skip-systemd")
+	}
+
+	if !rs.collectDmesg {
+		cmds = append(cmds, "--skip-dmesg")
+	}
+	if !rs.collectNetwork {
+		cmds = append(cmds, "--skip-network")
+	}
+	if !rs.collectClusterInfo {
+		cmds = append(cmds, "--skip-cluster-info")
+	}
+
+	if !rs.collectPods {
+		cmds = append(cmds, "--skip-pod-logs")
+	} else if !rs.allNamespaces {
+		cmds = append(cmds, "--pod-namespaces", strings.Join(rs.podNamespaces, ","))
+	}
+
+	return cmds
+}

--- a/daemon/pkg/commands/collect_logs/param.go
+++ b/daemon/pkg/commands/collect_logs/param.go
@@ -1,0 +1,66 @@
+package collectlogs
+
+// Wildcard means "all" within a group. For namespaces it is role-relative
+// (owner/admin => every namespace; normal => every namespace they own); for
+// systemd components it means every known Olares service.
+const Wildcard = "*"
+
+// SystemdGroup selects systemd service logs. Components nil/empty => skip the
+// group; ["*"] => all known services; a concrete list => that subset. Since
+// and MaxLines only affect this group (journalctl).
+type SystemdGroup struct {
+	Components []string `json:"components,omitempty"`
+	Since      string   `json:"since,omitempty"`
+	MaxLines   int      `json:"maxLines,omitempty"`
+}
+
+// HostGroup selects node-level, non-namespaced host data.
+type HostGroup struct {
+	Dmesg   bool `json:"dmesg,omitempty"`
+	Network bool `json:"network,omitempty"`
+}
+
+// ClusterGroup selects cluster-level info (kubectl describe / pods-list /
+// envoy config) plus olares-cli's own logs.
+type ClusterGroup struct {
+	Info bool `json:"info,omitempty"`
+}
+
+// NamespacesGroup selects pod logs by namespace. Names nil/empty => skip;
+// ["*"] => all (role-relative); a concrete list => those namespaces.
+type NamespacesGroup struct {
+	Names []string `json:"names,omitempty"`
+}
+
+// Param is the collect-logs request contract.
+type Param struct {
+	Systemd    SystemdGroup    `json:"systemd"`
+	Host       HostGroup       `json:"host"`
+	Cluster    ClusterGroup    `json:"cluster"`
+	Namespaces NamespacesGroup `json:"namespaces"`
+
+	// CallerOlaresID is injected by the handler from the signature-verified
+	// client; it is intentionally not decoded from the request body.
+	CallerOlaresID string `json:"-"`
+	// CallerSignature is the verified X-Signature, injected by the master
+	// handler so the orchestrator can forward it to each node's olaresd.
+	CallerSignature string `json:"-"`
+}
+
+// NodeRequest is what the master orchestrator sends to each node's node-local
+// endpoint. It carries the (un-expanded) user scope plus the run id used to
+// compute the shared staging directory. Identity fields stay json:"-" so each
+// node re-derives them from its own signature check.
+type NodeRequest struct {
+	Param
+	RunID string `json:"runID"`
+}
+
+func hasWildcard(items []string) bool {
+	for _, it := range items {
+		if it == Wildcard {
+			return true
+		}
+	}
+	return false
+}

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -37,8 +37,39 @@ import (
 )
 
 const (
-	RoleOwner = "owner"
+	RoleOwner  = "owner"
+	RoleAdmin  = "admin"
+	RoleNormal = "normal"
 )
+
+// GetUserRoleByOlaresID maps a verified Olares ID to its username and role. The
+// user CR name is the local part of the Olares ID; a missing role annotation is
+// treated as the least-privileged "normal".
+func GetUserRoleByOlaresID(ctx context.Context, dynamicClient dynamic.Interface, olaresID string) (username, role string, err error) {
+	if olaresID == "" {
+		return "", "", errors.New("empty caller identity")
+	}
+	username = olaresID
+	if at := strings.Index(olaresID, "@"); at > 0 {
+		username = olaresID[:at]
+	}
+
+	users, err := ListUsers(ctx, dynamicClient)
+	if err != nil {
+		return "", "", err
+	}
+	for _, u := range users {
+		if u.GetName() != username {
+			continue
+		}
+		role = u.GetAnnotations()[bflconst.UserAnnotationOwnerRole]
+		if role == "" {
+			role = RoleNormal
+		}
+		return username, role, nil
+	}
+	return "", "", fmt.Errorf("caller %q not found among Olares users", olaresID)
+}
 
 func GetKubeClient() (kubernetes.Interface, error) {
 	config, err := ctrl.GetConfig()


### PR DESCRIPTION
## Summary

Reworks `collect-logs` from a "dump everything to admin" call into a scoped, role-aware, multi-node collector. Three commits:

1. **cli**: `olares-cli logs` gains composable section switches — `--pod-namespaces` plus `--skip-systemd/--skip-dmesg/--skip-network/--skip-cluster-info/--skip-pod-logs`. Defaults preserve the original full-collection behavior; pod logs are pruned per namespace by the `/var/log/pods` dir prefix.
2. **daemon (contract + authz)**: defines the `collect-logs` request contract (`systemd`/`host`/`cluster`/`namespaces` groups) and authorizes it against the signature-verified caller. Identity is injected from the verified client, never the body. owner/admin may collect anything; a normal user is limited to pod logs from namespaces they own (`bytetrade.io/ns-owner`), with out-of-scope items hard-rejected (403 + denied list). Adds `RequireOwnerOrAdmin` + a role-resolution helper. Output now lands in the requesting user's own Home (so any allowed role can retrieve it).
3. **daemon (multi-node fan-out)**: a generic `cluster/fanout` package (decoupled from logging) dispatches a node-local action to every Ready node's olaresd and aggregates per-node results, treating an unreachable node as a first-class result. `collect-logs` splits into a master orchestrator (`RequireMaster`, owner/admin) that fans out and merges into one archive with a `collect-report.json`, and a node-local executor (`/command/collect-logs-node`, any role, scope-checked) collecting into the caller's shared Home staging.

### Endpoint authz
- `/command/collect-logs` — `RequireMaster` -> `RequireSignature` -> `RequireOwnerOrAdmin`. Caller must target the master; non-master returns 403 (no proxy). Workers' logs are still collected via fan-out.
- `/command/collect-logs-node` — `RequireSignature` only (all roles); `authorize()` scopes normal users to their own namespaces.

### Notes
- Node-local reuses the `CollectLogs` op name so state-machine validators admit it without changes.
- Single-node runs through the same path (master -> self via loopback).
- A failed/unreachable node yields a partial archive plus a `nodes/<node>/error.txt` and a status entry in `collect-report.json`; the run is `Completed` (not `Failed`) unless every node fails. Completed != all-nodes-OK; `collect-report.json` is authoritative.
- `os.Chown(..., 1000, 1000)` on the output is best-effort; precise per-user uid resolution is a follow-up.

## Test plan

- [ ] `olares-cli logs` with no flags behaves as before (full collection).
- [ ] `--pod-namespaces a,b` only includes those namespaces under `pods/`; `--skip-*` switches each drop their section.
- [ ] owner/admin: `collect-logs` collects requested scope; archive lands in caller Home with `collect-report.json`.
- [ ] normal user: `collect-logs` -> 403; direct `collect-logs-node` only yields their own namespaces; systemd/host/cluster denied.
- [ ] multi-node: each node's pods/host logs appear under `nodes/<node>/`; kill one node -> partial archive + `error.txt` + report entry, others still collected.
- [ ] non-master `collect-logs` -> 403.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/authorization boundaries, forwards signatures across nodes for host log collection, and exposes cluster-wide sensitive logs to owner/admin—incorrect scope or fan-out handling could leak data or allow privilege escalation.
> 
> **Overview**
> **Scoped, role-aware, multi-node log collection** replaces the previous “run full `olares-cli logs` into admin Home” flow.
> 
> `olares-cli logs` gains **`--pod-namespaces`** and **`--skip-*`** section switches so the daemon can request partial collection; defaults keep the old full dump when no skips are set.
> 
> On the daemon, **`/command/collect-logs`** is now **master-only**, **signed**, and **owner/admin**-gated. It accepts a structured scope (`systemd`, `host`, `cluster`, `namespaces`), **authorizes** it from the verified caller (not the body), writes results to the **requester’s Home**, and **fans out** to every Ready node via new **`/command/collect-logs-node`** (signature only, re-authz on each node). A generic **`fanout`** package aggregates per-node outcomes; the master merges staging into one **`olares-logs-*.tar.gz`** with **`nodes/<node>/`** layout and root **`collect-report.json`** (partial success is **Completed** unless every node fails).
> 
> **Normal users** are limited to pod logs in namespaces they own; out-of-scope requests return **403** with a denied list. **`GetUserRoleByOlaresID`** and **`RequireOwnerOrAdmin`** support role checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2082d3a39f996d22a6fad3a325f130207d6cd3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->