### PR TITLE
chore(manifest): add system level huggingface envs

### DIFF
--- a/build/system-env.yaml
+++ b/build/system-env.yaml
@@ -40,3 +40,14 @@ systemEnvs:
   - envName: OLARES_SYSTEM_CUDA_VERSION
     editable: false
     required: false
+  # system-level Hugging Face service endpoint, shared across users
+  - envName: OLARES_SYSTEM_HUGGINGFACE_SERVICE
+    default: "https://huggingface.co/"
+    type: url
+    editable: true
+    required: false
+  # system-level Hugging Face access token, shared across users
+  - envName: OLARES_SYSTEM_HUGGINGFACE_TOKEN
+    type: password
+    editable: true
+    required: false

--- a/framework/app-service/controllers/systemenv_processenv_controller.go
+++ b/framework/app-service/controllers/systemenv_processenv_controller.go
@@ -144,6 +144,11 @@ func InitializeSystemEnvProcessEnv(ctx context.Context, c client.Client) error {
 					if isCNDomain {
 						newDefaultVal = "https://cdn.olares.cn"
 					}
+				case "OLARES_SYSTEM_HUGGINGFACE_SERVICE":
+					newDefaultVal = "https://huggingface.co/"
+					if isCNDomain {
+						newDefaultVal = "https://hf-mirror.com"
+					}
 
 				}
 				if newDefaultVal != "" && se.Default != newDefaultVal {


### PR DESCRIPTION
* **Background**
Add system level envs for huggingface `OLARES_SYSTEM_HUGGINGFACE_SERVICE`

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a shared, editable system password env for Hugging Face tokens alongside URL defaults; behavior mirrors existing regional service envs but expands secret handling at system scope.
> 
> **Overview**
> Adds **system-wide** Hugging Face configuration via two new `SystemEnv` entries in `build/system-env.yaml`: `OLARES_SYSTEM_HUGGINGFACE_SERVICE` (URL, default `https://huggingface.co/`, editable) and `OLARES_SYSTEM_HUGGINGFACE_TOKEN` (password, optional, editable).
> 
> Startup migration in `SystemEnvProcessEnvController` now patches `OLARES_SYSTEM_HUGGINGFACE_SERVICE` defaults like other regional services—**global** `huggingface.co`, **`.cn` domains** `https://hf-mirror.com`—when not yet migrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ee112d73fe0e39b799dcce2ffadc6195da9964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->