### PR TITLE
cli: add ComfyUI cache directory creation in app common directory setup

### DIFF
--- a/cli/pkg/storage/constants.go
+++ b/cli/pkg/storage/constants.go
@@ -46,4 +46,5 @@ var (
 	HuggingFaceCacheDir = path.Join(AppCommonDir, "huggingface")
 	LLampCPPCacheDir    = path.Join(AppCommonDir, "llama.cpp")
 	OllamaCacheDir      = path.Join(AppCommonDir, "ollama")
+	ComfyUICacheDir     = path.Join(AppCommonDir, "comfyui")
 )

--- a/cli/pkg/storage/tasks.go
+++ b/cli/pkg/storage/tasks.go
@@ -425,8 +425,8 @@ func (t *CreateAppCommonDir) Execute(runtime connector.Runtime) error {
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", HuggingFaceCacheDir, HuggingFaceCacheDir), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "failed to create huggingface cache dir")
 	}
-	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", LLampCPPCacheDir, LLampCPPCacheDir), false, false); err != nil {
-		return errors.Wrap(errors.WithStack(err), "failed to create llama.cpp cache dir")
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", ComfyUICacheDir, ComfyUICacheDir), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to create comfyui cache dir")
 	}
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown 1000:1000 %s", OllamaCacheDir, OllamaCacheDir), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "failed to create ollama cache dir")

--- a/cli/pkg/upgrade/1_12_7_20260603.go
+++ b/cli/pkg/upgrade/1_12_7_20260603.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260603 struct {
+	upgrader_1_12_7_20260527
+}
+
+func (u upgrader_1_12_7_20260603) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260603")
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260603{})
+}


### PR DESCRIPTION
* **Background**
Add ComfyUI cache directory creation in app common directory setup

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to filesystem directory creation during install/upgrade; no auth or data-path logic changes.
> 
> **Overview**
> Adds a shared **ComfyUI** cache path under the JuiceFS app `Common` tree and provisions it during non-Darwin storage setup (`mkdir` + `chown 1000:1000`), alongside the existing Hugging Face and Ollama cache dirs.
> 
> **`CreateAppCommonDir` no longer creates the `llama.cpp` cache directory**; that step is replaced by ComfyUI. The `LLampCPPCacheDir` constant remains defined but is unused in this provisioning path.
> 
> Registers daily upgrade **`1.12.7-20260603`**, embedding the prior `1.12.7-20260527` upgrader so existing upgrade behavior carries forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3922c5608b1218b28a409819126d81cbdf81d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->