### PR TITLE
feat(appservice): AdvertiseExitNode and nats ref

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.30
+        image: beclab/app-service:0.5.31
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260603032434-aced6784e517
-	github.com/beclab/api v0.0.12
+	github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b
+	github.com/beclab/api v0.0.13
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29
 	github.com/containers/image/v5 v5.36.1

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -114,10 +114,16 @@ github.com/beclab/Olares/framework/oac v0.0.0-20260601121600-b2b5bb20726e h1:J4P
 github.com/beclab/Olares/framework/oac v0.0.0-20260601121600-b2b5bb20726e/go.mod h1:DiZ0SUoJ5iG5aimSjdboB/tEBol14gIyLYOzoxTBkQg=
 github.com/beclab/Olares/framework/oac v0.0.0-20260603032434-aced6784e517 h1:Y7jUsyc9lbzyHvqu2boVBN7SczDPhW7SV6V0o1sj5F4=
 github.com/beclab/Olares/framework/oac v0.0.0-20260603032434-aced6784e517/go.mod h1:wXiRJGn0/C+6r2U3StJukbJ932h6wmGMHKUNJEdMMtI=
+github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b h1:nMoZVtw2YMia2u4rEssTxko5mTS1o4J7n3FJzcnYdjU=
+github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
 github.com/beclab/api v0.0.11 h1:jNVX+hnZ4UJoF0S2wUEjepEULrhQcAs5Oh97IPbnBtA=
 github.com/beclab/api v0.0.11/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.12 h1:8+pxq5I7Xt9XfSM23RuOJD2kIKggdJ/LaUYWM0gcj04=
 github.com/beclab/api v0.0.12/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.13-0.20260603073817-917af9848082 h1:nUHE7nfgx1hQzG89g1tus85+dc6TlkdNxH8H7wOITd4=
+github.com/beclab/api v0.0.13-0.20260603073817-917af9848082/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.13 h1:j1mD9jEM8blE2ZhJigCe0B0X9APX0sHH0plGlBSOjak=
+github.com/beclab/api v0.0.13/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=
 github.com/beclab/lldap-client v0.0.11/go.mod h1:Y74tcKzyNL73a9pFAvImwXgzqp7S7Jb8RY1mMY90e/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -340,7 +340,8 @@ func (h *Handler) getOriginChartVersion(rawAppName, owner string) (string, error
 		return "", err
 	}
 	for _, am := range ams.Items {
-		if am.Spec.AppName == rawAppName && am.Spec.AppOwner == owner {
+		isV3 := am.Labels[constants.AppApiVersionLabel] == "v3"
+		if (am.Spec.AppName == rawAppName && am.Spec.AppOwner == owner) || (am.Spec.AppName == rawAppName && isV3) {
 			return am.Annotations[api.AppVersionKey], nil
 		}
 	}

--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -1050,7 +1050,9 @@ func (h *Handler) getApplicationSubject(req *restful.Request, resp *restful.Resp
 					refSubject := tapr.RefSubject{}
 					rsMap := rs.(map[string]interface{})
 					refSubject.Name, _, _ = unstructured.NestedString(rsMap, "name")
-					refSubject.Perm, _, _ = unstructured.NestedStringSlice(rsMap, "perm")
+					refSubject.Pub, _, _ = unstructured.NestedString(rsMap, "pub")
+					refSubject.Sub, _, _ = unstructured.NestedString(rsMap, "sub")
+
 					ref.Subjects = append(ref.Subjects, refSubject)
 				}
 

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -117,6 +117,7 @@ type ApplicationConfig struct {
 	LLMGatewaySupported bool
 	OverlayGateway      OverlayGateway
 	WorkloadReplicas    *WorkloadReplicas
+	TemplateOnly        bool
 }
 
 func (c *ApplicationConfig) IsMiddleware() bool {

--- a/framework/app-service/pkg/tapr/middleware_request_tpl.go
+++ b/framework/app-service/pkg/tapr/middleware_request_tpl.go
@@ -193,13 +193,12 @@ spec:
     refs: 
       {{- range $k, $v := .Middleware.Refs }}
       - appName: {{ $v.AppName }}
+        appNamespace: {{ $v.AppNamespace }}
         subjects:
           {{- range $sk, $sv := $v.Subjects }}
           - name: {{ $sv.Name }}
-            perm:
-            {{- range $pk, $pv := $sv.Perm }}
-            - {{ $pv }}
-            {{- end }}
+            pub: {{ $sv.Pub }}
+            sub: {{ $sv.Sub }}
           {{- end }}
       {{- end }}
     {{- else }}

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -1096,6 +1096,7 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		LLMGatewaySupported:  cfg.Options.LLMGatewaySupported,
 		OverlayGateway:       cfg.OverlayGateway,
 		WorkloadReplicas:     cfg.WorkloadReplicas,
+		TemplateOnly:         cfg.Options.TemplateOnly,
 	}
 
 	// v3 / shared apps are themselves the destination of cross-namespace


### PR DESCRIPTION


* **Background**

* **Target Version for Merge**
    fix(app-service/tapr): render nats ref subjects with new schema and proper indentation
    
    The NATS MiddlewareRequest template still emitted the old
    `perm: []` array for each ref subject, and the recently added
    `pub:` line was indented with tab characters. The rendered YAML
    was therefore rejected by the parser with
    
    Align the refs block with the RefSubject schema shipped in
    github.com/beclab/api v0.0.13 (Name/Pub/Sub) and render the new
    Ref.AppNamespace field. All indentation is normalized to spaces
    so the resulting MiddlewareRequest parses cleanly.
* **Related Issues**
v1.12.6,v1.12.7
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes middleware NATS CR rendering and install chart-version resolution for v3 apps; mis-rendered refs could break NATS provisioning until charts are re-applied.
> 
> **Overview**
> Bumps **app-service** to image `0.5.31` and pulls in **`github.com/beclab/api` v0.0.13** (and a newer **oac** pin) so NATS middleware and install paths match the updated API types.
> 
> **NATS refs** are aligned with the new `RefSubject` shape: generated `MiddlewareRequest` YAML now emits **`appNamespace`** on each ref and **`pub` / `sub`** per ref subject (replacing the old **`perm`** list), with consistent space indentation so manifests parse cleanly. The **get application subject** API reads the same fields when unmarshalling live `MiddlewareRequest` objects.
> 
> **Install / clone** chart-version lookup for a raw app name now resolves **v3** `ApplicationManager` records by app name and the **v3 API version label**, not only when `appOwner` matches the caller—so shared v3 apps can supply the origin chart version without an owner match.
> 
> Manifest options gain **`TemplateOnly`**, wired through **`ApplicationConfig`** and chart loading like other option flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633a0259891fc6124e8aaff00ac7e72bab158d54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->