### PR TITLE
helm-charts/system-apps: bump system-frontend & user-service images (files, compute, i18n)

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.40
+          image: beclab/system-frontend:v1.10.42
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.96
+          image: beclab/user-service:v0.0.97
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

Bumps the system-app container images (`system-frontend` → v1.10.42, `user-service` → v0.0.97) to ship the following changes:

- **Files**: archive preview and transfer support (TermiPass#1161); NFS mount alongside SMB (TermiPass#1164); restrict Common drive sharing to public only (TermiPass#1163); remove the external drive menu option from `DriveDataAPI` (TermiPass#1167).
- **Compute**: accelerator resource management and compute-binding dialogs on the frontend (TermiPass#1165), backed by replacing `GPUController` with `ComputeController` in user-service (user-service#82).
- **i18n**: batch update of UX copies (TermiPass#1166).
- **Backend fix**: mdns proxy auth header resolution (user-service#82).

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/user-service/pull/82
https://github.com/beclab/TermiPass/pull/1165
https://github.com/beclab/TermiPass/pull/1166
https://github.com/beclab/TermiPass/pull/1167
https://github.com/beclab/TermiPass/pull/1164
https://github.com/beclab/TermiPass/pull/1161
https://github.com/beclab/TermiPass/pull/1163

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image-only deploy change but touches user-facing Files/compute flows and user-service auth/mDNS behavior; rollout risk is mainly regression in those areas, not manifest misconfiguration.
> 
> **Overview**
> This PR only updates pinned container images in `olares-app.yaml` for the **olares-app** deployment: the `olares-app-init` init container moves from `beclab/system-frontend:v1.10.40` to **v1.10.42**, and the `user-service` container from **v0.0.96** to **v0.0.97**. No Helm values, env vars, or other manifest structure change.
> 
> Those tags roll out bundled app changes described in the PR: **Files** (archive preview/transfer, NFS alongside SMB, Common-drive sharing limited to public, external-drive menu removed), **compute** UI for accelerator resources and binding (with user-service moving from `GPUController` to `ComputeController`), **i18n** copy updates, and a user-service fix for **mDNS proxy auth header** resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2227a9a3572df5285a0b618892bce91b4e254df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->