### PR TITLE
files archive: source/password preflight, conflict modes, fix progress

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.177
+          image: beclab/files-server:v0.2.178
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat: preflight source existence on compress/extract/entries/entry — 400 when missing.
- feat: preflight archive password — 30001 (required), 30002 (incorrect), 30003 (not required).
- feat: detect .zip per-entry encryption (invisible to `7z l`) via stdlib `archive/zip`.
- feat: compress conflict modes — rename / overwrite (with `.bak.<taskid>` rollback) / skip.
- fix: extract `rename` now renames the colliding top-level entry instead of overwriting.
- fix: 7z progress updates continuously (split scanner on `\b`) instead of jumping 0→100.
- fix: restore external destination mount-alive check in compress / extract / rsync tasks.
- chore: rename archive response field `msg` → `message` to match the rest of the API.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/341

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling the files-server image can change compress/extract/archive behavior and API responses cluster-wide; the diff itself is a one-line tag change with no config rollback in-repo.
> 
> **Overview**
> Bumps the **`files`** container image in the Olares cluster **`files` DaemonSet** from `beclab/files-server:v0.2.177` to **`v0.2.178`** in `files_deploy.yaml`. No other manifest fields change in this diff.
> 
> That tag roll is the deployment hook for the archive/files-server behavior described in the PR (preflight, password errors, conflict modes, progress and extract fixes, `message` field rename)—those logic changes live in the image, not in this repository diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04473173bd99cd83f2b09e6ccc23893a8f564b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->