### PR TITLE
daemon: enhance NFS listing with mounted status

### DIFF
--- a/cli/pkg/bootstrap/os/templates/init_script.go
+++ b/cli/pkg/bootstrap/os/templates/init_script.go
@@ -98,6 +98,15 @@ systemctl disable firewalld 1>/dev/null 2>/dev/null
 systemctl stop ufw 1>/dev/null 2>/dev/null
 systemctl disable ufw 1>/dev/null 2>/dev/null
 
+cat > /etc/NetworkManager/conf.d/20-bridge-ignore-carrier.conf  << EOF
+[device-with-carrier]
+match-device=type:bridge
+ignore-carrier=no
+EOF
+
+systemctl restart NetworkManager 1>/dev/null 2>/dev/null
+
+
 modinfo br_netfilter > /dev/null 2>&1
 if [ $? -eq 0 ]; then
    modprobe br_netfilter

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -41,6 +41,7 @@ func (u upgrader_1_12_6) PrepareForUpgrade() []task.Interface {
 	tasks = append(tasks, upgradeNodeExporter()...)
 	tasks = append(tasks, upgradeMultus()...)
 	tasks = append(tasks, createAppCommonDir()...)
+	tasks = append(tasks, upgradeNetworkManagerConfig()...)
 
 	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
 	return tasks

--- a/cli/pkg/upgrade/1_12_7_20260604.go
+++ b/cli/pkg/upgrade/1_12_7_20260604.go
@@ -1,0 +1,71 @@
+package upgrade
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+	"github.com/pkg/errors"
+)
+
+type upgrader_1_12_7_20260604 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260604) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260604")
+}
+
+func (u upgrader_1_12_7_20260604) PrepareForUpgrade() []task.Interface {
+	tasks := make([]task.Interface, 0)
+	tasks = append(tasks, &task.LocalTask{
+		Name:   "UpgradeCniPluginsBinary",
+		Action: new(upgradeCniPluginsBinary),
+	},
+	)
+	tasks = append(tasks, upgradeNetworkManagerConfig()...)
+
+	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+	return tasks
+
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260604{})
+}
+
+// only for daily build to fix cni-plugins binary issue, will be removed in future
+type upgradeCniPluginsBinary struct {
+	common.KubeAction
+}
+
+func (u *upgradeCniPluginsBinary) Execute(runtime connector.Runtime) error {
+	m, err := manifest.ReadAll(u.KubeConf.Arg.Manifest)
+
+	binary, err := m.Get("cni-plugins")
+	if err != nil {
+		return fmt.Errorf("get cni-plugins binary info failed: %w", err)
+	}
+
+	path := binary.FilePath(runtime.GetBaseDir())
+
+	fileName := binary.Filename
+	dst := filepath.Join(common.TmpDir, fileName)
+	logger.Debugf("SyncKubeBinary cp cni-plugins from %s to %s", path, dst)
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
+		return err
+	}
+
+	if _, err := runtime.GetRunner().SudoCmd("systemctl restart cni-dhcp", false, false); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -724,3 +724,37 @@ func createAppCommonDir() []task.Interface {
 		},
 	}
 }
+
+type generateNetworkManagerConfigAction struct {
+	common.KubeAction
+}
+
+func (a *generateNetworkManagerConfigAction) Execute(runtime connector.Runtime) error {
+	cmd := `cat > /etc/NetworkManager/conf.d/20-bridge-ignore-carrier.conf  << EOF
+[device-with-carrier]
+match-device=type:bridge
+ignore-carrier=no
+EOF
+`
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), "failed to generate NetworkManager config")
+	}
+
+	if _, err := runtime.GetRunner().SudoCmd("systemctl restart NetworkManager", false, false); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func upgradeNetworkManagerConfig() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "GenerateNetworkManagerConfig",
+			Action: new(generateNetworkManagerConfigAction),
+			Retry:  5,
+			Delay:  5 * time.Second,
+		},
+	}
+}

--- a/daemon/internel/apiserver/handlers/handler_list_nfs.go
+++ b/daemon/internel/apiserver/handlers/handler_list_nfs.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/beclab/Olares/daemon/pkg/utils"
@@ -13,8 +14,9 @@ type ListNfsReq struct {
 }
 
 type nfsInfo struct {
-	Path string `json:"path"`
-	Acl  string `json:"acl"`
+	Path    string `json:"path"`
+	Acl     string `json:"acl"`
+	Mounted bool   `json:"mounted"`
 }
 
 func (h *Handlers) PostListNfs(ctx *fiber.Ctx) error {
@@ -38,11 +40,27 @@ func (h *Handlers) PostListNfs(ctx *fiber.Ctx) error {
 		return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
 	}
 
+	mountedNfsList, err := utils.MountedPath(ctx.Context())
+	if err != nil {
+		return h.ErrJSON(ctx, http.StatusInternalServerError, err.Error())
+	}
+
+	isMounted := func(nfsPath string) bool {
+		devicePath := fmt.Sprintf("%s:%s", req.Server, nfsPath)
+		for _, m := range mountedNfsList {
+			if m.Device == devicePath {
+				return true
+			}
+		}
+		return false
+	}
+
 	infoRes := make([]*nfsInfo, 0, len(nfsList))
 	for _, n := range nfsList {
 		infoRes = append(infoRes, &nfsInfo{
-			Path: n.Path,
-			Acl:  n.Acl,
+			Path:    n.Path,
+			Acl:     n.Acl,
+			Mounted: isMounted(n.Path),
 		})
 	}
 

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -153,6 +153,10 @@ func CheckCurrentStatus(ctx context.Context) error {
 					CurrentState.WifiSSID = &d.Connection
 				case "ethernet":
 					CurrentState.WiredConnected = true
+				case "bridge":
+					if d.Name == "br-olares" {
+						CurrentState.WiredConnected = true
+					}
 				}
 				continue
 			}

--- a/daemon/pkg/nets/net.go
+++ b/daemon/pkg/nets/net.go
@@ -61,6 +61,7 @@ func GetInternalIpv4Addr(opts ...any) (internalAddrs []*NetInterface, err error)
 		case strings.HasPrefix(ief.Name, "eth"):
 		case strings.HasPrefix(ief.Name, "en"):
 		case strings.HasPrefix(ief.Name, "wl"):
+		case ief.Name == "br-olares":
 		case ief.Name == gatewayInf.Name:
 		default:
 			continue

--- a/infrastructure/cni/.olares/Olares.yaml
+++ b/infrastructure/cni/.olares/Olares.yaml
@@ -8,6 +8,6 @@ output:
   binaries:
     - 
       id: cni-plugins
-      name: cni-plugins-v1.6.2.tgz,pkg/cni/v1.6.2,
+      name: cni-plugins-v1.6.2-olares1.tgz,pkg/cni/v1.6.2,
       amd64: https://github.com/beclab/plugins/releases/download/v1.6.2-olares1/cni-plugins-linux-amd64-v1.6.2-olares1.tgz
       arm64: https://github.com/beclab/plugins/releases/download/v1.6.2-olares1/cni-plugins-linux-arm64-v1.6.2-olares1.tgz


### PR DESCRIPTION
* **Background**
Listing NFS server shared path with mounted status

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes node-level networking (NetworkManager restarts, bridge carrier behavior) and replaces CNI plugin binaries on upgrade, which can briefly affect connectivity and pod networking on affected nodes.
> 
> **Overview**
> Extends the **NFS list API** so each export includes a **`mounted`** flag by comparing `server:path` against the host’s current mount table (same pattern as SMB listing).
> 
> On the **host networking** side, new installs and upgrades (v1.12.6 prepare + shared upgrade task, plus a **1.12.7 daily** upgrader) write **NetworkManager** `ignore-carrier=no` for bridges and **restart NetworkManager**. **`br-olares`** is treated like wired connectivity in cluster state and is included when resolving internal IPv4 addresses.
> 
> **CNI** artifacts switch to **`cni-plugins-v1.6.2-olares1`**; the daily upgrader redeploys that tarball to `/opt/cni/bin` and restarts **`cni-dhcp`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fee93477e225f09529760321a9b28e8686c11ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->