### PR TITLE
feat(cli): version-compatible remote commands (market / settings gpu / network overlay)

### DIFF
--- a/cli/cmd/ctl/market/client.go
+++ b/cli/cmd/ctl/market/client.go
@@ -278,12 +278,20 @@ func (c *MarketClient) CloneApp(ctx context.Context, appName, source, title stri
 	})
 }
 
-func (c *MarketClient) UninstallApp(ctx context.Context, appName string, all, deleteData bool) (*APIResponse, error) {
-	return c.doRequest(ctx, http.MethodDelete, "/apps/"+appName, UninstallRequest{
-		Sync:       true,
-		All:        all,
-		DeleteData: deleteData,
-	})
+// Do implements olaresclient.Doer: it executes a single JSON request and
+// returns the unwrapped `data` payload of the API envelope. The version-compat
+// layer (pkg/olaresclient) shapes the request line (method/path/body) per
+// backend version; transport (auth injection, refresh-on-401, envelope
+// validation, error reformatting) stays here so it is never re-implemented.
+func (c *MarketClient) Do(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	resp, err := c.doRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.Data, nil
 }
 
 // UpgradeApp issues PUT /apps/{name}/upgrade. The payload intentionally
@@ -309,15 +317,11 @@ func (c *MarketClient) CancelOperation(ctx context.Context, appName string) (*AP
 	})
 }
 
-func (c *MarketClient) ResumeApp(ctx context.Context, appName string) (*APIResponse, error) {
-	return c.doRequest(ctx, http.MethodPost, "/apps/resume", map[string]string{
-		"appName": appName,
-	})
-}
-
-func (c *MarketClient) StopApp(ctx context.Context, appName string, all bool) (*APIResponse, error) {
-	return c.doRequest(ctx, http.MethodPost, "/apps/stop", map[string]interface{}{
-		"appName": appName,
-		"all":     all,
-	})
-}
+// StopApp / ResumeApp / UninstallApp used to build their request bodies here.
+// Their wire format diverges across Olares versions (TermiPass PR #1162:
+// stop/resume/uninstall all moved to {app_name, source, ...}), so the body
+// shaping moved to pkg/olaresclient (clientV1_12_5 / clientV1_12_6) and the
+// runners dispatch through cmdutil.Factory.WithOlaresClient, with this
+// MarketClient acting as the version-agnostic olaresclient.Doer (see Do
+// above). UninstallRequest is retained in types.go as the 1.12.5 body shape
+// reference.

--- a/cli/cmd/ctl/market/common.go
+++ b/cli/cmd/ctl/market/common.go
@@ -34,6 +34,40 @@ func resolveCatalogSource(opts *MarketOptions) string {
 	return defaultCatalogSource
 }
 
+// resolveInstalledSource determines which market source an installed app
+// belongs to. The 1.12.6 stop/resume/uninstall wire format requires `source`
+// in the request body (TermiPass PR #1162), but those verbs don't expose
+// `-s` (source is implicit). An explicit --source wins when present;
+// otherwise it is read from the per-user state row via /market/state. Returns
+// a clear error when the app has no installed row, so the caller can fail
+// fast instead of sending a request the backend will reject for a missing
+// source.
+//
+// "Installed" mirrors the SPA's appStore.findAppByName(): it skips rows whose
+// state is in `uninstalledAppStates` (`!uninstalledApp(status)`), so a row
+// that lingers in /market/state in a terminal not-installed state
+// (installFailed, uninstalled, downloadFailed, the *Canceled variants — see
+// notInstalledStates / isInstalledState in types.go) is treated as "not
+// installed" rather than yielding a source for a request the backend will
+// reject. An explicit --source bypasses this guard (the user is asserting the
+// source themselves).
+func resolveInstalledSource(ctx context.Context, opts *MarketOptions, mc *MarketClient, appName string) (string, error) {
+	if s := strings.TrimSpace(opts.Source); s != "" {
+		return s, nil
+	}
+	row, err := lookupInstalledApp(ctx, mc, appName)
+	if err != nil {
+		return "", err
+	}
+	if row == nil || strings.TrimSpace(row.Source) == "" {
+		return "", fmt.Errorf("could not determine the source for %q: no installed app row found for this user (run `olares-cli market list --mine` to see installed apps)", appName)
+	}
+	if !isInstalledState(row.State) {
+		return "", fmt.Errorf("%q is not an installed app (state %q); nothing to operate on (run `olares-cli market list --mine` to see installed apps)", appName, row.State)
+	}
+	return row.Source, nil
+}
+
 func validateVersion(version string) error {
 	if _, err := semver.StrictNewVersion(strings.TrimPrefix(version, "v")); err != nil {
 		return fmt.Errorf("invalid version '%s': must be a valid semver (e.g. 1.0.0, 1.2.3)", version)

--- a/cli/cmd/ctl/market/resume.go
+++ b/cli/cmd/ctl/market/resume.go
@@ -2,10 +2,12 @@ package market
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
 )
 
 func NewCmdMarketResume(f *cmdutil.Factory) *cobra.Command {
@@ -50,11 +52,23 @@ func runResume(opts *MarketOptions, appName string) error {
 	opts.info("Resuming '%s' for user '%s'...", appName, mc.olaresID)
 
 	ctx := context.Background()
-	resp, err := mc.ResumeApp(ctx, appName)
+
+	// 1.12.6 requires source in the resume body; resolve it from the
+	// installed app's state row (resume exposes no -s).
+	source, err := resolveInstalledSource(ctx, opts, mc, appName)
 	if err != nil {
 		return opts.failOp("resume", appName, err)
 	}
 
-	result := newOperationResult(mc, "resume", appName, "", "", "resume requested", resp)
+	var data json.RawMessage
+	if err := opts.factory.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		d, e := c.ResumeApp(ctx, mc, appName, source)
+		data = d
+		return e
+	}); err != nil {
+		return opts.failOp("resume", appName, err)
+	}
+
+	result := newOperationResult(mc, "resume", appName, "", "", "resume requested", &APIResponse{Success: true, Data: data})
 	return runWithWatch(opts, mc, result, newWatchTarget(watchResume, appName, opts.Source))
 }

--- a/cli/cmd/ctl/market/stop.go
+++ b/cli/cmd/ctl/market/stop.go
@@ -2,10 +2,12 @@ package market
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
 )
 
 func NewCmdMarketStop(f *cmdutil.Factory) *cobra.Command {
@@ -84,11 +86,25 @@ func runStop(opts *MarketOptions, cmd *cobra.Command, appName string) error {
 		opts.info("  --cascade: will stop all sub-charts")
 	}
 
-	resp, err := mc.StopApp(ctx, appName, cascade)
+	// 1.12.6 requires source in the stop body; resolve it from the
+	// installed app's state row (stop exposes no -s).
+	source, err := resolveInstalledSource(ctx, opts, mc, appName)
 	if err != nil {
 		return opts.failOp("stop", appName, err)
 	}
 
-	result := newOperationResult(mc, "stop", appName, "", "", "stop requested", resp)
+	// Dispatch through the version-compat aspect: the request body shape
+	// (appName vs {app_name, source}) is chosen from the detected backend
+	// version.
+	var data json.RawMessage
+	if err := opts.factory.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		d, e := c.StopApp(ctx, mc, appName, source, cascade)
+		data = d
+		return e
+	}); err != nil {
+		return opts.failOp("stop", appName, err)
+	}
+
+	result := newOperationResult(mc, "stop", appName, "", "", "stop requested", &APIResponse{Success: true, Data: data})
 	return runWithWatch(opts, mc, result, newWatchTarget(watchStop, appName, opts.Source))
 }

--- a/cli/cmd/ctl/market/uninstall.go
+++ b/cli/cmd/ctl/market/uninstall.go
@@ -2,12 +2,14 @@ package market
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
 )
 
 func NewCmdMarketUninstall(f *cmdutil.Factory) *cobra.Command {
@@ -91,12 +93,28 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 		opts.info("  --delete-data: will delete persistent data")
 	}
 
-	resp, err := mc.UninstallApp(ctx, appName, cascade, opts.DeleteData)
+	// 1.12.6 requires app_name + source in the uninstall body (this is the
+	// change that broke `market uninstall` against the new backend);
+	// resolve source from the installed app's state row (uninstall exposes
+	// no -s).
+	source, err := resolveInstalledSource(ctx, opts, mc, appName)
 	if err != nil {
 		return opts.failOp("uninstall", appName, err)
 	}
 
-	result := newOperationResult(mc, "uninstall", appName, "", "", "uninstall requested", resp)
+	// Dispatch through the version-compat aspect. opts.Version is empty
+	// unless a future --version flag supplies one; the 1.12.6 client
+	// includes it when set and the 1.12.5 client ignores it.
+	var data json.RawMessage
+	if err := opts.factory.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		d, e := c.UninstallApp(ctx, mc, appName, source, opts.Version, cascade, opts.DeleteData)
+		data = d
+		return e
+	}); err != nil {
+		return opts.failOp("uninstall", appName, err)
+	}
+
+	result := newOperationResult(mc, "uninstall", appName, "", "", "uninstall requested", &APIResponse{Success: true, Data: data})
 	// Uninstall is unique: the row may simply disappear from /market/state
 	// once the backend cleans it up, so the watch target opts in to the
 	// "absent means success (provided we saw it earlier)" shortcut.

--- a/cli/cmd/ctl/profile/import.go
+++ b/cli/cmd/ctl/profile/import.go
@@ -90,5 +90,6 @@ func runImport(ctx context.Context, o *importOptions) error {
 	printSwitchNotice(res, profile.DisplayName())
 	printStorageNotice(profile.OlaresID)
 	eagerWhoami(ctx, cfg, profile, tok.AccessToken)
+	eagerBackendVersion(ctx, cfg, profile, tok.AccessToken)
 	return nil
 }

--- a/cli/cmd/ctl/profile/login.go
+++ b/cli/cmd/ctl/profile/login.go
@@ -139,6 +139,10 @@ func runLogin(ctx context.Context, o *loginOptions) error {
 	// warning so a transient backend blip doesn't shadow a successful
 	// login (see eagerWhoami doc comment).
 	eagerWhoami(ctx, cfg, profile, tok.AccessToken)
+	// Best-effort: pre-fill the backend-version cache so version-aware help
+	// / subcommand visibility (settings gpu, settings network overlay) is
+	// accurate from the first command. Same downgrade-to-warning contract.
+	eagerBackendVersion(ctx, cfg, profile, tok.AccessToken)
 	return nil
 }
 

--- a/cli/cmd/ctl/profile/version_eager.go
+++ b/cli/cmd/ctl/profile/version_eager.go
@@ -1,0 +1,75 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+	"github.com/beclab/Olares/cli/pkg/olares"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// eagerBackendVersion runs a best-effort GET /api/olares-info right after
+// `profile login` / `profile import` has persisted the new credentials, and
+// caches the backend osVersion into ProfileConfig.BackendVersion. This is the
+// version-cache analogue of eagerWhoami's role pre-fetch: it makes the
+// version-aware help / subcommand visibility (e.g. `settings gpu`, `settings
+// network overlay`) accurate from the very first command after login, rather
+// than only after some version-touching command happens to run.
+//
+// Best-effort means: any failure downgrades to a one-line stderr warning and
+// returns. Login/import already succeeded — a transient backend hiccup must
+// not shadow it; the cache will populate naturally on the next version-aware
+// command via the TTL path.
+//
+// We can't piggyback on eagerWhoami: /api/backend/v1/user-info returns only
+// {name, owner_role}, not osVersion — the version lives on the separate
+// /api/olares-info endpoint. Like eagerWhoami we use NewHTTPClientWithToken
+// (the just-minted token) rather than cmdutil.Factory.HTTPClient, which
+// memoizes the token from the first ResolveProfile and may be tied to a
+// different active profile under --no-switch.
+func eagerBackendVersion(
+	ctx context.Context,
+	cfg *cliconfig.MultiProfileConfig,
+	profile cliconfig.ProfileConfig,
+	accessToken string,
+) {
+	if accessToken == "" || cfg == nil {
+		return
+	}
+	id, err := olares.ParseID(profile.OlaresID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: skipped post-login version fetch: %v\n", err)
+		return
+	}
+	desktopURL := id.DesktopURL(profile.LocalURLPrefix)
+	client := whoami.NewHTTPClientWithToken(desktopURL, profile.OlaresID, accessToken, profile.InsecureSkipVerify)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var env struct {
+		Data struct {
+			OsVersion string `json:"osVersion"`
+		} `json:"data"`
+	}
+	if err := client.DoJSON(ctx, "GET", "/api/olares-info", nil, &env); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: post-login version fetch failed: %v\n", err)
+		return
+	}
+	osVersion := strings.TrimSpace(env.Data.OsVersion)
+	if osVersion == "" {
+		return
+	}
+	v, err := utils.ParseOlaresVersionString(osVersion)
+	if err != nil {
+		return
+	}
+	if _, err := cfg.SetBackendVersion(profile.OlaresID, v.Original(), time.Now().Unix()); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not cache Olares backend version: %v\n", err)
+	}
+}

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -59,6 +59,12 @@ func NewDefaultCommand() *cobra.Command {
 		},
 	}
 	cmds.Flags().BoolVar(&showVendor, "vendor", false, "show the vendor type of olares-cli")
+
+	// Version-compat controls for remote/API commands. These are persistent
+	// so any subcommand that dispatches through cmdutil.Factory.WithOlaresClient
+	// can honor them; PersistentPreRun binds them into viper above.
+	cmds.PersistentFlags().String(cmdutil.FlagOlaresVersion, "", "override the detected Olares backend version (e.g. 1.12.6, 1.12.6-20260603); skips /api/olares-info detection")
+	cmds.PersistentFlags().Bool(cmdutil.FlagRefreshVersion, false, "force a fresh backend-version read from /api/olares-info, ignoring the cached value")
 	// Identity is single-source: whichever profile `olares-cli profile use`
 	// (or the most recent `profile login` / `profile import`) selected. There
 	// is intentionally no per-invocation `--profile` override — agents and

--- a/cli/cmd/ctl/settings/gpu/bindings.go
+++ b/cli/cmd/ctl/settings/gpu/bindings.go
@@ -1,0 +1,88 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings gpu bindings <app>` (Olares 1.12.6+)
+//
+// Lists the compute (GPU) device bindings held by an app, via
+// olaresclient.ComputeOps.GetAppBindings (GET
+// /api/apps/<app>/compute-resources/bindings).
+func NewBindingsCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "bindings <app>",
+		Short: "show an app's compute (GPU) bindings (Olares 1.12.6+)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "list GPU bindings"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runBindings(ctx, f, args[0], output), "list GPU bindings")
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runBindings(ctx context.Context, f *cmdutil.Factory, appName, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.GetAppBindings(ctx, doer, appName)
+		if err != nil {
+			return err
+		}
+		var bindings []computeBinding
+		if err := decodeData(raw, &bindings); err != nil {
+			return err
+		}
+		if format == FormatJSON {
+			return printJSON(os.Stdout, bindings)
+		}
+		return renderBindings(os.Stdout, appName, bindings)
+	})
+}
+
+func renderBindings(w io.Writer, appName string, bindings []computeBinding) error {
+	if len(bindings) == 0 {
+		_, err := fmt.Fprintf(w, "%s has no compute bindings\n", appName)
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NODE\tDEVICE\tMODE\tMEMORY"); err != nil {
+		return err
+	}
+	for _, b := range bindings {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			nonEmpty(b.NodeName), nonEmpty(b.DeviceID), nonEmpty(b.Mode), formatMem(b.Memory),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/cli/cmd/ctl/settings/gpu/common.go
+++ b/cli/cmd/ctl/settings/gpu/common.go
@@ -1,27 +1,56 @@
-// Package gpu hosts `olares-cli settings gpu`. Mirrors the SPA's
-// Settings -> GPU page (devices, mode, per-app assignment). Backed by
-// user-service's gpu.controller.ts which proxies HAMI; all responses
-// wrapped with returnSucceed/returnError.
+// Package gpu hosts `olares-cli settings gpu` — the profile-based Settings ->
+// GPU / "Compute Acceleration" surface (NOT the kubeconfig-based top-level
+// `olares-cli gpu` tree, which is a separate lower-level command for cluster
+// admins).
 //
-// Note: this is the profile-based settings surface that mirrors the SPA.
-// The kubeconfig-based "olares-cli gpu" tree is a separate, lower-level
-// command for cluster admins; the two should not be confused.
+// This area is the canonical "complete replacement" example for the
+// version-compatibility framework (pkg/olaresclient): Olares 1.12.5 exposed a
+// HAMI-backed GPU device/mode model under /api/gpu/*, while 1.12.6 replaced it
+// wholesale with a node → device → supportType → binding model under
+// /api/compute-resources* (the old GPUController was deleted upstream). The two
+// share no wire format, so every verb dispatches through
+// Factory.WithOlaresClient and the olaresclient.ComputeOps capability:
+//
+//   - list          works on both lines; renders the matching shape per the
+//                   detected backend version (legacy GPUInfo vs ComputeResourceNode).
+//   - bindings      1.12.6+ only (ErrUnsupportedVersion below).
+//   - unbind        1.12.6+ only.
+//   - support-type  1.12.6+ only.
+//
+// Subcommand VISIBILITY (root.go) is driven by the LOCALLY CACHED backend
+// version so `--help` / completion stay offline; runtime CORRECTNESS is still
+// enforced by WithOlaresClient + the capability gate, so a stale cache only
+// affects what help advertises, never what actually runs.
 package gpu
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
-	"github.com/beclab/Olares/cli/pkg/cmdutil"
-	"github.com/beclab/Olares/cli/pkg/credential"
-	"github.com/beclab/Olares/cli/pkg/whoami"
+	"github.com/beclab/Olares/cli/pkg/utils"
 )
+
+// computeResourcesFloor is the first Olares line that speaks the
+// /api/compute-resources model. At or above this (core) version the new
+// surface is used; below it the legacy /api/gpu/list shape is rendered.
+var computeResourcesFloor = semver.MustParse("1.12.6")
+
+// usesComputeResources reports whether version v should be treated as the
+// new compute-resources line. A nil version (unknown / no cache) optimistically
+// assumes the newest surface — the runtime capability gate corrects an actually
+// older backend.
+func usesComputeResources(v *semver.Version) bool {
+	if v == nil {
+		return true
+	}
+	return !utils.CoreVersion(v).LessThan(computeResourcesFloor)
+}
 
 type Format string
 
@@ -46,62 +75,6 @@ func addOutputFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVarP(target, "output", "o", "table", "output format: table, json")
 }
 
-type Doer interface {
-	DoJSON(ctx context.Context, method, path string, body, out interface{}) error
-}
-
-type preparedClient struct {
-	profile *credential.ResolvedProfile
-	doer    Doer
-}
-
-func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
-	if f == nil {
-		return nil, fmt.Errorf("internal error: settings gpu not wired with cmdutil.Factory")
-	}
-	rp, err := f.ResolveProfile(ctx)
-	if err != nil {
-		return nil, err
-	}
-	hc, err := f.HTTPClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &preparedClient{
-		profile: rp,
-		doer:    whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID),
-	}, nil
-}
-
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
-func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
-	var env bflEnvelope
-	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
-		return err
-	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
-		}
-		return fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("GET %s: decode data: %w", path, err)
-	}
-	return nil
-}
-
 func printJSON(w io.Writer, v interface{}) error {
 	if w == nil {
 		w = os.Stdout
@@ -123,4 +96,29 @@ func boolStr(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+// formatMem renders a byte count as a short "12G" / "1.5G" label, matching the
+// SPA's formatComputeMemory. Zero / negative renders as "0G".
+func formatMem(bytes int64) string {
+	if bytes <= 0 {
+		return "0G"
+	}
+	g := float64(bytes) / (1024 * 1024 * 1024)
+	if g >= 10 {
+		return fmt.Sprintf("%dG", int64(g+0.5))
+	}
+	return fmt.Sprintf("%.1fG", g)
+}
+
+// decodeData unmarshals an olaresclient op's returned `data` payload, tolerating
+// an empty/absent body (treated as the zero value of T).
+func decodeData[T any](raw json.RawMessage, out *T) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
 }

--- a/cli/cmd/ctl/settings/gpu/list.go
+++ b/cli/cmd/ctl/settings/gpu/list.go
@@ -5,34 +5,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
 
 // `olares-cli settings gpu list`
 //
-// Backed by user-service's /api/gpu/list, which proxies HAMI. The body
-// is a BFL envelope around an array of GPUInfo:
-//
-//   {
-//     "nodeName": "...", "id": "...", "type": "...",
-//     "count": 1, "devmem": 12288, "devcore": 80,
-//     "mode": "exclusive" | "shared",
-//     "sharemode": "...",
-//     "health": true,
-//     "memoryAllocated": 0, "memoryAvailable": 0,
-//     "apps": [{"appName": "...", "memory": <int>}],
-//   }
+// Dispatches through olaresclient.ComputeOps.ListAccelerators, which targets
+// the version-appropriate endpoint (1.12.5: GET /api/gpu/list; 1.12.6: GET
+// /api/compute-resources). The two payloads have different shapes, so the
+// renderer branches on the dispatched client's version.
 func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "list GPUs / per-app assignment",
+		Short: "list GPU devices / per-app bindings",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
@@ -46,24 +41,54 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
+// --- legacy 1.12.5 shape (/api/gpu/list) ---
+
 type gpuApp struct {
 	AppName string `json:"appName"`
 	Memory  int    `json:"memory,omitempty"`
 }
 
 type gpuInfo struct {
-	NodeName        string   `json:"nodeName"`
-	ID              string   `json:"id"`
-	Count           int      `json:"count"`
-	DevMem          int      `json:"devmem"`
-	DevCore         int      `json:"devcore"`
-	Type            string   `json:"type"`
-	Mode            string   `json:"mode"`
-	ShareMode       string   `json:"sharemode"`
-	Health          bool     `json:"health"`
-	MemoryAvailable int      `json:"memoryAvailable,omitempty"`
-	MemoryAllocated int      `json:"memoryAllocated,omitempty"`
-	Apps            []gpuApp `json:"apps,omitempty"`
+	NodeName  string   `json:"nodeName"`
+	ID        string   `json:"id"`
+	Count     int      `json:"count"`
+	DevMem    int      `json:"devmem"`
+	DevCore   int      `json:"devcore"`
+	Type      string   `json:"type"`
+	Mode      string   `json:"mode"`
+	ShareMode string   `json:"sharemode"`
+	Health    bool     `json:"health"`
+	Apps      []gpuApp `json:"apps,omitempty"`
+}
+
+// --- 1.12.6 compute-resources shape (/api/compute-resources) ---
+
+type computeBinding struct {
+	AppID    string `json:"appId,omitempty"`
+	AppName  string `json:"appName"`
+	Owner    string `json:"owner,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	NodeName string `json:"nodeName,omitempty"`
+	DeviceID string `json:"deviceId"`
+	Memory   int64  `json:"memory,omitempty"`
+}
+
+type computeDevice struct {
+	ID                   string           `json:"id"`
+	NodeName             string           `json:"nodeName"`
+	CardModel            string           `json:"cardModel"`
+	Memory               int64            `json:"memory"`
+	Health               string           `json:"health,omitempty"`
+	SupportType          string           `json:"supportType"`
+	AvailableSupportType []string         `json:"availableSupportTypes,omitempty"`
+	Bindings             []computeBinding `json:"bindings,omitempty"`
+}
+
+type computeNode struct {
+	NodeName string          `json:"nodeName"`
+	GPUType  string          `json:"gpuType,omitempty"`
+	Modes    []string        `json:"modes,omitempty"`
+	Devices  []computeDevice `json:"devices,omitempty"`
 }
 
 func runList(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
@@ -74,26 +99,38 @@ func runList(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
 	if err != nil {
 		return err
 	}
-
-	pc, err := prepare(ctx, f)
+	doer, _, err := edge.New(ctx, f)
 	if err != nil {
 		return err
 	}
 
-	var rows []gpuInfo
-	if err := doGetEnvelope(ctx, pc.doer, "/api/gpu/list", &rows); err != nil {
-		return err
-	}
-
-	switch format {
-	case FormatJSON:
-		return printJSON(os.Stdout, rows)
-	default:
-		return renderGPUTable(os.Stdout, rows)
-	}
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.ListAccelerators(ctx, doer)
+		if err != nil {
+			return err
+		}
+		if usesComputeResources(c.Version()) {
+			var nodes []computeNode
+			if err := decodeData(raw, &nodes); err != nil {
+				return err
+			}
+			if format == FormatJSON {
+				return printJSON(os.Stdout, nodes)
+			}
+			return renderComputeTable(os.Stdout, nodes)
+		}
+		var rows []gpuInfo
+		if err := decodeData(raw, &rows); err != nil {
+			return err
+		}
+		if format == FormatJSON {
+			return printJSON(os.Stdout, rows)
+		}
+		return renderLegacyGPUTable(os.Stdout, rows)
+	})
 }
 
-func renderGPUTable(w io.Writer, rows []gpuInfo) error {
+func renderLegacyGPUTable(w io.Writer, rows []gpuInfo) error {
 	if len(rows) == 0 {
 		_, err := fmt.Fprintln(w, "no GPUs (no compatible devices, or HAMI is not running)")
 		return err
@@ -103,18 +140,65 @@ func renderGPUTable(w io.Writer, rows []gpuInfo) error {
 		return err
 	}
 	for _, r := range rows {
-		appCount := len(r.Apps)
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
-			nonEmpty(r.NodeName),
-			nonEmpty(r.ID),
-			nonEmpty(r.Type),
-			nonEmpty(r.Mode),
-			boolStr(r.Health),
-			r.DevMem,
-			r.DevCore,
-			appCount,
+			nonEmpty(r.NodeName), nonEmpty(r.ID), nonEmpty(r.Type), nonEmpty(r.Mode),
+			boolStr(r.Health), r.DevMem, r.DevCore, len(r.Apps),
 		); err != nil {
 			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// deviceUsedMemory sums allocated memory (bytes) across a device's bindings,
+// mirroring the SPA's deviceUsedMemory helper.
+func deviceUsedMemory(d computeDevice) int64 {
+	var sum int64
+	for _, b := range d.Bindings {
+		sum += b.Memory
+	}
+	return sum
+}
+
+func renderComputeTable(w io.Writer, nodes []computeNode) error {
+	hasDevice := false
+	for _, n := range nodes {
+		if len(n.Devices) > 0 {
+			hasDevice = true
+			break
+		}
+	}
+	if !hasDevice {
+		_, err := fmt.Fprintln(w, "no compute devices (no compatible accelerators detected)")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NODE\tDEVICE\tMODEL\tSUPPORT-TYPE\tMEM\tUSED\tHEALTH\tAPPS"); err != nil {
+		return err
+	}
+	for _, n := range nodes {
+		if len(n.Devices) == 0 {
+			if _, err := fmt.Fprintf(tw, "%s\t-\t-\t-\t-\t-\t-\t-\n", nonEmpty(n.NodeName)); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, d := range n.Devices {
+			apps := make([]string, 0, len(d.Bindings))
+			for _, b := range d.Bindings {
+				apps = append(apps, b.AppName)
+			}
+			appCol := "-"
+			if len(apps) > 0 {
+				appCol = strings.Join(apps, ",")
+			}
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				nonEmpty(n.NodeName), nonEmpty(d.ID), nonEmpty(d.CardModel),
+				nonEmpty(d.SupportType), formatMem(d.Memory), formatMem(deviceUsedMemory(d)),
+				nonEmpty(d.Health), appCol,
+			); err != nil {
+				return err
+			}
 		}
 	}
 	return tw.Flush()

--- a/cli/cmd/ctl/settings/gpu/root.go
+++ b/cli/cmd/ctl/settings/gpu/root.go
@@ -1,7 +1,3 @@
-// Package gpu implements the `olares-cli settings gpu` subtree (Settings ->
-// GPU). Backed by user-service's gpu.controller.ts. There's also a top-level
-// `olares-cli gpu` tree from earlier work that talks via kubeconfig — this
-// one is the profile-based settings surface that mirrors the Settings UI.
 package gpu
 
 import (
@@ -10,27 +6,78 @@ import (
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
-// NewGPUCommand returns the `settings gpu` parent: list devices and
-// per-app GPU assignments. Mutating verbs (mode set, assign,
-// unassign, bulk-assign) are out of scope for now.
+// NewGPUCommand returns the `settings gpu` parent (Settings -> Compute
+// Acceleration). Its subcommand surface and help text adapt to the LOCALLY
+// CACHED backend version (no network call at construction time, so `--help`
+// and shell completion stay fast and offline):
+//
+//   - Olares 1.12.6+ (or unknown cache): list + bindings + unbind + support-type
+//     (the compute-resources model).
+//   - Olares 1.12.5: only list (the legacy /api/gpu/list device view); the
+//     1.12.6-only verbs are hidden and the help notes the requirement.
+//
+// Visibility is advisory: runtime dispatch (WithOlaresClient) re-detects the
+// version and the capability gate returns a clear "requires Olares >= 1.12.6"
+// error if a hidden verb is invoked against an older backend anyway, so a
+// stale cache never produces a wrong action — only stale help.
 func NewGPUCommand(f *cmdutil.Factory) *cobra.Command {
+	newSurface := true
+	if v, ok := f.CachedOlaresBackendVersion(); ok {
+		newSurface = usesComputeResources(v)
+	}
+
 	cmd := &cobra.Command{
 		Use:   "gpu",
-		Short: "GPU mode + per-app GPU assignment (Settings -> GPU)",
-		Long: `Inspect GPU device list, mode, and per-app assignment.
-
-Subcommands:
-  list
-
-Out of scope for now:
-  mode set, assign, unassign, bulk-assign
-
-Note: this differs from the top-level "olares-cli gpu" command — that one
-talks to the cluster via kubeconfig. "settings gpu" is the profile-based
-edge-API surface that mirrors the SPA's Settings -> GPU page.
-`,
+		Short: "Compute acceleration: GPU devices + per-app bindings (Settings -> GPU)",
+		Long:  gpuLong(newSurface),
 	}
 	cmd.SilenceUsage = true
+
 	cmd.AddCommand(NewListCommand(f))
+
+	bindings := NewBindingsCommand(f)
+	unbind := NewUnbindCommand(f)
+	supportType := NewSupportTypeCommand(f)
+	if !newSurface {
+		// Legacy backend: keep these reachable (the runtime gate gives a
+		// precise error) but hide them from help/completion so the
+		// advertised surface matches what actually works.
+		bindings.Hidden = true
+		unbind.Hidden = true
+		supportType.Hidden = true
+	}
+	cmd.AddCommand(bindings)
+	cmd.AddCommand(unbind)
+	cmd.AddCommand(supportType)
+
 	return cmd
+}
+
+func gpuLong(newSurface bool) string {
+	if newSurface {
+		return `Inspect and manage compute-acceleration resources (Olares 1.12.6+).
+
+Subcommands:
+  list                       list nodes / GPU devices and their support type + bindings
+  bindings <app>             show an app's compute (GPU) bindings
+  unbind <app>               release an app's compute bindings (suspends the app)
+  support-type set <node> <device> <type>
+                             switch a device's support type
+                             (Exclusive | MemorySlice | TimeSlice | MemoryShared)
+
+Note: this differs from the top-level "olares-cli gpu" command, which talks to
+the cluster via kubeconfig. "settings gpu" is the profile-based edge-API surface
+that mirrors the SPA's Settings -> GPU page.`
+	}
+	return `Inspect GPU devices (Olares 1.12.5).
+
+Subcommands:
+  list   list GPU devices, mode, and per-app assignment
+
+The compute-resources verbs (bindings, unbind, support-type) require Olares
+1.12.6 or newer and are hidden on this backend. Upgrade Olares to manage
+per-app GPU bindings and device support types from the CLI.
+
+Note: this differs from the top-level "olares-cli gpu" command, which talks to
+the cluster via kubeconfig.`
 }

--- a/cli/cmd/ctl/settings/gpu/support_type.go
+++ b/cli/cmd/ctl/settings/gpu/support_type.go
@@ -1,0 +1,166 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// validSupportTypes is the set the backend (and SPA) recognize for a device's
+// support type. Nvidia cards use Exclusive|MemorySlice|TimeSlice; non-Nvidia
+// single-virtual-device nodes use Exclusive|MemoryShared.
+var validSupportTypes = []string{"Exclusive", "MemorySlice", "TimeSlice", "MemoryShared"}
+
+func isValidSupportType(s string) bool {
+	for _, v := range validSupportTypes {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// NewSupportTypeCommand is the `settings gpu support-type` parent (Olares
+// 1.12.6+); today it carries the single `set` verb.
+func NewSupportTypeCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "support-type",
+		Short: "manage a device's support type (Olares 1.12.6+)",
+		Long: `Inspect and change a compute device's support type.
+
+Subcommands:
+  set <node> <device> <type>   switch a device's support type
+
+Valid types: Exclusive | MemorySlice | TimeSlice | MemoryShared.`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newSupportTypeSetCommand(f))
+	return cmd
+}
+
+// `olares-cli settings gpu support-type set <node> <device> <type>`
+//
+// Switches a device's support type via
+// olaresclient.ComputeOps.SwitchSupportType (PUT
+// /api/compute-resources/nodes/<node>/devices/<device>/support-type). The
+// backend reports the outcome via a `status` discriminator
+// (switched / unchanged / bound-apps-stop-blocked) it keeps at HTTP 200, so we
+// branch on that rather than on an HTTP error.
+func newSupportTypeSetCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "set <node> <device> <type>",
+		Short: "switch a device's support type",
+		Long: `Switch a compute device's support type.
+
+Valid types: Exclusive | MemorySlice | TimeSlice | MemoryShared.
+
+Changing the support type may stop apps currently bound to the device, so this
+prompts for confirmation by default; pass --yes to skip it. If apps that must be
+stopped first are blocking the switch, the command reports them and exits
+non-zero without changing anything.
+
+Example:
+  olares-cli settings gpu support-type set node-1 GPU-abc123 TimeSlice --yes`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "switch device support type"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runSupportTypeSet(ctx, f, args[0], args[1], args[2], assumeYes), "switch device support type")
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt (required for non-TTY automation)")
+	return cmd
+}
+
+type supportTypeAppRef struct {
+	AppName string `json:"appName"`
+	Owner   string `json:"owner,omitempty"`
+	State   string `json:"state,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type supportTypeResult struct {
+	Status      string              `json:"status"`
+	StoppedApps []supportTypeAppRef `json:"stoppedApps,omitempty"`
+	BlockedApps []supportTypeAppRef `json:"blockedApps,omitempty"`
+}
+
+func runSupportTypeSet(ctx context.Context, f *cmdutil.Factory, node, deviceID, supportType string, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	supportType = strings.TrimSpace(supportType)
+	if !isValidSupportType(supportType) {
+		return fmt.Errorf("invalid support type %q (allowed: %s)", supportType, strings.Join(validSupportTypes, ", "))
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		fmt.Sprintf("Switch device %q on node %q to %q? Apps bound to this device may be stopped.", deviceID, node, supportType),
+		assumeYes); err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.SwitchSupportType(ctx, doer, node, deviceID, supportType)
+		if err != nil {
+			return err
+		}
+		var res supportTypeResult
+		if err := decodeData(raw, &res); err != nil {
+			return err
+		}
+		switch res.Status {
+		case "switched":
+			fmt.Fprintf(os.Stdout, "switched device %s to %s\n", deviceID, supportType)
+			if len(res.StoppedApps) > 0 {
+				fmt.Fprintf(os.Stdout, "stopped %d app(s) bound to the device:\n", len(res.StoppedApps))
+				for _, a := range res.StoppedApps {
+					fmt.Fprintf(os.Stdout, "  - %s\n", appRefLabel(a))
+				}
+			}
+			return nil
+		case "unchanged":
+			fmt.Fprintf(os.Stdout, "device %s already uses %s; nothing to do\n", deviceID, supportType)
+			return nil
+		case "bound-apps-stop-blocked":
+			var b strings.Builder
+			fmt.Fprintf(&b, "cannot switch device %s to %s: stop the following bound app(s) first", deviceID, supportType)
+			for _, a := range res.BlockedApps {
+				fmt.Fprintf(&b, "\n  - %s", appRefLabel(a))
+			}
+			return fmt.Errorf("%s", b.String())
+		default:
+			return fmt.Errorf("switch device %s: unexpected status %q from backend", deviceID, res.Status)
+		}
+	})
+}
+
+func appRefLabel(a supportTypeAppRef) string {
+	label := a.AppName
+	if a.Owner != "" {
+		label += " (" + a.Owner + ")"
+	}
+	if a.Reason != "" {
+		label += ": " + a.Reason
+	} else if a.State != "" {
+		label += " [" + a.State + "]"
+	}
+	return label
+}

--- a/cli/cmd/ctl/settings/gpu/unbind.go
+++ b/cli/cmd/ctl/settings/gpu/unbind.go
@@ -1,0 +1,74 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings gpu unbind <app>` (Olares 1.12.6+)
+//
+// Releases an app's compute (GPU) bindings via
+// olaresclient.ComputeOps.ReleaseAppBindings (DELETE
+// /api/apps/<app>/compute-resources/bindings). The backend implements release
+// as a suspend, so this stops the app — a destructive action that prompts for
+// confirmation unless --yes is passed.
+func NewUnbindCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "unbind <app>",
+		Short: "release an app's compute bindings, suspending it (Olares 1.12.6+)",
+		Long: `Release the compute (GPU) device bindings held by an app.
+
+The backend frees the bindings by suspending the app, so the app stops until
+it is bound and resumed again. Prompts for confirmation by default; pass --yes
+to skip the prompt for automation. Non-TTY stdin without --yes is a hard error.
+
+Example:
+  olares-cli settings gpu unbind ollama
+  olares-cli settings gpu unbind ollama --yes`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "release GPU bindings"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runUnbind(ctx, f, args[0], assumeYes), "release GPU bindings")
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt (required for non-TTY automation)")
+	return cmd
+}
+
+func runUnbind(ctx context.Context, f *cmdutil.Factory, appName string, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		fmt.Sprintf("Release compute bindings for %q? This suspends (stops) the app.", appName),
+		assumeYes); err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		if _, err := c.ReleaseAppBindings(ctx, doer, appName); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "released compute bindings for %s (app suspended)\n", appName)
+		return nil
+	})
+}

--- a/cli/cmd/ctl/settings/internal/edge/edge.go
+++ b/cli/cmd/ctl/settings/internal/edge/edge.go
@@ -1,0 +1,81 @@
+// Package edge adapts the `settings` per-user edge transport to the
+// olaresclient.Doer contract used by the version-compatibility layer.
+//
+// The version clients in pkg/olaresclient shape only the request line
+// (method / path / body) and expect Doer.Do to return the unwrapped `data`
+// of the BFL `{code, message, data}` envelope. Market commands satisfy that
+// over the app-store transport; the `settings` areas (gpu, network overlay,
+// ...) talk to user-service on the profile's DesktopURL via
+// whoami.NewHTTPClient. This package provides one small adapter both reuse so
+// the envelope-unwrap logic lives in exactly one place.
+package edge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/credential"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// jsonDoer is the minimal HTTP surface this adapter wraps (one
+// JSON-in/JSON-out method). *whoami.HTTPClient satisfies it.
+type jsonDoer interface {
+	DoJSON(ctx context.Context, method, path string, body, out interface{}) error
+}
+
+// Doer implements olaresclient.Doer over the settings edge transport. It is
+// satisfied structurally — callers pass *Doer where olaresclient.Doer is
+// expected, so this package need not import olaresclient (avoiding a cycle).
+type Doer struct {
+	inner jsonDoer
+}
+
+// New builds a Doer for the active profile, returning the resolved profile so
+// callers that need identity (e.g. the overlay status `{user}` path) can read
+// it without a second lookup.
+func New(ctx context.Context, f *cmdutil.Factory) (*Doer, *credential.ResolvedProfile, error) {
+	if f == nil {
+		return nil, nil, fmt.Errorf("internal error: settings edge not wired with cmdutil.Factory")
+	}
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	hc, err := f.HTTPClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &Doer{inner: whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID)}, rp, nil
+}
+
+// envelope is the BFL `{code, message, data}` wrapper user-service forwards
+// (or wraps via returnSucceed). code 0 or 200 means success.
+type envelope struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// Do sends a JSON request and returns the unwrapped `data` payload. A non
+// 0/200 code is surfaced as an error (some BFL validation failures arrive as
+// HTTP 200 with a non-zero body code, mirroring the SPA's interceptor).
+func (d *Doer) Do(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var env envelope
+	if err := d.inner.DoJSON(ctx, method, path, body, &env); err != nil {
+		return nil, err
+	}
+	switch env.Code {
+	case 0, 200:
+	default:
+		msg := strings.TrimSpace(env.Message)
+		if msg == "" {
+			return nil, fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
+		}
+		return nil, fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
+	}
+	return env.Data, nil
+}

--- a/cli/cmd/ctl/settings/me/version.go
+++ b/cli/cmd/ctl/settings/me/version.go
@@ -2,7 +2,9 @@ package me
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -34,6 +36,7 @@ import (
 // PreflightRole check.
 func NewVersionCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
+	var dispatch bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "show the installed Olares OS version (Settings -> Person -> Version)",
@@ -45,13 +48,25 @@ In table mode (default) you get the OS version, terminus identity, and
 the wizard / reverse-proxy / TailScale flags the Person page surfaces.
 In JSON mode you get the full OlaresInfo struct verbatim — useful for
 scripting against future fields without waiting on a CLI bump.
+
+--dispatch shows the version-compat view instead: the backend version
+the CLI will dispatch remote/API commands on, where it came from
+(--olares-version flag / per-profile cache / a fresh /api/olares-info
+read), when the cache was last refreshed, and which versioned client
+implementation handles your commands. Combine with --refresh-version to
+force a fresh read, or --olares-version to preview a specific version's
+dispatch.
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
+			if dispatch {
+				return runVersionDispatch(c.Context(), f, output)
+			}
 			return runVersion(c.Context(), f, output)
 		},
 	}
 	addOutputFlag(cmd, &output)
+	cmd.Flags().BoolVar(&dispatch, "dispatch", false, "show the backend version the CLI dispatches commands on (source, cache age, selected client) instead of the live OS version")
 	return cmd
 }
 
@@ -106,6 +121,85 @@ func runVersion(ctx context.Context, f *cmdutil.Factory, outputRaw string) error
 			{"Olaresd", nonEmpty(info.Olaresd)},
 		}, 14)
 	}
+}
+
+// runVersionDispatch renders the version-compat dispatch view: which backend
+// version the CLI resolves for remote/API commands, its provenance, the cache
+// timestamp, and the selected client implementation. Honors --refresh-version
+// and --olares-version (both persistent root flags) via the Factory.
+func runVersionDispatch(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+
+	info, err := f.OlaresBackendVersionInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	if format == FormatJSON {
+		out := struct {
+			Version        string `json:"version"`
+			Source         string `json:"source"`
+			CachedVersion  string `json:"cachedVersion,omitempty"`
+			RefreshedAt    int64  `json:"refreshedAt,omitempty"`
+			RefreshedAtRFC string `json:"refreshedAtRFC,omitempty"`
+			TTLSeconds     int64  `json:"ttlSeconds"`
+			Implementation string `json:"implementation"`
+		}{
+			Version:        versionString(info.Version),
+			Source:         string(info.Source),
+			CachedVersion:  info.CachedVersion,
+			RefreshedAt:    info.RefreshedAt,
+			TTLSeconds:     int64(info.TTL.Seconds()),
+			Implementation: info.Implementation,
+		}
+		if info.RefreshedAt > 0 {
+			out.RefreshedAtRFC = time.Unix(info.RefreshedAt, 0).Format(time.RFC3339)
+		}
+		return printJSON(os.Stdout, out)
+	}
+
+	refreshed := "-"
+	if info.RefreshedAt > 0 {
+		t := time.Unix(info.RefreshedAt, 0)
+		refreshed = fmt.Sprintf("%s (%s ago)", t.Format("2006-01-02 15:04:05"), durShort(time.Since(t)))
+	}
+	return printKV(os.Stdout, [][2]string{
+		{"Backend Version", versionString(info.Version)},
+		{"Source", string(info.Source)},
+		{"Cached Value", nonEmpty(info.CachedVersion)},
+		{"Refreshed At", refreshed},
+		{"TTL", info.TTL.String()},
+		{"Dispatches To", nonEmpty(info.Implementation) + " client"},
+	}, 18)
+}
+
+func versionString(v interface{ String() string }) string {
+	if v == nil {
+		return "-"
+	}
+	return v.String()
+}
+
+// durShort renders a duration as a coarse "12m" / "3h" / "2d" string for the
+// "refreshed N ago" hint. Sub-minute ages collapse to "0m" to avoid noisy
+// seconds in a human-facing freshness indicator.
+func durShort(d time.Duration) string {
+	if d < time.Minute {
+		return "0m"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
 }
 
 func nonEmpty(s string) string {

--- a/cli/cmd/ctl/settings/network/overlay.go
+++ b/cli/cmd/ctl/settings/network/overlay.go
@@ -1,0 +1,345 @@
+package network
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olares"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// overlayFloor is the first Olares line that ships the overlay gateway. This is
+// the canonical "brand new feature" example for the version framework: there is
+// no overlay surface at all below 1.12.6, so the whole `overlay` subtree is
+// hidden (advisory) on older backends and every olaresclient.OverlayOps method
+// returns *ErrUnsupportedVersion (authoritative) there.
+var overlayFloor = semver.MustParse("1.12.6")
+
+func supportsOverlay(v *semver.Version) bool {
+	if v == nil {
+		return true
+	}
+	return !utils.CoreVersion(v).LessThan(overlayFloor)
+}
+
+// overlayPollInterval mirrors the SPA's OVERLAY_GATEWAY_POLL_MS.
+const overlayPollInterval = 8 * time.Second
+
+// overlayWatchTimeout caps a --watch poll. A gateway toggle restarts the edge
+// network (which briefly returns HTTP 530), so the window is generous.
+const overlayWatchTimeout = 3 * time.Minute
+
+// --- wire shapes (overlay-gateway.types.ts) ---
+
+type overlayUnderlayPort struct {
+	Title       string `json:"title"`
+	Port        int    `json:"port"`
+	Workload    string `json:"workload"`
+	Description string `json:"description,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+}
+
+type overlayUnderlayNetwork struct {
+	IP    string                `json:"ip"`
+	Ports []overlayUnderlayPort `json:"ports,omitempty"`
+}
+
+type overlaySupportedApp struct {
+	AppName          string                   `json:"app_name"`
+	AppID            string                   `json:"app_id"`
+	Enabled          bool                     `json:"enabled"`
+	SharedApp        bool                     `json:"shared_app"`
+	UnderlayNetworks []overlayUnderlayNetwork `json:"underlay_networks,omitempty"`
+}
+
+type overlayStatus struct {
+	Status        string                `json:"status"` // on | off | activating | deactivating
+	Disable       bool                  `json:"disable"`
+	DisableReason string                `json:"disable_reason"`
+	SupportedApps []overlaySupportedApp `json:"supported_apps,omitempty"`
+	ErrorMessage  string                `json:"error_message,omitempty"`
+}
+
+// NewOverlayCommand builds the `settings network overlay` subtree. Backed by
+// the overlay-gateway endpoints (user-service overlay-gateway.controller.ts ->
+// olaresd). Enable/disable are owner-only; status is read-only.
+func NewOverlayCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "overlay",
+		Short: "Overlay gateway: assign LAN IPs to supported apps (Olares 1.12.6+)",
+		Long: `Inspect and control the overlay gateway, which assigns reachable LAN (underlay)
+IP addresses to supported apps.
+
+Subcommands:
+  status              show gateway status, availability, and per-app overlay state
+  enable [--watch]    turn the gateway on (owner only)
+  disable [--watch]   turn the gateway off (owner only)
+
+Toggling the gateway restarts the edge network, during which the API is briefly
+unavailable (HTTP 530); --watch polls until the gateway reaches the target
+state, treating that window as "restarting".
+
+Requires Olares 1.12.6 or newer.`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newOverlayStatusCommand(f))
+	cmd.AddCommand(newOverlayEnableCommand(f))
+	cmd.AddCommand(newOverlayDisableCommand(f))
+	return cmd
+}
+
+func newOverlayStatusCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "show overlay gateway status (Olares 1.12.6+)",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "read overlay gateway status"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runOverlayStatus(ctx, f, output), "read overlay gateway status")
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newOverlayEnableCommand(f *cmdutil.Factory) *cobra.Command {
+	var watch bool
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "turn the overlay gateway on (owner only, Olares 1.12.6+)",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleOwner, "enable overlay gateway"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runOverlayToggle(ctx, f, true, watch), "enable overlay gateway")
+		},
+	}
+	cmd.Flags().BoolVar(&watch, "watch", false, "poll until the gateway is on (tolerates the restart window)")
+	return cmd
+}
+
+func newOverlayDisableCommand(f *cmdutil.Factory) *cobra.Command {
+	var watch bool
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "turn the overlay gateway off (owner only, Olares 1.12.6+)",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleOwner, "disable overlay gateway"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runOverlayToggle(ctx, f, false, watch), "disable overlay gateway")
+		},
+	}
+	cmd.Flags().BoolVar(&watch, "watch", false, "poll until the gateway is off (tolerates the restart window)")
+	return cmd
+}
+
+// overlayUser derives the username the status path expects (the Olares local
+// name, matching the SPA's meStore.user.name) from the resolved profile.
+func overlayUser(olaresID string) (string, error) {
+	id, err := olares.ParseID(olaresID)
+	if err != nil {
+		return "", fmt.Errorf("parse olaresId %q: %w", olaresID, err)
+	}
+	return id.Local(), nil
+}
+
+func runOverlayStatus(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	doer, rp, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+	user, err := overlayUser(rp.OlaresID)
+	if err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		st, err := fetchOverlayStatus(ctx, c, doer, user)
+		if err != nil {
+			return err
+		}
+		if format == FormatJSON {
+			return printJSON(os.Stdout, st)
+		}
+		return renderOverlayStatus(os.Stdout, st)
+	})
+}
+
+// fetchOverlayStatus calls OverlayGatewayStatus and decodes the payload.
+func fetchOverlayStatus(ctx context.Context, c olaresclient.OlaresClient, doer olaresclient.Doer, user string) (*overlayStatus, error) {
+	raw, err := c.OverlayGatewayStatus(ctx, doer, user)
+	if err != nil {
+		return nil, err
+	}
+	var st overlayStatus
+	if len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &st); err != nil {
+			return nil, fmt.Errorf("decode overlay status: %w", err)
+		}
+	}
+	return &st, nil
+}
+
+func runOverlayToggle(ctx context.Context, f *cmdutil.Factory, enable, watch bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	doer, rp, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+	user, err := overlayUser(rp.OlaresID)
+	if err != nil {
+		return err
+	}
+	target := "off"
+	verb := "disable"
+	if enable {
+		target = "on"
+		verb = "enable"
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		var toggleErr error
+		if enable {
+			_, toggleErr = c.EnableOverlayGateway(ctx, doer)
+		} else {
+			_, toggleErr = c.DisableOverlayGateway(ctx, doer)
+		}
+		// A 530 means the toggle was accepted and the edge network is
+		// restarting (mirrors the SPA's toggleGateway swallow). Any other
+		// error is a genuine failure.
+		if toggleErr != nil && !isOverlayTransient(toggleErr) {
+			return toggleErr
+		}
+		fmt.Fprintf(os.Stdout, "overlay gateway %s requested\n", verb)
+
+		if !watch {
+			fmt.Fprintf(os.Stdout, "the edge network is restarting; run `olares-cli settings network overlay status` to check\n")
+			return nil
+		}
+		return watchOverlayUntil(ctx, c, doer, user, target)
+	})
+}
+
+// watchOverlayUntil polls the gateway status until it reaches target ('on' /
+// 'off'), tolerating the HTTP 530 restart window. Returns when the target is
+// reached, or an error on timeout / a non-transient failure.
+func watchOverlayUntil(ctx context.Context, c olaresclient.OlaresClient, doer olaresclient.Doer, user, target string) error {
+	deadline := time.Now().Add(overlayWatchTimeout)
+	restartingNoted := false
+	for {
+		st, err := fetchOverlayStatus(ctx, c, doer, user)
+		switch {
+		case err == nil:
+			if st.Status == target {
+				fmt.Fprintf(os.Stdout, "overlay gateway is %s\n", target)
+				if target == "on" {
+					_ = renderOverlayStatus(os.Stdout, st)
+				}
+				return nil
+			}
+			if st.ErrorMessage != "" {
+				return fmt.Errorf("overlay gateway error: %s", st.ErrorMessage)
+			}
+			fmt.Fprintf(os.Stdout, "  ... gateway is %s, waiting for %s\n", nonEmpty(st.Status), target)
+		case isOverlayTransient(err):
+			if !restartingNoted {
+				fmt.Fprintf(os.Stdout, "  ... edge network restarting (HTTP 530), waiting\n")
+				restartingNoted = true
+			}
+		default:
+			return err
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for overlay gateway to become %s", overlayWatchTimeout, target)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(overlayPollInterval):
+		}
+	}
+}
+
+// isOverlayTransient reports whether err is the HTTP 530 the edge ingress
+// returns while the network restarts (mirrors the SPA's isOverlayTransientError,
+// which keys on response.status === 530). whoami's DoJSON renders non-2xx as a
+// message containing "HTTP 530", so we key on that.
+func isOverlayTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "HTTP 530")
+}
+
+func renderOverlayStatus(w io.Writer, st *overlayStatus) error {
+	fmt.Fprintf(w, "GATEWAY:   %s\n", nonEmpty(st.Status))
+	fmt.Fprintf(w, "AVAILABLE: %s\n", boolStr(!st.Disable))
+	if st.Disable && st.DisableReason != "" {
+		fmt.Fprintf(w, "REASON:    %s\n", st.DisableReason)
+	}
+	if st.ErrorMessage != "" {
+		fmt.Fprintf(w, "ERROR:     %s\n", st.ErrorMessage)
+	}
+	if st.Status != "on" || len(st.SupportedApps) == 0 {
+		return nil
+	}
+	fmt.Fprintln(w, "\nAPPS:")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tOVERLAY\tSHARED\tLAN-IP"); err != nil {
+		return err
+	}
+	for _, a := range st.SupportedApps {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			nonEmpty(a.AppName), boolStr(a.Enabled), boolStr(a.SharedApp), overlayIPs(a.UnderlayNetworks),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func overlayIPs(nets []overlayUnderlayNetwork) string {
+	ips := make([]string, 0, len(nets))
+	for _, n := range nets {
+		if strings.TrimSpace(n.IP) != "" {
+			ips = append(ips, n.IP)
+		}
+	}
+	if len(ips) == 0 {
+		return "-"
+	}
+	return strings.Join(ips, ",")
+}

--- a/cli/cmd/ctl/settings/network/root.go
+++ b/cli/cmd/ctl/settings/network/root.go
@@ -46,5 +46,15 @@ Note: reverse-proxy set is owner-only; non-owner callers will hit a
 	cmd.AddCommand(NewFRPCommand(f))
 	cmd.AddCommand(NewSSLCommand(f))
 	cmd.AddCommand(NewHostsFileCommand(f))
+
+	// Overlay gateway is a 1.12.6+ feature. Hide the whole subtree on older
+	// backends (advisory, driven by the locally cached version so --help stays
+	// offline); the runtime capability gate still returns a precise
+	// "requires Olares >= 1.12.6" error if it's invoked anyway.
+	overlay := NewOverlayCommand(f)
+	if v, ok := f.CachedOlaresBackendVersion(); ok && !supportsOverlay(v) {
+		overlay.Hidden = true
+	}
+	cmd.AddCommand(overlay)
 	return cmd
 }

--- a/cli/pkg/cliconfig/backend_version_test.go
+++ b/cli/pkg/cliconfig/backend_version_test.go
@@ -1,0 +1,66 @@
+package cliconfig
+
+import (
+	"testing"
+)
+
+func TestSetBackendVersion(t *testing.T) {
+	// Isolate the config dir to a temp location.
+	t.Setenv(homeEnv, t.TempDir())
+
+	const id = "alice@olares.com"
+	seed := &MultiProfileConfig{}
+	seed.Upsert(ProfileConfig{OlaresID: id})
+	if err := SaveMultiProfileConfig(seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// First write: empty -> version reports changed.
+	cfg, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	changed, err := cfg.SetBackendVersion(id, "1.12.5", 1000)
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if !changed {
+		t.Error("first write empty->1.12.5 should report changed=true")
+	}
+
+	// Persisted across reloads.
+	reloaded, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	p := reloaded.FindByOlaresID(id)
+	if p == nil || p.BackendVersion != "1.12.5" || p.BackendVersionRefreshedAt != 1000 {
+		t.Fatalf("persisted profile = %+v, want version 1.12.5 @ 1000", p)
+	}
+
+	// Same version again: not changed (but timestamp still updated).
+	changed, err = reloaded.SetBackendVersion(id, "1.12.5", 2000)
+	if err != nil {
+		t.Fatalf("set same: %v", err)
+	}
+	if changed {
+		t.Error("rewriting the same version should report changed=false")
+	}
+	if reloaded.FindByOlaresID(id).BackendVersionRefreshedAt != 2000 {
+		t.Error("refreshedAt should update even when version is unchanged")
+	}
+
+	// Upgrade detected: 1.12.5 -> 1.12.6 reports changed.
+	changed, err = reloaded.SetBackendVersion(id, "1.12.6", 3000)
+	if err != nil {
+		t.Fatalf("set upgrade: %v", err)
+	}
+	if !changed {
+		t.Error("1.12.5 -> 1.12.6 should report changed=true")
+	}
+
+	// Unknown profile errors.
+	if _, err := reloaded.SetBackendVersion("bob@olares.com", "1.12.6", 4000); err == nil {
+		t.Error("setting version for an unknown profile should error")
+	}
+}

--- a/cli/pkg/cliconfig/config.go
+++ b/cli/pkg/cliconfig/config.go
@@ -106,6 +106,26 @@ type ProfileConfig struct {
 	// WhoamiRefreshedAt; used by `cluster context` to render "last
 	// refreshed" hints.
 	ClusterContextRefreshedAt int64 `json:"clusterContextRefreshedAt,omitempty"`
+
+	// BackendVersion caches the Olares OS version of the target instance,
+	// read from /api/olares-info's osVersion. The version-compat layer
+	// (pkg/olaresclient) uses it to dispatch a command to the right
+	// version-specific implementation without a network round-trip on
+	// every invocation. Unlike the access token (which self-heals via
+	// /api/refresh on a 401), the backend version has no implicit refresh
+	// signal, so it is paired with a refresh timestamp + TTL below.
+	//
+	// Empty for pre-existing profiles or before the first
+	// version-dispatched command runs. Treated as "unknown — detect on
+	// next use".
+	BackendVersion string `json:"backendVersion,omitempty"`
+
+	// BackendVersionRefreshedAt is the unix-second timestamp of the last
+	// successful /api/olares-info read that wrote BackendVersion. Used to
+	// apply a TTL: once the cache is older than the TTL it is re-fetched
+	// on the next version-dispatched command. `--refresh-version` forces a
+	// re-fetch regardless of this timestamp.
+	BackendVersionRefreshedAt int64 `json:"backendVersionRefreshedAt,omitempty"`
 }
 
 // ClusterContextCache is the per-profile snapshot of /capi/app/detail
@@ -302,6 +322,33 @@ func (m *MultiProfileConfig) SetClusterContext(olaresID string, ctx *ClusterCont
 		newRole = ctx.GlobalRole
 	}
 	return newRole != "" && prevRole != newRole, nil
+}
+
+// SetBackendVersion atomically updates the BackendVersion +
+// BackendVersionRefreshedAt fields for the profile keyed by olaresID, then
+// persists config.json. Mirrors SetOwnerRole's contract.
+//
+// Returns:
+//   - changed: true iff BackendVersion transitioned to a different non-empty
+//     value (callers can use this to notice "the backend was upgraded"). A
+//     first-time write (empty → version) also reports changed=true.
+//   - err:     any I/O / serialization error from SaveMultiProfileConfig.
+//
+// refreshedAt is the wall-clock the caller observed the /api/olares-info
+// success at; passed in (rather than re-read here) so test code can pin it
+// deterministically.
+func (m *MultiProfileConfig) SetBackendVersion(olaresID, version string, refreshedAt int64) (changed bool, err error) {
+	target := m.FindByOlaresID(olaresID)
+	if target == nil {
+		return false, fmt.Errorf("profile %q not found", olaresID)
+	}
+	prev := target.BackendVersion
+	target.BackendVersion = version
+	target.BackendVersionRefreshedAt = refreshedAt
+	if err := SaveMultiProfileConfig(m); err != nil {
+		return false, fmt.Errorf("save config: %w", err)
+	}
+	return version != "" && prev != version, nil
 }
 
 // Remove deletes a profile by Name or OlaresID. If the removed profile was

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/beclab/Olares/cli/pkg/auth"
 	"github.com/beclab/Olares/cli/pkg/credential"
 )
@@ -106,6 +108,15 @@ type Factory struct {
 
 	uploadClientOnce sync.Once
 	uploadClient     *http.Client
+
+	// backendVersion memoizes the detected Olares backend version (see
+	// olares_version.go). backendVersionMu guards the cell for the
+	// self-heal path (RefreshOlaresBackendVersion) that may overwrite it
+	// after the initial sync.Once resolution.
+	backendVersionOnce sync.Once
+	backendVersionMu   sync.Mutex
+	backendVersion     *semver.Version
+	backendVersionErr  error
 }
 
 // NewFactory builds a fresh Factory. Cheap; intended to be called once per

--- a/cli/pkg/cmdutil/olares_dispatch.go
+++ b/cli/pkg/cmdutil/olares_dispatch.go
@@ -1,0 +1,121 @@
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+)
+
+// VersionSuspectError lets a command's operation tell the dispatch aspect "this
+// failure might be caused by talking to a backend whose version differs from
+// the one I dispatched on". The aspect reacts by re-detecting the backend
+// version and, if it changed, re-dispatching and retrying the operation once
+// (the self-heal path, analogous to the token refresh-and-retry in
+// refreshingTransport). Implement it on a typed error, or use
+// MarkVersionSuspect to wrap an existing error.
+type VersionSuspectError interface {
+	error
+	VersionSuspect() bool
+}
+
+type versionSuspectError struct{ err error }
+
+func (e *versionSuspectError) Error() string        { return e.err.Error() }
+func (e *versionSuspectError) Unwrap() error        { return e.err }
+func (e *versionSuspectError) VersionSuspect() bool { return true }
+
+// MarkVersionSuspect wraps err so the dispatch aspect treats it as a possible
+// version mismatch and attempts a refresh-and-retry. Returns nil for a nil err.
+func MarkVersionSuspect(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &versionSuspectError{err: err}
+}
+
+// isVersionSuspect reports whether err signals a likely version mismatch worth
+// a refresh-and-retry: either it implements VersionSuspectError, or it carries
+// an HTTP status the backend uses when a route/shape is unknown (404 Not Found,
+// 501 Not Implemented). Auth failures are intentionally excluded — those are
+// the refreshingTransport's domain, not a version problem.
+func isVersionSuspect(err error) bool {
+	if err == nil {
+		return false
+	}
+	var vs VersionSuspectError
+	if errors.As(err, &vs) && vs.VersionSuspect() {
+		return true
+	}
+	var he interface{ HTTPStatus() int }
+	if errors.As(err, &he) {
+		switch he.HTTPStatus() {
+		case http.StatusNotFound, http.StatusNotImplemented:
+			return true
+		}
+	}
+	return false
+}
+
+// WithOlaresClient is the version-dispatch "aspect" for multi-version commands.
+// Only commands wired through this entry point get version-aware behavior; all
+// other commands are untouched.
+//
+// It resolves the backend version, builds the matching olaresclient.OlaresClient
+// (floor-selected, see olaresclient.GetClient), and runs op with it. Two
+// cross-cutting behaviors wrap op:
+//
+//	A. Stale-version self-heal: if op fails with a version-suspect error
+//	   (see isVersionSuspect), the backend version is re-detected; if it
+//	   changed, a fresh client is built and op is retried exactly once.
+//	B. Capability gate: if op fails with *olaresclient.ErrUnsupportedVersion,
+//	   the error is surfaced verbatim (its Error() renders the "requires
+//	   Olares >= X" hint) and is NOT retried.
+func (f *Factory) WithOlaresClient(ctx context.Context, op func(c olaresclient.OlaresClient) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	version, err := f.OlaresBackendVersion(ctx)
+	if err != nil {
+		return err
+	}
+	client, err := olaresclient.GetClient(version)
+	if err != nil {
+		return err
+	}
+
+	runErr := op(client)
+	if runErr == nil {
+		return nil
+	}
+
+	// B. Capability gate — never retried.
+	var unsupported *olaresclient.ErrUnsupportedVersion
+	if errors.As(runErr, &unsupported) {
+		return runErr
+	}
+
+	// A. Stale-version self-heal — re-detect, re-dispatch, retry once.
+	if !isVersionSuspect(runErr) {
+		return runErr
+	}
+	newVersion, changed, refreshErr := f.RefreshOlaresBackendVersion(ctx)
+	if refreshErr != nil || !changed {
+		// Couldn't refresh, or the backend version is unchanged — the
+		// failure is not a version mismatch we can recover from.
+		return runErr
+	}
+	fmt.Fprintf(os.Stderr, "notice: backend version changed to %s; retrying with the matching client\n", newVersion)
+	newClient, err := olaresclient.GetClient(newVersion)
+	if err != nil {
+		return runErr
+	}
+	if retryErr := op(newClient); retryErr != nil {
+		return retryErr
+	}
+	return nil
+}

--- a/cli/pkg/cmdutil/olares_dispatch_test.go
+++ b/cli/pkg/cmdutil/olares_dispatch_test.go
@@ -1,0 +1,54 @@
+package cmdutil
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+type statusErr struct {
+	code int
+	msg  string
+}
+
+func (e *statusErr) Error() string   { return e.msg }
+func (e *statusErr) HTTPStatus() int { return e.code }
+
+func TestIsVersionSuspect(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"marked suspect", MarkVersionSuspect(errors.New("shape mismatch")), true},
+		{"wrapped marked suspect", fmt.Errorf("op failed: %w", MarkVersionSuspect(errors.New("x"))), true},
+		{"http 404", &statusErr{code: http.StatusNotFound, msg: "not found"}, true},
+		{"http 501", &statusErr{code: http.StatusNotImplemented, msg: "not implemented"}, true},
+		{"http 401 not suspect", &statusErr{code: http.StatusUnauthorized, msg: "unauth"}, false},
+		{"http 500 not suspect", &statusErr{code: http.StatusInternalServerError, msg: "boom"}, false},
+		{"wrapped http 404", fmt.Errorf("call: %w", &statusErr{code: http.StatusNotFound, msg: "nf"}), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isVersionSuspect(c.err); got != c.want {
+				t.Fatalf("isVersionSuspect(%v)=%v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMarkVersionSuspectNilPassthrough(t *testing.T) {
+	if MarkVersionSuspect(nil) != nil {
+		t.Fatal("MarkVersionSuspect(nil) must be nil")
+	}
+	wrapped := MarkVersionSuspect(errors.New("inner"))
+	if wrapped.Error() != "inner" {
+		t.Fatalf("Error()=%q, want %q", wrapped.Error(), "inner")
+	}
+	if !errors.Is(wrapped, wrapped) {
+		t.Fatal("sanity")
+	}
+}

--- a/cli/pkg/cmdutil/olares_version.go
+++ b/cli/pkg/cmdutil/olares_version.go
@@ -1,0 +1,311 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+	"github.com/beclab/Olares/cli/pkg/credential"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// Flag / viper keys for the version-compat layer. Registered as persistent
+// flags on the root command (see cmd/ctl/root.go) and bound to viper there.
+const (
+	// FlagOlaresVersion overrides the detected backend version. Useful when
+	// /api/olares-info is unreachable, or to force a specific code path for
+	// debugging. Value is any Olares semver, e.g. 1.12.6 or 1.12.6-20260603.
+	FlagOlaresVersion = "olares-version"
+	// FlagRefreshVersion forces a fresh /api/olares-info read, bypassing the
+	// persisted per-profile cache regardless of its TTL.
+	FlagRefreshVersion = "refresh-version"
+)
+
+// backendVersionTTL is how long a cached backend version is trusted before it
+// is re-fetched from /api/olares-info. The token self-heals on a 401, but the
+// version has no such signal, so the cache must expire. One hour balances
+// avoiding a round-trip on every command against noticing an out-of-band
+// backend upgrade; the dispatch aspect (WithOlaresClient) additionally
+// re-checks on version-suspect errors.
+const backendVersionTTL = time.Hour
+
+// olaresInfoEnvelope mirrors the BFL `{code, message, data}` envelope returned
+// by /api/olares-info, decoding only the osVersion field the version-compat
+// layer needs. Same endpoint `settings me version` reads.
+type olaresInfoEnvelope struct {
+	Code int `json:"code"`
+	Data struct {
+		OsVersion string `json:"osVersion"`
+	} `json:"data"`
+}
+
+// OlaresBackendVersion returns the Olares OS version of the target instance,
+// memoized for the lifetime of this Factory. Resolution order:
+//
+//  1. --olares-version flag (explicit override; never hits the network).
+//  2. Per-profile cache in ~/.olares-cli/config.json, when present and within
+//     backendVersionTTL and --refresh-version was not set.
+//  3. A fresh GET {DesktopURL}/api/olares-info, whose osVersion is parsed and
+//     written back to the cache.
+//
+// If the network read fails but a (stale) cached value exists, the stale value
+// is returned with a warning rather than failing the command. Only when there
+// is neither a reachable backend nor any cached value does this return an error.
+func (f *Factory) OlaresBackendVersion(ctx context.Context) (*semver.Version, error) {
+	f.backendVersionOnce.Do(func() {
+		v, err := f.resolveBackendVersion(ctx)
+		f.backendVersionMu.Lock()
+		f.backendVersion, f.backendVersionErr = v, err
+		f.backendVersionMu.Unlock()
+	})
+	f.backendVersionMu.Lock()
+	defer f.backendVersionMu.Unlock()
+	return f.backendVersion, f.backendVersionErr
+}
+
+// CachedOlaresBackendVersion returns the active profile's persisted backend
+// version WITHOUT any network call and WITHOUT enforcing the TTL. It is the
+// read used at command-tree construction time to drive version-aware help /
+// subcommand visibility (e.g. `settings gpu`, `settings network overlay`):
+// reading the local cache keeps `--help` and tab-completion offline and fast,
+// while runtime dispatch (WithOlaresClient) still enforces correctness via the
+// TTL-refreshing OlaresBackendVersion.
+//
+// Returns (nil, false) when there is no active profile or no cached version
+// yet — callers should then present their forward-looking (newest) surface and
+// let the runtime capability gate handle an actually-older backend. The cache
+// is populated eagerly at `profile login` / `import` and refreshed on a TTL by
+// normal version-aware commands, so this is accurate in the common case.
+func (f *Factory) CachedOlaresBackendVersion() (*semver.Version, bool) {
+	if f == nil {
+		return nil, false
+	}
+	rp, err := f.ResolveProfile(context.Background())
+	if err != nil || rp == nil {
+		return nil, false
+	}
+	v, _ := loadCachedBackendVersion(rp.OlaresID)
+	if v == nil {
+		return nil, false
+	}
+	return v, true
+}
+
+// BackendVersionSource describes where the dispatched backend version came
+// from, for the `settings me version --dispatch` transparency view.
+type BackendVersionSource string
+
+const (
+	// BackendVersionFromFlag: resolved from the --olares-version override.
+	BackendVersionFromFlag BackendVersionSource = "flag (--olares-version)"
+	// BackendVersionFromCache: served from the per-profile cache (within TTL).
+	BackendVersionFromCache BackendVersionSource = "cache (within TTL)"
+	// BackendVersionFromFetch: freshly read from /api/olares-info.
+	BackendVersionFromFetch BackendVersionSource = "fetched from /api/olares-info"
+	// BackendVersionFromStaleCache: fetch failed; fell back to a stale cache.
+	BackendVersionFromStaleCache BackendVersionSource = "stale cache (fetch failed)"
+)
+
+// BackendVersionInfo is the transparency view for version-compat dispatch: the
+// effective version, where it came from, the persisted cache state, the TTL,
+// and the client implementation it selects. Returned by
+// OlaresBackendVersionInfo for `settings me version --dispatch`.
+type BackendVersionInfo struct {
+	Version        *semver.Version
+	Source         BackendVersionSource
+	CachedVersion  string
+	RefreshedAt    int64
+	TTL            time.Duration
+	Implementation string
+}
+
+// OlaresBackendVersionInfo resolves the backend version the same way the
+// dispatch path does (flag > fresh cache > /api/olares-info, with stale-cache
+// fallback) but additionally reports the provenance, cache timestamp, TTL and
+// the selected client implementation. It honors --refresh-version. Unlike
+// OlaresBackendVersion it is not memoized — it is a diagnostic read meant to
+// reflect live state when the user asks.
+func (f *Factory) OlaresBackendVersionInfo(ctx context.Context) (*BackendVersionInfo, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	info := &BackendVersionInfo{TTL: backendVersionTTL}
+
+	// 1. Explicit override.
+	if raw := strings.TrimSpace(viper.GetString(FlagOlaresVersion)); raw != "" {
+		v, err := utils.ParseOlaresVersionString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --%s %q: %w", FlagOlaresVersion, raw, err)
+		}
+		info.Version = v
+		info.Source = BackendVersionFromFlag
+		info.Implementation = olaresclient.SelectedImplementation(v)
+		return info, nil
+	}
+
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cached, cachedAt := loadCachedBackendVersion(rp.OlaresID)
+	if cached != nil {
+		info.CachedVersion = cached.Original()
+		info.RefreshedAt = cachedAt
+	}
+	forceRefresh := viper.GetBool(FlagRefreshVersion)
+	fresh := cached != nil && time.Since(time.Unix(cachedAt, 0)) <= backendVersionTTL
+
+	// 2. Fresh cache.
+	if !forceRefresh && fresh {
+		info.Version = cached
+		info.Source = BackendVersionFromCache
+		info.Implementation = olaresclient.SelectedImplementation(cached)
+		return info, nil
+	}
+
+	// 3. Fetch from the backend.
+	fetched, fetchErr := f.fetchBackendVersion(ctx, rp)
+	if fetchErr != nil {
+		if cached != nil {
+			info.Version = cached
+			info.Source = BackendVersionFromStaleCache
+			info.Implementation = olaresclient.SelectedImplementation(cached)
+			return info, nil
+		}
+		return nil, fmt.Errorf("detect Olares backend version: %w (pass --%s <version> to set it manually)", fetchErr, FlagOlaresVersion)
+	}
+	if cfg, err := cliconfig.LoadMultiProfileConfig(); err == nil {
+		now := time.Now().Unix()
+		if _, serr := cfg.SetBackendVersion(rp.OlaresID, fetched.Original(), now); serr == nil {
+			info.RefreshedAt = now
+			info.CachedVersion = fetched.Original()
+		}
+	}
+	info.Version = fetched
+	info.Source = BackendVersionFromFetch
+	info.Implementation = olaresclient.SelectedImplementation(fetched)
+	return info, nil
+}
+
+// RefreshOlaresBackendVersion forces a fresh /api/olares-info read, updates the
+// per-profile cache, and resets the in-process memoization so subsequent
+// OlaresBackendVersion calls observe the new value. Used by the dispatch
+// aspect's self-heal path when a command fails with a version-suspect error.
+// Returns (newVersion, changed, err) where changed reports whether the version
+// differs from what was previously cached.
+func (f *Factory) RefreshOlaresBackendVersion(ctx context.Context) (*semver.Version, bool, error) {
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	fetched, err := f.fetchBackendVersion(ctx, rp)
+	if err != nil {
+		return nil, false, err
+	}
+	changed := false
+	if cfg, lerr := cliconfig.LoadMultiProfileConfig(); lerr == nil {
+		changed, _ = cfg.SetBackendVersion(rp.OlaresID, fetched.Original(), time.Now().Unix())
+	}
+	f.backendVersionMu.Lock()
+	f.backendVersion = fetched
+	f.backendVersionErr = nil
+	f.backendVersionMu.Unlock()
+	return fetched, changed, nil
+}
+
+func (f *Factory) resolveBackendVersion(ctx context.Context) (*semver.Version, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// 1. Explicit override.
+	if raw := strings.TrimSpace(viper.GetString(FlagOlaresVersion)); raw != "" {
+		v, err := utils.ParseOlaresVersionString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --%s %q: %w", FlagOlaresVersion, raw, err)
+		}
+		return v, nil
+	}
+
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	olaresID := rp.OlaresID
+	forceRefresh := viper.GetBool(FlagRefreshVersion)
+
+	// 2. Per-profile cache (subject to TTL unless a refresh is forced).
+	cached, cachedAt := loadCachedBackendVersion(olaresID)
+	if !forceRefresh && cached != nil && time.Since(time.Unix(cachedAt, 0)) <= backendVersionTTL {
+		return cached, nil
+	}
+
+	// 3. Fetch from the backend.
+	fetched, fetchErr := f.fetchBackendVersion(ctx, rp)
+	if fetchErr != nil {
+		// Degrade to the (stale) cache when one exists; only the first
+		// detection ever fails hard.
+		if cached != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not refresh Olares backend version (%v); using cached %s\n", fetchErr, cached)
+			return cached, nil
+		}
+		return nil, fmt.Errorf("detect Olares backend version: %w (pass --%s <version> to set it manually)", fetchErr, FlagOlaresVersion)
+	}
+
+	// Persist best-effort; a write failure must not break the command.
+	if cfg, err := cliconfig.LoadMultiProfileConfig(); err == nil {
+		if _, serr := cfg.SetBackendVersion(olaresID, fetched.Original(), time.Now().Unix()); serr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not cache Olares backend version: %v\n", serr)
+		}
+	}
+	return fetched, nil
+}
+
+// fetchBackendVersion reads osVersion from /api/olares-info on the profile's
+// desktop ingress, reusing the Factory's auth-injecting http.Client.
+func (f *Factory) fetchBackendVersion(ctx context.Context, rp *credential.ResolvedProfile) (*semver.Version, error) {
+	hc, err := f.HTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	doer := whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID)
+
+	var env olaresInfoEnvelope
+	if err := doer.DoJSON(ctx, http.MethodGet, "/api/olares-info", nil, &env); err != nil {
+		return nil, err
+	}
+	osVersion := strings.TrimSpace(env.Data.OsVersion)
+	if osVersion == "" {
+		return nil, fmt.Errorf("/api/olares-info returned an empty osVersion")
+	}
+	v, err := utils.ParseOlaresVersionString(osVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse backend osVersion %q: %w", osVersion, err)
+	}
+	return v, nil
+}
+
+func loadCachedBackendVersion(olaresID string) (*semver.Version, int64) {
+	cfg, err := cliconfig.LoadMultiProfileConfig()
+	if err != nil {
+		return nil, 0
+	}
+	p := cfg.FindByOlaresID(olaresID)
+	if p == nil || strings.TrimSpace(p.BackendVersion) == "" {
+		return nil, 0
+	}
+	v, err := utils.ParseOlaresVersionString(p.BackendVersion)
+	if err != nil {
+		return nil, 0
+	}
+	return v, p.BackendVersionRefreshedAt
+}

--- a/cli/pkg/olaresclient/client_1_12_5.go
+++ b/cli/pkg/olaresclient/client_1_12_5.go
@@ -1,0 +1,103 @@
+package olaresclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var version_1_12_5 = semver.MustParse("1.12.5")
+
+// clientV1_12_5 is the baseline implementation: the market app-lifecycle wire
+// format as it existed on Olares 1.12.5 (pre TermiPass PR #1162). It provides
+// the full MarketAppOps surface so newer clients only need to override the
+// methods that actually changed.
+type clientV1_12_5 struct {
+	baseClient
+}
+
+func newClientV1_12_5(backendVersion *semver.Version) (OlaresClient, error) {
+	return &clientV1_12_5{baseClient{version: backendVersion}}, nil
+}
+
+// StopApp on 1.12.5: POST /apps/stop with body {appName, all}. The source
+// argument is ignored on this line — 1.12.5 does not send it.
+func (c *clientV1_12_5) StopApp(ctx context.Context, d Doer, appName, source string, all bool) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/apps/stop", map[string]any{
+		"appName": appName,
+		"all":     all,
+	})
+}
+
+// ResumeApp on 1.12.5: POST /apps/resume with body {appName}. source ignored.
+func (c *clientV1_12_5) ResumeApp(ctx context.Context, d Doer, appName, source string) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/apps/resume", map[string]any{
+		"appName": appName,
+	})
+}
+
+// UninstallApp on 1.12.5: DELETE /apps/{name}; the app name rides the path and
+// the body carries only {sync, all, deleteData}. The source / version
+// arguments are ignored on this line — 1.12.5 does not send them.
+func (c *clientV1_12_5) UninstallApp(ctx context.Context, d Doer, appName, source, version string, all, deleteData bool) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodDelete, "/apps/"+appName, map[string]any{
+		"sync":       true,
+		"all":        all,
+		"deleteData": deleteData,
+	})
+}
+
+// --- ComputeOps (GPU / compute acceleration) ---
+
+// ListAccelerators on 1.12.5: GET /api/gpu/list (the legacy HAMI-backed GPU
+// list; the compute-resources model did not exist yet).
+func (c *clientV1_12_5) ListAccelerators(ctx context.Context, d Doer) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodGet, "/api/gpu/list", nil)
+}
+
+// GetAppBindings is a 1.12.6+ capability; 1.12.5 has no compute-resources API.
+func (c *clientV1_12_5) GetAppBindings(_ context.Context, _ Doer, _ string) (json.RawMessage, error) {
+	return nil, c.computeUnsupported("settings gpu bindings")
+}
+
+// ReleaseAppBindings is a 1.12.6+ capability.
+func (c *clientV1_12_5) ReleaseAppBindings(_ context.Context, _ Doer, _ string) (json.RawMessage, error) {
+	return nil, c.computeUnsupported("settings gpu unbind")
+}
+
+// SwitchSupportType is a 1.12.6+ capability.
+func (c *clientV1_12_5) SwitchSupportType(_ context.Context, _ Doer, _, _, _ string) (json.RawMessage, error) {
+	return nil, c.computeUnsupported("settings gpu support-type set")
+}
+
+// --- OverlayOps (overlay gateway) — entirely 1.12.6+ ---
+
+func (c *clientV1_12_5) OverlayGatewayStatus(_ context.Context, _ Doer, _ string) (json.RawMessage, error) {
+	return nil, c.overlayUnsupported("settings network overlay status")
+}
+
+func (c *clientV1_12_5) EnableOverlayGateway(_ context.Context, _ Doer) (json.RawMessage, error) {
+	return nil, c.overlayUnsupported("settings network overlay enable")
+}
+
+func (c *clientV1_12_5) DisableOverlayGateway(_ context.Context, _ Doer) (json.RawMessage, error) {
+	return nil, c.overlayUnsupported("settings network overlay disable")
+}
+
+// computeUnsupported / overlayUnsupported build the capability-gate error for
+// operations that only exist on Olares 1.12.6+. Current reflects the real
+// detected backend version (from baseClient), so the message is accurate even
+// for the default/fallback client which embeds this type.
+func (c *clientV1_12_5) computeUnsupported(feature string) error {
+	return &ErrUnsupportedVersion{Feature: feature, MinVersion: version_1_12_6, Current: c.Version()}
+}
+
+func (c *clientV1_12_5) overlayUnsupported(feature string) error {
+	return &ErrUnsupportedVersion{Feature: feature, MinVersion: version_1_12_6, Current: c.Version()}
+}
+
+func init() {
+	registerClientFactory(version_1_12_5, newClientV1_12_5)
+}

--- a/cli/pkg/olaresclient/client_1_12_6.go
+++ b/cli/pkg/olaresclient/client_1_12_6.go
@@ -1,0 +1,117 @@
+package olaresclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var version_1_12_6 = semver.MustParse("1.12.6")
+
+// clientV1_12_6 embeds clientV1_12_5 so any capability NOT overridden here
+// transparently delegates to the 1.12.5 implementation — the "1.12.6 didn't
+// change this operation, so reuse 1.12.5" method-level fallback. Only the
+// market operations whose wire format changed in TermiPass PR #1162 are
+// overridden below.
+type clientV1_12_6 struct {
+	clientV1_12_5
+}
+
+func newClientV1_12_6(backendVersion *semver.Version) (OlaresClient, error) {
+	return &clientV1_12_6{clientV1_12_5{baseClient{version: backendVersion}}}, nil
+}
+
+// StopApp on 1.12.6: body moved to {app_name, source, all} (TermiPass
+// PR #1162 — StopRequest extends BaseOperationRequest{app_name, source}).
+func (c *clientV1_12_6) StopApp(ctx context.Context, d Doer, appName, source string, all bool) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/apps/stop", map[string]any{
+		"app_name": appName,
+		"source":   source,
+		"all":      all,
+	})
+}
+
+// ResumeApp on 1.12.6: body moved to {app_name, source} (TermiPass PR #1162 —
+// Resume2RestartRequest extends BaseOperationRequest; computeBinding is
+// optional and not exposed by the CLI).
+func (c *clientV1_12_6) ResumeApp(ctx context.Context, d Doer, appName, source string) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/apps/resume", map[string]any{
+		"app_name": appName,
+		"source":   source,
+	})
+}
+
+// UninstallApp on 1.12.6: the request body now carries app_name + source
+// (UninstallRequest extends BaseOperationRequest) alongside sync / all /
+// deleteData (DELETE /apps/{name}). version is included only when the caller
+// supplies one.
+func (c *clientV1_12_6) UninstallApp(ctx context.Context, d Doer, appName, source, version string, all, deleteData bool) (json.RawMessage, error) {
+	body := map[string]any{
+		"app_name":   appName,
+		"source":     source,
+		"sync":       true,
+		"all":        all,
+		"deleteData": deleteData,
+	}
+	if version != "" {
+		body["version"] = version
+	}
+	return d.Do(ctx, http.MethodDelete, "/apps/"+appName, body)
+}
+
+// --- ComputeOps (compute-resources model, replaces the 1.12.5 /api/gpu/*) ---
+//
+// clientV1_12_6 embeds clientV1_12_5 only to reuse the unchanged MarketAppOps
+// methods. ComputeOps is a COMPLETE replacement (different endpoints + data
+// model), so every method is overridden here — none of the 1.12.5 /api/gpu/*
+// behavior must leak through.
+
+// ListAccelerators on 1.12.6: GET /api/compute-resources (nodes → devices →
+// bindings), replacing the legacy /api/gpu/list.
+func (c *clientV1_12_6) ListAccelerators(ctx context.Context, d Doer) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodGet, "/api/compute-resources", nil)
+}
+
+// GetAppBindings on 1.12.6: GET /api/apps/{app}/compute-resources/bindings.
+func (c *clientV1_12_6) GetAppBindings(ctx context.Context, d Doer, appName string) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodGet, "/api/apps/"+url.PathEscape(appName)+"/compute-resources/bindings", nil)
+}
+
+// ReleaseAppBindings on 1.12.6: DELETE /api/apps/{app}/compute-resources/bindings.
+// The backend implements this as a suspend to free the GPU binding.
+func (c *clientV1_12_6) ReleaseAppBindings(ctx context.Context, d Doer, appName string) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodDelete, "/api/apps/"+url.PathEscape(appName)+"/compute-resources/bindings", nil)
+}
+
+// SwitchSupportType on 1.12.6: PUT
+// /api/compute-resources/nodes/{node}/devices/{device}/support-type with body
+// {supportType}. The result carries a status discriminant
+// (switched/unchanged/bound-apps-stop-blocked) the caller inspects.
+func (c *clientV1_12_6) SwitchSupportType(ctx context.Context, d Doer, node, deviceID, supportType string) (json.RawMessage, error) {
+	path := "/api/compute-resources/nodes/" + url.PathEscape(node) + "/devices/" + url.PathEscape(deviceID) + "/support-type"
+	return d.Do(ctx, http.MethodPut, path, map[string]any{"supportType": supportType})
+}
+
+// --- OverlayOps (overlay gateway, new in 1.12.6) ---
+
+// OverlayGatewayStatus on 1.12.6: GET /api/system/overlay-gateway-status/{user}.
+func (c *clientV1_12_6) OverlayGatewayStatus(ctx context.Context, d Doer, user string) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodGet, "/api/system/overlay-gateway-status/"+url.PathEscape(user), nil)
+}
+
+// EnableOverlayGateway on 1.12.6: POST /api/command/enable-overlay-gateway (no body).
+func (c *clientV1_12_6) EnableOverlayGateway(ctx context.Context, d Doer) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/api/command/enable-overlay-gateway", nil)
+}
+
+// DisableOverlayGateway on 1.12.6: POST /api/command/disable-overlay-gateway (no body).
+func (c *clientV1_12_6) DisableOverlayGateway(ctx context.Context, d Doer) (json.RawMessage, error) {
+	return d.Do(ctx, http.MethodPost, "/api/command/disable-overlay-gateway", nil)
+}
+
+func init() {
+	registerClientFactory(version_1_12_6, newClientV1_12_6)
+}

--- a/cli/pkg/olaresclient/client_common.go
+++ b/cli/pkg/olaresclient/client_common.go
@@ -1,0 +1,14 @@
+package olaresclient
+
+import "github.com/Masterminds/semver/v3"
+
+// baseClient holds state common to every version implementation. Concrete
+// version clients embed it (directly or transitively) to satisfy VersionAware.
+type baseClient struct {
+	// version is the FULL detected backend version (with any prerelease),
+	// not the core patch the registry keyed on.
+	version *semver.Version
+}
+
+// Version implements VersionAware.
+func (c baseClient) Version() *semver.Version { return c.version }

--- a/cli/pkg/olaresclient/client_default.go
+++ b/cli/pkg/olaresclient/client_default.go
@@ -1,0 +1,22 @@
+package olaresclient
+
+import "github.com/Masterminds/semver/v3"
+
+// clientDefault is the fallback used when the backend version is unknown or
+// below the lowest registered implementation. It behaves like the oldest
+// supported line (1.12.5) — the most conservative wire format we still
+// understand — maximizing the chance of working against an unexpected backend.
+// It is a distinct type (rather than reusing clientV1_12_5 directly) so its
+// behavior can be tightened independently later without disturbing the 1.12.5
+// path.
+type clientDefault struct {
+	clientV1_12_5
+}
+
+func newClientDefault(backendVersion *semver.Version) (OlaresClient, error) {
+	return &clientDefault{clientV1_12_5{baseClient{version: backendVersion}}}, nil
+}
+
+func init() {
+	registerDefaultFactory(newClientDefault)
+}

--- a/cli/pkg/olaresclient/interface.go
+++ b/cli/pkg/olaresclient/interface.go
@@ -1,0 +1,156 @@
+// Package olaresclient is the runtime version-compatibility layer for the
+// remote / API commands of olares-cli. A single CLI binary may talk to Olares
+// backends of different versions (e.g. 1.12.5 and 1.12.6); this package lets a
+// command dispatch to a version-specific implementation chosen at runtime from
+// the detected backend version, while version-agnostic transport (auth,
+// envelope unwrapping, retries) stays in the calling package.
+//
+// Design mirrors pkg/upgrade's proven pattern: every version implementation
+// lives in this single package (one file each) and self-registers via init().
+// Keeping them in one package — rather than vX_Y_Z subpackages — is deliberate:
+// subpackages would import this package for the registry while this package
+// would have to blank-import them to trigger their init(), which is an import
+// cycle. The upgrade package sidesteps the same problem the same way.
+//
+// Selection is by the backend's CORE version (Major.Minor.Patch, prerelease
+// stripped) using a floor match: the registered implementation with the
+// greatest core version that is <= the backend's core version wins. So:
+//
+//   - 1.12.6 / 1.12.6-20260603 (daily) / 1.12.6-alpha1 (prerelease) → 1.12.6
+//   - 1.12.7-20260524 (newer than any known impl)                   → 1.12.6
+//   - 1.12.5*                                                       → 1.12.5
+//   - below the lowest registered impl / unknown                    → default
+//
+// Method-level fallback ("1.12.6 didn't change this op → use 1.12.5") is
+// achieved with plain Go embedding: clientV1_12_6 embeds clientV1_12_5 and
+// only overrides the methods whose wire format actually changed.
+package olaresclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// Doer executes a single JSON request against the per-user Olares backend and
+// returns the raw `data` payload of the response envelope. The transport
+// (token injection, refresh-on-401, envelope unwrapping, error reformatting)
+// is owned by the caller — e.g. market.MarketClient implements this over its
+// existing doRequest — so version implementations here only shape the request
+// line (method / path / body) and never re-implement transport.
+type Doer interface {
+	Do(ctx context.Context, method, path string, body any) (json.RawMessage, error)
+}
+
+// VersionAware is implemented by every version client. Version reports the
+// FULL backend version the client was created for (including any prerelease),
+// so an implementation can branch internally on daily / alpha builds even
+// though selection collapses to the core patch version.
+type VersionAware interface {
+	Version() *semver.Version
+}
+
+// MarketAppOps groups the market app-lifecycle operations whose wire format
+// diverges across Olares versions. Per TermiPass PR #1162 the stop / resume /
+// uninstall request bodies all moved from `{appName}` (and the old
+// uninstall `{sync, all, deleteData}`) to a common `{app_name, source, ...}`
+// shape — these are the representative version-specific operations.
+//
+// source is the market source the installed app belongs to (resolved by the
+// caller from /market/state). 1.12.5 ignores it; 1.12.6 requires it.
+type MarketAppOps interface {
+	// StopApp suspends a running app (POST /apps/stop).
+	StopApp(ctx context.Context, d Doer, appName, source string, all bool) (json.RawMessage, error)
+	// ResumeApp resumes a suspended app (POST /apps/resume).
+	ResumeApp(ctx context.Context, d Doer, appName, source string) (json.RawMessage, error)
+	// UninstallApp uninstalls an app (DELETE /apps/{name}). version may be
+	// empty for callers / versions that don't carry it.
+	UninstallApp(ctx context.Context, d Doer, appName, source, version string, all, deleteData bool) (json.RawMessage, error)
+}
+
+// ComputeOps groups the GPU / compute-acceleration operations. This is the
+// "complete replacement" version axis: Olares 1.12.5 exposed a GPU
+// assign/mode model under /api/gpu/*, while 1.12.6 replaced it wholesale with
+// a node/device/supportType/binding model under /api/compute-resources*
+// (the old GPUController was deleted). The two share no wire format, so the
+// version clients implement this interface independently (no embedding reuse).
+//
+// ListAccelerators exists on both lines (mapped to each version's list
+// endpoint); the binding/support-type operations are 1.12.6+ only and return
+// *ErrUnsupportedVersion on older lines. Every method returns the unwrapped
+// `data` payload of the {code,message,data} envelope (the Doer owns transport
+// + envelope unwrapping).
+type ComputeOps interface {
+	// ListAccelerators lists GPUs / compute resources. 1.12.5: GET
+	// /api/gpu/list; 1.12.6: GET /api/compute-resources.
+	ListAccelerators(ctx context.Context, d Doer) (json.RawMessage, error)
+	// GetAppBindings returns an app's compute bindings (1.12.6+):
+	// GET /api/apps/{app}/compute-resources/bindings.
+	GetAppBindings(ctx context.Context, d Doer, appName string) (json.RawMessage, error)
+	// ReleaseAppBindings releases an app's compute bindings (1.12.6+),
+	// which suspends the app: DELETE /api/apps/{app}/compute-resources/bindings.
+	ReleaseAppBindings(ctx context.Context, d Doer, appName string) (json.RawMessage, error)
+	// SwitchSupportType changes a device's support type (1.12.6+):
+	// PUT /api/compute-resources/nodes/{node}/devices/{device}/support-type.
+	SwitchSupportType(ctx context.Context, d Doer, node, deviceID, supportType string) (json.RawMessage, error)
+}
+
+// OverlayOps groups the overlay-gateway operations. This is the "brand new
+// feature" version axis: the overlay gateway (macvlan/bridge LAN-IP assignment
+// for supported apps) landed in Olares 1.12.6; older backends have no such
+// routes. All methods therefore return *ErrUnsupportedVersion below 1.12.6.
+// Like ComputeOps, each method returns the unwrapped `data` payload.
+type OverlayOps interface {
+	// OverlayGatewayStatus reports gateway + per-app overlay status (1.12.6+):
+	// GET /api/system/overlay-gateway-status/{user}.
+	OverlayGatewayStatus(ctx context.Context, d Doer, user string) (json.RawMessage, error)
+	// EnableOverlayGateway turns the gateway on (1.12.6+, owner-only):
+	// POST /api/command/enable-overlay-gateway (no body).
+	EnableOverlayGateway(ctx context.Context, d Doer) (json.RawMessage, error)
+	// DisableOverlayGateway turns the gateway off (1.12.6+, owner-only):
+	// POST /api/command/disable-overlay-gateway (no body).
+	DisableOverlayGateway(ctx context.Context, d Doer) (json.RawMessage, error)
+}
+
+// OlaresClient is the umbrella interface a version implementation satisfies.
+// It is intentionally composed of small capability interfaces (VersionAware,
+// MarketAppOps, ...) so it can grow feature-by-feature without becoming a
+// single monster interface — addressing the "interface bloat" risk.
+type OlaresClient interface {
+	VersionAware
+	MarketAppOps
+	ComputeOps
+	OverlayOps
+}
+
+// ErrUnsupportedVersion is returned by a version implementation when the
+// connected backend does not provide a capability the command needs (the
+// "capability gate"). The dispatch aspect (cmdutil.Factory.WithOlaresClient)
+// renders it into an actionable hint and does NOT retry — retrying cannot
+// close a capability gap.
+type ErrUnsupportedVersion struct {
+	// Feature is a short, user-facing name of the operation, e.g.
+	// "market clone --entrance".
+	Feature string
+	// MinVersion is the lowest Olares version that supports Feature.
+	MinVersion *semver.Version
+	// Current is the detected backend version (may be nil if unknown).
+	Current *semver.Version
+}
+
+func (e *ErrUnsupportedVersion) Error() string {
+	feature := e.Feature
+	if feature == "" {
+		feature = "this operation"
+	}
+	cur := "unknown"
+	if e.Current != nil {
+		cur = e.Current.String()
+	}
+	if e.MinVersion != nil {
+		return fmt.Sprintf("%s requires Olares >= %s (connected backend is %s)", feature, e.MinVersion.String(), cur)
+	}
+	return fmt.Sprintf("%s is not supported by the connected backend (%s)", feature, cur)
+}

--- a/cli/pkg/olaresclient/olaresclient_test.go
+++ b/cli/pkg/olaresclient/olaresclient_test.go
@@ -1,0 +1,364 @@
+package olaresclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// fakeDoer records the last request a client shaped so tests can assert on the
+// method / path / body without any network.
+type fakeDoer struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+func (d *fakeDoer) Do(_ context.Context, method, path string, body any) (json.RawMessage, error) {
+	d.method = method
+	d.path = path
+	// Round-trip through JSON so we observe exactly what would go on the
+	// wire (json tags, omitted empties), mirroring MarketClient.doRequest.
+	raw, _ := json.Marshal(body)
+	m := map[string]any{}
+	_ = json.Unmarshal(raw, &m)
+	d.body = m
+	return json.RawMessage(`{}`), nil
+}
+
+func mustParse(t *testing.T, s string) *semver.Version {
+	t.Helper()
+	v, err := semver.NewVersion(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+func TestGetClientFloorSelection(t *testing.T) {
+	cases := []struct {
+		name    string
+		backend string
+		want    string // expected Version().String() of the selected client's *registered* line
+	}{
+		{"exact 1.12.5", "1.12.5", "1.12.5"},
+		{"exact 1.12.6", "1.12.6", "1.12.6"},
+		{"1.12.5 daily", "1.12.5-20260101", "1.12.5"},
+		{"1.12.6 daily", "1.12.6-20260603", "1.12.6"},
+		{"1.12.6 alpha", "1.12.6-alpha1", "1.12.6"},
+		{"newer than known floors to 1.12.6", "1.12.7-20260524", "1.12.6"},
+		{"much newer floors to 1.12.6", "1.13.0", "1.12.6"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			backend := mustParse(t, c.backend)
+			client, err := GetClient(backend)
+			if err != nil {
+				t.Fatalf("GetClient(%s): %v", c.backend, err)
+			}
+			// The client carries the FULL backend version, while the
+			// chosen implementation is identified by its wire behavior.
+			// Assert behavior: stop body field name distinguishes 1.12.5
+			// (appName) from 1.12.6 (app_name).
+			d := &fakeDoer{}
+			if _, err := client.StopApp(context.Background(), d, "firefox", "market.olares", false); err != nil {
+				t.Fatalf("StopApp: %v", err)
+			}
+			gotLine := "1.12.5"
+			if _, ok := d.body["app_name"]; ok {
+				gotLine = "1.12.6"
+			}
+			if gotLine != c.want {
+				t.Fatalf("backend %s selected %s line (stop body=%v), want %s", c.backend, gotLine, d.body, c.want)
+			}
+			// Version() must reflect the full backend version, not the core.
+			if !client.Version().Equal(backend) {
+				t.Fatalf("Version()=%s, want full backend %s", client.Version(), backend)
+			}
+		})
+	}
+}
+
+func TestGetClientNilFallsBackToDefault(t *testing.T) {
+	client, err := GetClient(nil)
+	if err != nil {
+		t.Fatalf("GetClient(nil): %v", err)
+	}
+	// default behaves like 1.12.5 (appName).
+	d := &fakeDoer{}
+	if _, err := client.StopApp(context.Background(), d, "firefox", "market.olares", false); err != nil {
+		t.Fatalf("StopApp: %v", err)
+	}
+	if _, ok := d.body["appName"]; !ok {
+		t.Fatalf("default client should use 1.12.5 wire (appName); got body=%v", d.body)
+	}
+}
+
+func TestStopResumeWireShapes(t *testing.T) {
+	v5, _ := newClientV1_12_5(mustParse(t, "1.12.5"))
+	v6, _ := newClientV1_12_6(mustParse(t, "1.12.6"))
+
+	// stop
+	d5 := &fakeDoer{}
+	_, _ = v5.StopApp(context.Background(), d5, "firefox", "market.olares", true)
+	if d5.path != "/apps/stop" || d5.body["appName"] != "firefox" {
+		t.Fatalf("1.12.5 stop: path=%s body=%v", d5.path, d5.body)
+	}
+	if _, ok := d5.body["app_name"]; ok {
+		t.Fatalf("1.12.5 stop must NOT carry app_name: %v", d5.body)
+	}
+	if _, ok := d5.body["source"]; ok {
+		t.Fatalf("1.12.5 stop must NOT carry source: %v", d5.body)
+	}
+
+	d6 := &fakeDoer{}
+	_, _ = v6.StopApp(context.Background(), d6, "firefox", "market.olares", true)
+	if d6.path != "/apps/stop" || d6.body["app_name"] != "firefox" || d6.body["source"] != "market.olares" {
+		t.Fatalf("1.12.6 stop must carry app_name+source: path=%s body=%v", d6.path, d6.body)
+	}
+	if _, ok := d6.body["appName"]; ok {
+		t.Fatalf("1.12.6 stop must NOT carry appName: %v", d6.body)
+	}
+
+	// resume
+	r5 := &fakeDoer{}
+	_, _ = v5.ResumeApp(context.Background(), r5, "ollama", "market.olares")
+	if r5.body["appName"] != "ollama" {
+		t.Fatalf("1.12.5 resume body=%v", r5.body)
+	}
+	if _, ok := r5.body["source"]; ok {
+		t.Fatalf("1.12.5 resume must NOT carry source: %v", r5.body)
+	}
+	r6 := &fakeDoer{}
+	_, _ = v6.ResumeApp(context.Background(), r6, "ollama", "market.olares")
+	if r6.body["app_name"] != "ollama" || r6.body["source"] != "market.olares" {
+		t.Fatalf("1.12.6 resume must carry app_name+source: %v", r6.body)
+	}
+}
+
+func TestUninstallWireShapes(t *testing.T) {
+	v5, _ := newClientV1_12_5(mustParse(t, "1.12.5"))
+	v6, _ := newClientV1_12_6(mustParse(t, "1.12.6"))
+
+	d5 := &fakeDoer{}
+	_, _ = v5.UninstallApp(context.Background(), d5, "windows", "market.olares", "1.2.3", true, true)
+	if d5.method != "DELETE" || d5.path != "/apps/windows" {
+		t.Fatalf("1.12.5 uninstall method=%s path=%s", d5.method, d5.path)
+	}
+	// 1.12.5 does NOT send app_name / source / version in the body.
+	for _, k := range []string{"version", "app_name", "source"} {
+		if _, ok := d5.body[k]; ok {
+			t.Fatalf("1.12.5 uninstall must NOT carry %s: %v", k, d5.body)
+		}
+	}
+
+	d6 := &fakeDoer{}
+	_, _ = v6.UninstallApp(context.Background(), d6, "windows", "market.olares", "1.2.3", true, true)
+	if d6.body["app_name"] != "windows" || d6.body["source"] != "market.olares" || d6.body["version"] != "1.2.3" {
+		t.Fatalf("1.12.6 uninstall must carry app_name+source+version: %v", d6.body)
+	}
+
+	// version omitted when empty even on 1.12.6 (source still required).
+	d6e := &fakeDoer{}
+	_, _ = v6.UninstallApp(context.Background(), d6e, "windows", "market.olares", "", true, true)
+	if _, ok := d6e.body["version"]; ok {
+		t.Fatalf("1.12.6 uninstall should omit empty version: %v", d6e.body)
+	}
+	if d6e.body["source"] != "market.olares" {
+		t.Fatalf("1.12.6 uninstall must still carry source: %v", d6e.body)
+	}
+}
+
+func TestMethodFallbackThroughEmbedding(t *testing.T) {
+	// clientV1_12_6 embeds clientV1_12_5; a *V1_12_6 must still satisfy the
+	// full interface, and Version() (defined on baseClient, reused via
+	// embedding) must work without an explicit override.
+	v6, err := newClientV1_12_6(mustParse(t, "1.12.6-20260603"))
+	if err != nil {
+		t.Fatalf("new 1.12.6: %v", err)
+	}
+	if got := v6.Version().String(); got != "1.12.6-20260603" {
+		t.Fatalf("Version()=%s, want 1.12.6-20260603 (inherited from baseClient)", got)
+	}
+}
+
+// --- ComputeOps ---
+
+func TestComputeWireShapes_1_12_6(t *testing.T) {
+	v6, _ := newClientV1_12_6(mustParse(t, "1.12.6"))
+
+	d := &fakeDoer{}
+	if _, err := v6.ListAccelerators(context.Background(), d); err != nil {
+		t.Fatalf("ListAccelerators: %v", err)
+	}
+	if d.method != "GET" || d.path != "/api/compute-resources" {
+		t.Fatalf("1.12.6 list: method=%s path=%s", d.method, d.path)
+	}
+
+	gb := &fakeDoer{}
+	if _, err := v6.GetAppBindings(context.Background(), gb, "ollama"); err != nil {
+		t.Fatalf("GetAppBindings: %v", err)
+	}
+	if gb.method != "GET" || gb.path != "/api/apps/ollama/compute-resources/bindings" {
+		t.Fatalf("1.12.6 bindings: method=%s path=%s", gb.method, gb.path)
+	}
+
+	rl := &fakeDoer{}
+	if _, err := v6.ReleaseAppBindings(context.Background(), rl, "ollama"); err != nil {
+		t.Fatalf("ReleaseAppBindings: %v", err)
+	}
+	if rl.method != "DELETE" || rl.path != "/api/apps/ollama/compute-resources/bindings" {
+		t.Fatalf("1.12.6 unbind: method=%s path=%s", rl.method, rl.path)
+	}
+
+	sw := &fakeDoer{}
+	if _, err := v6.SwitchSupportType(context.Background(), sw, "node-1", "GPU-abc", "TimeSlice"); err != nil {
+		t.Fatalf("SwitchSupportType: %v", err)
+	}
+	if sw.method != "PUT" || sw.path != "/api/compute-resources/nodes/node-1/devices/GPU-abc/support-type" {
+		t.Fatalf("1.12.6 support-type: method=%s path=%s", sw.method, sw.path)
+	}
+	if sw.body["supportType"] != "TimeSlice" {
+		t.Fatalf("1.12.6 support-type body=%v", sw.body)
+	}
+}
+
+func TestComputeListLegacy_1_12_5(t *testing.T) {
+	v5, _ := newClientV1_12_5(mustParse(t, "1.12.5"))
+	d := &fakeDoer{}
+	if _, err := v5.ListAccelerators(context.Background(), d); err != nil {
+		t.Fatalf("ListAccelerators: %v", err)
+	}
+	if d.method != "GET" || d.path != "/api/gpu/list" {
+		t.Fatalf("1.12.5 list must hit legacy endpoint: method=%s path=%s", d.method, d.path)
+	}
+}
+
+func TestComputeGatingOnLegacy_1_12_5(t *testing.T) {
+	v5, _ := newClientV1_12_5(mustParse(t, "1.12.5"))
+	d := &fakeDoer{}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"bindings", func() error { _, err := v5.GetAppBindings(context.Background(), d, "ollama"); return err }},
+		{"unbind", func() error { _, err := v5.ReleaseAppBindings(context.Background(), d, "ollama"); return err }},
+		{"support-type", func() error {
+			_, err := v5.SwitchSupportType(context.Background(), d, "n", "dev", "Exclusive")
+			return err
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.call()
+			var unsupported *ErrUnsupportedVersion
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("%s on 1.12.5 must return ErrUnsupportedVersion, got %v", c.name, err)
+			}
+			if unsupported.MinVersion == nil || unsupported.MinVersion.String() != "1.12.6" {
+				t.Fatalf("%s gate must require 1.12.6, got %v", c.name, unsupported.MinVersion)
+			}
+		})
+	}
+}
+
+// --- OverlayOps ---
+
+func TestOverlayWireShapes_1_12_6(t *testing.T) {
+	v6, _ := newClientV1_12_6(mustParse(t, "1.12.6"))
+
+	st := &fakeDoer{}
+	if _, err := v6.OverlayGatewayStatus(context.Background(), st, "alice"); err != nil {
+		t.Fatalf("OverlayGatewayStatus: %v", err)
+	}
+	if st.method != "GET" || st.path != "/api/system/overlay-gateway-status/alice" {
+		t.Fatalf("1.12.6 overlay status: method=%s path=%s", st.method, st.path)
+	}
+
+	en := &fakeDoer{}
+	if _, err := v6.EnableOverlayGateway(context.Background(), en); err != nil {
+		t.Fatalf("EnableOverlayGateway: %v", err)
+	}
+	if en.method != "POST" || en.path != "/api/command/enable-overlay-gateway" {
+		t.Fatalf("1.12.6 overlay enable: method=%s path=%s", en.method, en.path)
+	}
+
+	dis := &fakeDoer{}
+	if _, err := v6.DisableOverlayGateway(context.Background(), dis); err != nil {
+		t.Fatalf("DisableOverlayGateway: %v", err)
+	}
+	if dis.method != "POST" || dis.path != "/api/command/disable-overlay-gateway" {
+		t.Fatalf("1.12.6 overlay disable: method=%s path=%s", dis.method, dis.path)
+	}
+}
+
+func TestOverlayGatingOnLegacy_1_12_5(t *testing.T) {
+	v5, _ := newClientV1_12_5(mustParse(t, "1.12.5"))
+	d := &fakeDoer{}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"status", func() error { _, err := v5.OverlayGatewayStatus(context.Background(), d, "alice"); return err }},
+		{"enable", func() error { _, err := v5.EnableOverlayGateway(context.Background(), d); return err }},
+		{"disable", func() error { _, err := v5.DisableOverlayGateway(context.Background(), d); return err }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.call()
+			var unsupported *ErrUnsupportedVersion
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("overlay %s on 1.12.5 must return ErrUnsupportedVersion, got %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestDefaultClientCapabilities ensures the fallback (nil version) client
+// inherits the conservative 1.12.5 behavior: legacy GPU list, and the
+// compute/overlay extras gated off.
+func TestDefaultClientCapabilities(t *testing.T) {
+	client, err := GetClient(nil)
+	if err != nil {
+		t.Fatalf("GetClient(nil): %v", err)
+	}
+	d := &fakeDoer{}
+	if _, err := client.ListAccelerators(context.Background(), d); err != nil {
+		t.Fatalf("default ListAccelerators: %v", err)
+	}
+	if d.path != "/api/gpu/list" {
+		t.Fatalf("default client should use legacy gpu list, got path=%s", d.path)
+	}
+	if _, err := client.EnableOverlayGateway(context.Background(), d); err == nil {
+		t.Fatal("default client EnableOverlayGateway must be gated")
+	} else {
+		var unsupported *ErrUnsupportedVersion
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("default overlay enable must return ErrUnsupportedVersion, got %v", err)
+		}
+	}
+}
+
+func TestErrUnsupportedVersionMessage(t *testing.T) {
+	err := &ErrUnsupportedVersion{
+		Feature:    "market clone --entrance",
+		MinVersion: mustParse(t, "1.12.6"),
+		Current:    mustParse(t, "1.12.5"),
+	}
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("empty error message")
+	}
+	// Must mention both the requirement and the current version.
+	for _, want := range []string{"1.12.6", "1.12.5", "market clone --entrance"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q missing %q", msg, want)
+		}
+	}
+}

--- a/cli/pkg/olaresclient/registry.go
+++ b/cli/pkg/olaresclient/registry.go
@@ -1,0 +1,113 @@
+package olaresclient
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/beclab/Olares/cli/pkg/utils"
+)
+
+// clientFactory builds an OlaresClient for a concrete backend version. The
+// FULL backendVersion (including prerelease) is passed in so an implementation
+// can branch on daily / alpha if it ever needs to, even though the registry
+// keys on the core patch version.
+type clientFactory func(backendVersion *semver.Version) (OlaresClient, error)
+
+// registeredClient pairs a core patch version key with its factory.
+type registeredClient struct {
+	patch   *semver.Version // core Major.Minor.Patch (prerelease stripped)
+	factory clientFactory
+}
+
+// registeredClients is the ascending-sorted registry of version
+// implementations. Populated by each client file's init().
+var registeredClients []registeredClient
+
+// defaultFactory builds the fallback client used when the backend version is
+// below the lowest registered implementation, or unknown.
+var defaultFactory clientFactory
+
+// registerClientFactory registers factory under the core patch version of
+// patch, keeping registeredClients sorted ascending so GetClient's floor match
+// can scan linearly.
+func registerClientFactory(patch *semver.Version, factory clientFactory) {
+	registeredClients = append(registeredClients, registeredClient{
+		patch:   utils.CoreVersion(patch),
+		factory: factory,
+	})
+	sort.Slice(registeredClients, func(i, j int) bool {
+		return registeredClients[i].patch.LessThan(registeredClients[j].patch)
+	})
+}
+
+// registerDefaultFactory records the fallback factory. Last registration wins;
+// there is only one default in practice.
+func registerDefaultFactory(factory clientFactory) {
+	defaultFactory = factory
+}
+
+// GetClient selects the version implementation for backendVersion using a
+// floor match on the core (Major.Minor.Patch) version: the registered client
+// with the greatest core version that is still <= the backend's core version.
+// This gives the two fallback layers the design calls for:
+//
+//   - selection floor: a backend newer than any known implementation (e.g.
+//     1.12.7-20260524 when the CLI only knows up to 1.12.6) resolves to the
+//     newest known implementation (1.12.6).
+//   - method fallback: handled by embedding inside the chosen implementation
+//     (see clientV1_12_6).
+//
+// A backend below the lowest registered version, or a nil version, resolves to
+// the default factory; if none is registered an error is returned.
+func GetClient(backendVersion *semver.Version) (OlaresClient, error) {
+	if backendVersion == nil {
+		return useDefault(backendVersion, "backend version is unknown")
+	}
+	chosen := selectClient(backendVersion)
+	if chosen == nil {
+		return useDefault(backendVersion, fmt.Sprintf("backend version %s is below the minimum supported version", backendVersion))
+	}
+	return chosen.factory(backendVersion)
+}
+
+// selectClient runs the floor match (greatest registered core version that is
+// <= the backend's core version) and returns the chosen entry, or nil when the
+// backend is below the lowest registered version. Shared by GetClient and
+// SelectedImplementation so the dispatch decision is computed in exactly one
+// place.
+func selectClient(backendVersion *semver.Version) *registeredClient {
+	if backendVersion == nil {
+		return nil
+	}
+	core := utils.CoreVersion(backendVersion)
+	var chosen *registeredClient
+	for i := range registeredClients {
+		if registeredClients[i].patch.Compare(core) <= 0 {
+			chosen = &registeredClients[i] // ascending: keep the last one that fits
+			continue
+		}
+		break
+	}
+	return chosen
+}
+
+// SelectedImplementation reports which registered client implementation
+// GetClient would dispatch backendVersion to, as a human-readable label
+// ("1.12.6", "1.12.5", or "default"). Used by `settings me version --dispatch`
+// to show users exactly which version-specific code path their commands take.
+func SelectedImplementation(backendVersion *semver.Version) string {
+	chosen := selectClient(backendVersion)
+	if chosen == nil {
+		return "default"
+	}
+	return chosen.patch.String()
+}
+
+func useDefault(backendVersion *semver.Version, reason string) (OlaresClient, error) {
+	if defaultFactory == nil {
+		return nil, fmt.Errorf("cannot resolve Olares client: %s and no default client is registered", reason)
+	}
+	return defaultFactory(backendVersion)
+}

--- a/cli/pkg/utils/version.go
+++ b/cli/pkg/utils/version.go
@@ -6,3 +6,30 @@ func ParseOlaresVersionString(versionString string) (*semver.Version, error) {
 	// todo: maybe some other custom processing only for olares
 	return semver.NewVersion(versionString)
 }
+
+// CoreVersion returns the Major.Minor.Patch "core" of v with the prerelease
+// and build-metadata stripped. It is the canonical key for version-aware
+// dispatch: an Olares backend reported as 1.12.6, 1.12.6-20260603 (daily) or
+// 1.12.6-alpha1 (prerelease) all share the same core 1.12.6 and therefore the
+// same client implementation. Stripping the prerelease also sidesteps the
+// Masterminds/semver rule that constraints exclude prerelease versions (and
+// that 1.12.6-alpha1 sorts *before* 1.12.6), which makes naive range matching
+// silently drop daily / alpha builds.
+func CoreVersion(v *semver.Version) *semver.Version {
+	if v == nil {
+		return nil
+	}
+	core := semver.New(v.Major(), v.Minor(), v.Patch(), "", "")
+	return core
+}
+
+// SamePatchLevel reports whether a and b share the same Major.Minor.Patch,
+// ignoring any prerelease / build metadata. Mirrors the helper of the same
+// intent in pkg/upgrade (samePatchLevelVersion) so version-line semantics stay
+// consistent across the codebase.
+func SamePatchLevel(a, b *semver.Version) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Major() == b.Major() && a.Minor() == b.Minor() && a.Patch() == b.Patch()
+}

--- a/cli/pkg/utils/version_test.go
+++ b/cli/pkg/utils/version_test.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestCoreVersionStripsPrerelease(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1.12.6", "1.12.6"},
+		{"1.12.6-20260603", "1.12.6"},
+		{"1.12.6-alpha1", "1.12.6"},
+		{"1.12.7-20260524", "1.12.7"},
+		{"1.12.6+build.7", "1.12.6"},
+	}
+	for _, c := range cases {
+		v := semver.MustParse(c.in)
+		if got := CoreVersion(v).String(); got != c.want {
+			t.Errorf("CoreVersion(%s)=%s, want %s", c.in, got, c.want)
+		}
+	}
+	if CoreVersion(nil) != nil {
+		t.Error("CoreVersion(nil) should be nil")
+	}
+}
+
+func TestSamePatchLevel(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"1.12.6", "1.12.6-20260603", true},
+		{"1.12.6-alpha1", "1.12.6", true},
+		{"1.12.6", "1.12.5", false},
+		{"1.12.6", "1.13.6", false},
+		{"1.12.6", "2.12.6", false},
+	}
+	for _, c := range cases {
+		a := semver.MustParse(c.a)
+		b := semver.MustParse(c.b)
+		if got := SamePatchLevel(a, b); got != c.want {
+			t.Errorf("SamePatchLevel(%s,%s)=%v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+	if SamePatchLevel(nil, semver.MustParse("1.12.6")) {
+		t.Error("SamePatchLevel(nil, _) should be false")
+	}
+}


### PR DESCRIPTION
## Summary
Introduce a version-compatibility layer so one `olares-cli` binary can drive
multiple Olares backend versions (today 1.12.5 and 1.12.6) whose remote/edge API
contracts differ — without forcing users to re-install the CLI when they upgrade
Olares. Built around a Strategy + Factory design in `cli/pkg/olaresclient`,
runtime version detection with a TTL cache, a dispatch "aspect"
(`Factory.WithOlaresClient`) that does self-heal + capability gating, and
version-aware (offline) help/visibility. Demonstrated across three representative
migration shapes: minor body change (market), complete endpoint replacement
(settings gpu), and a brand-new feature (settings network overlay).

## Motivation
Backends evolve their API per release: fields rename, endpoints get replaced,
features appear. The CLI is shipped independently and users upgrade Olares on
their own schedule, so the binary must talk to whichever version is actually
running. Concrete trigger: after 1.12.6 renamed `appName`->`app_name` and made
`source` required, `market uninstall` failed with
`Missing required fields: source and app_name are required`.

## Architecture
```mermaid
flowchart TD
    cmd[command RunE] --> withClient["Factory.WithOlaresClient(ctx, op)"]
    withClient --> detect["OlaresBackendVersion: cache+TTL, else GET /api/olares-info"]
    detect --> getClient["GetClient(version): floor-select"]
    getClient --> v5[clientV1_12_5]
    getClient --> v6["clientV1_12_6 (embeds v5)"]
    getClient --> def["clientDefault (embeds v5)"]
    withClient --> runOp["op(client): shape method/path/body via Doer"]
    runOp --> result{error?}
    result -->|"*ErrUnsupportedVersion"| gate["surface 'requires Olares >= X' (no retry)"]
    result -->|"version-suspect 404/501"| heal["re-detect; if changed rebuild + retry once"]
    result -->|ok| done[done]
```

Key pieces:
- Capability interfaces (`cli/pkg/olaresclient/interface.go`): small interfaces
  `VersionAware`, `MarketAppOps`, `ComputeOps`, `OverlayOps` composed into the
  umbrella `OlaresClient`. Grows feature-by-feature, no monster interface.
- `Doer` transport seam: clients only shape `(method, path, body)` and parse the
  unwrapped `data`; the caller owns HTTP + envelope. Market uses its app-store
  transport; settings reuse a shared edge adapter
  (`cli/cmd/ctl/settings/internal/edge/edge.go`).
- Version clients: `client_1_12_5.go` (baseline), `client_1_12_6.go` (embeds
  1.12.5 to inherit unchanged methods, overrides changed ones),
  `client_default.go` (conservative fallback, embeds 1.12.5).
- Registry + floor selection (`registry.go`): clients register under a core
  version; `GetClient(detected)` picks the highest registered line <= detected
  (so 1.12.7 / 1.13.0 dailies map to 1.12.6 until a new line is added; prerelease
  / daily tags are ignored via the core version).
- Detection & cache: `GET /api/olares-info` -> `osVersion`, persisted per profile
  in `ProfileConfig.BackendVersion` + `BackendVersionRefreshedAt` with a TTL
  (`cli/pkg/cmdutil/olares_version.go`, `cli/pkg/cliconfig/config.go`). Eager
  refresh at `profile login` / `import` (`cli/cmd/ctl/profile/version_eager.go`)
  so help is accurate from the first command. Flags `--olares-version` (override)
  and `--refresh-version` (force).
- Dispatch aspect `Factory.WithOlaresClient` (`cli/pkg/cmdutil/olares_dispatch.go`):
  (A) stale-version self-heal — a version-suspect error (404/501 or explicitly
  marked) triggers a re-detect + retry-once if the version changed; (B) capability
  gate — `*ErrUnsupportedVersion` is surfaced verbatim and never retried.
- Help/visibility uses `Factory.CachedOlaresBackendVersion()` (local cache only,
  no network) so `--help` and completion stay fast/offline; runtime dispatch still
  enforces correctness, so a stale cache only affects what help advertises.
- Diagnostics: `olares-cli settings me version --dispatch` shows the resolved
  version, its source, and cache freshness.

## The three migration shapes
1. Minor change — same endpoint, different body
   (`cli/cmd/ctl/market/{stop,resume,uninstall}.go`): 1.12.5 body `{appName}`;
   1.12.6 `{app_name, source}`, same path. 1.12.6 embeds 1.12.5 and overrides only
   these methods.
2. Complete replacement — different endpoints + data model
   (`cli/cmd/ctl/settings/gpu/*`): 1.12.5 `/api/gpu/*` (HAMI) -> 1.12.6
   `/api/compute-resources*` (node -> device -> supportType -> binding). No shared
   wire, so `ComputeOps` is fully overridden, not inherited. `list` works on both
   (version-aware rendering); `bindings` / `unbind` / `support-type set` are
   1.12.6+ (hidden on older backends, gated at runtime).
3. Brand-new feature — absent below the floor
   (`cli/cmd/ctl/settings/network/overlay.go`): the overlay gateway only exists in
   1.12.6+. The whole `overlay` subtree is hidden below the floor and every
   `OverlayOps` method returns `ErrUnsupportedVersion`. `enable` / `disable` are
   owner-gated; `--watch` polls to the target state and treats the HTTP 530 restart
   window as "restarting".

## Adding a new versioned command (developer guide)
1. Add/extend a capability interface in `interface.go`.
2. Implement it on the lowest supported line; override on newer lines that changed;
   return `ErrUnsupportedVersion` where unsupported.
3. Wire the command's RunE through `f.WithOlaresClient(ctx, func(c) {...})`, getting
   a `Doer` (market client, or `settings/internal/edge`).
4. For version-dependent help/visibility, branch on
   `f.CachedOlaresBackendVersion()` at construction time.
5. Add wire-shape + gating tests in `olaresclient_test.go` using `fakeDoer`.

## Why this over "just copy the whole file per version"
- One command tree / flag set / help text: no duplicated cobra wiring to drift;
  only the wire-shaping methods differ between versions.
- Method-level reuse via embedding: unchanged operations are inherited, so you
  touch only what actually changed.
- One dispatch + gate + self-heal path for all commands, instead of per-file
  `if version == ...` scattered around.
- Compile-time safety: a new line must satisfy the same interfaces, so you cannot
  forget a method.
- Floor selection gives forward-compatibility (future dailies do not break) with
  no new code.
- Testable in isolation: `fakeDoer` asserts exact method/path/body with no network.

## Shortcomings / trade-offs
- Indirection: one command's behavior is spread across interface + 2-3 client
  files; harder to read top-to-bottom than a single copied file.
- Embedding is implicit fallback — forgetting to override a *changed* method
  silently inherits old behavior (a duplicated file would force you to confront
  it). Mitigated by wire-shape tests.
- Version detection adds a network dependency + a cache-staleness window;
  `--olares-version` / `--refresh-version` and self-heal mitigate but do not fully
  eliminate edge cases.
- Help/visibility uses the cached version, so a freshly upgraded backend may
  briefly advertise the wrong surface until the cache refreshes (runtime stays
  correct).
- Manual registry: each new supported line needs a new client + registration;
  nothing is generated from an API schema.
- Floor selection assumes backward-compatible-within-line; a hotfix that changes
  the wire mid-line would not be captured by core-version keying.

## Better / alternative approaches (future)
- Generate clients from a versioned OpenAPI/schema per release instead of
  hand-written wire shapes (removes the "forgot to override" bug class).
- Server-advertised capabilities / API-version header so the CLI negotiates per
  call instead of mapping on `osVersion`.
- A capability/feature-flag matrix rather than discrete version lines, for
  finer-grained gating.
- For near-zero-shared-surface features, per-version sub-packages behind the same
  interface — closer to "copy a file" but still unified by the interface.

## Test plan
- `go build ./...`, `go vet`, and `go test ./pkg/olaresclient/... ./pkg/cmdutil/... ./pkg/cliconfig/... ./cmd/ctl/...` all green.
- New unit tests: floor selection, wire shapes (market / compute / overlay),
  capability gating, default fallback, version cache, `CoreVersion` /
  `SamePatchLevel`.
- Manual against a 1.12.6 backend: `market uninstall`; `settings gpu list/bindings/unbind/support-type set`; `settings network overlay status/enable --watch`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting change to market lifecycle and settings APIs with version detection/cache; mitigated by capability gates, tests, and conservative default client, but wrong wire shape would still break remote operations until self-heal runs.
> 
> **Overview**
> Adds a **runtime version-compatibility layer** (`pkg/olaresclient` + `Factory.WithOlaresClient`) so one CLI binary can speak **Olares 1.12.5 and 1.12.6** APIs: floor-selected clients, per-profile **backend version cache** (TTL + `--olares-version` / `--refresh-version`), and **retry-once** when a version mismatch is suspected.
> 
> **Market:** `stop`, `resume`, and `uninstall` no longer hard-code request bodies; they **resolve `source` from installed app state** and dispatch version-specific wire shapes (fixes 1.12.6 `app_name` + `source` requirements). `MarketClient` gains **`Do`** as the shared transport seam.
> 
> **Settings:** **GPU** moves to compute-resources on 1.12.6 (`list` dual-renders; new **`bindings` / `unbind` / `support-type`** with help hidden below 1.12.6). **Network overlay** is new (status / enable / disable with optional `--watch`). Shared **`settings/internal/edge`** unwraps BFL envelopes for `olaresclient.Doer`.
> 
> **Profile / UX:** **`eagerBackendVersion`** after login/import; **`settings me version --dispatch`** shows which client implementation is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4570245d882a6c6d27873b08fbe78424b2ecae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->