### PR TITLE
feat(cli): add compute-resources GPU settings surface

### DIFF
--- a/cli/cmd/ctl/settings/gpu/bindings.go
+++ b/cli/cmd/ctl/settings/gpu/bindings.go
@@ -1,0 +1,88 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings gpu bindings <app>` (Olares 1.12.6+)
+//
+// Lists the compute (GPU) device bindings held by an app, via
+// olaresclient.ComputeOps.GetAppBindings (GET
+// /api/apps/<app>/compute-resources/bindings).
+func NewBindingsCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "bindings <app>",
+		Short: "show an app's compute (GPU) bindings (Olares 1.12.6+)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "list GPU bindings"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runBindings(ctx, f, args[0], output), "list GPU bindings")
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runBindings(ctx context.Context, f *cmdutil.Factory, appName, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.GetAppBindings(ctx, doer, appName)
+		if err != nil {
+			return err
+		}
+		var bindings []computeBinding
+		if err := decodeData(raw, &bindings); err != nil {
+			return err
+		}
+		if format == FormatJSON {
+			return printJSON(os.Stdout, bindings)
+		}
+		return renderBindings(os.Stdout, appName, bindings)
+	})
+}
+
+func renderBindings(w io.Writer, appName string, bindings []computeBinding) error {
+	if len(bindings) == 0 {
+		_, err := fmt.Fprintf(w, "%s has no compute bindings\n", appName)
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NODE\tDEVICE\tMODE\tMEMORY"); err != nil {
+		return err
+	}
+	for _, b := range bindings {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			nonEmpty(b.NodeName), nonEmpty(b.DeviceID), nonEmpty(b.Mode), formatMem(b.Memory),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/cli/cmd/ctl/settings/gpu/common.go
+++ b/cli/cmd/ctl/settings/gpu/common.go
@@ -1,27 +1,56 @@
-// Package gpu hosts `olares-cli settings gpu`. Mirrors the SPA's
-// Settings -> GPU page (devices, mode, per-app assignment). Backed by
-// user-service's gpu.controller.ts which proxies HAMI; all responses
-// wrapped with returnSucceed/returnError.
+// Package gpu hosts `olares-cli settings gpu` — the profile-based Settings ->
+// GPU / "Compute Acceleration" surface (NOT the kubeconfig-based top-level
+// `olares-cli gpu` tree, which is a separate lower-level command for cluster
+// admins).
 //
-// Note: this is the profile-based settings surface that mirrors the SPA.
-// The kubeconfig-based "olares-cli gpu" tree is a separate, lower-level
-// command for cluster admins; the two should not be confused.
+// This area is the canonical "complete replacement" example for the
+// version-compatibility framework (pkg/olaresclient): Olares 1.12.5 exposed a
+// HAMI-backed GPU device/mode model under /api/gpu/*, while 1.12.6 replaced it
+// wholesale with a node → device → supportType → binding model under
+// /api/compute-resources* (the old GPUController was deleted upstream). The two
+// share no wire format, so every verb dispatches through
+// Factory.WithOlaresClient and the olaresclient.ComputeOps capability:
+//
+//   - list          works on both lines; renders the matching shape per the
+//                   detected backend version (legacy GPUInfo vs ComputeResourceNode).
+//   - bindings      1.12.6+ only (ErrUnsupportedVersion below).
+//   - unbind        1.12.6+ only.
+//   - support-type  1.12.6+ only.
+//
+// Subcommand VISIBILITY (root.go) is driven by the LOCALLY CACHED backend
+// version so `--help` / completion stay offline; runtime CORRECTNESS is still
+// enforced by WithOlaresClient + the capability gate, so a stale cache only
+// affects what help advertises, never what actually runs.
 package gpu
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
-	"github.com/beclab/Olares/cli/pkg/cmdutil"
-	"github.com/beclab/Olares/cli/pkg/credential"
-	"github.com/beclab/Olares/cli/pkg/whoami"
+	"github.com/beclab/Olares/cli/pkg/utils"
 )
+
+// computeResourcesFloor is the first Olares line that speaks the
+// /api/compute-resources model. At or above this (core) version the new
+// surface is used; below it the legacy /api/gpu/list shape is rendered.
+var computeResourcesFloor = semver.MustParse("1.12.6")
+
+// usesComputeResources reports whether version v should be treated as the
+// new compute-resources line. A nil version (unknown / no cache) optimistically
+// assumes the newest surface — the runtime capability gate corrects an actually
+// older backend.
+func usesComputeResources(v *semver.Version) bool {
+	if v == nil {
+		return true
+	}
+	return !utils.CoreVersion(v).LessThan(computeResourcesFloor)
+}
 
 type Format string
 
@@ -46,62 +75,6 @@ func addOutputFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVarP(target, "output", "o", "table", "output format: table, json")
 }
 
-type Doer interface {
-	DoJSON(ctx context.Context, method, path string, body, out interface{}) error
-}
-
-type preparedClient struct {
-	profile *credential.ResolvedProfile
-	doer    Doer
-}
-
-func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
-	if f == nil {
-		return nil, fmt.Errorf("internal error: settings gpu not wired with cmdutil.Factory")
-	}
-	rp, err := f.ResolveProfile(ctx)
-	if err != nil {
-		return nil, err
-	}
-	hc, err := f.HTTPClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &preparedClient{
-		profile: rp,
-		doer:    whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID),
-	}, nil
-}
-
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
-func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
-	var env bflEnvelope
-	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
-		return err
-	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
-		}
-		return fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("GET %s: decode data: %w", path, err)
-	}
-	return nil
-}
-
 func printJSON(w io.Writer, v interface{}) error {
 	if w == nil {
 		w = os.Stdout
@@ -123,4 +96,29 @@ func boolStr(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+// formatMem renders a byte count as a short "12G" / "1.5G" label, matching the
+// SPA's formatComputeMemory. Zero / negative renders as "0G".
+func formatMem(bytes int64) string {
+	if bytes <= 0 {
+		return "0G"
+	}
+	g := float64(bytes) / (1024 * 1024 * 1024)
+	if g >= 10 {
+		return fmt.Sprintf("%dG", int64(g+0.5))
+	}
+	return fmt.Sprintf("%.1fG", g)
+}
+
+// decodeData unmarshals an olaresclient op's returned `data` payload, tolerating
+// an empty/absent body (treated as the zero value of T).
+func decodeData[T any](raw json.RawMessage, out *T) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
 }

--- a/cli/cmd/ctl/settings/gpu/list.go
+++ b/cli/cmd/ctl/settings/gpu/list.go
@@ -5,34 +5,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
 
 // `olares-cli settings gpu list`
 //
-// Backed by user-service's /api/gpu/list, which proxies HAMI. The body
-// is a BFL envelope around an array of GPUInfo:
-//
-//   {
-//     "nodeName": "...", "id": "...", "type": "...",
-//     "count": 1, "devmem": 12288, "devcore": 80,
-//     "mode": "exclusive" | "shared",
-//     "sharemode": "...",
-//     "health": true,
-//     "memoryAllocated": 0, "memoryAvailable": 0,
-//     "apps": [{"appName": "...", "memory": <int>}],
-//   }
+// Dispatches through olaresclient.ComputeOps.ListAccelerators, which targets
+// the version-appropriate endpoint (1.12.5: GET /api/gpu/list; 1.12.6: GET
+// /api/compute-resources). The two payloads have different shapes, so the
+// renderer branches on the dispatched client's version.
 func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "list GPUs / per-app assignment",
+		Short: "list GPU devices / per-app bindings",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
@@ -46,24 +41,54 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
+// --- legacy 1.12.5 shape (/api/gpu/list) ---
+
 type gpuApp struct {
 	AppName string `json:"appName"`
 	Memory  int    `json:"memory,omitempty"`
 }
 
 type gpuInfo struct {
-	NodeName        string   `json:"nodeName"`
-	ID              string   `json:"id"`
-	Count           int      `json:"count"`
-	DevMem          int      `json:"devmem"`
-	DevCore         int      `json:"devcore"`
-	Type            string   `json:"type"`
-	Mode            string   `json:"mode"`
-	ShareMode       string   `json:"sharemode"`
-	Health          bool     `json:"health"`
-	MemoryAvailable int      `json:"memoryAvailable,omitempty"`
-	MemoryAllocated int      `json:"memoryAllocated,omitempty"`
-	Apps            []gpuApp `json:"apps,omitempty"`
+	NodeName  string   `json:"nodeName"`
+	ID        string   `json:"id"`
+	Count     int      `json:"count"`
+	DevMem    int      `json:"devmem"`
+	DevCore   int      `json:"devcore"`
+	Type      string   `json:"type"`
+	Mode      string   `json:"mode"`
+	ShareMode string   `json:"sharemode"`
+	Health    bool     `json:"health"`
+	Apps      []gpuApp `json:"apps,omitempty"`
+}
+
+// --- 1.12.6 compute-resources shape (/api/compute-resources) ---
+
+type computeBinding struct {
+	AppID    string `json:"appId,omitempty"`
+	AppName  string `json:"appName"`
+	Owner    string `json:"owner,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	NodeName string `json:"nodeName,omitempty"`
+	DeviceID string `json:"deviceId"`
+	Memory   int64  `json:"memory,omitempty"`
+}
+
+type computeDevice struct {
+	ID                   string           `json:"id"`
+	NodeName             string           `json:"nodeName"`
+	CardModel            string           `json:"cardModel"`
+	Memory               int64            `json:"memory"`
+	Health               string           `json:"health,omitempty"`
+	SupportType          string           `json:"supportType"`
+	AvailableSupportType []string         `json:"availableSupportTypes,omitempty"`
+	Bindings             []computeBinding `json:"bindings,omitempty"`
+}
+
+type computeNode struct {
+	NodeName string          `json:"nodeName"`
+	GPUType  string          `json:"gpuType,omitempty"`
+	Modes    []string        `json:"modes,omitempty"`
+	Devices  []computeDevice `json:"devices,omitempty"`
 }
 
 func runList(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
@@ -74,26 +99,38 @@ func runList(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
 	if err != nil {
 		return err
 	}
-
-	pc, err := prepare(ctx, f)
+	doer, _, err := edge.New(ctx, f)
 	if err != nil {
 		return err
 	}
 
-	var rows []gpuInfo
-	if err := doGetEnvelope(ctx, pc.doer, "/api/gpu/list", &rows); err != nil {
-		return err
-	}
-
-	switch format {
-	case FormatJSON:
-		return printJSON(os.Stdout, rows)
-	default:
-		return renderGPUTable(os.Stdout, rows)
-	}
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.ListAccelerators(ctx, doer)
+		if err != nil {
+			return err
+		}
+		if usesComputeResources(c.Version()) {
+			var nodes []computeNode
+			if err := decodeData(raw, &nodes); err != nil {
+				return err
+			}
+			if format == FormatJSON {
+				return printJSON(os.Stdout, nodes)
+			}
+			return renderComputeTable(os.Stdout, nodes)
+		}
+		var rows []gpuInfo
+		if err := decodeData(raw, &rows); err != nil {
+			return err
+		}
+		if format == FormatJSON {
+			return printJSON(os.Stdout, rows)
+		}
+		return renderLegacyGPUTable(os.Stdout, rows)
+	})
 }
 
-func renderGPUTable(w io.Writer, rows []gpuInfo) error {
+func renderLegacyGPUTable(w io.Writer, rows []gpuInfo) error {
 	if len(rows) == 0 {
 		_, err := fmt.Fprintln(w, "no GPUs (no compatible devices, or HAMI is not running)")
 		return err
@@ -103,18 +140,65 @@ func renderGPUTable(w io.Writer, rows []gpuInfo) error {
 		return err
 	}
 	for _, r := range rows {
-		appCount := len(r.Apps)
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
-			nonEmpty(r.NodeName),
-			nonEmpty(r.ID),
-			nonEmpty(r.Type),
-			nonEmpty(r.Mode),
-			boolStr(r.Health),
-			r.DevMem,
-			r.DevCore,
-			appCount,
+			nonEmpty(r.NodeName), nonEmpty(r.ID), nonEmpty(r.Type), nonEmpty(r.Mode),
+			boolStr(r.Health), r.DevMem, r.DevCore, len(r.Apps),
 		); err != nil {
 			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// deviceUsedMemory sums allocated memory (bytes) across a device's bindings,
+// mirroring the SPA's deviceUsedMemory helper.
+func deviceUsedMemory(d computeDevice) int64 {
+	var sum int64
+	for _, b := range d.Bindings {
+		sum += b.Memory
+	}
+	return sum
+}
+
+func renderComputeTable(w io.Writer, nodes []computeNode) error {
+	hasDevice := false
+	for _, n := range nodes {
+		if len(n.Devices) > 0 {
+			hasDevice = true
+			break
+		}
+	}
+	if !hasDevice {
+		_, err := fmt.Fprintln(w, "no compute devices (no compatible accelerators detected)")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NODE\tDEVICE\tMODEL\tSUPPORT-TYPE\tMEM\tUSED\tHEALTH\tAPPS"); err != nil {
+		return err
+	}
+	for _, n := range nodes {
+		if len(n.Devices) == 0 {
+			if _, err := fmt.Fprintf(tw, "%s\t-\t-\t-\t-\t-\t-\t-\n", nonEmpty(n.NodeName)); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, d := range n.Devices {
+			apps := make([]string, 0, len(d.Bindings))
+			for _, b := range d.Bindings {
+				apps = append(apps, b.AppName)
+			}
+			appCol := "-"
+			if len(apps) > 0 {
+				appCol = strings.Join(apps, ",")
+			}
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				nonEmpty(n.NodeName), nonEmpty(d.ID), nonEmpty(d.CardModel),
+				nonEmpty(d.SupportType), formatMem(d.Memory), formatMem(deviceUsedMemory(d)),
+				nonEmpty(d.Health), appCol,
+			); err != nil {
+				return err
+			}
 		}
 	}
 	return tw.Flush()

--- a/cli/cmd/ctl/settings/gpu/root.go
+++ b/cli/cmd/ctl/settings/gpu/root.go
@@ -1,7 +1,3 @@
-// Package gpu implements the `olares-cli settings gpu` subtree (Settings ->
-// GPU). Backed by user-service's gpu.controller.ts. There's also a top-level
-// `olares-cli gpu` tree from earlier work that talks via kubeconfig — this
-// one is the profile-based settings surface that mirrors the Settings UI.
 package gpu
 
 import (
@@ -10,27 +6,78 @@ import (
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
-// NewGPUCommand returns the `settings gpu` parent: list devices and
-// per-app GPU assignments. Mutating verbs (mode set, assign,
-// unassign, bulk-assign) are out of scope for now.
+// NewGPUCommand returns the `settings gpu` parent (Settings -> Compute
+// Acceleration). Its subcommand surface and help text adapt to the LOCALLY
+// CACHED backend version (no network call at construction time, so `--help`
+// and shell completion stay fast and offline):
+//
+//   - Olares 1.12.6+ (or unknown cache): list + bindings + unbind + support-type
+//     (the compute-resources model).
+//   - Olares 1.12.5: only list (the legacy /api/gpu/list device view); the
+//     1.12.6-only verbs are hidden and the help notes the requirement.
+//
+// Visibility is advisory: runtime dispatch (WithOlaresClient) re-detects the
+// version and the capability gate returns a clear "requires Olares >= 1.12.6"
+// error if a hidden verb is invoked against an older backend anyway, so a
+// stale cache never produces a wrong action — only stale help.
 func NewGPUCommand(f *cmdutil.Factory) *cobra.Command {
+	newSurface := true
+	if v, ok := f.CachedOlaresBackendVersion(); ok {
+		newSurface = usesComputeResources(v)
+	}
+
 	cmd := &cobra.Command{
 		Use:   "gpu",
-		Short: "GPU mode + per-app GPU assignment (Settings -> GPU)",
-		Long: `Inspect GPU device list, mode, and per-app assignment.
-
-Subcommands:
-  list
-
-Out of scope for now:
-  mode set, assign, unassign, bulk-assign
-
-Note: this differs from the top-level "olares-cli gpu" command — that one
-talks to the cluster via kubeconfig. "settings gpu" is the profile-based
-edge-API surface that mirrors the SPA's Settings -> GPU page.
-`,
+		Short: "Compute acceleration: GPU devices + per-app bindings (Settings -> GPU)",
+		Long:  gpuLong(newSurface),
 	}
 	cmd.SilenceUsage = true
+
 	cmd.AddCommand(NewListCommand(f))
+
+	bindings := NewBindingsCommand(f)
+	unbind := NewUnbindCommand(f)
+	supportType := NewSupportTypeCommand(f)
+	if !newSurface {
+		// Legacy backend: keep these reachable (the runtime gate gives a
+		// precise error) but hide them from help/completion so the
+		// advertised surface matches what actually works.
+		bindings.Hidden = true
+		unbind.Hidden = true
+		supportType.Hidden = true
+	}
+	cmd.AddCommand(bindings)
+	cmd.AddCommand(unbind)
+	cmd.AddCommand(supportType)
+
 	return cmd
+}
+
+func gpuLong(newSurface bool) string {
+	if newSurface {
+		return `Inspect and manage compute-acceleration resources (Olares 1.12.6+).
+
+Subcommands:
+  list                       list nodes / GPU devices and their support type + bindings
+  bindings <app>             show an app's compute (GPU) bindings
+  unbind <app>               release an app's compute bindings (suspends the app)
+  support-type set <node> <device> <type>
+                             switch a device's support type
+                             (Exclusive | MemorySlice | TimeSlice | MemoryShared)
+
+Note: this differs from the top-level "olares-cli gpu" command, which talks to
+the cluster via kubeconfig. "settings gpu" is the profile-based edge-API surface
+that mirrors the SPA's Settings -> GPU page.`
+	}
+	return `Inspect GPU devices (Olares 1.12.5).
+
+Subcommands:
+  list   list GPU devices, mode, and per-app assignment
+
+The compute-resources verbs (bindings, unbind, support-type) require Olares
+1.12.6 or newer and are hidden on this backend. Upgrade Olares to manage
+per-app GPU bindings and device support types from the CLI.
+
+Note: this differs from the top-level "olares-cli gpu" command, which talks to
+the cluster via kubeconfig.`
 }

--- a/cli/cmd/ctl/settings/gpu/support_type.go
+++ b/cli/cmd/ctl/settings/gpu/support_type.go
@@ -1,0 +1,166 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// validSupportTypes is the set the backend (and SPA) recognize for a device's
+// support type. Nvidia cards use Exclusive|MemorySlice|TimeSlice; non-Nvidia
+// single-virtual-device nodes use Exclusive|MemoryShared.
+var validSupportTypes = []string{"Exclusive", "MemorySlice", "TimeSlice", "MemoryShared"}
+
+func isValidSupportType(s string) bool {
+	for _, v := range validSupportTypes {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// NewSupportTypeCommand is the `settings gpu support-type` parent (Olares
+// 1.12.6+); today it carries the single `set` verb.
+func NewSupportTypeCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "support-type",
+		Short: "manage a device's support type (Olares 1.12.6+)",
+		Long: `Inspect and change a compute device's support type.
+
+Subcommands:
+  set <node> <device> <type>   switch a device's support type
+
+Valid types: Exclusive | MemorySlice | TimeSlice | MemoryShared.`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newSupportTypeSetCommand(f))
+	return cmd
+}
+
+// `olares-cli settings gpu support-type set <node> <device> <type>`
+//
+// Switches a device's support type via
+// olaresclient.ComputeOps.SwitchSupportType (PUT
+// /api/compute-resources/nodes/<node>/devices/<device>/support-type). The
+// backend reports the outcome via a `status` discriminator
+// (switched / unchanged / bound-apps-stop-blocked) it keeps at HTTP 200, so we
+// branch on that rather than on an HTTP error.
+func newSupportTypeSetCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "set <node> <device> <type>",
+		Short: "switch a device's support type",
+		Long: `Switch a compute device's support type.
+
+Valid types: Exclusive | MemorySlice | TimeSlice | MemoryShared.
+
+Changing the support type may stop apps currently bound to the device, so this
+prompts for confirmation by default; pass --yes to skip it. If apps that must be
+stopped first are blocking the switch, the command reports them and exits
+non-zero without changing anything.
+
+Example:
+  olares-cli settings gpu support-type set node-1 GPU-abc123 TimeSlice --yes`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "switch device support type"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runSupportTypeSet(ctx, f, args[0], args[1], args[2], assumeYes), "switch device support type")
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt (required for non-TTY automation)")
+	return cmd
+}
+
+type supportTypeAppRef struct {
+	AppName string `json:"appName"`
+	Owner   string `json:"owner,omitempty"`
+	State   string `json:"state,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type supportTypeResult struct {
+	Status      string              `json:"status"`
+	StoppedApps []supportTypeAppRef `json:"stoppedApps,omitempty"`
+	BlockedApps []supportTypeAppRef `json:"blockedApps,omitempty"`
+}
+
+func runSupportTypeSet(ctx context.Context, f *cmdutil.Factory, node, deviceID, supportType string, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	supportType = strings.TrimSpace(supportType)
+	if !isValidSupportType(supportType) {
+		return fmt.Errorf("invalid support type %q (allowed: %s)", supportType, strings.Join(validSupportTypes, ", "))
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		fmt.Sprintf("Switch device %q on node %q to %q? Apps bound to this device may be stopped.", deviceID, node, supportType),
+		assumeYes); err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		raw, err := c.SwitchSupportType(ctx, doer, node, deviceID, supportType)
+		if err != nil {
+			return err
+		}
+		var res supportTypeResult
+		if err := decodeData(raw, &res); err != nil {
+			return err
+		}
+		switch res.Status {
+		case "switched":
+			fmt.Fprintf(os.Stdout, "switched device %s to %s\n", deviceID, supportType)
+			if len(res.StoppedApps) > 0 {
+				fmt.Fprintf(os.Stdout, "stopped %d app(s) bound to the device:\n", len(res.StoppedApps))
+				for _, a := range res.StoppedApps {
+					fmt.Fprintf(os.Stdout, "  - %s\n", appRefLabel(a))
+				}
+			}
+			return nil
+		case "unchanged":
+			fmt.Fprintf(os.Stdout, "device %s already uses %s; nothing to do\n", deviceID, supportType)
+			return nil
+		case "bound-apps-stop-blocked":
+			var b strings.Builder
+			fmt.Fprintf(&b, "cannot switch device %s to %s: stop the following bound app(s) first", deviceID, supportType)
+			for _, a := range res.BlockedApps {
+				fmt.Fprintf(&b, "\n  - %s", appRefLabel(a))
+			}
+			return fmt.Errorf("%s", b.String())
+		default:
+			return fmt.Errorf("switch device %s: unexpected status %q from backend", deviceID, res.Status)
+		}
+	})
+}
+
+func appRefLabel(a supportTypeAppRef) string {
+	label := a.AppName
+	if a.Owner != "" {
+		label += " (" + a.Owner + ")"
+	}
+	if a.Reason != "" {
+		label += ": " + a.Reason
+	} else if a.State != "" {
+		label += " [" + a.State + "]"
+	}
+	return label
+}

--- a/cli/cmd/ctl/settings/gpu/unbind.go
+++ b/cli/cmd/ctl/settings/gpu/unbind.go
@@ -1,0 +1,74 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/edge"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/olaresclient"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings gpu unbind <app>` (Olares 1.12.6+)
+//
+// Releases an app's compute (GPU) bindings via
+// olaresclient.ComputeOps.ReleaseAppBindings (DELETE
+// /api/apps/<app>/compute-resources/bindings). The backend implements release
+// as a suspend, so this stops the app — a destructive action that prompts for
+// confirmation unless --yes is passed.
+func NewUnbindCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "unbind <app>",
+		Short: "release an app's compute bindings, suspending it (Olares 1.12.6+)",
+		Long: `Release the compute (GPU) device bindings held by an app.
+
+The backend frees the bindings by suspending the app, so the app stops until
+it is bound and resumed again. Prompts for confirmation by default; pass --yes
+to skip the prompt for automation. Non-TTY stdin without --yes is a hard error.
+
+Example:
+  olares-cli settings gpu unbind ollama
+  olares-cli settings gpu unbind ollama --yes`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "release GPU bindings"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runUnbind(ctx, f, args[0], assumeYes), "release GPU bindings")
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt (required for non-TTY automation)")
+	return cmd
+}
+
+func runUnbind(ctx context.Context, f *cmdutil.Factory, appName string, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	doer, _, err := edge.New(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		fmt.Sprintf("Release compute bindings for %q? This suspends (stops) the app.", appName),
+		assumeYes); err != nil {
+		return err
+	}
+
+	return f.WithOlaresClient(ctx, func(c olaresclient.OlaresClient) error {
+		if _, err := c.ReleaseAppBindings(ctx, doer, appName); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "released compute bindings for %s (app suspended)\n", appName)
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
Split PR (3/4) of `feat/cli-upgrade`. Stacked on the version-compat foundation (#3263).

- Extend `olares-cli settings gpu` to the 1.12.6 compute-resources model via `olaresclient.ComputeOps`: `list` (nodes/devices/bindings), `bindings <app>`, `unbind <app>`, `support-type set`.
- Subcommand surface adapts to the cached backend version: legacy 1.12.5 keeps only `list`; the new verbs are hidden and gated at runtime with a clear "requires Olares >= 1.12.6" error.

> Base branch is `feat/cli-olares-version-compat`; retarget to `main` after the foundation PR merges.

## Test plan
- [x] `CGO_ENABLED=0 go build ./...`
- [x] `go vet ./cmd/ctl/settings/gpu/...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admin-only CLI that can suspend apps (unbind) or stop bound apps when switching device support types; mitigated by confirmations, version gates, and legacy backends keeping only list.
> 
> **Overview**
> Extends **`olares-cli settings gpu`** for Olares **1.12.6** compute-resources APIs via **`olaresclient.ComputeOps`** and **`Factory.WithOlaresClient`**, replacing the old direct **`/api/gpu/*`** envelope handling in this package.
> 
> **`list`** now picks endpoint and output shape by backend version: legacy **1.12.5** flat GPU table vs **1.12.6** node/device table (support type, memory used, bound apps). New **1.12.6+** commands: **`bindings <app>`**, **`unbind <app>`** (releases bindings by suspending the app), and **`support-type set <node> <device> <type>`** with backend **`status`** handling and optional **`--yes`** on destructive actions.
> 
> **`root`** help and subcommand visibility follow the **cached** backend version (hide **bindings** / **unbind** / **support-type** on **1.12.5**); runtime capability checks still block unsupported verbs on older servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e4a80f53db48eef1bdfc260eb13dec40ebf5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->