### PR TITLE
fix(app-service): use origin owner when fetching shared/v3 chart on clone

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.31
+        image: beclab/app-service:0.5.32
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/tailscale_acl_controller.go
+++ b/framework/app-service/controllers/tailscale_acl_controller.go
@@ -218,7 +218,11 @@ func (r *TailScaleACLController) Reconcile(ctx context.Context, req ctrl.Request
 		if sysApp == nil {
 			return false
 		}
-		if sysApp.Spec.TailScale.AdvertiseExitNode == advertiseExitNodeEnv {
+		exitNode := sysApp.Spec.TailScale.AdvertiseExitNode
+		if exitNode == advertiseExitNodeEnv {
+			return false
+		}
+		if exitNode != "false" && exitNode != "true" {
 			return false
 		}
 		return true

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b
+	github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd
 	github.com/beclab/api v0.0.13
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -116,6 +116,8 @@ github.com/beclab/Olares/framework/oac v0.0.0-20260603032434-aced6784e517 h1:Y7j
 github.com/beclab/Olares/framework/oac v0.0.0-20260603032434-aced6784e517/go.mod h1:wXiRJGn0/C+6r2U3StJukbJ932h6wmGMHKUNJEdMMtI=
 github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b h1:nMoZVtw2YMia2u4rEssTxko5mTS1o4J7n3FJzcnYdjU=
 github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
+github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd h1:7UfKFR7d31rB0y5PQBR5UZ1tCoIedlsyZ3ThLURWPgw=
+github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
 github.com/beclab/api v0.0.11 h1:jNVX+hnZ4UJoF0S2wUEjepEULrhQcAs5Oh97IPbnBtA=
 github.com/beclab/api v0.0.11/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.12 h1:8+pxq5I7Xt9XfSM23RuOJD2kIKggdJ/LaUYWM0gcj04=

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -40,7 +40,7 @@ type depRequest struct {
 type installHelperIntf interface {
 	getAdminUsers() (admin []string, isAdmin bool, err error)
 	getInstalledApps() (installed bool, app []*v1alpha1.Application, err error)
-	getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error)
+	getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType, originOwner string) (appConfig *appcfg.ApplicationConfig, err error)
 	setAppConfig(req *api.InstallRequest, appName string)
 	validate(bool, []*v1alpha1.Application) error
 	lintChart() error
@@ -107,8 +107,9 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 	}
 	klog.Infof("rawAppName: %s", rawAppName)
 	chartVersion := ""
+	originOwner := ""
 	if insReq.RawAppName != "" {
-		chartVersion, err = h.getOriginChartVersion(rawAppName, owner)
+		chartVersion, originOwner, err = h.getOriginChartVersion(rawAppName, owner)
 		if err != nil {
 			api.HandleBadRequest(resp, req, err)
 			return
@@ -123,8 +124,9 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		MarketSource: marketSource,
 		Version:      chartVersion,
 		SelectedGpu:  insReq.SelectedGpuType,
+		OriginOwner:  originOwner,
 	})
-	klog.Infof("chartVersion: %s", chartVersion)
+	klog.Infof("chartVersion: %s, originOwner: %s", chartVersion, originOwner)
 
 	if err != nil {
 		klog.Errorf("Failed to get api version err=%v", err)
@@ -216,7 +218,7 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	appCfg, err := helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, insReq.SelectedGpuType)
+	appCfg, err := helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, insReq.SelectedGpuType, originOwner)
 	if err != nil {
 		klog.Errorf("Failed to get app config err=%v", err)
 		return
@@ -270,7 +272,7 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		// from appCfg.Requirement, so we need to re-parse from the
 		// manifest with the chosen mode to recover them.
 		if chosen != appCfg.SelectedGpuType {
-			appCfg, err = helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, chosen)
+			appCfg, err = helper.getAppConfig(adminUsers, marketSource, isAdmin, appInstalled, installedApps, chartVersion, chosen, originOwner)
 			if err != nil {
 				klog.Errorf("Failed to reload appConfig with auto-selected gpu type %s: %v", chosen, err)
 				api.HandleError(resp, req, err)
@@ -333,19 +335,23 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 	})
 }
 
-func (h *Handler) getOriginChartVersion(rawAppName, owner string) (string, error) {
+func (h *Handler) getOriginChartVersion(rawAppName, owner string) (string, string, error) {
 	var ams v1alpha1.ApplicationManagerList
 	err := h.ctrlClient.List(context.TODO(), &ams)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	for _, am := range ams.Items {
 		isV3 := am.Labels[constants.AppApiVersionLabel] == "v3"
 		if (am.Spec.AppName == rawAppName && am.Spec.AppOwner == owner) || (am.Spec.AppName == rawAppName && isV3) {
-			return am.Annotations[api.AppVersionKey], nil
+			// For v3 / shared apps the caller (current admin) may differ
+			// from the user that originally installed the app; return that
+			// original install owner so the chart-repo lookup can be keyed
+			// off the user the chart was first uploaded under.
+			return am.Annotations[api.AppVersionKey], am.Spec.AppOwner, nil
 		}
 	}
-	return "", fmt.Errorf("rawApp %s not found", rawAppName)
+	return "", "", fmt.Errorf("rawApp %s not found", rawAppName)
 }
 
 func (h *installHandlerHelper) getAdminUsers() (admin []string, isAdmin bool, err error) {
@@ -511,7 +517,7 @@ func (h *installHandlerHelper) getInstalledApps() (installed bool, app []*v1alph
 	return
 }
 
-func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error) {
+func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType, originOwner string) (appConfig *appcfg.ApplicationConfig, err error) {
 	var (
 		admin                   string
 		installAsAdmin          bool
@@ -563,6 +569,7 @@ func (h *installHandlerHelper) getAppConfig(adminUsers []string, marketSource st
 		IsAdmin:      installAsAdmin,
 		MarketSource: marketSource,
 		SelectedGpu:  selectedGpuType,
+		OriginOwner:  originOwner,
 	})
 	if err != nil {
 		klog.Errorf("Failed to get appconfig err=%v", err)
@@ -811,7 +818,7 @@ func (h *installHandlerHelperV2) _validateClusterScope(isAdmin bool, installedAp
 	return nil
 }
 
-func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error) {
+func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType, originOwner string) (appConfig *appcfg.ApplicationConfig, err error) {
 	klog.Info("get app config for install handler v2")
 
 	var (
@@ -841,6 +848,7 @@ func (h *installHandlerHelperV2) getAppConfig(adminUsers []string, marketSource 
 		MarketSource: marketSource,
 		IsAdmin:      isAdmin,
 		SelectedGpu:  selectedGpuType,
+		OriginOwner:  originOwner,
 	})
 	if err != nil {
 		klog.Errorf("Failed to get appconfig err=%v", err)
@@ -878,7 +886,7 @@ func (h *installHandlerHelperV3) getInstalledApps() (installed bool, apps []*v1a
 // getAppConfig loads the chart with admin context (the caller is admin —
 // gated above) and forces the namespace to the deterministic shared one so
 // every code path agrees on it regardless of what the manifest specified.
-func (h *installHandlerHelperV3) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType string) (appConfig *appcfg.ApplicationConfig, err error) {
+func (h *installHandlerHelperV3) getAppConfig(adminUsers []string, marketSource string, isAdmin, appInstalled bool, installedApps []*v1alpha1.Application, chartVersion, selectedGpuType, originOwner string) (appConfig *appcfg.ApplicationConfig, err error) {
 	var chartPath string
 	appConfig, chartPath, err = apputils.GetAppConfig(h.req.Request.Context(), &apputils.ConfigOptions{
 		App:          h.app,
@@ -890,6 +898,7 @@ func (h *installHandlerHelperV3) getAppConfig(adminUsers []string, marketSource 
 		IsAdmin:      true,
 		MarketSource: marketSource,
 		SelectedGpu:  selectedGpuType,
+		OriginOwner:  originOwner,
 	})
 	if err != nil {
 		klog.Errorf("Failed to get appconfig err=%v", err)

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -756,6 +756,8 @@ type ConfigOptions struct {
 	// download step is skipped and the chart is assumed to be already present
 	// at the conventional local path (appcfg.ChartsPath + "/" + RawAppName).
 	NeedDownloadChart bool
+	// for v3 app, upload source need to find origin chart
+	OriginOwner string
 }
 
 // GetAppConfig get app installation configuration from app store
@@ -1146,11 +1148,14 @@ func GetIndexAndDownloadChart(ctx context.Context, options *ConfigOptions) (stri
 		SetAuthToken(options.Token).
 		SetHeader(constants.MarketUser, options.Owner).
 		SetHeader(constants.MarketSource, options.MarketSource)
+	if options.OriginOwner != "" {
+		client.SetHeader(constants.MarketUser, options.OriginOwner)
+	}
 	indexFileURL := options.RepoURL
 	if options.RepoURL[len(options.RepoURL)-1] != '/' {
 		indexFileURL += "/"
 	}
-	klog.Infof("GetIndexAndDownloadChart: user: %v, source: %v", options.Owner, options.MarketSource)
+	klog.Infof("GetIndexAndDownloadChart: user: %v, source: %v, originOwner: %v", options.Owner, options.MarketSource, options.OriginOwner)
 
 	indexFileURL += "static-index.yaml"
 	resp, err := client.R().Get(indexFileURL)
@@ -1198,20 +1203,23 @@ func GetIndexAndDownloadChart(ctx context.Context, options *ConfigOptions) (stri
 			return "", err
 		}
 	}
-	_, err = downloadAndUnpack(ctx, url, options.Token, options.Owner, options.MarketSource)
+	_, err = downloadAndUnpack(ctx, url, options.Token, options.Owner, options.MarketSource, options.OriginOwner)
 	if err != nil {
 		return "", err
 	}
 	return chartPath, nil
 }
 
-func downloadAndUnpack(ctx context.Context, tgz *url.URL, token, owner, marketSource string) (string, error) {
+func downloadAndUnpack(ctx context.Context, tgz *url.URL, token, owner, marketSource, originOwner string) (string, error) {
 	dst := appcfg.ChartsPath
 	g := new(getter.HttpGetter)
 	g.Header = make(http.Header)
 	g.Header.Set("Authorization", "Bearer "+token)
 	g.Header.Set(constants.MarketUser, owner)
 	g.Header.Set(constants.MarketSource, marketSource)
+	if originOwner != "" {
+		g.Header.Set(constants.MarketUser, originOwner)
+	}
 
 	downloader := &getter.Client{
 		Ctx:       ctx,


### PR DESCRIPTION

* **Background**
    
    
    For shared apps the user triggering install (an admin) is not
    necessarily the user under whom the chart was originally uploaded to
    the chart repo. Looking the chart up by the current caller therefore
    fails when the caller is not the original installer.
    
    Propagate the original install owner through the install flow:
    - getOriginChartVersion now also returns the ApplicationManager's
      AppOwner as originOwner.
    - Thread originOwner through install handler v1/v2/v3 getAppConfig and
      into appcfg.ConfigOptions.
    - GetIndexAndDownloadChart / downloadAndUnpack override the
      MarketUser header with originOwner when set, so the chart-repo
      lookup is keyed off the user the chart was first uploaded under.
    
    Also fix tailscale ACL reconcile: treat any AdvertiseExitNode value
    other than "true"/"false" as needing reconciliation, so malformed or
    empty values no longer get silently skipped.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install and chart-repo identity changes affect shared/v3 clone paths; Tailscale env updates are narrowed to boolean spec values only.
> 
> **Overview**
> Fixes **clone / re-install** of shared or v3 apps when the installing admin is not the user who first uploaded the chart. **`getOriginChartVersion`** now returns **`ApplicationManager.Spec.AppOwner`** as **`originOwner`**, threaded through install handlers and **`ConfigOptions`**; chart index fetch and tarball download send **`X-Market-User`** as **`originOwner`** when set so the repo lookup matches the original uploader.
> 
> **Tailscale ACL** reconcile only treats **`AdvertiseExitNode`** as changed when the spec value differs from the deployment env and is exactly **`"true"`** or **`"false"`** (other spec values no longer trigger an env patch).
> 
> Bumps **`beclab/app-service`** to **0.5.32** and refreshes the **`framework/oac`** module pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a94497ae4002fc1be9d1c35a9564353ffb9a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->