### PR TITLE
files: NFS external mount + archive overhaul

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.177
+          image: beclab/files-server:v0.2.179
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -340,6 +340,8 @@ spec:
               value: '*'
             - name: UPLOAD_LIMITED_SIZE
               value: "118111600640"
+            - name: ARCHIVE_THREADS
+              value: '4'
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Background
- feat(external): NFS list via POST /command/list-nfs when operate is set.
- feat(external): NFS mount reads server from req.URL; IDL adds url/operate/acl.
- fix(external): unmount skips pre-stat to return fast on dead NFS.
- feat(archive): ARCHIVE_THREADS env caps 7z -mmt (default 4).
- fix(archive): preflight skips passwordless formats; password-invalid → 30001/30002.
- feat(archive): tar.gz/bz2/xz extract & list unwrap in one pass.
- fix(archive): compound tar progress starts immediately; overwrite/skip merge per file.
- fix(archive): extract progress falls back to packed src size.
- feat(archive): .gzip/.bzip2 aliases; gzip/bzip2/xz reject multi-source or folders.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/342
- https://github.com/beclab/files/pull/343

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment image tag and a single tuning env var; no auth, secrets, or routing changes in this diff.
> 
> **Overview**
> Rolls out **`beclab/files-server` v0.2.179** (from v0.2.177) on the files DaemonSet and wires **`ARCHIVE_THREADS=4`** into the `files` container so archive jobs can cap 7z multi-threading at deploy time.
> 
> This manifest-only change ships the NFS external-mount and archive behavior described in the linked `beclab/files` PRs; no other cluster config in this diff is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6821b0a1ffad7a74afcf8f96f62d4955a875f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->