### PR TITLE
fix(tailscale): resolve nft conflicts; member pod, owner hostNetwork

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -369,8 +369,10 @@ spec:
               matchLabels:
                 app: headscale
             topologyKey: kubernetes.io/hostname
+      {{- if eq $role "owner" }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
       - name: tailscale
         image: tailscale/tailscale:v1.94.2
@@ -409,6 +411,12 @@ spec:
         {{- if eq $role "owner" }}
         - name: TS_DEBUG_FIREWALL_MODE
           value: nftables
+        {{- else }}
+        - name: TS_DEST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
         {{- end }}
         - name: TS_SOCKET
           value: "/var/run/tailscale/tailscaled.sock"
@@ -423,15 +431,13 @@ spec:
             --tun=tailscale0{{ if and .Values.tailscaleUserIndex (ne .Values.tailscaleUserIndex  "0") }}$(USER_INDEX){{ end }}
         - name: TS_ROUTES
           value: $(COREDNS_SVC)/32
-        {{- if eq $role "owner" }}
         - name: ADVERTISE_EXIT_NODE
           value: "false"
-        {{- end }}
         - name: TS_EXTRA_ARGS
           value: >-
             --login-server https://headscale-server-svc
-            --netfilter-mode {{ if eq $role "owner" }}on{{ else }}off{{ end }}{{ if eq $role "owner" }}
-            --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset{{ end }}
+            --netfilter-mode=on
+            --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset
         - name: TS_USERSPACE
           value: "false"
 

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -411,12 +411,6 @@ spec:
         {{- if eq $role "owner" }}
         - name: TS_DEBUG_FIREWALL_MODE
           value: nftables
-        {{- else }}
-        - name: TS_DEST_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
         {{- end }}
         - name: TS_SOCKET
           value: "/var/run/tailscale/tailscaled.sock"


### PR DESCRIPTION

* **Background**
After tailscale #11601 (startup cleanup), co-located hostNetwork tailscaled instances clash; members run as pods.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VPN pod networking and netfilter behavior by role; misconfiguration could break member connectivity or reintroduce host-level nft conflicts for owners.
> 
> **Overview**
> The **tailscale** Deployment in `headscale_deploy.yaml` now treats **owner** and **member** roles differently for pod networking while aligning tailscaled CLI flags.
> 
> **Owners** still use **hostNetwork** and `ClusterFirstWithHostNet`; that block is now gated on `eq $role "owner"` so **members** run as normal pods without host networking. That avoids multiple co-located **hostNetwork** tailscaled instances fighting over **nftables** (per the Tailscale startup-cleanup behavior in recent releases).
> 
> **All roles** now get the same `TS_EXTRA_ARGS`: `--netfilter-mode=on` and `--advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset` (with `ADVERTISE_EXIT_NODE` always set to `"false"`). Members no longer use `--netfilter-mode off` or omit exit-node advertise flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59be0a790783cc0355cc5a6631361bf3b6bc8500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->