### PR TITLE
helm-charts/system-apps: bump system-frontend image to v1.10.43 (server mounts & archive previews)

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.42
+          image: beclab/system-frontend:v1.10.43
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

Bumps the `system-frontend` container image (`v1.10.42` → `v1.10.43`) to ship the Files changes from TermiPass#1168:

- **Server mounts**: add explicit SMB/NFS protocol selection in **Connect to server**, with protocol-specific address validation and i18n, and refactor external mounting through a typed `mountServerInExternal` (NFS host-only list vs full export path, shared path formatting).
- **Files navigation**: clear Drive/Data menus when their origin is excluded, deduplicate nested origins in `getMenu`, replace hard-coded Home paths with `openFirstMenuRepo` in the folder picker and after repo removal, and only offer **Add folder** where the location allows it.
- **Archive previews**: add `getPreviewStreamUrl`, `ArchiveEntryPreviewDialog`, and `isArchivePreviewSupported` (hiding preview for unsupported types such as bzip2/xz); filter compressible formats via `canCompressItemsWithFormat`; fix archive listing layout to reduce horizontal scroll.
- **Preview resolution**: centralize previews on `resolveFilePreview` (desktop dialog, mobile page, archive entry), share `CodeEditor` for plain-text views, restrict image prev/next (and mobile swipe) to images only, and support streamed archive bytes via `rawUrl` / `previewUrl`.
- **Share**: add the **Common** drive to public sharing while removing it from the internal share menu in one path.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1168

* **Other information**
Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.43
Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.42...v1.10.43

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on an init container that stages static frontend assets; no chart logic, secrets, or runtime service images change.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image in `system-apps` from **`beclab/system-frontend:v1.10.42`** to **`v1.10.43`**, so the Olares pod copies the newer bundled system/Files frontend into the shared `www` volume on deploy.
> 
> That release tag carries TermiPass Files work: **SMB/NFS protocol selection** and typed server mounting, **navigation/menu** fixes (excluded origins, deduped menus, smarter default paths), **archive entry previews** with streamed URLs and tighter format support, **centralized file preview** (desktop/mobile/archive), and a small **Common drive** sharing adjustment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea094c754d2be3c3b3eef3bcb3173765718a70f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->