### PR TITLE
feat(lldap): add read-only snapshot endpoint and Go account-sync SDK

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -202,7 +202,7 @@ spec:
             - name: NATS_SUBJECT_SYSTEM_GROUPS
               value: "os.groups"
 
-          image: beclab/lldap:0.0.18
+          image: beclab/lldap:0.0.19
           imagePullPolicy: IfNotPresent
           name: lldap
           ports:

--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -201,6 +201,8 @@ spec:
               value: "os.users"
             - name: NATS_SUBJECT_SYSTEM_GROUPS
               value: "os.groups"
+            - name: LLDAP_HTTP_READONLY_PORT
+              value: "17171"
 
           image: beclab/lldap:0.0.19
           imagePullPolicy: IfNotPresent
@@ -208,6 +210,7 @@ spec:
           ports:
             - containerPort: 3890
             - containerPort: 17170
+            - containerPort: 17171
 
 
 ---
@@ -229,6 +232,9 @@ spec:
     - name: "17170"
       port: 17170
       targetPort: 17170
+    - name: "17171"
+      port: 17171
+      targetPort: 17171
   selector:
     app: lldap
 ---


### PR DESCRIPTION


* **Background**
add read-only snapshot endpoint and Go account-sync SDK
* **Target Version for Merge**
v1.12.6,v.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/lldap/pull/28

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Identity stack image bump and new exposed service port; rollout depends on 0.0.19 behavior and any consumers of the readonly endpoint.
> 
> **Overview**
> Updates the platform **lldap** Kubernetes manifest to ship **beclab/lldap:0.0.19** and expose the new read-only HTTP snapshot API on port **17171**.
> 
> The deployment sets `LLDAP_HTTP_READONLY_PORT=17171`, adds container port `17171`, and publishes it on `lldap-service` alongside the existing LDAP (`3890`) and main HTTP (`17170`) ports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0e173338fc504cff03f7d1826d9db6ed8cede9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->