### PR TITLE
cli: replace NetworkManager restart with nmcli general reload for improved efficiency

### DIFF
--- a/cli/pkg/bootstrap/os/templates/init_script.go
+++ b/cli/pkg/bootstrap/os/templates/init_script.go
@@ -104,7 +104,7 @@ match-device=type:bridge
 ignore-carrier=no
 EOF
 
-systemctl restart NetworkManager 1>/dev/null 2>/dev/null
+nmcli general reload 1>/dev/null 2>/dev/null
 
 
 modinfo br_netfilter > /dev/null 2>&1

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -740,7 +740,7 @@ EOF
 		return errors.Wrap(errors.WithStack(err), "failed to generate NetworkManager config")
 	}
 
-	if _, err := runtime.GetRunner().SudoCmd("systemctl restart NetworkManager", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("nmcli general reload", false, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* **Background**
Replace NetworkManager restart with nmcli general reload for improved efficiency

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line command swaps on nodes with NetworkManager; no auth or cluster API changes, with slightly less disruptive reload behavior.
> 
> **Overview**
> After writing `20-bridge-ignore-carrier.conf`, **bootstrap** (`init_script.go`) and **upgrade** (`generateNetworkManagerConfigAction` in `task_set.go`) now run **`nmcli general reload`** instead of **`systemctl restart NetworkManager`** so the new bridge settings apply without a full NetworkManager restart.
> 
> The drop-in content and when it is written are unchanged; only the apply step is lighter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed0d69d650e1b5cc5e82c2f58fa60072dd2762ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->