### PR TITLE
chore(cli): align olares-* skills with OpenCode and ClawHub format

### DIFF
--- a/cli/skills/README.md
+++ b/cli/skills/README.md
@@ -31,7 +31,7 @@ ClawHub publishes the entire skill directory (including `references/`), so refer
 
 ## Writing style
 
-`SKILL.md` is NOT meant to compete with `olares-cli <command> --help`. The frontmatter already declares `cliHelp:` so the agent knows the authoritative `--help` invocation. The body should only carry what `--help` cannot give:
+`SKILL.md` is NOT meant to compete with `olares-cli <command> --help`. The body references `olares-cli <command> --help` for authoritative flag syntax. The body should only carry what `--help` cannot give:
 
 - **Routing** — when to use this skill vs. siblings
 - **Cross-cutting concepts** referenced by ≥2 subcommands (e.g. olares-files' 3-segment frontend path)
@@ -55,10 +55,15 @@ Target sizes: SKILL.md ≤ 250 lines (≤ 300 for the most complex command tree)
 Each `SKILL.md` declares:
 
 ```yaml
+compatibility: Requires olares-cli on PATH
 metadata:
-  requires:
-    bins: ["olares-cli"]
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ```
+
+`description` must stay ≤ 1024 characters (OpenCode limit). Put detailed trigger phrases in the skill body's `## When to use` section.
 
 ClawHub does **not** install the `olares-cli` binary for you — it is part of every Olares device, so the `bins:` line just gates the skill behind "you must be on a host that has olares-cli on PATH". The binary itself ships through Olares' regular release channels (see [`cli/.goreleaser.yaml`](../.goreleaser.yaml) and [`.github/workflows/release-cli.yaml`](../../.github/workflows/release-cli.yaml)).
 
@@ -73,7 +78,7 @@ ClawHub does **not** install the `olares-cli` binary for you — it is part of e
 
 ### Local validation (no network)
 
-`clawhub skill publish` does not have a `--dry-run` flag. The `--dry-run` mode here is a **local-only** sanity check: parses each `SKILL.md` frontmatter, verifies that `name` matches the folder slug, that `version` is valid semver, and that the required `metadata.requires.bins: ["olares-cli"]` declaration is present. It then prints the `clawhub skill publish` command that would actually run.
+`clawhub skill publish` does not have a `--dry-run` flag. The `--dry-run` mode here is a **local-only** sanity check: parses each `SKILL.md` frontmatter, verifies that `name` matches the folder slug, that `version` is valid semver, that `description` is ≤ 1024 characters, and that `metadata.openclaw.requires.bins` includes `olares-cli`. It then prints the `clawhub skill publish` command that would actually run.
 
 ```bash
 ./cli/skills/publish.sh --dry-run                  # validate all 7

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,16 +1,28 @@
 ---
 name: olares-chart
-version: 1.5.1
-description: "Olares Chart authoring (olares-cli chart) — turn a docker-compose project, a generic Helm chart, or a bare source repo into a publishable, deployable Olares app chart. Start by establishing state on two orthogonal-but-coupled axes: PACKAGING (Dockerfile/image — how the app is built into a runnable artifact) and DEPLOYMENT (docker-compose/chart — how it is orchestrated). The core verbs are local-only (NO Olares login needed): `chart from-compose` runs the same kompose conversion Olares Studio/devbox uses to scaffold an Olares chart layout (Chart.yaml + OlaresManifest.yaml + values.yaml + templates/), `chart lint` validates a chart directory or .tgz with the exact pipeline the Olares Market uses to ingest it, and `chart package` archives the chart into an uploadable .tgz. The conversion is a starting point: this skill drives the four judgment calls kompose cannot make — app metadata (title/icon/developer/categories), storage (compose volumes → Olares appData/appCache/userData + permission), middleware (replace bundled postgres/redis/mongo/... with Olares system middleware), and entrances/ports (which services to expose). On the packaging axis it guides (with the developer, never on their behalf) checking/installing docker, logging in to Docker Hub or ghcr, and building+pushing a target-arch (multi-arch) image when the repo has no Dockerfile, a Dockerfile but no official/target-arch image, or only a wrong-architecture community image — Olares pulls images from a registry and never builds from source, so the image arch must match the node. The axes are coupled: an image's baked paths / run-user constrain manifest permissions and mounts, and Olares deployment constraints can force an image rebuild. It also covers the optional live-validation loop (requires login): package + market upload, market install to actually run the app, and fetching market / app-service / chartrepo logs to diagnose an install or runtime failure, then looping back to fix the chart or the image. Use when the user mentions Olares chart, OlaresManifest, OlaresManifest.yaml, packaging an app for Olares, publishing to the Olares Market/app store, converting docker-compose to Olares, turning a Helm chart or a source repo into an Olares app, building/pushing a docker image for an Olares app, no official image / build from source / wrong arch (amd64 vs arm64), olares-cli chart, chart from-compose, chart lint, chart package, uploading a chart to validate it, why an app failed to install or start, ImagePullBackOff, or reading market / app-service logs for a chart problem, or 'how do I turn my compose file / Docker app / repo into an Olares app', or porting a headless / CLI app, an MCP server, or any tool with no web UI (terminal entrance + invisible entrance)."
+version: 1.6.0
+description: "Olares Chart via olares-cli chart — from-compose, lint, package; turn compose/Helm/repo into publishable Olares app chart (local-only, no login). Use for OlaresManifest, docker-compose to Olares, chart lint/package, Market upload, ImagePullBackOff."
+compatibility: Requires olares-cli on PATH; chart authoring is local-only
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli chart --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # chart (compose → Olares app chart)
 
 > **Source of truth for flags is always `olares-cli chart <verb> --help`.** This file only carries what `--help` cannot: when to use this skill, the convert→refine→lint loop, and the four judgment calls that turn a raw conversion into a publishable chart.
+
+## When to use
+
+- Olares chart, OlaresManifest / OlaresManifest.yaml, olares-cli chart, chart from-compose, chart lint, chart package
+- Turn docker-compose, a generic Helm chart, or a bare source repo into a publishable Olares app chart
+- Packaging for Olares Market / app store, building/pushing docker image (amd64 vs arm64), no official image, wrong arch
+- Install/runtime failures: ImagePullBackOff, app failed to install or start, market / app-service / chartrepo logs
+- Headless / CLI app, MCP server, or tool with no web UI (terminal entrance + invisible entrance)
+- Two axes: **packaging** (Dockerfile/image) and **deployment** (compose/chart); four post-kompose judgment calls (metadata, storage, middleware, entrances)
+- Optional live validation (requires login): package + market upload/install — see [`olares-shared`](../olares-shared/SKILL.md), [`olares-market`](../olares-market/SKILL.md), [`olares-cluster`](../olares-cluster/SKILL.md)
 
 ## Start here: establish your state
 

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: olares-cluster
-version: 4.0.0
-description: "Olares ControlHub view (olares-cli cluster) — per-Olares-ID command-line mirror of the Olares ControlHub SPA's Cluster page, the Kubernetes view of an Olares instance. Reads pods, containers, workloads (Deployment / StatefulSet / DaemonSet), application spaces (KubeSphere-grouped namespaces), namespaces, nodes, jobs, cronjobs, and Olares-managed middleware (databases, queues, object stores) that the active Olares ID is allowed to see. Mutating verbs (scale / restart / stop / start / delete on workloads, delete / restart on pods, suspend / resume on cronjobs, rerun on jobs) all go through a confirmation prompt that --yes skips. Watch verbs (pod get -w, workload rollout-status -w, application status -w, pod / container logs -f) poll on --interval. Use when the user mentions Olares, Olares ID, Olares ControlHub, olares-cli cluster, or asks 'what's running on my Olares', 'tail logs of <pod>', 'restart / scale / delete this workload', 'who am I on this ControlHub', 'suspend this cronjob', or 'rerun this job'. Do NOT use for Olares app-store lifecycle (use olares-cli market) or host-side install / node join / OS upgrade (use olares-cli node / os / gpu)."
+version: 4.1.0
+description: "Olares ControlHub K8s view via olares-cli cluster — pods, workloads, logs, scale/restart, jobs, cronjobs, middleware. Not for app lifecycle (market) or host install (node/os/gpu). Use for ControlHub, pods, logs, workloads."
+compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli cluster --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # cluster (per-user K8s view)
 
-**CRITICAL — before doing anything, MUST use the Read tool to read [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) for the profile model, login flow, automatic token refresh, and the auth-error recovery table.**
+**CRITICAL — before doing anything, load the `olares-shared` skill first (profile model, login, token refresh, auth-error recovery). Flag reference: `olares-cli cluster --help`.**
 
 > **Source of truth for flags & wire shapes is always `olares-cli cluster <noun> <verb> --help`.** This file only carries what `--help` cannot give: routing, the mental model of nouns, the identity-vs-server principle, the mutating-verb safety contract, cross-verb output conventions, and the common-errors → fix table.
 
@@ -18,12 +20,14 @@ metadata:
 
 Against the cluster the active profile can see:
 
+- Olares ControlHub, olares-cli cluster, what's running on my Olares
 - "What pods / containers / workloads / jobs / cronjobs / namespaces / nodes are running?"
 - "Tail / show logs of `<pod>` (or `<container>` of `<pod>`)"
-- "Restart / scale / stop / start / delete `<workload>`" — the K8s controller, not the Olares app
+- "Restart / scale / stop / start / delete `<workload>`" — the K8s controller, not the Olares app (mutating verbs prompt for confirmation; `--yes` skips)
 - "Suspend / resume `<cronjob>`" or "rerun `<job>`"
 - "Who am I on this cluster, what's my role?" (`cluster context`)
 - "What does this object's YAML look like?" (`cluster <noun> yaml`)
+- Watch / follow: pod `-w`, workload `rollout-status -w`, application `status -w`, logs `-f` (poll on `--interval`)
 
 ## When NOT to use — route to a sibling skill
 

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: olares-dashboard
-version: 4.0.0
-description: "Olares Dashboard (olares-cli dashboard) — query the Olares Dashboard SPA's Overview and Applications routes from the command line, scoped to the active Olares ID. An AI-agent-first JSON mirror with a strict dual-shape envelope (leaf items / aggregated sections), stable Kind constants, and human-readable table output. Covers Overview leaves (CPU, memory, disk, network, pods, fan, GPU, ranking), Applications listing and detail, the --watch HTTP-polling loop (interval / iterations / timeout / NDJSON-per-iteration / SIGINT-graceful), --since (sliding window) vs --start/--end (fixed window) selection, three-state empty-data semantics (no_<feature>_integration / no_<feature>_detected / vgpu_unavailable), and capability gates (fan is hard-gated to Olares One hardware; GPU is a soft advisory mirroring the SPA sidebar). Use when the user mentions Olares, Olares ID, Olares Dashboard, Olares One (fan / cooling), olares-cli dashboard, the Olares overview / applications view, 'show CPU / memory / disk / pods / network / fan / GPU / ranking on Olares', wants JSON for an AI agent, or hits errors like 'fan is only available on Olares One devices' or 'gpu data temporarily unavailable'."
+version: 4.1.0
+description: "Olares Dashboard via olares-cli dashboard — CPU, memory, disk, network, pods, fan, GPU, ranking, applications; JSON envelope and --watch. Use for Olares Dashboard, overview, resource usage, Olares One fan."
+compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli dashboard --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # dashboard (overview + applications, AI-agent first)
 
-**CRITICAL — before doing anything, MUST use the Read tool to read [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) for profile selection, login, automatic token refresh, and the auth-error recovery table.**
+**CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli dashboard --help`.**
 
 > **Source of truth for flags is always `olares-cli dashboard --help` (global flags) and `olares-cli dashboard <verb> --help` (per-leaf flags).** This file only carries what `--help` cannot give: the dual-shape JSON envelope contract, three-state empty-data semantics, capability gates, watch / window rules, and the verb index.
 
@@ -22,6 +24,8 @@ This subtree is an **AI-agent-first JSON mirror of the Olares Dashboard SPA's Ov
 - The user wants the workload-grain or application-grain resource ranking.
 - The user wants the JSON form of what the SPA Overview / Applications pages show.
 - The user wants `--watch` for live-tailing one of the above.
+- Errors: `fan is only available on Olares One devices`, `gpu data temporarily unavailable`
+- Empty-data reasons: `no_<feature>_integration`, `no_<feature>_detected`, `vgpu_unavailable`; windows: `--since` vs `--start`/`--end`
 
 Sibling-skill routing:
 

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: olares-files
-version: 4.0.0
-description: "Olares Files (olares-cli files) — manage files on an Olares system from the command line, scoped to the active Olares ID. Covers list (ls), upload, download, cat, edit (open in $EDITOR), mkdir, rm, cp, mv, rename, chown (POSIX owner uid get/set), folder share (internal cross-Olares-ID, public link with password + expiration, SMB Samba), mount / unmount / favorite external SMB servers, and Sync (Seafile) repo CRUD — all against the per-Olares-ID files-backend on Olares (drive/Home, drive/Data, sync, cache, external, awss3, dropbox, google, tencent, share). Use when the user mentions Olares, Olares ID, Olares Files, olares-cli files, LarePass Files on Olares, drive, Home, Data, sync, cache, uploading / downloading / listing / editing remote files on Olares, in-place rename, POSIX file ownership, sharing a folder with another Olares user (by Olares ID), public link with password / expiration, SMB / Samba network shares, the LarePass 'Connect to Server' dialog, or Sync (Seafile) libraries."
+version: 4.1.0
+description: "Olares Files via olares-cli files — ls, upload, download, edit, share, SMB mount, Seafile sync on drive/Home, drive/Data, cache, external, cloud. Use for Olares Files, drive, upload, download, share, SMB, LarePass Files."
+compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli files --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # files (per-user files-backend)
 
-**CRITICAL — before running any verb here, MUST use the Read tool to read [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) for profile selection, login, and 401/403 recovery rules.**
+**CRITICAL — before running any verb here, load the `olares-shared` skill first (profile selection, login, 401/403 recovery). Flag reference: `olares-cli files --help`.**
 
 > **Source of truth for flags & wire shapes is always `olares-cli files <verb> --help`.** This file only carries what `--help` cannot give: the cross-cutting frontend-path concept, the trailing-slash convention, the five client-side hard constraints, and the verb index.
+
+## When to use
+
+- Olares Files, olares-cli files, LarePass Files, drive, Home, Data, sync, cache, upload, download, list, edit, rename, chown
+- Share: internal cross-Olares-ID, public link (password / expiration), SMB / Samba, Connect to Server, Seafile sync repos
+- Namespaces: `drive`, `cache`, `sync`, `external`, `awss3`, `dropbox`, `google`, `tencent`, `share`
 
 ## Core concept: the 3-segment frontend path
 

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: olares-market
-version: 4.0.0
-description: "Olares Market (olares-cli market) — install, upgrade, and manage Olares apps on Olares from the command line. Per-Olares-ID Market app-store v2 mirror of the Olares Market UI, scoped to the active Olares ID. Covers catalog browsing (list, get, categories), the full Olares app lifecycle (install, uninstall, upgrade, clone, cancel, stop, resume), runtime status, --mine view of the active Olares ID's apps (same set the Market UI's My Terminus tab shows, including in-flight installs / upgrades / failures), upload / delete for local Helm chart packages, and --watch flags that block until the app reaches a terminal state. Use when the user mentions Olares, Olares ID, Olares Market, olares-cli market, Olares app store, installing / upgrading / uninstalling / cloning / stopping / resuming / cancelling an Olares app, 'my Olares apps', '我的应用', upload chart, --watch, or asks 'is <app> installed yet on my Olares' / 'show me my Olares apps'."
+version: 4.1.0
+description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, upload chart."
+compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli market --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # market (App-store v2)
 
-**CRITICAL — before doing anything, MUST use the Read tool to read [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) for profile selection, login, automatic token refresh, and the auth-error recovery table.**
+**CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli market --help`.**
 
 > **Source of truth for flags is always `olares-cli market <verb> --help`.** This file only carries what `--help` cannot give: source resolution, the lifecycle state machine, OpType-vs-State race safety, the verb index, the `-s`/`-a` matrix, and the "what apps do I have" routing.
+
+## When to use
+
+- Olares Market, olares-cli market, Olares app store, install / upgrade / uninstall / clone / stop / resume / cancel an app
+- `my Olares apps`, `我的应用`, `market list --mine`, `is <app> installed yet`, chart upload / delete, `--watch` until terminal state
+- Catalog: `list`, `get`, `categories`; runtime: `status`
 
 ## Routing
 

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: olares-settings
-version: 4.0.0
-description: "Olares Settings (olares-cli settings) — read and mutate Olares Settings UI surfaces from the command line, scoped to the active Olares ID. Per-Olares-ID mirror of every section the Olares Settings SPA exposes (https://docs.olares.com/manual/olares/settings/). Read-only coverage: users, appearance, apps (list, get, entrances, env, domain, policy), integration accounts, VPN (devices, ACL, SSH, subroutes, public-domain policy), network (reverse proxy, frp, hosts file), GPU, video, search status + dirs, backup plans + snapshots, restore plans, advanced (containerd registries, images, env system / user), plus a `me` self-service tree (whoami on Olares, version, check-update, SSO list). Verified mutating verbs: appearance language set, search rebuild, integration accounts add awss3|tencent / delete, VPN SSH enable/disable, VPN ACL add/remove, users create/delete (new Olares ID). Use when the user mentions Olares, Olares ID, Olares Settings, olares-cli settings, the Olares Settings UI, role (owner / admin / normal) on Olares, integration accounts, SSO tokens, GPU mode, search index, backup / restore plans, containerd registries, VPN ACLs, language preference, or 'who am I on this Olares instance'."
+version: 4.1.0
+description: "Olares Settings via olares-cli settings — mirror of Settings SPA: users, apps, VPN, backup, integration, GPU, search, me/whoami. Use for Olares Settings, role, VPN ACL, backup, integration accounts, language."
+compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli settings --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # settings (Olares Settings UI mirror)
 
-**CRITICAL — before doing anything, MUST use the Read tool to read [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) for profile selection, login, automatic token refresh, and the auth-error recovery table.**
+**CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli settings --help`.**
 
 > **Source of truth for flags is always `olares-cli settings <area> <verb> --help`.** This file only carries what `--help` cannot give: routing, the 13-section index, the role-caching / admin-vs-normal floor, the wire-format cheat sheet, and the common-errors table.
+
+## When to use
+
+- Olares Settings UI (https://docs.olares.com/manual/olares/settings/), olares-cli settings, role (owner / admin / normal), who am I on this Olares instance
+- Areas: users, appearance, apps (entrances / env / domain / policy), integration (awss3 / tencent), VPN (devices / ACL / SSH), network, GPU, video, search, backup / restore, advanced (containerd registries, env)
+- Mutating: language set, search rebuild, integration add/delete, VPN SSH / ACL, users create/delete
 
 ## Routing
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: olares-shared
-version: 4.0.0
-description: "Olares profile and authentication foundation for olares-cli — required prerequisite for every other olares-cli skill on Olares (files, market, settings, dashboard, cluster). Covers the Olares profile model (one profile = one Olares instance + one Olares ID, e.g. alice@olares.com), first-time Olares login with password and optional TOTP, importing an existing refresh_token, switching / listing / removing Olares profiles, OS-keychain token storage keyed by Olares ID, automatic access_token refresh on 401/403, and the full Olares auth-error recovery table. Use when the user mentions Olares, Olares ID, olares-cli, OpenClaw on Olares, profile, login, logout, two-factor / 2FA / TOTP, refresh token, keychain, or sees errors like 'server rejected the access token', 'refresh token for X became invalid', 'no access token for X', 'already authenticated', or 'two-factor authentication required'."
+version: 4.1.0
+description: "Olares profile and auth foundation for olares-cli — prerequisite for all olares-* skills. Profile login, import, list, use, remove, keychain tokens, 401/403 recovery. Use for Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, auth errors."
+compatibility: Requires olares-cli on PATH
 metadata:
-  requires:
-    bins: ["olares-cli"]
-  cliHelp: "olares-cli profile --help"
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
 ---
 
 # olares-cli shared rules
 
 Foundation for every other `olares-cli` skill. Every business verb under `cluster` / `files` / `market` / `settings` / `dashboard` rides the active profile's token. **Read this first.**
 
-> **Source of truth for flags & syntax is always `olares-cli <command> --help`.** This file only carries what `--help` cannot give: the profile mental model, agent-driven login flow, token-storage backends, refresh semantics, and the error → fix matrix.
+> **Source of truth for flags & syntax is always `olares-cli profile --help`.** This file only carries what `--help` cannot give: the profile mental model, agent-driven login flow, token-storage backends, refresh semantics, and the error → fix matrix.
+
+## When to use
+
+- Olares, Olares ID, olares-cli, OpenClaw on Olares, profile, login, logout, two-factor / 2FA / TOTP, refresh token, keychain
+- Auth errors: `server rejected the access token`, `refresh token for X became invalid`, `no access token for X`, `already authenticated`, `two-factor authentication required`
 
 ## Profile model
 

--- a/cli/skills/publish.sh
+++ b/cli/skills/publish.sh
@@ -23,7 +23,7 @@
 #
 # The CLI binary `olares-cli` itself is NOT published here — it ships with
 # Olares. Each skill declares it as a host requirement via
-# metadata.requires.bins: ["olares-cli"].
+# metadata.openclaw.requires.bins: ["olares-cli"].
 
 set -euo pipefail
 
@@ -80,6 +80,14 @@ read_name() {
   awk '/^---[[:space:]]*$/{n++; next} n==1 && /^name:[[:space:]]*/ {sub(/^name:[[:space:]]*/, ""); gsub(/[[:space:]"]/, ""); print; exit}' "$file"
 }
 
+# Read quoted `description:` value length from frontmatter (OpenCode max 1024).
+read_description_len() {
+  local file="$1"
+  awk '/^---[[:space:]]*$/{n++; next} n==1 && /^description:[[:space:]]*"/ {
+    sub(/^description:[[:space:]]*"/, ""); sub(/"[[:space:]]*$/, ""); print length($0); exit
+  }' "$file"
+}
+
 # Local validation: check required frontmatter fields + semver.
 validate_skill() {
   local dir="$1" slug="$2" file="$dir/SKILL.md"
@@ -88,17 +96,28 @@ validate_skill() {
   [[ -f "$file" ]] || { echo "  - SKILL.md missing"; return 1; }
   head -n1 "$file" | grep -q '^---[[:space:]]*$' || errs+=("frontmatter does not start with --- on line 1")
 
-  local fm_name fm_version
+  local fm_name fm_version desc_len
   fm_name="$(read_name "$file")"
   fm_version="$(read_version "$file")"
+  desc_len="$(read_description_len "$file")"
   [[ -n "$fm_name" ]] || errs+=("missing name: in frontmatter")
   [[ "$fm_name" == "$slug" ]] || errs+=("frontmatter name '$fm_name' != folder slug '$slug'")
   [[ -n "$fm_version" ]] || errs+=("missing version: in frontmatter")
   [[ "$fm_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] \
     || errs+=("version '$fm_version' is not valid semver")
   grep -qE '^description:' "$file" || errs+=("missing description: in frontmatter")
+  if [[ -z "$desc_len" ]]; then
+    errs+=("description must be a single quoted line in frontmatter")
+  elif [[ "$desc_len" -gt 1024 ]]; then
+    errs+=("description length $desc_len exceeds OpenCode limit of 1024")
+  fi
+  grep -qE '^compatibility:' "$file" || errs+=("missing compatibility: in frontmatter")
   grep -qE '^metadata:' "$file" || errs+=("missing metadata: block in frontmatter")
-  grep -qE '"olares-cli"' "$file" || errs+=("metadata.requires.bins should include \"olares-cli\"")
+  grep -qE '^[[:space:]]+openclaw:' "$file" || errs+=("missing metadata.openclaw block in frontmatter")
+  grep -qE '^[[:space:]]+- olares-cli[[:space:]]*$' "$file" || errs+=("metadata.openclaw.requires.bins must list olares-cli")
+  if grep -qE '^  requires:[[:space:]]*$' "$file"; then
+    errs+=("deprecated top-level metadata.requires — use metadata.openclaw.requires.bins")
+  fi
 
   if [[ ${#errs[@]} -gt 0 ]]; then
     for e in "${errs[@]}"; do echo "  - $e"; done


### PR DESCRIPTION
## Summary

- Normalize all 7 `cli/skills/olares-*` frontmatter for [OpenCode](https://open-code.ai/en/docs/skills) and [ClawHub](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md): `description` ≤ 1024 chars, `compatibility`, and `metadata.openclaw.requires.bins`
- Move detailed trigger phrases from frontmatter into body `## When to use` sections (especially `olares-chart`, which dropped from 2780 → 250 chars)
- Replace Cursor-specific "Read tool" instructions with agent-neutral "load `olares-shared` skill" wording
- Bump versions: runtime skills `4.0.0` → `4.1.0`, `olares-chart` `1.5.1` → `1.6.0`
- Strengthen `publish.sh --dry-run` validation (description length, openclaw namespace, reject deprecated `metadata.requires`)

## Test plan

- [x] `./cli/skills/publish.sh --dry-run` — 7/7 local validation OK
- [ ] After merge: `bash cli/skills/publish.sh` to ClawHub (requires `CLAWHUB_TOKEN`)
- [ ] Users upgrade with `npx skills update beclab/Olares -y -g`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-metadata only; no olares-cli runtime or auth logic changes.
> 
> **Overview**
> Aligns all seven `cli/skills/olares-*` packages with **OpenCode / ClawHub** skill format: frontmatter now includes **`compatibility`**, **`metadata.openclaw.requires.bins`** (replacing deprecated `metadata.requires`), and **short `description` lines** (≤1024 chars). Long trigger text moves into new or expanded **`## When to use`** sections—especially **`olares-chart`**, where the description shrinks dramatically.
> 
> Runtime skills bump **4.0.0 → 4.1.0**; **`olares-chart`** **1.5.1 → 1.6.0**. Prerequisite wording drops Cursor-specific “Read tool” instructions in favor of **“load `olares-shared` skill first”**; **`cli/skills/README.md`** documents the new frontmatter contract.
> 
> **`publish.sh --dry-run`** validation now enforces description length, `compatibility`, the `openclaw` metadata block, and **rejects** legacy `metadata.requires`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b9adbcdf7231c99b697b71fa22baa36009c02c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->