### PR TITLE
cli: Update GitHub Actions runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -31,7 +31,7 @@ on:
         default: true
 jobs:
   goreleaser:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
* **Background**
update to a larger github runner

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single runner image bump for CI only; no application or release logic changes, with minor risk if 24.04 package/apt behavior differs for cross-compiler installs.
> 
> **Overview**
> Moves the **`goreleaser`** job in `release-cli.yaml` from **`ubuntu-22.04`** to **`ubuntu-24.04`**, so CLI release builds (GoReleaser, cross-compilers, binary version check, Tencent COS upload) run on the newer GitHub-hosted image. The **`publish-npm`** job is unchanged and still uses `ubuntu-22.04`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9a2bca23e7c12ba1b56adac97f6db096a55476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->