### PR TITLE
chore: update NVIDIA driver version to 595.80

### DIFF
--- a/cli/pkg/dashboard/overview/gpu/format_test.go
+++ b/cli/pkg/dashboard/overview/gpu/format_test.go
@@ -167,7 +167,7 @@ func TestGpuDetailDisplayCopy_SPAFieldWhitelist(t *testing.T) {
 		"powerLimit":     0,
 		"temperature":    0,
 		"device_no":      "nvidia0",
-		"driver_version": "595.71.05",
+		"driver_version": "595.80",
 		"health":         true,
 	}
 	got := gpuDetailDisplayCopy(src)
@@ -246,6 +246,7 @@ func TestGpuTaskDetailDisplayCopy_SPAFieldWhitelist(t *testing.T) {
 //   - a range-vector point whose timestamp is epoch ms
 //     ("1779636713000") and value is a noisy 7-digit float
 //     (`23.889648`).
+//
 // The envelope's `trends.points[0].timestamp` MUST be
 // `2026-05-24 …` (SPA `YYYY-MM-DD HH:mm:ss`), `value` MUST be
 // `23.89` (lodash.round(2)), and the wire-shape epoch MUST be

--- a/cli/pkg/upgrade/1_12_7_20260605.go
+++ b/cli/pkg/upgrade/1_12_7_20260605.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260605 struct {
+	upgrader_1_12_7_20260513
+}
+
+func (u upgrader_1_12_7_20260605) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260605")
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260605{})
+}

--- a/infrastructure/cuda/.olares/Olares.yaml
+++ b/infrastructure/cuda/.olares/Olares.yaml
@@ -4,9 +4,9 @@ output:
   binaries:
     - 
       id: cuda-driver
-      name: cuda-driver-595.71.05.run
-      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.71.05/NVIDIA-Linux-x86_64-595.71.05.run
-      arm64: https://us.download.nvidia.com/XFree86/aarch64/595.71.05/NVIDIA-Linux-aarch64-595.71.05.run
+      name: cuda-driver-595.80.run
+      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.80/NVIDIA-Linux-x86_64-595.80.run
+      arm64: https://us.download.nvidia.com/XFree86/aarch64/595.80/NVIDIA-Linux-aarch64-595.80.run
     - 
       id: libnvidia-gpgkey 
       name: libnvidia-gpgkey


### PR DESCRIPTION
* **Background**
Bump NVIDIA driver version to 595.80

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes host GPU driver artifacts and upgrade paths; incorrect URLs or upgrade logic can break installs or trigger driver reboots on upgrade.
> 
> **Overview**
> Bumps the bundled **NVIDIA CUDA driver** from **595.71.05** to **595.80** in `infrastructure/cuda/.olares/Olares.yaml`, including the prebuilt `.run` artifact name and amd64/arm64 download URLs.
> 
> Registers a new daily Olares upgrader **`1.12.7-20260605`** that embeds the prior `1.12.7-20260513` upgrader (GPU driver upgrade + reboot-if-needed behavior unchanged). Test fixtures in `format_test.go` use `driver_version` **595.80**; one comment block gets a blank line only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b91deb2c8b24bd59250ad0ff0aca561dfcb236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->