### PR TITLE
fix(bfl): tailscale exit node api

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.46
+        image: beclab/bfl:v0.4.47
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
* **Background**
tailscale exit node api

* **Target Version for Merge**
v1.12.6,v1.2.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in the launcher template; rollout risk is limited to whatever changed in the v0.4.47 BFL image.
> 
> **Overview**
> Bumps the BFL StatefulSet **api** container image from `beclab/bfl:v0.4.46` to `beclab/bfl:v0.4.47` in `bfl_deploy.yaml`, so deployments pick up the Tailscale exit-node API fix described in the PR title (the fix itself lives in the new image, not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b6254dfa3fa3584c784495b3cbe171c210a0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->