### PR TITLE
files external mount probing decoupled + archive task hardening

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.179
+          image: beclab/files-server:v0.2.180
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat(external): mount health checked in background; uploads / list / create no longer wait on the probe.
- fix(upload): map external mount unavailable to HTTP 503.
- fix(archive): disable pause for compress/extract (UI flag + backend hard guard).
- fix(tasks): surface PauseTask/ResumeTask errors instead of always returning success.
- fix(archive): cleanup sweeps multi-volume .tmp leftovers and triggers on retErr (not stale state).

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/344
- https://github.com/beclab/files/pull/345

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Single-tag rollout affects uploads, external mounts, and archive tasks cluster-wide; risk is moderate because behavior changes live in the new image, not in this YAML beyond the version pin.
> 
> **Overview**
> Bumps the **files** DaemonSet container image from `beclab/files-server:v0.2.179` to **`v0.2.180`** in `files_deploy.yaml`, rolling out the newer files-server build with no other manifest changes in this diff.
> 
> That image carries the behavior described for this release: **background external mount health checks** so uploads/list/create are not blocked on probing, **503** when an external mount is unavailable, **archive task** hardening (pause disabled, improved `.tmp` cleanup on errors), and **honest errors** from pause/resume task APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00362933980d61f7e05947e5a6cf3e469f82ce22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->