### PR TITLE
helm-charts/system-apps, wizard: bump system-frontend, user-service, and wizard images to v1.10.44

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.43
+          image: beclab/system-frontend:v1.10.44
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.97
+          image: beclab/user-service:v0.0.98
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
+++ b/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
@@ -29,7 +29,7 @@ spec:
 
       containers:
       - name: wizard
-        image: beclab/wizard:v1.10.27
+        image: beclab/wizard:v1.10.44
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80


### PR DESCRIPTION
* **Background**

Bumps the system frontend stack container images to ship the latest market, settings, desktop, and user-service changes:

- **`system-frontend`** (`v1.10.43` → `v1.10.44`) in `olares-app-init`
- **`user-service`** (`v0.0.97` → `v0.0.98`) in `olares-app`
- **`wizard`** (`v1.10.27` → `v1.10.44`) in `wizard` deployment

**Market / settings / desktop (TermiPass#1170)**
- Hoist `APP_BACKEND_ERROR` handling into `NormalApplication` and register it on market, desktop, and settings so backend failures (e.g. member uninstall on desktop) surface a toast instead of failing silently.
- Persist market search keyword and My Olares source in route query; key `MarketMainLayout` router-view on `route.path` to avoid remounts and input lag on query changes.
- Scale `EmptyView` images so empty states do not overflow small iframes.
- Rebuild app entrance host from app id on `.olares.local` instead of a hardcoded `.com` domain when opening an app in a new tab.
- Add update entry and confirmation for stopped apps; limit primary Update to running apps; only enforce install progress monotonicity within the same state.
- Refactor settings route metadata/back navigation; enhance network overlay confirmation with i18n; show application detail operations for admins.

**App clone model (TermiPass#1173)**
- Treat each clone as a standalone app: drop `rawAppName` fallbacks in aggregation/simple-info lookup, judge upgrades from the clone's own chart version, allow removing a local chart even when clones exist, and show the clone's custom name in stop/uninstall dialogs.

**CSV2 shared-server behavior (TermiPass#1174)**
- For v2 apps, lock the "also stop/uninstall the shared server" checkbox as checked and disabled in stop/uninstall dialogs for admin + multi-user scenarios.

**Transfer tasks (TermiPass#1172)**
- Hide pause entries when `pause_able` is false for download/copy/move/compress/extract tasks; sync `pause_able` from backend during polling.

**i18n (TermiPass#1171)**
- Split `controlPanelCommon` locale options into modular `options1` / `options2` / `options3` groups for easier maintenance.

**Market API proxy (user-service#83)**
- Forward the full upstream business error body from market-backend proxy responses (e.g. `data.backend_response`) instead of a generic `{ code, message }` wrapper.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/user-service/pull/83
https://github.com/beclab/TermiPass/pull/1170
https://github.com/beclab/TermiPass/pull/1171
https://github.com/beclab/TermiPass/pull/1172
https://github.com/beclab/TermiPass/pull/1173
https://github.com/beclab/TermiPass/pull/1174

* **Other information**:
TermiPass release: https://github.com/beclab/TermiPass/releases/tag/v1.10.44
TermiPass changelog: https://github.com/beclab/TermiPass/compare/v1.10.43...v1.10.44
user-service release: https://github.com/beclab/user-service/releases/tag/v0.0.98
user-service changelog: https://github.com/beclab/user-service/compare/v0.0.97...v0.0.98


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core olares-app and wizard workloads; risk is mainly from application changes in the new images rather than from Helm edits.
> 
> **Overview**
> Bumps pinned container images in user Helm charts so clusters run **TermiPass v1.10.44** and **user-service v0.0.98**.
> 
> In **`olares-app`**, **`beclab/system-frontend`** moves **v1.10.43 → v1.10.44** on the `olares-app-init` init container (static UI copied into the pod), and **`beclab/user-service`** moves **v0.0.97 → v0.0.98** on the `user-service` sidecar. In **`wizard`**, **`beclab/wizard`** moves **v1.10.27 → v1.10.44**. No chart structure, env, or routing changes—only image tags.
> 
> Shipped behavior in those images (per release notes) includes shared backend-error toasts across market/desktop/settings, clone-as-standalone app handling, CSV2 shared-server stop/uninstall UX, transfer-task pause visibility, and richer market API error bodies from the user-service proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061b40e9e403f0818eaa2756e6a7ba6abd559feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->