### PR TITLE
fix(app-service): recover apps stuck in Initializing that block uninstall

### DIFF
--- a/framework/app-service/pkg/apiserver/api/types.go
+++ b/framework/app-service/pkg/apiserver/api/types.go
@@ -158,6 +158,10 @@ type Image struct {
 type UninstallRequest struct {
 	All        bool `json:"all"`
 	DeleteData bool `json:"deleteData"`
+	// Force bypasses the operation-state gate so an app stuck in a
+	// transitional state (e.g. initializing) can still be uninstalled. The
+	// controller cleans up any in-progress operation before uninstalling.
+	Force bool `json:"force"`
 }
 
 // StopRequest represents a request to stop an application.

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -685,7 +685,7 @@ func (h *installHandlerHelper) applyAppMgr(name string, extraLabels map[string]s
 		}
 	} else {
 		if !appstate.IsOperationAllowed(a.Status.State, v1alpha1.InstallOp) {
-			err = fmt.Errorf("%s operation is not allowed for %s state", v1alpha1.InstallOp, a.Status.State)
+			err = appstate.ExplainOperationNotAllowed(a.Status.State, v1alpha1.InstallOp)
 			api.HandleBadRequest(h.resp, h.req, err)
 			return
 		}

--- a/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
@@ -49,9 +49,12 @@ func (h *Handler) uninstall(req *restful.Request, resp *restful.Response) {
 	}
 	am := *amPtr
 
-	if !appstate.IsOperationAllowed(am.Status.State, v1alpha1.UninstallOp) {
+	if !request.Force && !appstate.IsOperationAllowed(am.Status.State, v1alpha1.UninstallOp) {
 		api.HandleBadRequest(resp, req, appstate.ExplainOperationNotAllowed(am.Status.State, v1alpha1.UninstallOp))
 		return
+	}
+	if request.Force {
+		klog.Warningf("force uninstalling app %s from %s state", app, am.Status.State)
 	}
 	am.Spec.OpType = v1alpha1.UninstallOp
 	if am.Annotations == nil {

--- a/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
@@ -50,7 +50,7 @@ func (h *Handler) uninstall(req *restful.Request, resp *restful.Response) {
 	am := *amPtr
 
 	if !appstate.IsOperationAllowed(am.Status.State, v1alpha1.UninstallOp) {
-		api.HandleBadRequest(resp, req, fmt.Errorf("%s operation is not allowed for %s state", v1alpha1.UninstallOp, am.Status.State))
+		api.HandleBadRequest(resp, req, appstate.ExplainOperationNotAllowed(am.Status.State, v1alpha1.UninstallOp))
 		return
 	}
 	am.Spec.OpType = v1alpha1.UninstallOp

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -986,6 +986,11 @@ func (h *HelmOps) WaitForLaunch() (bool, error) {
 			entranceCount++
 		}
 	}
+	// unrecoverableSince records when an unrecoverable pod condition was first
+	// observed while the entrances are still unreachable. Once it persists past
+	// unrecoverableGrace, the launch fails fast instead of polling until the
+	// outer initializing TTL (60m) expires.
+	var unrecoverableSince time.Time
 	for {
 		select {
 		case <-timer.C:
@@ -1004,11 +1009,88 @@ func (h *HelmOps) WaitForLaunch() (bool, error) {
 				return true, nil
 			}
 
+			if reason, ok := h.hasUnrecoverablePod(h.ctx); ok {
+				if unrecoverableSince.IsZero() {
+					unrecoverableSince = time.Now()
+					klog.Warningf("app %s has unrecoverable pod (%s); will fail launch if it persists for %s",
+						h.app.AppName, reason, unrecoverableGrace)
+				} else if time.Since(unrecoverableSince) > unrecoverableGrace {
+					return false, fmt.Errorf("app %s failed to launch: %s", h.app.AppName, reason)
+				}
+			} else {
+				unrecoverableSince = time.Time{}
+			}
+
 		case <-h.ctx.Done():
 			klog.Infof("Waiting for launch canceled appName=%s", h.app.AppName)
 			return false, h.ctx.Err()
 		}
 	}
+}
+
+const (
+	// unrecoverableGrace is how long an unrecoverable pod condition must
+	// persist (while entrances remain unreachable) before WaitForLaunch
+	// gives up. It tolerates transient crashes during normal startup.
+	unrecoverableGrace = 5 * time.Minute
+	// crashLoopRestartThreshold is the minimum container restart count for a
+	// CrashLoopBackOff pod to be treated as unrecoverable. CrashLoopBackOff
+	// backoff caps at 300s, so >=5 restarts means several minutes of failing.
+	crashLoopRestartThreshold = 5
+)
+
+// hasUnrecoverablePod inspects pods in the app namespace and reports whether
+// any is in a state that will not heal on its own. It returns a human-readable
+// reason and true when such a pod is found.
+//
+// Two tiers are considered:
+//   - hard errors that never self-heal: ImagePullBackOff, ErrImagePull,
+//     InvalidImageName, CreateContainerConfigError, and Unschedulable pods.
+//   - CrashLoopBackOff with RestartCount >= crashLoopRestartThreshold, which
+//     covers a dependency that keeps crashing (e.g. due to a permission error)
+//     while avoiding false positives on slow-starting apps.
+func (h *HelmOps) hasUnrecoverablePod(ctx context.Context) (string, bool) {
+	pods, err := h.client.KubeClient.Kubernetes().CoreV1().Pods(h.app.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Warningf("list pods in namespace %s failed, skip unrecoverable check: %v", h.app.Namespace, err)
+		return "", false
+	}
+
+	hardErrorReasons := map[string]bool{
+		"ImagePullBackOff":           true,
+		"ErrImagePull":               true,
+		"InvalidImageName":           true,
+		"CreateContainerConfigError": true,
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse &&
+				cond.Reason == corev1.PodReasonUnschedulable {
+				return fmt.Sprintf("pod %s unschedulable: %s", pod.Name, cond.Message), true
+			}
+		}
+
+		statuses := append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
+		statuses = append(statuses, pod.Status.ContainerStatuses...)
+		for _, cs := range statuses {
+			waiting := cs.State.Waiting
+			if waiting == nil {
+				continue
+			}
+			if hardErrorReasons[waiting.Reason] {
+				return fmt.Sprintf("pod %s container %s: %s (%s)", pod.Name, cs.Name, waiting.Reason, waiting.Message), true
+			}
+			if waiting.Reason == "CrashLoopBackOff" && cs.RestartCount >= crashLoopRestartThreshold {
+				return fmt.Sprintf("pod %s container %s: CrashLoopBackOff after %d restarts (%s)",
+					pod.Name, cs.Name, cs.RestartCount, waiting.Message), true
+			}
+		}
+	}
+
+	return "", false
 }
 
 func (h *HelmOps) App() *appcfg.ApplicationConfig {

--- a/framework/app-service/pkg/appstate/initializing_app.go
+++ b/framework/app-service/pkg/appstate/initializing_app.go
@@ -81,18 +81,29 @@ func (p *InitializingApp) Exec(ctx context.Context) (StatefulInProgressApp, erro
 
 				ok, err := ops.WaitForLaunch()
 				if !ok {
-					klog.Errorf("wait for launch failed %v", err)
-					if err != nil {
-						klog.Error("wait for launch error: ", err, ", ", p.manager.Name)
-						p.finally = func() {
-							klog.Info("update app manager status to initializing canceling, ", p.manager.Name)
-							updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InitializingCanceling, nil, appsv1.InitializingCanceling.String(), constants.AppStopDueToInitFailed)
-							if updateErr != nil {
-								klog.Errorf("update app manager %s to %s state failed %v", p.manager.Name, appsv1.InitializingCanceling, updateErr)
-								return
-							}
+					// A cancel (POST /cancel) or a force uninstall cancels opCtx,
+					// on which WaitForLaunch returns (false, ctx.Err()). That is
+					// NOT an init failure: the initiator has already written the
+					// terminal target state (InitializingCanceling for cancel,
+					// Uninstalling for force uninstall) and owns the transition.
+					// Writing InitializingCanceling here would both mislabel the
+					// initiator's intent and race the cancel/uninstall path.
+					// Bail out quietly and let the initiator drive the state.
+					if err == nil || c.Err() != nil {
+						klog.Infof("initialization of app %s canceled while waiting for launch; leaving terminal state to the initiator", p.manager.Spec.AppName)
+						return
+					}
 
+					klog.Errorf("wait for launch failed %v", err)
+					klog.Error("wait for launch error: ", err, ", ", p.manager.Name)
+					p.finally = func() {
+						klog.Info("update app manager status to initializing canceling, ", p.manager.Name)
+						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InitializingCanceling, nil, appsv1.InitializingCanceling.String(), constants.AppStopDueToInitFailed)
+						if updateErr != nil {
+							klog.Errorf("update app manager %s to %s state failed %v", p.manager.Name, appsv1.InitializingCanceling, updateErr)
+							return
 						}
+
 					}
 					return
 				}

--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -345,17 +345,29 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				if p.manager.Spec.Type == appsv1.Middleware {
 					ok, err := ops.WaitForLaunch()
 					if !ok {
-						klog.Errorf("wait for middleware %s launch failed %v", p.manager.Spec.AppName, err)
-						if err != nil {
-							p.finally = func() {
-								klog.Info("update app manager status to installing canceling, ", p.manager.Name)
-								updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallingCanceling, nil, appsv1.InstallingCanceling.String(), constants.AppStopDueToInitFailed)
-								if updateErr != nil {
-									klog.Errorf("update app manager %s to %s state failed %v", p.manager.Name, appsv1.InstallingCanceling, updateErr)
-									return
-								}
+						// A cancel (DELETE /apps/{name}/install) or a force
+						// uninstall cancels opCtx, on which WaitForLaunch returns
+						// (false, ctx.Err()). That is NOT a launch failure: the
+						// initiator has already written the terminal target state
+						// (InstallingCanceling for cancel, Uninstalling for force
+						// uninstall) and owns the transition. Writing
+						// InstallingCanceling here would mislabel the initiator's
+						// intent and race the cancel/uninstall path. Bail out
+						// quietly and let the initiator drive the state.
+						if err == nil || c.Err() != nil {
+							klog.Infof("install of middleware %s canceled while waiting for launch; leaving terminal state to the initiator", p.manager.Spec.AppName)
+							return
+						}
 
+						klog.Errorf("wait for middleware %s launch failed %v", p.manager.Spec.AppName, err)
+						p.finally = func() {
+							klog.Info("update app manager status to installing canceling, ", p.manager.Name)
+							updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallingCanceling, nil, appsv1.InstallingCanceling.String(), constants.AppStopDueToInitFailed)
+							if updateErr != nil {
+								klog.Errorf("update app manager %s to %s state failed %v", p.manager.Name, appsv1.InstallingCanceling, updateErr)
+								return
 							}
+
 						}
 						return
 					}

--- a/framework/app-service/pkg/appstate/state_transition.go
+++ b/framework/app-service/pkg/appstate/state_transition.go
@@ -1,6 +1,7 @@
 package appstate
 
 import (
+	"fmt"
 	"time"
 
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -359,6 +360,20 @@ func IsOperationAllowed(curState appv1alpha1.ApplicationManagerState, op appv1al
 		return allowedOps[op]
 	}
 	return false
+}
+
+// ExplainOperationNotAllowed builds the error returned when op is rejected in
+// curState. When the state has an in-progress operation that can be cancelled
+// (CancelOp is allowed), the message guides the caller to cancel first instead
+// of just reporting "not allowed", which otherwise leaves callers retrying the
+// same blocked operation (e.g. uninstall stuck behind an initializing app).
+func ExplainOperationNotAllowed(curState appv1alpha1.ApplicationManagerState, op appv1alpha1.OpType) error {
+	if IsOperationAllowed(curState, appv1alpha1.CancelOp) {
+		return fmt.Errorf("%s operation is not allowed while the app is in %s state: an operation is in progress; "+
+			"cancel it first via POST /app-service/v1/apps/{name}/cancel and wait until the app reaches a terminal state, then retry %s",
+			op, curState, op)
+	}
+	return fmt.Errorf("%s operation is not allowed for %s state", op, curState)
 }
 
 func IsCancelable(curState appv1alpha1.ApplicationManagerState) bool {


### PR DESCRIPTION
## Summary

When an app's pods can never become ready (e.g. a dependency crash-looping due to a permission error), `HelmOps.WaitForLaunch()` polls entrance reachability forever, so the ApplicationManager stays in `Initializing`. Since `Initializing` only allows `CancelOp`, `uninstall`/`install` are rejected with a bare `400 "operation is not allowed for initializing state"`, leaving the namespace and deployments behind with no obvious way out.

This PR addresses the three underlying gaps, one per commit:

1. **Fail fast in `WaitForLaunch`** — while entrances stay unreachable, inspect pods for unrecoverable conditions and give up after a grace window instead of hanging until the 60m initializing TTL:
   - hard errors (never self-heal): `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError`, and `Unschedulable` pods;
   - `CrashLoopBackOff` with `RestartCount >= 5`;
   - must persist past a 5m grace window (tolerates transient startup crashes). On trigger, initializing fails into `InitializingCanceling`.

2. **Actionable rejection error** — add `appstate.ExplainOperationNotAllowed`; when the current state allows `CancelOp`, the error tells the caller to cancel the in-progress operation first (instead of just "not allowed"). Used by the uninstall and install handlers.

3. **Force uninstall** — add a `force` flag to `UninstallRequest`. When set, the uninstall handler skips the operation-state gate so a wedged app can still be uninstalled; the controller cleans up any in-progress operation via the `IsUnknownInProgressApp` path. Defaults to `false`, so existing callers are unaffected.

## Test plan

- [ ] `cd framework/app-service && go build ./...` (passes locally)
- [ ] `go vet ./pkg/appstate/... ./pkg/apiserver/... ./pkg/appinstaller/...` (clean locally)
- [ ] Install an app whose dependency stays in CrashLoopBackOff; confirm it fails out of `Initializing` within ~5m instead of hanging ~60m.
- [ ] Confirm uninstall/install on an initializing app returns the cancel-first guidance.
- [ ] Confirm `uninstall {"force": true}` removes an app stuck in `Initializing` (namespace + deployments cleaned up).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install/uninstall gates, launch polling, and ApplicationManager state transitions; force uninstall bypasses normal guards but defaults off.
> 
> **Overview**
> Apps stuck in **Initializing** (because `WaitForLaunch` never saw reachable entrances) could not uninstall or get clear API errors. This PR adds recovery paths and clearer lifecycle behavior.
> 
> **`WaitForLaunch`** now watches pod conditions while entrances stay down. Persistent **unrecoverable** states (image pull errors, unschedulable, sustained **CrashLoopBackOff** after a restart threshold) trigger failure after a **5-minute grace** instead of waiting for the long initializing TTL.
> 
> **API / state machine:** **`UninstallRequest.force`** skips the normal operation gate so wedged transitional states can still uninstall (controller cleanup unchanged). **`ExplainOperationNotAllowed`** tells clients to **cancel** first when `CancelOp` is allowed; install/uninstall handlers use it. **Initializing** and **installing** (middleware launch wait) no longer write canceling states when **`WaitForLaunch`** ends due to **context cancel** (user cancel or force uninstall), avoiding races with the initiator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a43896e5775ed27396de20d4f2180fc216f6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->