### PR TITLE
docs(cli): single-source Olares platform model across olares-* skills

### DIFF
--- a/cli/skills/README.md
+++ b/cli/skills/README.md
@@ -11,7 +11,9 @@ cli/skills/
 ├── README.md          # this file
 ├── publish.sh         # publish helper (used locally and from CI)
 ├── olares-shared/
-│   └── SKILL.md       # foundation: profile model, login, token refresh
+│   ├── SKILL.md       # foundation: profile model, login, token refresh
+│   └── references/
+│       └── olares-platform.md   # cross-skill platform model (storage, uid 1000, namespaces, middleware, versions)
 ├── olares-files/
 │   ├── SKILL.md       # cross-cutting concepts + verb index
 │   └── references/    # one file per non-trivial subcommand
@@ -27,7 +29,9 @@ cli/skills/
     └── references/    # one file per refinement area / capability
 ```
 
-`olares-shared` is the foundation — every runtime skill cross-references it for the profile selection, login, and HTTP 401/403 recovery rules. Always install it first. The exception is `olares-chart`: its `chart` verbs are local-only (no profile / login / cluster), so it does not depend on `olares-shared`.
+**Install the whole suite together.** These skills are designed as one set and cross-reference each other by relative path (e.g. `../olares-shared/SKILL.md`, `../olares-shared/references/olares-platform.md`). Installing only a subset leaves those links dangling. `olares-shared` is the foundation — every runtime skill cross-references it for profile selection, login, and HTTP 401/403 recovery, **and it hosts the cross-skill platform model** ([`olares-shared/references/olares-platform.md`](olares-shared/references/olares-platform.md)) that `files` / `chart` / `cluster` link to (one hop from their `SKILL.md`) instead of re-describing it.
+
+`olares-chart` is a partial exception on **login**, not on linking: its authoring verbs (`from-compose` / `lint` / `package`) are local-only and need **no profile / login / cluster**, so it never logs in to author a chart. It still reads `olares-platform.md` for platform facts (no login needed) and only requires `olares-shared` login when **pushing a chart to a real Olares to test** (`market upload` + `install`).
 
 ClawHub publishes the entire skill directory (including `references/`), so reference files ship automatically without any change to `publish.sh`.
 
@@ -52,7 +56,19 @@ What to leave out of SKILL.md (and references):
 
 Target sizes: SKILL.md ≤ 250 lines (≤ 300 for the most complex command tree). Each reference: ≤ 150 lines.
 
+**Reference depth (one level deep):** all reference files link **directly from a `SKILL.md`**, never reference→reference. Nested references get partially read (agents preview with `head` instead of reading the whole file), so a concept buried two hops down is unreliable. Any reference longer than ~100 lines gets a table of contents at the top so a partial read still shows its full scope.
+
 These rules apply to **every** skill, including `olares-chart` — even though it is a local-only chart-authoring skill (no live profile / login) rather than a CLI-driving one, it still avoids Go source-path citations and keeps each reference ≤ 150 lines.
+
+## Cross-skill shared concepts (single source of truth)
+
+Facts used by **≥2 skills** are defined **once** and linked, never copied. This keeps the suite consistent and token-efficient (the lark-cli pattern these skills are modeled on; see also [Anthropic's skill-authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)).
+
+- **One canonical home per shared concept.** The cross-skill Olares platform model (userspace storage, uid-1000 run identity, app/namespace & networking, system middleware, version/semver) lives once in [`olares-shared/references/olares-platform.md`](olares-shared/references/olares-platform.md), with a TOC. Auth/profile facts likewise live once in `olares-shared/SKILL.md`.
+- **Link the shared source one hop from each consumer's `SKILL.md`** with a short must-read prerequisite (`> Platform model (read once): … see ../olares-shared/references/olares-platform.md`). This is the lark-cli `CRITICAL — MUST Read ../lark-shared/SKILL.md` convention.
+- **Do NOT deep-link the shared source from reference files.** A reference that points at another skill's reference is a two-hop nested read. Instead, refer to the shared concept **by name** (matching the source's heading) and rely on the `SKILL.md` prerequisite to have loaded it. (See the chart references, which name "the platform **Userspace storage model**" rather than linking it.)
+- **Self-containment is traded for a suite contract.** Strictly, Skills are self-contained and "cannot reference files in other skill folders". We deliberately cross-link because these skills **ship and install as one suite** (stated under Layout). A standalone install leaves cross-skill links dangling — that is the documented trade-off, not an accident.
+- **When a fact is genuinely two skills' own angle, let each keep its own framing.** `files` describes the storage areas as *addressing* (`drive/Home`), `chart` as *mounting* (`.Values.userspace.appData`). That is not duplication to dedupe — only the underlying platform facts (backends, durability, uid, version gates) are centralized in `olares-platform.md`.
 
 ## Runtime requirement
 

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-chart
 version: 4.2.0
-description: "Olares Chart via olares-cli chart — from-compose, lint, package; turn compose/Helm/repo into an Olares app chart. Release targets: local-run (upload on your Olares) or market-distribute (public Market). Use for OlaresManifest, docker-compose to Olares, chart lint/package, Market upload, ImagePullBackOff."
+description: "Help a developer turn their own code or any open-source project into an app that runs on their own Olares, or is published to the public Olares Market. Three coupled axes: packaging the container image, authoring/refining the Olares app chart (OlaresManifest), and the release target — local-run on your own Olares vs market-distribute to the catalog. Use when deploying a repo, docker-compose, or Helm chart to Olares, packaging an Olares app, wiring storage / system middleware / entrances / env / GPU, or fixing a failed install (ImagePullBackOff, permission denied / EACCES, app won't start)."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only
 metadata:
   openclaw:
@@ -10,126 +10,92 @@ metadata:
         - olares-cli
 ---
 
-# chart (compose → Olares app chart)
+# Deploy your code or any project to Olares — local-run or Market
 
-> **Source of truth for flags is always `olares-cli chart <verb> --help`.** This file only carries what `--help` cannot: when to use this skill, the convert→refine→lint loop, release-target routing, and the four refinement areas that turn a raw conversion into a working chart.
+> **Source of truth for flags is always `olares-cli chart <verb> --help`.** This file only carries what `--help` cannot: the three coupled axes of a port, where to start on each, the per-axis concerns to get right, and the gotchas `lint` won't catch.
 
 > **Porting baseline: Olares >= 1.12.6.** This skill targets Olares >= 1.12.6 (other `olares-cli` features have no such floor). Check the target with `olares-cli profile list` (VERSION column). Full version rules — `apiVersion: v3`, the several chart version fields, `type: system` dependency — are in [references/olares-chart-versioning.md](references/olares-chart-versioning.md).
 
-> **Platform model (read once, no login needed for authoring).** The porting decisions below rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). **Packaging an image and authoring/validating the chart (`from-compose` / `lint` / `package`) need no profile login.** Only **pushing to a real Olares to test** (`market upload` + `install`) requires login (see Publish-local below).
+> **Platform model (read once, no login needed for authoring).** The porting decisions below rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). **Packaging an image and authoring/validating the chart need no profile login.** Only **pushing to a real Olares to test** (`market upload` + `install`) requires login.
 
-## When to use
+## The shape of the work — three axes
 
-- Olares chart, OlaresManifest / OlaresManifest.yaml, olares-cli chart, chart from-compose, chart lint, chart package
-- Turn docker-compose, a generic Helm chart, or a bare source repo into a **lint-passing** Olares app chart — or a **market-ready** one when distributing publicly
-- **Local run** on your own Olares (upload + install); **market distribute** (full metadata, multi-arch, PR to `beclab/apps`)
-- Building/pushing docker image (amd64 vs arm64), no official image, wrong arch
-- GPU / CUDA app: building a CUDA image without a GPU on the build machine, `TORCH_CUDA_ARCH_LIST`, nvidia mode = amd64; model download / Hugging Face weights / shared model cache via `appCommon` (`drive/Common`)
-- Accelerator compute resources: declare `spec.accelerator` modes (nvidia/amd-gpu/amd-apu/strix-halo/nvidia-gb10/apple-m/cpu, per what the repo supports), GPU memory via `requiredGPUMemory`, and how much CPU/memory/GPU to request for a ported project
-- Install/runtime failures: ImagePullBackOff, app failed to install or start, market / app-service / chartrepo logs
-- **Permission denied / EACCES** on userspace volumes, third-party image runs as root or non-1000 uid, `spec.runAsUser`, initContainer volume `chown`
-- Headless / CLI app, MCP server, or tool with no web UI (terminal entrance + invisible entrance)
-- Run `docker` / `docker compose` from inside a terminal/agent app: privileged Docker-in-Docker sidecar gated by `ENABLE_DIND`, `DOCKER_HOST=tcp://localhost:2375`, trusted `beclab/docker` daemon image
-- Depend on another already-ported app instead of bundling it (`options.dependencies` `type: application`, e.g. searxng companion service)
-- Shared app: a heavy/accelerator backend with its own accounts, used by many people, sharing one data set — installed **once by an admin** cluster-wide via `apiVersion: v3` (admin-only, `<app>-shared` namespace), consumed by reference apps over cross-namespace Service DNS (e.g. ollama / vLLM / LLM gateway)
-- Environment variables: declare app config in `envs[]`, prompt the user at install (e.g. init admin username/password via `required`), map system/user vars (`OLARES_SYSTEM_*` / `OLARES_USER_*`) through `valueFrom`, `.Values.olaresEnv`, env `type`/`regex`/`options` validation
-- Version rules: Olares system version (semver), `apiVersion: v3`, `olaresManifest.version` 0.8.0 vs 0.12.0, `metadata.version` vs `spec.versionName`, `type: system` dependency, checking the target with `profile list`
-- Three axes: **packaging** (Dockerfile/image), **deployment** (compose/chart), **publishing** (release target); four post-kompose refinement areas (metadata depth gated by target, storage, middleware, entrances)
-- Optional live validation (requires login): package + market upload/install — see [`olares-shared`](../olares-shared/SKILL.md), [`olares-market`](../olares-market/SKILL.md), [`olares-cluster`](../olares-cluster/SKILL.md)
+Porting an app is **not** a fixed `from-compose → lint → publish` pipeline — it is driving three **orthogonal but coupled** axes each to its own *ready* state, looping back across the coupling edges as constraints surface (an image's baked-in uid/paths constrain the chart's mounts/permissions; a deploy constraint can send you back to rebuild the image). Start wherever your app already stands, not at a fixed step 1.
 
-## Olares readiness checklist (think through these before declaring a port done)
+- **Packaging — the image:** the app built into a pullable, arch-correct artifact. Olares only pulls, never builds.
+- **Deployment — the chart:** a `lint`-passing OlaresManifest + templates. `from-compose` is only **one** way in.
+- **Publishing — the release target:** who consumes it — **local-run** on your own Olares, or **market-distribute** to the public catalog. This choice gates how strict the other two must be.
 
-kompose/`from-compose` produces a chart that lints but is not yet a good Olares app. Every ported app must satisfy the items below — use this as the entry index; each links to where the actual work is described. (Platform background for all of them: [platform.md](../olares-shared/references/olares-platform.md).)
+**First move (not a pipeline):** settle the release target (Axis 3) → locate where the app already sits on the packaging and deployment state tables → drive the concerns to ready, looping as constraints surface.
 
-- **Image** — pullable from a registry, pinned to a version tag (never `:latest`), arch-correct (node arch for local-run; multi-arch for market). Olares pulls images, never builds. → [image.md](references/olares-chart-image.md)
-- **Run identity** — process runs as uid 1000; `spec.runAsUser: true`; initContainer `chown` for root-owned volumes; no root main on non-trusted images (OPA). → [run-as-user.md](references/olares-chart-run-as-user.md)
-- **Storage** — every compose volume mapped to the right userspace area (Data / Cache / Home / Common / External), matching `permission` declared, leftover kompose PVCs deleted. → [manifest.md](references/olares-chart-manifest.md) §2
-- **Middleware** — no bundled `postgres`/`redis`/`mongo`/...; wired to system middleware; SQLite switched to Postgres where supported; companion apps declared as `type: application` deps. → [middleware.md](references/olares-chart-middleware.md)
-- **Entrances & ports** — at least one `entrances[]`; HTTP via entrances, non-HTTP via `ports[]`; internal-only services `invisible: true`; headless apps use the web-terminal archetype. → [manifest.md](references/olares-chart-manifest.md) §4, [archetypes.md](references/olares-chart-archetypes.md)
-- **Env** — app config declared in `envs[]` (v3 `valueFrom`, no inline `OLARES_USER`); install-time `required` prompts; middleware/system/user vars mapped. → [env.md](references/olares-chart-env.md)
-- **Version** — `apiVersion: v3`; `olaresManifest.version` 0.8.0 vs 0.12.0; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`). → [versioning.md](references/olares-chart-versioning.md)
-- **Shared-app gating** — `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; flag this to the user; for a deliberate multi-user backend follow shared. → [shared.md](references/olares-chart-shared.md)
-- **Resources / accelerator** — a sane CPU/memory envelope; for GPU apps the `spec.accelerator` modes match the image arch and `requiredGPUMemory` is set. → [accelerator.md](references/olares-chart-accelerator.md)
-- **Lint** — `olares-cli chart lint ./<app>` passes (it does NOT catch pinned tags, bundled dbs, or apiVersion — those are on you). → [lint.md](references/olares-chart-lint.md)
+## Axis 1 — Packaging (the image)
 
-## Start here: establish your release target
+Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **guided** — you check/install docker and drive `docker login` / build / push **with the developer, never on their behalf** ([references/olares-chart-image.md](references/olares-chart-image.md)). No login needed.
 
-Before the packaging/deployment state tables, decide **who consumes the chart** and what "done" means. Infer from user language; ask if ambiguous. Full decision tree and checklists: [references/olares-chart-publish-targets.md](references/olares-chart-publish-targets.md).
+| Packaging state | Do this | Ready when |
+|---|---|---|
+| No Dockerfile (just source) | author a Dockerfile, then build+push | — |
+| Dockerfile, but no pullable image | build+push (Docker Hub or ghcr) | — |
+| A pullable image exists | check its arch; rebuild if it doesn't match the target (node arch for local-run; multi-arch for market) | every workload has a pullable, arch-correct image |
+
+## Axis 2 — Deployment (the chart)
+
+The target is a `lint`-passing Olares chart. `from-compose` (kompose) is **just one entry method** for a compose-based start — a bare repo, a generic Helm chart, or an already-Olares chart each begin elsewhere. Local authoring (`from-compose` / `lint` / `package`) needs **no login**.
+
+| Deployment state | Do this | Ready when |
+|---|---|---|
+| Source only (no compose) | author a docker-compose from the code ([compose.md](references/olares-chart-compose.md)) | — |
+| A docker-compose | `chart from-compose` then refine ([from-compose.md](references/olares-chart-from-compose.md)) | — |
+| A generic Helm chart (no OlaresManifest) | hand-author `OlaresManifest.yaml` + refine (skip `from-compose`) | — |
+| Already an Olares chart | go straight to validation | a chart that passes `chart lint` |
+
+## Axis 3 — Publishing (the release target)
+
+Decide **who consumes the chart** and what "done" means **before** refining — it gates image arch and metadata depth. Infer from user language; ask if ambiguous. Full decision tree: [references/olares-chart-publish-targets.md](references/olares-chart-publish-targets.md).
 
 | Release target | User signals | Done when |
 |---|---|---|
 | **local-run** (default for most users) | "run on my Olares", "upload and install", "just for myself" | `lint` OK → package → upload + install reaches `running` on the developer's Olares |
 | **market-distribute** | "publish to Market", "submit to beclab/apps", "上架" | local validation passes **plus** market-ready metadata/images/arch → PR merged into `beclab/apps:main` |
 
-**What differs by target** (full matrix in [publish-targets.md](references/olares-chart-publish-targets.md)): **image arch** (local-run = single-arch for this node via `cluster node list`; market = multi-arch + `spec.supportArch`); **metadata depth** (local = stub OK if `lint` passes; market = full metadata, dual-version categories, listing images, developer links); and the **publish path** (local = upload + install; market = the same validation first, then a `beclab/apps` PR). **Refine §2–4 (storage / middleware / entrances) is functional and identical for both.**
+**What differs by target:** **image arch** (local-run = single-arch for this node via `cluster node list`; market = multi-arch + `spec.supportArch`); **metadata depth** (local = stub OK if `lint` passes; market = full metadata, dual-version categories, listing images, developer links); and the **publish path** (local = upload + install; market = the same validation first, then a `beclab/apps` PR). Functional refinement (storage / middleware / entrances) is **identical for both**.
 
-## Start here: establish your state
+## The concerns to get right (reflect on these per axis)
 
-State where the app stands on **three orthogonal axes**. Packaging and deployment each have their own "ready" target; **publishing** gates how strictly you apply image arch and metadata depth. The axes are orthogonal (having a compose says nothing about whether an image needs building) but **coupled**: an image's baked-in paths / run-user constrain what the manifest can mount and which `permission`s it grants, and Olares deployment constraints (non-root, userspace volumes, system middleware) can send you back to rebuild the image rather than just edit the manifest. Drive all three to ready and loop across these edges as constraints surface.
+`from-compose` produces a chart that **lints but is not yet a good Olares app**. These are the same concerns viewed three ways — what triggers them, what they let you do, and when they're done — collapsed into one row each. Drive each to "get this right", and loop back here when its trigger reappears.
 
-**Packaging axis — the image** (how the app is built into a runnable artifact). Olares **pulls images from a registry and never builds from source**, so every workload must end up referencing a publicly pullable, node-arch-correct image.
+| Axis | Concern | Get this right | Loop back when | Reference |
+|---|---|---|---|---|
+| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct (per release target — see Axis 3) | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
+| packaging+deployment | **Run identity** | process runs as uid 1000; `spec.runAsUser: true`; initContainer `chown` for root-owned volumes; no root main on non-trusted images (OPA) | EACCES on appData/appCache/userData, admission denies a root third-party image | [run-as-user.md](references/olares-chart-run-as-user.md) |
+| deployment | **Storage** | every compose volume mapped to the right userspace area (Data / Cache / Home / Common / External), `permission` declared to match, leftover kompose PVCs deleted | a volume isn't persisting or lands in the wrong area | [manifest.md](references/olares-chart-manifest.md) §2 |
+| deployment | **Middleware & deps** | no bundled `postgres`/`redis`/`mongo`/…; wired to system middleware; SQLite→Postgres where supported; companion apps as `type: application` deps | a bundled db/queue is still in the chart, or a companion should be a dependency | [middleware.md](references/olares-chart-middleware.md) |
+| deployment | **Env** | app config in `envs[]` (v3 `valueFrom`, no inline `OLARES_USER`); install-time `required` prompts; middleware/system/user vars mapped via `.Values.olaresEnv` | install fails on `appenv` 422, or config must be user-supplied | [env.md](references/olares-chart-env.md), [env-defaults.md](references/olares-chart-env-defaults.md) |
+| deployment | **Entrances & ports** | ≥1 `entrances[]`; HTTP via entrances, non-HTTP via `ports[]`; internal-only services `invisible: true` | a service is unreachable, or an internal port is exposed as a desktop entrance | [manifest.md](references/olares-chart-manifest.md) §4 |
+| packaging+deployment | **GPU / models** | build a CUDA image without a local GPU (custom-kernel arch flags); download model weights via initContainer into the shared `appCommon` Hugging Face cache | AI app needs a CUDA build, model provisioning, or a shared model cache | [gpu.md](references/olares-chart-gpu.md) |
+| deployment | **Accelerator** | declare `spec.accelerator` modes (nvidia/amd-gpu/apple-m/cpu/…) per what the repo supports; set `requiredGPUMemory`; a sane CPU/memory envelope | GPU/accelerator app needs a resource envelope, or `lint` flags `spec.resources` | [accelerator.md](references/olares-chart-accelerator.md) |
+| packaging+deployment | **DinD** | a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`) while the main container stays non-privileged | a terminal/agent app must run `docker` / `docker compose` | [dind.md](references/olares-chart-dind.md) |
+| deployment | **Shared backend** | `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; consumers reach it over cross-namespace Service DNS; flag the admin-install to the user | a heavy/accelerator backend serves many users over shared data | [shared.md](references/olares-chart-shared.md) |
+| deployment | **Version rules** | `apiVersion: v3`; `olaresManifest.version` 0.8.0 vs 0.12.0; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`) | install rejects the manifest, or behavior differs by Olares version | [versioning.md](references/olares-chart-versioning.md) |
+| deployment | **Metadata** | depth gated by release target (see Axis 3); market needs full `metadata.*` + `spec.{developer,website,sourceCode,submitter,fullDescription}` + listing images | publishing to market, or `lint`/ingest flags missing metadata | [manifest.md](references/olares-chart-manifest.md) §1 |
+| deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
+| publishing | **Publish-local** | `market upload` + `market install`, then diagnose from logs (login required) | proving the chart actually runs on the developer's Olares | [publish-verify.md](references/olares-chart-publish-verify.md) |
+| publishing | **Publish-market** | market-ready checklist + a PR to `beclab/apps` | local validation passed and the user wants a public listing | [market-submit.md](references/olares-chart-market-submit.md) |
 
-| Packaging state | Do this | Ready when |
-|---|---|---|
-| No Dockerfile (just source) | author a Dockerfile, then build+push | — |
-| Dockerfile, but no pullable image | build+push (Docker Hub or ghcr) | — |
-| A pullable image exists | check its arch; rebuild if it doesn't match the target (node arch for local-run; multi-arch for market-distribute) | every workload has a pullable, arch-correct image |
-
-**Deployment axis — the orchestration** (how the app is deployed). The target is a `lint`-passing Olares chart.
-
-| Deployment state | Do this | Ready when |
-|---|---|---|
-| Source only (no compose) | author a docker-compose from the code | — |
-| A CLI / headless service (no web UI) | classify it and apply an archetype recipe ([archetypes.md](references/olares-chart-archetypes.md)) | a chart that passes `chart lint` |
-| A docker-compose | `chart from-compose` then refine | — |
-| A generic Helm chart (no OlaresManifest) | hand-author `OlaresManifest.yaml` + refine (skip `from-compose`) | — |
-| Already an Olares chart | go straight to validation | a chart that passes `chart lint` |
-
-The image-building work is **guided** — you check/install docker and drive `docker login` / build / push **with the developer, never on their behalf** ([references/olares-chart-image.md](references/olares-chart-image.md)). Local authoring (`from-compose` / `lint` / `package`) needs **no login**; live validation does (see below).
-
-## Capabilities (composable, loopable)
-
-| Capability | Axis | What it does | Login? | Loop back here when | Reference |
-|---|---|---|---|---|---|
-| **Image** | packaging | author a Dockerfile if needed, build + push a pullable, arch-correct image (single-arch or multi-arch per release target) | no (docker + registry) | install hits `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
-| **Compose** | deployment | obtain or author a docker-compose from the code | no | — | [compose.md](references/olares-chart-compose.md) |
-| **Convert** | deployment | `chart from-compose` scaffolds an Olares chart | no | — | [from-compose.md](references/olares-chart-from-compose.md) |
-| **Refine** | deployment | the four refinement areas / hand-author `OlaresManifest.yaml` | no | `lint` fails, or install fails on env/wiring | [manifest.md](references/olares-chart-manifest.md) |
-| **Middleware** | deployment | replace bundled db/queue with system middleware, SQLite→Postgres, depend on a ported companion app | no | bundled `postgres`/`redis`/... still in the chart, or a companion app should be a dependency | [middleware.md](references/olares-chart-middleware.md) |
-| **Env** | deployment | declare app config (`envs[]`), prompt the user at install, map system/user vars via `valueFrom`, `type`/`regex` validation | no | install fails on `appenv` 422 (missing/invalid env), or config must be user-supplied | [env.md](references/olares-chart-env.md) |
-| **Run-as-user** | packaging + deployment | align image uid with Olares userspace (1000): Dockerfile `USER`, `spec.runAsUser`, initContainer `chown` | no | EACCES on appData/appCache/userData, OPA root deny on third-party image | [run-as-user.md](references/olares-chart-run-as-user.md) |
-| **GPU / models** | packaging + deployment | build a CUDA image without a local GPU; download model weights via initContainer into the shared `appCommon` Hugging Face cache | no | AI app needs CUDA build or model provisioning, custom-kernel arch flags, shared model cache | [gpu.md](references/olares-chart-gpu.md) |
-| **Accelerator** | deployment | declare `spec.accelerator` modes (nvidia/amd-gpu/apple-m/cpu/...) per what the repo supports, and size CPU/memory/GPU-memory | no | GPU/accelerator app needs a resource envelope, or `lint` flags `spec.resources` | [accelerator.md](references/olares-chart-accelerator.md) |
-| **DinD** | packaging + deployment | give a terminal/agent app a `docker` CLI via a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`) while keeping the main container non-privileged | no | app must run `docker` / `docker compose` / containerized dev stacks from the terminal | [dind.md](references/olares-chart-dind.md) |
-| **Shared** | deployment | make the app an admin-installed, cluster-wide shared backend (`apiVersion: v3` ⇒ `<app>-shared` namespace, admin-only, cross-namespace Service DNS for consumers) | no | heavy/accelerator backend with its own accounts, multi-user, shared data; consumed by separate reference apps | [shared.md](references/olares-chart-shared.md) |
-| **Validate-local** | deployment | `chart lint` + `chart package` | no | — | [lint.md](references/olares-chart-lint.md) |
-| **Publish-local** | publishing | `market upload` + `market install` + diagnose from logs | yes | — | [publish-verify.md](references/olares-chart-publish-verify.md) |
-| **Publish-market** | publishing | market-ready checklist + `beclab/apps` PR guidance | no (GitHub) | local validation passed, user wants public Market listing | [market-submit.md](references/olares-chart-market-submit.md) |
-
-> **Publish-local** leans on sibling skills: [`olares-shared`](../olares-shared/SKILL.md) (login check), [`olares-market`](../olares-market/SKILL.md) (upload / install / cleanup), [`olares-cluster`](../olares-cluster/SKILL.md) (logs). **Never log in or upload on the developer's behalf without asking first.**
-
-## App archetypes (thin upstream context)
-
-When the upstream ships no compose/chart and the deployment shape is unclear, classify it into an archetype and apply a vetted Olares recipe before refining. Full templates and the canonical example chart live in [references/olares-chart-archetypes.md](references/olares-chart-archetypes.md).
-
-| Archetype | Olares mapping | Reference |
-|---|---|---|
-| Headless CLI / service (no web UI) — CLI tool, MCP server, API daemon | a **web terminal** as a visible desktop entrance + the service/MCP port as an **invisible** internal entrance (Settings-only) | [archetypes.md](references/olares-chart-archetypes.md) |
+> **Publish-local** leans on sibling skills: [`olares-shared`](../olares-shared/SKILL.md) (login check), [`olares-market`](../olares-market/SKILL.md) (upload / install / cleanup), [`olares-cluster`](../olares-cluster/SKILL.md) (logs). **Never log in or upload on the developer's behalf without asking first.** One way to sequence the whole assembly (and the file tree `from-compose` emits) lives in [references/olares-chart-workflow.md](references/olares-chart-workflow.md) — a reference, not a required order.
 
 ## Routing (this skill vs siblings)
 
-Use this skill to **author/validate your own** Olares chart from a repo, compose, or Helm chart (see the state tables above for where to start). Hand off to a sibling when the task is not authoring:
+Use this skill to **author/validate your own** Olares chart from a repo, compose, or Helm chart. Hand off to a sibling when the task is not authoring:
 
 | User intent | Where |
 |---|---|
 | Turn a repo / compose / Helm chart into an Olares app, or validate one you authored | ✅ this skill |
 | Run the app on **my own** Olares (upload + install) | ✅ this skill — release target **local-run** |
 | Publish / list the app on the **public** Olares Market | ✅ this skill — release target **market-distribute** → [market-submit.md](references/olares-chart-market-submit.md) |
-| "My chart won't install / the app won't start — why?" | ✅ this skill — diagnosis step of [references/olares-chart-publish-verify.md](references/olares-chart-publish-verify.md) (then [`olares-cluster`](../olares-cluster/SKILL.md) for deeper log digging) |
+| "My chart won't install / the app won't start — why?" | ✅ this skill — diagnosis step of [publish-verify.md](references/olares-chart-publish-verify.md) (then [`olares-cluster`](../olares-cluster/SKILL.md) for deeper log digging) |
 | "Just install / upgrade an existing catalog app" (not validating your own chart) | [`olares-market`](../olares-market/SKILL.md) |
 | "Inspect pods / logs of an unrelated running app" | [`olares-cluster`](../olares-cluster/SKILL.md) |
-
-> **Mental model:** the heart of this skill is **authoring** (produce a valid chart on disk). **Publish-local** — uploading and running the chart on the developer's Olares — proves it works for local-run. **Publish-market** — polishing metadata and opening a PR — is the path to the public catalog. Routine app-store lifecycle on apps you did not author belongs to `olares-market`.
 
 ## CLI verbs
 
@@ -137,28 +103,16 @@ The only `olares-cli chart` subcommands (source of truth: `--help`). Everything 
 
 | Verb | What it does | Reference |
 |---|---|---|
-| `from-compose` (alias `init`) | kompose-convert compose file(s) into an Olares chart skeleton | [references/olares-chart-from-compose.md](references/olares-chart-from-compose.md) |
-| `lint` | validate a chart dir / `.tgz` with the Market ingest pipeline | [references/olares-chart-lint.md](references/olares-chart-lint.md) |
-| `package` | package a chart dir into a `<name>-<version>.tgz` for upload (mirrors `helm package`, no helm binary needed) | [references/olares-chart-workflow.md](references/olares-chart-workflow.md) (D4 / M3) |
+| `from-compose` (alias `init`) | kompose-convert compose file(s) into an Olares chart skeleton | [from-compose.md](references/olares-chart-from-compose.md) |
+| `lint` | validate a chart dir / `.tgz` with the Market ingest pipeline | [lint.md](references/olares-chart-lint.md) |
+| `package` | package a chart dir into a `<name>-<version>.tgz` for upload (mirrors `helm package`, no helm binary needed) | [workflow.md](references/olares-chart-workflow.md) (D4 / M3) |
 
-## Typical assembly & conversion output
+## Special porting patterns & official ports (beclab/apps)
 
-One way to compose the capabilities (packaging → deployment authoring → publish-local → publish-market), plus the file tree `from-compose` emits, lives in [references/olares-chart-workflow.md](references/olares-chart-workflow.md). It is **not** a fixed pipeline — start wherever your state tables put you, and loop across the coupling edges as failures surface. Step D1 scaffolds a chart that **already passes `lint`** but is not yet a good app; the value you add is the refinement below.
+Most of this skill assumes a web app with an HTTP entrance. When the upstream doesn't fit, match a known pattern first; if still unsure, see how the official ports solved it.
 
-## The four refinement areas (the actual work)
-
-kompose cannot decide these — you must. Full field-by-field mapping and edit recipes are in [references/olares-chart-manifest.md](references/olares-chart-manifest.md).
-
-1. **Metadata** — kompose leaves a stub (`title=name`, default icon, `Utilities` category, no developer info). **Depth depends on release target:** local-run can keep the stub if `lint` passes; market-distribute requires full `metadata.{title,icon,description,categories}` and `spec.{developer,website,sourceCode,submitter,fullDescription}` plus listing images.
-2. **Storage** — compose `volumes:` become raw PVCs. Decide each one: app-private state → `.Values.userspace.appData` / `.Values.userspace.appCache` (set `permission.appData/appCache: true`); user-visible files → `.Values.userspace.userData` + list the path under `permission.userData`. Delete the kompose PVCs you replaced and rewrite the `volumeMounts`. Align run identity (uid 1000) with [run-as-user.md](references/olares-chart-run-as-user.md). **Same for both release targets.**
-3. **Middleware & dependencies** — drop any bundled `postgres`/`redis`/`mongo`/`mysql`/`mariadb`/`minio`/`rabbitmq`/`nats` workload + its PVC and wire to Olares **system middleware** (`middleware:` block + an `options.dependencies` `type: middleware` entry, env repointed at `.Values.<mw>.*`); `lint` won't flag a bundled db, so it's on you. If the upstream defaults to **SQLite**, switch to Postgres where supported. If it bundles a **companion app** already in the Market (e.g. searxng), depend on it via `options.dependencies` `type: application` instead. Full rules, Postgres extension catalog, and the escape hatch: [middleware.md](references/olares-chart-middleware.md). **Same for both release targets.**
-4. **Entrances & ports** — keep/add one `entrances[]` per user-facing HTTP service (tune `host`/`port`/`title`/`authLevel`); expose non-HTTP services via `ports[]` (`exposePort`). Mark internal-only services `invisible: true` or drop their entrance. **Same for both release targets.**
-
-> **Env wiring (cross-cutting):** any config the app needs — user-supplied at install (admin credentials via `required`), reused Olares system/user vars (`valueFrom`), middleware connection strings — is declared in `envs[]` and surfaced as `.Values.olaresEnv.<name>`, then mapped into the workload's `env:`. Full rules (system/user/app levels, `required` vs optional, `type`/`regex` validation): [references/olares-chart-env.md](references/olares-chart-env.md), with worked examples and the default `OLARES_SYSTEM_*`/`OLARES_USER_*` variable lists in [references/olares-chart-env-defaults.md](references/olares-chart-env-defaults.md).
-
-## Reference official ports (beclab/apps)
-
-When you need inspiration or are unsure how Olares expects something wired (manifest fields, entrance shapes, middleware/app dependencies, GPU specs), look at how the official ports do it in [beclab/apps](https://github.com/beclab/apps) before guessing:
+- **Headless CLI / service (no web UI)** — no GUI to point an entrance at: add a web-terminal sidecar as a **visible** entrance + expose the API/MCP port as an `invisible` internal entrance. → [archetypes.md](references/olares-chart-archetypes.md)
+- **Still no idea?** look at how the official ports wire it (manifest fields, entrance shapes, middleware/app dependencies, GPU specs) in [beclab/apps](https://github.com/beclab/apps) before guessing:
 
 ```bash
 gh search code --repo beclab/apps <keyword>      # find charts using a pattern (e.g. type: application, accelerator, appCommon)
@@ -167,20 +121,10 @@ gh search code --repo beclab/apps <keyword>      # find charts using a pattern (
 
 This is the canonical source for cross-app wiring (how a dependency app is reached, real `entrances`/`ports`, accelerator modes) that this skill intentionally does not hardcode.
 
-## Hard constraints that bite
+## Gotchas (what `lint` won't catch)
 
-- **Pin every `image:` to a specific version tag** (e.g. `nginx:1.27`, `<user>/<repo>:1.2.3`). **Never use `:latest`** or an untagged image (implicit `latest`): it drifts, making installs non-reproducible and rollbacks/caching unreliable — and Olares pulls images, it never rebuilds. `lint` does **not** catch this; it is the author's responsibility.
-- **Set `apiVersion: v3` in `OlaresManifest.yaml`** (skill rule for 1.12.6+ ports). `from-compose` omits it (implicit `v1`), so hand-add it after scaffolding. v3 enables the declarative env rules (`valueFrom`, no inline `OLARES_USER`); `lint` allows `v1`/`v2`/`v3` and does **not** force it. On Olares >= 1.12.6 the install handler treats **v3 as an admin-installed, cluster-wide shared app** (`<app>-shared` namespace, admin-only) — so flag the admin-install requirement to the user, and for a multi-user shared backend follow [shared.md](references/olares-chart-shared.md). Details: [versioning.md](references/olares-chart-versioning.md).
-- **`metadata.name` must match the chart folder name and `Chart.yaml` `name`**, and be `^[a-z][a-z0-9]{0,29}$`. `from-compose --name` keeps them consistent; if you rename the folder, fix all three.
-- **At least one entrance is required.** Never delete the last `entrances[]` entry.
-- **If a template uses `.Values.userspace.appData`/`appCache`/`userData`, the matching `permission` field MUST be declared**, or `lint` fails the app-data cross-check.
-- **`hostPath` volumes + rolling updates are incompatible** — `lint` rejects them. Replace host mounts with the userspace volumes above.
-- **A Docker-in-Docker daemon sidecar must use a trusted `beclab/docker` image and be the only `privileged: true` container**, paired with `strategy: Recreate` (it relies on `hostPath`); the main container stays non-privileged. Non-trusted privileged images are denied by OPA. Details: [dind.md](references/olares-chart-dind.md).
-- **`metadata.version` (Chart Version) and `Chart.yaml` `version` must match**, and `spec.versionName` should track the upstream app version (`Chart.yaml` `appVersion`).
+`lint` validates structure, not Olares correctness. Beyond the concerns table above, these blind spots bite and are entirely on you:
 
-## Common errors → where to fix
-
-- **`lint` failures** (workload not named after the app, app-data/permission mismatch, version mismatch, hostPath + rolling update, namespace, missing resource limits): full failure→fix table in [lint.md](references/olares-chart-lint.md).
-- **Install OK but Permission denied / data not persisted**, or **admission denied (untrusted image + root)**: image uid ≠ 1000 — [run-as-user.md](references/olares-chart-run-as-user.md).
-- **`ImagePullBackOff` / wrong arch**: [image.md](references/olares-chart-image.md).
-- **Install/start failure needing logs**: diagnosis step in [publish-verify.md](references/olares-chart-publish-verify.md).
+- **`metadata.name` must match the chart folder and `Chart.yaml` `name`**, and be `^[a-z][a-z0-9]{0,29}$`. Rename all three together.
+- **Declared `.Values.userspace.appData`/`appCache`/`userData` mounts MUST have the matching `permission` field**, or the app-data cross-check fails.
+- **`hostPath` volumes + rolling updates are incompatible** — replace host mounts with the userspace volumes above.

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-chart
-version: 4.1.0
+version: 4.2.0
 description: "Olares Chart via olares-cli chart — from-compose, lint, package; turn compose/Helm/repo into an Olares app chart. Release targets: local-run (upload on your Olares) or market-distribute (public Market). Use for OlaresManifest, docker-compose to Olares, chart lint/package, Market upload, ImagePullBackOff."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only
 metadata:
@@ -15,6 +15,8 @@ metadata:
 > **Source of truth for flags is always `olares-cli chart <verb> --help`.** This file only carries what `--help` cannot: when to use this skill, the convert→refine→lint loop, release-target routing, and the four refinement areas that turn a raw conversion into a working chart.
 
 > **Porting baseline: Olares >= 1.12.6.** This skill targets Olares >= 1.12.6 (other `olares-cli` features have no such floor). Check the target with `olares-cli profile list` (VERSION column). Full version rules — `apiVersion: v3`, the several chart version fields, `type: system` dependency — are in [references/olares-chart-versioning.md](references/olares-chart-versioning.md).
+
+> **Platform model (read once, no login needed for authoring).** The porting decisions below rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). **Packaging an image and authoring/validating the chart (`from-compose` / `lint` / `package`) need no profile login.** Only **pushing to a real Olares to test** (`market upload` + `install`) requires login (see Publish-local below).
 
 ## When to use
 
@@ -34,6 +36,21 @@ metadata:
 - Version rules: Olares system version (semver), `apiVersion: v3`, `olaresManifest.version` 0.8.0 vs 0.12.0, `metadata.version` vs `spec.versionName`, `type: system` dependency, checking the target with `profile list`
 - Three axes: **packaging** (Dockerfile/image), **deployment** (compose/chart), **publishing** (release target); four post-kompose refinement areas (metadata depth gated by target, storage, middleware, entrances)
 - Optional live validation (requires login): package + market upload/install — see [`olares-shared`](../olares-shared/SKILL.md), [`olares-market`](../olares-market/SKILL.md), [`olares-cluster`](../olares-cluster/SKILL.md)
+
+## Olares readiness checklist (think through these before declaring a port done)
+
+kompose/`from-compose` produces a chart that lints but is not yet a good Olares app. Every ported app must satisfy the items below — use this as the entry index; each links to where the actual work is described. (Platform background for all of them: [platform.md](../olares-shared/references/olares-platform.md).)
+
+- **Image** — pullable from a registry, pinned to a version tag (never `:latest`), arch-correct (node arch for local-run; multi-arch for market). Olares pulls images, never builds. → [image.md](references/olares-chart-image.md)
+- **Run identity** — process runs as uid 1000; `spec.runAsUser: true`; initContainer `chown` for root-owned volumes; no root main on non-trusted images (OPA). → [run-as-user.md](references/olares-chart-run-as-user.md)
+- **Storage** — every compose volume mapped to the right userspace area (Data / Cache / Home / Common / External), matching `permission` declared, leftover kompose PVCs deleted. → [manifest.md](references/olares-chart-manifest.md) §2
+- **Middleware** — no bundled `postgres`/`redis`/`mongo`/...; wired to system middleware; SQLite switched to Postgres where supported; companion apps declared as `type: application` deps. → [middleware.md](references/olares-chart-middleware.md)
+- **Entrances & ports** — at least one `entrances[]`; HTTP via entrances, non-HTTP via `ports[]`; internal-only services `invisible: true`; headless apps use the web-terminal archetype. → [manifest.md](references/olares-chart-manifest.md) §4, [archetypes.md](references/olares-chart-archetypes.md)
+- **Env** — app config declared in `envs[]` (v3 `valueFrom`, no inline `OLARES_USER`); install-time `required` prompts; middleware/system/user vars mapped. → [env.md](references/olares-chart-env.md)
+- **Version** — `apiVersion: v3`; `olaresManifest.version` 0.8.0 vs 0.12.0; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`). → [versioning.md](references/olares-chart-versioning.md)
+- **Shared-app gating** — `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; flag this to the user; for a deliberate multi-user backend follow shared. → [shared.md](references/olares-chart-shared.md)
+- **Resources / accelerator** — a sane CPU/memory envelope; for GPU apps the `spec.accelerator` modes match the image arch and `requiredGPUMemory` is set. → [accelerator.md](references/olares-chart-accelerator.md)
+- **Lint** — `olares-cli chart lint ./<app>` passes (it does NOT catch pinned tags, bundled dbs, or apiVersion — those are on you). → [lint.md](references/olares-chart-lint.md)
 
 ## Start here: establish your release target
 

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -64,15 +64,7 @@ Category values: [manifest docs](https://docs.olares.com/developer/develop/packa
 
 > **Same for both release targets** — functional requirement, not cosmetic.
 
-Each compose volume became a raw `persistentvolumeclaim-*.yaml`. Map each to a userspace area (table below), **delete the PVC template you replace**, and rewrite `volumeMounts` to the injected userspace path. Olares exposes five mountable areas:
-
-| Dir | Mount value | Permission | Files entry | Scope | Backend / traits |
-|---|---|---|---|---|---|
-| **Home** | `.Values.userspace.userData` | `userData` (list paths) | `drive/Home` | user-level (shared by the user's apps that get the perm) | JuiceFS — cross-node, backed up; for **user-visible** files |
-| **Cache** | `.Values.userspace.appCache` | `appCache: true` | `cache/<node>` | per-app (auto `/<appName>`) | **node-local PV** (`/olares/userdata/Cache/`) — pins the pod to that node via `schedule.nodeName`; fast, regenerable, not guaranteed durable/backed-up |
-| **Data** | `.Values.userspace.appData` | `appData: true` | `drive/Data` | per-app (auto `/<appName>`) | JuiceFS — cross-node, backed up; for **app-private persistent state** (db files, config) |
-| **Common** | `.Values.userspace.appCommon` | `appCommon: true` | `drive/Common` | **cross-app shared** (no `appName` suffix) | JuiceFS; reserved `huggingface`/`ollama`/`llama.cpp`/`comfyui` shared caches; needs Olares ≥ 1.12.6 |
-| **External** | `.Values.sharedlib` | `externalData: true` | `external/<node>/<volume>` | user's external storage | SMB/NFS/USB volumes the user attaches via LarePass; needs schema ≥ 0.12.0 |
+Each compose volume became a raw `persistentvolumeclaim-*.yaml`. Map each to a userspace area, **delete the PVC template you replace**, and rewrite `volumeMounts` to the injected userspace path. The five areas — their mount values, `permission` fields, backends (JuiceFS vs node-local PV), scope, uid-1000 ownership, and version gates — are defined once in the platform **Userspace storage model** (loaded via the SKILL.md prerequisite). **Pick by need:** private db/config → **Data** (`appData`); regenerable cache → **Cache** (`appCache`); user-facing files → **Home** (`userData`); multi-app shared model weights / HF cache → **Common** (`appCommon`, see [olares-chart-gpu.md](olares-chart-gpu.md) §B); external disk/network share → **External** (`sharedlib`).
 
 ```yaml
 permission:
@@ -82,14 +74,6 @@ permission:
   userData:
   - Home/Documents/MyApp/
 ```
-
-Key differences to remember when authoring:
-
-- **Per-app vs shared vs user.** `appData`/`appCache` auto-append `/<appName>` (app-private); `appCommon` is bare `/rootfs/Common` (every app with the perm sees the same dir — that's what makes shared model caches work); `userData` is the user's `/Home`.
-- **Backend decides scheduling + durability.** `userData`/`appData`/`appCommon` are JuiceFS (cross-node, backed up). `appCache` is a node-local PV, so app-service pins the pod to that node — fast local disk, but treat it as disposable.
-- **Owner is uid 1000.** All five are read/written as uid/gid 1000 (`appCommon` is created `chown 1000:1000`). If the main process runs as 1000 it can write any of them directly — see [olares-chart-run-as-user.md](olares-chart-run-as-user.md).
-- **Version gates.** `appCommon` needs Olares ≥ 1.12.6; `externalData`/`sharedlib` needs `olaresManifest.version` ≥ 0.12.0.
-- **Pick by need.** Private db/config → **Data**; regenerable cache → **Cache**; user-facing files → **Home**; multi-app shared model weights / HF cache → **Common** (see [olares-chart-gpu.md](olares-chart-gpu.md) §B); external disk/network share → **External**.
 
 In the deployment template, replace the PVC mount with the injected host path (`appData`/`appCache` are host paths):
 

--- a/cli/skills/olares-chart/references/olares-chart-middleware.md
+++ b/cli/skills/olares-chart/references/olares-chart-middleware.md
@@ -95,7 +95,7 @@ Env wiring in the deployment (PostgreSQL example; Redis/Mongo/MySQL/MariaDB/MinI
 
 > **Env wiring is its own topic.** The `.Values.<mw>.*` mappings above, plus app config the user supplies at install (admin credentials), reused `OLARES_SYSTEM_*`/`OLARES_USER_*` vars, and the `envs[]` `required`/`type`/`regex` rules, are all covered in [olares-chart-env.md](olares-chart-env.md).
 
-> **PostgreSQL and Redis are always available — no admin pre-install, no extra steps.** Given the extension catalog above (vector/vectors/vchord/postgis/zhparser/... + standard contrib), the system postgres covers nearly every app, so reach for it by default. MongoDB, MySQL, MariaDB, MinIO, RabbitMQ require an admin to install them from the Market first.
+> **Which middleware is always available vs admin-installed** is the platform **System middleware model** (loaded via the SKILL.md prerequisite): PostgreSQL + Redis are always on; MongoDB/MySQL/MariaDB/MinIO/RabbitMQ/NATS need an admin install first. Given the extension catalog above, the system postgres covers nearly every app, so reach for it by default.
 >
 > **Escape hatch (rare):** keep a self-hosted db ONLY when the app needs a specific version or extension that the system middleware genuinely cannot provide — and only after checking the extension catalog above. State the exact missing version/extension when you do; "it's simpler" is not a valid reason.
 

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -1,9 +1,9 @@
 # Run identity: UID/GID 1000 (packaging + deployment)
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
-> Olares userspace volumes (`appData`, `appCache`, `userData`) are owned and accessed as **uid/gid 1000**. This doc covers how to align a self-built or third-party image with that convention — in the Dockerfile, in `OlaresManifest.yaml`, and in deployment templates.
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first (which loads the platform **Run identity** model — uid-1000 ownership of userspace volumes + the OPA root-deny rule).
+> This doc covers the chart-side delta: how to align a self-built or third-party image with that convention — in the Dockerfile, in `OlaresManifest.yaml`, and in deployment templates.
 
-## Why 1000 matters
+## Why 1000 matters (chart-side)
 
 - Userspace paths injected via `.Values.userspace.*` expect the app process to run as **1000**.
 - Setting `spec.runAsUser: true` in `OlaresManifest.yaml` tells Olares to inject `pod.spec.securityContext.runAsUser: 1000` at Pod creation (app-service mutating webhook).

--- a/cli/skills/olares-chart/references/olares-chart-shared.md
+++ b/cli/skills/olares-chart/references/olares-chart-shared.md
@@ -80,11 +80,7 @@ Required / expected fields:
 
 ## How consumers (reference apps) reach it
 
-A shared app is consumed by **separate reference/client apps**, not by per-user copies of itself:
-
-1. The client declares the dependency: `options.dependencies` with `type: application` on the shared app.
-2. At render time app-service injects the shared namespace's Services into the client's Helm values as `.Values.svcs.<svcName>_host` (= `<svcName>.<app>-shared`) and `.Values.svcs.<svcName>_ports`. The client points its config at that host — a plain in-cluster Service DNS, **no entrance/URL involved**.
-3. Cross-namespace reachability is automatic: a v3 shared app gets the mesh sidecar + NetworkPolicy that allow other namespaces to call it.
+A shared app is consumed by **separate reference/client apps**, not by per-user copies of itself. The client declares an `options.dependencies` `type: application` on the shared app; app-service then injects the shared namespace's Services into the client's Helm values and grants cross-namespace reachability automatically. The full mechanism (`.Values.svcs.<svc>_host` = `<svc>.<app>-shared`, mesh sidecar + NetworkPolicy, no entrance/URL) is the platform **App, namespace & networking model** (loaded via the SKILL.md prerequisite).
 
 ## Legacy v2 shared form (context only)
 

--- a/cli/skills/olares-chart/references/olares-chart-versioning.md
+++ b/cli/skills/olares-chart/references/olares-chart-versioning.md
@@ -4,29 +4,11 @@
 
 ## Olares system version
 
-Olares releases follow [semver](https://docs.olares.com/developer/install/versioning.html) — `Major.Minor.Patch[-PreRelease]`:
-
-| Release type | Example |
-|---|---|
-| Stable | `1.12.6` |
-| Release candidate | `1.12.0-rc.0` |
-| Daily build | `1.12.0-20241201` |
-
-The running version lives in the `Terminus` CR `spec.version` and is injected into every chart as `.Values.sysVersion`. "At least" comparisons strip the prerelease/build segment, so a daily build like `1.12.6-20260327` still counts as `>= 1.12.6`.
+The semver scheme (stable / RC / daily), `.Values.sysVersion`, the `-0` prerelease-matching rule, and how to read the target version (`profile list` VERSION column, `--refresh-version`, `settings me version`) are the platform **Olares version & semver model** (loaded via the SKILL.md prerequisite).
 
 ## Porting baseline: Olares >= 1.12.6
 
-**This skill (porting apps) targets Olares >= 1.12.6.** This baseline applies only to porting — other `olares-cli` features have no such floor. The reason: the userspace backends a ported app commonly relies on — `drive/Common` (`appCommon`), archive, and NFS — are gated at `1.12.6`.
-
-Check the target Olares version before porting:
-
-```bash
-olares-cli profile list        # VERSION column shows each profile's Olares version
-olares-cli profile list --refresh-version   # re-fetch for the active profile
-olares-cli settings me version               # live fetch of the running version
-```
-
-`profile list` shows a `VERSION` column — the cached `BackendVersion`, populated at login from `/api/olares-info` `osVersion` (which comes from the Terminus CR). See [`olares-shared`](../../olares-shared/SKILL.md) for profile management.
+**This skill (porting apps) targets Olares >= 1.12.6.** This baseline applies only to porting — other `olares-cli` features have no such floor. The reason: the userspace backends a ported app commonly relies on — `drive/Common` (`appCommon`), archive, and NFS — are gated at `1.12.6`. Check the target before porting (`olares-cli profile list` VERSION column; `--refresh-version` or `settings me version` for a live re-fetch).
 
 ## apiVersion: v3 (skill rule)
 

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-cluster
-version: 4.1.0
+version: 4.2.0
 description: "Olares ControlHub K8s view via olares-cli cluster — pods, workloads, logs, scale/restart, jobs, cronjobs, middleware. Not for app lifecycle (market) or host install (node/os/gpu). Use for ControlHub, pods, logs, workloads."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -13,6 +13,8 @@ metadata:
 # cluster (per-user K8s view)
 
 **CRITICAL — before doing anything, load the `olares-shared` skill first (profile model, login, token refresh, auth-error recovery). Flag reference: `olares-cli cluster --help`.**
+
+> **Platform model (read once):** the app/namespace model (`<app>-<owner>` vs `<app>-shared`, application spaces, cross-namespace DNS) and the system-middleware model that this view surfaces are defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). This skill is the **K8s runtime** view of them.
 
 > **Source of truth for flags & wire shapes is always `olares-cli cluster <noun> <verb> --help`.** This file only carries what `--help` cannot give: routing, the mental model of nouns, the identity-vs-server principle, the mutating-verb safety contract, cross-verb output conventions, and the common-errors → fix table.
 

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-dashboard
-version: 4.1.0
+version: 4.2.0
 description: "Olares Dashboard via olares-cli dashboard — CPU, memory, disk, network, pods, fan, GPU, ranking, applications; JSON envelope and --watch. Use for Olares Dashboard, overview, resource usage, Olares One fan."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-files
-version: 4.1.0
+version: 4.2.0
 description: "Olares Files via olares-cli files — ls, upload, download, edit, share, SMB mount, Seafile sync on drive/Home, drive/Data, cache, external, cloud. Use for Olares Files, drive, upload, download, share, SMB, LarePass Files."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -13,6 +13,8 @@ metadata:
 # files (per-user files-backend)
 
 **CRITICAL — before running any verb here, load the `olares-shared` skill first (profile selection, login, 401/403 recovery). Flag reference: `olares-cli files --help`.**
+
+> **Platform model (read once):** the storage areas these paths address — the five userspace areas, their backends/durability, uid-1000 ownership, and the system-managed `drive/Home` directories — are defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). This skill only adds the **addressing** view.
 
 > **Source of truth for flags & wire shapes is always `olares-cli files <verb> --help`.** This file only carries what `--help` cannot give: the cross-cutting frontend-path concept, the trailing-slash convention, the five client-side hard constraints, and the verb index.
 
@@ -91,16 +93,14 @@ This level has no backing filesystem — it just enumerates attached volumes (`h
 
 CLI client-side guards: `mkdir`, `cp` destination, `mv` destination, `upload`, AND `share` (all flavors) reject `external/<node>/` (and one level deeper for `mkdir`). Errors point at the corrected shape `external/<node>/<volume>/<sub>/`. Pure reads (`ls`, `cat`, `rm`, `rename`) DO work — that's how the user discovers what volumes are attached. Mount new volumes via LarePass, not via files-backend mkdir.
 
-### 4. `drive/Home/{Pictures, Music, Movies, Downloads, Documents, Code, Cache, Data, Home, Ollama, Huggingface}` are system-managed
+### 4. The system-managed `drive/Home` directories are protected
 
-These eleven names under `drive/Home/` are LarePass bootstrap directories that user apps look up by exact name (e.g. the model-runtime app's `Ollama` cache, the LarePass UI's "Pictures" sidebar tile). The LarePass GUI greys out cut / copy / paste / delete / rename for them, and so does the CLI:
+The eleven LarePass bootstrap directories under `drive/Home/` (the canonical name list, casing, and why apps depend on them are in [platform.md → System-managed Home directories](../olares-shared/references/olares-platform.md#system-managed-home-directories)). The LarePass GUI greys out cut / copy / paste / delete / rename for them, and so does the CLI:
 
 - `rename`, `rm`, and `mv source` REFUSE these names at the **first level under `drive/Home/` only**.
 - `cp` (copy) is intentionally NOT gated — duplicating bytes (e.g. `cp -r drive/Home/Pictures/ drive/Home/Pictures-Backup/`) preserves the original and is fine.
 - Content nested inside (`drive/Home/Pictures/Trip2024/`) is fully editable.
 - Other namespaces (`drive/Data/Pictures`, `sync/<repo>/Pictures`, `external/...`) are unaffected.
-
-Note LarePass casing: `Huggingface` is one word (not `HuggingFace`). Names are case-sensitive.
 
 ### 5. `cache/<node>/` is a node-picker for share-create only
 

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-market
-version: 4.1.0
+version: 4.2.0
 description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, upload chart."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -15,6 +15,8 @@ metadata:
 **CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli market --help`.**
 
 > **Source of truth for flags is always `olares-cli market <verb> --help`.** This file only carries what `--help` cannot give: source resolution, the lifecycle state machine, OpType-vs-State race safety, the verb index, the `-s`/`-a` matrix, and the "what apps do I have" routing.
+
+> **Platform model:** app namespaces (`<app>-<owner>` vs the admin-only `<app>-shared`) and which system-middleware apps an admin installs are defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md#app-namespace--networking-model).
 
 ## When to use
 

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-settings
-version: 4.1.0
+version: 4.2.0
 description: "Olares Settings via olares-cli settings — mirror of Settings SPA: users, apps, VPN, backup, integration, GPU, search, me/whoami. Use for Olares Settings, role, VPN ACL, backup, integration accounts, language."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -15,6 +15,8 @@ metadata:
 **CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli settings --help`.**
 
 > **Source of truth for flags is always `olares-cli settings <area> <verb> --help`.** This file only carries what `--help` cannot give: routing, the 13-section index, the role-caching / admin-vs-normal floor, the wire-format cheat sheet, and the common-errors table.
+
+> **Platform model:** the Olares version/semver scheme behind `settings me version` is defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md#olares-version--semver-model).
 
 ## When to use
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-shared
 version: 4.2.0
-description: "Olares profile and auth foundation for olares-cli — prerequisite for all olares-* skills. Profile login, import, list, use, remove, keychain tokens, 401/403 recovery. Use for Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, auth errors."
+description: "Set up and manage the Olares login/identity that every other olares-cli skill depends on — one profile per Olares ID, keychain-stored tokens, transparent token refresh, and auth-error recovery. Use for Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, and auth errors (token rejected / invalidated / not logged in)."
 compatibility: Requires olares-cli on PATH
 metadata:
   openclaw:
@@ -20,8 +20,10 @@ Foundation for every other `olares-cli` skill. Every business verb under `cluste
 
 ## When to use
 
-- Olares, Olares ID, olares-cli, OpenClaw on Olares, profile, login, logout, two-factor / 2FA / TOTP, refresh token, keychain
-- Auth errors: `server rejected the access token`, `refresh token for X became invalid`, `no access token for X`, `already authenticated`, `two-factor authentication required`
+- First time operating on an Olares / a given Olares ID (not logged in yet) — set up the profile
+- Switching identity between several Olares IDs
+- Any `olares-cli` command failed with an auth error (token invalidated / not logged in / 2FA required)
+- Keywords: Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, `server rejected the access token`, `refresh token ... became invalid`, `no access token`, `already authenticated`
 
 ## Profile model
 
@@ -31,7 +33,7 @@ One profile = one Olares instance + one user identity, keyed by **olaresId** (e.
 |---------|---------|
 | `olares-cli profile login` | Mode A — password (+ TOTP if 2FA is on); auto-creates the profile on first run |
 | `olares-cli profile import` | Mode B — bootstrap an access_token from an existing refresh_token |
-| `olares-cli profile list` | List every profile, mark the current one, show login status per profile |
+| `olares-cli profile list` | List every profile (NAME / OLARES-ID / STATUS / VERSION), mark the current one, show login status; `--refresh-version` re-reads the current profile's cached backend version |
 | `olares-cli profile use <name\|->` | Switch the current profile; `-` reverts to the previous one (like `cd -`) |
 | `olares-cli profile remove <name>` | Delete a profile and its stored token in one shot |
 
@@ -46,8 +48,7 @@ olares-cli profile login --olares-id <olaresId>
 ```
 
 - Interactive: prompts for password (echo disabled); prompts for TOTP if 2FA is enabled.
-- Scripted: pipe via `--password-stdin`; if 2FA is on, you MUST also pass `--totp <code>` because there is no second prompt.
-- **There is no `--password <plaintext>` flag** — passwords are never accepted on the command line.
+- Scripted: pipe via `--password-stdin`; if 2FA is on, you MUST also pass `--totp <code>` because there is no second prompt. (Passwords only ever go through the TTY or `--password-stdin` — see Security rules.)
 
 ### Mode B — existing refresh_token
 
@@ -66,22 +67,22 @@ When you (an AI agent) drive the login on the user's behalf, do NOT pass passwor
 `profile list` output:
 
 ```
-   NAME             OLARES-ID              STATUS
-*  alice            alice@olares.com       logged-in (23h59m)
-   bob              bob@olares.com         expired
-   eve              eve@olares.com         invalidated
-   frank            frank@olares.com       never
+   NAME             OLARES-ID              STATUS        VERSION
+*  alice            alice@olares.com       logged-in     1.12.6
+   bob              bob@olares.com         expired        1.12.5
+   eve              eve@olares.com         invalidated   -
+   frank            frank@olares.com       never         -
 ```
 
 | STATUS | Meaning | Recovery |
 |--------|---------|----------|
-| `logged-in (Xh Ym)` | Token valid; column shows time-to-expiry | — |
-| `logged-in` | Token present but JWT has no exp claim (can't verify locally) | Trust until the server says no |
+| `logged-in` | Token valid — JWT exp is in the future, **or** the JWT carries no exp claim (can't verify locally; trust until the server says no) | — |
 | `expired` | JWT exp is in the past | `profile login` |
 | `invalidated` | Server explicitly rejected the refresh leg | `profile login` directly (no need to `profile remove` first) |
 | `never` | No token has ever been stored | `profile login` or `profile import` |
+| `unknown` / `logged-in (unparseable token)` | Token store couldn't be read / the JWT couldn't be parsed | re-run `profile login` if it persists |
 
-The leading `*` marks the current profile. `profile use` accepts either the NAME alias or the olaresId.
+STATUS reflects only what the local token store can prove without a network call (no `(Xh Ym)` time-to-expiry is printed). The `VERSION` column is the cached Olares backend version (`-` until a login eager-fetch or a version-aware command populates it; `--refresh-version` re-reads it). The leading `*` marks the current profile; `profile use` accepts either the NAME alias or the olaresId.
 
 ## Token storage
 
@@ -103,7 +104,7 @@ After `login` / `import` succeeds, the CLI prints `token stored via <backend> (s
 
 **The CLI rotates expired access_tokens transparently.** Users do NOT need to run `profile login` just because their access_token aged out — only when the *refresh_token itself* becomes invalid.
 
-- Replayable requests (every JSON verb, `files cat`, `files download`, `files rm`, `market` verbs, …): on 401/403 the transport calls `/api/refresh` and retries once with the new token.
+- Replayable requests (every JSON verb, `files cat`, `files download`, `files rm`, `market` verbs, …): on 401/403/459 the transport calls `/api/refresh` and retries once with the new token. (459 is Olares' edge / Authelia "auth failed" status, treated like 401/403.)
 - Streaming uploads (`files upload` chunks): pre-decode the JWT exp; if within 60s of expiry, refresh BEFORE sending, because once a `*os.File` chunk is consumed it can't be replayed on a 401.
 
 Across goroutines AND across concurrent `olares-cli` processes, `/api/refresh` is hit at most once per stale token (in-process mutex + cross-process flock).
@@ -116,7 +117,7 @@ Across goroutines AND across concurrent `olares-cli` processes, `/api/refresh` i
 |-------------------------|---------|-----|
 | `refresh token for <id> became invalid at <ts>` | `/api/refresh` returned 401/403 — the grant is dead | `olares-cli profile login --olares-id <id>` |
 | `no access token for <id>` | Profile selected but keychain has no entry | `olares-cli profile login` or `profile import` |
-| `server rejected the access token (HTTP 401)` / `(HTTP 403)` | After auto-refresh the server still rejects (rare) | `olares-cli profile login --olares-id <id>` |
+| `server rejected the access token (HTTP 401)` / `(HTTP 403)` / `(HTTP 459)` | After auto-refresh the server still rejects (rare); 459 = Olares edge (Authelia) "auth failed", handled like 401/403 | `olares-cli profile login --olares-id <id>` |
 | `--olares-id is required` | login / import invoked without olaresId | Add `--olares-id <id>` |
 | `already authenticated for <id> (expires in ...)` | Still-valid token exists | `olares-cli profile remove <id>` then re-run |
 | `a token is already stored for <id> but its expiry can't be determined client-side` | Token present but JWT carries no exp claim | `profile remove <id>` then re-run |
@@ -124,7 +125,7 @@ Across goroutines AND across concurrent `olares-cli` processes, `/api/refresh` i
 | `password is empty` / `TOTP code is empty` | stdin / TTY returned an empty string | Check for premature EOF or an empty pipe |
 | `profile <name> not found` | `profile use` / `profile remove` referenced an unknown profile | `profile list` to see the actual names |
 
-> **Do not silently retry auth errors.** 401/403 after auto-refresh and `already authenticated` are deterministic — follow the table; blind retries make it worse.
+> These auth errors are deterministic — pick the fix from the table above (see also the auto-refresh rules), don't loop.
 
 ## Security rules
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-shared
-version: 4.1.0
+version: 4.2.0
 description: "Olares profile and auth foundation for olares-cli — prerequisite for all olares-* skills. Profile login, import, list, use, remove, keychain tokens, 401/403 recovery. Use for Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, auth errors."
 compatibility: Requires olares-cli on PATH
 metadata:
@@ -13,6 +13,8 @@ metadata:
 # olares-cli shared rules
 
 Foundation for every other `olares-cli` skill. Every business verb under `cluster` / `files` / `market` / `settings` / `dashboard` rides the active profile's token. **Read this first.**
+
+> **This skill also hosts the cross-skill platform model** in [references/olares-platform.md](references/olares-platform.md) — the userspace storage model, uid-1000 run identity, system-managed `drive/Home` dirs, app/namespace & networking, system middleware, and version/semver. `files` / `chart` / `cluster` link there (one hop) instead of re-describing it. That reference is pure platform model and needs no login.
 
 > **Source of truth for flags & syntax is always `olares-cli profile --help`.** This file only carries what `--help` cannot give: the profile mental model, agent-driven login flow, token-storage backends, refresh semantics, and the error → fix matrix.
 

--- a/cli/skills/olares-shared/references/olares-platform.md
+++ b/cli/skills/olares-shared/references/olares-platform.md
@@ -31,6 +31,8 @@ Key facts:
 - **Version gates.** `appCommon` needs Olares ≥ 1.12.6; `externalData`/`sharedlib` needs `olaresManifest.version` ≥ 0.12.0.
 - **Drive's `extend` must be `Home` or `Data` exactly** — `home` is rejected with `invalid drive type`.
 
+Used by: `files` (addressing) and `chart` (mounting).
+
 ## Run identity: uid/gid 1000
 
 Every userspace area above is owned and accessed as **uid/gid 1000**. This is the shared root cause behind two skills:
@@ -39,6 +41,8 @@ Every userspace area above is owned and accessed as **uid/gid 1000**. This is th
 - `files` — `chown` UID conventions: 0 (root) vs 1000 (the userspace owner). Only `drive/Home`, `drive/Data`, `cache/<node>` accept `chown`.
 
 OPA admission: a non-trusted image running as root (or `privileged`/`runAsNonRoot: false`) is denied. Init containers may run as root only with a trusted `beclab/` image. Chart-side alignment recipes (Dockerfile `USER`, initContainer `chown`, OPA boundaries) live in `chart`'s run-as-user reference.
+
+Used by: `chart` (runAsUser) and `files` (chown).
 
 ## System-managed Home directories
 
@@ -53,6 +57,8 @@ Platform invariants:
 - They are created and managed by LarePass; apps depend on the exact names (e.g. the model-runtime app's `Ollama` cache, the LarePass UI's `Pictures` sidebar tile).
 - Casing is significant: `Huggingface` is one word (not `HuggingFace`).
 - `files` enforces them as protected names: `rename` / `rm` / `mv source` refuse them at the **first level under `drive/Home/` only**; `cp` (copy) is allowed; nested content (`drive/Home/Pictures/Trip2024/`) is fully editable; other namespaces (`drive/Data/Pictures`, `sync/...`) are unaffected.
+
+Used by: `files` (protected names) and `chart` (reserved caches).
 
 ## App, namespace & networking model
 

--- a/cli/skills/olares-shared/references/olares-platform.md
+++ b/cli/skills/olares-shared/references/olares-platform.md
@@ -1,15 +1,6 @@
 # Olares platform concepts (single source of truth)
 
-> Cross-skill platform facts that ≥2 `olares-cli` skills rely on. Each section notes which skill reads it from which angle. Skills link here from their `SKILL.md` (one hop) instead of re-describing these facts. Pure platform model — no login/profile content (that is in [`../SKILL.md`](../SKILL.md)).
-
-## Contents
-
-- [Userspace storage model](#userspace-storage-model) — `files` (addressing) + `chart` (mounting)
-- [Run identity: uid/gid 1000](#run-identity-uidgid-1000) — `chart` (runAsUser) + `files` (chown)
-- [System-managed Home directories](#system-managed-home-directories) — `files` (protected names) + `chart` (reserved caches)
-- [App, namespace & networking model](#app-namespace--networking-model) — `chart` (shared apps / deps) + `cluster` (application space)
-- [System middleware model](#system-middleware-model) — `chart` (wire to it) + `cluster` (middleware aggregator)
-- [Olares version & semver model](#olares-version--semver-model) — `chart` (version floor) + `shared` (profile VERSION) + `settings` (me version)
+> Cross-skill platform facts that ≥2 `olares-cli` skills rely on. Each section ends with a `Used by:` note of which skill reads it from which angle. Skills link here from their `SKILL.md` (one hop) instead of re-describing these facts. Pure platform model — no login/profile content (that is in [`../SKILL.md`](../SKILL.md)).
 
 ## Userspace storage model
 

--- a/cli/skills/olares-shared/references/olares-platform.md
+++ b/cli/skills/olares-shared/references/olares-platform.md
@@ -1,0 +1,88 @@
+# Olares platform concepts (single source of truth)
+
+> Cross-skill platform facts that ≥2 `olares-cli` skills rely on. Each section notes which skill reads it from which angle. Skills link here from their `SKILL.md` (one hop) instead of re-describing these facts. Pure platform model — no login/profile content (that is in [`../SKILL.md`](../SKILL.md)).
+
+## Contents
+
+- [Userspace storage model](#userspace-storage-model) — `files` (addressing) + `chart` (mounting)
+- [Run identity: uid/gid 1000](#run-identity-uidgid-1000) — `chart` (runAsUser) + `files` (chown)
+- [System-managed Home directories](#system-managed-home-directories) — `files` (protected names) + `chart` (reserved caches)
+- [App, namespace & networking model](#app-namespace--networking-model) — `chart` (shared apps / deps) + `cluster` (application space)
+- [System middleware model](#system-middleware-model) — `chart` (wire to it) + `cluster` (middleware aggregator)
+- [Olares version & semver model](#olares-version--semver-model) — `chart` (version floor) + `shared` (profile VERSION) + `settings` (me version)
+
+## Userspace storage model
+
+Olares exposes five mountable storage areas. Each has a stable frontend path (how `files` addresses it), a Helm value (how `chart` mounts it), a backend, and a scope.
+
+| Area | Frontend path (`files`) | Chart mount value | `permission` field | Scope | Backend / traits |
+|---|---|---|---|---|---|
+| **Home** | `drive/Home` | `.Values.userspace.userData` | `userData` (list paths) | user-level (shared by the user's apps granted the perm) | JuiceFS — cross-node, backed up; for **user-visible** files |
+| **Data** | `drive/Data` | `.Values.userspace.appData` | `appData: true` | per-app (auto `/<appName>`) | JuiceFS — cross-node, backed up; for **app-private persistent state** (db files, config) |
+| **Cache** | `cache/<node>` | `.Values.userspace.appCache` | `appCache: true` | per-app (auto `/<appName>`) | **node-local PV** (`/olares/userdata/Cache/`) — pins the pod to that node via `schedule.nodeName`; fast, regenerable, not guaranteed durable/backed-up |
+| **Common** | `drive/Common` | `.Values.userspace.appCommon` | `appCommon: true` | **cross-app shared** (no `appName` suffix) | JuiceFS; reserved `huggingface`/`ollama`/`llama.cpp`/`comfyui` shared caches; needs Olares ≥ 1.12.6 |
+| **External** | `external/<node>/<volume>` | `.Values.sharedlib` | `externalData: true` | user's external storage | SMB/NFS/USB volumes attached via LarePass; needs schema ≥ 0.12.0 |
+
+Key facts:
+
+- **Per-app vs shared vs user.** `appData`/`appCache` auto-append `/<appName>` (app-private); `appCommon` is a bare cross-app dir (every app with the perm sees the same dir — that is what makes shared model caches work); `userData` is the user's `/Home`.
+- **Backend decides scheduling + durability.** `userData`/`appData`/`appCommon` are JuiceFS (cross-node, backed up). `appCache` is a node-local PV, so app-service pins the pod to that node — fast local disk, treat as disposable.
+- **Owner is uid 1000.** All five are read/written as uid/gid 1000 (see next section).
+- **Version gates.** `appCommon` needs Olares ≥ 1.12.6; `externalData`/`sharedlib` needs `olaresManifest.version` ≥ 0.12.0.
+- **Drive's `extend` must be `Home` or `Data` exactly** — `home` is rejected with `invalid drive type`.
+
+## Run identity: uid/gid 1000
+
+Every userspace area above is owned and accessed as **uid/gid 1000**. This is the shared root cause behind two skills:
+
+- `chart` — the app process must run as 1000 (`spec.runAsUser: true` injects `pod.spec.securityContext.runAsUser: 1000`). If the image runs as root or another uid, writes to userspace mounts fail with `Permission denied` or never persist. `appCommon` is created `chown 1000:1000`.
+- `files` — `chown` UID conventions: 0 (root) vs 1000 (the userspace owner). Only `drive/Home`, `drive/Data`, `cache/<node>` accept `chown`.
+
+OPA admission: a non-trusted image running as root (or `privileged`/`runAsNonRoot: false`) is denied. Init containers may run as root only with a trusted `beclab/` image. Chart-side alignment recipes (Dockerfile `USER`, initContainer `chown`, OPA boundaries) live in `chart`'s run-as-user reference.
+
+## System-managed Home directories
+
+These eleven names directly under `drive/Home/` are LarePass bootstrap directories that user apps look up by exact name:
+
+```
+Pictures  Music  Movies  Downloads  Documents  Code  Cache  Data  Home  Ollama  Huggingface
+```
+
+Platform invariants:
+
+- They are created and managed by LarePass; apps depend on the exact names (e.g. the model-runtime app's `Ollama` cache, the LarePass UI's `Pictures` sidebar tile).
+- Casing is significant: `Huggingface` is one word (not `HuggingFace`).
+- `files` enforces them as protected names: `rename` / `rm` / `mv source` refuse them at the **first level under `drive/Home/` only**; `cp` (copy) is allowed; nested content (`drive/Home/Pictures/Trip2024/`) is fully editable; other namespaces (`drive/Data/Pictures`, `sync/...`) are unaffected.
+
+## App, namespace & networking model
+
+How Olares apps are placed in namespaces and reach each other:
+
+- **Per-user app** → namespace `<app>-<owner>`. This is the default and what a normal install produces.
+- **Shared app** (`apiVersion: v3` on Olares ≥ 1.12.6) → deterministic namespace `<app>-shared`, admin-only install, cluster-wide. app-service rewrites the namespace regardless of what the manifest says.
+- **Application space** (`cluster` framing) is a KubeSphere-grouped K8s namespace; the same namespace, grouped by workspace.
+- **Cross-namespace reachability.** A v3 shared app gets a service-mesh sidecar + NetworkPolicy so other namespaces can call it. Consumers reach it by plain in-cluster Service DNS — **no entrance/URL**.
+- **Dependency injection.** When app B declares a `type: application` dependency on a shared app A, app-service injects A's Services into B's Helm values as `.Values.svcs.<svcName>_host` (= `<svcName>.<app>-shared`) and `.Values.svcs.<svcName>_ports`.
+- **`sharedEntrances` was removed in 1.12.6+.** Do not add it; treat any leftover as stale.
+
+Used by: `chart` (authoring shared apps and `application` dependencies) and `cluster` (the application-space / namespace runtime view).
+
+## System middleware model
+
+Olares manages shared datastores so apps do not bundle their own:
+
+- **Always available, no admin pre-install:** PostgreSQL (v17, Citus image, ships pgvector/pgvecto.rs/vchord/postgis/zhparser + standard contrib) and Redis. Reach for these by default.
+- **Require an admin to install from the Market first:** MongoDB, MySQL, MariaDB, MinIO, RabbitMQ, NATS.
+- These are NOT native K8s resources — `cluster` surfaces them through a separate `/middleware/v1/*` aggregator (the `middleware` noun), not the K8s API.
+
+Used by: `chart` (replace a bundled db, wire to `.Values.<mw>.*`, declare an `options.dependencies` `type: middleware` entry) and `cluster` (listing Olares-managed middleware). Single-instance only for ported apps (do not declare `distributed`).
+
+## Olares version & semver model
+
+Olares releases follow [semver](https://docs.olares.com/developer/install/versioning.html) — `Major.Minor.Patch[-PreRelease]` (stable `1.12.6`, RC `1.12.0-rc.0`, daily `1.12.0-20241201`).
+
+- The running version lives in the `Terminus` CR `spec.version` and is injected into every chart as `.Values.sysVersion`.
+- **"At least" comparisons strip the prerelease/build segment**, so a daily build `1.12.6-20260327` still counts as `>= 1.12.6`. Always use the `-0` suffix in constraints (`>=1.12.6-0`) or prerelease/daily/RC builds fail to match.
+- Reading the target version: `olares-cli profile list` (cached `VERSION` column, populated at login from `/api/olares-info`), `olares-cli profile list --refresh-version`, or live `olares-cli settings me version`.
+
+Used by: `chart` (the `>= 1.12.6` porting floor + `options.dependencies` `type: system`), `shared` (the profile `VERSION` column), and `settings` (`me version`).


### PR DESCRIPTION
## Summary

- Centralize the cross-skill Olares platform facts (userspace storage model, uid-1000 run identity, system-managed `drive/Home` dirs, app/namespace & networking, system middleware, version/semver) into a single source of truth: `cli/skills/olares-shared/references/olares-platform.md` (with a TOC). They were previously duplicated and described at inconsistent depth across `olares-chart` references, `olares-files`, and `olares-cluster`.
- Each consuming `SKILL.md` now links the platform model **one hop** via a must-read prerequisite (the lark-cli pattern); reference files refer to those concepts **by name** instead of cross-skill deep links, so every reference stays one level deep from its `SKILL.md`.
- `olares-chart`: add a top-of-skill **Olares readiness checklist** (entry index for a port), and clarify the login boundary — authoring (`from-compose`/`lint`/`package`) needs no login; only pushing to a real Olares to test does.
- `README.md`: document the **install-the-whole-suite** contract and a new **Cross-skill shared concepts** writing-style section (single source of truth, one-hop linking, reference-depth rule, self-containment trade-off).
- Bump all skills to `4.2.0`.

## Why

The chart-porting docs had grown fragmented, and platform architecture facts were repeated (and drifting) across skills. This establishes one canonical home per shared concept and codifies the writing rules so future skills stay consistent. Aligned with the lark-cli skill structure and Anthropic's skill-authoring best practices.

## Test plan

- [x] `bash ./cli/skills/publish.sh --dry-run` — all 7 skills `local validation OK`.
- [x] Link check: every `olares-platform.md` reference resolves (0 broken) and originates only from `SKILL.md` files + `README.md` (no reference-to-reference deep links).
- [x] `olares-chart/SKILL.md` stays within the 250-line budget.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI skills; no runtime or auth code paths are modified.
> 
> **Overview**
> Introduces **`olares-shared/references/olares-platform.md`** as the single canonical home for cross-skill Olares facts (userspace storage, uid 1000, system-managed `drive/Home` dirs, app/namespace networking, system middleware, version/semver). Consumer skills now point at it **one hop from each `SKILL.md`**; chart and other references **drop repeated tables** and refer to those concepts **by name** instead of deep-linking across skills.
> 
> **`cli/skills/README.md`** documents the install-the-whole-suite contract, reference-depth rules (no reference→reference), and a **Cross-skill shared concepts** authoring section aligned with the lark-cli pattern.
> 
> **`olares-chart`** is restructured around **three coupled axes** (packaging / deployment / publishing) with a consolidated **concerns** table and clearer **login boundary** (local `from-compose`/`lint`/`package` need no profile; test deploy via `market upload` + `install` does). **`olares-shared`** gains `profile list` **VERSION**, treats **HTTP 459** like 401/403 for refresh, and bumps all skills to **4.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02499f923e9c822f9b8777c0ab42bc87a5f5465a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->