### PR TITLE
docs(cli): dedup olares-* skill routing into a single suite map

### DIFF
--- a/cli/skills/README.md
+++ b/cli/skills/README.md
@@ -39,7 +39,7 @@ ClawHub publishes the entire skill directory (including `references/`), so refer
 
 `SKILL.md` is NOT meant to compete with `olares-cli <command> --help`. The body references `olares-cli <command> --help` for authoritative flag syntax. The body should only carry what `--help` cannot give:
 
-- **Routing** — when to use this skill vs. siblings
+- **When to use** — this skill's scope / trigger phrases, plus the suite-map pointer for outbound routing (see "Cross-skill shared concepts")
 - **Cross-cutting concepts** referenced by ≥2 subcommands (e.g. olares-files' 3-segment frontend path)
 - **Client-side hard constraints that bite users** (quirks the GUI enforces, server-side auto-rename traps, …)
 - **Error → fix matrix** that is not in `--help`
@@ -69,6 +69,7 @@ Facts used by **≥2 skills** are defined **once** and linked, never copied. Thi
 - **Do NOT deep-link the shared source from reference files.** A reference that points at another skill's reference is a two-hop nested read. Instead, refer to the shared concept **by name** (matching the source's heading) and rely on the `SKILL.md` prerequisite to have loaded it. (See the chart references, which name "the platform **Userspace storage model**" rather than linking it.)
 - **Self-containment is traded for a suite contract.** Strictly, Skills are self-contained and "cannot reference files in other skill folders". We deliberately cross-link because these skills **ship and install as one suite** (stated under Layout). A standalone install leaves cross-skill links dangling — that is the documented trade-off, not an accident.
 - **When a fact is genuinely two skills' own angle, let each keep its own framing.** `files` describes the storage areas as *addressing* (`drive/Home`), `chart` as *mounting* (`.Values.userspace.appData`). That is not duplication to dedupe — only the underlying platform facts (backends, durability, uid, version gates) are centralized in `olares-platform.md`.
+- **Routing has one source of truth too: the Skill suite map** in [`olares-shared/SKILL.md`](olares-shared/SKILL.md). The canonical intent->skill scope for the whole suite lives there once. Each skill folds routing into its `## When to use` section — trigger phrases, then the suite-map pointer (`> Anything outside this scope -> see the Skill suite map …`), plus an optional `> Mental model` one-liner — with no separate `## Routing` section and no per-sibling ✅/❌ rows. `olares-shared` is a must-read prerequisite for the runtime skills, so the map is always already in context.
 
 ## Runtime requirement
 

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -99,6 +99,8 @@ Use this skill to **author/validate your own** Olares chart from a repo, compose
 | "Just install / upgrade an existing catalog app" (not validating your own chart) | [`olares-market`](../olares-market/SKILL.md) |
 | "Inspect pods / logs of an unrelated running app" | [`olares-cluster`](../olares-cluster/SKILL.md) |
 
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md).
+
 ## CLI verbs
 
 The only `olares-cli chart` subcommands (source of truth: `--help`). Everything else above is docker or sibling skills.

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 
 > **Source of truth for flags & wire shapes is always `olares-cli cluster <noun> <verb> --help`.** This file only carries what `--help` cannot give: routing, the mental model of nouns, the identity-vs-server principle, the mutating-verb safety contract, cross-verb output conventions, and the common-errors → fix table.
 
-## When to use this skill
+## When to use
 
 Against the cluster the active profile can see:
 
@@ -31,15 +31,7 @@ Against the cluster the active profile can see:
 - "What does this object's YAML look like?" (`cluster <noun> yaml`)
 - Watch / follow: pod `-w`, workload `rollout-status -w`, application `status -w`, logs `-f` (poll on `--interval`)
 
-## When NOT to use — route to a sibling skill
-
-| User intent | Use instead | Why |
-|---|---|---|
-| Install / uninstall / upgrade / start / stop an Olares **app** | [`olares-market`](../olares-market/SKILL.md) | App-store lifecycle, not K8s object lifecycle |
-| Edit app entrances / domains / env / policy / ACL from the **user** perspective | [`olares-settings`](../olares-settings/SKILL.md) | The settings UI mirror, scoped to the user's apps |
-| Browse / sync drive files | [`olares-files`](../olares-files/SKILL.md) | File API, not K8s |
-| Cluster install / node join / OS upgrade / GPU drivers | `olares-cli node`, `olares-cli os`, `olares-cli gpu` | Kubeconfig-based host maintenance, NOT profile-based |
-| Profile management, login, token refresh | [`olares-shared`](../olares-shared/SKILL.md) | Auth lives there |
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
 > **Mental model:** if the question is *runtime state* of an existing cluster, you are here. If it's *lifecycle* of an Olares app or *day-zero* host setup, you are not.
 
@@ -108,7 +100,7 @@ For flags, examples, and wire shapes, **always start with `olares-cli cluster <n
 Every mutating verb — `pod delete` / `pod restart`, all of `workload scale|restart|stop|start|delete`, `cronjob suspend`, `job rerun` — follows the same contract:
 
 1. **Wrapped in a `ConfirmDestructive` y/N prompt.** Even for "reversible" changes — the prompt is the safety net. **`--yes` / `-y` opts out for scripts.**
-2. **No client-side authorization preflight** — server is the only authority. A 403 surfaces; the CLI does not gate against `cluster context`.
+2. **Authorization follows the identity-vs-server principle above** — no client-side preflight; a 403 surfaces as the authoritative "no".
 3. **Stable JSON summary on success**, not the apiserver's response. JSON consumers care whether the change took, not every field of the object.
 
 Non-destructive verbs (`cronjob resume`, `workload start`, `pod logs`) are NOT wrapped. **Confirm intent with the user BEFORE invoking any destructive verb, even when scripts pass `--yes`.**
@@ -122,7 +114,12 @@ Non-destructive verbs (`cronjob resume`, `workload start`, `pod logs`) are NOT w
 
 ### Pagination (`--page N` / `--all`)
 
-Every `list` verb under `pod` / `cronjob` / `job` / `namespace` / `node` / `workload` (and the `application pods` / `application workloads` wrappers) supports pagination. Defaults: `--limit 100`, `--page 1`. Pass `--page N` to walk pages, or `--all` to drain every page. `cluster workload images [IMAGE]` follows the same pagination contract (covers Deployment/StatefulSet/DaemonSet/Job/CronJob; `--kind` also accepts `job` / `cronjob`; pass an IMAGE arg to find where a specific image is referenced — an IMAGE lookup always full-scans the cluster); for the plain listing do not assume full-cluster coverage unless `--all` is explicitly set. For a local-image-vs-workload diagnostic, use the top-level `doctor images` command instead — it always scans the cluster in full (no pagination), annotates each local containerd image with its workload reference count across Deployment/StatefulSet/DaemonSet/Job/CronJob, skips pause/sandbox images, and takes `--unused` to show only zero-reference orphans (biggest first, with a reclaimable-size summary). Two caveats: (1) completeness — the local image list reflects the node serving the request (control node), so images living only on a worker node aren't listed; but every listed image is checked cluster-wide, so a listed image's "unused" verdict is safe. (2) coverage — references come only from Deployment/StatefulSet/DaemonSet/Job/CronJob specs, so an image used only by a bare Pod / static pod / other-controller-owned Pod can be mislabeled unused, and the count reflects the workload spec rather than the digest a running container is pinned to; cross-check running Pods before reclaiming.
+Every `list` verb under `pod` / `cronjob` / `job` / `namespace` / `node` / `workload` (and the `application pods` / `application workloads` wrappers) supports pagination. Defaults: `--limit 100`, `--page 1`. Pass `--page N` to walk pages, or `--all` to drain every page.
+
+Two image-inventory commands ride on top of this:
+
+- `cluster workload images [IMAGE]` follows the same pagination contract. An IMAGE-argument lookup always full-scans the cluster, but the plain listing is NOT full-cluster unless `--all` is set. See [references/olares-cluster-workload.md](references/olares-cluster-workload.md).
+- For a local-image-vs-workload diagnostic, use the top-level `doctor images` instead — always full-scans (no pagination), annotates each local containerd image with its workload reference count, and takes `--unused` for zero-reference orphans. Its completeness/coverage caveats live in that same workload reference's Agent notes.
 
 ### `--watch` / `--follow` semantics (uniform)
 

--- a/cli/skills/olares-cluster/references/olares-cluster-application.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-application.md
@@ -66,4 +66,3 @@ olares-cli cluster application pods user-system-alice
 |---|---|---|
 | `(failed: ...)` in one section of `status` | One sub-endpoint errored; others succeeded | Report the partial result; re-run with `-o json` for raw details if needed |
 | 404 on `application get <ns>` | Active profile can't see this namespace, OR the namespace doesn't exist | `application list` to see what's visible |
-| `--interval requires --watch` | Polling cadence without gate flag | Add `-w` or drop `--interval` |

--- a/cli/skills/olares-cluster/references/olares-cluster-cronjob.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-cronjob.md
@@ -18,7 +18,9 @@ K8s CronJobs (`apis/batch/v1beta1` — different from `cluster job`'s `batch/v1`
 
 ## Safety constraints
 
-- **`suspend` is destructive — confirm with the user.** Suspending stops the CronJob from spawning new Jobs at scheduled times; **already-running Jobs are NOT affected**, only future schedule fires.
+`suspend` follows the parent SKILL.md's Mutating verb safety contract (confirm, `--yes` for scripts, server decides). CronJob-specific points:
+
+- **Suspending only stops future schedule fires** — **already-running Jobs are NOT affected**.
 - **`suspend` is reversible via `resume`** — flag it as "pause schedule" to the user, not "delete".
 - **No-op short-circuit**: if the cronjob is already in the target state, the verb prints a notice and skips the PATCH — saves an API round-trip and a wasted resource-version bump.
 

--- a/cli/skills/olares-cluster/references/olares-cluster-job.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-job.md
@@ -18,7 +18,9 @@ K8s Jobs (`apis/batch/v1`) — one-shot batch runs.
 
 ## Safety constraints
 
-- **`rerun` is destructive — confirm with the user.** It re-fires the Job's pod template against the cluster; for jobs with side effects (sends notifications, mutates external state) this happens AGAIN.
+`rerun` follows the parent SKILL.md's Mutating verb safety contract (confirm, `--yes` for scripts, server decides). Job-specific points:
+
+- **`rerun` re-fires the Job's pod template** against the cluster; for jobs with side effects (sends notifications, mutates external state) this happens AGAIN.
 - The CLI fetches the Job's current `resourceVersion` before posting; concurrent reruns by a third party between Get and POST will fail with a conflict (which is the safe outcome).
 
 ## The `pods` two-step
@@ -59,4 +61,3 @@ olares-cli cluster job rerun user-system-alice/migrate-2026-q1
 |---|---|---|
 | `job pods` returned empty | Job has not yet spawned a pod (e.g. just created), OR pods were garbage-collected | Check `cluster job get` → `Conditions`; if older, the pods may be gone |
 | `rerun` returned 409 / conflict | Concurrent modification | Re-run; if persistent, someone else is operating on the same Job |
-| `aborted by user` | y/N prompt rejected | Re-run with `--yes` if intentional |

--- a/cli/skills/olares-cluster/references/olares-cluster-middleware.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-middleware.md
@@ -43,5 +43,4 @@ olares-cli cluster middleware list -o json --show-passwords
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| 403 | Active profile lacks the middleware view scope | `cluster context --refresh` to confirm role; switch profile if needed |
 | Empty `list` output | No middleware visible to this profile; OR the aggregator is unreachable | `cluster context` to confirm cluster connectivity; LarePass settings for middleware enrollment |

--- a/cli/skills/olares-cluster/references/olares-cluster-pod.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-pod.md
@@ -19,8 +19,8 @@ Inspect Pods visible to the active profile. **Cross-namespace by default** — l
 
 ## Safety constraints
 
-- **`delete` / `restart` mutate the server — confirm intent with the user.**
-- `--yes` skips the y/N prompt for scripts; the server still has final say.
+`delete` / `restart` follow the parent SKILL.md's Mutating verb safety contract (y/N confirm, `--yes` for scripts, server decides). Pod-specific points:
+
 - `--grace-period -1` (default) honors the pod's `terminationGracePeriodSeconds`; `0` forces immediate kill.
 - **Most Olares pods are controller-managed** — `delete` will recreate them. That's usually the user's actual intent ("restart this pod") but confirm before invoking.
 
@@ -69,6 +69,4 @@ olares-cli cluster pod delete user-system-alice/my-pod --yes   # script mode
 |---|---|---|
 | `pod has multiple containers; please specify --container` | Multi-container pod without `-c` | Add `-c <name>` (the error lists them) |
 | `--previous is incompatible with --follow` | Both flags set | Drop one |
-| `--interval requires --follow` | `--interval` without `-f` | Add `-f` |
 | 404 on a known-existing pod | Cross-tenant visibility or wrong namespace | `cluster pod list -n <ns>` to confirm the active profile can see it |
-| 403 | Active profile's role lacks pod read/delete | `cluster context --refresh` to confirm current role; switch profile if needed |

--- a/cli/skills/olares-cluster/references/olares-cluster-workload.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-workload.md
@@ -29,7 +29,8 @@
 
 ## Safety constraints
 
-- **Every destructive verb confirms with the user.** `--yes` opts out for scripts.
+Every destructive verb follows the parent SKILL.md's Mutating verb safety contract (confirm, `--yes` for scripts, server decides). Workload-specific points:
+
 - **DaemonSet has no `replicas`** — `scale` / `stop` reject it client-side. `start` requires `--replicas` so it implicitly excludes DaemonSet too.
 - **`restart` deletes pods one-by-one (parallel-bounded).** During the operation pods are recreated by the controller. For Deployments with a single replica, this means a brief downtime.
 - **`delete --propagation foreground` waits for the cascade.** Pass `background` only when you intentionally want fire-and-forget.
@@ -94,4 +95,3 @@ This combines the PATCH and the rollout-status poll into one invocation. The age
 | `DaemonSet does not have replicas; use 'cluster workload delete --kind ds' instead` | `scale` / `stop` on a DS | Use `delete` |
 | `--replicas is required` (on `start`) | Tried to "start" without saying how many | Ask the user; there is no cached previous count |
 | 404 on a known-existing workload | Wrong `--kind` | Try with the correct kind, or `list --kind all -n <ns>` |
-| `aborted by user` | Destructive prompt rejected | If intentional, re-run with `--yes` |

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 > **Source of truth for flags is always `olares-cli dashboard --help` (global flags) and `olares-cli dashboard <verb> --help` (per-leaf flags).** This file only carries what `--help` cannot give: the dual-shape JSON envelope contract, three-state empty-data semantics, capability gates, watch / window rules, and the verb index.
 
-## Routing
+## When to use
 
 This subtree is an **AI-agent-first JSON mirror of the Olares Dashboard SPA's Overview and Applications routes**. Use it when:
 
@@ -27,14 +27,7 @@ This subtree is an **AI-agent-first JSON mirror of the Olares Dashboard SPA's Ov
 - Errors: `fan is only available on Olares One devices`, `gpu data temporarily unavailable`
 - Empty-data reasons: `no_<feature>_integration`, `no_<feature>_detected`, `vgpu_unavailable`; windows: `--since` vs `--start`/`--end`
 
-Sibling-skill routing:
-
-| User intent | Use instead |
-|---|---|
-| "What pods / workloads / nodes / namespaces exist?" (object inventory) | [`olares-cluster`](../olares-cluster/SKILL.md) |
-| "Install / start / stop an Olares app" | [`olares-market`](../olares-market/SKILL.md) |
-| "Configure my user settings" | [`olares-settings`](../olares-settings/SKILL.md) |
-| "Browse files / drives" | [`olares-files`](../olares-files/SKILL.md) |
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
 > **Mental model:** dashboard answers *"what's the resource usage and health"*. For inventory and lifecycle, route elsewhere.
 

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -24,6 +24,8 @@ metadata:
 - Share: internal cross-Olares-ID, public link (password / expiration), SMB / Samba, Connect to Server, Seafile sync repos
 - Namespaces: `drive`, `cache`, `sync`, `external`, `awss3`, `dropbox`, `google`, `tencent`, `share`
 
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
+
 ## Core concept: the 3-segment frontend path
 
 Every resource on the per-user files-backend is addressed by:

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -24,17 +24,7 @@ metadata:
 - `my Olares apps`, `我的应用`, `market list --mine`, `is <app> installed yet`, chart upload / delete, `--watch` until terminal state
 - Catalog: `list`, `get`, `categories`; runtime: `status`
 
-## Routing
-
-| User intent | Use this skill? |
-|---|---|
-| "Install / upgrade / uninstall an Olares app" | ✅ yes |
-| "What apps do I have?" / "我的应用" | ✅ yes — `market list --mine` |
-| "Is `<app>` installed yet?" / "Wait for `<app>` to be running" | ✅ yes — `market status <app> --watch` |
-| "Upload my custom helm chart" | ✅ yes — `market upload` |
-| "What pods is `<app>` running?" | use [`olares-cluster`](../olares-cluster/SKILL.md) (`cluster application status <ns>`) |
-| "Edit my app's entrance / domain / env / ACL" | use [`olares-settings`](../olares-settings/SKILL.md) (`settings apps`) |
-| "What's eating CPU on my cluster?" | use [`olares-dashboard`](../olares-dashboard/SKILL.md) (`dashboard overview ranking`) |
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
 > **Mental model:** `market` is **lifecycle and inventory** at the app-store level (install / upgrade / chart push). For runtime K8s objects, settings, or metrics, route to a sibling.
 

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -24,20 +24,7 @@ metadata:
 - Areas: users, appearance, apps (entrances / env / domain / policy), integration (awss3 / tencent), VPN (devices / ACL / SSH), network, GPU, video, search, backup / restore, advanced (containerd registries, env)
 - Mutating: language set, search rebuild, integration add/delete, VPN SSH / ACL, users create/delete
 
-## Routing
-
-| User intent | Use this skill? |
-|---|---|
-| "Change language / theme / appearance" | ✅ yes |
-| "Add a user / delete a user" | ✅ yes |
-| "Edit my app's entrance / domain / policy / env" | ✅ yes (post-install surface) |
-| "Add an S3 / Tencent integration account" | ✅ yes |
-| "Manage VPN devices / ACL / SSH toggle" | ✅ yes |
-| "Browse backup plans / snapshots / restore plans" | ✅ yes |
-| "Install / uninstall / upgrade / start / stop an Olares app" | ❌ use [`olares-market`](../olares-market/SKILL.md) (this is post-install) |
-| "Identify / log in / switch profile" | ❌ use [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (`profile login`) |
-| "Inspect pods / workloads / nodes" | ❌ use [`olares-cluster`](../olares-cluster/SKILL.md) |
-| "Show CPU / memory / disk metrics" | ❌ use [`olares-dashboard`](../olares-dashboard/SKILL.md) |
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
 > **Mental model:** `settings` covers configuration that the Olares Settings SPA exposes — **post-install per-app config**, mesh / VPN, backup, accounts, system appearance. Lifecycle and runtime live in sibling skills.
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -25,6 +25,22 @@ Foundation for every other `olares-cli` skill. Every business verb under `cluste
 - Any `olares-cli` command failed with an auth error (token invalidated / not logged in / 2FA required)
 - Keywords: Olares ID, profile, login, 2FA/TOTP, refresh token, keychain, `server rejected the access token`, `refresh token ... became invalid`, `no access token`, `already authenticated`
 
+## Skill suite map (routing source of truth)
+
+The olares-cli skills ship and install as one suite; each owns a distinct slice. This is the canonical intent->skill map — a skill's own `## When to use` lists its scope and points here for everything else.
+
+| Skill | Owns | Reach for it when |
+|---|---|---|
+| [`olares-shared`](SKILL.md) | Profile / login / token refresh / auth-error recovery; hosts the platform model | logging in, switching Olares ID, any auth error |
+| [`olares-market`](../olares-market/SKILL.md) | App-store lifecycle: install / uninstall / upgrade / clone / start / stop / cancel; `--mine`; chart upload | installing or managing an app's lifecycle |
+| [`olares-settings`](../olares-settings/SKILL.md) | Post-install config (Settings SPA): app entrance / domain / env / policy, users, VPN, network, backup / restore, integrations | changing config of an installed app or the system |
+| [`olares-cluster`](../olares-cluster/SKILL.md) | K8s runtime view: pods / workloads / jobs / cronjobs / nodes / namespaces; logs; scale / restart / delete | inspecting or operating running K8s objects |
+| [`olares-dashboard`](../olares-dashboard/SKILL.md) | Resource metrics & health: CPU / memory / disk / network / pods / GPU / fan / ranking | "what's the usage / what's eating CPU" |
+| [`olares-files`](../olares-files/SKILL.md) | Per-user file API: drive / sync / cache / external; upload / download; share; SMB; Seafile | browsing or moving files / drives |
+| [`olares-chart`](../olares-chart/SKILL.md) | Local chart authoring: from-compose / lint / package, then publish | authoring or validating your own chart |
+
+> Host-side maintenance (cluster install, node join, OS upgrade, GPU drivers) is NOT a skill — it's the kubeconfig-based `olares-cli node` / `os` / `gpu` trees, separate from this profile-based suite.
+
 ## Profile model
 
 One profile = one Olares instance + one user identity, keyed by **olaresId** (e.g. `alice@olares.com`). Each profile owns its own access_token / refresh_token pair, stored in the OS keychain.


### PR DESCRIPTION
## Summary

- Add a canonical **Skill suite map** to `olares-shared/SKILL.md` as the single source of truth for intent->skill routing across the suite.
- Fold each runtime skill's routing into its `## When to use` section (one-line scope + suite-map pointer + optional `> Mental model`), removing the per-sibling `✅/❌` tables that duplicated the same facts across `cluster` / `market` / `settings` / `dashboard` / `files`. Also fills prior gaps (e.g. files had no routing; cluster lacked a dashboard route).
- Keep `olares-chart`'s routing table as-is — it is scope-disambiguation plus genuine handoffs, not the redundant N×N sibling overlap.
- Tighten the `olares-cluster` tree: collapse the near-verbatim `doctor images` caveats and per-verb safety-contract restatements to single sources; drop common-error rows that merely restated the SKILL.md matrix.
- Update `cli/skills/README.md` to document the routing single-source-of-truth convention and align the writing-style guidance.

## Test plan

- [ ] `./cli/skills/publish.sh --dry-run` passes frontmatter/slug/version/description validation for all skills.
- [ ] Skim each edited `SKILL.md`: routing lives only under `## When to use` (5 runtime skills), exactly one suite-map pointer per file, links resolve, line counts within limits.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI skill markdown; no runtime or auth behavior changes.
> 
> **Overview**
> **Centralizes cross-skill routing** in a new **Skill suite map** on `olares-shared/SKILL.md`, and updates `cli/skills/README.md` so each skill’s `## When to use` holds scope/triggers plus one pointer to that map (no separate `## Routing` or N×N sibling ✅/❌ tables).
> 
> **Runtime skills** (`cluster`, `dashboard`, `files`, `market`, `settings`) drop duplicated routing tables in favor of the suite-map link and optional mental-model one-liner. **`olares-chart`** keeps its scope table but adds the same outbound pointer.
> 
> **`olares-cluster` cleanup:** shortens the parent `SKILL.md` pagination/image-inventory blurb; ties mutating-verb safety to the parent contract in reference docs; removes common-error rows that only repeated parent matrices (403, watch/interval, aborted-by-user).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acbfeb37a0ead29a326ffbead162d1dc30704a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->