### PR TITLE
feat(oac): skip quantity check for auto resource of template app

### DIFF
--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -322,6 +322,17 @@ func ensureNoGPUSection(sectionPath, mode string, rr ResourceRequirement) error 
 	return errors.Join(errs...)
 }
 
+// AutoResourceValue is the sentinel a template-app author writes into a
+// resource field to declare "resolve this value from the rendered chart at
+// install time" (see app-service compute auto-resource resolution). It is not
+// a Kubernetes quantity, so the quantity / limit-ordering validators below
+// treat it as a valid, deferred value rather than rejecting it.
+const AutoResourceValue = "-1"
+
+func isAutoResourceQuantity(s string) bool {
+	return strings.TrimSpace(s) == AutoResourceValue
+}
+
 func validateQuantities(prefix string, rr ResourceRequirement) error {
 	pairs := []struct {
 		field string
@@ -338,7 +349,7 @@ func validateQuantities(prefix string, rr ResourceRequirement) error {
 	}
 	var errs []error
 	for _, p := range pairs {
-		if p.value == "" {
+		if p.value == "" || isAutoResourceQuantity(p.value) {
 			continue
 		}
 		if !k8sQuantity.MatchString(p.value) {
@@ -362,6 +373,11 @@ func checkLimitGERequired(prefix string, rr ResourceRequirement) error {
 	var errs []error
 	for _, d := range dims {
 		if d.required == "" || d.limited == "" {
+			continue
+		}
+		// An auto-compute sentinel on either side is resolved at install time;
+		// the limit >= required ordering cannot be checked yet, so skip it.
+		if isAutoResourceQuantity(d.required) || isAutoResourceQuantity(d.limited) {
 			continue
 		}
 		req, err := resource.ParseQuantity(d.required)


### PR DESCRIPTION
* **Background**
For resource requirements specified as the special indicator `-1` of template apps, the regular validity check of resource quantity is skipped to avoid corruption.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to manifest validation only; allows a documented sentinel without altering install-time resolution behavior.
> 
> **Overview**
> Template apps can mark resource fields with the **`-1`** sentinel (`AutoResourceValue`) so values are resolved from the rendered chart at install time instead of being fixed in the manifest.
> 
> OAC manifest validation in `resources.go` now treats that sentinel as a deferred value: **`validateQuantities`** no longer requires it to match a Kubernetes quantity string, and **`checkLimitGERequired`** skips limit ≥ required checks when either side is `-1`, since ordering is only meaningful after install-time resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61803384fb93bc530cc70421b7335e1b026e80de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->