### PR TITLE
feat(app-service): auto-resolve template app resource requirements from rendered chart

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.32
+        image: beclab/app-service:0.5.33
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd
+	github.com/beclab/Olares/framework/oac v0.0.0-20260608092748-493fd828848c
 	github.com/beclab/api v0.0.13
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -118,6 +118,8 @@ github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b h1:nMo
 github.com/beclab/Olares/framework/oac v0.0.0-20260603125709-ea2e3451977b/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
 github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd h1:7UfKFR7d31rB0y5PQBR5UZ1tCoIedlsyZ3ThLURWPgw=
 github.com/beclab/Olares/framework/oac v0.0.0-20260604115724-31cd5c6d8fcd/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
+github.com/beclab/Olares/framework/oac v0.0.0-20260608092748-493fd828848c h1:0RelH/VB/B9s332R0LKjw02v0xxoR7cp59ogRknOdrM=
+github.com/beclab/Olares/framework/oac v0.0.0-20260608092748-493fd828848c/go.mod h1:dsVFWFH8dTGE4zNXXg0epcyVUXDqd98m/Mb+BQjnyok=
 github.com/beclab/api v0.0.11 h1:jNVX+hnZ4UJoF0S2wUEjepEULrhQcAs5Oh97IPbnBtA=
 github.com/beclab/api v0.0.11/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/api v0.0.12 h1:8+pxq5I7Xt9XfSM23RuOJD2kIKggdJ/LaUYWM0gcj04=

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute/validation"
@@ -28,6 +29,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"helm.sh/helm/v3/pkg/time"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -46,6 +48,7 @@ type installHelperIntf interface {
 	lintChart() error
 	setAppEnv(overrides []sysv1alpha1.AppEnvVar) error
 	applyAppEnv(ctx context.Context) error
+	resolveAutoResources(ctx context.Context) error
 	applyApplicationManager(marketSource string) (opID string, err error)
 }
 
@@ -319,6 +322,20 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 	err = helper.applyAppEnv(req.Request.Context())
 	if err != nil {
 		klog.Errorf("Failed to apply app env err=%v", err)
+		return
+	}
+
+	// For template apps that declare auto-compute ("-1") resource fields, the
+	// concrete demand is only known once the chosen mode + just-applied appenv
+	// are rendered into the chart. Resolve it now — before the
+	// ApplicationManager is created — so the persisted application config
+	// already carries concrete resource requirements and the entire downstream
+	// pipeline (state machine, compute allocation, HAMI binding, resume) runs
+	// the normal flow against real values.
+	err = helper.resolveAutoResources(req.Request.Context())
+	if err != nil {
+		klog.Errorf("Failed to resolve auto compute resources err=%v", err)
+		api.HandleError(resp, req, err)
 		return
 	}
 
@@ -791,6 +808,98 @@ func (h *installHandlerHelper) applyAppEnv(ctx context.Context) (err error) {
 		api.HandleError(h.resp, h.req, err)
 	}
 	return
+}
+
+// resolveAutoResources resolves any auto-compute ("-1") resource field the app
+// declares in its accelerator/resources matrix. It renders the chart once with
+// the selected mode and the just-applied appenv (a side-effect-free dry-run),
+// sums the workload container resource requests/limits, and rewrites the
+// selected mode's sentinel fields with the concrete values. It then re-derives
+// appConfig.Requirement so every downstream consumer sees a single resolved
+// requirement.
+//
+// It is a no-op for apps that declare no sentinel, so it is safe to call
+// unconditionally on the install / clone path.
+func (h *installHandlerHelper) resolveAutoResources(ctx context.Context) (err error) {
+	if h.appConfig == nil || !h.appConfig.HasAutoResource() {
+		return nil
+	}
+	if h.chartPath == "" {
+		return fmt.Errorf("cannot resolve auto compute resources: chart path is empty")
+	}
+
+	values, err := appinstaller.BuildBaseHelmValues(ctx, h.h.kubeConfig, h.appConfig, h.appConfig.OwnerName, true)
+	if err != nil {
+		return fmt.Errorf("build helm values for auto resource resolution: %w", err)
+	}
+	totals, err := utils.GetWorkloadResourcesFromChart(h.chartPath, values)
+	if err != nil {
+		return fmt.Errorf("sum workload resources for auto resource resolution: %w", err)
+	}
+
+	backfillAutoResourceMode(h.appConfig, totals)
+
+	resolved, err := h.appConfig.ResolveRequirement(h.appConfig.SelectedGpuType)
+	if err != nil {
+		return fmt.Errorf("resolve requirement after auto resource backfill: %w", err)
+	}
+	h.appConfig.Requirement = *resolved
+	return nil
+}
+
+// backfillAutoResourceMode replaces the auto-compute ("-1") fields of the
+// selected resource mode (or every mode when no specific GPU type is selected)
+// with the concrete totals summed from the rendered chart. Non-sentinel fields
+// are left untouched so manifest-declared values still win.
+func backfillAutoResourceMode(appConfig *appcfg.ApplicationConfig, totals utils.WorkloadResourceTotals) {
+	// GPU memory is conventionally declared only as a limit; fall back across
+	// requests/limits so a sentinel on either side resolves to a usable value.
+	gpuReq := totals.RequestsGPUMem
+	if gpuReq.IsZero() {
+		gpuReq = totals.LimitsGPUMem
+	}
+	gpuLim := totals.LimitsGPUMem
+	if gpuLim.IsZero() {
+		gpuLim = totals.RequestsGPUMem
+	}
+
+	for i := range appConfig.Accelerator {
+		mode := &appConfig.Accelerator[i]
+		if appConfig.SelectedGpuType != "" && mode.Mode != appConfig.SelectedGpuType {
+			continue
+		}
+		rr := &mode.ResourceRequirement
+		if appcfg.IsAutoResource(rr.RequiredCPU) {
+			rr.RequiredCPU = totals.RequestsCPU.String()
+		}
+		if appcfg.IsAutoResource(rr.LimitedCPU) {
+			rr.LimitedCPU = totals.LimitsCPU.String()
+		}
+		if appcfg.IsAutoResource(rr.RequiredMemory) {
+			rr.RequiredMemory = totals.RequestsMemory.String()
+		}
+		if appcfg.IsAutoResource(rr.LimitedMemory) {
+			rr.LimitedMemory = totals.LimitsMemory.String()
+		}
+		if appcfg.IsAutoResource(rr.RequiredGPU) {
+			rr.RequiredGPU = gpuMemMiBToByteString(gpuReq)
+		}
+		if appcfg.IsAutoResource(rr.LimitedGPU) {
+			rr.LimitedGPU = gpuMemMiBToByteString(gpuLim)
+		}
+	}
+}
+
+// gpuMemMiBToByteString converts a summed pod nvidia.com/gpumem quantity (a
+// plain integer count in MiB, the HAMi convention for the extended resource)
+// into a byte-quantity string suitable for the resource mode's
+// requiredGPUMemory/limitedGPUMemory fields, which the compute scheduler and
+// the gpu-inject webhook interpret as bytes. e.g. 8000 (MiB) -> "8000Mi".
+func gpuMemMiBToByteString(mib apiresource.Quantity) string {
+	if mib.IsZero() {
+		return mib.String()
+	}
+	return apiresource.NewQuantity(mib.Value()*1024*1024, apiresource.BinarySI).String()
 }
 
 func (h *installHandlerHelperV2) setAppConfig(req *api.InstallRequest, appName string) {

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -348,6 +348,14 @@ func ParseResourceRequirement(req *ResourceRequirement) (AppRequirement, error) 
 		if s == "" {
 			return nil, nil
 		}
+		// The auto-compute sentinel means "to be resolved from the rendered
+		// chart at install time". Treat it as unset here so it never becomes a
+		// negative quantity that would corrupt capacity comparisons; the
+		// install handler backfills the concrete value before this requirement
+		// is persisted / scheduled against.
+		if IsAutoResource(s) {
+			return nil, nil
+		}
 		q, err := resource.ParseQuantity(s)
 		if err != nil {
 			if errors.Is(err, resource.ErrFormatWrong) {

--- a/framework/app-service/pkg/appcfg/auto_resource.go
+++ b/framework/app-service/pkg/appcfg/auto_resource.go
@@ -1,0 +1,41 @@
+package appcfg
+
+import "strings"
+
+// AutoResourceValue is the sentinel a manifest author writes into a
+// spec.resources / accelerator resource field (e.g. requiredGPUMemory) to
+// declare "this value is not known until the app is instantiated; compute it
+// from the rendered chart at install time".
+//
+// It is used by template-style apps where the concrete
+// resource demand depends on a user-supplied choice (model, gpu memory, ...)
+// injected as an appenv and only materializes after the chart is rendered.
+
+const AutoResourceValue = "-1"
+
+// IsAutoResource reports whether a resource field value is the auto-compute
+// sentinel.
+func IsAutoResource(s string) bool {
+	return strings.TrimSpace(s) == AutoResourceValue
+}
+
+// ResourceRequirementHasAuto reports whether any field of the given
+// ResourceRequirement is the auto-compute sentinel.
+func ResourceRequirementHasAuto(rr ResourceRequirement) bool {
+	return IsAutoResource(rr.RequiredCPU) || IsAutoResource(rr.LimitedCPU) ||
+		IsAutoResource(rr.RequiredMemory) || IsAutoResource(rr.LimitedMemory) ||
+		IsAutoResource(rr.RequiredDisk) || IsAutoResource(rr.LimitedDisk) ||
+		IsAutoResource(rr.RequiredGPU) || IsAutoResource(rr.LimitedGPU)
+}
+
+// HasAutoResource reports whether the app declares any auto-compute resource
+// field in its accelerator/resources matrix. Legacy apps (no Accelerator
+// matrix) never use the sentinel, so only the explicit matrix is inspected.
+func (c *ApplicationConfig) HasAutoResource() bool {
+	for _, mode := range c.Accelerator {
+		if ResourceRequirementHasAuto(mode.ResourceRequirement) {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -449,7 +449,11 @@ func minInt64(a, b int64) int64 {
 }
 
 func parseQuantityBytes(value string) int64 {
-	if value == "" {
+	// The auto-compute sentinel means the value is resolved from the rendered
+	// chart at install time. Until the install handler backfills it, treat it
+	// as 0 ("no constraint") so the install-time mode feasibility gate only
+	// checks architecture / mode matching for this field, not its capacity.
+	if value == "" || appcfg.IsAutoResource(value) {
 		return 0
 	}
 	q, err := resource.ParseQuantity(value)
@@ -460,7 +464,7 @@ func parseQuantityBytes(value string) int64 {
 }
 
 func parseQuantityMilli(value string) int64 {
-	if value == "" {
+	if value == "" || appcfg.IsAutoResource(value) {
 		return 0
 	}
 	q, err := resource.ParseQuantity(value)

--- a/framework/app-service/pkg/utils/workload_resources.go
+++ b/framework/app-service/pkg/utils/workload_resources.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	v1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+)
+
+// nvidiaGPUMem is the HAMi per-pod GPU-memory extended resource key. Declared
+// locally to keep this file free of an extra package dependency.
+const nvidiaGPUMem corev1.ResourceName = "nvidia.com/gpumem"
+
+// WorkloadResourceTotals is the per-pod sum (across every rendered workload's
+// pod template) of the container resource requests and limits relevant to
+// install-time auto-resource resolution.
+//
+// GPUMem is summed from the per-pod nvidia.com/gpumem extended resource. The
+// remaining fields are standard k8s quantities (cpu, memory) and are summed in
+// their declared representation.
+type WorkloadResourceTotals struct {
+	RequestsCPU    apiresource.Quantity
+	LimitsCPU      apiresource.Quantity
+	RequestsMemory apiresource.Quantity
+	LimitsMemory   apiresource.Quantity
+	RequestsGPUMem apiresource.Quantity
+	LimitsGPUMem   apiresource.Quantity
+}
+
+// GetWorkloadResourcesFromChart renders the chart at chartPath with the given
+// Helm values (a side-effect-free dry-run, reusing GetResourceListFromChart)
+// and sums the per-pod container resource requests/limits across every
+// workload's pod template.
+//
+// It is the install-time mechanism behind the auto-resource ("-1") sentinel:
+// for a template app whose concrete resource demand only materializes once the
+// user-selected appenv (model, gpu memory, ...) is injected into the chart, the
+// caller renders once with the chosen mode + applied appenv and reads back the
+// real requirement here.
+//
+// Per-pod effective request/limit for a resource follows the Kubernetes rule
+// max(maxInitContainer, sum(regularContainers)).
+func GetWorkloadResourcesFromChart(chartPath string, values map[string]interface{}) (WorkloadResourceTotals, error) {
+	var totals WorkloadResourceTotals
+	resources, err := GetResourceListFromChart(chartPath, values)
+	if err != nil {
+		klog.Infof("get resourcelist from chart err=%v", err)
+		return totals, err
+	}
+
+	add := func(dst *apiresource.Quantity, perPod apiresource.Quantity) {
+		if perPod.IsZero() {
+			return
+		}
+		dst.Add(perPod)
+	}
+
+	// The resource mode requirement is a PER-POD value by convention: HAMI
+	// binds GPU memory per pod, the sidecar webhook injects nvidia.com/gpumem
+	// per pod from RequiredGPU, and node-pressure adds the requirement to a
+	// single node. The compute package never multiplies by replica count, so
+	// neither do we — replicas are intentionally ignored here.
+	accumulate := func(podSpec corev1.PodSpec) {
+		req, lim := effectivePodResources(podSpec)
+		add(&totals.RequestsCPU, *req.Cpu())
+		add(&totals.LimitsCPU, *lim.Cpu())
+		add(&totals.RequestsMemory, *req.Memory())
+		add(&totals.LimitsMemory, *lim.Memory())
+		add(&totals.RequestsGPUMem, req[nvidiaGPUMem])
+		add(&totals.LimitsGPUMem, lim[nvidiaGPUMem])
+	}
+
+	for _, r := range resources {
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		switch kind {
+		case "Deployment":
+			var d v1.Deployment
+			if err := scheme.Scheme.Convert(r.Object, &d, nil); err != nil {
+				return totals, err
+			}
+			accumulate(d.Spec.Template.Spec)
+		case "StatefulSet":
+			var s v1.StatefulSet
+			if err := scheme.Scheme.Convert(r.Object, &s, nil); err != nil {
+				return totals, err
+			}
+			accumulate(s.Spec.Template.Spec)
+		case "DaemonSet":
+			var ds v1.DaemonSet
+			if err := scheme.Scheme.Convert(r.Object, &ds, nil); err != nil {
+				return totals, err
+			}
+			accumulate(ds.Spec.Template.Spec)
+		case "ReplicaSet":
+			var rs v1.ReplicaSet
+			if err := scheme.Scheme.Convert(r.Object, &rs, nil); err != nil {
+				return totals, err
+			}
+			accumulate(rs.Spec.Template.Spec)
+		case "Job":
+			var j batchv1.Job
+			if err := scheme.Scheme.Convert(r.Object, &j, nil); err != nil {
+				return totals, err
+			}
+			accumulate(j.Spec.Template.Spec)
+		case "Pod":
+			var p corev1.Pod
+			if err := scheme.Scheme.Convert(r.Object, &p, nil); err != nil {
+				return totals, err
+			}
+			accumulate(p.Spec)
+		}
+	}
+	return totals, nil
+}
+
+// effectivePodResources computes the pod-level effective resource requests and
+// limits following the Kubernetes scheduling rule: for each resource the value
+// is max(maxInitContainer, sum(regularContainers)).
+func effectivePodResources(spec corev1.PodSpec) (corev1.ResourceList, corev1.ResourceList) {
+	sumReq := corev1.ResourceList{}
+	sumLim := corev1.ResourceList{}
+	for _, c := range spec.Containers {
+		addResourceList(sumReq, c.Resources.Requests)
+		addResourceList(sumLim, c.Resources.Limits)
+	}
+	for _, c := range spec.InitContainers {
+		maxResourceList(sumReq, c.Resources.Requests)
+		maxResourceList(sumLim, c.Resources.Limits)
+	}
+	return sumReq, sumLim
+}
+
+func addResourceList(dst corev1.ResourceList, src corev1.ResourceList) {
+	for name, q := range src {
+		cur := dst[name]
+		cur.Add(q)
+		dst[name] = cur
+	}
+}
+
+func maxResourceList(dst corev1.ResourceList, src corev1.ResourceList) {
+	for name, q := range src {
+		cur, ok := dst[name]
+		if !ok || q.Cmp(cur) > 0 {
+			dst[name] = q.DeepCopy()
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds install-time **auto-resource resolution** for template-style apps (e.g. a vLLM template) whose concrete compute demand isn't known until the user picks a value (model / GPU memory) injected as an appenv.

A manifest author writes the auto-compute sentinel `"-1"` into an `accelerator` mode resource field (e.g. `requiredGPUMemory` / `limitedGPUMemory`). At install time app-service renders the chart with the selected mode + applied appenv, sums the workload pod resources, and backfills the concrete value into the application config **before the `ApplicationManager` is created** — so the whole downstream pipeline (state machine, compute allocation, HAMI binding, resume, availability) sees concrete values and needs no changes.

## How it works

- `appcfg`: `AutoResourceValue` sentinel + helpers; `ParseResourceRequirement` treats `-1` as unset (never a negative quantity); `ApplicationConfig.HasAutoResource()`.
- `compute/scheduler.go`: `parseQuantityBytes/Milli` treat the sentinel as `0` so the install-time mode-feasibility gate only checks architecture / mode matching for an auto field (capacity check skipped), matching the agreed "`-1` = skip pre-check, still match arch" semantics.
- `utils/workload_resources.go`: `GetWorkloadResourcesFromChart` — side-effect-free helm dry-run render (reuses `GetResourceListFromChart`) that sums per-pod container requests/limits (cpu / memory / `nvidia.com/gpumem`). Per-pod by design (replicas not multiplied), matching how compute consumes the requirement.
- `apiserver/handler_installer_install.go`: `resolveAutoResources` runs after appenv apply and before AM creation — renders, sums, backfills the selected mode's sentinel fields, re-runs `ResolveRequirement`. GPU memory is converted MiB → bytes on backfill (pod `nvidia.com/gpumem` is an integer MiB; the mode field / scheduler / webhook interpret bytes).

Companion oac change (already merged, #3291) skips the k8s-quantity validation for the sentinel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install pipeline and how compute interprets manifest resources for sentinel values; impact is limited to apps using `-1`, but wrong chart sums could mis-schedule GPU/memory.
> 
> **Overview**
> Adds **install-time auto-resource resolution** for template apps that declare the `"-1"` sentinel on accelerator/resource fields (CPU, memory, GPU) when demand depends on user appenv (e.g. model / GPU memory).
> 
> **`appcfg`**: introduces `AutoResourceValue` and helpers; `ParseResourceRequirement` treats `-1` as unset; **`compute`**: pre-backfill feasibility treats `-1` as zero capacity so mode/arch checks still run without bogus negative quantities.
> 
> **Install path**: after appenv apply and **before** `ApplicationManager` creation, `resolveAutoResources` dry-runs Helm with the selected mode, sums per-pod workload requests/limits via new `GetWorkloadResourcesFromChart`, backfills sentinel fields (including MiB→byte GPU memory), and refreshes `appConfig.Requirement`.
> 
> Also bumps **app-service** image to `0.5.33` and the **oac** module pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c65c3b795a32ce3aa3e07bde593db0d62a8e113a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->