### PR TITLE
fix(l4): add allow header x-archive-password

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -142,7 +142,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.21"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.22"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.21
+          value: v0.3.22
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.21
+      name: beclab/l4-bfl-proxy:v0.3.22
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -630,7 +630,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -725,7 +725,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -820,7 +820,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -915,7 +915,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1115,7 +1115,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1210,7 +1210,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1305,7 +1305,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1400,7 +1400,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -657,7 +657,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -722,7 +722,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -787,7 +787,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -852,7 +852,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -917,7 +917,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1087,7 +1087,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1152,7 +1152,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1217,7 +1217,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1282,7 +1282,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1347,7 +1347,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -1242,7 +1242,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1307,7 +1307,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1372,7 +1372,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1437,7 +1437,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1607,7 +1607,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1702,7 +1702,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1797,7 +1797,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1892,7 +1892,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1987,7 +1987,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2082,7 +2082,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2282,7 +2282,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2347,7 +2347,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2412,7 +2412,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2477,7 +2477,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2647,7 +2647,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2742,7 +2742,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2837,7 +2837,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2932,7 +2932,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3027,7 +3027,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3122,7 +3122,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -1697,7 +1697,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1762,7 +1762,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1827,7 +1827,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1892,7 +1892,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1957,7 +1957,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2127,7 +2127,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2192,7 +2192,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2257,7 +2257,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2322,7 +2322,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2387,7 +2387,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2557,7 +2557,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2622,7 +2622,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2687,7 +2687,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2752,7 +2752,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2817,7 +2817,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -2987,7 +2987,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3052,7 +3052,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3117,7 +3117,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3182,7 +3182,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3247,7 +3247,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3417,7 +3417,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3482,7 +3482,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3547,7 +3547,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3612,7 +3612,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3677,7 +3677,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3847,7 +3847,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3912,7 +3912,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -3977,7 +3977,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -4042,7 +4042,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -4107,7 +4107,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -722,7 +722,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -787,7 +787,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -852,7 +852,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -917,7 +917,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -982,7 +982,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1152,7 +1152,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1217,7 +1217,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1282,7 +1282,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1347,7 +1347,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1412,7 +1412,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -705,7 +705,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -770,7 +770,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -835,7 +835,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -900,7 +900,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -965,7 +965,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1135,7 +1135,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1200,7 +1200,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1265,7 +1265,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1330,7 +1330,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },
@@ -1395,7 +1395,7 @@
             {
               "header": {
                 "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"
+                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
               },
               "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             },

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -668,7 +668,7 @@ func translateVirtualHost(vhIR *ir.VirtualHostIR) *routev3.VirtualHost {
 	// which is invalid per the Fetch spec.
 	vh.ResponseHeadersToAdd = append(vh.ResponseHeadersToAdd,
 		&corev3.HeaderValueOption{
-			Header:       &corev3.HeaderValue{Key: "access-control-allow-headers", Value: "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization"},
+			Header:       &corev3.HeaderValue{Key: "access-control-allow-headers", Value: "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"},
 			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 		},
 		&corev3.HeaderValueOption{


### PR DESCRIPTION


* **Background**
add allow header x-archive-password
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CORS header allowlist and a routine proxy image version bump on the edge layer; no auth or routing logic changes.
> 
> **Overview**
> Bumps **l4-bfl-proxy** to **v0.3.22** in the Olares upgrade path, BFL launcher deploy (`L4_PROXY_IMAGE_VERSION`), and prebuilt image metadata.
> 
> The proxy’s normalized CORS **`access-control-allow-headers`** list now includes **`x-archive-password`**, so browsers can send that custom header on cross-origin API calls (e.g. archive/backup). E2E golden Envoy configs were refreshed to match the translator change in `translator.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c038e21de1b4a1d6ae48d92224f65f415cbc44ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->