### PR TITLE
daemon: add bridge connection watcher to monitor network carrier changes

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -101,6 +101,7 @@ func main() {
 
 	state.WatchStatus(mainCtx, []watcher.Watcher{
 		system.NewSystemWatcher(),
+		system.NewBridgeConnectionWatcher(),
 		// usb.NewUsbWatcher(),
 		usb.NewUmountWatcher(),
 		upgrade.NewUpgradeWatcher(),

--- a/daemon/internel/watcher/system/watchers.go
+++ b/daemon/internel/watcher/system/watchers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	changeip "github.com/beclab/Olares/daemon/pkg/commands/change_ip"
 	"github.com/beclab/Olares/daemon/pkg/commands/uninstall"
+	"github.com/beclab/Olares/daemon/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -51,5 +52,67 @@ func (w *autoRepair) Watch(ctx context.Context) {
 		if err != nil {
 			klog.Error("auto uninstall error, ", err)
 		}
+	}
+}
+
+type bridgeConnectionWatcher struct {
+	watcher.Watcher
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewBridgeConnectionWatcher() *bridgeConnectionWatcher {
+	return &bridgeConnectionWatcher{}
+}
+
+func (w *bridgeConnectionWatcher) Watch(ctx context.Context) {
+	if c, err := utils.FindBridgeConnection(ctx); err != nil {
+		klog.Error("find bridge connection error, ", err)
+	} else if c == nil {
+		// bridge connection is removed, stop watching
+		if w.cancel != nil {
+			w.cancel()
+			w.cancel = nil
+			w.ctx = nil
+		}
+	} else if w.ctx == nil {
+		// bridge connection is back, start watching
+		w.ctx, w.cancel = context.WithCancel(context.Background())
+		klog.Info("start watching network carrier changes for bridge connection")
+		go func() {
+			err := utils.ListenNetworkCarrierChanges(w.ctx, func() {
+				// disable the overlay gateway supported apps' option for all users
+				apps, err := utils.GetOverlayGatewaySupportedApps(ctx, "")
+				if err != nil {
+					klog.Error("get overlay gateway supported apps error, ", err)
+					return
+				}
+
+				// network carrier down, disable overlay gateway enabled apps
+				for _, app := range apps {
+					if app.Enabled {
+						// set the app's option to disable overlay gateway
+						err = utils.UpdateApplicationSettings(ctx, app.AppResourceName, "enableOverlayGateway", "false")
+						if err != nil {
+							klog.Error("disable overlay gateway supported app error, ", err)
+							return
+						}
+					}
+				}
+
+				// restart the overlay gateway supported apps
+				// call restarting from the frontend
+				go func() {
+					err = utils.RestartOverlayGatewaySupportedApps(ctx, apps)
+					if err != nil {
+						klog.Error("restart overlay gateway supported apps error, ", err)
+					}
+				}()
+			})
+
+			if err != nil {
+				klog.Error("listen network carrier changes error, ", err)
+			}
+		}()
 	}
 }

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -293,7 +293,8 @@ func CheckCurrentStatus(ctx context.Context) error {
 		currentTerminusState = Uninitialized
 	}
 
-	if utils.IsIpChanged(ctx, CurrentState.TerminusState != NotInstalled) {
+	if utils.IsIpChanged(ctx, CurrentState.TerminusState != NotInstalled) &&
+		CurrentState.TerminusState != IPChanging {
 		currentTerminusState = InvalidIpAddress
 		return nil
 	}

--- a/daemon/pkg/utils/network_linux.go
+++ b/daemon/pkg/utils/network_linux.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
 
@@ -840,4 +841,31 @@ func FindBridgeConnection(ctx context.Context) (*BridgeConnection, error) {
 	}
 
 	return nil, nil
+}
+
+func ListenNetworkCarrierChanges(ctx context.Context, downCallback func()) error {
+	updates := make(chan netlink.LinkUpdate)
+
+	if err := netlink.LinkSubscribe(updates, ctx.Done()); err != nil {
+		klog.Error("subscribe network changes error, ", err)
+		return err
+	}
+
+	for {
+		select {
+		case update := <-updates:
+			if update.Attrs().Name == bridgeConnectionName {
+				isLowerUp := (update.Flags & 0x10000) != 0
+				isUp := (update.Flags & 1) != 0
+
+				if !isLowerUp || !isUp {
+					klog.Infof("network change detected: %s, state: %s", update.Attrs().Name, update.Link.Attrs().OperState.String())
+					downCallback()
+				}
+			}
+		case <-ctx.Done():
+			klog.Info("stop listening network changes")
+			return nil
+		}
+	}
 }


### PR DESCRIPTION
* **Background**
Add a bridge connection watcher to monitor network carrier changes, automatically disable apps `enableOverlayWary` settings when the Ethernet cable connection is broken

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically mutates per-app `enableOverlayGateway` settings and triggers app restarts on network events; incorrect carrier detection could disrupt overlay features for all users.
> 
> **Overview**
> Adds a **bridge connection watcher** to `terminusd` that reacts when the `br-olares` link loses carrier (e.g. Ethernet unplugged).
> 
> When a bridge setup exists, the daemon subscribes to **netlink** updates on `br-olares`. On link-down, it turns off **`enableOverlayGateway`** for all users’ overlay-gateway-capable apps that had it enabled, then **restarts** those apps asynchronously. The listener is started and stopped as the bridge connection appears or disappears (`FindBridgeConnection`).
> 
> **State handling:** `CheckCurrentStatus` no longer marks the cluster **`InvalidIpAddress`** from `IsIpChanged` while **`IPChanging`** is already in progress, avoiding a race with active IP-change flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf89a1bcc75768c2ed34e99a148e87b35f02689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->