### PR TITLE
fix(gpu): minimize sharemode update delay

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.20"
+version: "v2.6.21"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.20
+      name: beclab/hami:v2.6.21
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
After https://github.com/beclab/HAMi/pull/19, the share mode of all devices are managed by app-service, and the update event of node resource is watched by scheduler's node informer, although immediately, but the device update frequency is capped by the update logic, delaying the update of sharemode, we make the share mode update prior to other metadata update.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/21

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GPU scheduler/device-plugin version used in production clusters; behavior change is localized to share-mode refresh timing but affects scheduling-sensitive GPU workloads.
> 
> **Overview**
> Bumps the bundled **HAMi** GPU virtualization stack from **`v2.6.20`** to **`v2.6.21`** so Olares ships the upstream fix that **prioritizes share-mode updates** over other device metadata refresh, reducing delay after app-service manages share mode and the scheduler’s node informer sees resource events.
> 
> **`infrastructure/gpu/.olares/config/gpu/hami/values.yaml`** sets `version: "v2.6.21"` (scheduler extender and device plugin images use `beclab/hami` with this tag). **`platform/hami/.olares/Olares.yaml`** updates the prebuilt container list to **`beclab/hami:v2.6.21`**. No other chart or image pins change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b97a3bff53ba842356af91479c5efbf21bb20c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->