### PR TITLE
fix: disable LAN subnet routing for nftables compatibility

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -369,10 +369,8 @@ spec:
               matchLabels:
                 app: headscale
             topologyKey: kubernetes.io/hostname
-      {{- if eq $role "owner" }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
       containers:
       - name: tailscale
         image: tailscale/tailscale:v1.94.2
@@ -425,16 +423,12 @@ spec:
             --tun=tailscale0{{ if and .Values.tailscaleUserIndex (ne .Values.tailscaleUserIndex  "0") }}$(USER_INDEX){{ end }}
         - name: TS_ROUTES
           value: $(COREDNS_SVC)/32
-        - name: ADVERTISE_EXIT_NODE
-          value: "false"
         - name: TS_EXTRA_ARGS
           value: >-
             --login-server https://headscale-server-svc
-            --netfilter-mode=on
-            --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset
+            --netfilter-mode=off --reset
         - name: TS_USERSPACE
           value: "false"
-
         - name: TS_KUBE_SECRET
       volumes:
       - name: config
@@ -504,8 +498,7 @@ data:
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:80"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:443"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:18088"] },
-        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] },
-        { "action": "accept", "src": ["*"], "dst": ["autogroup:internet:*"] }
+        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] }
       ],
       "autoApprovers": {
         "routes": {
@@ -513,7 +506,7 @@ data:
           "172.16.0.0/12": ["default@"],
           "192.168.0.0/16": ["default@"]
         },
-        "exitNode": ["default@"]
+        "exitNode": []
       }
     }
 kind: ConfigMap

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -369,8 +369,10 @@ spec:
               matchLabels:
                 app: headscale
             topologyKey: kubernetes.io/hostname
+      {{- if eq $role "owner" }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
       - name: tailscale
         image: tailscale/tailscale:v1.94.2
@@ -423,10 +425,12 @@ spec:
             --tun=tailscale0{{ if and .Values.tailscaleUserIndex (ne .Values.tailscaleUserIndex  "0") }}$(USER_INDEX){{ end }}
         - name: TS_ROUTES
           value: $(COREDNS_SVC)/32
+        - name: ADVERTISE_EXIT_NODE
+          value: "false"
         - name: TS_EXTRA_ARGS
           value: >-
             --login-server https://headscale-server-svc
-            --netfilter-mode=off --reset
+            --netfilter-mode=off --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset
         - name: TS_USERSPACE
           value: "false"
         - name: TS_KUBE_SECRET


### PR DESCRIPTION

* **Background**
LAN subnet routing instability caused by the changed Tailscale nftables cleanup rules

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster-wide Tailscale networking (hostNetwork for all users, netfilter off, no exit node), which can alter VPN routing and egress behavior until validated in target releases.
> 
> **Overview**
> Addresses **LAN subnet routing instability** tied to Tailscale’s nftables cleanup by changing how the **tailscale** sidecar is deployed and what Headscale ACLs allow.
> 
> The **tailscale** Deployment now always uses **`hostNetwork: true`** and **`ClusterFirstWithHostNet`** (the previous **owner**-only Helm guard is removed). **`TS_EXTRA_ARGS`** switches from **`--netfilter-mode=on`** to **`--netfilter-mode=off`**, and **exit-node advertisement** (`ADVERTISE_EXIT_NODE` / `--advertise-exit-node`) is removed so the node no longer offers itself as an exit node.
> 
> The embedded **`tailscale-acl`** ConfigMap drops the broad **`autogroup:internet:*`** accept rule and sets **`autoApprovers.exitNode`** to an empty list instead of **`default@`**, aligning policy with disabled exit-node usage while keeping private RFC1918 route auto-approval unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4243996da5ba193a03dffebe952b0a047a3533a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->