### PR TITLE
helm-charts/system-apps: bump system-frontend to v1.10.45 and user-service to v0.0.99

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.44
+          image: beclab/system-frontend:v1.10.45
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.98
+          image: beclab/user-service:v0.0.99
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

  Bump the `system-frontend` image to `v1.10.45` and the `user-service` image to `v0.0.99` to ship the TermiPass `v1.10.45` release. This release bundles the following sub-system changes:

  - **Settings / Olares One** ([TermiPass#1175](https://github.com/beclab/TermiPass/pull/1175)): add two Olares One–only toggles on the *My hardware* page — **CPU frequency limit** and **Auto power on** — wired to the settings-server mDNS endpoints. Auto power on gracefully degrades (disabled with a hint) when the device EC version is unsupported (HTTP 501).
  - **Market / Accelerator** ([TermiPass#1178](https://github.com/beclab/TermiPass/pull/1178)): add an accelerator-aware **Resource** card on the app detail page (compute-mode dropdown, per-mode resource display, cluster shortfall banner). Accelerator apps are no longer blocked by the frontend install pre-check (resource availability is surfaced as a hint only); compute-mode display titles are unified across the app via `compute.ts`.
  - **Desktop / Layout sync** ([TermiPass#1151](https://github.com/beclab/TermiPass/pull/1151)): bring the desktop layout (launchpad + dock) under server-side ownership so it syncs across devices, add a desktop bookmark surface, and ship a reset flow. This pairs with the `user-service` change, hence the `user-service` bump to `v0.0.99`.
  - **Files / Archives** ([TermiPass#1181](https://github.com/beclab/TermiPass/pull/1181)): tag `rar` as an unsupported archive (shows an "Unsupported" badge, no extract/preview actions) and harden archive preview/extract over the browser fetch (CORS) path.
  - **Files / Sort persistence** ([TermiPass#1177](https://github.com/beclab/TermiPass/pull/1177)): persist the root directory sort preference (field + direction) to IndexedDB so it is restored across sessions.
  - **Control Hub / Terminal** ([TermiPass#1180](https://github.com/beclab/TermiPass/pull/1180)): adjust the node terminal box height and styling to align with the 56px header and improve layout on Windows browsers.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  - https://github.com/beclab/TermiPass/pull/1175
  - https://github.com/beclab/TermiPass/pull/1178
  - https://github.com/beclab/TermiPass/pull/1151
  - https://github.com/beclab/TermiPass/pull/1180
  - https://github.com/beclab/TermiPass/pull/1181
  - https://github.com/beclab/TermiPass/pull/1177

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.45
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.44...v1.10.45

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version-only Helm change, but it rolls out user-facing Settings/Market/Desktop/Files behavior and server-side desktop sync via user-service, so regressions depend on the new images rather than chart edits.
> 
> **Overview**
> Updates the **system-apps** `olares-app` deployment to ship TermiPass **v1.10.45**: the `olares-app-init` init container moves from `beclab/system-frontend:v1.10.44` to **v1.10.45**, and the `user-service` sidecar moves from **v0.0.98** to **v0.0.99**. No chart structure, env, or routing changes—only image tags.
> 
> That frontend release adds Olares One hardware toggles (CPU frequency limit, auto power on), Market accelerator resource UI and relaxed install pre-check behavior, server-synced desktop layout with bookmarks/reset (paired with the user-service bump), Files changes (unsupported `rar`, archive fetch hardening, persisted root sort), and Control Hub terminal layout tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4586cd12e21d672c7eab485045b6fbae78aae35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->