### PR TITLE
files archive: volume-aware extract/compress + friendlier errors

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.180
+          image: beclab/files-server:v0.2.181
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat(archive): extract/entries/entry rewrites .NNN+ src to .001 so any volume the user picks resolves to the first.
- feat(archive): preflight rejects extract requests where an intermediate volume is missing.
- fix(archive): map 7z extract failures to actionable messages instead of raw `exit status 2`.
- fix(archive): rename/skip/overwrite scan every <base>.NNN sibling so partial volume sets don't slip past.
- feat(archive): reject compress basenames that would overflow NAME_MAX (255).
- fix(cors): allow x-archive-password header across origins.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/347

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag change in cluster deploy; behavior changes live in the container image, not in this YAML beyond the version pin.
> 
> **Overview**
> Bumps the **files** DaemonSet container image from `beclab/files-server:v0.2.180` to **`v0.2.181`** in `files_deploy.yaml`, rolling out the archive/CORS fixes described for that release (volume-aware extract/compress, clearer 7z errors, `x-archive-password` CORS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5bd2eecd069cf57b64c3f88076c404122e41a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->