### PR TITLE
hami: bump hami core

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.21"
+version: "v2.6.22"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.21
+      name: beclab/hami:v2.6.22
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Bump hami core version

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/e7e98b3b2bdf565e55b5f646ed60eb4a8dbd422b

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GPU scheduler extender and device-plugin images; rolling upgrades can restart GPU-related DaemonSets and briefly affect vGPU workloads, though the change is a patch-version tag bump only.
> 
> **Overview**
> Bumps the **HAMi core** container image from **v2.6.21** to **v2.6.22** in deployment packaging only.
> 
> `infrastructure/gpu/.olares/config/gpu/hami/values.yaml` updates the top-level `version` value, which Helm uses as the image tag for `beclab/hami` on the scheduler extender and NVIDIA device plugin (including vGPU monitor). `platform/hami/.olares/Olares.yaml` updates the prebuilt output list to the same `beclab/hami:v2.6.22` tag. Web UI and dcgm-exporter image pins are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130a057d5507072131ae8f04744f1469a91cb3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->