### PR TITLE
fix(tailscale): disable LAN subnet routing for nftables compatibility

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -369,10 +369,8 @@ spec:
               matchLabels:
                 app: headscale
             topologyKey: kubernetes.io/hostname
-      {{- if eq $role "owner" }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
       containers:
       - name: tailscale
         image: tailscale/tailscale:v1.94.2
@@ -425,16 +423,12 @@ spec:
             --tun=tailscale0{{ if and .Values.tailscaleUserIndex (ne .Values.tailscaleUserIndex  "0") }}$(USER_INDEX){{ end }}
         - name: TS_ROUTES
           value: $(COREDNS_SVC)/32
-        - name: ADVERTISE_EXIT_NODE
-          value: "false"
         - name: TS_EXTRA_ARGS
           value: >-
             --login-server https://headscale-server-svc
-            --netfilter-mode=on
-            --advertise-exit-node=$(ADVERTISE_EXIT_NODE) --reset
+            --netfilter-mode=off --reset
         - name: TS_USERSPACE
           value: "false"
-
         - name: TS_KUBE_SECRET
       volumes:
       - name: config
@@ -504,8 +498,7 @@ data:
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:80"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:443"] },
         { "action": "accept", "src": ["*"], "proto": "tcp", "dst": ["*:18088"] },
-        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] },
-        { "action": "accept", "src": ["*"], "dst": ["autogroup:internet:*"] }
+        { "action": "accept", "src": ["*"], "proto": "udp", "dst": ["*:53"] }
       ],
       "autoApprovers": {
         "routes": {
@@ -513,7 +506,7 @@ data:
           "172.16.0.0/12": ["default@"],
           "192.168.0.0/16": ["default@"]
         },
-        "exitNode": ["default@"]
+        "exitNode": []
       }
     }
 kind: ConfigMap


### PR DESCRIPTION


* **Background**
LAN subnet routing instability caused by the changed Tailscale nftables cleanup rules

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster networking behavior (hostNetwork for all roles, no Tailscale-managed netfilter, no exit-node/internet ACL), which can affect VPN routing and connectivity until validated on target versions.
> 
> **Overview**
> Addresses **LAN subnet routing instability** tied to Tailscale’s nftables cleanup by changing how the user-space Tailscale pod is deployed and what traffic Headscale ACLs allow.
> 
> The **Tailscale** deployment now always uses **hostNetwork** (the owner-role-only guard is removed) and sets **`--netfilter-mode=off`** instead of managing firewall rules via Tailscale, dropping **`--advertise-exit-node`** and the related env var. The **`tailscale-acl`** ConfigMap no longer accepts traffic to **`autogroup:internet:*`** and clears **`autoApprovers.exitNode`** (was `default@`), while keeping CoreDNS route auto-approval for private ranges.
> 
> **CoreDNS `/32` route advertisement** via `TS_ROUTES` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4243996da5ba193a03dffebe952b0a047a3533a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->