### PR TITLE
fix: Use app-shared label to identify shared namespaces in Corefile regeneration

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -79,7 +79,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.21
+        image: beclab/sys-event:0.2.22
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -237,9 +237,9 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 				refAppName := ns.Labels["applications.app.bytetrade.io/name"]
 				sharedNamespace := ns.Labels["bytetrade.io/ns-shared"]
 				installedUser := ns.Labels["applications.app.bytetrade.io/install_user"]
-				isV3 := ns.Labels["app.bytetrade.io/api-version"] == "v3"
-				namespaceV3 := ns.Labels["bytetrade.io/namespace"]
-				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner || (isV3 && app.Spec.Namespace == namespaceV3) {
+				isShared := ns.Labels["app.bytetrade.io/app-shared"] == "true"
+				namespaceShared := ns.Labels["bytetrade.io/namespace"]
+				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner || (isShared && app.Spec.Namespace == namespaceShared) {
 					sharedNs = append(sharedNs, &ns)
 				}
 			}

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -243,6 +243,12 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
+			klog.Infof("appName: %s", app.Spec.Name)
+			nss := make([]string, 0)
+			for _, n := range sharedNs {
+				nss = append(nss, n.Name)
+			}
+			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -243,12 +243,6 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
-			klog.Infof("appName: %s", app.Spec.Name)
-			nss := make([]string, 0)
-			for _, n := range sharedNs {
-				nss = append(nss, n.Name)
-			}
-			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {


### PR DESCRIPTION

* **Background**
fix: Use app-shared label to identify shared namespaces in Corefile regeneration  Replace the v3 API version check with the app.bytetrade.io/app-shared label when determining whether a namespace should be included in shared Corefile generation
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which namespaces get shared-entrance DNS templates in CoreDNS; mis-labeling could omit or mis-associate records, but scope is limited to shared-entrance regeneration.
> 
> **Overview**
> **Corefile regeneration** for shared application entrances now treats a namespace as the app’s shared namespace when `app.bytetrade.io/app-shared=true` and `bytetrade.io/namespace` matches `app.Spec.Namespace`, instead of requiring `app.bytetrade.io/api-version=v3` with the same namespace label check.
> 
> The **tapr-sysevent** deployment image is bumped from `beclab/sys-event:0.2.21` to `0.2.22` so clusters pick up this watcher behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d553b40552c3db076096ced5578c69ee18b90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->