### PR TITLE
feat(bfl): accept timezone setting in user activation

### DIFF
--- a/framework/bfl/pkg/apis/base.go
+++ b/framework/bfl/pkg/apis/base.go
@@ -25,6 +25,7 @@ type Base struct {
 type PostLocale struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
+	Timezone string `json:"timezone"`
 	// dark/light
 	Theme string `json:"theme"`
 }
@@ -131,6 +132,7 @@ func (b *Base) HandleGetSysConfig(_ *restful.Request, resp *restful.Response) {
 	cfg := PostLocale{
 		Language: user.Annotations[constants.UserLanguage],
 		Location: user.Annotations[constants.UserLocation],
+		Timezone: user.Annotations[constants.UserTimezone],
 		Theme:    user.Annotations[constants.UserTheme],
 	}
 	response.Success(resp, &cfg)

--- a/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
@@ -232,6 +232,9 @@ func (h *Handler) handleActivate(req *restful.Request, resp *restful.Response) {
 			if payload.Location != "" {
 				u.Annotations[constants.UserLocation] = payload.Location
 			}
+			if payload.Timezone != "" {
+				u.Annotations[constants.UserTimezone] = payload.Timezone
+			}
 			if payload.Theme == "" {
 				payload.Theme = "light"
 			}
@@ -673,6 +676,10 @@ func (h *Handler) handleUpdateLocale(req *restful.Request, resp *restful.Respons
 
 				if locale.Location != "" {
 					u.Annotations[constants.UserLocation] = locale.Location
+				}
+
+				if locale.Timezone != "" {
+					u.Annotations[constants.UserTimezone] = locale.Timezone
 				}
 
 				if locale.Theme == "" {

--- a/framework/bfl/pkg/apis/settings/v1alpha1/model.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/model.go
@@ -110,6 +110,7 @@ type ExternalNetworkSwitchStatusView struct {
 type ActivateRequest struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
+	Timezone string `json:"timezone"`
 	Theme    string `json:"theme"`
 	FRP      struct {
 		Host string `json:"host"`

--- a/framework/bfl/pkg/constants/constants.go
+++ b/framework/bfl/pkg/constants/constants.go
@@ -169,6 +169,7 @@ var (
 	UserLanguage = fmt.Sprintf("%s/language", AnnotationGroup)
 
 	UserLocation = fmt.Sprintf("%s/location", AnnotationGroup)
+	UserTimezone = fmt.Sprintf("%s/timezone", AnnotationGroup)
 	UserTheme    = fmt.Sprintf("%s/theme", AnnotationGroup)
 
 	UserTerminusWizardStatus = fmt.Sprintf("%s/wizard-status", AnnotationGroup)


### PR DESCRIPTION
* **Background**
accept timezone setting in user activation

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive locale field on existing user-annotation flows with no auth or network behavior changes.
> 
> **Overview**
> Adds **timezone** as a first-class user locale setting alongside language, location, and theme.
> 
> The BFL APIs now accept an optional `timezone` field on **system activation** (`ActivateRequest`) and **locale updates** (`PostLocale`), persisting it to the IAM user annotation `bytetrade.io/timezone` when non-empty. **Sys config** responses include the stored timezone so the UI can read it back during setup and later.
> 
> No new validation logic is introduced in this diff; behavior mirrors the existing optional locale fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbf8743e555e0bd9361922ab1abfdd019eb1b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->