### PR TITLE
fix(cli): add hostname check for install and node join

### DIFF
--- a/cli/pkg/bootstrap/precheck/module.go
+++ b/cli/pkg/bootstrap/precheck/module.go
@@ -75,6 +75,7 @@ func (m *RunPrechecksModule) Init() {
 
 	checkers := []Checker{
 		new(SystemSupportCheck),
+		new(HostnameCheck),
 		new(SystemdCheck),
 		new(RequiredPortsCheck),
 		new(ConflictingContainerdCheck),

--- a/cli/pkg/bootstrap/precheck/tasks.go
+++ b/cli/pkg/bootstrap/precheck/tasks.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -143,6 +144,27 @@ func (t *ConflictingContainerdCheck) Check(runtime connector.Runtime) error {
 	containerdSocket := "/run/containerd/containerd.sock"
 	if util.IsExist(containerdSocket) {
 		return fmt.Errorf("found existing containerd socket: %s, a containerd managed by Olares is required to ensure normal function%s", containerdSocket, fixMSG)
+	}
+	return nil
+}
+
+type HostnameCheck struct{}
+
+func (t *HostnameCheck) Name() string {
+	return "Hostname"
+}
+
+func (t *HostnameCheck) Check(runtime connector.Runtime) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("failed to get hostname: %v", err)
+	}
+	hostname = strings.ToLower(hostname)
+	if errs := validation.IsDNS1123Subdomain(hostname); len(errs) > 0 {
+		return fmt.Errorf("hostname %q is not a valid Kubernetes node name: %s; "+
+			"please change the hostname to consist of lowercase alphanumeric characters, '-' or '.', "+
+			"and to start and end with an alphanumeric character, then try again",
+			hostname, strings.Join(errs, "; "))
 	}
 	return nil
 }

--- a/cli/pkg/gpu/amdgpu/tasks.go
+++ b/cli/pkg/gpu/amdgpu/tasks.go
@@ -3,9 +3,11 @@ package amdgpu
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/beclab/Olares/cli/pkg/clientset"
 	"github.com/beclab/Olares/cli/pkg/common"
@@ -279,9 +281,18 @@ func (t *CheckAmdGpuStatus) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
+	// in a multi-node cluster there is one amdgpu-device-plugin pod per GPU node,
+	// so we must only check the pod scheduled on the current node.
+	nodeName, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "get hostname error")
+	}
+	nodeName = strings.ToLower(nodeName)
+
 	// Check AMD device plugin pod status using the label from amdgpu-device-plugin.yaml
 	selector := "name=amdgpu-dp-ds"
-	cmd := fmt.Sprintf("%s get pod -n kube-system -l '%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, selector)
+	fieldSelector := fmt.Sprintf("spec.nodeName=%s", nodeName)
+	cmd := fmt.Sprintf("%s get pod -n kube-system -l '%s' --field-selector '%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, selector, fieldSelector)
 
 	rphase, _ := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if rphase == "Running" {

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -325,8 +325,17 @@ func (t *CheckGpuStatus) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
+	// in a multi-node cluster there is one hami-device-plugin pod per GPU node,
+	// so we must only check the pod scheduled on the current node.
+	nodeName, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "get hostname error")
+	}
+	nodeName = strings.ToLower(nodeName)
+
 	selector := "app.kubernetes.io/component=hami-device-plugin"
-	cmd := fmt.Sprintf("%s get pod  -n kube-system -l '%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, selector)
+	fieldSelector := fmt.Sprintf("spec.nodeName=%s", nodeName)
+	cmd := fmt.Sprintf("%s get pod -n kube-system -l '%s' --field-selector '%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, selector, fieldSelector)
 
 	rphase, _ := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if rphase == "Running" {


### PR DESCRIPTION
* **Background**
Only check GPU plugin status on the current node to be compatible with a multi-node env with both/all nodes equipped with GPUs
Check for hostname validity before install to be compatible with K8s resource name requirement

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to install prechecks and kubectl field selectors for GPU plugin validation; no auth or data-path changes.
> 
> **Overview**
> Adds a **Hostname** bootstrap precheck that lowercases the machine hostname and rejects install/join when it fails Kubernetes **DNS-1123 subdomain** rules (`validation.IsDNS1123Subdomain`), with guidance to fix the hostname before retrying.
> 
> **NVIDIA (hami)** and **AMD** GPU device-plugin health checks now scope `kubectl get pod` to the **current node** via `--field-selector spec.nodeName=<hostname>` instead of aggregating phases from every plugin pod in the cluster, so multi-node GPU clusters do not fail when another node’s plugin is not Running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abad38c2ef932a6cf0203bf00fc0f20320ba8d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->