### PR TITLE
feat(oac): enforce allowMultipleInstall safety rules and options cross-field validation

### DIFF
--- a/framework/oac/allow_multiple_install_test.go
+++ b/framework/oac/allow_multiple_install_test.go
@@ -54,10 +54,9 @@ func TestLint_AllowMultipleInstall_FixedWorkloadName_Bad(t *testing.T) {
 }
 
 // TestReleaseNameWorkloadCheckApplies pins the gate to its current
-// definition: the release-name workload rule fires whenever
-// options.allowMultipleInstall is true, regardless of apiVersion. The
-// flag (not the schema version) is what enables multiple coexisting
-// installs and therefore demands a release-scoped primary workload.
+// definition: the release-name workload rule fires when
+// options.allowMultipleInstall is true on v1/v3 manifests. v2 is skipped
+// because workloads are rendered from spec.subCharts[], not the parent path.
 func TestReleaseNameWorkloadCheckApplies(t *testing.T) {
 	cases := []struct {
 		api   string
@@ -66,7 +65,7 @@ func TestReleaseNameWorkloadCheckApplies(t *testing.T) {
 	}{
 		{"v1", true, true},
 		{"v3", true, true},
-		{"v2", true, true},
+		{"v2", true, false},
 		{"", true, true},
 		{"v1", false, false},
 		{"v2", false, false},

--- a/framework/oac/allow_multiple_install_test.go
+++ b/framework/oac/allow_multiple_install_test.go
@@ -32,6 +32,57 @@ func TestLint_AllowMultipleInstall_ClusterScopedDynamicName_OK(t *testing.T) {
 	}
 }
 
+// TestLint_AllowMultipleInstall_FixedWorkloadName_Bad covers the
+// release-name workload check: when options.allowMultipleInstall=true the
+// chart must declare at least one Deployment/StatefulSet whose
+// metadata.name is templated on `{{ .Release.Name }}`. The fixture's
+// Deployment uses a fixed name so the new check must fire; the existing
+// cluster-scoped fixed-name check still passes because the ClusterRole
+// is properly release-scoped.
+func TestLint_AllowMultipleInstall_FixedWorkloadName_Bad(t *testing.T) {
+	err := Lint("testdata/multiclusterbadworkload",
+		WithOwnerAdmin("alice"),
+		SkipResourceCheck(),
+		SkipHostPathCheck(),
+	)
+	if err == nil {
+		t.Fatal("expected Lint to fail: allowMultipleInstall without a {{ .Release.Name }} workload")
+	}
+	if !strings.Contains(err.Error(), "options.allowMultipleInstall=true requires at least one Deployment or StatefulSet") {
+		t.Fatalf("error should flag the missing {{ .Release.Name }} workload, got: %v", err)
+	}
+}
+
+// TestReleaseNameWorkloadCheckApplies pins the gate to its current
+// definition: the release-name workload rule fires whenever
+// options.allowMultipleInstall is true, regardless of apiVersion. The
+// flag (not the schema version) is what enables multiple coexisting
+// installs and therefore demands a release-scoped primary workload.
+func TestReleaseNameWorkloadCheckApplies(t *testing.T) {
+	cases := []struct {
+		api   string
+		allow bool
+		want  bool
+	}{
+		{"v1", true, true},
+		{"v3", true, true},
+		{"v2", true, true},
+		{"", true, true},
+		{"v1", false, false},
+		{"v2", false, false},
+		{"v3", false, false},
+	}
+	for _, tc := range cases {
+		cfg := &manifest.AppConfiguration{
+			APIVersion: tc.api,
+			Options:    manifest.Options{AllowMultipleInstall: tc.allow},
+		}
+		if got := releaseNameWorkloadCheckApplies(cfg); got != tc.want {
+			t.Errorf("api=%q allow=%v: got %v want %v", tc.api, tc.allow, got, tc.want)
+		}
+	}
+}
+
 func TestAllowMultipleInstallClusterScopedCheckApplies(t *testing.T) {
 	cases := []struct {
 		api    string

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -38,8 +38,8 @@ import (
 //     turn off with SkipResourceNamespaceCheck()
 //     7b. allowMultipleInstall cluster-scoped fixed-name check (v1/v3 only;
 //     skipped for v2) - ALWAYS run when options.allowMultipleInstall is true
-//     7c. allowMultipleInstall release-name workload check - ALWAYS run
-//     when options.allowMultipleInstall is true (any apiVersion);
+//     7c. allowMultipleInstall release-name workload check (v1/v3 only;
+//     skipped for v2) - ALWAYS run when options.allowMultipleInstall is true;
 //     requires at least one Deployment/StatefulSet whose metadata.name
 //     is templated on `{{ .Release.Name }}`
 //  8. Container-level resource limits check - skipped by SkipResourceCheck
@@ -551,12 +551,15 @@ func allowClusterScopedCheckApplies(cfg *manifest.AppConfiguration) bool {
 
 // releaseNameWorkloadCheckApplies reports whether the chart must declare at
 // least one Deployment/StatefulSet whose metadata.name is templated on
-// `{{ .Release.Name }}`. The rule fires whenever
-// options.allowMultipleInstall is true, regardless of apiVersion: that's
-// the flag that allows several installs to coexist, and without a
-// release-scoped workload name those installs would collide.
+// `{{ .Release.Name }}`. The rule fires when options.allowMultipleInstall is
+// true on v1/v3 manifests. v2 is excluded: workloads live in spec.subCharts[]
+// and are rendered per subchart, so a parent-path dry-run cannot inspect them.
 func releaseNameWorkloadCheckApplies(cfg *manifest.AppConfiguration) bool {
-	return cfg.Options.AllowMultipleInstall
+	if !cfg.Options.AllowMultipleInstall {
+		return false
+	}
+	api := strings.ToLower(strings.TrimSpace(cfg.APIVersion))
+	return api != manifest.APIVersionV2
 }
 
 // checkAllowMultipleInstall helm-renders the chart twice with synthetic

--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -38,6 +38,10 @@ import (
 //     turn off with SkipResourceNamespaceCheck()
 //     7b. allowMultipleInstall cluster-scoped fixed-name check (v1/v3 only;
 //     skipped for v2) - ALWAYS run when options.allowMultipleInstall is true
+//     7c. allowMultipleInstall release-name workload check - ALWAYS run
+//     when options.allowMultipleInstall is true (any apiVersion);
+//     requires at least one Deployment/StatefulSet whose metadata.name
+//     is templated on `{{ .Release.Name }}`
 //  8. Container-level resource limits check - skipped by SkipResourceCheck
 //  9. Chart.yaml <-> manifest same-version check - ON by default, turn off
 //     with SkipSameVersionCheck()
@@ -152,7 +156,7 @@ func (c *OAC) lintRenderedScenario(oacPath string, m Manifest, sc ownerScenario)
 		return err
 	}
 
-	if err := c.checkAllowMultipleInstallClusterScoped(oacPath, m, sc); err != nil {
+	if err := c.checkAllowMultipleInstall(oacPath, m, sc); err != nil {
 		return err
 	}
 
@@ -545,25 +549,65 @@ func allowClusterScopedCheckApplies(cfg *manifest.AppConfiguration) bool {
 	return false
 }
 
-// checkAllowMultipleInstallClusterScoped helm-renders the chart twice with
-// synthetic release names and flags any cluster-scoped resource whose name is
-// identical across both renders.
-func (c *OAC) checkAllowMultipleInstallClusterScoped(oacPath string, m Manifest, sc ownerScenario) error {
+// releaseNameWorkloadCheckApplies reports whether the chart must declare at
+// least one Deployment/StatefulSet whose metadata.name is templated on
+// `{{ .Release.Name }}`. The rule fires whenever
+// options.allowMultipleInstall is true, regardless of apiVersion: that's
+// the flag that allows several installs to coexist, and without a
+// release-scoped workload name those installs would collide.
+func releaseNameWorkloadCheckApplies(cfg *manifest.AppConfiguration) bool {
+	return cfg.Options.AllowMultipleInstall
+}
+
+// checkAllowMultipleInstall helm-renders the chart twice with synthetic
+// release names and runs the two allowMultipleInstall safety checks that
+// can share those renders:
+//
+//  1. cluster-scoped fixed-name detection — any cluster-scoped resource
+//     whose name is identical across both renders has a release-independent
+//     metadata.name and would collide on second install. Gated by
+//     allowClusterScopedCheckApplies.
+//  2. release-name workload presence — at least one Deployment or
+//     StatefulSet must have its metadata.name templated as
+//     `{{ .Release.Name }}` so each install gets a uniquely-named primary
+//     workload. Gated by releaseNameWorkloadCheckApplies.
+//
+// Both checks reuse listA / listB, so the function only renders when at
+// least one of the two gates is open. Errors from each sub-check are
+// aggregated so a chart that violates both rules surfaces both messages
+// in a single Lint run.
+func (c *OAC) checkAllowMultipleInstall(oacPath string, m Manifest, sc ownerScenario) error {
 	cfg, ok := m.Raw().(*manifest.AppConfiguration)
-	if !ok || !allowClusterScopedCheckApplies(cfg) {
+	if !ok {
+		return nil
+	}
+	needCluster := allowClusterScopedCheckApplies(cfg)
+	needWorkload := releaseNameWorkloadCheckApplies(cfg)
+	if !needCluster && !needWorkload {
 		return nil
 	}
 	values := c.buildRenderValues(m, sc)
 	probeA, probeB := resources.ClusterScopedProbeNames()
 	listA, err := helmrender.Render(oacPath, values, probeA)
 	if err != nil {
-		return fmt.Errorf("helm render (allowMultipleInstall cluster-scoped probe %q): %w", probeA, err)
+		return fmt.Errorf("helm render (allowMultipleInstall probe %q): %w", probeA, err)
 	}
 	listB, err := helmrender.Render(oacPath, values, probeB)
 	if err != nil {
-		return fmt.Errorf("helm render (allowMultipleInstall cluster-scoped probe %q): %w", probeB, err)
+		return fmt.Errorf("helm render (allowMultipleInstall probe %q): %w", probeB, err)
 	}
-	return resources.CheckClusterScopedFixedNames(listA, listB)
+	var errs []error
+	if needCluster {
+		if err := resources.CheckClusterScopedFixedNames(listA, listB); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if needWorkload {
+		if err := resources.CheckReleaseNameWorkload(listA, listB, probeA, probeB); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // checkWorkloadReplicaValues verifies that values.yaml declares a

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/beclab/api v0.0.13
+	github.com/beclab/api v0.0.14
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
 	helm.sh/helm/v3 v3.19.5

--- a/framework/oac/go.sum
+++ b/framework/oac/go.sum
@@ -27,6 +27,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/api v0.0.13 h1:j1mD9jEM8blE2ZhJigCe0B0X9APX0sHH0plGlBSOjak=
 github.com/beclab/api v0.0.13/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.14 h1:/KGHYsb1TpWzOLws2JfPhxpa0tOK9ZyLSDJlBZmY8ko=
+github.com/beclab/api v0.0.14/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -322,6 +322,17 @@ func ensureNoGPUSection(sectionPath, mode string, rr ResourceRequirement) error 
 	return errors.Join(errs...)
 }
 
+// AutoResourceValue is the sentinel a template-app author writes into a
+// resource field to declare "resolve this value from the rendered chart at
+// install time" (see app-service compute auto-resource resolution). It is not
+// a Kubernetes quantity, so the quantity / limit-ordering validators below
+// treat it as a valid, deferred value rather than rejecting it.
+const AutoResourceValue = "-1"
+
+func isAutoResourceQuantity(s string) bool {
+	return strings.TrimSpace(s) == AutoResourceValue
+}
+
 func validateQuantities(prefix string, rr ResourceRequirement) error {
 	pairs := []struct {
 		field string
@@ -338,7 +349,7 @@ func validateQuantities(prefix string, rr ResourceRequirement) error {
 	}
 	var errs []error
 	for _, p := range pairs {
-		if p.value == "" {
+		if p.value == "" || isAutoResourceQuantity(p.value) {
 			continue
 		}
 		if !k8sQuantity.MatchString(p.value) {
@@ -362,6 +373,11 @@ func checkLimitGERequired(prefix string, rr ResourceRequirement) error {
 	var errs []error
 	for _, d := range dims {
 		if d.required == "" || d.limited == "" {
+			continue
+		}
+		// An auto-compute sentinel on either side is resolved at install time;
+		// the limit >= required ordering cannot be checked yet, so skip it.
+		if isAutoResourceQuantity(d.required) || isAutoResourceQuantity(d.limited) {
 			continue
 		}
 		req, err := resource.ParseQuantity(d.required)

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -104,7 +104,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 			validation.Required.Error("spec is required"),
 			validation.By(validateAppSpecFor(c)),
 		),
-		validation.Field(&c.Options, validation.By(validateOptions)),
+		validation.Field(&c.Options, validation.By(validateOptionsFor(c))),
 		validation.Field(&c.OverlayGateway, validation.By(validateOverlayGateway)),
 	)
 	return errors.Join(structErr, checkSubCharts(c), validatePermission(c.ConfigVersion, c.Permission), validateV3Configuration(c))
@@ -468,18 +468,56 @@ func validateOverlayGateway(v interface{}) error {
 	return errors.Join(errs...)
 }
 
-func validateOptions(v interface{}) error {
-	o, ok := v.(Options)
-	if !ok {
-		return fmt.Errorf("options: unexpected type %T", v)
+// validateOptionsFor binds the manifest's apiVersion so options-level
+// cross-field checks (templateOnly => allowMultipleInstall, shared => v3)
+// can reach it. ozzo's validation.By only sees the Options value, so the
+// outer AppConfiguration must be captured here in a closure.
+func validateOptionsFor(cfg *AppConfiguration) validation.RuleFunc {
+	return func(v interface{}) error {
+		o, ok := v.(Options)
+		if !ok {
+			return fmt.Errorf("options: unexpected type %T", v)
+		}
+		return validateOptions(cfg.APIVersion, o)
 	}
-	return validation.ValidateStruct(&o,
+}
+
+// validateOptions runs the options-level validation. It is parameterised on
+// apiVersion because two cross-field rules depend on it:
+//
+//   - options.templateOnly=true requires options.allowMultipleInstall=true.
+//     Template-only apps are installed as multiple clones from a single
+//     template chart; without allowMultipleInstall the platform would only
+//     ever install a single instance, defeating the purpose of the flag.
+//   - options.shared=true is only meaningful on apiVersion=v3. v3 is the
+//     only schema where a single install services multiple users, so a
+//     shared install on v1/v2 would be silently ignored at install time
+//     and is rejected here to avoid the foot-gun.
+//
+// Both cross-field errors are aggregated alongside the existing per-field
+// struct validation so a manifest that violates more than one rule sees
+// every offender in a single Lint run.
+func validateOptions(apiVersion string, o Options) error {
+	structErr := validation.ValidateStruct(&o,
 		validation.Field(&o.Policies, validation.Each(validation.By(validatePolicyValue))),
 		validation.Field(&o.ResetCookie),
 		validation.Field(&o.Dependencies, validation.Each(validation.By(validateDependencyValue))),
 		validation.Field(&o.AppScope),
 		validation.Field(&o.WsConfig),
 	)
+	var crossErrs []error
+	if o.TemplateOnly && !o.AllowMultipleInstall {
+		crossErrs = append(crossErrs, fmt.Errorf(
+			"options.allowMultipleInstall must be true when options.templateOnly is true; template-only apps are installed as multiple clones",
+		))
+	}
+	if o.Shared && normalizeAPIVersion(apiVersion) != APIVersionV3 {
+		crossErrs = append(crossErrs, fmt.Errorf(
+			"options.shared=true is only supported for apiVersion=v3 (got %q)",
+			apiVersion,
+		))
+	}
+	return errors.Join(structErr, errors.Join(crossErrs...))
 }
 
 func validatePolicyValue(v interface{}) error {

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -1152,3 +1152,91 @@ func TestOverlayGateway_RequiredAndPortRules(t *testing.T) {
 		})
 	}
 }
+
+// TestOptions_TemplateOnlyRequiresAllowMultipleInstall pins down the
+// templateOnly => allowMultipleInstall=true cross-field rule on Options:
+// templateOnly apps install as multiple clones, so allowMultipleInstall is
+// mandatory. The default zero value (false) must surface the error, the
+// explicit-false case must too, and pairing templateOnly with
+// allowMultipleInstall=true must validate cleanly.
+func TestOptions_TemplateOnlyRequiresAllowMultipleInstall(t *testing.T) {
+	c := newValidConfig()
+	c.Options.TemplateOnly = true
+	err := ValidateAppConfiguration(c)
+	if err == nil {
+		t.Fatal("expected error: options.templateOnly=true requires allowMultipleInstall=true")
+	}
+	if !strings.Contains(err.Error(), "options.allowMultipleInstall must be true when options.templateOnly is true") {
+		t.Fatalf("error should flag the templateOnly cross-field rule, got: %v", err)
+	}
+
+	c = newValidConfig()
+	c.Options.TemplateOnly = true
+	c.Options.AllowMultipleInstall = false
+	if err := ValidateAppConfiguration(c); err == nil {
+		t.Fatal("expected error: explicit allowMultipleInstall=false still violates the rule")
+	}
+
+	c = newValidConfig()
+	c.Options.TemplateOnly = true
+	c.Options.AllowMultipleInstall = true
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("templateOnly=true + allowMultipleInstall=true must pass: %v", err)
+	}
+
+	// allowMultipleInstall=true on its own is fine; the rule only fires
+	// when templateOnly is true. Keeps backward compatibility for charts
+	// that already opt into multi-install without being template-only.
+	c = newValidConfig()
+	c.Options.AllowMultipleInstall = true
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("allowMultipleInstall=true alone must remain valid: %v", err)
+	}
+}
+
+// TestOptions_SharedRequiresAPIVersionV3 pins down the shared => v3
+// cross-field rule on Options: shared installs only make sense on the v3
+// schema (a single install services multiple users). v1/v2/empty must
+// reject; v3 must accept. The control case (shared=false on v1) confirms
+// the rule does not fire for the default shape.
+func TestOptions_SharedRequiresAPIVersionV3(t *testing.T) {
+	cases := []struct {
+		name       string
+		apiVersion string
+		shared     bool
+		wantErr    bool
+	}{
+		{"v1 + shared=true rejected", APIVersionV1, true, true},
+		{"v2 + shared=true rejected", APIVersionV2, true, true},
+		{"empty + shared=true rejected", "", true, true},
+		{"v3 + shared=true accepted", APIVersionV3, true, false},
+		{"v1 + shared=false accepted", APIVersionV1, false, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := newValidConfig()
+			c.APIVersion = tc.apiVersion
+			c.Options.Shared = tc.shared
+			// v2 needs a shared subchart to satisfy checkSubCharts, otherwise the
+			// test would fail for an unrelated reason. Keep the focus on the
+			// options.shared cross-field rule.
+			if tc.apiVersion == APIVersionV2 {
+				c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+			}
+			err := ValidateAppConfiguration(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s", tc.name)
+				}
+				if !strings.Contains(err.Error(), "options.shared=true is only supported for apiVersion=v3") {
+					t.Fatalf("error should flag the shared cross-field rule, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error for %s: %v", tc.name, err)
+				}
+			}
+		})
+	}
+}

--- a/framework/oac/internal/resources/cluster_scoped.go
+++ b/framework/oac/internal/resources/cluster_scoped.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/kube"
 )
@@ -26,20 +27,27 @@ func ClusterScopedProbeNames() (a, b string) {
 // CheckClusterScopedFixedNames compares two helm dry-run outputs rendered with
 // different release names. Any cluster-scoped resource (empty namespace) whose
 // kind+name is identical in both lists is treated as having a fixed name.
+//
+// All offenders are reported in a single multi-line error: one summary line
+// carrying the remediation hint, followed by one bullet line per (kind, name)
+// violation. Embedding explicit "\n" separators (instead of relying on
+// errors.Join's invisible newlines) keeps the offenders visually separated
+// even when a downstream logger or terminal collapses whitespace, and avoids
+// repeating the long remediation hint once per violation.
 func CheckClusterScopedFixedNames(listA, listB kube.ResourceList) error {
 	fixed := intersectClusterScopedKeys(listA, listB)
 	if len(fixed) == 0 {
 		return nil
 	}
-	var errs []error
+	var b strings.Builder
+	fmt.Fprintf(&b,
+		"the following cluster-scoped resource(s) have a fixed metadata.name; use a release-unique name such as {{ .Release.Name }} when app is v1 or v3 with options.allowMultipleInstall is true\n",
+	)
 	for _, key := range fixed {
 		kind, name := splitClusterScopedKey(key)
-		errs = append(errs, fmt.Errorf(
-			"cluster-scoped %s %q has a fixed name (unchanged across release names %q and %q); use a release-unique name such as {{ .Release.Name }} when app is v1 or v3 with options.allowMultipleInstall is true",
-			kind, name, clusterScopedProbeA, clusterScopedProbeB,
-		))
+		fmt.Fprintf(&b, "\n  - %s %q", kind, name)
 	}
-	return errors.Join(errs...)
+	return errors.New(b.String())
 }
 
 func clusterScopedKeys(list kube.ResourceList) map[string]struct{} {

--- a/framework/oac/internal/resources/cluster_scoped_test.go
+++ b/framework/oac/internal/resources/cluster_scoped_test.go
@@ -37,8 +37,13 @@ func TestCheckClusterScopedFixedNames_FixedName(t *testing.T) {
 	if !strings.Contains(err.Error(), fixed) {
 		t.Fatalf("error should mention %q, got: %v", fixed, err)
 	}
-	if !strings.Contains(err.Error(), clusterScopedProbeA) {
-		t.Fatalf("error should mention probe release %q, got: %v", clusterScopedProbeA, err)
+	// The user-facing remediation hint replaces the older "probe release"
+	// wording: the synthetic probe names (clusterScopedProbeA/B) are an
+	// implementation detail of the two-render comparison, so the error now
+	// points authors directly at the fix -- name resources after
+	// {{ .Release.Name }}.
+	if !strings.Contains(err.Error(), "{{ .Release.Name }}") {
+		t.Fatalf("error should mention the {{ .Release.Name }} remediation hint, got: %v", err)
 	}
 }
 

--- a/framework/oac/internal/resources/workloads.go
+++ b/framework/oac/internal/resources/workloads.go
@@ -65,6 +65,42 @@ func CheckWorkloadReplicas(list kube.ResourceList, replicas map[string]int32) er
 	return errors.Join(errs...)
 }
 
+// CheckReleaseNameWorkload reports whether at least one Deployment or
+// StatefulSet in the rendered chart has its metadata.name templated as
+// `{{ .Release.Name }}`. listA and listB must be two helm dry-runs of the
+// same chart rendered with distinct release names probeA and probeB; a
+// workload whose name is templated on the release name shows up as probeA
+// in listA and probeB in listB simultaneously, while any workload with a
+// fixed name (or with a name that mixes the release name with other tokens,
+// e.g. `{{ .Release.Name }}-web`) won't satisfy both predicates at once.
+//
+// The check exists to back the options.allowMultipleInstall=true safety
+// rule: multiple installs of the same chart need at least one
+// release-scoped primary workload so that namespaced resources do not
+// collide between installs. Callers should only invoke this function when
+// that flag is true; the gate lives in the OAC package.
+func CheckReleaseNameWorkload(listA, listB kube.ResourceList, probeA, probeB string) error {
+	if hasReleaseNamedWorkload(listA, probeA) && hasReleaseNamedWorkload(listB, probeB) {
+		return nil
+	}
+	return fmt.Errorf(
+		"options.allowMultipleInstall=true requires at least one Deployment or StatefulSet whose metadata.name is set to {{ .Release.Name }}; without it multiple installs of this chart would collide on workload names",
+	)
+}
+
+// hasReleaseNamedWorkload reports whether list contains a Deployment or
+// StatefulSet whose metadata.name equals name. It is the per-render half of
+// CheckReleaseNameWorkload's two-render comparison.
+func hasReleaseNamedWorkload(list kube.ResourceList, name string) bool {
+	for _, r := range list {
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		if (kind == KindDeployment || kind == KindStatefulSet) && r.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // CheckOverlayGatewayWorkloads verifies that every overlayGateway entrance
 // references a workload that exists as a rendered Deployment or StatefulSet.
 // Like CheckWorkloadReplicas it relies on the release-name == app-name render

--- a/framework/oac/internal/resources/workloads_test.go
+++ b/framework/oac/internal/resources/workloads_test.go
@@ -65,6 +65,65 @@ func TestCheckWorkloadReplicas_UnknownEntry(t *testing.T) {
 	}
 }
 
+func TestCheckReleaseNameWorkload_Deployment(t *testing.T) {
+	probeA, probeB := "probe-a", "probe-b"
+	listA := kube.ResourceList{newDeployment(probeA), newDeployment("static")}
+	listB := kube.ResourceList{newDeployment(probeB), newDeployment("static")}
+	if err := CheckReleaseNameWorkload(listA, listB, probeA, probeB); err != nil {
+		t.Fatalf("a {{ .Release.Name }} Deployment must satisfy the check: %v", err)
+	}
+}
+
+func TestCheckReleaseNameWorkload_StatefulSet(t *testing.T) {
+	probeA, probeB := "probe-a", "probe-b"
+	listA := kube.ResourceList{newStatefulSet(probeA)}
+	listB := kube.ResourceList{newStatefulSet(probeB)}
+	if err := CheckReleaseNameWorkload(listA, listB, probeA, probeB); err != nil {
+		t.Fatalf("a {{ .Release.Name }} StatefulSet must satisfy the check: %v", err)
+	}
+}
+
+func TestCheckReleaseNameWorkload_NoMatch(t *testing.T) {
+	probeA, probeB := "probe-a", "probe-b"
+	// Both lists contain only fixed-name workloads -- no metadata.name is
+	// templated on the release name, so neither rendered list contains a
+	// workload whose name equals the probe.
+	listA := kube.ResourceList{newDeployment("fixed")}
+	listB := kube.ResourceList{newDeployment("fixed")}
+	err := CheckReleaseNameWorkload(listA, listB, probeA, probeB)
+	if err == nil {
+		t.Fatal("expected error when no Deployment/StatefulSet uses {{ .Release.Name }}")
+	}
+	if !strings.Contains(err.Error(), "{{ .Release.Name }}") {
+		t.Fatalf("error should reference the {{ .Release.Name }} remediation, got: %v", err)
+	}
+}
+
+func TestCheckReleaseNameWorkload_DaemonSetIgnored(t *testing.T) {
+	probeA, probeB := "probe-a", "probe-b"
+	// A DaemonSet whose name happens to render to the release name does
+	// not satisfy the rule -- the check is about Deployment/StatefulSet
+	// primary workloads only, which mirrors CollectWorkloadNames.
+	listA := kube.ResourceList{newDaemonSet(probeA)}
+	listB := kube.ResourceList{newDaemonSet(probeB)}
+	if err := CheckReleaseNameWorkload(listA, listB, probeA, probeB); err == nil {
+		t.Fatal("DaemonSet alone must not satisfy the release-name workload rule")
+	}
+}
+
+func TestCheckReleaseNameWorkload_PartialMatch(t *testing.T) {
+	probeA, probeB := "probe-a", "probe-b"
+	// listA carries a release-named Deployment but listB does not -- this
+	// only happens when a chart conditionally emits a release-named
+	// workload. The check must fail closed (require both) because we
+	// cannot prove a single template uses {{ .Release.Name }} otherwise.
+	listA := kube.ResourceList{newDeployment(probeA)}
+	listB := kube.ResourceList{newDeployment("fixed")}
+	if err := CheckReleaseNameWorkload(listA, listB, probeA, probeB); err == nil {
+		t.Fatal("expected error when only one render contains a release-named workload")
+	}
+}
+
 func TestCheckOverlayGatewayWorkloads(t *testing.T) {
 	list := kube.ResourceList{
 		newDeployment("jellyfin"),

--- a/framework/oac/testdata/multiclusterbadworkload/Chart.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: multiclusterbadworkload
+description: fixture for allowMultipleInstall + fixed-name primary workload
+type: application
+version: 1.0.0
+appVersion: "1"

--- a/framework/oac/testdata/multiclusterbadworkload/OlaresManifest.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/OlaresManifest.yaml
@@ -1,0 +1,31 @@
+olaresManifest.version: "0.11.0"
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: multiclusterbadworkload
+  icon: https://example.com/icon.png
+  description: fixture
+  title: Fixture
+  version: 1.0.0
+entrances:
+  - name: main
+    host: multiclusterbadworkload
+    port: 8080
+    title: Main
+    icon: https://example.com/e.png
+    authLevel: public
+    openMethod: default
+spec:
+  versionName: v1
+  requiredCpu: 100m
+  limitedCpu: 200m
+  requiredMemory: 128Mi
+  limitedMemory: 256Mi
+  requiredDisk: 1Gi
+  supportArch: [amd64, arm64]
+permission:
+  appData: false
+options:
+  policies: []
+  resetCookie: { enabled: false }
+  allowMultipleInstall: true

--- a/framework/oac/testdata/multiclusterbadworkload/templates/clusterrole.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/framework/oac/testdata/multiclusterbadworkload/templates/deployment.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/templates/deployment.yaml
@@ -1,16 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: multiclusterbadworkload
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.workloads.wlreplicas.replicaCount }}
+  replicas: {{ .Values.workloads.multiclusterbadworkload.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: multiclusterbadworkload
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}
+        app: multiclusterbadworkload
     spec:
       containers:
         - name: main

--- a/framework/oac/testdata/multiclusterbadworkload/values.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/values.yaml
@@ -1,0 +1,3 @@
+workloads:
+  multiclusterbadworkload:
+    replicaCount: 1


### PR DESCRIPTION

* **Background**
    Add a lint check that requires at least one Deployment or StatefulSet whose
    metadata.name is {{ .Release.Name }} when options.allowMultipleInstall is
    true, preventing workload name collisions across multiple installs. Fold this
    into checkAllowMultipleInstall alongside the existing cluster-scoped
    fixed-name check, sharing the same dual-render probe.
    
    Validate manifest options cross-field rules: templateOnly=true requires
    allowMultipleInstall=true, and options.shared=true is only allowed on
    apiVersion=v3. Improve cluster-scoped fixed-name error output to a single
    summary with per-resource bullets.
    
    Bump github.com/beclab/api to v0.0.14.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens lint and manifest validation for charts using allowMultipleInstall, templateOnly, or shared options; existing manifests that violate the new rules will fail CI until fixed.
> 
> **Overview**
> **OAC lint** gains a second `allowMultipleInstall` guard: when the flag is set on v1/v3 manifests, charts must expose at least one Deployment or StatefulSet whose `metadata.name` is exactly `{{ .Release.Name }}` (dual-render probe via `CheckReleaseNameWorkload`). This is folded into `checkAllowMultipleInstall` with the existing cluster-scoped fixed-name check; violations from both rules are aggregated in one lint run.
> 
> **Manifest options** now enforce cross-field rules: `templateOnly=true` requires `allowMultipleInstall=true`, and `shared=true` is only valid for `apiVersion=v3`. Cluster-scoped fixed-name lint errors are reformatted as one summary line plus bullet offenders pointing at `{{ .Release.Name }}`.
> 
> Resource validators accept the `-1` auto-resource sentinel (skip quantity parsing and limit ≥ required checks). `github.com/beclab/api` is bumped to v0.0.14; a `multiclusterbadworkload` fixture and tests cover the new workload rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39fe214e3bbdec58bd9c253e41fc51b8bbf01d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->