### PR TITLE
daemon: use IsShared instead of IsV3 for shared app detection

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/beclab/Olares/cli v0.0.0-20251230161135-5264df60cc33
 	github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82
-	github.com/beclab/api v0.0.13
+	github.com/beclab/api v0.0.14
 	github.com/containerd/containerd v1.7.29
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -48,8 +48,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82 h1:BE/T9N2OyH0ZKMTzK7RY/EvKy8pfr0dokDBINJHLE8g=
 github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82/go.mod h1:LYHBxvVI3cDiRa116LbDQ09Uiphi3i3tWX2Cjeoyi9w=
-github.com/beclab/api v0.0.13 h1:j1mD9jEM8blE2ZhJigCe0B0X9APX0sHH0plGlBSOjak=
-github.com/beclab/api v0.0.13/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.14 h1:/KGHYsb1TpWzOLws2JfPhxpa0tOK9ZyLSDJlBZmY8ko=
+github.com/beclab/api v0.0.14/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/bfl v0.3.36 h1:PgeSPGc+XoONiwFsKq9xX8rqcL4kVM1G/ut0lYYj/js=
 github.com/beclab/bfl v0.3.36/go.mod h1:A82u38MxYk1C3Lqnm4iUUK4hBeY9HHIs+xU4V93OnJk=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -384,7 +384,7 @@ func CheckCurrentStatus(ctx context.Context) error {
 				klog.Error(err)
 			}
 
-			restarting, err := utils.SystemStartLessThan(3 * time.Minute) // uptime less then 3 minutes
+			restarting, err := utils.SystemStartLessThan(1 * time.Minute) // uptime less then 1 minutes
 			if err != nil {
 				return err
 			}

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -148,7 +148,12 @@ func IsTerminusRunning(ctx context.Context, client kubernetes.Interface) (bool, 
 	for _, pod := range pods.Items {
 		if isKeyPod(&pod) {
 			switch pod.Status.Phase {
-			case corev1.PodRunning, corev1.PodSucceeded:
+			case corev1.PodRunning:
+				if !isPodReady(&pod) {
+					return false, nil
+				}
+				continue
+			case corev1.PodSucceeded:
 				continue
 			default:
 				return false, nil
@@ -832,4 +837,45 @@ func GetUserRole(ctx context.Context, username string, client dynamic.Interface)
 	}
 
 	return role, nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	hasReadyCondition := false
+	for _, cond := range pod.Status.Conditions {
+		// K8s 1.28+
+		if cond.Type == "PodReadyToStartContainers" && cond.Status != corev1.ConditionTrue {
+			return false
+		}
+		if cond.Type == corev1.PodReady {
+			if cond.Status == corev1.ConditionTrue {
+				hasReadyCondition = true
+			}
+		}
+	}
+
+	if !hasReadyCondition {
+		return false
+	}
+
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.State.Running == nil {
+			if containerStatus.State.Waiting != nil {
+				return false
+			}
+			return false
+		}
+
+		if !containerStatus.Ready {
+			return false
+		}
+
+		if containerStatus.State.Running.StartedAt.IsZero() {
+			return false
+		}
+	}
+	return false
 }

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -574,7 +574,7 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 	for _, app := range apps.Items {
 		var entrances []appcfg.Entrance
 		var err error
-		if !isV3(&app) {
+		if !appv1alpha1.IsShared(&app) {
 			entrances, err = appcfg.GenEntranceURL(ctx, &app)
 			if err != nil {
 				klog.Error("generate application entrance url error, ", err, ", ", app.Name)
@@ -784,17 +784,8 @@ func GetWorkloadNameFromPod(pod *corev1.Pod) string {
 	return podNameTokens[0]
 }
 
-const (
-	AppApiVersionLabel = "app.bytetrade.io/api-version"
-	AppVersionV3       = "v3"
-)
-
-func isV3(a *appv1alpha1.Application) bool {
-	return a.Labels != nil && a.Labels[AppApiVersionLabel] == AppVersionV3
-}
-
 func BatchGenSharedAppEntranceURL(ctx context.Context, app *appv1alpha1.Application) ([]appcfg.Entrance, error) {
-	if !isV3(app) {
+	if !appv1alpha1.IsShared(app) {
 		return nil, nil
 	}
 

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -655,7 +655,7 @@ func GetOverlayGatewaySupportedApps(ctx context.Context, user string) ([]Overlay
 				continue
 			}
 
-			sharedApp := appv1alpha1.IsV3(app)
+			sharedApp := appv1alpha1.IsShared(app)
 			if !sharedApp {
 				if user != "" && app.Spec.Owner != user {
 					continue

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -877,5 +877,5 @@ func isPodReady(pod *corev1.Pod) bool {
 			return false
 		}
 	}
-	return false
+	return true
 }


### PR DESCRIPTION
* **Background**
Use IsShared instead of IsV3 for shared app detection

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shared apps are classified and when the UI reports Terminus as running vs restarting; misclassification or stricter readiness could affect entrance URLs and overlay gateway behavior until pods fully ready.
> 
> **Overview**
> **Shared apps:** Entrance URLs, overlay gateway listing, and `BatchGenSharedAppEntranceURL` now use `appv1alpha1.IsShared` from `github.com/beclab/api` v0.0.14 instead of the daemon’s local `isV3` label check (`app.bytetrade.io/api-version: v3`), which was removed.
> 
> **Cluster “running” health:** `IsTerminusRunning` no longer treats a key pod in `Running` as healthy unless `isPodReady` passes (PodReady, container running/ready, `PodReadyToStartContainers` on K8s 1.28+, non-zero `StartedAt`). After init, the **Restarting** state uses system uptime **&lt; 1 minute** (was 3 minutes) before trusting pod state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b92c1bd994a6576152e33f5df698995eb8f2f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->