### PR TITLE
fix(oac): skip total resource check upon auto resource

### DIFF
--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -329,7 +329,7 @@ func ensureNoGPUSection(sectionPath, mode string, rr ResourceRequirement) error 
 // treat it as a valid, deferred value rather than rejecting it.
 const AutoResourceValue = "-1"
 
-func isAutoResourceQuantity(s string) bool {
+func IsAutoResourceQuantity(s string) bool {
 	return strings.TrimSpace(s) == AutoResourceValue
 }
 
@@ -349,7 +349,7 @@ func validateQuantities(prefix string, rr ResourceRequirement) error {
 	}
 	var errs []error
 	for _, p := range pairs {
-		if p.value == "" || isAutoResourceQuantity(p.value) {
+		if p.value == "" || IsAutoResourceQuantity(p.value) {
 			continue
 		}
 		if !k8sQuantity.MatchString(p.value) {
@@ -377,7 +377,7 @@ func checkLimitGERequired(prefix string, rr ResourceRequirement) error {
 		}
 		// An auto-compute sentinel on either side is resolved at install time;
 		// the limit >= required ordering cannot be checked yet, so skip it.
-		if isAutoResourceQuantity(d.required) || isAutoResourceQuantity(d.limited) {
+		if IsAutoResourceQuantity(d.required) || IsAutoResourceQuantity(d.limited) {
 			continue
 		}
 		req, err := resource.ParseQuantity(d.required)

--- a/framework/oac/internal/resources/limits.go
+++ b/framework/oac/internal/resources/limits.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/beclab/Olares/framework/oac/internal/manifest"
 	"helm.sh/helm/v3/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,10 +39,18 @@ func CheckResourceLimits(list kube.ResourceList, limits ResourceLimits) error {
 	appLCPU, _ := resource.ParseQuantity(limits.LimitedCPU)
 	appLMem, _ := resource.ParseQuantity(limits.LimitedMemory)
 
-	if appRCPU.Cmp(appLCPU) > 0 {
+	// Auto-compute ("-1") envelope fields are resolved at install time from the
+	// rendered chart; their value is unknown at author/lint time, so the
+	// comparisons that involve them are skipped.
+	autoRCPU := manifest.IsAutoResourceQuantity(limits.RequiredCPU)
+	autoRMem := manifest.IsAutoResourceQuantity(limits.RequiredMemory)
+	autoLCPU := manifest.IsAutoResourceQuantity(limits.LimitedCPU)
+	autoLMem := manifest.IsAutoResourceQuantity(limits.LimitedMemory)
+
+	if !autoRCPU && !autoLCPU && appRCPU.Cmp(appLCPU) > 0 {
 		errs = append(errs, fmt.Errorf("spec.requiredCpu should be <= spec.limitedCpu"))
 	}
-	if appRMem.Cmp(appLMem) > 0 {
+	if !autoRMem && !autoLMem && appRMem.Cmp(appLMem) > 0 {
 		errs = append(errs, fmt.Errorf("spec.requiredMemory should be <= spec.limitedMemory"))
 	}
 
@@ -78,16 +87,16 @@ func CheckResourceLimits(list kube.ResourceList, limits ResourceLimits) error {
 		}
 	})
 
-	if sumLimCPU.Cmp(appLCPU) > 0 {
+	if !autoLCPU && sumLimCPU.Cmp(appLCPU) > 0 {
 		errs = append(errs, fmt.Errorf("sum of container resources.limits.cpu must be <= spec.limitedCpu"))
 	}
-	if sumLimMem.Cmp(appLMem) > 0 {
+	if !autoLMem && sumLimMem.Cmp(appLMem) > 0 {
 		errs = append(errs, fmt.Errorf("sum of container resources.limits.memory must be <= spec.limitedMemory"))
 	}
-	if sumReqCPU.Cmp(appRCPU) > 0 {
+	if !autoRCPU && sumReqCPU.Cmp(appRCPU) > 0 {
 		errs = append(errs, fmt.Errorf("sum of container resources.requests.cpu must be <= spec.requiredCpu"))
 	}
-	if sumReqMem.Cmp(appRMem) > 0 {
+	if !autoRMem && sumReqMem.Cmp(appRMem) > 0 {
 		errs = append(errs, fmt.Errorf("sum of container resources.requests.memory must be <= spec.requiredMemory"))
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
* **Background**
When installing an app, app-service checks the workloads' actual K8s resource requests is below the decalred resource in OlaresManifest.yaml, this check should be skipped if that resource is an auto resource that should be computed dynamically upon installation.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change for a documented sentinel; reduces false failures on template apps without altering install-time app-service checks.
> 
> **Overview**
> **Skips aggregate resource checks when manifest CPU/memory fields use the `-1` auto-compute sentinel**, so OAC no longer compares rendered workload totals against unknown install-time values.
> 
> `CheckResourceLimits` now treats `requiredCpu`, `limitedCpu`, `requiredMemory`, and `limitedMemory` marked with `-1` like manifest validation already does: envelope ordering (required ≤ limited) and sum-of-container vs spec checks are omitted for any side that is auto. Per-container request/limit rules are unchanged.
> 
> `isAutoResourceQuantity` is exported as **`IsAutoResourceQuantity`** so the resources package can share the same sentinel detection as manifest parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e227bf1e2f591f83eea314a0c762eecdc0921f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->