### PR TITLE
 refactor(bfl): use IsShared instead of IsV3 for shared app detection

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.47
+        image: beclab/bfl:v0.4.48
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/framework/bfl/go.mod
+++ b/framework/bfl/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
-	github.com/beclab/api v0.0.12
+	github.com/beclab/api v0.0.14
 	github.com/beclab/lldap-client v0.0.11
 	github.com/emicklei/go-restful v2.16.0+incompatible
 	github.com/emicklei/go-restful-openapi/v2 v2.11.0

--- a/framework/bfl/go.sum
+++ b/framework/bfl/go.sum
@@ -8,6 +8,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/api v0.0.12 h1:8+pxq5I7Xt9XfSM23RuOJD2kIKggdJ/LaUYWM0gcj04=
 github.com/beclab/api v0.0.12/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.14 h1:/KGHYsb1TpWzOLws2JfPhxpa0tOK9ZyLSDJlBZmY8ko=
+github.com/beclab/api v0.0.14/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=
 github.com/beclab/lldap-client v0.0.11/go.mod h1:Y74tcKzyNL73a9pFAvImwXgzqp7S7Jb8RY1mMY90e/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/framework/bfl/internal/frpc/controllers/controllers.go
+++ b/framework/bfl/internal/frpc/controllers/controllers.go
@@ -354,10 +354,10 @@ func (f *FrpcController) getApps(parentCtx context.Context) (*v1alpha1App.Applic
 func (f *FrpcController) getCustomDomains(apps *v1alpha1App.ApplicationList) (customDomains []string, err error) {
 	for i := range apps.Items {
 		app := &apps.Items[i]
-		// For v3 apps, the customDomain blob lives in
+		// For shared apps, the customDomain blob lives in
 		// Spec.UserSettings[constants.Username]; for v1/v2 it stays in
 		// Spec.Settings. EffectiveSettings hides the difference. We
-		// reject v3 apps that this BFL has no overlay for so we don't
+		// reject shared apps that this BFL has no overlay for so we don't
 		// publish another user's domains via this user's frpc.
 		settings := app.EffectiveSettings(constants.Username)
 		if len(settings) == 0 {
@@ -385,7 +385,7 @@ func (f *FrpcController) getCustomDomains(apps *v1alpha1App.ApplicationList) (cu
 
 // isOwnerApp gates which Applications this BFL's frpc reacts to:
 //   - v1/v2: only the apps owned by constants.Username (legacy).
-//   - v3: every BFL needs to see CR-level changes because each user
+//   - shared: every BFL needs to see CR-level changes because each user
 //     manages their own UserSettings.
 func isOwnerApp(objs ...client.Object) bool {
 	var isTrue = len(objs) != 0
@@ -394,7 +394,7 @@ func isOwnerApp(objs ...client.Object) bool {
 		if !ok {
 			return false
 		}
-		if v1alpha1App.IsV3(app) {
+		if v1alpha1App.IsShared(app) {
 			continue
 		}
 		isTrue = app.Spec.Owner == constants.Username && isTrue

--- a/framework/bfl/pkg/apis/base.go
+++ b/framework/bfl/pkg/apis/base.go
@@ -25,6 +25,7 @@ type Base struct {
 type PostLocale struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
+	Timezone string `json:"timezone"`
 	// dark/light
 	Theme string `json:"theme"`
 }
@@ -131,6 +132,7 @@ func (b *Base) HandleGetSysConfig(_ *restful.Request, resp *restful.Response) {
 	cfg := PostLocale{
 		Language: user.Annotations[constants.UserLanguage],
 		Location: user.Annotations[constants.UserLocation],
+		Timezone: user.Annotations[constants.UserTimezone],
 		Theme:    user.Annotations[constants.UserTheme],
 	}
 	response.Success(resp, &cfg)

--- a/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
@@ -232,6 +232,9 @@ func (h *Handler) handleActivate(req *restful.Request, resp *restful.Response) {
 			if payload.Location != "" {
 				u.Annotations[constants.UserLocation] = payload.Location
 			}
+			if payload.Timezone != "" {
+				u.Annotations[constants.UserTimezone] = payload.Timezone
+			}
 			if payload.Theme == "" {
 				payload.Theme = "light"
 			}
@@ -673,6 +676,10 @@ func (h *Handler) handleUpdateLocale(req *restful.Request, resp *restful.Respons
 
 				if locale.Location != "" {
 					u.Annotations[constants.UserLocation] = locale.Location
+				}
+
+				if locale.Timezone != "" {
+					u.Annotations[constants.UserTimezone] = locale.Timezone
 				}
 
 				if locale.Theme == "" {

--- a/framework/bfl/pkg/apis/settings/v1alpha1/handler_application.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/handler_application.go
@@ -323,10 +323,10 @@ func (h *Handler) listEntrancesWithCustomDomain(req *restful.Request, resp *rest
 	var entrances app_service.EntrancesWithCustomDomain
 	for i := range appList.Items {
 		app := &appList.Items[i]
-		isV3 := appv1.IsV3(app)
-		// v1/v2: only this user's apps. v3: every app is shared but the
+		isShared := appv1.IsShared(app)
+		// v1/v2: only this user's apps. shared: every app is shared but the
 		// caller's customDomain blob lives under UserSettings[Username].
-		if !isV3 && app.Spec.Owner != constants.Username {
+		if !isShared && app.Spec.Owner != constants.Username {
 			continue
 		}
 
@@ -341,7 +341,7 @@ func (h *Handler) listEntrancesWithCustomDomain(req *restful.Request, resp *rest
 			log.Errorf("failed to unmarshal custom domain settings of app %s: %w", app.Name, err)
 			continue
 		}
-		// EffectiveEntrances picks up per-user AuthLevel overlays for v3.
+		// EffectiveEntrances picks up per-user AuthLevel overlays for shared.
 		for _, entrance := range app.EffectiveEntrances(constants.Username) {
 			entranceSetting := customDomainSettings[entrance.Name]
 			if entranceSetting == nil {

--- a/framework/bfl/pkg/apis/settings/v1alpha1/model.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/model.go
@@ -110,6 +110,7 @@ type ExternalNetworkSwitchStatusView struct {
 type ActivateRequest struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
+	Timezone string `json:"timezone"`
 	Theme    string `json:"theme"`
 	FRP      struct {
 		Host string `json:"host"`

--- a/framework/bfl/pkg/apis/settings/v1alpha1/reverseproxyconf.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/reverseproxyconf.go
@@ -260,10 +260,10 @@ func (configurator *ReverseProxyConfigurator) setProxyTypeForRelevantComponents(
 	}
 	for i := range appList.Items {
 		app := &appList.Items[i]
-		isV3 := appv1alpha1.IsV3(app)
-		// v1/v2: only this user's apps. v3: every app, but we only care
+		isShared := appv1alpha1.IsShared(app)
+		// v1/v2: only this user's apps. shared: every app, but we only care
 		// when this user has a customDomain overlay.
-		if !isV3 && app.Spec.Owner != constants.Username {
+		if !isShared && app.Spec.Owner != constants.Username {
 			continue
 		}
 
@@ -296,7 +296,7 @@ func (configurator *ReverseProxyConfigurator) setProxyTypeForRelevantComponents(
 			return errors.Wrapf(err, "failed to marshal custom domain settings of app %s", app.Name)
 		}
 
-		if isV3 {
+		if isShared {
 			if app.Spec.UserSettings == nil {
 				app.Spec.UserSettings = make(map[string]map[string]string)
 			}

--- a/framework/bfl/pkg/constants/constants.go
+++ b/framework/bfl/pkg/constants/constants.go
@@ -169,6 +169,7 @@ var (
 	UserLanguage = fmt.Sprintf("%s/language", AnnotationGroup)
 
 	UserLocation = fmt.Sprintf("%s/location", AnnotationGroup)
+	UserTimezone = fmt.Sprintf("%s/timezone", AnnotationGroup)
 	UserTheme    = fmt.Sprintf("%s/theme", AnnotationGroup)
 
 	UserTerminusWizardStatus = fmt.Sprintf("%s/wizard-status", AnnotationGroup)

--- a/framework/bfl/pkg/watchers/apps/applications.go
+++ b/framework/bfl/pkg/watchers/apps/applications.go
@@ -146,7 +146,7 @@ func (s *Subscriber) removeCustomDomainRetry(request *appv1.Application) error {
 
 func (s *Subscriber) checkCustomDomainStatus(app *appv1.Application) error {
 	var err error
-	// For v3 apps the customDomain blob lives in
+	// For shared apps the customDomain blob lives in
 	// Spec.UserSettings[constants.Username]; for v1/v2 it's still
 	// Spec.Settings. EffectiveSettings hides the difference.
 	effective := app.EffectiveSettings(constants.Username)
@@ -210,9 +210,9 @@ func (s *Subscriber) checkCustomDomainStatus(app *appv1.Application) error {
 	if err != nil {
 		return err
 	}
-	// Write back into the same slot we read from: v3 → UserSettings[u],
+	// Write back into the same slot we read from: shared → UserSettings[u],
 	// v1/v2 → Spec.Settings.
-	if appv1.IsV3(app) {
+	if appv1.IsShared(app) {
 		if app.Spec.UserSettings == nil {
 			app.Spec.UserSettings = make(map[string]map[string]string)
 		}
@@ -409,7 +409,7 @@ func (s *Subscriber) removeCustomDomainCnameData(app *appv1.Application) error {
 		return nil
 	}
 
-	// Reflect v3 per-user storage when reading the customDomain blob so
+	// Reflect per-user storage when reading the customDomain blob so
 	// we delete the right user's cloudflare CNAMEs on app delete.
 	customDomainData := app.EffectiveSettings(constants.Username)[constants.ApplicationCustomDomain]
 	if customDomainData == "" {
@@ -483,11 +483,11 @@ func (s *Subscriber) getObj(appName string) (*appv1.Application, error) {
 }
 
 // isOwnerApp reports whether this BFL instance should react to the given
-// Application. For v1/v2 it's the legacy Spec.Owner check; for v3 the CR
+// Application. For v1/v2 it's the legacy Spec.Owner check; for shared the CR
 // is cluster-wide and every BFL instance is a stake-holder (each BFL
 // manages its own user's per-user overlay).
 func (s *Subscriber) isOwnerApp(app *appv1.Application) bool {
-	if appv1.IsV3(app) {
+	if appv1.IsShared(app) {
 		return true
 	}
 	return app.Spec.Owner == constants.Username


### PR DESCRIPTION


* **Background**
use IsShared instead of IsV3 for shared app detection
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> IsShared semantics come from the external api bump and affect frpc, custom-domain, and reverse-proxy paths; timezone is additive locale persistence with low blast radius.
> 
> **Overview**
> Replaces **`IsV3`** with **`IsShared`** from `github.com/beclab/api` everywhere BFL decides ownership, custom domains, reverse-proxy updates, and frpc reconciliation—same branching logic, clearer naming aligned with the API.
> 
> Adds **user timezone** to locale: new `UserTimezone` annotation and `timezone` on `PostLocale` / `ActivateRequest`, persisted on activate and locale update and returned from get sys config.
> 
> Ships **`beclab/bfl:v0.4.48`** and bumps **`github.com/beclab/api`** to **v0.0.14**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5cad489759417c8a65ec06da56fbf0e38253f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->