### PR TITLE
system-frontend: bump image version to v1.10.46

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.45
+          image: beclab/system-frontend:v1.10.46
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Bump the `system-frontend` (olares-app-init) image in `system-apps` from `v1.10.45` to `v1.10.46`, shipping the latest frontend changes from TermiPass:
  - Market: template-only apps and unified instance creation
  - Compute: backend-authoritative GPU binding validation, dialog refactor, and unified pre-check policy
  - Market: backend-authoritative shared flag and v2 upgrade debug bypass

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1183
https://github.com/beclab/TermiPass/pull/1184
https://github.com/beclab/TermiPass/pull/1185

* **Other information**:
None

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single init-container image tag bump with no Helm template or config changes; rollout risk is limited to regressions in the new frontend image.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image in `system-apps` from `beclab/system-frontend:v1.10.45` to **`v1.10.46`**, so new `olares-app` pods pull the updated TermiPass system frontend bundle into `/www` before nginx starts.
> 
> No chart logic, env, or volume changes—only the image tag. Behavior shifts come from whatever shipped in **v1.10.46** (per linked TermiPass PRs: Market template-only apps / unified instance creation, Compute backend GPU binding validation and dialog refactor, Market shared-flag handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07be6d056237a5848f82e7f51fde6d08be31da17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->