### PR TITLE
feat(cli): add breaking upgrader to bump per-user reverse-proxy-agent

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -42,6 +42,7 @@ func (u upgrader_1_12_6) PrepareForUpgrade() []task.Interface {
 	tasks = append(tasks, upgradeMultus()...)
 	tasks = append(tasks, createAppCommonDir()...)
 	tasks = append(tasks, upgradeNetworkManagerConfig()...)
+	tasks = append(tasks, upgradeUserReverseProxy()...)
 
 	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
 	return tasks

--- a/cli/pkg/upgrade/1_12_7_20260610.go
+++ b/cli/pkg/upgrade/1_12_7_20260610.go
@@ -1,0 +1,34 @@
+package upgrade
+
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+const reverseProxyAgentImage = "beclab/reverse-proxy:v0.1.11"
+
+type upgrader_1_12_7_20260610 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260610) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260610")
+}
+
+func (u upgrader_1_12_7_20260610) PrepareForUpgrade() []task.Interface {
+	pre := []task.Interface{
+		&task.LocalTask{
+			Name:   "UpgradeUserReverseProxyAgent",
+			Action: new(upgradeUserReverseProxyAgent),
+			Retry:  5,
+			Delay:  10 * time.Second,
+		},
+	}
+	return append(pre, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260610{})
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -38,6 +38,10 @@ import (
 	"github.com/beclab/Olares/cli/pkg/utils"
 	appv1alpha1 "github.com/beclab/Olares/framework/app-service/api/app.bytetrade.io/v1alpha1"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kkubernetes "k8s.io/client-go/kubernetes"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -753,6 +757,76 @@ func upgradeNetworkManagerConfig() []task.Interface {
 		&task.LocalTask{
 			Name:   "GenerateNetworkManagerConfig",
 			Action: new(generateNetworkManagerConfigAction),
+			Retry:  5,
+			Delay:  5 * time.Second,
+		},
+	}
+}
+
+// upgradeUserReverseProxyAgent iterates over the user list and, for each
+// user-space-<username> namespace that contains a reverse-proxy-agent
+// deployment, sets its image to reverseProxyAgentImage. Namespaces without the
+// deployment are skipped.
+type upgradeUserReverseProxyAgent struct {
+	common.KubeAction
+}
+
+func (u *upgradeUserReverseProxyAgent) Execute(runtime connector.Runtime) error {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %s", err)
+	}
+
+	scheme := kruntime.NewScheme()
+	if err := iamv1alpha2.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add user scheme: %s", err)
+	}
+	userClient, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %s", err)
+	}
+
+	client, err := kkubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	var userList iamv1alpha2.UserList
+	if err := userClient.List(ctx, &userList); err != nil {
+		return fmt.Errorf("failed to list users: %s", err)
+	}
+
+	for _, user := range userList.Items {
+		ns := fmt.Sprintf("user-space-%s", user.Name)
+
+		getCtx, getCancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		_, err := client.AppsV1().Deployments(ns).Get(getCtx, "reverse-proxy-agent", metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Infof("reverse-proxy-agent deployment not found in namespace %s, skipping", ns)
+				continue
+			}
+			return fmt.Errorf("failed to get reverse-proxy-agent deployment in namespace %s: %v", ns, err)
+		}
+
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
+			"/usr/local/bin/kubectl set image deployment/reverse-proxy-agent agent=%s -n %s", reverseProxyAgentImage, ns), false, true); err != nil {
+			return errors.Wrapf(errors.WithStack(err), "failed to upgrade reverse-proxy-agent in namespace %s", ns)
+		}
+		logger.Infof("reverse-proxy-agent in namespace %s upgraded to %s successfully", ns, reverseProxyAgentImage)
+	}
+
+	return nil
+}
+
+func upgradeUserReverseProxy() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "upgradeUserReverseProxy",
+			Action: new(upgradeUserReverseProxyAgent),
 			Retry:  5,
 			Delay:  5 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -309,7 +309,7 @@ spec:
         - name: L4_PROXY_NAMESPACE
           value: os-network
         - name: REVERSE_PROXY_AGENT_IMAGE_VERSION
-          value: v0.1.10
+          value: v0.1.11
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/framework/reverse-proxy/.olares/Olares.yaml
+++ b/framework/reverse-proxy/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/reverse-proxy:v0.1.10
+      name: beclab/reverse-proxy:v0.1.11
 
 
       


### PR DESCRIPTION
## Summary
- Add a new daily breaking-change upgrader `1.12.7-20260610` (`cli/pkg/upgrade/1_12_7_20260610.go`).
- In `UpgradeSystemComponents`, run a new `upgradeUserReverseProxyAgent` action that iterates the user list, builds the `user-space-<username>` namespace, and—only when a `reverse-proxy-agent` deployment exists in that namespace—sets its image to `beclab/reverse-proxy:v0.1.11`. Namespaces without the deployment are skipped.

## Test plan
- [ ] `go build ./...` passes
- [ ] On a cluster with multiple users, verify only namespaces that already have `reverse-proxy-agent` get the image bumped, and others are skipped

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cluster-wide kubectl image updates across user namespaces affect user-facing proxy traffic, though changes are limited to existing deployments and a single image tag.
> 
> **Overview**
> Bumps the **reverse-proxy agent** image from **v0.1.10** to **v0.1.11** in the BFL launcher template (`REVERSE_PROXY_AGENT_IMAGE_VERSION`) and the reverse-proxy prebuilt manifest so new installs match the upgraded runtime.
> 
> Adds an upgrade path that **lists IAM users**, targets each `user-space-<username>` namespace, and runs `kubectl set image` on `reverse-proxy-agent` only when that deployment already exists; namespaces without it are skipped. The task is wired into the **1.12.6** `PrepareForUpgrade` pipeline and registered again under a new daily breaking upgrader **`1.12.7-20260610`** (same action, retries/delay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90327940b081cdce6bfdec98f5cfdcc49a4bf0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->