### PR TITLE
feat(appservice): add quantity type validation for env

### DIFF
--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
 	github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1
-	github.com/beclab/api v0.0.14
+	github.com/beclab/api v0.0.15
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29
 	github.com/containers/image/v5 v5.36.1

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,12 +110,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260609100446-2c843cd18541 h1:EZwth3YIj6EYTLbNaSF0ywXVl+89IcO9LEhFsrcYp/U=
-github.com/beclab/Olares/framework/oac v0.0.0-20260609100446-2c843cd18541/go.mod h1:lW+D7UM6mHOXKlVPM6MYsvh3AIKUN18yEptcQh58QZI=
 github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1 h1:2FcZdyIHKfhD3Xv5iqDT0DJBHgY40zkrnXH7dQ5VKFk=
 github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1/go.mod h1:lW+D7UM6mHOXKlVPM6MYsvh3AIKUN18yEptcQh58QZI=
-github.com/beclab/api v0.0.14 h1:/KGHYsb1TpWzOLws2JfPhxpa0tOK9ZyLSDJlBZmY8ko=
-github.com/beclab/api v0.0.14/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.15 h1:6fBCTwMncaYkSAgGTZaD5p12Kq3SHpN3QxBEivV4jFI=
+github.com/beclab/api v0.0.15/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=
 github.com/beclab/lldap-client v0.0.11/go.mod h1:Y74tcKzyNL73a9pFAvImwXgzqp7S7Jb8RY1mMY90e/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
* **Background**
Add a new type `quantity` for Env for validation of K8s standard quantity value strings such as `8192`/`8Mi`/`8Gi`

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/api/commit/35c4965cad7491d1359d4280effcaa8aa0b9d859

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change; behavior change is stricter validation on env values typed as quantity via the shared api package.
> 
> **Overview**
> **Bumps `framework/app-service` onto `github.com/beclab/api` v0.0.15** (from v0.0.14) and refreshes `go.sum`, so app-service picks up the new **`quantity` env type** validation for Kubernetes-style quantity strings (e.g. `8192`, `8Mi`, `8Gi`). The PR description ties this to the upstream api change; **this repo diff is dependency wiring only**—no new validation logic in app-service itself.
> 
> Also updates the **`github.com/beclab/Olares/framework/oac`** pseudo-version in `go.mod`/`go.sum` alongside the api bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae38c2a329fa3850f590b9b6f9c027ef2fd0106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->