### PR TITLE
feat(appservice): add seperate validation API for compute selection

### DIFF
--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1
+	github.com/beclab/Olares/framework/oac v0.0.0-20260610065302-4039c03b0b70
 	github.com/beclab/api v0.0.15
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,8 +110,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1 h1:2FcZdyIHKfhD3Xv5iqDT0DJBHgY40zkrnXH7dQ5VKFk=
-github.com/beclab/Olares/framework/oac v0.0.0-20260609150043-92e3da08c8a1/go.mod h1:lW+D7UM6mHOXKlVPM6MYsvh3AIKUN18yEptcQh58QZI=
+github.com/beclab/Olares/framework/oac v0.0.0-20260609165114-1b4b40ef78e9 h1:sdzhbllZ+QdwlFlQ1eh9eMWOd5sc0DOtGYTAYPVYKxc=
+github.com/beclab/Olares/framework/oac v0.0.0-20260609165114-1b4b40ef78e9/go.mod h1:lW+D7UM6mHOXKlVPM6MYsvh3AIKUN18yEptcQh58QZI=
+github.com/beclab/Olares/framework/oac v0.0.0-20260610065302-4039c03b0b70 h1:CJkiX/PkVw64qMpKGgZGNV+WIUa6EX7PdExfpfz74qs=
+github.com/beclab/Olares/framework/oac v0.0.0-20260610065302-4039c03b0b70/go.mod h1:lW+D7UM6mHOXKlVPM6MYsvh3AIKUN18yEptcQh58QZI=
 github.com/beclab/api v0.0.15 h1:6fBCTwMncaYkSAgGTZaD5p12Kq3SHpN3QxBEivV4jFI=
 github.com/beclab/api v0.0.15/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,6 +29,23 @@ type ComputeResourcesResponse struct {
 type ComputeBindingResponse struct {
 	api.Response `json:",inline"`
 	Data         []compute.Allocation `json:"data"`
+}
+
+// ComputeBindingValidationResponse is the 200 success payload returned by
+// the read-only compute binding validation endpoint when the binding is
+// acceptable (BindingApplyStatusValid or BindingApplyStatusNotRequired).
+// The Required / Unavailable cases instead return a FailedCheckResponse
+// carrying ComputeBindingFailedCheck, matching the resume endpoint.
+type ComputeBindingValidationResponse struct {
+	api.Response `json:",inline"`
+	Data         ComputeBindingValidationData `json:"data"`
+}
+
+type ComputeBindingValidationData struct {
+	Status       string                           `json:"status"`
+	Availability *compute.AvailabilityResult      `json:"availability,omitempty"`
+	Validation   *compute.BindingValidationResult `json:"validation,omitempty"`
+	Allocations  []compute.Allocation             `json:"allocations,omitempty"`
 }
 
 // ComputeBindingFailedCheck is the payload returned by the resume endpoint
@@ -317,6 +335,75 @@ func (h *Handler) listComputeBindings(req *restful.Request, resp *restful.Respon
 	resp.WriteAsJson(ComputeBindingResponse{
 		Response: api.Response{Code: api.CodeSuccess},
 		Data:     allocations,
+	})
+}
+
+func (h *Handler) validateComputeBinding(req *restful.Request, resp *restful.Response) {
+	app := req.PathParameter(ParamAppName)
+	owner := req.Attribute(constants.UserContextAttribute).(string)
+	request := &ResumeRequest{}
+	if err := readOptionalEntity(req, request); err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+
+	_, amPtr, ok := h.loadAuthorizedLifecycleAM(req.Request.Context(), req, resp, app, owner)
+	if !ok {
+		return
+	}
+	am := *amPtr
+
+	var appCfg *appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(am.Spec.Config), &appCfg); err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	isAdmin, err := kubesphere.IsAdmin(req.Request.Context(), h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	includeSharedServer, err := compute.ShouldIncludeSharedServerForResume(req.Request.Context(), h.ctrlClient, appCfg, isAdmin)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	bindingResult, err := compute.ValidateBindingForResume(req.Request.Context(), h.ctrlClient, appCfg, request.ComputeBinding, includeSharedServer)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	// Required / Unavailable still report through the same FailedCheckResponse
+	// envelope the resume endpoint uses so the frontend can reuse identical
+	// handling. Valid / NotRequired mean the binding is acceptable, so return
+	// a plain 200 success carrying the resolved status plus the available
+	// options for context.
+	switch bindingResult.Status {
+	case compute.BindingApplyStatusRequired:
+		api.HandleFailedCheck(resp, api.CheckTypeComputeBindingRequired, ComputeBindingFailedCheck{
+			Availability: bindingResult.Availability,
+			Validation:   bindingResult.Validation,
+		})
+		return
+	case compute.BindingApplyStatusUnavailable:
+		api.HandleFailedCheck(resp, api.CheckTypeComputeBindingUnavailable, ComputeBindingFailedCheck{
+			Availability: bindingResult.Availability,
+			Validation:   bindingResult.Validation,
+		})
+		return
+	}
+
+	resp.WriteAsJson(ComputeBindingValidationResponse{
+		Response: api.Response{Code: api.CodeSuccess},
+		Data: ComputeBindingValidationData{
+			Status:       bindingResult.Status,
+			Availability: bindingResult.Availability,
+			Validation:   bindingResult.Validation,
+			Allocations:  bindingResult.Allocations,
+		},
 	})
 }
 

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -53,10 +53,22 @@ func (h *Handler) suspend(req *restful.Request, resp *restful.Response) {
 	if am.Annotations == nil {
 		am.Annotations = make(map[string]string)
 	}
-	am.Annotations[api.AppStopAllKey] = fmt.Sprintf("%t", request.All)
+	am.Annotations[api.AppStopAllKey] = fmt.Sprintf("%t", true)
 
 	err := h.ctrlClient.Update(req.Request.Context(), &am)
 	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	var appCfg appcfg.ApplicationConfig
+	if err = json.Unmarshal([]byte(am.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup of app %s failed %v", app, err)
+		api.HandleError(resp, req, err)
+		return
+	}
+	if err = compute.DeleteAllocationsForComputeTarget(req.Request.Context(), h.ctrlClient, &appCfg, true); err != nil {
+		klog.Errorf("delete compute allocation for suspended app %s failed %v", app, err)
 		api.HandleError(resp, req, err)
 		return
 	}

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -367,6 +367,13 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Param(ws.PathParameter(ParamAppName, "the name of a application")).
 		Returns(http.StatusOK, "Success to list compute resource bindings", &ComputeBindingResponse{}))
 
+	ws.Route(ws.POST("/apps/{"+ParamAppName+"}/compute-resources/bindings/validate").
+		To(handler.validateComputeBinding).
+		Doc("Validate a compute resource binding selection without applying it").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Param(ws.PathParameter(ParamAppName, "the name of a application")).
+		Returns(http.StatusOK, "Success to validate the compute resource binding", &ComputeBindingValidationResponse{}))
+
 	ws.Route(ws.DELETE("/apps/{"+ParamAppName+"}/compute-resources/bindings").
 		To(handler.queued(handler.suspend)).
 		Doc("Suspend the application to release compute resource bindings").

--- a/framework/app-service/pkg/appstate/suspend_failed_app.go
+++ b/framework/app-service/pkg/appstate/suspend_failed_app.go
@@ -2,10 +2,13 @@ package appstate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubeblocks"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -69,6 +72,16 @@ func (p *SuspendFailedApp) StateReconcile(ctx context.Context) error {
 			klog.Errorf("stop-failed-middleware %s state reconcile failed %v", p.manager.Spec.AppName, err)
 			return err
 		}
+	}
+
+	var appCfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup of app %s failed %v", p.manager.Spec.AppName, err)
+		return err
+	}
+	if err := compute.DeleteAllocationsForComputeTarget(ctx, p.client, &appCfg, stopServer); err != nil {
+		klog.Errorf("delete compute allocation for suspend-failed app %s failed %v", p.manager.Spec.AppName, err)
+		return err
 	}
 	return nil
 }

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -146,6 +146,7 @@ func makeDeviceOption(req Requirement, node Node, device Device, pressure Pressu
 		Capacity:    device.Memory,
 		Available:   available,
 		Health:      device.Health,
+		Bindings:    device.Bindings,
 	}
 	if option.Health == "" {
 		option.Health = deviceHealthYes
@@ -187,7 +188,7 @@ func markOperable(result *AvailabilityResult) {
 			}
 		}
 		for di := range node.Devices {
-			node.Devices[di].Operable = node.Devices[di].Health == deviceHealthYes
+			node.Devices[di].Operable = node.Devices[di].Health == deviceHealthYes && node.Devices[di].Available > 0
 		}
 	}
 }
@@ -320,6 +321,79 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		Allocations: allocations,
 		TargetApp:   appConfig.AppName,
 		TargetOwner: appConfig.OwnerName,
+	}, nil
+}
+
+// ValidateBindingForResume mirrors ApplyBindingSelection's feasibility
+// checks but performs NO writes: it never mutates the allocation config
+// map and never creates HAMI bindings. It is the read-only counterpart
+// intended for a pre-flight "would this resume succeed?" call the
+// frontend can make before issuing the real resume.
+//
+// The returned BindingApplyResult uses the same status/availability/
+// validation shapes as ApplyBindingSelection so the two endpoints stay
+// format-compatible, with one difference: where ApplyBindingSelection
+// returns BindingApplyStatusApplied after writing, this returns
+// BindingApplyStatusValid (the selection is valid but nothing was
+// applied). The accompanying Allocations describe what WOULD be written.
+func ValidateBindingForResume(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, selections []BindingSelection, includeSharedServer bool) (*BindingApplyResult, error) {
+	if appConfig == nil {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	if appConfig.IsV2() && appConfig.HasClusterSharedCharts() && !includeSharedServer {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	targetConfig, _, err := resolveComputeTarget(ctx, c, appConfig, includeSharedServer)
+	if err != nil {
+		return nil, err
+	}
+	appConfig = targetConfig
+	req, ok := SelectedRequirement(appConfig)
+	if !ok || req.Mode == utils.CPUType {
+		return &BindingApplyResult{Status: BindingApplyStatusNotRequired}, nil
+	}
+	pressure, err := FetchPressureSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Exclude the app's own existing allocation rows so a re-binding of the
+	// same app does not count its current claim against availability, matching
+	// the node view ApplyBindingSelection validates against.
+	nodes, err := FetchNodeComputeAllocationsExcludingApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	if err != nil {
+		return nil, err
+	}
+	if len(selections) == 0 {
+		return &BindingApplyResult{
+			Status:       BindingApplyStatusRequired,
+			Availability: listAvailableForLaunch(req, nodes, pressure),
+			TargetApp:    appConfig.AppName,
+			TargetOwner:  appConfig.OwnerName,
+		}, nil
+	}
+	resolved, resolveErr := resolveSelection(selections, nodes)
+	if resolveErr != nil {
+		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error())), nil
+	}
+	validation := validateResolvedBindingSelection(req, resolved, pressure)
+	if !validation.OK {
+		return unavailableBindingApplyResult(req, nodes, pressure, validation), nil
+	}
+	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
+	if len(allocations) == 0 {
+		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding")), nil
+	}
+	// Even when the selection is valid we still hand back the full list of
+	// available options so the frontend can render the current selection in
+	// context and offer alternatives, mirroring the Required / Unavailable
+	// payloads exactly (Availability is always populated).
+	return &BindingApplyResult{
+		Status:       BindingApplyStatusValid,
+		Allocations:  allocations,
+		Availability: listAvailableForLaunch(req, nodes, pressure),
+		Validation:   validation,
+		TargetApp:    appConfig.AppName,
+		TargetOwner:  appConfig.OwnerName,
 	}, nil
 }
 

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -92,6 +92,7 @@ const (
 	BindingApplyStatusRequired     = "required"
 	BindingApplyStatusUnavailable  = "unavailable"
 	BindingApplyStatusApplied      = "applied"
+	BindingApplyStatusValid        = "valid"
 	BindingValidationReasonValid   = "valid"
 	BindingValidationReasonInvalid = "invalid"
 	deviceHealthYes                = "yes"
@@ -99,15 +100,16 @@ const (
 )
 
 type DeviceOption struct {
-	NodeName    string `json:"nodeName"`
-	DeviceID    string `json:"deviceId"`
-	CardModel   string `json:"cardModel,omitempty"`
-	SupportType string `json:"supportType"`
-	Capacity    int64  `json:"capacity"`
-	Available   int64  `json:"available"`
-	FitLevel    string `json:"fitLevel,omitempty"`
-	Health      string `json:"health"`
-	Operable    bool   `json:"operable"`
+	NodeName    string       `json:"nodeName"`
+	DeviceID    string       `json:"deviceId"`
+	CardModel   string       `json:"cardModel,omitempty"`
+	SupportType string       `json:"supportType"`
+	Capacity    int64        `json:"capacity"`
+	Available   int64        `json:"available"`
+	FitLevel    string       `json:"fitLevel,omitempty"`
+	Health      string       `json:"health"`
+	Operable    bool         `json:"operable"`
+	Bindings    []Allocation `json:"bindings,omitempty"`
 }
 
 type NodeOption struct {


### PR DESCRIPTION
* **Background**
Add a separate validation API handler to allow frontend check and refresh the validity of user's compute resource selection without actually submits it
Add current compute bindings of a device when returning the availability to the frontend for extra info
For V2 shared app, always suspend the server side, and clean up allocations upon suspend failed state to make sure no dirty allocation remains after app is suspended 

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes suspend semantics (always stop-all, eager allocation deletion) and compute availability operability rules, which can affect GPU scheduling UX and shared V2 apps; validation path reuses resume logic without writes, lowering risk there.
> 
> **Overview**
> Adds a **read-only** `POST .../compute-resources/bindings/validate` endpoint so the UI can check a compute binding (same `FailedCheck` shapes as resume for required/unavailable; `valid` / `not-required` on success) via new `ValidateBindingForResume` and status `BindingApplyStatusValid`.
> 
> Availability responses now include **per-device `bindings`** on `DeviceOption`, and devices are only **operable** when healthy and `available > 0`.
> 
> **Suspend** always sets stop-all to true (no longer honors optional `all` from the body), and **deletes compute allocations** immediately on user suspend and again in **suspend-failed** reconcile to avoid stale GPU claims (notably for V2 shared apps).
> 
> Bumps the **`framework/oac`** module dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffddee049ee89f6af37580160b0f35b94db16a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->