### PR TITLE
docs: add troubleshooting entry for ComfyUI --normalvram error after upgrade

### DIFF
--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -32,7 +32,9 @@ This is usually caused by insufficient resources or incorrect GPU allocation. To
 
 If ComfyUI starts successfully, most of these messages do not require action. Investigate logs only if ComfyUI fails to start, a workflow cannot run, or a plugin stops working.
 
-## ComfyUI fails to start after upgrade with `--normalvram` error
+## ComfyUI fails to start after upgrading to v1.0.37 or later
+
+This issue may occur after upgrading to ComfyUI v1.0.37 or later.
 
 After upgrading ComfyUI, the app may fail to start and show an error like:
 
@@ -47,7 +49,7 @@ To fix this:
 1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
 2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **Save**. Alternatively, click **Restore default** to reset to the default launch arguments.
 3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
-4. Restart ComfyUI.
+4. In ComfyUI Launcher, click **Start ComfyUI** to launch the app.
 
 ## Models cannot be downloaded directly to Olares
 

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -36,7 +36,7 @@ If ComfyUI starts successfully, most of these messages do not require action. In
 
 This issue may occur after upgrading to ComfyUI v1.0.37 or later.
 
-After upgrading ComfyUI, the app may fail to start and show an error like:
+After the upgrade, ComfyUI app may fail to start and show an error like:
 
 ```
 main.py: error: unrecognized arguments: --normalvram

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -32,6 +32,23 @@ This is usually caused by insufficient resources or incorrect GPU allocation. To
 
 If ComfyUI starts successfully, most of these messages do not require action. Investigate logs only if ComfyUI fails to start, a workflow cannot run, or a plugin stops working.
 
+## ComfyUI fails to start after upgrade with `--normalvram` error
+
+After upgrading ComfyUI, the app may fail to start and show an error like:
+
+```
+main.py: error: unrecognized arguments: --normalvram
+```
+
+This means a custom launch argument from a previous version is still in use, but the new version no longer supports it.
+
+To fix this:
+
+1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
+2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **Save**. Alternatively, click **Restore default** to reset to the default launch arguments.
+3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
+4. Restart ComfyUI.
+
 ## Models cannot be downloaded directly to Olares
 
 Some models require login, access approval, a token, or manual confirmation before they can be downloaded. These models cannot be downloaded directly to Olares through ComfyUI Launcher or Server Download.

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -49,7 +49,7 @@ To fix this:
 1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
 2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **SAVE MANUAL ARGS*. Alternatively, click **RESTORE DEFAULT** to reset to the default launch arguments.
 3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
-4. In ComfyUI Launcher Home, click **Start** to launch the ComfyUI.
+4. Go back to **Home** in ComfyUI Launcher, then click **Start** to launch ComfyUI.
 
 ## Models cannot be downloaded directly to Olares
 

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -47,7 +47,7 @@ This means a custom launch argument from a previous version is still in use, but
 To fix this:
 
 1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
-2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **Save**. Alternatively, click **Restore default** to reset to the default launch arguments.
+2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **SAVE MANUAL ARGS*. Alternatively, click **RESTORE DEFAULT** to reset to the default launch arguments.
 3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
 4. In ComfyUI Launcher Home, click **Start** to launch the ComfyUI.
 

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -47,7 +47,7 @@ This means a custom launch argument from a previous version is still in use, but
 To fix this:
 
 1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
-2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **SAVE MANUAL ARGS*. Alternatively, click **RESTORE DEFAULT** to reset to the default launch arguments.
+2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **SAVE MANUAL ARGS**. Alternatively, click **RESTORE DEFAULT** to reset to the default launch arguments.
 3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
 4. Go back to **Home** in ComfyUI Launcher, then click **Start** to launch ComfyUI.
 

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -49,7 +49,7 @@ To fix this:
 1. Open **ComfyUI Launcher** and go to **Lab** from the left sidebar.
 2. In the **Manually edit extra arguments** field, remove `--normalvram` manually and click **Save**. Alternatively, click **Restore default** to reset to the default launch arguments.
 3. Verify that **Current full launch command** at the top no longer contains `--normalvram`.
-4. In ComfyUI Launcher, click **Start ComfyUI** to launch the app.
+4. In ComfyUI Launcher Home, click **Start** to launch the ComfyUI.
 
 ## Models cannot be downloaded directly to Olares
 


### PR DESCRIPTION
* **Background**
After upgrading ComfyUI to v1.0.37 or later, the app may fail to start with the error:
```
main.py: error: unrecognized arguments: --normalvram
```
This is caused by a legacy launch argument (`--normalvram`) that is no longer supported in newer versions of ComfyUI but persists in the Launcher's saved configuration.

* **Target Version for Merge**
1.12

* **Related Issues**
None

* **PRs Involving Sub-Systems**
None

* **Other information**:
Added a new troubleshooting entry in `docs/use-cases/comfyui-common-issues.md` with step-by-step instructions to remove the outdated `--normalvram` argument from ComfyUI Launcher's Lab settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **Common issues** troubleshooting section for ComfyUI **v1.0.37+** upgrades where startup fails with `main.py: error: unrecognized arguments: --normalvram` because Launcher still has the removed `--normalvram` extra arg.
> 
> The doc explains the cause and walks users through **Lab** → edit or **RESTORE DEFAULT** manual args → confirm **Current full launch command** → restart from **Home**. Also fixes a missing newline at EOF after the CPU frequency code block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d59ba0ae1b3ef7b7392a5f9e00fd9520c5a474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->