### PR TITLE
feat(l4-bfl-proxy): gate shared apps behind Authelia ext_auth

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -142,7 +142,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.23"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.24"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.23
+          value: v0.3.24
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.23
+      name: beclab/l4-bfl-proxy:v0.3.24
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -55,6 +55,33 @@
       }
     },
     {
+      "name": "authelia_backend_admin",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_admin",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-admin.svc.cluster.local",
+                      "portValue": 9091
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
       "name": "nonapp_auth_admin",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -136,33 +163,6 @@
       }
     },
     {
-      "name": "authelia_backend_admin",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_admin",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-admin.svc.cluster.local",
-                      "portValue": 9091
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
       "name": "profile_service_alice",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -204,6 +204,33 @@
                     "socketAddress": {
                       "address": "shareme-svc.shareme-shared.svc.cluster.local",
                       "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
+      "name": "authelia_backend_alice",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_alice",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
+                      "portValue": 9091
                     }
                   }
                 }
@@ -298,33 +325,6 @@
       }
     },
     {
-      "name": "authelia_backend_alice",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_alice",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
-                      "portValue": 9091
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
       "name": "profile_service_bob",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -366,6 +366,33 @@
                     "socketAddress": {
                       "address": "shareme-svc.shareme-shared.svc.cluster.local",
                       "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
+      "name": "authelia_backend_bob",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_bob",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-bob.svc.cluster.local",
+                      "portValue": 9091
                     }
                   }
                 }
@@ -447,33 +474,6 @@
                     "socketAddress": {
                       "address": "wizard.user-space-bob.svc.cluster.local",
                       "portValue": 80
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
-      "name": "authelia_backend_bob",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_bob",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-bob.svc.cluster.local",
-                      "portValue": 9091
                     }
                   }
                 }
@@ -1747,6 +1747,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -2176,6 +2182,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {
@@ -2607,6 +2619,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -3036,6 +3054,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {
@@ -3467,6 +3491,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -3896,6 +3926,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -550,7 +550,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			routes = append(routes, t.buildFileserverRoutes(user, clusterSet)...)
 		}
 
-		routes = append(routes, &ir.HTTPRouteIR{
+		defaultRoute := &ir.HTTPRouteIR{
 			Name:       fmt.Sprintf("default_%s_%s_%s", user.Name, app.Name, entrance.Name),
 			PathPrefix: "/",
 			Cluster:    clusterName,
@@ -558,13 +558,40 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 				"X-BFL-USER": user.Name,
 			},
 			WebSocketUpgrade: true,
-		})
+		}
+
+		// Shared (v3) apps are cluster-wide and open to all users, so the
+		// whole app is gated behind the viewing user's Authelia instance.
+		if app.IsShared {
+			defaultRoute.ExtAuth = buildSharedAppExtAuthConfig(user)
+		}
+
+		routes = append(routes, defaultRoute)
 
 		vhost.Routes = routes
 		vhosts = append(vhosts, vhost)
 	}
 
 	return vhosts
+}
+
+// buildSharedAppExtAuthConfig returns the Authelia ext_auth config used to gate
+// shared (v3) apps behind the viewing user's per-user Authelia instance. It is
+// intentionally independent from the fileserver ext_auth wiring so the two can
+// evolve separately.
+func buildSharedAppExtAuthConfig(user *message.UserInfo) *ir.ExtAuthConfigIR {
+	return &ir.ExtAuthConfigIR{
+		Cluster:    fmt.Sprintf("%s_%s", autheliaClusterPrefix, user.Name),
+		PathPrefix: autheliaPathPrefix,
+		RequestHeaders: []string{
+			"X-Original-URL",
+			"X-Original-Method",
+			"X-Forwarded-For",
+			"X-BFL-USER",
+			"X-Authorization",
+			"Cookie",
+		},
+	}
 }
 
 func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet map[string]*ir.ClusterIR) []*ir.HTTPRouteIR {
@@ -706,21 +733,29 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			Name: clusterName, Host: upstreamHost, Port: uint32(entrance.Port), UseDNS: true,
 		}
 
+		customRoute := &ir.HTTPRouteIR{
+			Name:       fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
+			PathPrefix: "/",
+			Cluster:    clusterName,
+			RequestHeaders: map[string]string{
+				"X-BFL-USER": user.Name,
+			},
+			WebSocketUpgrade: true,
+		}
+
+		// Shared (v3) apps stay gated behind Authelia even when reached via a
+		// custom domain, so the auth requirement can't be bypassed.
+		if app.IsShared {
+			customRoute.ExtAuth = buildSharedAppExtAuthConfig(user)
+		}
+
 		vhost := &ir.VirtualHostIR{
 			Name:     fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),
 			Domains:  []string{customDomainName},
 			Language: user.Language,
 			UserZone: user.Zone,
 			UserName: user.Name,
-			Routes: []*ir.HTTPRouteIR{{
-				Name:       fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
-				PathPrefix: "/",
-				Cluster:    clusterName,
-				RequestHeaders: map[string]string{
-					"X-BFL-USER": user.Name,
-				},
-				WebSocketUpgrade: true,
-			}},
+			Routes:   []*ir.HTTPRouteIR{customRoute},
 		}
 		vhosts = append(vhosts, vhost)
 	}

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/beclab/l4-bfl-proxy/internal/ir"
@@ -596,8 +597,28 @@ func TestBuildAppVirtualHosts_SharedApp_OpenToAllUsers(t *testing.T) {
 			assert.Nil(t, r.DirectResponse, "no 403 gate is emitted; shared apps are open")
 			assert.NotEmpty(t, r.Cluster, "every user must reach the upstream cluster")
 			assert.NotEmpty(t, clusterSet, "an upstream cluster must be registered")
+
+			require.NotNil(t, r.ExtAuth, "shared apps must be gated behind Authelia ext_auth")
+			assert.Equal(t, fmt.Sprintf("authelia_backend_%s", name), r.ExtAuth.Cluster)
+			assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
+			assert.False(t, r.ExtAuth.Disabled)
 		})
 	}
+}
+
+// Shared apps reached via a custom domain are also gated behind Authelia.
+func TestBuildCustomDomainVirtualHosts_SharedApp_ExtAuth(t *testing.T) {
+	tr := &Translator{cfg: &Config{}}
+	user := &message.UserInfo{Name: "alice", Language: "en", Zone: "alice.example.com"}
+	clusterSet := make(map[string]*ir.ClusterIR)
+
+	vhosts := tr.buildCustomDomainVirtualHosts(user, makeSharedAppWithCustom(), clusterSet)
+	require.Len(t, vhosts, 1)
+	require.Len(t, vhosts[0].Routes, 1)
+	r := vhosts[0].Routes[0]
+	require.NotNil(t, r.ExtAuth, "shared apps must stay gated even on a custom domain")
+	assert.Equal(t, "authelia_backend_alice", r.ExtAuth.Cluster)
+	assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
 }
 
 // v1/v2 (non-shared) apps continue to reach their upstream cluster directly.
@@ -620,6 +641,7 @@ func TestBuildAppVirtualHosts_NonSharedApp(t *testing.T) {
 	require.Len(t, vhosts, 1)
 	require.Len(t, vhosts[0].Routes, 1)
 	assert.Nil(t, vhosts[0].Routes[0].DirectResponse)
+	assert.Nil(t, vhosts[0].Routes[0].ExtAuth, "non-shared apps must not be gated behind ext_auth")
 	assert.NotEmpty(t, clusterSet)
 }
 


### PR DESCRIPTION


* **Background**
    feat(l4-bfl-proxy): gate shared apps behind Authelia ext_auth
    Shared (v3) apps are cluster-wide and fanned out to every user, but their
    default route was previously unauthenticated. Add a per-user Authelia
    ext_auth check on shared apps' default route, including when reached via a
    custom domain, so the whole app is protected and the auth requirement
    cannot be bypassed.
    The ext_auth wiring is implemented independently from the fileserver
    ext_auth (buildSharedAppExtAuthConfig) so the two can evolve separately. It
    reuses each user's existing authelia_backend_<user> cluster, so no extra
    cluster or xDS-layer change is needed. Non-shared apps are unaffected.
    Update the shared-app-open golden file and add unit tests asserting shared
    apps are gated (default and custom-domain routes) while non-shared apps are
    not.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes edge authentication for cluster-wide shared apps and bumps the production L4 proxy image; misconfiguration could block legitimate access or leave a bypass if custom-domain paths were wrong.
> 
> **Overview**
> **Shared (v3) apps are now authenticated** on the L4 proxy: default and custom-domain routes for `IsShared` apps get per-viewer **Authelia `ext_auth`** via new `buildSharedAppExtAuthConfig`, reusing each user's existing `authelia_backend_<user>` cluster (separate from fileserver ext_auth wiring). Non-shared apps are unchanged.
> 
> **Release alignment:** `l4-bfl-proxy` image tag is bumped to **`v0.3.24`** in the CLI upgrade task, BFL launcher deploy env, and Olares prebuilt manifest.
> 
> **Tests:** `shared-app-open.json` golden output adds route-level `ExtAuthzPerRoute` `checkSettings` on shared app routes; unit tests assert ext_auth on shared default/custom routes and absence on non-shared apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd03de7d2c06a53f284825a7019ead93bcd6ef30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->