### PR TITLE
feat: bump monitoring-server image version to v0.3.13

### DIFF
--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -23,7 +23,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.12
+        image: beclab/monitoring-server-v1:v0.3.13
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**
Fix the issue where regular users cannot view metrics of v3 version applications

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/ks-apiserver-proxy/pull/4


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag change in a Helm/deploy manifest with no application code or config changes beyond the version bump.
> 
> **Overview**
> Bumps the **monitoring-server** container image in `ks_server_deploy.yaml` from `beclab/monitoring-server-v1:v0.3.12` to **v0.3.13**. This rolls out the server build that addresses regular users being unable to view metrics for v3 applications (behavior lives in the image; related proxy work is in **ks-apiserver-proxy**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d7276e3eabcecee4f37df74b423b2c4f0d59fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->