### PR TITLE
fix: files archive: cross-storage gate, ENXIO friendly error, raw 7z log

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.181
+          image: beclab/files-server:v0.2.182
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix(archive): reject compress/extract that cross storages (drive/Home, Data, Common, cache, each external mount root).
- fix(archive): map ENXIO 7z warnings (Wayland sockets, FIFOs, device files) to a friendly typed error.
- fix(archive): always log raw 7z stderr on failure; soften compress fallback wording (no longer suggests "free disk space").

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/348

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single container image tag change in cluster deploy; application behavior changes are scoped to archive handling in the bumped image.
> 
> **Overview**
> Bumps the **`files`** container image in the Files DaemonSet from **`beclab/files-server:v0.2.181`** to **`v0.2.182`**, rolling out the companion **files-server** release (see beclab/files#348).
> 
> That release improves **archive compress/extract**: blocks operations that span different storage roots, maps **ENXIO** 7z warnings to a clearer user-facing error, and improves failure logging (raw 7z stderr; softer compress fallback text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6edbd5192c0cbaec35f9e25d8c7e5e316162d575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->