### PR TITLE
system-frontend: bump image version to v1.10.47

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.46
+          image: beclab/system-frontend:v1.10.47
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Bump the `system-frontend` (olares-app-init) image in `system-apps` from `v1.10.46` to `v1.10.47`, shipping the latest frontend changes from TermiPass:
  - Market: template-only app support, install gating, and richer failure messages
  - Market: add drag-and-drop app package upload
  - Env: multi-select environment variables and EnvVarInput refactor
  - Icons: Node-based icon font subsetting with missing-icon CI guard
  - VPN: improve cross-platform notify and exit-node handling
  - Files: harden archive compression flow and mobile data visibility
  - Electron: ensure Linux window shows on startup and tray click focuses
  - Fix exclusive-mode display, tri-state usage capsule, and device-scoped validation
  - Chore: enforce LF line endings

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1190
https://github.com/beclab/TermiPass/pull/1194
https://github.com/beclab/TermiPass/pull/1191
https://github.com/beclab/TermiPass/pull/1187
https://github.com/beclab/TermiPass/pull/1186
https://github.com/beclab/TermiPass/pull/1188
https://github.com/beclab/TermiPass/pull/1189
https://github.com/beclab/TermiPass/pull/1192
https://github.com/beclab/TermiPass/pull/1193

* **Other information**:
None

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on an init container; no auth, API, or Helm behavior changes in this diff.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image from `beclab/system-frontend:v1.10.46` to **`v1.10.47`** in the system-apps Helm chart so Olares pods pull the latest TermiPass system frontend bundle into `/www` on startup.
> 
> This is a **deploy-only** change (no chart logic or env changes). The new image carries the TermiPass updates noted for this release—Market (template-only apps, install gating, drag-and-drop package upload), environment multi-select / `EnvVarInput` work, VPN and Files UX fixes, Electron/Linux window behavior, icon subsetting CI, and assorted UI/validation fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd8127506a11edbf8e0f5484b0cc98e1356be85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->