### PR TITLE
fix(appservice): ensure app compute binding cleared in final state

### DIFF
--- a/framework/app-service/controllers/load.go
+++ b/framework/app-service/controllers/load.go
@@ -163,11 +163,13 @@ func LoadStatefulApp(ctx context.Context, appmgr *ApplicationManagerController, 
 		case appv1alpha1.ResumeFailed:
 			return appstate.NewResumeFailedApp(appmgr, &am)
 
+		case appv1alpha1.Stopped:
+			return appstate.NewStoppedApp(appmgr, &am)
 		case appv1alpha1.DownloadFailed,
 			appv1alpha1.PendingCanceled, appv1alpha1.DownloadingCanceled,
 			appv1alpha1.InstallingCanceled, appv1alpha1.InitializingCanceled,
 			appv1alpha1.UpgradingCanceled, appv1alpha1.ApplyingEnvCanceled,
-			appv1alpha1.ResumingCanceled, appv1alpha1.Stopped:
+			appv1alpha1.ResumingCanceled:
 			return appstate.NewDoNothingApp(appmgr, &am)
 		case appv1alpha1.InstallFailed:
 			return appstate.NewInstallFailedApp(appmgr, &am)

--- a/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_uninstall.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -56,12 +57,21 @@ func (h *Handler) uninstall(req *restful.Request, resp *restful.Response) {
 	if request.Force {
 		klog.Warningf("force uninstalling app %s from %s state", app, am.Status.State)
 	}
+
+	// if current user is admin, also uninstall server side
+	isAdmin, err := kubesphere.IsAdmin(req.Request.Context(), h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	uninstallAll := isAdmin || request.All
+
 	am.Spec.OpType = v1alpha1.UninstallOp
 	if am.Annotations == nil {
 		am.Annotations = make(map[string]string)
 	}
 	am.Annotations[api.AppTokenKey] = token
-	am.Annotations[api.AppUninstallAllKey] = fmt.Sprintf("%t", request.All)
+	am.Annotations[api.AppUninstallAllKey] = fmt.Sprintf("%t", uninstallAll)
 	am.Annotations[api.AppDeleteDataKey] = fmt.Sprintf("%t", request.DeleteData)
 	err = h.ctrlClient.Update(req.Request.Context(), &am)
 	if err != nil {

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -49,13 +49,22 @@ func (h *Handler) suspend(req *restful.Request, resp *restful.Response) {
 		api.HandleBadRequest(resp, req, fmt.Errorf("%s operation is not allowed for %s state", v1alpha1.StopOp, am.Status.State))
 		return
 	}
+
+	// if current user is admin, also stop server side
+	isAdmin, err := kubesphere.IsAdmin(req.Request.Context(), h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	stopAll := isAdmin || request.All
+
 	am.Spec.OpType = v1alpha1.StopOp
 	if am.Annotations == nil {
 		am.Annotations = make(map[string]string)
 	}
-	am.Annotations[api.AppStopAllKey] = fmt.Sprintf("%t", true)
+	am.Annotations[api.AppStopAllKey] = fmt.Sprintf("%t", stopAll)
 
-	err := h.ctrlClient.Update(req.Request.Context(), &am)
+	err = h.ctrlClient.Update(req.Request.Context(), &am)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return
@@ -67,7 +76,7 @@ func (h *Handler) suspend(req *restful.Request, resp *restful.Response) {
 		api.HandleError(resp, req, err)
 		return
 	}
-	if err = compute.DeleteAllocationsForComputeTarget(req.Request.Context(), h.ctrlClient, &appCfg, true); err != nil {
+	if err = compute.DeleteAllocationsForComputeTarget(req.Request.Context(), h.ctrlClient, &appCfg, stopAll); err != nil {
 		klog.Errorf("delete compute allocation for suspended app %s failed %v", app, err)
 		api.HandleError(resp, req, err)
 		return

--- a/framework/app-service/pkg/appstate/install_failed_app.go
+++ b/framework/app-service/pkg/appstate/install_failed_app.go
@@ -2,8 +2,11 @@ package appstate
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
@@ -70,7 +73,37 @@ func (p *InstallFailedApp) Exec(ctx context.Context) (StatefulInProgressApp, err
 		}
 	}
 
+	// A failed install tears down the namespace above, so any allocation that
+	// AllocateForInstall reserved for this app is now backing a workload that no
+	// longer exists. Release it (guarded, so it is a no-op once cleaned up) to
+	// avoid leaking the GPU/compute reservation.
+	if err := p.cleanupComputeAllocation(ctx); err != nil {
+		klog.Errorf("cleanup compute allocation for install-failed app %s failed %v", p.manager.Spec.AppName, err)
+		return nil, err
+	}
+
 	return nil, nil
+}
+
+func (p *InstallFailedApp) cleanupComputeAllocation(ctx context.Context) error {
+	if p.manager.Spec.Config == "" {
+		return nil
+	}
+	var appCfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup of install-failed app %s failed %v", p.manager.Spec.AppName, err)
+		return err
+	}
+	// A failed install never owns a shared server, so only its own allocation
+	// row (if any) needs releasing; never touch a shared server here.
+	cleaned, err := compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, &appCfg, false)
+	if err != nil {
+		return err
+	}
+	if cleaned {
+		klog.Infof("released leaked compute allocation for install-failed app %s", p.manager.Spec.AppName)
+	}
+	return nil
 }
 
 func (p *InstallFailedApp) Cancel(ctx context.Context) error {

--- a/framework/app-service/pkg/appstate/stopped_app.go
+++ b/framework/app-service/pkg/appstate/stopped_app.go
@@ -1,0 +1,80 @@
+package appstate
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ OperationApp = &StoppedApp{}
+
+// StoppedApp is the steady-state handler for the Stopped state.
+//
+// The compute allocation is normally released during the Stopping -> Stopped
+// transition (SuspendingApp) or by SuspendFailedApp, but a handful of paths can
+// land an app in Stopped without that cleanup having run: apps that were stopped
+// before compute accounting existed, or any out-of-band write that sets the
+// state directly. StoppedApp re-runs a guarded cleanup so a stopped app never
+// keeps a leaked GPU/compute reservation while its workload is scaled to zero.
+type StoppedApp struct {
+	*baseOperationApp
+}
+
+func NewStoppedApp(c client.Client,
+	manager *appsv1.ApplicationManager) (StatefulApp, StateError) {
+
+	return appFactory.New(c, manager, 0,
+		func(c client.Client, manager *appsv1.ApplicationManager, ttl time.Duration) StatefulApp {
+			return &StoppedApp{
+				&baseOperationApp{
+					ttl: ttl,
+					baseStatefulApp: &baseStatefulApp{
+						manager: manager,
+						client:  c,
+					},
+				},
+			}
+		})
+}
+
+func (p *StoppedApp) Exec(ctx context.Context) (StatefulInProgressApp, error) {
+	if err := p.cleanupComputeAllocation(ctx); err != nil {
+		klog.Errorf("cleanup compute allocation for stopped app %s failed %v", p.manager.Spec.AppName, err)
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *StoppedApp) cleanupComputeAllocation(ctx context.Context) error {
+	if p.manager.Spec.Config == "" {
+		return nil
+	}
+	var appCfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup of stopped app %s failed %v", p.manager.Spec.AppName, err)
+		return err
+	}
+	// Mirror SuspendingApp / SuspendFailedApp: stop-all also frees the shared
+	// server's allocation, a client-only stop must not.
+	stopServer := p.manager.Annotations[api.AppStopAllKey] == "true"
+	cleaned, err := compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, &appCfg, stopServer)
+	if err != nil {
+		return err
+	}
+	if cleaned {
+		klog.Infof("released leaked compute allocation for stopped app %s", p.manager.Spec.AppName)
+	}
+	return nil
+}
+
+func (p *StoppedApp) Cancel(ctx context.Context) error {
+	return nil
+}

--- a/framework/app-service/pkg/appstate/types.go
+++ b/framework/app-service/pkg/appstate/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/middlewareinstaller"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -127,6 +128,17 @@ func (p *baseStatefulApp) forceDeleteApp(ctx context.Context) error {
 			klog.Errorf("uninstall app %s failed err %v", appCfg.AppName, err)
 			return err
 		}
+	}
+
+	// forceDeleteApp is the shared exit toward Uninstalled for the force-delete
+	// paths (UninstallFailed, RunningApp / UninstalledApp self-heal). The normal
+	// Uninstalling -> Uninstalled flow releases the compute allocation, but
+	// these paths bypass UninstallingApp, so release it here too or the app
+	// would leak its GPU/compute reservation after the workload is gone.
+	uninstallAll := p.manager.Annotations[api.AppUninstallAllKey] == "true"
+	if _, err = compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, appCfg, uninstallAll); err != nil {
+		klog.Errorf("delete compute allocation for force-deleted app %s failed %v", appCfg.AppName, err)
+		return err
 	}
 
 	// Wait for namespace to be fully deleted before updating status

--- a/framework/app-service/pkg/appstate/uninstalled_app.go
+++ b/framework/app-service/pkg/appstate/uninstalled_app.go
@@ -2,19 +2,23 @@ package appstate
 
 import (
 	"context"
+	"encoding/json"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ StatefulApp = &UninstalledApp{}
+var _ OperationApp = &UninstalledApp{}
 
 type UninstalledApp struct {
-	baseStatefulApp
+	*baseOperationApp
 }
 
 func NewUninstalledApp(ctx context.Context, client client.Client,
@@ -30,9 +34,12 @@ func NewUninstalledApp(ctx context.Context, client client.Client,
 	}
 
 	r := &UninstalledApp{
-		baseStatefulApp: baseStatefulApp{
-			manager: manager,
-			client:  client,
+		baseOperationApp: &baseOperationApp{
+			ttl: 0,
+			baseStatefulApp: &baseStatefulApp{
+				manager: manager,
+				client:  client,
+			},
 		},
 	}
 
@@ -40,7 +47,8 @@ func NewUninstalledApp(ctx context.Context, client client.Client,
 		// app is not expected to exist
 		return nil, NewErrorUnknownState(func() func(ctx context.Context) error {
 			return func(ctx context.Context) error {
-				// Force delete the app if it does not exist
+				// Force delete the app if it does not exist.
+				// forceDeleteApp also releases the compute allocation.
 				err = r.forceDeleteApp(ctx)
 				if err != nil {
 					klog.Errorf("delete app %s failed %v", manager.Spec.AppName, err)
@@ -53,4 +61,42 @@ func NewUninstalledApp(ctx context.Context, client client.Client,
 	}
 
 	return r, nil
+}
+
+// Exec runs a guarded compute cleanup for the terminal Uninstalled state.
+//
+// The Uninstalling -> Uninstalled transition (and forceDeleteApp) already
+// release the allocation, so in the normal flow this is a cheap no-op (a single
+// ConfigMap read). It exists to catch apps that reached Uninstalled without that
+// cleanup running, e.g. apps uninstalled before compute accounting existed.
+func (p *UninstalledApp) Exec(ctx context.Context) (StatefulInProgressApp, error) {
+	if err := p.cleanupComputeAllocation(ctx); err != nil {
+		klog.Errorf("cleanup compute allocation for uninstalled app %s failed %v", p.manager.Spec.AppName, err)
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *UninstalledApp) cleanupComputeAllocation(ctx context.Context) error {
+	if p.manager.Spec.Config == "" {
+		return nil
+	}
+	var appCfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
+		klog.Errorf("unmarshal app config for compute cleanup of uninstalled app %s failed %v", p.manager.Spec.AppName, err)
+		return err
+	}
+	uninstallAll := p.manager.Annotations[api.AppUninstallAllKey] == "true"
+	cleaned, err := compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, &appCfg, uninstallAll)
+	if err != nil {
+		return err
+	}
+	if cleaned {
+		klog.Infof("released leaked compute allocation for uninstalled app %s", p.manager.Spec.AppName)
+	}
+	return nil
+}
+
+func (p *UninstalledApp) Cancel(ctx context.Context) error {
+	return nil
 }

--- a/framework/app-service/pkg/compute/auto_select.go
+++ b/framework/app-service/pkg/compute/auto_select.go
@@ -141,7 +141,7 @@ func autoSelectModeFromInputs(appModes []string, clusterGPUTypes map[string]stru
 		if validCPU {
 			return utils.CPUType, nil
 		}
-		return "", fmt.Errorf("no compute mode runnable on this cluster; please install on a compatible cluster")
+		return "", fmt.Errorf("The Olares cluster cannot meet the required resource specifications. No matching GPU type")
 	default:
 		return "", ErrAmbiguousComputeMode
 	}

--- a/framework/app-service/pkg/compute/auto_select_test.go
+++ b/framework/app-service/pkg/compute/auto_select_test.go
@@ -103,7 +103,7 @@ func TestAutoSelectModeFromInputs(t *testing.T) {
 			name:        "case1/C: app supports strix-halo/apple-m, no overlap with cluster, errors",
 			appModes:    []string{utils.StrixHaloChipType, utils.AppleMChipType},
 			cluster:     clusterNvidiaOnly,
-			wantErrFrag: "no compute mode runnable",
+			wantErrFrag: "No matching GPU type",
 		},
 		{
 			name:     "case1/D: app supports cpu only, picks cpu",
@@ -155,7 +155,7 @@ func TestAutoSelectModeFromInputs(t *testing.T) {
 			name:        "no GPU in cluster: GPU-only app errors",
 			appModes:    []string{utils.NvidiaCardType},
 			cluster:     stringSet(),
-			wantErrFrag: "no compute mode runnable",
+			wantErrFrag: "No matching GPU type",
 		},
 	}
 

--- a/framework/app-service/pkg/compute/target.go
+++ b/framework/app-service/pkg/compute/target.go
@@ -60,6 +60,44 @@ func DeleteAllocationsForComputeTarget(ctx context.Context, c client.Client, app
 	return DeleteAllocationsForApp(ctx, c, target.AppName, target.OwnerName)
 }
 
+// EnsureAllocationsDeletedForComputeTarget releases any leftover compute
+// allocation (and its HAMI bindings) for the app's compute target, but only
+// when one still exists. Unlike DeleteAllocationsForComputeTarget it first
+// reads the allocation rows and skips the ConfigMap rewrite when there is
+// nothing to remove, so it is safe to call from steady-state reconciles (the
+// Stopped / Uninstalled / *Failed handlers run on every pass) without churning
+// the single shared allocation ConfigMap or contending on its optimistic lock.
+// It returns true only when a cleanup was actually performed.
+func EnsureAllocationsDeletedForComputeTarget(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, includeSharedServer bool) (bool, error) {
+	if appConfig == nil {
+		return false, nil
+	}
+	// Mirror DeleteAllocationsForComputeTarget: for v2 cluster-shared apps the
+	// only allocation row lives at (appName, sharedServerOwner). Leave it and
+	// its bindings alone unless the caller intends to touch the shared server.
+	if appConfig.IsV2() && appConfig.HasClusterSharedCharts() && !includeSharedServer {
+		return false, nil
+	}
+	target, _, err := resolveComputeTarget(ctx, c, appConfig, includeSharedServer)
+	if err != nil {
+		return false, err
+	}
+	if target == nil {
+		return false, nil
+	}
+	allocations, err := FindAllocationsForApp(ctx, c, target.AppName, target.OwnerName)
+	if err != nil {
+		return false, err
+	}
+	if len(allocations) == 0 {
+		return false, nil
+	}
+	if err := DeleteAllocationsForApp(ctx, c, target.AppName, target.OwnerName); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func ManagesSharedServer(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, error) {
 	target, manage, err := resolveComputeTarget(ctx, c, appConfig, false)
 	if err != nil {


### PR DESCRIPTION
* **Background**
Under rare circumstances, an App can enter `uninstalled` state without going through and executing under the `uninstalling` state, such as when the App Chart is malformed so that `Application` cannot be generated, leading uncleared compute resource bindings, we ensure such cases to be consistent too by executing a check and clear in the final state `uninstalled`. It also guarantees the clear even if the clear is unsuccessful in `uninstalling`. Same applied to the `stopped` state.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared allocation ConfigMap deletion, shared-server stop/uninstall semantics for admins, and steady-state reconciles for terminal states—incorrect scope could free another user’s shared GPU reservation.
> 
> **Overview**
> Adds **guarded compute/GPU allocation cleanup** on terminal and edge app states so bindings are not left behind when apps skip the normal uninstall/stop pipelines or when earlier cleanup failed.
> 
> **`Stopped`** now uses a dedicated **`StoppedApp`** reconcile handler (no longer `DoNothingApp`) that calls **`EnsureAllocationsDeletedForComputeTarget`**, honoring **`AppStopAllKey`** for shared-server scope. **`UninstalledApp`** and **`InstallFailedApp`** get the same pattern; **`forceDeleteApp`** also releases allocations when force-uninstall paths bypass **`Uninstalling`**.
> 
> New **`EnsureAllocationsDeletedForComputeTarget`** only deletes when allocation rows still exist, avoiding ConfigMap churn on every reconcile pass.
> 
> **Suspend/uninstall APIs**: cluster **admins** automatically get **stop-all / uninstall-all** behavior (same as `request.All`), including compute cleanup and annotation flags. Suspend’s immediate allocation delete now uses that **`stopAll`** flag instead of always treating stop as “all”.
> 
> Minor: GPU auto-select **no-match** error text updated; tests adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcdc15e07b5a28c279863a70f15c9145f7071b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->