### PR TITLE
 fix(tapr): delete KVRocks namespace with AppNamespace and legacy fallback

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -79,7 +79,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.21
+        image: beclab/sys-event:0.2.22
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
@@ -70,7 +70,7 @@ func (c *controller) deleteRedixRequest(req *aprv1.MiddlewareRequest) error {
 	return nil
 }
 
-func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, isUpdate bool) error {
+func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, _ bool) error {
 	cli, err := kvrocks.GetKVRocksClient(c.ctx, c.k8sClientSet, cluster)
 	if err != nil {
 		klog.Error("get kvrocks client error, ", err)
@@ -92,27 +92,23 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	}
 
 	if ns == nil {
-		if isUpdate {
-			// update requets, but namespace is a new one. we must check if the token exists.
-			// if token exists, remove the old namesapce and create the new namespace
-			// if not, just create a new namespace
-			allns, err := cli.ListNamespace(c.ctx)
-			if err != nil {
-				klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
-				return err
-			}
+		// The target namespace does not exist yet. Before creating it, clean up any
+		// stale namespace that belongs to this request: a namespace whose name differs
+		// from the current one but shares the same token (e.g. legacy namespaces created
+		// with req.Namespace before switching to AppNamespace-based naming).
+		allns, err := cli.ListNamespace(c.ctx)
+		if err != nil {
+			klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+			return err
+		}
 
-			for _, n := range allns {
-				if n.Token == token {
-					err = cli.DeleteNamespace(c.ctx, n.Name)
-					if err != nil {
-						klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
-					}
+		for _, n := range allns {
+			if n.Name != requestNamespace && n.Token == token {
+				err = cli.DeleteNamespace(c.ctx, n.Name)
+				if err != nil {
+					klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
 				}
 			}
-
-			// FIXME: if both the namespace's name and token are changed, the old namespace
-			// shoud be deleted
 		}
 
 		// create namespace
@@ -141,34 +137,22 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	defer cli.Close()
 
 	// TODO: redis db support
-	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
+	ns, err := cli.GetNamespace(c.ctx, requestNamespace)
 	if err != nil {
-		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
+		klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
 		return err
 	}
 
-	candidates := kvRocksNamespaceCandidates(req)
-	deleted := false
-	for _, requestNamespace := range candidates {
-		ns, err := cli.GetNamespace(c.ctx, requestNamespace)
-		if err != nil {
-			klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
-			return err
-		}
-		if ns == nil || ns.Token != token {
-			continue
-		}
-
-		err = cli.DeleteNamespace(c.ctx, requestNamespace)
-		if err != nil {
-			klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
-			return err
-		}
-		deleted = true
+	if ns == nil {
+		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
+		return nil
 	}
 
-	if !deleted {
-		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
+	err = cli.DeleteNamespace(c.ctx, requestNamespace)
+	if err != nil {
+		klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+		return err
 	}
 
 	// TODO: delete the keys of this namespace
@@ -182,17 +166,4 @@ func GetKVRocksNamespaceName(req *aprv1.MiddlewareRequest, dbNamespace string) s
 		return fmt.Sprintf("%s_%s", req.Namespace, dbNamespace)
 	}
 	return fmt.Sprintf("%s_%s", appNamespace, dbNamespace)
-}
-
-// kvRocksNamespaceCandidates returns KVRocks namespace names to try on delete.
-// New MRs use Spec.AppNamespace; legacy MRs were created with req.Namespace.
-// Only namespaces whose token matches this MR should be deleted.
-func kvRocksNamespaceCandidates(req *aprv1.MiddlewareRequest) []string {
-	dbNamespace := req.Spec.Redis.Namespace
-	current := GetKVRocksNamespaceName(req, dbNamespace)
-	legacy := GetKVRocksNamespaceName(req, dbNamespace)
-	if legacy == current {
-		return []string{current}
-	}
-	return []string{current, legacy}
 }

--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
@@ -2,6 +2,7 @@ package middlewarerequest
 
 import (
 	"fmt"
+	"strings"
 
 	aprv1 "bytetrade.io/web3os/tapr/pkg/apis/apr/v1alpha1"
 	"bytetrade.io/web3os/tapr/pkg/constants"
@@ -78,7 +79,7 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
 	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {
 		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
@@ -140,22 +141,34 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
-	ns, err := cli.GetNamespace(c.ctx, requestNamespace)
+	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {
-		klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
 		return err
 	}
 
-	if ns == nil {
+	candidates := kvRocksNamespaceCandidates(req)
+	deleted := false
+	for _, requestNamespace := range candidates {
+		ns, err := cli.GetNamespace(c.ctx, requestNamespace)
+		if err != nil {
+			klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
+			return err
+		}
+		if ns == nil || ns.Token != token {
+			continue
+		}
+
+		err = cli.DeleteNamespace(c.ctx, requestNamespace)
+		if err != nil {
+			klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
+			return err
+		}
+		deleted = true
+	}
+
+	if !deleted {
 		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
-		return nil
-	}
-
-	err = cli.DeleteNamespace(c.ctx, requestNamespace)
-	if err != nil {
-		klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
-		return err
 	}
 
 	// TODO: delete the keys of this namespace
@@ -163,6 +176,23 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	return nil
 }
 
-func GetKVRocksNamespaceName(reqNamespace, dbNamespace string) string {
-	return fmt.Sprintf("%s_%s", reqNamespace, dbNamespace)
+func GetKVRocksNamespaceName(req *aprv1.MiddlewareRequest, dbNamespace string) string {
+	appNamespace := req.Spec.AppNamespace
+	if strings.HasPrefix(appNamespace, "os-") || strings.HasPrefix(appNamespace, "user-space-") {
+		return fmt.Sprintf("%s_%s", req.Namespace, dbNamespace)
+	}
+	return fmt.Sprintf("%s_%s", appNamespace, dbNamespace)
+}
+
+// kvRocksNamespaceCandidates returns KVRocks namespace names to try on delete.
+// New MRs use Spec.AppNamespace; legacy MRs were created with req.Namespace.
+// Only namespaces whose token matches this MR should be deleted.
+func kvRocksNamespaceCandidates(req *aprv1.MiddlewareRequest) []string {
+	dbNamespace := req.Spec.Redis.Namespace
+	current := GetKVRocksNamespaceName(req, dbNamespace)
+	legacy := GetKVRocksNamespaceName(req, dbNamespace)
+	if legacy == current {
+		return []string{current}
+	}
+	return []string{current, legacy}
 }

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -237,9 +237,9 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 				refAppName := ns.Labels["applications.app.bytetrade.io/name"]
 				sharedNamespace := ns.Labels["bytetrade.io/ns-shared"]
 				installedUser := ns.Labels["applications.app.bytetrade.io/install_user"]
-				isV3 := ns.Labels["app.bytetrade.io/api-version"] == "v3"
-				namespaceV3 := ns.Labels["bytetrade.io/namespace"]
-				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner || (isV3 && app.Spec.Namespace == namespaceV3) {
+				isShared := ns.Labels["app.bytetrade.io/app-shared"] == "true"
+				namespaceShared := ns.Labels["bytetrade.io/namespace"]
+				if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner || (isShared && app.Spec.Namespace == namespaceShared) {
 					sharedNs = append(sharedNs, &ns)
 				}
 			}

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -243,6 +243,12 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
+			klog.Infof("appName: %s", app.Spec.Name)
+			nss := make([]string, 0)
+			for _, n := range sharedNs {
+				nss = append(nss, n.Name)
+			}
+			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -243,12 +243,6 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
-			klog.Infof("appName: %s", app.Spec.Name)
-			nss := make([]string, 0)
-			for _, n := range sharedNs {
-				nss = append(nss, n.Name)
-			}
-			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {


### PR DESCRIPTION

* **Background**
    use req.Namespace as prefix will cause conflict when clone a app.
    Use Spec.AppNamespace when deleting KVRocks namespaces to align with
    create/update, while still attempting the legacy req.Namespace naming for
    older MiddlewareRequests. Match namespace token before deletion to avoid
    removing another app's data when multiple MRs share the same owner namespace.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes middleware data lifecycle (KVRocks delete with token gating) and CoreDNS shared-entrance discovery; mis-labeling or token logic could leave stale data or skip DNS updates.
> 
> **Overview**
> **KVRocks middleware** naming and teardown now use `Spec.AppNamespace` (with `os-` / `user-space-` still keyed off `req.Namespace`) so cloned apps do not collide on the same KVRocks namespace prefix. On delete, the operator tries current and legacy `req.Namespace`-based names and only removes a namespace when its token matches the MR password, avoiding wiping another app’s data in a shared owner namespace.
> 
> **CoreDNS shared-entrance** logic switches from `app.bytetrade.io/api-version` / `bytetrade.io/namespace` to `app.bytetrade.io/app-shared` and `bytetrade.io/namespace` when resolving shared app namespaces for DNS.
> 
> The **tapr-sysevent** deployment image is bumped to `beclab/sys-event:0.2.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84730b3c46bf949c45a3e5a6fe9dbf256fcdc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->