### PR TITLE
fix(cli/files): harden archive format inference and single-source compression guard

### DIFF
--- a/cli/cmd/ctl/files/archive.go
+++ b/cli/cmd/ctl/files/archive.go
@@ -129,7 +129,7 @@ Output modes:
 Format detection:
 
     The server infers the archive container from the source's filename
-    extension (.zip / .7z / .tar.gz / .tgz / ...) — no client-side hint
+    extension (.zip / .7z / .zip.001 / .7z.001 / .tar.gz / .tgz / ...) — no client-side hint
     travels on the wire. We still accept --format locally so the CLI can
     pre-validate flag combinations (e.g. --password-stdin only on zip /
     7z); pass it when the file has no canonical extension and you need
@@ -410,7 +410,7 @@ piping into ` + "`less`" + ` / ` + "`hexdump`" + ` / ` + "`head -c`" + ` works a
 Format detection:
 
     The server infers the archive container from the source's filename
-    extension (.zip / .7z / .tar.gz / .tgz / ...) — no client-side hint
+    extension (.zip / .7z / .zip.001 / .7z.001 / .tar.gz / .tgz / ...) — no client-side hint
     travels on the wire. We still accept --format locally so the CLI can
     pre-validate flag combinations (e.g. --password-stdin only on zip /
     7z); pass it when the file has no canonical extension.

--- a/cli/cmd/ctl/files/archive_test.go
+++ b/cli/cmd/ctl/files/archive_test.go
@@ -288,7 +288,7 @@ func TestResolveVolumeSizeMB(t *testing.T) {
 		{"mb-only", "", 100, 100, false},
 		{"size-only-bare", "100", 0, 100, false},
 		{"size-only-unit", "1.5GB", 0, 1536, false},
-		{"size-sub-mib-floors", "500KB", 0, 1, false},
+		{"size-kb-rejected", "500KB", 0, 0, true},
 		{"both-set", "100MB", 50, 0, true},
 		{"negative-mb", "", -1, 0, true},
 		{"bad-size", "abc", 0, 0, true},
@@ -301,6 +301,75 @@ func TestResolveVolumeSizeMB(t *testing.T) {
 			}
 			if !c.err && got != c.want {
 				t.Errorf("resolveVolumeSizeMB(%q, %d): got %d want %d", c.volumeSize, c.volumeMB, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDetectCompressedSingleSource(t *testing.T) {
+	cases := []struct {
+		name        string
+		sourceCount int
+		isDir       bool
+		plainPath   string
+		statName    string
+		wantFormat  string
+		wantReject  bool
+	}{
+		{
+			name:        "single zip file rejected",
+			sourceCount: 1,
+			isDir:       false,
+			plainPath:   "drive/Home/a.zip",
+			statName:    "a.zip",
+			wantFormat:  "zip",
+			wantReject:  true,
+		},
+		{
+			name:        "single split zip main part rejected",
+			sourceCount: 1,
+			isDir:       false,
+			plainPath:   "drive/Home/a.zip.001",
+			statName:    "a.zip.001",
+			wantFormat:  "zip",
+			wantReject:  true,
+		},
+		{
+			name:        "single normal file allowed",
+			sourceCount: 1,
+			isDir:       false,
+			plainPath:   "drive/Home/a.txt",
+			statName:    "a.txt",
+			wantFormat:  "",
+			wantReject:  false,
+		},
+		{
+			name:        "single directory allowed",
+			sourceCount: 1,
+			isDir:       true,
+			plainPath:   "drive/Home/dir",
+			statName:    "dir",
+			wantFormat:  "",
+			wantReject:  false,
+		},
+		{
+			name:        "multiple sources skip format check",
+			sourceCount: 2,
+			isDir:       false,
+			plainPath:   "drive/Home/a.zip",
+			statName:    "a.zip",
+			wantFormat:  "",
+			wantReject:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotFormat, gotReject := detectCompressedSingleSource(c.sourceCount, c.isDir, c.plainPath, c.statName)
+			if gotReject != c.wantReject {
+				t.Fatalf("detectCompressedSingleSource(...): reject=%v want %v", gotReject, c.wantReject)
+			}
+			if gotFormat != c.wantFormat {
+				t.Fatalf("detectCompressedSingleSource(...): format=%q want %q", gotFormat, c.wantFormat)
 			}
 		})
 	}

--- a/cli/cmd/ctl/files/compress.go
+++ b/cli/cmd/ctl/files/compress.go
@@ -24,7 +24,7 @@ type compressOptions struct {
 	format           string
 	level            int
 	volumeSizeMB     int    // explicit MiB (legacy/precise knob)
-	volumeSize       string // unit-aware: "100MB" / "1.5GB" / "500KB" / bare MiB
+	volumeSize       string // unit-aware: "100MB" / "1.5GB" / bare MiB
 	preserveSymlinks bool
 	conflict         string
 	passwordStdin    bool
@@ -98,7 +98,7 @@ Supported formats:
 
 The format is derived from <dst>'s filename suffix when --format
 is omitted (.zip / .7z / .tar.gz / .tgz / .tar.bz2 / .tar.xz /
-.tar / .gz / .bz2 / .xz). Pass --format when the destination has
+.tar / .gz / .gzip / .bz2 / .bzip2 / .xz). Pass --format when the destination has
 no canonical suffix.
 
 Format constraints (mirrors the LarePass web app):
@@ -118,8 +118,8 @@ Knobs (most apply only to specific formats):
                         default.
 
     --volume-size SIZE  Split-archive volume size with a unit
-                        suffix: KB / MB / GB (e.g. 100MB, 1.5GB,
-                        500KB). A bare number is MiB. Rounded up,
+                        suffix: MB / GB (e.g. 100MB, 1.5GB).
+                        A bare number is MiB. Rounded up,
                         floored at 1 MiB. zip / 7z only. Preferred
                         over --volume-size-mb.
 
@@ -191,7 +191,7 @@ Examples:
 	cmd.Flags().IntVar(&o.volumeSizeMB, "volume-size-mb", 0,
 		"split-archive volume size in MiB (zip / 7z only; 0 = single volume). Prefer --volume-size for unit suffixes")
 	cmd.Flags().StringVar(&o.volumeSize, "volume-size", "",
-		"split-archive volume size with a unit suffix: KB / MB / GB (e.g. 100MB, 1.5GB, 500KB; bare number = MiB). zip / 7z only")
+		"split-archive volume size with a unit suffix: MB / GB (e.g. 100MB, 1.5GB; bare number = MiB). zip / 7z only")
 	cmd.Flags().BoolVar(&o.preserveSymlinks, "preserve-symlinks", false,
 		"archive symlinks as symlinks (default: dereference at compress time)")
 	cmd.Flags().StringVar(&o.conflict, "conflict", string(archive.ConflictDefault),
@@ -376,7 +376,7 @@ func runCompress(
 //
 //   - --volume-size (unit-aware string) takes precedence and is the
 //     documented knob (parsed via archive.ParseVolumeSize so
-//     100MB / 1.5GB / 500KB all work, rounding up, floored at 1).
+//     100MB / 1.5GB all work, rounding up, floored at 1).
 //   - --volume-size-mb (raw int MiB) stays for back-compat.
 //   - Supplying BOTH is rejected — there is no sensible merge and a
 //     silent winner would surprise the user.
@@ -520,6 +520,16 @@ func preflightCompress(
 				return fmt.Errorf("compress: source %s: %w", plain, err)
 			}
 		}
+		// Product policy: refuse "single source file that is already an
+		// archive/compressed file" to avoid accidental double-compression.
+		// Intentionally scoped to the single-file case only — when the
+		// user compresses multiple sources, we skip this format check.
+		if detectedFormat, reject := detectCompressedSingleSource(len(srcs), info.IsDir, plain, info.Name); reject {
+			return fmt.Errorf(
+				"compress: source %s appears to already be a compressed/archive file (detected format %q from filename %q); "+
+					"single-file compression of an already compressed file is blocked",
+				plain, detectedFormat, info.Name)
+		}
 		srcHasTrailingSlash := strings.HasSuffix(s.SubPath, "/")
 		if srcHasTrailingSlash && !info.IsDir {
 			return fmt.Errorf(
@@ -556,6 +566,28 @@ func preflightCompress(
 	}
 	_ = dstWire // already in the caller's plan log
 	return nil
+}
+
+// detectCompressedSingleSource reports whether the source should be
+// rejected by the "single-file already compressed" gate:
+//   - applies ONLY when sourceCount == 1
+//   - applies ONLY to files (not directories)
+//   - detects archive/compressed formats by filename suffix via
+//     archive.FormatFromExtension (zip / 7z / tar.* / gzip / bzip2 / xz,
+//     including split main-part names like .zip.001 / .7z.001).
+//
+// Returns the detected format when reject=true.
+func detectCompressedSingleSource(sourceCount int, isDir bool, plainPath, statName string) (string, bool) {
+	if sourceCount != 1 || isDir {
+		return "", false
+	}
+	if f := archive.FormatFromExtension(statName); f != "" {
+		return f, true
+	}
+	if f := archive.FormatFromExtension(plainPath); f != "" {
+		return f, true
+	}
+	return "", false
 }
 
 // waitArchiveTask blocks on the supplied task_id, printing

--- a/cli/cmd/ctl/files/extract.go
+++ b/cli/cmd/ctl/files/extract.go
@@ -78,7 +78,7 @@ Supported formats:
     zip, 7z, tar, tar.gz, tgz, tar.bz2, tar.xz, gzip, bzip2, xz
 
 The format is derived from <archive>'s filename suffix when
---format is omitted (.zip / .7z / .tar.gz / .tgz / ...). Pass
+--format is omitted (.zip / .7z / .zip.001 / .7z.001 / .tar.gz / .tgz / ...). Pass
 --format when the archive has no canonical suffix.
 
 Knobs:

--- a/cli/internal/files/archive/archive_test.go
+++ b/cli/internal/files/archive/archive_test.go
@@ -190,8 +190,14 @@ func TestFormatFromExtension(t *testing.T) {
 		{"foo.7z", "7z"},
 		{"foo.zip", "zip"},
 		{"foo.gz", "gzip"},
+		{"foo.gzip", "gzip"},
 		{"foo.bz2", "bzip2"},
+		{"foo.bzip2", "bzip2"},
 		{"foo.xz", "xz"},
+		{"foo.zip.001", "zip"},
+		{"foo.zip.123", "zip"},
+		{"foo.7z.001", "7z"},
+		{"foo.7z.999", "7z"},
 		{"FOO.ZIP", "zip"},
 		{"foo.rar", ""}, // unknown
 		{"foo", ""},
@@ -942,15 +948,13 @@ func TestParseVolumeSize(t *testing.T) {
 		{"1GB", 1024, false},    // GiB
 		{"1.5GB", 1536, false},  // fractional GiB
 		{"2G", 2048, false},     // short suffix
-		{"500KB", 1, false},     // sub-MiB floors at 1
-		{"1024KB", 1, false},    // exactly 1 MiB
-		{"1536KB", 2, false},    // 1.5 MiB rounds up to 2
 		{"3M", 3, false},        // short M
 		{"", 0, true},           // empty
 		{"abc", 0, true},        // non-numeric
 		{"-5MB", 0, true},       // negative
 		{"0", 0, true},          // non-positive
-		{"10TB", 0, true},       // unknown suffix (parses "10t" -> not a number)
+		{"500KB", 0, true},      // KB no longer supported
+		{"10TB", 0, true},       // unsupported unit
 	}
 	for _, c := range cases {
 		got, err := ParseVolumeSize(c.in)

--- a/cli/internal/files/archive/format.go
+++ b/cli/internal/files/archive/format.go
@@ -23,6 +23,7 @@ package archive
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -309,23 +310,21 @@ func ValidateFormat(format, usage string) error {
 
 // ParseVolumeSize parses a split-volume size string with an
 // optional unit suffix into whole MiB — the unit the compress
-// endpoint's `volumeSizeMB` field expects. It mirrors the
-// LarePass web app's KB / MB / GB selector (see
-// ArchiveCompressDialog's splitVolumeMB() and
-// olaresTask/archive.ts's normalizeSplitVolume):
+// endpoint's `volumeSizeMB` field expects. The server accepts
+// integer MiB only, so this parser normalizes the user input to
+// an integer MiB count.
 //
 //	"100"     → 100   (bare number = MiB)
 //	"100MB"   → 100
 //	"1.5GB"   → 1536  (1.5 * 1024, rounded up)
-//	"500KB"   → 1     (500/1024 = 0.49 MiB, floored at 1)
 //	"2G"      → 2048
 //
-// Accepted suffixes (case-insensitive): K / KB, M / MB, G / GB.
+// Accepted suffixes (case-insensitive): M / MB, G / GB.
 // A bare number is treated as MiB. The result is rounded UP to the
 // nearest MiB and floored at 1, matching the web app's
 // Math.max(1, ceil(mbValue)) — the backend rejects a 0-size
-// volume, and rounding up keeps "500KB" from silently becoming
-// "no split".
+// volume, and rounding up keeps fractional GiB inputs from silently
+// shrinking the split size.
 //
 // Returns an error for empty input, a non-numeric value, an
 // unknown suffix, or a non-positive size, so a typo surfaces as a
@@ -345,21 +344,22 @@ func ParseVolumeSize(raw string) (int, error) {
 		numPart, unit = lower[:len(lower)-2], "g"
 	case strings.HasSuffix(lower, "mb"):
 		numPart, unit = lower[:len(lower)-2], "m"
-	case strings.HasSuffix(lower, "kb"):
-		numPart, unit = lower[:len(lower)-2], "k"
 	case strings.HasSuffix(lower, "g"):
 		numPart, unit = lower[:len(lower)-1], "g"
 	case strings.HasSuffix(lower, "m"):
 		numPart, unit = lower[:len(lower)-1], "m"
-	case strings.HasSuffix(lower, "k"):
-		numPart, unit = lower[:len(lower)-1], "k"
 	default:
+		// Reject other alpha suffixes early (e.g. KB/TB) so the
+		// error points at unsupported units explicitly.
+		if strings.HasSuffix(lower, "b") || strings.HasSuffix(lower, "k") || strings.HasSuffix(lower, "t") {
+			return 0, fmt.Errorf("invalid volume size %q: unsupported unit (only MB and GB are supported)", raw)
+		}
 		numPart, unit = lower, "m" // bare number = MiB
 	}
 	numPart = strings.TrimSpace(numPart)
 	value, err := strconv.ParseFloat(numPart, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid volume size %q: %q is not a number (use forms like 100MB, 1.5GB, 500KB, or a bare MiB count)", raw, numPart)
+		return 0, fmt.Errorf("invalid volume size %q: %q is not a number (use forms like 100MB, 1.5GB, or a bare MiB count)", raw, numPart)
 	}
 	if value <= 0 || math.IsNaN(value) || math.IsInf(value, 0) {
 		return 0, fmt.Errorf("invalid volume size %q: must be a positive number", raw)
@@ -368,8 +368,6 @@ func ParseVolumeSize(raw string) (int, error) {
 	switch unit {
 	case "g":
 		mb = value * 1024
-	case "k":
-		mb = value / 1024
 	default: // "m"
 		mb = value
 	}
@@ -420,6 +418,14 @@ func joinConflicts(cs []Conflict) string {
 // format with its own contextualised message.
 func FormatFromExtension(name string) string {
 	lower := strings.ToLower(name)
+	// Multi-volume main-part naming used by backend/archive tools:
+	//   *.zip.001 / *.zip.002 / ...
+	//   *.7z.001  / *.7z.002  / ...
+	// The user may pass the first (main) part directly; treat it as
+	// zip / 7z for extract and preview format inference.
+	if m := splitVolumeMainRe.FindStringSubmatch(lower); len(m) == 2 {
+		return m[1]
+	}
 	// Longest-suffix-first. The order here is the contract the
 	// cobra-layer help text quotes; do NOT alphabetise.
 	for _, c := range []struct {
@@ -429,6 +435,8 @@ func FormatFromExtension(name string) string {
 		{".tar.gz", "tar.gz"},
 		{".tar.bz2", "tar.bz2"},
 		{".tar.xz", "tar.xz"},
+		{".bzip2", "bzip2"},
+		{".gzip", "gzip"},
 		{".tgz", "tgz"},
 		{".7z", "7z"},
 		{".tar", "tar"},
@@ -443,3 +451,5 @@ func FormatFromExtension(name string) string {
 	}
 	return ""
 }
+
+var splitVolumeMainRe = regexp.MustCompile(`\.(zip|7z)\.\d+$`)


### PR DESCRIPTION
## Summary
- reject `--volume-size` KB units and keep split-volume size input aligned with backend integer MB constraints
- extend archive format inference to recognize `.gzip`, `.bzip2`, and split main-part names like `.zip.001` / `.7z.001` for extract and archive preview flows
- block single-source compression when the source file already looks like an archive/compressed file, while intentionally skipping this check for multi-source compression

## Test plan
- [ ] `go test ./cmd/ctl/files -run TestDetectCompressedSingleSource -count=1`
- [ ] `go test ./internal/files/archive -run TestFormatFromExtension -count=1`
- [ ] Manual: `olares-cli files extract drive/Home/test/a.zip.001 drive/Home/test/a/`
- [ ] Manual: `olares-cli files archive entries drive/Home/test/a.7z.001`
- [ ] Manual: `olares-cli files compress drive/Home/test/already.zip drive/Home/test/out.zip` (expect blocked)
- [ ] Manual: `olares-cli files compress drive/Home/test/a.txt drive/Home/test/b.zip drive/Home/test/out.zip` (multi-source allowed)


Made with [Cursor](https://cursor.com)