### PR TITLE
fix: files rename '%' filenames and reject invalid :node segment

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.182
+          image: beclab/files-server:v0.2.183
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- Fix rename failure when source/destination filename contains '%' (was: invalid URL escape "%xx").
- Add NodeGuard middleware so unknown :node path segments return 400 invalid node instead of being silently accepted.
- NodeGuard accepts the local NODE_NAME and any node ever seen in the cluster, so existing single-node and multi-node traffic is unaffected.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/349

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy config; behavior changes live in the application image, not in this repo’s YAML beyond the version.
> 
> **Overview**
> Bumps the **files** DaemonSet container image from `beclab/files-server:v0.2.182` to **`v0.2.183`** in `files_deploy.yaml`, rolling out the companion **files** server release (rename handling for `%` in filenames and **NodeGuard** validation on `:node` path segments per the linked application PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132a6623d3e2537276afc65a100e9443896d5e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->