### PR TITLE
system-apps: bump system-frontend to v1.10.49 and user-service to v0.0.100

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.47
+          image: beclab/system-frontend:v1.10.49
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.99
+          image: beclab/user-service:v0.0.100
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
This change bumps the subsystem images consumed by the `system-apps` Helm chart so Olares ships the latest frontend and user-service builds. In `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml`, the `olares-app-init` container moves from `beclab/system-frontend:v1.10.47` to `v1.10.49`, and the `user-service` container moves from `beclab/user-service:v0.0.99` to `v0.0.100`.

The new images package the following subsystem changes:

`system-frontend` (TermiPass #1198, #1199):
- Desktop dashboard: reworked `DailyDescription` (PC and mobile) to match the Figma design (clock/date layout, AM/PM indicators, fonts and spacing); 12-hour time now formats as `h:mm` without a leading zero while honoring existing date/time-format and dashboard-visibility settings.
- Market & compute: fixed `templateOnly` app clones briefly showing the original template body; corrected `effectiveDeviceUsedMemory` so idle exclusive GPU cards no longer report full VRAM; `AppResourceCard` now renders `-1` values as "Custom", uses a responsive metric grid, and disables the resource select when no node matches; responsive fixes for `RecommendAppCard` (manager mode) and `ComputeBoundApps`.
- Settings: fixed back navigation from application sub-pages (e.g. Environment Variables) landing on a blank page via `inheritParams`/`inheritQuery` route meta; fixed the snapshot query dialog pagination and the "All shows only one row" bug.
- Files: refactored desktop transfer UI into type-based table components with shared composables; unified archive task rendering across desktop and mobile (size display, retry visibility, navigation guards); fixed mobile compress/extract entry conditions and added archive password validation rules.

`user-service` (#84):
- Enhanced the `collectLogs` method to include authorization and improved error logging.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1198
https://github.com/beclab/TermiPass/pull/1199
https://github.com/beclab/user-service/pull/84

* **Other information**:
None