### PR TITLE
fix(appservice): prevent IM state regression after download cancel

### DIFF
--- a/framework/app-service/Dockerfile.image
+++ b/framework/app-service/Dockerfile.image
@@ -21,7 +21,7 @@ RUN cd github.com/beclab/Olares/framework/app-service && \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:debug
+FROM beclab/distroless-static:debug
 WORKDIR /
 COPY --from=builder /workspace/github.com/beclab/Olares/framework/app-service/image-service .
 

--- a/framework/app-service/controllers/image_controller.go
+++ b/framework/app-service/controllers/image_controller.go
@@ -125,6 +125,16 @@ func (r *ImageManagerController) reconcile(ctx context.Context, instance *appv1a
 	if _, ok := imageManager[instance.Name]; ok {
 		return nil
 	}
+
+	// Guard against terminal states so a stale Reconcile request (e.g. one
+	// queued while a previous reconcile was still running) does not overwrite
+	// a terminal state set by app-service (downloadingCanceled) or by an
+	// earlier reconcile (failed/completed).
+	if isTerminalState(cur.Status.State) {
+		klog.Infof("skip reconcile for im=%s in terminal state=%s", cur.Name, cur.Status.State)
+		return nil
+	}
+
 	imageManager[instance.Name] = cancel
 	if cur.Status.State != appv1alpha1.Downloading.String() {
 		err = r.updateStatus(ctx, &cur, appv1alpha1.Downloading.String(), "start downloading")
@@ -153,7 +163,15 @@ func (r *ImageManagerController) reconcile(ctx context.Context, instance *appv1a
 		}
 		return err
 	}
-	time.Sleep(2 * time.Second)
+	// Respect cancellation in this final window: if the user canceled the
+	// download right after it finished, do not proceed to mark the IM as
+	// completed (which would race with the downloadingCanceled state).
+	select {
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		klog.Infof("reconcile canceled for im=%s before marking completed err=%v", instance.Name, ctx.Err())
+		return ctx.Err()
+	}
 	err = r.updateStatus(context.TODO(), instance, "completed", "image download completed")
 	if err != nil {
 		klog.Infof("Failed to update status err=%v", err)
@@ -164,10 +182,17 @@ func (r *ImageManagerController) reconcile(ctx context.Context, instance *appv1a
 	return nil
 }
 
+// isTerminalState returns true when the IM has reached a state from which
+// the controller must not transition back to an in-progress state.
+func isTerminalState(state string) bool {
+	return state == "failed" ||
+		state == "completed" ||
+		state == appv1alpha1.DownloadingCanceled.String()
+}
+
 func (r *ImageManagerController) preEnqueueCheckForCreate(obj client.Object) bool {
 	im, _ := obj.(*appv1alpha1.ImageManager)
-	if im.Status.State == "failed" || im.Status.State == appv1alpha1.DownloadingCanceled.String() ||
-		im.Status.State == "completed" {
+	if isTerminalState(im.Status.State) {
 		return false
 	}
 	klog.Infof("enqueue check: %v", im.Status.State)
@@ -175,9 +200,22 @@ func (r *ImageManagerController) preEnqueueCheckForCreate(obj client.Object) boo
 }
 
 func (r *ImageManagerController) preEnqueueCheckForUpdate(old, new client.Object) bool {
-	im, _ := new.(*appv1alpha1.ImageManager)
-	if im.Status.State == appv1alpha1.DownloadingCanceled.String() {
-		go r.cancel(im)
+	oldIm, _ := old.(*appv1alpha1.ImageManager)
+	newIm, _ := new.(*appv1alpha1.ImageManager)
+	if newIm == nil {
+		return false
+	}
+	// On transition to downloadingCanceled, fire the in-process cancel so the
+	// running reconcile (if any) stops pulling. The IM state itself is
+	// already persisted by the writer (app-service); reconcile/updateStatus
+	// is responsible for not regressing it (see isTerminalState guards).
+	if newIm.Status.State == appv1alpha1.DownloadingCanceled.String() &&
+		(oldIm == nil || oldIm.Status.State != appv1alpha1.DownloadingCanceled.String()) {
+		go func() {
+			if err := r.cancel(newIm); err != nil {
+				klog.Infof("cancel im=%s on downloadingCanceled: %v", newIm.Name, err)
+			}
+		}()
 	}
 	return false
 }
@@ -221,6 +259,19 @@ func (r *ImageManagerController) updateStatus(ctx context.Context, im *appv1alph
 		err = r.Get(ctx, types.NamespacedName{Name: im.Name}, im)
 		if err != nil {
 			return err
+		}
+
+		// Refuse to overwrite a terminal state with a different state. This
+		// protects against races where app-service patched the IM to
+		// downloadingCanceled while this reconcile was already on its way to
+		// write another state (e.g. "downloading" at the start of reconcile,
+		// or "completed" right after the download finished). Idempotent
+		// re-writes of the same terminal state are allowed; the only valid
+		// transition out of a terminal state is recreating the IM.
+		if isTerminalState(im.Status.State) && im.Status.State != state {
+			klog.Infof("skip updateStatus for im=%s: cannot move terminal state=%s to state=%s",
+				im.Name, im.Status.State, state)
+			return nil
 		}
 
 		now := metav1.Now()

--- a/framework/app-service/pkg/images/jobs.go
+++ b/framework/app-service/pkg/images/jobs.go
@@ -70,18 +70,30 @@ func showProgress(ctx context.Context, rCtx *containerd.RemoteContext, ongoing *
 
 	attempt := 0
 	var descs []ocispec.Descriptor
+	// Honor ctx so cancellation propagates: stop retrying if the parent
+	// context is canceled (e.g. user canceled the download). Without this the
+	// loop can spin for ~17 minutes against context.TODO() and block the
+	// whole reconcile (and any others queued behind it).
 	err := retry.OnError(wait.Backoff{
 		Steps:    10,
 		Duration: time.Second,
 		Factor:   2.0,
 		Jitter:   0.1,
-	}, func(error) bool { return true }, func() error {
-		_, desc, err := rCtx.Resolver.Resolve(context.TODO(), ongoing.name)
+	}, func(err error) bool {
+		if ctx.Err() != nil {
+			return false
+		}
+		return true
+	}, func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, desc, err := rCtx.Resolver.Resolve(ctx, ongoing.name)
 		if err != nil {
 			klog.Infof("resolve ref failed err=%v", err)
 			return err
 		}
-		descs, err = getAllLayerDescriptor(rCtx, desc, cs)
+		descs, err = getAllLayerDescriptor(ctx, rCtx, desc, cs)
 		if err != nil {
 			attempt++
 			klog.Infof("image %s,attempt %d to get layer descriptor err=%v", ongoing.name, attempt, err)
@@ -96,6 +108,10 @@ func showProgress(ctx context.Context, rCtx *containerd.RemoteContext, ongoing *
 	})
 	if err != nil {
 		klog.Infof("get all layer descriptor failed err=%v", err)
+		return
+	}
+	if ctx.Err() != nil {
+		klog.Infof("show progress aborted before tick loop name=%s err=%v", ongoing.name, ctx.Err())
 		return
 	}
 	var imageSize int64
@@ -218,7 +234,11 @@ outer:
 				return
 			}
 		case <-ctx.Done():
-			done = true // allow ui to update once more
+			// On cancellation just exit; do NOT loop once more with done=true,
+			// which would force every status to "done"/"exists" and report
+			// progress=100%, racing against the canceled state update.
+			klog.Infof("show progress canceled name=%s err=%v", ongoing.name, ctx.Err())
+			return
 		}
 	}
 }
@@ -402,7 +422,7 @@ func (j *jobs) isResolved() bool {
 	return j.resolved
 }
 
-func getAllLayerDescriptor(rCtx *containerd.RemoteContext, root ocispec.Descriptor, cs content.Store) ([]ocispec.Descriptor, error) {
+func getAllLayerDescriptor(ctx context.Context, rCtx *containerd.RemoteContext, root ocispec.Descriptor, cs content.Store) ([]ocispec.Descriptor, error) {
 	ans := make([]ocispec.Descriptor, 0)
 	childrenHandler := images.ChildrenHandler(cs)
 	childrenHandler = images.SetChildrenMappedLabels(cs, childrenHandler, rCtx.ChildLabelMap)
@@ -418,12 +438,17 @@ func getAllLayerDescriptor(rCtx *containerd.RemoteContext, root ocispec.Descript
 			return nil
 		}
 		for _, c := range descs {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			ans = append(ans, c)
-			children, err := childrenHandler.Handle(context.TODO(), c)
+			children, err := childrenHandler.Handle(ctx, c)
 			if err != nil {
 				return err
 			}
-			getDescriptor(children...)
+			if err := getDescriptor(children...); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/framework/app-service/pkg/images/puller.go
+++ b/framework/app-service/pkg/images/puller.go
@@ -176,7 +176,16 @@ func (is *imageService) PullImage(ctx context.Context, ref appv1alpha1.Ref, opts
 		return "", err
 	}
 
-	<-progress
+	// Even on success, do not block forever on showProgress: it can be stuck
+	// in retries (e.g. resolving manifest from a content store that has not
+	// yet been populated). If the parent context is canceled we must return
+	// promptly so the caller's wg.Wait()/reconcile can unwind.
+	select {
+	case <-progress:
+	case <-ctx.Done():
+		klog.Infof("fetch image name=%s pull ok but ctx canceled before progress drained err=%v", ref, ctx.Err())
+		return "", ctx.Err()
+	}
 	return originNamed.String(), nil
 }
 


### PR DESCRIPTION




* **Background**
When the user cancels an in-progress download, app-service patches the ImageManager to downloadingCanceled, but the image-service controller could still be racing in three places:

1. A reconcile request that was queued earlier (while the previous reconcile was blocked) gets dequeued after the cancel, sees `cur.Status.State != "downloading"` and overwrites the terminal state back to "downloading".
2. `updateStatus` Get/Patch has a window where app-service can flip the IM to downloadingCanceled in between, and the in-flight Patch then clobbers the terminal state.
3. `showProgress` is stuck for ~17 minutes in a `retry.OnError` loop that uses `context.TODO()` to resolve manifest layer descriptors, which holds `<-progress` in `PullImage` and blocks the entire reconcile worker (MaxConcurrentReconciles=1), making subsequent IMs (including a re-installed app) wait many minutes before the controller can react. On cancellation the same loop also forces all per-layer statuses to "done"/"exists" and reports progress=100%, racing the canceled state.

This change:

- Adds an `isTerminalState` helper and short-circuits `reconcile` whenever `cur.Status.State` is already `failed` / `completed` / `downloadingCanceled`, so a stale dequeued request can no longer reset the IM to `downloading`.
- Makes `updateStatus` refuse to move a terminal state to a different state, allowing only idempotent rewrites of the same terminal state.
- Replaces the 2s `time.Sleep` before marking `completed` with a `select` against `ctx.Done()`, so a cancel that arrives just after download success no longer races with the `completed` write.
- `preEnqueueCheckForUpdate` now triggers `cancel` only on the edge transition into `downloadingCanceled` (old != canceled, new == canceled) and logs the cancel result for debuggability.
- `showProgress` honors the parent ctx: the resolver retry stops early when ctx is canceled, `getAllLayerDescriptor` takes a ctx and propagates cancellation through the children walk (replacing `context.TODO()` on `Resolver.Resolve` and `childrenHandler.Handle`), and the tick loop now exits immediately on `ctx.Done()` instead of looping once more with `done=true` and emitting a misleading 100%.
- `PullImage` no longer blocks unconditionally on `<-progress` after a successful pull; it `select`s against `ctx.Done()` so a stuck `showProgress` can no longer pin the reconcile.

Together these changes eliminate the observed inconsistency where appmgr reports `downloadingCanceled` while the corresponding IM is still `downloading`, and unblock the single reconcile worker so a canceled download no longer delays the next install by minutes.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ImageManager status transitions and long-running pull/progress cancellation paths; incorrect guards could leave downloads stuck or skip legitimate reconciles, but scope is narrowly targeted at cancel/race handling.
> 
> **Overview**
> Fixes races where canceling an image download left **ImageManager** stuck in `downloading` or blocked the single reconcile worker for minutes while UI showed `downloadingCanceled`.
> 
> The image controller now treats `failed`, `completed`, and `downloadingCanceled` as **terminal**: stale reconciles skip work, `updateStatus` will not clobber a terminal state with another state, and the post-download delay before `completed` respects `ctx` cancellation. Updates that transition into `downloadingCanceled` trigger in-process cancel only on that edge.
> 
> Pull/progress paths propagate the parent **context** instead of `context.TODO()`: resolver retries and layer walks stop on cancel, `showProgress` exits without a final 100% progress write, and `PullImage` no longer blocks forever waiting for the progress goroutine.
> 
> The image-service container base image switches from `gcr.io/distroless/static:debug` to `beclab/distroless-static:debug`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbad98e9d201d18933ee3337d78551189e9cc529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->