### PR TITLE
fix(tapr): delete KVRocks namespace with AppNamespace and legacy fallback

### DIFF
--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
@@ -70,7 +70,7 @@ func (c *controller) deleteRedixRequest(req *aprv1.MiddlewareRequest) error {
 	return nil
 }
 
-func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, isUpdate bool) error {
+func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, _ bool) error {
 	cli, err := kvrocks.GetKVRocksClient(c.ctx, c.k8sClientSet, cluster)
 	if err != nil {
 		klog.Error("get kvrocks client error, ", err)
@@ -92,27 +92,23 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	}
 
 	if ns == nil {
-		if isUpdate {
-			// update requets, but namespace is a new one. we must check if the token exists.
-			// if token exists, remove the old namesapce and create the new namespace
-			// if not, just create a new namespace
-			allns, err := cli.ListNamespace(c.ctx)
-			if err != nil {
-				klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
-				return err
-			}
+		// The target namespace does not exist yet. Before creating it, clean up any
+		// stale namespace that belongs to this request: a namespace whose name differs
+		// from the current one but shares the same token (e.g. legacy namespaces created
+		// with req.Namespace before switching to AppNamespace-based naming).
+		allns, err := cli.ListNamespace(c.ctx)
+		if err != nil {
+			klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+			return err
+		}
 
-			for _, n := range allns {
-				if n.Token == token {
-					err = cli.DeleteNamespace(c.ctx, n.Name)
-					if err != nil {
-						klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
-					}
+		for _, n := range allns {
+			if n.Name != requestNamespace && n.Token == token {
+				err = cli.DeleteNamespace(c.ctx, n.Name)
+				if err != nil {
+					klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
 				}
 			}
-
-			// FIXME: if both the namespace's name and token are changed, the old namespace
-			// shoud be deleted
 		}
 
 		// create namespace
@@ -141,34 +137,22 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	defer cli.Close()
 
 	// TODO: redis db support
-	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
+	ns, err := cli.GetNamespace(c.ctx, requestNamespace)
 	if err != nil {
-		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
+		klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
 		return err
 	}
 
-	candidates := kvRocksNamespaceCandidates(req)
-	deleted := false
-	for _, requestNamespace := range candidates {
-		ns, err := cli.GetNamespace(c.ctx, requestNamespace)
-		if err != nil {
-			klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
-			return err
-		}
-		if ns == nil || ns.Token != token {
-			continue
-		}
-
-		err = cli.DeleteNamespace(c.ctx, requestNamespace)
-		if err != nil {
-			klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
-			return err
-		}
-		deleted = true
+	if ns == nil {
+		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
+		return nil
 	}
 
-	if !deleted {
-		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
+	err = cli.DeleteNamespace(c.ctx, requestNamespace)
+	if err != nil {
+		klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+		return err
 	}
 
 	// TODO: delete the keys of this namespace
@@ -182,17 +166,4 @@ func GetKVRocksNamespaceName(req *aprv1.MiddlewareRequest, dbNamespace string) s
 		return fmt.Sprintf("%s_%s", req.Namespace, dbNamespace)
 	}
 	return fmt.Sprintf("%s_%s", appNamespace, dbNamespace)
-}
-
-// kvRocksNamespaceCandidates returns KVRocks namespace names to try on delete.
-// New MRs use Spec.AppNamespace; legacy MRs were created with req.Namespace.
-// Only namespaces whose token matches this MR should be deleted.
-func kvRocksNamespaceCandidates(req *aprv1.MiddlewareRequest) []string {
-	dbNamespace := req.Spec.Redis.Namespace
-	current := GetKVRocksNamespaceName(req, dbNamespace)
-	legacy := GetKVRocksNamespaceName(req, dbNamespace)
-	if legacy == current {
-		return []string{current}
-	}
-	return []string{current, legacy}
 }

--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
@@ -2,6 +2,7 @@ package middlewarerequest
 
 import (
 	"fmt"
+	"strings"
 
 	aprv1 "bytetrade.io/web3os/tapr/pkg/apis/apr/v1alpha1"
 	"bytetrade.io/web3os/tapr/pkg/constants"
@@ -78,7 +79,7 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
 	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {
 		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
@@ -140,22 +141,34 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
-	ns, err := cli.GetNamespace(c.ctx, requestNamespace)
+	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {
-		klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
 		return err
 	}
 
-	if ns == nil {
+	candidates := kvRocksNamespaceCandidates(req)
+	deleted := false
+	for _, requestNamespace := range candidates {
+		ns, err := cli.GetNamespace(c.ctx, requestNamespace)
+		if err != nil {
+			klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
+			return err
+		}
+		if ns == nil || ns.Token != token {
+			continue
+		}
+
+		err = cli.DeleteNamespace(c.ctx, requestNamespace)
+		if err != nil {
+			klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", requestNamespace)
+			return err
+		}
+		deleted = true
+	}
+
+	if !deleted {
 		klog.Info("kvrocks namespace not exists, ", req.Name, ", ", req.Namespace)
-		return nil
-	}
-
-	err = cli.DeleteNamespace(c.ctx, requestNamespace)
-	if err != nil {
-		klog.Error("delete kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
-		return err
 	}
 
 	// TODO: delete the keys of this namespace
@@ -163,6 +176,23 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	return nil
 }
 
-func GetKVRocksNamespaceName(reqNamespace, dbNamespace string) string {
-	return fmt.Sprintf("%s_%s", reqNamespace, dbNamespace)
+func GetKVRocksNamespaceName(req *aprv1.MiddlewareRequest, dbNamespace string) string {
+	appNamespace := req.Spec.AppNamespace
+	if strings.HasPrefix(appNamespace, "os-") || strings.HasPrefix(appNamespace, "user-space-") {
+		return fmt.Sprintf("%s_%s", req.Namespace, dbNamespace)
+	}
+	return fmt.Sprintf("%s_%s", appNamespace, dbNamespace)
+}
+
+// kvRocksNamespaceCandidates returns KVRocks namespace names to try on delete.
+// New MRs use Spec.AppNamespace; legacy MRs were created with req.Namespace.
+// Only namespaces whose token matches this MR should be deleted.
+func kvRocksNamespaceCandidates(req *aprv1.MiddlewareRequest) []string {
+	dbNamespace := req.Spec.Redis.Namespace
+	current := GetKVRocksNamespaceName(req, dbNamespace)
+	legacy := GetKVRocksNamespaceName(req, dbNamespace)
+	if legacy == current {
+		return []string{current}
+	}
+	return []string{current, legacy}
 }


### PR DESCRIPTION

* **Background**
    use req.Namespace as prefix will cause conflict when clone a app.
    Use Spec.AppNamespace when deleting KVRocks namespaces to align with
    create/update, while still attempting the legacy req.Namespace naming for
    older MiddlewareRequests. Match namespace token before deletion to avoid
    removing another app's data when multiple MRs share the same owner namespace.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes middleware data isolation and deletion behavior for KVRocks; incorrect token or naming logic could remove or mis-route another app's namespace.
> 
> **Overview**
> **KVRocks namespace naming** now uses `Spec.AppNamespace` (with `req.Namespace` only when `AppNamespace` is prefixed `os-` or `user-space-`), via an updated `GetKVRocksNamespaceName` that takes the full `MiddlewareRequest`. Create/update and delete both use this helper so cloned apps no longer collide on the same `req.Namespace` prefix.
> 
> **Create/update cleanup** no longer gates stale-namespace removal on `isUpdate`. When the target KVRocks namespace is missing, the controller lists namespaces and deletes any *other* name that shares the same token before creating the new one, reducing leftover legacy namespaces without deleting unrelated tenants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd80344881f24ada05829da39ee3fe633a72491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->