### PR TITLE
fix(tapr): delete KVRocks namespace with AppNamespace and legacy fallback

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.36
+        image: beclab/middleware-operator:0.2.37
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
+++ b/platform/tapr/cmd/middleware/operator/middleware-request/handler_redis.go
@@ -2,6 +2,7 @@ package middlewarerequest
 
 import (
 	"fmt"
+	"strings"
 
 	aprv1 "bytetrade.io/web3os/tapr/pkg/apis/apr/v1alpha1"
 	"bytetrade.io/web3os/tapr/pkg/constants"
@@ -69,7 +70,7 @@ func (c *controller) deleteRedixRequest(req *aprv1.MiddlewareRequest) error {
 	return nil
 }
 
-func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, isUpdate bool) error {
+func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, cluster *aprv1.RedixCluster, _ bool) error {
 	cli, err := kvrocks.GetKVRocksClient(c.ctx, c.k8sClientSet, cluster)
 	if err != nil {
 		klog.Error("get kvrocks client error, ", err)
@@ -78,7 +79,7 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
 	token, err := req.Spec.Redis.Password.GetVarValue(c.ctx, c.k8sClientSet, req.Namespace)
 	if err != nil {
 		klog.Error("get redis request password error, ", err, ", ", req.Name, ", ", req.Namespace)
@@ -91,27 +92,23 @@ func (c *controller) createOrUpdateKVRocksRequest(req *aprv1.MiddlewareRequest, 
 	}
 
 	if ns == nil {
-		if isUpdate {
-			// update requets, but namespace is a new one. we must check if the token exists.
-			// if token exists, remove the old namesapce and create the new namespace
-			// if not, just create a new namespace
-			allns, err := cli.ListNamespace(c.ctx)
-			if err != nil {
-				klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
-				return err
-			}
+		// The target namespace does not exist yet. Before creating it, clean up any
+		// stale namespace that belongs to this request: a namespace whose name differs
+		// from the current one but shares the same token (e.g. legacy namespaces created
+		// with req.Namespace before switching to AppNamespace-based naming).
+		allns, err := cli.ListNamespace(c.ctx)
+		if err != nil {
+			klog.Error("list kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
+			return err
+		}
 
-			for _, n := range allns {
-				if n.Token == token {
-					err = cli.DeleteNamespace(c.ctx, n.Name)
-					if err != nil {
-						klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
-					}
+		for _, n := range allns {
+			if n.Name != requestNamespace && n.Token == token {
+				err = cli.DeleteNamespace(c.ctx, n.Name)
+				if err != nil {
+					klog.Warning("delete kvrocks namespace error, ", err, ", ", n.Name)
 				}
 			}
-
-			// FIXME: if both the namespace's name and token are changed, the old namespace
-			// shoud be deleted
 		}
 
 		// create namespace
@@ -140,7 +137,7 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	defer cli.Close()
 
 	// TODO: redis db support
-	requestNamespace := GetKVRocksNamespaceName(req.Namespace, req.Spec.Redis.Namespace)
+	requestNamespace := GetKVRocksNamespaceName(req, req.Spec.Redis.Namespace)
 	ns, err := cli.GetNamespace(c.ctx, requestNamespace)
 	if err != nil {
 		klog.Error("get kvrocks namespace error, ", err, ", ", req.Name, ", ", req.Namespace)
@@ -163,6 +160,10 @@ func (c *controller) deleteKVRocksRequest(req *aprv1.MiddlewareRequest, cluster 
 	return nil
 }
 
-func GetKVRocksNamespaceName(reqNamespace, dbNamespace string) string {
-	return fmt.Sprintf("%s_%s", reqNamespace, dbNamespace)
+func GetKVRocksNamespaceName(req *aprv1.MiddlewareRequest, dbNamespace string) string {
+	appNamespace := req.Spec.AppNamespace
+	if strings.HasPrefix(appNamespace, "os-") || strings.HasPrefix(appNamespace, "user-space-") {
+		return fmt.Sprintf("%s_%s", req.Namespace, dbNamespace)
+	}
+	return fmt.Sprintf("%s_%s", appNamespace, dbNamespace)
 }

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -282,6 +282,12 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
+			klog.Infof("appName: %s", app.Spec.Name)
+			nss := make([]string, 0)
+			for _, n := range sharedNs {
+				nss = append(nss, n.Name)
+			}
+			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -282,12 +282,6 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 					sharedNs = append(sharedNs, &ns)
 				}
 			}
-			klog.Infof("appName: %s", app.Spec.Name)
-			nss := make([]string, 0)
-			for _, n := range sharedNs {
-				nss = append(nss, n.Name)
-			}
-			klog.Infof("sharedNs: %#v", nss)
 
 			// get the service of entrance
 			for i, entrance := range app.Spec.SharedEntrances {


### PR DESCRIPTION

* **Background**
    use req.Namespace as prefix will cause conflict when clone a app.
    Use Spec.AppNamespace when deleting KVRocks namespaces to align with
    create/update, while still attempting the legacy req.Namespace naming for
    older MiddlewareRequests. Match namespace token before deletion to avoid
    removing another app's data when multiple MRs share the same owner namespace.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes middleware data isolation and deletion behavior for KVRocks; mis-naming or token-based cleanup could affect the wrong logical namespace in edge cases.
> 
> **Overview**
> Bumps the deployed **middleware-operator** image to `0.2.37` and fixes how KVRocks logical namespace names are derived for MiddlewareRequests.
> 
> **KVRocks naming** now goes through `GetKVRocksNamespaceName(req, …)` using `Spec.AppNamespace` for app workloads, while `os-*` and `user-space-*` app namespaces still use the legacy `req.Namespace` prefix so cloned apps do not collide on the same KVRocks namespace name. Create/update and delete both use this helper.
> 
> When the target KVRocks namespace does not exist yet, create/update **always** lists existing namespaces and deletes stale ones that share the request’s password token but a different name (covering renames from legacy `req.Namespace` naming), instead of only doing that on update paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b68991eff19ab4d5bfb5c3c5edd6c321ff909bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->