### PR TITLE
app-gaetway: Add Envoy container to Olares.yaml

### DIFF
--- a/framework/app-gateway/.olares/Olares.yaml
+++ b/framework/app-gateway/.olares/Olares.yaml
@@ -4,3 +4,5 @@ output:
   containers:
     - 
       name: envoyproxy/ratelimit:ff287602
+    - 
+      name: envoyproxy/envoy:distroless-v1.38.0


### PR DESCRIPTION
* **Background**
Add Envoy image to Olares.yaml for install wizard packaging

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging metadata only; no runtime or application logic changes.
> 
> **Overview**
> Adds **`envoyproxy/envoy:distroless-v1.38.0`** to the `output.containers` list in `framework/app-gateway/.olares/Olares.yaml`, alongside the existing ratelimit image, so the install wizard prebuilt bundle includes the Envoy image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84855ec5c557d27a697ced8d9db5400fd2fc6bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->