### PR TITLE
system-apps: bump system-frontend to v1.10.51 and user-service to v0.1.1

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.49
+          image: beclab/system-frontend:v1.10.51
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.0.100
+          image: beclab/user-service:v0.1.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
  This PR bumps the system-apps component images to roll in the latest `system-frontend` and `user-service` changes:
  - **system-frontend** `v1.10.49` → `v1.10.51`: adds an IndexedDB-backed Developer Log collection history (with status, path display, and reopen for completed runs), hardens the file preview/open flows with user feedback when a target file was deleted or renamed, improves the Electron drag-and-drop upload success toast and archive compress/extract menu state timing, and unifies the compute resource display across app detail pages while refining the GPU/VRAM configuration flow (per-card VRAM floor with aggregate validation, a reusable VRAM input component, and memory display precision fixes).
  - **user-service** `v0.0.100` → `v0.1.1`: updates the `collectLogs` method to accept a request body and enhances error logging, backing the new Developer Log collection history feature.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  - https://github.com/beclab/TermiPass/pull/1204
  - https://github.com/beclab/TermiPass/pull/1203
  - https://github.com/beclab/user-service/pull/85

* **Other information**:
  - Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.51
  - Full Changelog (system-frontend): https://github.com/beclab/TermiPass/compare/v1.10.50...v1.10.51
  - Full Changelog (user-service): https://github.com/beclab/user-service/compare/v0.0.100...v0.1.1

Made with [Cursor](https://cursor.com)