### PR TITLE
fix(app-service): create one GPU binding per selected card for multi-card

### DIFF
--- a/framework/app-service/controllers/userenv_sync_controller.go
+++ b/framework/app-service/controllers/userenv_sync_controller.go
@@ -44,6 +44,36 @@ var localeEnvAnnotations = map[string]string{
 	"OLARES_USER_TIMEZONE": users.UserAnnotationTimezone,
 }
 
+// userEnvTypeLabel categorizes a UserEnv so other components can select it by
+// type. For example, l4-bfl-proxy lists the language preference env via the
+// label selector sys.bytetrade.io/env-type=language.
+const userEnvTypeLabel = "sys.bytetrade.io/env-type"
+
+// envTypeLabels maps a user env to the value of the userEnvTypeLabel that the
+// controller stamps on it when creating or syncing the env, so downstream
+// consumers can discover it by type.
+var envTypeLabels = map[string]string{
+	"OLARES_USER_LANGUAGE": "language",
+}
+
+// ensureEnvTypeLabel stamps the env-type label on envs that declare one in
+// envTypeLabels, adding it when missing or correcting a stale value. Envs not in
+// the map are left untouched. Returns true if ue.Labels was changed.
+func ensureEnvTypeLabel(ue *sysv1alpha1.UserEnv) bool {
+	envType, ok := envTypeLabels[ue.EnvName]
+	if !ok {
+		return false
+	}
+	if ue.Labels[userEnvTypeLabel] == envType {
+		return false
+	}
+	if ue.Labels == nil {
+		ue.Labels = make(map[string]string)
+	}
+	ue.Labels[userEnvTypeLabel] = envType
+	return true
+}
+
 // syncLocaleValue reconciles a locale-backed env's Value from the user CR
 // annotation that owns it. The direction is driven by the env's Editable flag:
 //
@@ -273,6 +303,9 @@ func (r *UserEnvSyncController) syncUserEnvForUser(ctx context.Context, username
 			if syncLocaleValue(ue, userAnnotations) {
 				updated = true
 			}
+			if ensureEnvTypeLabel(ue) {
+				updated = true
+			}
 
 			if updated {
 				if err := r.Patch(ctx, ue, client.MergeFrom(original)); err != nil {
@@ -291,6 +324,7 @@ func (r *UserEnvSyncController) syncUserEnvForUser(ctx context.Context, username
 		ue.Name = name
 		ue.Namespace = userNs
 		ue.EnvVarSpec = spec
+		ensureEnvTypeLabel(ue)
 		// seed locale-managed envs from the user CR annotation on first creation
 		syncLocaleValue(ue, userAnnotations)
 		if err := r.Create(ctx, ue); err != nil {

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -563,13 +563,23 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 	remaining := target
 	for _, item := range resolved {
 		amount := target
-		if item.device.SupportType == SupportTypeMemorySlice && item.memory > 0 {
+		switch {
+		case item.device.SupportType == SupportTypeMemorySlice && item.memory > 0:
+			// Memory-slice cards carve out an explicit per-card slice; the
+			// frontend always sends a positive Memory for them (enforced by
+			// validateResolvedBindingSelection).
 			amount = item.memory
-		}
-		if len(resolved) > 1 {
-			if item.device.SupportType != SupportTypeMemorySlice || item.memory <= 0 {
-				amount = minInt64(deviceAvailableMemory(item.device), remaining)
-			}
+		case isWholeCardMode(req.Mode, item.device.SupportType):
+			// Exclusive / TimeSlice hand the pod the whole card and
+			// buildAllocation records Memory=0, so every selected card must
+			// produce its own binding. These must never be gated on the
+			// shared `remaining` VRAM budget: once an earlier card covered
+			// the RequiredGPU target the budget reaches zero and the rest of
+			// a multi-card selection would be silently dropped, leaving only
+			// a single HAMI binding for a two-card request.
+			amount = deviceAvailableMemory(item.device)
+		case len(resolved) > 1:
+			amount = minInt64(deviceAvailableMemory(item.device), remaining)
 		}
 		if amount <= 0 {
 			continue

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -195,6 +195,99 @@ func TestValidateBindingSelectionTopologyAndMemorySlice(t *testing.T) {
 	}
 }
 
+// TestAllocationsFromResolvedSelectionMultiCardWholeCard is a regression test
+// for the multi-card binding bug: when the frontend submitted two whole-card
+// (Exclusive / TimeSlice) selections, allocationsFromResolvedSelection folded
+// them into a single RequiredGPU budget and dropped every card past the one
+// that first covered the budget, so only one HAMI GPUBinding was created for a
+// two-card request. Every selected whole card must yield its own allocation.
+func TestAllocationsFromResolvedSelectionMultiCardWholeCard(t *testing.T) {
+	cases := []struct {
+		name        string
+		supportType string
+	}{
+		{name: "exclusive", supportType: SupportTypeExclusive},
+		{name: "timeslice", supportType: SupportTypeTimeSlice},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &appcfg.ApplicationConfig{AppName: "trainer", OwnerName: "alice"}
+			req := Requirement{
+				Mode:              utils.NvidiaCardType,
+				RequiredGPU:       12 * gi,
+				LimitedGPU:        12 * gi,
+				SupportMultiCards: true,
+			}
+			nodes := []Node{
+				nvidiaNode("nvidia-a",
+					Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: tc.supportType},
+					Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: tc.supportType},
+				),
+			}
+			resolved, err := resolveSelection([]BindingSelection{
+				{NodeName: "nvidia-a", DeviceID: "gpu0"},
+				{NodeName: "nvidia-a", DeviceID: "gpu1"},
+			}, nodes)
+			if err != nil {
+				t.Fatalf("resolveSelection failed: %v", err)
+			}
+			allocations := allocationsFromResolvedSelection(app, req, resolved)
+			if len(allocations) != 2 {
+				t.Fatalf("expected one allocation per selected card, got %d: %#v", len(allocations), allocations)
+			}
+			devices := map[string]struct{}{}
+			for _, a := range allocations {
+				devices[a.DeviceID] = struct{}{}
+				if a.Memory != 0 {
+					t.Fatalf("whole-card allocation should record Memory=0, got %#v", a)
+				}
+				if a.AppName != "trainer" || a.Owner != "alice" || a.NodeName != "nvidia-a" {
+					t.Fatalf("unexpected allocation identity: %#v", a)
+				}
+			}
+			for _, id := range []string{"gpu0", "gpu1"} {
+				if _, ok := devices[id]; !ok {
+					t.Fatalf("expected an allocation for %s, got %#v", id, allocations)
+				}
+			}
+		})
+	}
+}
+
+// TestAllocationsFromResolvedSelectionMultiCardMemorySlice pins the unchanged
+// memory-slice path: each selected card keeps its own explicit slice amount.
+func TestAllocationsFromResolvedSelectionMultiCardMemorySlice(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "trainer", OwnerName: "alice"}
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       12 * gi,
+		LimitedGPU:        12 * gi,
+		SupportMultiCards: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+		),
+	}
+	resolved, err := resolveSelection([]BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0", Memory: 6 * gi},
+		{NodeName: "nvidia-a", DeviceID: "gpu1", Memory: 6 * gi},
+	}, nodes)
+	if err != nil {
+		t.Fatalf("resolveSelection failed: %v", err)
+	}
+	allocations := allocationsFromResolvedSelection(app, req, resolved)
+	if len(allocations) != 2 {
+		t.Fatalf("expected one allocation per memory-slice card, got %d: %#v", len(allocations), allocations)
+	}
+	for _, a := range allocations {
+		if a.Memory != 6*gi {
+			t.Fatalf("expected each memory-slice allocation to keep its 6Gi slice, got %#v", a)
+		}
+	}
+}
+
 func TestAvailabilityCrossNodeSumsRawAvailableDespitePerNodePressure(t *testing.T) {
 	req := Requirement{
 		Mode:              utils.NvidiaCardType,

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -376,8 +376,7 @@ func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node 
 	// omits spec.memory and HAMI treats the pod as unrestricted. The
 	// scheduler's accounting (deviceAvailableMemory / remainingMemory)
 	// never reads Allocation.Memory for these modes, so this is safe.
-	if req.Mode == utils.NvidiaCardType &&
-		(device.SupportType == SupportTypeExclusive || device.SupportType == SupportTypeTimeSlice) {
+	if isWholeCardMode(req.Mode, device.SupportType) {
 		memory = 0
 	}
 	return Allocation{
@@ -389,6 +388,17 @@ func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node 
 		DeviceID: device.ID,
 		Memory:   memory,
 	}
+}
+
+// isWholeCardMode reports whether binding a pod to a device with this NVIDIA
+// support type grants it the entire card: Exclusive (solo binding) or
+// TimeSlice (full memory during the pod's slice). buildAllocation records
+// Memory=0 for these, and they are always one-binding-per-card, so allocation
+// distribution must emit a separate binding for every selected card instead of
+// folding several of them into a single shared VRAM budget.
+func isWholeCardMode(mode, supportType string) bool {
+	return mode == utils.NvidiaCardType &&
+		(supportType == SupportTypeExclusive || supportType == SupportTypeTimeSlice)
 }
 
 func supportTypeOrder(mode string) []string {


### PR DESCRIPTION
## Summary
- **Fix multi-card GPU binding.** When the frontend submitted multiple whole-card (Exclusive / TimeSlice) selections, `allocationsFromResolvedSelection` folded them into a single `RequiredGPU` budget (`remaining`). Once an earlier card covered the target, the budget hit zero and every remaining selected card was silently dropped (`amount <= 0` → `continue`), so only **one** HAMI `GPUBinding` was created for a two-card request. Each selected whole card now yields its own allocation/binding. The memory-slice path (explicit per-card `Memory`) is unchanged.
- Add an `isWholeCardMode` helper and reuse it in `buildAllocation` so the two whole-card checks stay in lockstep.
- Stamp the `sys.bytetrade.io/env-type` label on typed user envs (e.g. `OLARES_USER_LANGUAGE` → `language`) during create/sync, so downstream consumers (e.g. l4-bfl-proxy) can select them by type.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/compute/`
- [x] `go test ./pkg/compute/` — incl. new `TestAllocationsFromResolvedSelectionMultiCardWholeCard` (Exclusive + TimeSlice) and `TestAllocationsFromResolvedSelectionMultiCardMemorySlice`
- [ ] Manual: resume a multi-card NVIDIA app with two Exclusive cards selected; verify two `GPUBinding` objects are created

Made with [Cursor](https://cursor.com)