### PR TITLE
feat(bfl): get & set locale settings by user env CRs

### DIFF
--- a/build/user-env.yaml
+++ b/build/user-env.yaml
@@ -10,18 +10,20 @@ userEnvs:
     type: password
     editable: true
   # OLARES_USER_LANGUAGE / OLARES_USER_THEME / OLARES_USER_TIMEZONE are user
-  # locale preferences. Their source of truth is the user CR annotation
-  # (bytetrade.io/language|theme|location), written during activation and via
-  # the locale settings page. app-service syncs the annotation into the Value
-  # one-way (see UserEnvSyncController).
+  # locale preferences. The UserEnv Value is the source of truth: it is seeded
+  # from the user CR annotation (bytetrade.io/language|theme|timezone) during
+  # activation, then owned by the user. app-service's UserEnvSyncController only
+  # seeds the Value when empty and never overrides a user-set value (see
+  # syncLocaleValue).
   #
-  # They are declared editable:false so the env settings page does not offer a
-  # conflicting second edit path. To allow editing env vars directly in
-  # settings later, flip editable:true: the controller then only seeds the
-  # value when empty and never overrides a user-set value.
+  # They are declared editable:true so the value can be edited directly and is
+  # the single source of truth: both the env settings page and bfl's
+  # config-system (locale settings) endpoint read and write these UserEnvs. The
+  # annotation is only used to seed the initial Value (when empty) during
+  # activation; bfl no longer keeps it in sync afterwards.
   - envName: OLARES_USER_LANGUAGE
     type: string
-    editable: false
+    editable: true
     default: "en-US"
     options:
     - title: "English (US)"
@@ -30,7 +32,7 @@ userEnvs:
       value: "zh-CN"
   - envName: OLARES_USER_THEME
     type: string
-    editable: false
+    editable: true
     default: "light"
     options:
     - title: "Light"
@@ -39,7 +41,7 @@ userEnvs:
       value: "dark"
   - envName: OLARES_USER_TIMEZONE
     type: string
-    editable: false
+    editable: true
     default: "UTC"
     options:
     - title: "Africa/Abidjan"

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.48
+        image: beclab/bfl:v0.4.49
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/framework/bfl/pkg/apis/base.go
+++ b/framework/bfl/pkg/apis/base.go
@@ -10,6 +10,7 @@ import (
 	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
 	"bytetrade.io/web3os/bfl/pkg/app_service/v1"
 	"bytetrade.io/web3os/bfl/pkg/constants"
+	"bytetrade.io/web3os/bfl/pkg/userenv"
 	"bytetrade.io/web3os/bfl/pkg/utils"
 
 	iamV1alpha2 "github.com/beclab/api/iam/v1alpha2"
@@ -118,10 +119,40 @@ func (b *Base) IsAdminUser(ctx context.Context) (bool, error) {
 	return role == constants.RoleOwner || role == constants.RoleAdmin, nil
 }
 
-func (b *Base) HandleGetSysConfig(_ *restful.Request, resp *restful.Response) {
+func (b *Base) HandleGetSysConfig(req *restful.Request, resp *restful.Response) {
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		response.HandleError(resp, errors.Errorf("get user sys config err: new kube client err, %v", err))
+		return
+	}
+	ctx := req.Request.Context()
+	c := kc.CtrlClient()
+
+	// language/theme/timezone are owned by the per-user UserEnvs (see
+	// build/user-env.yaml) and read directly from the UserEnv CRs; an unset
+	// env reads as empty.
+	cfg := PostLocale{}
+	targets := []struct {
+		env string
+		dst *string
+	}{
+		{userenv.EnvLanguage, &cfg.Language},
+		{userenv.EnvTimezone, &cfg.Timezone},
+		{userenv.EnvTheme, &cfg.Theme},
+	}
+	for _, t := range targets {
+		v, _, e := userenv.GetValue(ctx, c, constants.Username, t.env)
+		if e != nil {
+			response.HandleError(resp, errors.Errorf("get user sys config err: read userenv %s err, %v", t.env, e))
+			return
+		}
+		*t.dst = v
+	}
+
+	// Location has no backing UserEnv; it still lives on the user annotation.
 	userOp, err := operator.NewUserOperator()
 	if err != nil {
-		response.HandleError(resp, errors.Errorf("new user operator err, %v", err))
+		response.HandleError(resp, errors.Errorf("get user sys config err: new user operator err, %v", err))
 		return
 	}
 	user, err := userOp.GetUser(constants.Username)
@@ -129,11 +160,7 @@ func (b *Base) HandleGetSysConfig(_ *restful.Request, resp *restful.Response) {
 		response.HandleError(resp, errors.Errorf("get user sys config err: get user err, %v", err))
 		return
 	}
-	cfg := PostLocale{
-		Language: user.Annotations[constants.UserLanguage],
-		Location: user.Annotations[constants.UserLocation],
-		Timezone: user.Annotations[constants.UserTimezone],
-		Theme:    user.Annotations[constants.UserTheme],
-	}
+	cfg.Location = user.Annotations[constants.UserLocation]
+
 	response.Success(resp, &cfg)
 }

--- a/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/handler.go
@@ -16,6 +16,7 @@ import (
 	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
 	app_service "bytetrade.io/web3os/bfl/pkg/app_service/v1"
 	"bytetrade.io/web3os/bfl/pkg/constants"
+	"bytetrade.io/web3os/bfl/pkg/userenv"
 	"bytetrade.io/web3os/bfl/pkg/utils"
 	"bytetrade.io/web3os/bfl/pkg/utils/certmanager"
 
@@ -667,25 +668,15 @@ func (h *Handler) handleUpdateLocale(req *restful.Request, resp *restful.Respons
 		return
 	}
 
+	// Location has no backing UserEnv, so it stays on the user annotation; also
+	// advance the wizard status here. language/theme/timezone are persisted to
+	// the UserEnv CRs below.
 	err = func() error {
 		if err = userOp.UpdateUser(user, []func(*iamV1alpha2.User){
 			func(u *iamV1alpha2.User) {
-				if locale.Language != "" {
-					u.Annotations[constants.UserLanguage] = locale.Language
-				}
-
 				if locale.Location != "" {
 					u.Annotations[constants.UserLocation] = locale.Location
 				}
-
-				if locale.Timezone != "" {
-					u.Annotations[constants.UserTimezone] = locale.Timezone
-				}
-
-				if locale.Theme == "" {
-					locale.Theme = "light"
-				}
-				u.Annotations[constants.UserTheme] = locale.Theme
 
 				if u.Annotations[constants.UserTerminusWizardStatus] != string(constants.Completed) {
 					u.Annotations[constants.UserTerminusWizardStatus] = string(constants.WaitActivateNetwork)
@@ -700,6 +691,43 @@ func (h *Handler) handleUpdateLocale(req *restful.Request, resp *restful.Respons
 	if err != nil {
 		response.HandleError(resp, errors.Errorf("update user locale err: %v", err))
 		return
+	}
+
+	// language/theme/timezone are owned by the per-user UserEnvs (see
+	// build/user-env.yaml) and persisted directly to the UserEnv CRs as the
+	// single source of truth (the env settings page reads/writes the same CRs).
+	// These UserEnvs are provisioned when the user reaches the "Created" state,
+	// before activation, so they exist by the time this runs.
+	kc, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		response.HandleError(resp, errors.Errorf("update user locale err: new kube client err, %v", err))
+		return
+	}
+	ctx := req.Request.Context()
+	c := kc.CtrlClient()
+	envValues := []struct {
+		env string
+		val string
+	}{
+		{userenv.EnvLanguage, locale.Language},
+		{userenv.EnvTimezone, locale.Timezone},
+		{userenv.EnvTheme, locale.Theme},
+	}
+	for _, ev := range envValues {
+		if ev.val == "" {
+			continue
+		}
+		ok, e := userenv.SetValue(ctx, c, constants.Username, ev.env, ev.val)
+		if e != nil {
+			err = e
+			response.HandleError(resp, errors.Errorf("update user locale err: set userenv %s err, %v", ev.env, e))
+			return
+		}
+		if !ok {
+			err = errors.Errorf("update user locale err: userenv %s not provisioned", ev.env)
+			response.HandleError(resp, err)
+			return
+		}
 	}
 
 	response.SuccessNoData(resp)

--- a/framework/bfl/pkg/client/clientset/v1alpha1/client.go
+++ b/framework/bfl/pkg/client/clientset/v1alpha1/client.go
@@ -5,6 +5,7 @@ import (
 
 	"bytetrade.io/web3os/bfl/pkg/constants"
 
+	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
 	iamV1alpha2 "github.com/beclab/api/iam/v1alpha2"
 	aruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -22,6 +23,9 @@ var (
 func init() {
 	utilruntime.Must(iamV1alpha2.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	// UserEnv (sys.bytetrade.io) so the ctrl client can read/write the per-user
+	// locale env vars backing config-system.
+	utilruntime.Must(sysv1alpha1.AddToScheme(scheme))
 }
 
 // KubeClient global singleton client for kubernetes and kubesphere

--- a/framework/bfl/pkg/userenv/userenv.go
+++ b/framework/bfl/pkg/userenv/userenv.go
@@ -1,0 +1,78 @@
+// Package userenv provides thin read/write helpers over the per-user UserEnv
+// (sys.bytetrade.io/v1alpha1) custom resources. bfl's config-system (locale
+// settings) endpoints use it so the locale values share a single source of
+// truth with the app-service env settings page.
+package userenv
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"bytetrade.io/web3os/bfl/pkg/constants"
+
+	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Locale-related user environment variables backed by per-user UserEnv CRs.
+// These mirror the entries declared in build/user-env.yaml and the locale map
+// in app-service's UserEnvSyncController.
+const (
+	EnvLanguage = "OLARES_USER_LANGUAGE"
+	EnvTimezone = "OLARES_USER_TIMEZONE"
+	EnvTheme    = "OLARES_USER_THEME"
+)
+
+// resourceName mirrors app-service's EnvNameToResourceName: lowercase the env
+// name and replace underscores with hyphens (OLARES_USER_LANGUAGE ->
+// olares-user-language).
+func resourceName(envName string) string {
+	return strings.ReplaceAll(strings.ToLower(envName), "_", "-")
+}
+
+func namespace(username string) string {
+	return fmt.Sprintf(constants.UserspaceNameFormat, username)
+}
+
+// GetValue returns the stored Value of the given user env for the user. ok is
+// false when the UserEnv has not been provisioned yet (e.g. during activation,
+// before the sync controller creates it from the user annotation); callers
+// should fall back to the annotation in that case.
+func GetValue(ctx context.Context, c client.Client, username, envName string) (value string, ok bool, err error) {
+	var ue sysv1alpha1.UserEnv
+	key := types.NamespacedName{Namespace: namespace(username), Name: resourceName(envName)}
+	if getErr := c.Get(ctx, key, &ue); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return "", false, nil
+		}
+		return "", false, getErr
+	}
+	return ue.GetEffectiveValue(), true, nil
+}
+
+// SetValue writes value into the user env's Value field. ok is false (a no-op)
+// when the UserEnv does not exist yet; the caller-written user annotation seeds
+// it once app-service's sync controller provisions it. Editability is enforced
+// by the env settings API, not here: config-system is a trusted system writer.
+func SetValue(ctx context.Context, c client.Client, username, envName, value string) (ok bool, err error) {
+	var ue sysv1alpha1.UserEnv
+	key := types.NamespacedName{Namespace: namespace(username), Name: resourceName(envName)}
+	if getErr := c.Get(ctx, key, &ue); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return false, nil
+		}
+		return false, getErr
+	}
+	if ue.Value == value {
+		return true, nil
+	}
+	original := ue.DeepCopy()
+	ue.Value = value
+	if patchErr := c.Patch(ctx, &ue, client.MergeFrom(original)); patchErr != nil {
+		return false, patchErr
+	}
+	return true, nil
+}


### PR DESCRIPTION
* **Background**
Change `/config-system` API that's currently used by the frontend to get & set locale settings on the user CR to/from the UserEnv CR. The newly added 3 UserEnv is changed to be editable.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the persistence layer for locale settings used by the frontend; missing or late-provisioned UserEnvs can return empty values on read or fail updates until CRs exist, unlike the previous annotation-only path.
> 
> **Overview**
> Moves **language, theme, and timezone** for the frontend **`/config-system`** flow off the user CR annotations and onto per-user **UserEnv** custom resources, aligned with the env settings UI and **`build/user-env.yaml`**.
> 
> **GET** `config-system` now loads those three fields from UserEnv CRs via a new **`userenv`** helper; **location** is still read from the user annotation. **POST** `config-system` patches the same UserEnv values (and errors if a CR is not provisioned), while only **location** and wizard-related annotation updates stay on the user object. The kube **controller-runtime** client scheme is extended so BFL can read/write **`sys.bytetrade.io` UserEnv** resources. Locale env entries are marked **editable** in **`user-env.yaml`**, with docs updated so UserEnv **Value** is the source of truth after activation seeding. BFL deploy image is bumped to **`beclab/bfl:v0.4.49`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3993728b63e032b389fac448db11c94e7e7c1afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->