### PR TITLE
fix(app-service): create one GPU binding per selected card for multi-card

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -215,6 +215,8 @@ spec:
           value: "0"
         - name: USER_MEMORY_THRESHOLD
           value: "0"
+        - name: SHARED_BACKEND_RESPONSE_TIMEOUT
+          value: "600s"
         - name: NATS_HOST
           value: nats.os-platform
         - name: NATS_PORT

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.45
+        image: beclab/app-service:0.5.46
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -214,7 +214,6 @@ func main() {
 	if err = (&controllers.NodeAlertController{
 		Client:     mgr.GetClient(),
 		KubeConfig: config,
-		NatsConn:   nil,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "NodeAlert")
 		os.Exit(1)

--- a/framework/app-service/controllers/node_alert_controller.go
+++ b/framework/app-service/controllers/node_alert_controller.go
@@ -6,9 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	appevent "github.com/beclab/Olares/framework/app-service/pkg/event"
 
-	"github.com/nats-io/nats.go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -54,9 +53,7 @@ type NodeAlertController struct {
 	lastAlertTime map[string]time.Time
 	// lastPressureState tracks the last known pressure state for each node and pressure type
 	lastPressureState map[string]bool
-	mutex             sync.RWMutex
-	NatsConn          *nats.Conn
-	natsConnMux       sync.Mutex
+	mutex sync.RWMutex
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -166,32 +163,13 @@ func (r *NodeAlertController) checkPressureStateChange(node *corev1.Node, pressu
 	defer r.mutex.Unlock()
 
 	key := fmt.Sprintf("%s-%s", node.Name, pressureType)
-	lastPressure, _ := r.lastPressureState[key]
+	lastPressure := r.lastPressureState[key]
 	if lastPressure != currentPressure {
-		if currentPressure {
-			// from available to pressure
-			err := r.sendNodeAlert(node.Name, pressureType, conditionMessage, true)
-			if err != nil {
-				klog.Errorf("failed to publish available to pressure, type: %s, err: %v", pressureType, err)
-				return err
-			}
-		} else {
-			// from pressure to available
-			err := r.sendNodeAlert(node.Name, pressureType, conditionMessage, false)
-			if err != nil {
-				klog.Errorf("failed to publish pressure to available, type: %s, err: %v", pressureType, err)
-				return err
-			}
-		}
-	} else if currentPressure {
-		// pressure persists
-		if r.shouldSendAlert(node.Name, pressureType) {
-			err := r.sendNodeAlert(node.Name, pressureType, conditionMessage, true)
-			if err != nil {
-				klog.Errorf("failed to publish persists pressure, type: %s, err: %v", pressureType, err)
-				return err
-			}
-		}
+		// state changed: pressure onset or recovery
+		r.sendNodeAlert(node.Name, pressureType, conditionMessage, currentPressure)
+	} else if currentPressure && r.shouldSendAlert(node.Name, pressureType) {
+		// pressure persists; re-alert after cooldown
+		r.sendNodeAlert(node.Name, pressureType, conditionMessage, true)
 	}
 	r.lastPressureState[key] = currentPressure
 	return nil
@@ -209,14 +187,10 @@ func (r *NodeAlertController) shouldSendAlert(nodeName string, pressureType Node
 	return time.Since(lastTime) >= 60*time.Minute
 }
 
-// sendNodeAlertUnlocked sends an alert message to NATS
-func (r *NodeAlertController) sendNodeAlert(nodeName string, pressureType NodePressureType, message string, isPressure bool) error {
+// sendNodeAlert enqueues an alert message for delivery to NATS via the
+// shared AppEventQueue connection.
+func (r *NodeAlertController) sendNodeAlert(nodeName string, pressureType NodePressureType, message string, isPressure bool) {
 	key := fmt.Sprintf("%s-%s", nodeName, pressureType)
-
-	status := false
-	if isPressure {
-		status = true
-	}
 
 	data := NodeAlertEvent{
 		Topic: pressureType,
@@ -225,53 +199,15 @@ func (r *NodeAlertController) sendNodeAlert(nodeName string, pressureType NodePr
 			PressureType: pressureType,
 			Timestamp:    time.Now(),
 			Message:      message,
-			Status:       status,
+			Status:       isPressure,
 		},
 	}
 
-	if err := r.publishToNats("os.notification", data); err != nil {
-		klog.Errorf("failed to publish node alert to NATS: %v", err)
-		return err
-	} else {
-		if isPressure {
-			klog.Infof("successfully published node pressure alert for %s: %s", nodeName, pressureType)
-		} else {
-			klog.Infof("successfully published node pressure recovery for %s: %s", nodeName, pressureType)
-		}
-	}
+	appevent.PublishToQueue("os.notification", data)
 	if isPressure {
+		klog.Infof("enqueued node pressure alert for %s: %s", nodeName, pressureType)
 		r.lastAlertTime[key] = time.Now()
+	} else {
+		klog.Infof("enqueued node pressure recovery for %s: %s", nodeName, pressureType)
 	}
-	return nil
-}
-
-// publishToNats publishes a message to the specified NATS subject
-func (r *NodeAlertController) publishToNats(subject string, data interface{}) error {
-	if err := r.ensureNatsConnected(); err != nil {
-		return fmt.Errorf("failed to ensure NATS connection: %w", err)
-	}
-	return utils.PublishEvent(r.NatsConn, subject, data)
-}
-
-func (r *NodeAlertController) ensureNatsConnected() error {
-	r.natsConnMux.Lock()
-	defer r.natsConnMux.Unlock()
-
-	if r.NatsConn != nil && r.NatsConn.IsConnected() {
-		return nil
-	}
-	if r.NatsConn != nil {
-		r.NatsConn.Close()
-	}
-
-	klog.Info("NATS connection not established in NodeAlertController, attempting to connect...")
-	nc, err := utils.NewNatsConn()
-	if err != nil {
-		klog.Errorf("NodeAlertController failed to connect to NATS: %v", err)
-		return err
-	}
-
-	r.NatsConn = nc
-	klog.Info("NodeAlertController successfully connected to NATS")
-	return nil
 }

--- a/framework/app-service/controllers/userenv_sync_controller.go
+++ b/framework/app-service/controllers/userenv_sync_controller.go
@@ -44,6 +44,36 @@ var localeEnvAnnotations = map[string]string{
 	"OLARES_USER_TIMEZONE": users.UserAnnotationTimezone,
 }
 
+// userEnvTypeLabel categorizes a UserEnv so other components can select it by
+// type. For example, l4-bfl-proxy lists the language preference env via the
+// label selector sys.bytetrade.io/env-type=language.
+const userEnvTypeLabel = "sys.bytetrade.io/env-type"
+
+// envTypeLabels maps a user env to the value of the userEnvTypeLabel that the
+// controller stamps on it when creating or syncing the env, so downstream
+// consumers can discover it by type.
+var envTypeLabels = map[string]string{
+	"OLARES_USER_LANGUAGE": "language",
+}
+
+// ensureEnvTypeLabel stamps the env-type label on envs that declare one in
+// envTypeLabels, adding it when missing or correcting a stale value. Envs not in
+// the map are left untouched. Returns true if ue.Labels was changed.
+func ensureEnvTypeLabel(ue *sysv1alpha1.UserEnv) bool {
+	envType, ok := envTypeLabels[ue.EnvName]
+	if !ok {
+		return false
+	}
+	if ue.Labels[userEnvTypeLabel] == envType {
+		return false
+	}
+	if ue.Labels == nil {
+		ue.Labels = make(map[string]string)
+	}
+	ue.Labels[userEnvTypeLabel] = envType
+	return true
+}
+
 // syncLocaleValue reconciles a locale-backed env's Value from the user CR
 // annotation that owns it. The direction is driven by the env's Editable flag:
 //
@@ -273,6 +303,9 @@ func (r *UserEnvSyncController) syncUserEnvForUser(ctx context.Context, username
 			if syncLocaleValue(ue, userAnnotations) {
 				updated = true
 			}
+			if ensureEnvTypeLabel(ue) {
+				updated = true
+			}
 
 			if updated {
 				if err := r.Patch(ctx, ue, client.MergeFrom(original)); err != nil {
@@ -291,6 +324,7 @@ func (r *UserEnvSyncController) syncUserEnvForUser(ctx context.Context, username
 		ue.Name = name
 		ue.Namespace = userNs
 		ue.EnvVarSpec = spec
+		ensureEnvTypeLabel(ue)
 		// seed locale-managed envs from the user CR annotation on first creation
 		syncLocaleValue(ue, userAnnotations)
 		if err := r.Create(ctx, ue); err != nil {

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -563,13 +563,23 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 	remaining := target
 	for _, item := range resolved {
 		amount := target
-		if item.device.SupportType == SupportTypeMemorySlice && item.memory > 0 {
+		switch {
+		case item.device.SupportType == SupportTypeMemorySlice && item.memory > 0:
+			// Memory-slice cards carve out an explicit per-card slice; the
+			// frontend always sends a positive Memory for them (enforced by
+			// validateResolvedBindingSelection).
 			amount = item.memory
-		}
-		if len(resolved) > 1 {
-			if item.device.SupportType != SupportTypeMemorySlice || item.memory <= 0 {
-				amount = minInt64(deviceAvailableMemory(item.device), remaining)
-			}
+		case isWholeCardMode(req.Mode, item.device.SupportType):
+			// Exclusive / TimeSlice hand the pod the whole card and
+			// buildAllocation records Memory=0, so every selected card must
+			// produce its own binding. These must never be gated on the
+			// shared `remaining` VRAM budget: once an earlier card covered
+			// the RequiredGPU target the budget reaches zero and the rest of
+			// a multi-card selection would be silently dropped, leaving only
+			// a single HAMI binding for a two-card request.
+			amount = deviceAvailableMemory(item.device)
+		case len(resolved) > 1:
+			amount = minInt64(deviceAvailableMemory(item.device), remaining)
 		}
 		if amount <= 0 {
 			continue

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -195,6 +195,99 @@ func TestValidateBindingSelectionTopologyAndMemorySlice(t *testing.T) {
 	}
 }
 
+// TestAllocationsFromResolvedSelectionMultiCardWholeCard is a regression test
+// for the multi-card binding bug: when the frontend submitted two whole-card
+// (Exclusive / TimeSlice) selections, allocationsFromResolvedSelection folded
+// them into a single RequiredGPU budget and dropped every card past the one
+// that first covered the budget, so only one HAMI GPUBinding was created for a
+// two-card request. Every selected whole card must yield its own allocation.
+func TestAllocationsFromResolvedSelectionMultiCardWholeCard(t *testing.T) {
+	cases := []struct {
+		name        string
+		supportType string
+	}{
+		{name: "exclusive", supportType: SupportTypeExclusive},
+		{name: "timeslice", supportType: SupportTypeTimeSlice},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &appcfg.ApplicationConfig{AppName: "trainer", OwnerName: "alice"}
+			req := Requirement{
+				Mode:              utils.NvidiaCardType,
+				RequiredGPU:       12 * gi,
+				LimitedGPU:        12 * gi,
+				SupportMultiCards: true,
+			}
+			nodes := []Node{
+				nvidiaNode("nvidia-a",
+					Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: tc.supportType},
+					Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: tc.supportType},
+				),
+			}
+			resolved, err := resolveSelection([]BindingSelection{
+				{NodeName: "nvidia-a", DeviceID: "gpu0"},
+				{NodeName: "nvidia-a", DeviceID: "gpu1"},
+			}, nodes)
+			if err != nil {
+				t.Fatalf("resolveSelection failed: %v", err)
+			}
+			allocations := allocationsFromResolvedSelection(app, req, resolved)
+			if len(allocations) != 2 {
+				t.Fatalf("expected one allocation per selected card, got %d: %#v", len(allocations), allocations)
+			}
+			devices := map[string]struct{}{}
+			for _, a := range allocations {
+				devices[a.DeviceID] = struct{}{}
+				if a.Memory != 0 {
+					t.Fatalf("whole-card allocation should record Memory=0, got %#v", a)
+				}
+				if a.AppName != "trainer" || a.Owner != "alice" || a.NodeName != "nvidia-a" {
+					t.Fatalf("unexpected allocation identity: %#v", a)
+				}
+			}
+			for _, id := range []string{"gpu0", "gpu1"} {
+				if _, ok := devices[id]; !ok {
+					t.Fatalf("expected an allocation for %s, got %#v", id, allocations)
+				}
+			}
+		})
+	}
+}
+
+// TestAllocationsFromResolvedSelectionMultiCardMemorySlice pins the unchanged
+// memory-slice path: each selected card keeps its own explicit slice amount.
+func TestAllocationsFromResolvedSelectionMultiCardMemorySlice(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "trainer", OwnerName: "alice"}
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       12 * gi,
+		LimitedGPU:        12 * gi,
+		SupportMultiCards: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice},
+		),
+	}
+	resolved, err := resolveSelection([]BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0", Memory: 6 * gi},
+		{NodeName: "nvidia-a", DeviceID: "gpu1", Memory: 6 * gi},
+	}, nodes)
+	if err != nil {
+		t.Fatalf("resolveSelection failed: %v", err)
+	}
+	allocations := allocationsFromResolvedSelection(app, req, resolved)
+	if len(allocations) != 2 {
+		t.Fatalf("expected one allocation per memory-slice card, got %d: %#v", len(allocations), allocations)
+	}
+	for _, a := range allocations {
+		if a.Memory != 6*gi {
+			t.Fatalf("expected each memory-slice allocation to keep its 6Gi slice, got %#v", a)
+		}
+	}
+}
+
 func TestAvailabilityCrossNodeSumsRawAvailableDespitePerNodePressure(t *testing.T) {
 	req := Requirement{
 		Mode:              utils.NvidiaCardType,

--- a/framework/app-service/pkg/compute/notification.go
+++ b/framework/app-service/pkg/compute/notification.go
@@ -5,8 +5,7 @@ import (
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
-	"github.com/beclab/Olares/framework/app-service/pkg/utils"
-	"k8s.io/klog/v2"
+	appevent "github.com/beclab/Olares/framework/app-service/pkg/event"
 )
 
 const (
@@ -51,13 +50,5 @@ func PublishComputeInsufficientNotification(appConfig *appcfg.ApplicationConfig,
 			Timestamp: time.Now(),
 		},
 	}
-	nc, err := utils.NewNatsConn()
-	if err != nil {
-		klog.Warningf("failed to connect NATS for compute resource notification: %v", err)
-		return
-	}
-	defer nc.Close()
-	if err := utils.PublishEvent(nc, notificationSubject, data); err != nil {
-		klog.Warningf("failed to publish compute resource notification: %v", err)
-	}
+	appevent.PublishToQueue(notificationSubject, data)
 }

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -376,8 +376,7 @@ func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node 
 	// omits spec.memory and HAMI treats the pod as unrestricted. The
 	// scheduler's accounting (deviceAvailableMemory / remainingMemory)
 	// never reads Allocation.Memory for these modes, so this is safe.
-	if req.Mode == utils.NvidiaCardType &&
-		(device.SupportType == SupportTypeExclusive || device.SupportType == SupportTypeTimeSlice) {
+	if isWholeCardMode(req.Mode, device.SupportType) {
 		memory = 0
 	}
 	return Allocation{
@@ -389,6 +388,17 @@ func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node 
 		DeviceID: device.ID,
 		Memory:   memory,
 	}
+}
+
+// isWholeCardMode reports whether binding a pod to a device with this NVIDIA
+// support type grants it the entire card: Exclusive (solo binding) or
+// TimeSlice (full memory during the pod's slice). buildAllocation records
+// Memory=0 for these, and they are always one-binding-per-card, so allocation
+// distribution must emit a separate binding for every selected card instead of
+// folding several of them into a single shared VRAM budget.
+func isWholeCardMode(mode, supportType string) bool {
+	return mode == utils.NvidiaCardType &&
+		(supportType == SupportTypeExclusive || supportType == SupportTypeTimeSlice)
 }
 
 func supportTypeOrder(mode string) []string {

--- a/framework/app-service/pkg/event/event.go
+++ b/framework/app-service/pkg/event/event.go
@@ -214,6 +214,14 @@ func PublishAppEventToQueue(p utils.EventParams) {
 	})
 }
 
+// PublishToQueue enqueues an arbitrary message for asynchronous, retried
+// delivery to NATS. It reuses the single shared JetStream connection held
+// by AppEventQueue (see ensureNatsConnected) instead of dialing a new one,
+// so callers that previously opened their own connection should use this.
+func PublishToQueue(subject string, data interface{}) {
+	AppEventQueue.enqueue(&QueueEvent{Subject: subject, Data: data})
+}
+
 func PublishUserEventToQueue(topic, user, operator string) {
 	subject := "os.users"
 	data := UserEvent{

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -12,8 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gatewaytimeout "github.com/beclab/Olares/framework/app-service/pkg/gateway/timeout"
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 )
 
@@ -209,6 +212,15 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 		return "", fmt.Errorf("hostPatterns produced no usable hostnames: %v", srr.Spec.HostPatterns)
 	}
 
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	getErr := c.Get(ctx, types.NamespacedName{Namespace: srr.Namespace, Name: name}, current)
+	egConfigured := probeExternalSharedRouteTimeout(ctx, c, gw, srr, current)
+	effective, err := gatewaytimeout.EffectiveResponseTimeout(gatewaytimeout.DefaultTimeout(), nil, egConfigured)
+	if err != nil {
+		klog.Warningf("effective timeout fell back to %q for srr=%s/%s: %v", effective, srr.Namespace, srr.Name, err)
+	}
+
 	parentRef := map[string]any{
 		"group":     "gateway.networking.k8s.io",
 		"kind":      "Gateway",
@@ -246,6 +258,10 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	rule := map[string]any{
 		"matches":     matches,
 		"backendRefs": []any{backendRef},
+		"timeouts": map[string]any{
+			"backendRequest": effective,
+			"request":        effective,
+		},
 	}
 	desired := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "gateway.networking.k8s.io/v1",
@@ -266,17 +282,14 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	}}
 	setOwnerSRR(desired, srr)
 
-	current := &unstructured.Unstructured{}
-	current.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
-	err := c.Get(ctx, types.NamespacedName{Namespace: srr.Namespace, Name: name}, current)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(getErr):
 		if err := c.Create(ctx, desired); err != nil {
 			return "", err
 		}
 		return name, nil
-	case err != nil:
-		return "", err
+	case getErr != nil:
+		return "", getErr
 	}
 	if !reflect.DeepEqual(current.Object["spec"], desired.Object["spec"]) {
 		current.Object["spec"] = desired.Object["spec"]
@@ -292,6 +305,121 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 		}
 	}
 	return name, nil
+}
+
+func probeExternalSharedRouteTimeout(ctx context.Context, c client.Client, gw GatewayRef, srr *srrv1alpha1.SharedRouteRegistry, current *unstructured.Unstructured) time.Duration {
+	_ = gw
+	var floor time.Duration
+
+	if current != nil {
+		labels := current.GetLabels()
+		if labels[ManagedByLabel] != ManagedByValue {
+			probed, err := extractRouteTimeoutFloor(current)
+			if err != nil {
+				klog.Warningf("probe current route timeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+				return 0
+			}
+			if probed > floor {
+				floor = probed
+			}
+		}
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicyList"})
+	if err := c.List(ctx, list, client.InNamespace(srr.Namespace)); err != nil {
+		klog.Warningf("list BackendTrafficPolicy failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+		return 0
+	}
+
+	for i := range list.Items {
+		item := &list.Items[i]
+		group, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "group")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.group failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		kind, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "kind")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.kind failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		name, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "name")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.name failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if group != "gateway.networking.k8s.io" || kind != "HTTPRoute" || name != httpRouteName(srr) {
+			continue
+		}
+		raw, found, err := unstructured.NestedString(item.Object, "spec", "timeout", "http", "requestTimeout")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy requestTimeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if !found || raw == "" {
+			continue
+		}
+			d, err := gatewaytimeout.ParseSeconds(raw)
+		if err != nil {
+			klog.Warningf("parse BackendTrafficPolicy requestTimeout=%q failed for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
+			klog.Warningf("invalid BackendTrafficPolicy requestTimeout=%q for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if d > floor {
+			floor = d
+		}
+	}
+	return floor
+}
+
+func extractRouteTimeoutFloor(route *unstructured.Unstructured) (time.Duration, error) {
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, nil
+	}
+	var floor time.Duration
+	for _, rawRule := range rules {
+		ruleMap, ok := rawRule.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("rule has unexpected type %T", rawRule)
+		}
+		timeoutsRaw, ok := ruleMap["timeouts"]
+		if !ok || timeoutsRaw == nil {
+			continue
+		}
+		timeoutsMap, ok := timeoutsRaw.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("timeouts has unexpected type %T", timeoutsRaw)
+		}
+		for _, key := range []string{"backendRequest", "request"} {
+			val, ok := timeoutsMap[key]
+			if !ok || val == nil {
+				continue
+			}
+			timeoutStr, ok := val.(string)
+			if !ok {
+				return 0, fmt.Errorf("timeouts.%s has unexpected type %T", key, val)
+			}
+			d, err := gatewaytimeout.ParseSeconds(timeoutStr)
+			if err != nil {
+				return 0, fmt.Errorf("parse timeouts.%s=%q: %w", key, timeoutStr, err)
+			}
+			if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
+				return 0, fmt.Errorf("invalid timeouts.%s=%q: %w", key, timeoutStr, err)
+			}
+			if d > floor {
+				floor = d
+			}
+		}
+	}
+	return floor, nil
 }
 
 func deleteHTTPRoute(ctx context.Context, c client.Client, srr *srrv1alpha1.SharedRouteRegistry) error {

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
@@ -2,6 +2,7 @@ package routecontrol
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +70,23 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	gw := schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1"}
 	s.AddKnownTypeWithName(gw.WithKind("HTTPRoute"), &unstructured.Unstructured{})
 	s.AddKnownTypeWithName(gw.WithKind("HTTPRouteList"), &unstructured.UnstructuredList{})
+	eg := schema.GroupVersion{Group: "gateway.envoyproxy.io", Version: "v1alpha1"}
+	s.AddKnownTypeWithName(eg.WithKind("BackendTrafficPolicy"), &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(eg.WithKind("BackendTrafficPolicyList"), &unstructured.UnstructuredList{})
 	return s
+}
+
+func mustHTTPRouteFirstRule(t *testing.T, route *unstructured.Unstructured) map[string]any {
+	t.Helper()
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil || !found || len(rules) == 0 {
+		t.Fatalf("spec.rules missing: found=%v err=%v", found, err)
+	}
+	rule, ok := rules[0].(map[string]any)
+	if !ok {
+		t.Fatalf("rules[0] type=%T, want map[string]any", rules[0])
+	}
+	return rule
 }
 
 func TestResolveServicePort(t *testing.T) {
@@ -378,5 +395,194 @@ func TestReconcileSharedRouteDirectMode(t *testing.T) {
 	}
 	if res.Status != metav1.ConditionTrue || res.Reason != ReasonDirectMode {
 		t.Fatalf("direct result = %+v", res)
+	}
+}
+
+func TestApplyHTTPRouteMaterializesTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-timeout", Namespace: "demo-shared", UID: "uid-timeout"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"timeout.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-timeout"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+
+	rule := mustHTTPRouteFirstRule(t, route)
+	timeouts, ok := rule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", rule["timeouts"])
+	}
+	if got := timeouts["backendRequest"]; got != "600s" {
+		t.Fatalf("timeouts.backendRequest=%v, want 600s", got)
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
+	}
+}
+
+func TestApplyHTTPRouteProbeFailureStillWritesTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-probe-fail", Namespace: "demo-shared", UID: "uid-probe-fail"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"probe-fail.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-demo-probe-fail",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"timeouts": map[string]any{
+						"request": int64(12345), // malformed on purpose: triggers probe failure
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-probe-fail"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	rule := mustHTTPRouteFirstRule(t, route)
+	timeouts, ok := rule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", rule["timeouts"])
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
+	}
+}
+
+func TestApplyHTTPRouteDiffOnlyTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-diff-timeout", Namespace: "demo-shared", UID: "uid-diff-timeout"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"diff-timeout.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-demo-diff-timeout",
+			"namespace": "demo-shared",
+			"labels": map[string]any{
+				ManagedByLabel: ManagedByValue,
+				InstanceLabel:  "shared-demo-diff-timeout",
+			},
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"diff-timeout.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	before := &unstructured.Unstructured{}
+	before.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-diff-timeout"}, before); err != nil {
+		t.Fatalf("get before route: %v", err)
+	}
+	beforeRule := mustHTTPRouteFirstRule(t, before)
+	beforeMatches := beforeRule["matches"]
+	beforeBackendRefs := beforeRule["backendRefs"]
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	after := &unstructured.Unstructured{}
+	after.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-diff-timeout"}, after); err != nil {
+		t.Fatalf("get after route: %v", err)
+	}
+	afterRule := mustHTTPRouteFirstRule(t, after)
+	if !reflect.DeepEqual(beforeMatches, afterRule["matches"]) {
+		t.Fatalf("matches changed after timeout materialization")
+	}
+	if !reflect.DeepEqual(beforeBackendRefs, afterRule["backendRefs"]) {
+		t.Fatalf("backendRefs changed after timeout materialization")
+	}
+	timeouts, ok := afterRule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", afterRule["timeouts"])
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
 	}
 }

--- a/framework/app-service/pkg/gateway/timeout/timeout.go
+++ b/framework/app-service/pkg/gateway/timeout/timeout.go
@@ -1,0 +1,123 @@
+package timeout
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultSharedBackendResponseTimeout = 10 * time.Minute
+	MinResponseTimeout                  = DefaultSharedBackendResponseTimeout
+	MaxResponseTimeout                  = 24 * time.Hour
+	EnvDefaultResponseTimeout           = "SHARED_BACKEND_RESPONSE_TIMEOUT"
+	defaultTimeoutGatewayString         = "600s"
+)
+
+var configSecondsPattern = regexp.MustCompile(`^(\d+)s?$`)
+
+// ParseSeconds parses a duration configured in whole seconds (e.g. "600" or "600s").
+func ParseSeconds(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	if strings.ContainsAny(s, "hm") || strings.HasSuffix(s, "ms") {
+		return 0, fmt.Errorf("duration must use seconds only (e.g. 600 or 600s)")
+	}
+	m := configSecondsPattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("duration must be a whole number of seconds (e.g. 600 or 600s)")
+	}
+	secs, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse seconds: %w", err)
+	}
+	return time.Duration(secs) * time.Second, nil
+}
+
+// FormatSeconds formats a duration as a Gateway API seconds string (e.g. "600s").
+func FormatSeconds(d time.Duration) (string, error) {
+	if d <= 0 {
+		return "", fmt.Errorf("duration must be positive")
+	}
+	if d%time.Second != 0 {
+		return "", fmt.Errorf("duration must be a whole number of seconds: %s", d)
+	}
+	return fmt.Sprintf("%ds", d/time.Second), nil
+}
+
+// ClampResponseTimeout raises values below the platform default to 600s.
+func ClampResponseTimeout(d time.Duration) time.Duration {
+	if d < DefaultSharedBackendResponseTimeout {
+		return DefaultSharedBackendResponseTimeout
+	}
+	return d
+}
+
+func DefaultTimeout() time.Duration {
+	v := strings.TrimSpace(os.Getenv(EnvDefaultResponseTimeout))
+	if v == "" {
+		return DefaultSharedBackendResponseTimeout
+	}
+	d, err := ParseSeconds(v)
+	if err != nil {
+		klog.Warningf("invalid %s=%q, using default %s: %v", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, err)
+		return DefaultSharedBackendResponseTimeout
+	}
+	if err := ValidateResponseTimeout(d); err != nil {
+		klog.Warningf("invalid %s=%q, using default %s: %v", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, err)
+		return DefaultSharedBackendResponseTimeout
+	}
+	if clamped := ClampResponseTimeout(d); clamped != d {
+		klog.Warningf("%s=%q below minimum %s, using %s", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, defaultTimeoutGatewayString)
+		return clamped
+	}
+	return d
+}
+
+func EffectiveResponseTimeout(defaultTimeout time.Duration, manifest *metav1.Duration, egConfigured time.Duration) (string, error) {
+	if err := ValidateResponseTimeout(defaultTimeout); err != nil {
+		return defaultTimeoutGatewayString, fmt.Errorf("invalid default timeout: %w", err)
+	}
+	effective := defaultTimeout
+
+	for _, candidate := range []time.Duration{candidateDuration(manifest), egConfigured} {
+		if candidate <= 0 {
+			continue
+		}
+		if err := ValidateResponseTimeout(candidate); err != nil {
+			return defaultTimeoutGatewayString, fmt.Errorf("invalid timeout %s: %w", candidate, err)
+		}
+		if candidate > effective {
+			effective = candidate
+		}
+	}
+
+	effective = ClampResponseTimeout(effective)
+	formatted, err := FormatSeconds(effective)
+	if err != nil {
+		return defaultTimeoutGatewayString, fmt.Errorf("format effective timeout: %w", err)
+	}
+	return formatted, nil
+}
+
+func ValidateResponseTimeout(d time.Duration) error {
+	if d > MaxResponseTimeout {
+		return fmt.Errorf("timeout %s exceeds max %s", d, MaxResponseTimeout)
+	}
+	return nil
+}
+
+func candidateDuration(manifest *metav1.Duration) time.Duration {
+	if manifest == nil {
+		return 0
+	}
+	return manifest.Duration
+}

--- a/framework/app-service/pkg/gateway/timeout/timeout_test.go
+++ b/framework/app-service/pkg/gateway/timeout/timeout_test.go
@@ -1,0 +1,194 @@
+package timeout
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseSeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "plain seconds", in: "600", want: 10 * time.Minute},
+		{name: "seconds suffix", in: "600s", want: 10 * time.Minute},
+		{name: "minutes rejected", in: "10m", wantErr: true},
+		{name: "millis rejected", in: "500ms", wantErr: true},
+		{name: "invalid", in: "bad", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSeconds(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSeconds(%q) err=nil, want error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSeconds(%q) err=%v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseSeconds(%q)=%s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClampResponseTimeout(t *testing.T) {
+	if got := ClampResponseTimeout(31 * time.Second); got != DefaultSharedBackendResponseTimeout {
+		t.Fatalf("ClampResponseTimeout(31s)=%s, want %s", got, DefaultSharedBackendResponseTimeout)
+	}
+	if got := ClampResponseTimeout(12 * time.Minute); got != 12*time.Minute {
+		t.Fatalf("ClampResponseTimeout(12m)=%s, want 12m", got)
+	}
+}
+
+func TestDefaultTimeout(t *testing.T) {
+	t.Run("use env value when valid", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "720")
+		got := DefaultTimeout()
+		if got != 12*time.Minute {
+			t.Fatalf("DefaultTimeout() = %s, want 12m", got)
+		}
+	})
+
+	t.Run("use env value with s suffix", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "720s")
+		got := DefaultTimeout()
+		if got != 12*time.Minute {
+			t.Fatalf("DefaultTimeout() = %s, want 12m", got)
+		}
+	})
+
+	t.Run("fallback when env is empty", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("clamp when env below minimum", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "31")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("fallback when env uses minutes", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "12m")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("fallback when env is invalid", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "bad-value")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("clamp when env is ten seconds", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "10")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+}
+
+func TestEffectiveResponseTimeout(t *testing.T) {
+	t.Run("max compose default manifest eg", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(10*time.Minute, &metav1.Duration{Duration: 20 * time.Minute}, 30*time.Minute)
+		if err != nil {
+			t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+		}
+		if got != "1800s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 1800s", got)
+		}
+	})
+
+	t.Run("clamp below minimum", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(45*time.Second, nil, 0)
+		if err != nil {
+			t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+		}
+		if got != "600s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 600s", got)
+		}
+	})
+
+	t.Run("above max still returns safe default", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(MaxResponseTimeout+time.Second, nil, 0)
+		if err == nil {
+			t.Fatal("EffectiveResponseTimeout() err = nil, want error")
+		}
+		if got != "600s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 600s", got)
+		}
+	})
+}
+
+var gatewaySecondsPattern = regexp.MustCompile(`^\d+s$`)
+
+func TestEffectiveTimeoutSecondsFormat(t *testing.T) {
+	cases := []struct {
+		name       string
+		def        time.Duration
+		manifest   *metav1.Duration
+		eg         time.Duration
+		wantResult string
+	}{
+		{name: "below minimum clamped", def: 30 * time.Second, wantResult: "600s"},
+		{name: "ten minutes", def: 10 * time.Minute, wantResult: "600s"},
+		{name: "twelve minutes", def: 12 * time.Minute, wantResult: "720s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := EffectiveResponseTimeout(tc.def, tc.manifest, tc.eg)
+			if err != nil {
+				t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+			}
+			if got != tc.wantResult {
+				t.Fatalf("EffectiveResponseTimeout() = %q, want %q", got, tc.wantResult)
+			}
+			if !gatewaySecondsPattern.MatchString(got) {
+				t.Fatalf("result %q does not match seconds pattern", got)
+			}
+		})
+	}
+}
+
+func TestValidateResponseTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		d       time.Duration
+		wantErr bool
+	}{
+		{name: "min platform default", d: MinResponseTimeout, wantErr: false},
+		{name: "below platform default allowed", d: 31 * time.Second, wantErr: false},
+		{name: "max boundary", d: MaxResponseTimeout, wantErr: false},
+		{name: "above max", d: MaxResponseTimeout + time.Second, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateResponseTimeout(tc.d)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateResponseTimeout(%s) err=nil, want error", tc.d)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateResponseTimeout(%s) err=%v, want nil", tc.d, err)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/images/jobs.go
+++ b/framework/app-service/pkg/images/jobs.go
@@ -234,11 +234,7 @@ outer:
 				return
 			}
 		case <-ctx.Done():
-			// On cancellation just exit; do NOT loop once more with done=true,
-			// which would force every status to "done"/"exists" and report
-			// progress=100%, racing against the canceled state update.
-			klog.Infof("show progress canceled name=%s err=%v", ongoing.name, ctx.Err())
-			return
+			done = true // allow ui to update once more
 		}
 	}
 }

--- a/framework/app-service/pkg/utils/nats.go
+++ b/framework/app-service/pkg/utils/nats.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,8 +10,11 @@ import (
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"k8s.io/klog/v2"
 )
+
+const natsPublishTimeout = 10 * time.Second
 
 type Event struct {
 	EventID          string                    `json:"eventID"`
@@ -76,7 +80,14 @@ func publish(nc *nats.Conn, subject string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = nc.Publish(subject, d)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		klog.Infof("jetstream init err=%v", err)
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), natsPublishTimeout)
+	defer cancel()
+	_, err = js.Publish(ctx, subject, d)
 	if err != nil {
 		klog.Infof("publish err=%v", err)
 		return err


### PR DESCRIPTION
## Summary
- **Fix multi-card GPU binding.** When the frontend submitted multiple whole-card (Exclusive / TimeSlice) selections, `allocationsFromResolvedSelection` folded them into a single `RequiredGPU` budget (`remaining`). Once an earlier card covered the target, the budget hit zero and every remaining selected card was silently dropped (`amount <= 0` → `continue`), so only **one** HAMI `GPUBinding` was created for a two-card request. Each selected whole card now yields its own allocation/binding. The memory-slice path (explicit per-card `Memory`) is unchanged.
- Add an `isWholeCardMode` helper and reuse it in `buildAllocation` so the two whole-card checks stay in lockstep.
- Stamp the `sys.bytetrade.io/env-type` label on typed user envs (e.g. `OLARES_USER_LANGUAGE` → `language`) during create/sync, so downstream consumers (e.g. l4-bfl-proxy) can select them by type.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/compute/`
- [x] `go test ./pkg/compute/` — incl. new `TestAllocationsFromResolvedSelectionMultiCardWholeCard` (Exclusive + TimeSlice) and `TestAllocationsFromResolvedSelectionMultiCardMemorySlice`
- [ ] Manual: resume a multi-card NVIDIA app with two Exclusive cards selected; verify two `GPUBinding` objects are created

Made with [Cursor](https://cursor.com)