### PR TITLE
refactor(authelia): authorization logic for shared applications and fix xff

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.54
+        image: beclab/auth:0.2.55
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION


* **Background**
refactor(authelia): authorization logic for shared applications and fix xff
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/56

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the identity/auth service image with no config diff here; authorization and proxy-header behavior changes live in the new binary and warrant regression on login and protected apps.
> 
> **Overview**
> Rolls out **`beclab/auth:0.2.55`** for the Authelia backend by updating the container image in `auth_backend_deploy.yaml` from `0.2.54`. No Helm values, config maps, or deployment structure change—only the image tag.
> 
> That image is expected to carry the upstream auth work (shared-application authorization refactor and X-Forwarded-For handling) referenced in the related Authelia PR; this repo change is the platform deploy pin to pick up that release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a81cce339f09c0f150d53f06291c526014a5ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->