### PR TITLE
fix(l4): ext-authz allow header x-forwarded-for

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.27"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.28"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.26"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.27"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.27
+          value: v0.3.28
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.26
+          value: v0.3.27
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.27
+      name: beclab/l4-bfl-proxy:v0.3.28
 # must have blank new line            

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.26
+      name: beclab/l4-bfl-proxy:v0.3.27
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -296,6 +296,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -495,6 +498,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -323,6 +323,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -522,6 +525,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -512,6 +512,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -691,6 +694,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -890,6 +896,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -1069,6 +1078,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -647,6 +647,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -826,6 +829,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -1005,6 +1011,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -1204,6 +1213,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -1383,6 +1395,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -1562,6 +1577,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -350,6 +350,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -549,6 +552,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -350,6 +350,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }
@@ -549,6 +552,9 @@
                           },
                           {
                             "exact": "x-authorization"
+                          },
+                          {
+                            "exact": "x-forwarded-for"
                           }
                         ]
                       }

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -24,6 +24,8 @@ const (
 	settingsCustomDomain                 = "customDomain"
 	settingsCustomDomainThirdLevelDomain = "third_level_domain"
 	settingsCustomDomainThirdPartyDomain = "third_party_domain"
+	settingsCustomDomainCert             = "cert"
+	settingsCustomDomainKey              = "key"
 )
 
 var nodeLocationPrefixes = []string{
@@ -221,7 +223,7 @@ func (t *Translator) Translate(resources *message.Resources) *ir.Xds {
 			CertData: user.SSL.CertData,
 			KeyData:  user.SSL.KeyData,
 		})
-		for _, cert := range user.CustomDomainCerts {
+		for _, cert := range t.collectCustomDomainCerts(user) {
 			xds.Secrets = append(xds.Secrets, &ir.SecretIR{
 				Name:     fmt.Sprintf("custom-tls-%s-%s", user.Name, cert.Domain),
 				CertData: cert.CertData,
@@ -317,6 +319,58 @@ func (t *Translator) applyDenyAllRestrictions(user *message.UserInfo, vhosts []*
 	}
 }
 
+// collectCustomDomainCerts gathers the TLS certs that need their own filter
+// chain for a user, from two distinct sources by domain type:
+//
+//   - Third-party domains: cert/key are carried inline in each app's
+//     "customDomain" setting, next to "third_party_domain" (this is what the
+//     app CR stores). This is the authoritative source for third-party domains.
+//   - Third-level domains: certs come from the dedicated cert ConfigMaps loaded
+//     by the provider into user.CustomDomainCerts (the original source).
+//
+// Settings (third-party) are collected first so they win on any domain
+// collision. Results are deduped by domain and sorted for deterministic output.
+// Only entries with a non-empty domain, cert and key are kept, so a
+// half-provisioned domain (cert not issued yet) is skipped rather than
+// producing a filter chain with no usable cert.
+func (t *Translator) collectCustomDomainCerts(user *message.UserInfo) []*message.CertInfo {
+	seen := make(map[string]bool)
+	var certs []*message.CertInfo
+
+	// Third-party domains → app.settings.customDomain (inline cert/key).
+	for _, app := range user.Apps {
+		customDomainMap := parseSettingsJSON(app.Settings, settingsCustomDomain)
+		for _, entranceCfg := range customDomainMap {
+			domain := entranceCfg[settingsCustomDomainThirdPartyDomain]
+			certData := entranceCfg[settingsCustomDomainCert]
+			keyData := entranceCfg[settingsCustomDomainKey]
+			if domain == "" || certData == "" || keyData == "" {
+				continue
+			}
+			if seen[domain] {
+				continue
+			}
+			seen[domain] = true
+			certs = append(certs, &message.CertInfo{Domain: domain, CertData: certData, KeyData: keyData})
+		}
+	}
+
+	// Third-level domains → original cert ConfigMap source.
+	for _, c := range user.CustomDomainCerts {
+		if c == nil || c.Domain == "" || c.CertData == "" || c.KeyData == "" {
+			continue
+		}
+		if seen[c.Domain] {
+			continue
+		}
+		seen[c.Domain] = true
+		certs = append(certs, c)
+	}
+
+	sort.Slice(certs, func(i, j int) bool { return certs[i].Domain < certs[j].Domain })
+	return certs
+}
+
 // buildUserFilterChains produces one or more HTTPListenerIR entries for a
 // single user on a given port, using pre-built virtual hosts.
 //
@@ -352,8 +406,9 @@ func (t *Translator) buildUserFilterChains(user *message.UserInfo, vhosts []*ir.
 		}
 	}
 
-	customDomainSet := make(map[string]bool, len(user.CustomDomainCerts))
-	for _, cert := range user.CustomDomainCerts {
+	customCerts := t.collectCustomDomainCerts(user)
+	customDomainSet := make(map[string]bool, len(customCerts))
+	for _, cert := range customCerts {
 		customDomainSet[cert.Domain] = true
 	}
 
@@ -386,7 +441,7 @@ func (t *Translator) buildUserFilterChains(user *message.UserInfo, vhosts []*ir.
 	}
 
 	// Custom domain filter chains (separate TLS certs, same virtual hosts)
-	for _, cert := range user.CustomDomainCerts {
+	for _, cert := range customCerts {
 		customTLS := &ir.SecretIR{
 			Name:     fmt.Sprintf("custom-tls-%s-%s", user.Name, cert.Domain),
 			CertData: cert.CertData,

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -90,6 +90,87 @@ func TestBuildUserFilterChains_NoDeny_WithCustomDomainCert(t *testing.T) {
 	assert.Equal(t, []string{"myapp.custom.io"}, custom.SNIMatches)
 }
 
+// The third-party-domain cert/key may be carried inline in the app's
+// "customDomain" setting (as the app CR stores it) instead of a dedicated cert
+// ConfigMap. A custom-cert filter chain with the matching SNI must still be
+// produced from that inline cert.
+func TestBuildUserFilterChains_CustomDomainCertFromSettings(t *testing.T) {
+	tr := &Translator{cfg: &Config{SSLServerPort: 443}}
+
+	user := &message.UserInfo{
+		Name:              "myxzxcvb",
+		Zone:              "myxzxcvb.olares.com",
+		Namespace:         "user-space-myxzxcvb",
+		ServerNameDomains: []string{"myxzxcvb.olares.com"},
+		SSL:               &message.SSLConfig{Zone: "myxzxcvb.olares.com", CertData: "cert", KeyData: "key"},
+		Apps: []*message.AppInfo{
+			{
+				Name:      "halo",
+				Appid:     "57f84228",
+				Namespace: "halo-myxzxcvb",
+				Owner:     "myxzxcvb",
+				Entrances: []*message.EntranceInfo{
+					{Name: "halo", Host: "halo-svc", Port: 8090},
+				},
+				Settings: map[string]string{
+					"customDomain": `{"halo":{"cert":"custom-cert","key":"custom-key","third_party_domain":"app-test-jingjie0615.bytetrade.com"}}`,
+				},
+			},
+		},
+	}
+
+	clusterSet := make(map[string]*ir.ClusterIR)
+	vhosts := tr.buildUserVirtualHosts(user, user.SSL.Zone, false, clusterSet)
+	tr.applyDenyAllRestrictions(user, vhosts, nil)
+	listeners := tr.buildUserFilterChains(user, vhosts, 443, false)
+
+	// One per-zone main chain + one custom-cert chain derived from settings.
+	require.Len(t, listeners, 2)
+
+	custom := listeners[1]
+	assert.Equal(t, []string{"app-test-jingjie0615.bytetrade.com"}, custom.SNIMatches)
+	require.NotNil(t, custom.TLSCert)
+	assert.Equal(t, "custom-cert", custom.TLSCert.CertData)
+	assert.Equal(t, "custom-key", custom.TLSCert.KeyData)
+
+	// The custom domain must NOT leak into the zone chain's SNI list.
+	assert.NotContains(t, listeners[0].SNIMatches, "app-test-jingjie0615.bytetrade.com")
+}
+
+// A third-party domain whose cert/key has not been issued yet (empty in
+// settings) must be skipped so we don't emit a filter chain with no cert.
+func TestBuildUserFilterChains_CustomDomainCertFromSettings_NotReady(t *testing.T) {
+	tr := &Translator{cfg: &Config{SSLServerPort: 443}}
+
+	user := &message.UserInfo{
+		Name:              "myxzxcvb",
+		Zone:              "myxzxcvb.olares.com",
+		Namespace:         "user-space-myxzxcvb",
+		ServerNameDomains: []string{"myxzxcvb.olares.com"},
+		SSL:               &message.SSLConfig{Zone: "myxzxcvb.olares.com", CertData: "cert", KeyData: "key"},
+		Apps: []*message.AppInfo{
+			{
+				Name:      "halo",
+				Namespace: "halo-myxzxcvb",
+				Owner:     "myxzxcvb",
+				Entrances: []*message.EntranceInfo{
+					{Name: "halo", Host: "halo-svc", Port: 8090},
+				},
+				Settings: map[string]string{
+					"customDomain": `{"halo":{"cert":"","key":"","third_party_domain":"app-test-jingjie0615.bytetrade.com"}}`,
+				},
+			},
+		},
+	}
+
+	clusterSet := make(map[string]*ir.ClusterIR)
+	vhosts := tr.buildUserVirtualHosts(user, user.SSL.Zone, false, clusterSet)
+	listeners := tr.buildUserFilterChains(user, vhosts, 443, false)
+
+	// Only the zone chain — no custom chain because the cert isn't ready.
+	require.Len(t, listeners, 1)
+}
+
 func TestBuildUserFilterChains_NoDeny(t *testing.T) {
 	tr := &Translator{cfg: &Config{SSLServerPort: 443}}
 

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -846,6 +846,7 @@ func buildExtAuthzFilter(autheliaClusterName string, clusterMap map[string]*ir.C
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "accept"}},
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "cookie"}},
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "x-authorization"}},
+				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "x-forwarded-for"}},
 			},
 		},
 		TransportApiVersion: corev3.ApiVersion_V3,


### PR DESCRIPTION


* **Background**
ext-authz allow header x-forwarded-for
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches edge authentication (ext-authz header allowlist) and TLS/SNI for custom domains on the user ingress path; misconfiguration could break authz or third-party domain HTTPS until certs are ready.
> 
> **Overview**
> Ships **l4-bfl-proxy v0.3.28** by updating the upgrade task, BFL `L4_PROXY_IMAGE_VERSION`, and Olares prebuilt image metadata from **v0.3.26**.
> 
> The Envoy **ext_authz** filter now includes **`x-forwarded-for`** in `allowedHeaders` so Authelia can see client IP through the L4 proxy; e2e golden JSON is updated to match.
> 
> **Custom-domain TLS** no longer relies only on `user.CustomDomainCerts`. New **`collectCustomDomainCerts`** merges third-party domains from app `customDomain` settings (inline `cert`/`key` with `third_party_domain`) with third-level domains from ConfigMaps, dedupes by domain (settings win), skips incomplete certs, and uses the result for SDS secrets and per-domain SNI filter chains. Unit tests cover ready and not-ready inline cert cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a999b2877b722c3a70548e39c83d9bc460cc99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->