### PR TITLE
tapr: change container image repo

### DIFF
--- a/platform/tapr/.olares/Olares.yaml
+++ b/platform/tapr/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: bytetrade/envoy:v1.25.11.1
+      name: beclab/envoy:v1.25.11.1
 
 
       


### PR DESCRIPTION
* **Background**
Change container image repo to beclab

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry path change in a build/manifest file; low risk if `beclab/envoy:v1.25.11.1` is published and equivalent to the prior image.
> 
> **Overview**
> Updates the **tapr** Olares prebuilt manifest so the Envoy sidecar image is pulled from **`beclab/envoy:v1.25.11.1`** instead of **`bytetrade/envoy:v1.25.11.1`**, matching the org-wide container repo move described in the PR.
> 
> No tag or other manifest fields change—only the image repository name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fd82d86ddb02e067a91a180585322a26baf28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->