### PR TITLE
chore: update ignored images and bump alpine version to 3.18

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -314,7 +314,7 @@ spec:
        
       containers:
         - name: olares-envoy-sidecar
-          image: bytetrade/envoy:v1.25.11
+          image: beclab/envoy:v1.25.11.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/build/image-manifest.sh
+++ b/build/image-manifest.sh
@@ -33,11 +33,12 @@ for mod in "${PACKAGE_MODULE[@]}";do
                 bash ${BASE_DIR}/yaml2prop.sh -f $p | while read l;do 
                     if [[ "$l" == *".image = "* || "$l" == "output.containers."*".name"* ]]; then 
                         echo "$l"
-                        if [[ $(echo "$l" | awk '{print $3}') == "value" ]]; then
+                        img=$(echo "$l" | awk '{print $3}')
+                        if [[ "$img" == "value" ]]; then
                             echo "ignoring template value"
                             continue
                         fi
-                        $img=$(echo "$l" | awk '{print $3}')
+                        
                         if contains_element "$img" "${IGNORE_IMAGES[@]}"; then
                             echo "ignoring image in ignore list: $img"
                             continue

--- a/build/image-manifest.sh
+++ b/build/image-manifest.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 
-
+contains_element() {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
 
 BASE_DIR=$(dirname $(realpath -s $0))
 
 PACKAGE_MODULE=("apps" "framework" "daemon" "infrastructure" "platform" "vendor")
 IMAGE_MANIFEST="$BASE_DIR/../.manifest/images.mf"
+
+IGNORE_IMAGES=(
+    "ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.23.0"
+    "bytetrade/autoinstrumentation-apache-httpd:1.0.4-fix3"
+    "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.53.0"
+    "jaegertracing/jaeger:2.3.0"
+)
 
 rm -rf $BASE_DIR/../.manifest
 mkdir -p $BASE_DIR/../.manifest
@@ -25,6 +37,10 @@ for mod in "${PACKAGE_MODULE[@]}";do
                             echo "ignoring template value"
                             continue
                         fi
+                        if contains_element "$l" "${IGNORE_IMAGES[@]}"; then
+                            echo "ignoring image in ignore list: $l"
+                            continue
+                        fi  
                         echo "$l" >> ${TMP_MANIFEST}
                     fi;
                 done

--- a/build/image-manifest.sh
+++ b/build/image-manifest.sh
@@ -37,8 +37,9 @@ for mod in "${PACKAGE_MODULE[@]}";do
                             echo "ignoring template value"
                             continue
                         fi
-                        if contains_element "$l" "${IGNORE_IMAGES[@]}"; then
-                            echo "ignoring image in ignore list: $l"
+                        $img=$(echo "$l" | awk '{print $3}')
+                        if contains_element "$img" "${IGNORE_IMAGES[@]}"; then
+                            echo "ignoring image in ignore list: $img"
                             continue
                         fi  
                         echo "$l" >> ${TMP_MANIFEST}

--- a/cli/pkg/kubesphere/plugins/files/build/ks-config/templates/kubesphere-config.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/ks-config/templates/kubesphere-config.yaml
@@ -11,5 +11,5 @@ data:
     notification:
       endpoint: http://notification-manager-svc.kubesphere-monitoring-system.svc:19093
     terminal:
-      image: beclab/alpine:3.14
+      image: beclab/alpine:3.18
       timeout: 7200

--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/systemserver_deploy.yaml
@@ -98,7 +98,7 @@ spec:
         - name: OWNER
           value: "{{ .Values.bfl.username }}"
       - name: proxy
-        image: bytetrade/envoy:v1.25.11
+        image: beclab/envoy:v1.25.11.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/infrastructure/kubernetes/.olares/Olares.yaml
+++ b/infrastructure/kubernetes/.olares/Olares.yaml
@@ -23,7 +23,7 @@ output:
     -
       name: liangjw/kube-webhook-certgen:v1.1.1
     - 
-      name: beclab/alpine:3.14
+      name: beclab/alpine:3.18
     -
       name: beclab/kube-rbac-proxy:0.19.0
     - 


### PR DESCRIPTION
* **Background**
update ignored images and bump alpine version to 3.18

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine image tag bumps and manifest tooling; no application logic changes, though clusters must pull the new beclab images on rollout.
> 
> **Overview**
> Updates container pins across Helm and platform manifests: **Envoy** sidecars move from `bytetrade/envoy:v1.25.11` to **`beclab/envoy:v1.25.11.1`** on olares-app and system-server proxy deployments.
> 
> **KubeSphere terminal** and the **Olares prebuilt** container list bump **`beclab/alpine`** from **3.14** to **3.18**.
> 
> **`build/image-manifest.sh`** gains an **`IGNORE_IMAGES`** list (OpenTelemetry autoinstrumentation images, Apache httpd instrumentation, Jaeger) so those references are skipped when generating `.manifest/images.mf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4180deac2108237cf91fa34f757dba9328f71ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->