### PR TITLE
feat(app-service): materialize Shared HTTPRoute timeouts

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -215,6 +215,8 @@ spec:
           value: "0"
         - name: USER_MEMORY_THRESHOLD
           value: "0"
+        - name: SHARED_BACKEND_RESPONSE_TIMEOUT
+          value: "600s"
         - name: NATS_HOST
           value: nats.os-platform
         - name: NATS_PORT

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -12,8 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gatewaytimeout "github.com/beclab/Olares/framework/app-service/pkg/gateway/timeout"
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 )
 
@@ -209,6 +212,15 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 		return "", fmt.Errorf("hostPatterns produced no usable hostnames: %v", srr.Spec.HostPatterns)
 	}
 
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	getErr := c.Get(ctx, types.NamespacedName{Namespace: srr.Namespace, Name: name}, current)
+	egConfigured := probeExternalSharedRouteTimeout(ctx, c, gw, srr, current)
+	effective, err := gatewaytimeout.EffectiveResponseTimeout(gatewaytimeout.DefaultTimeout(), nil, egConfigured)
+	if err != nil {
+		klog.Warningf("effective timeout fell back to %q for srr=%s/%s: %v", effective, srr.Namespace, srr.Name, err)
+	}
+
 	parentRef := map[string]any{
 		"group":     "gateway.networking.k8s.io",
 		"kind":      "Gateway",
@@ -246,6 +258,10 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	rule := map[string]any{
 		"matches":     matches,
 		"backendRefs": []any{backendRef},
+		"timeouts": map[string]any{
+			"backendRequest": effective,
+			"request":        effective,
+		},
 	}
 	desired := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "gateway.networking.k8s.io/v1",
@@ -266,17 +282,14 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	}}
 	setOwnerSRR(desired, srr)
 
-	current := &unstructured.Unstructured{}
-	current.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
-	err := c.Get(ctx, types.NamespacedName{Namespace: srr.Namespace, Name: name}, current)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(getErr):
 		if err := c.Create(ctx, desired); err != nil {
 			return "", err
 		}
 		return name, nil
-	case err != nil:
-		return "", err
+	case getErr != nil:
+		return "", getErr
 	}
 	if !reflect.DeepEqual(current.Object["spec"], desired.Object["spec"]) {
 		current.Object["spec"] = desired.Object["spec"]
@@ -292,6 +305,121 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 		}
 	}
 	return name, nil
+}
+
+func probeExternalSharedRouteTimeout(ctx context.Context, c client.Client, gw GatewayRef, srr *srrv1alpha1.SharedRouteRegistry, current *unstructured.Unstructured) time.Duration {
+	_ = gw
+	var floor time.Duration
+
+	if current != nil {
+		labels := current.GetLabels()
+		if labels[ManagedByLabel] != ManagedByValue {
+			probed, err := extractRouteTimeoutFloor(current)
+			if err != nil {
+				klog.Warningf("probe current route timeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+				return 0
+			}
+			if probed > floor {
+				floor = probed
+			}
+		}
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicyList"})
+	if err := c.List(ctx, list, client.InNamespace(srr.Namespace)); err != nil {
+		klog.Warningf("list BackendTrafficPolicy failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+		return 0
+	}
+
+	for i := range list.Items {
+		item := &list.Items[i]
+		group, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "group")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.group failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		kind, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "kind")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.kind failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		name, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "name")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy targetRef.name failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if group != "gateway.networking.k8s.io" || kind != "HTTPRoute" || name != httpRouteName(srr) {
+			continue
+		}
+		raw, found, err := unstructured.NestedString(item.Object, "spec", "timeout", "http", "requestTimeout")
+		if err != nil {
+			klog.Warningf("read BackendTrafficPolicy requestTimeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if !found || raw == "" {
+			continue
+		}
+			d, err := gatewaytimeout.ParseSeconds(raw)
+		if err != nil {
+			klog.Warningf("parse BackendTrafficPolicy requestTimeout=%q failed for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
+			klog.Warningf("invalid BackendTrafficPolicy requestTimeout=%q for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
+			return 0
+		}
+		if d > floor {
+			floor = d
+		}
+	}
+	return floor
+}
+
+func extractRouteTimeoutFloor(route *unstructured.Unstructured) (time.Duration, error) {
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, nil
+	}
+	var floor time.Duration
+	for _, rawRule := range rules {
+		ruleMap, ok := rawRule.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("rule has unexpected type %T", rawRule)
+		}
+		timeoutsRaw, ok := ruleMap["timeouts"]
+		if !ok || timeoutsRaw == nil {
+			continue
+		}
+		timeoutsMap, ok := timeoutsRaw.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("timeouts has unexpected type %T", timeoutsRaw)
+		}
+		for _, key := range []string{"backendRequest", "request"} {
+			val, ok := timeoutsMap[key]
+			if !ok || val == nil {
+				continue
+			}
+			timeoutStr, ok := val.(string)
+			if !ok {
+				return 0, fmt.Errorf("timeouts.%s has unexpected type %T", key, val)
+			}
+			d, err := gatewaytimeout.ParseSeconds(timeoutStr)
+			if err != nil {
+				return 0, fmt.Errorf("parse timeouts.%s=%q: %w", key, timeoutStr, err)
+			}
+			if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
+				return 0, fmt.Errorf("invalid timeouts.%s=%q: %w", key, timeoutStr, err)
+			}
+			if d > floor {
+				floor = d
+			}
+		}
+	}
+	return floor, nil
 }
 
 func deleteHTTPRoute(ctx context.Context, c client.Client, srr *srrv1alpha1.SharedRouteRegistry) error {

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
@@ -2,6 +2,7 @@ package routecontrol
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +70,23 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	gw := schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1"}
 	s.AddKnownTypeWithName(gw.WithKind("HTTPRoute"), &unstructured.Unstructured{})
 	s.AddKnownTypeWithName(gw.WithKind("HTTPRouteList"), &unstructured.UnstructuredList{})
+	eg := schema.GroupVersion{Group: "gateway.envoyproxy.io", Version: "v1alpha1"}
+	s.AddKnownTypeWithName(eg.WithKind("BackendTrafficPolicy"), &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(eg.WithKind("BackendTrafficPolicyList"), &unstructured.UnstructuredList{})
 	return s
+}
+
+func mustHTTPRouteFirstRule(t *testing.T, route *unstructured.Unstructured) map[string]any {
+	t.Helper()
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil || !found || len(rules) == 0 {
+		t.Fatalf("spec.rules missing: found=%v err=%v", found, err)
+	}
+	rule, ok := rules[0].(map[string]any)
+	if !ok {
+		t.Fatalf("rules[0] type=%T, want map[string]any", rules[0])
+	}
+	return rule
 }
 
 func TestResolveServicePort(t *testing.T) {
@@ -378,5 +395,194 @@ func TestReconcileSharedRouteDirectMode(t *testing.T) {
 	}
 	if res.Status != metav1.ConditionTrue || res.Reason != ReasonDirectMode {
 		t.Fatalf("direct result = %+v", res)
+	}
+}
+
+func TestApplyHTTPRouteMaterializesTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-timeout", Namespace: "demo-shared", UID: "uid-timeout"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"timeout.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-timeout"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+
+	rule := mustHTTPRouteFirstRule(t, route)
+	timeouts, ok := rule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", rule["timeouts"])
+	}
+	if got := timeouts["backendRequest"]; got != "600s" {
+		t.Fatalf("timeouts.backendRequest=%v, want 600s", got)
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
+	}
+}
+
+func TestApplyHTTPRouteProbeFailureStillWritesTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-probe-fail", Namespace: "demo-shared", UID: "uid-probe-fail"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"probe-fail.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-demo-probe-fail",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"timeouts": map[string]any{
+						"request": int64(12345), // malformed on purpose: triggers probe failure
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-probe-fail"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	rule := mustHTTPRouteFirstRule(t, route)
+	timeouts, ok := rule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", rule["timeouts"])
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
+	}
+}
+
+func TestApplyHTTPRouteDiffOnlyTimeouts(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo-diff-timeout", Namespace: "demo-shared", UID: "uid-diff-timeout"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"diff-timeout.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-demo-diff-timeout",
+			"namespace": "demo-shared",
+			"labels": map[string]any{
+				ManagedByLabel: ManagedByValue,
+				InstanceLabel:  "shared-demo-diff-timeout",
+			},
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"diff-timeout.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	before := &unstructured.Unstructured{}
+	before.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-diff-timeout"}, before); err != nil {
+		t.Fatalf("get before route: %v", err)
+	}
+	beforeRule := mustHTTPRouteFirstRule(t, before)
+	beforeMatches := beforeRule["matches"]
+	beforeBackendRefs := beforeRule["backendRefs"]
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	after := &unstructured.Unstructured{}
+	after.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-demo-diff-timeout"}, after); err != nil {
+		t.Fatalf("get after route: %v", err)
+	}
+	afterRule := mustHTTPRouteFirstRule(t, after)
+	if !reflect.DeepEqual(beforeMatches, afterRule["matches"]) {
+		t.Fatalf("matches changed after timeout materialization")
+	}
+	if !reflect.DeepEqual(beforeBackendRefs, afterRule["backendRefs"]) {
+		t.Fatalf("backendRefs changed after timeout materialization")
+	}
+	timeouts, ok := afterRule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", afterRule["timeouts"])
+	}
+	if got := timeouts["request"]; got != "600s" {
+		t.Fatalf("timeouts.request=%v, want 600s", got)
 	}
 }

--- a/framework/app-service/pkg/gateway/timeout/timeout.go
+++ b/framework/app-service/pkg/gateway/timeout/timeout.go
@@ -1,0 +1,123 @@
+package timeout
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultSharedBackendResponseTimeout = 10 * time.Minute
+	MinResponseTimeout                  = DefaultSharedBackendResponseTimeout
+	MaxResponseTimeout                  = 24 * time.Hour
+	EnvDefaultResponseTimeout           = "SHARED_BACKEND_RESPONSE_TIMEOUT"
+	defaultTimeoutGatewayString         = "600s"
+)
+
+var configSecondsPattern = regexp.MustCompile(`^(\d+)s?$`)
+
+// ParseSeconds parses a duration configured in whole seconds (e.g. "600" or "600s").
+func ParseSeconds(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	if strings.ContainsAny(s, "hm") || strings.HasSuffix(s, "ms") {
+		return 0, fmt.Errorf("duration must use seconds only (e.g. 600 or 600s)")
+	}
+	m := configSecondsPattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("duration must be a whole number of seconds (e.g. 600 or 600s)")
+	}
+	secs, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse seconds: %w", err)
+	}
+	return time.Duration(secs) * time.Second, nil
+}
+
+// FormatSeconds formats a duration as a Gateway API seconds string (e.g. "600s").
+func FormatSeconds(d time.Duration) (string, error) {
+	if d <= 0 {
+		return "", fmt.Errorf("duration must be positive")
+	}
+	if d%time.Second != 0 {
+		return "", fmt.Errorf("duration must be a whole number of seconds: %s", d)
+	}
+	return fmt.Sprintf("%ds", d/time.Second), nil
+}
+
+// ClampResponseTimeout raises values below the platform default to 600s.
+func ClampResponseTimeout(d time.Duration) time.Duration {
+	if d < DefaultSharedBackendResponseTimeout {
+		return DefaultSharedBackendResponseTimeout
+	}
+	return d
+}
+
+func DefaultTimeout() time.Duration {
+	v := strings.TrimSpace(os.Getenv(EnvDefaultResponseTimeout))
+	if v == "" {
+		return DefaultSharedBackendResponseTimeout
+	}
+	d, err := ParseSeconds(v)
+	if err != nil {
+		klog.Warningf("invalid %s=%q, using default %s: %v", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, err)
+		return DefaultSharedBackendResponseTimeout
+	}
+	if err := ValidateResponseTimeout(d); err != nil {
+		klog.Warningf("invalid %s=%q, using default %s: %v", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, err)
+		return DefaultSharedBackendResponseTimeout
+	}
+	if clamped := ClampResponseTimeout(d); clamped != d {
+		klog.Warningf("%s=%q below minimum %s, using %s", EnvDefaultResponseTimeout, v, defaultTimeoutGatewayString, defaultTimeoutGatewayString)
+		return clamped
+	}
+	return d
+}
+
+func EffectiveResponseTimeout(defaultTimeout time.Duration, manifest *metav1.Duration, egConfigured time.Duration) (string, error) {
+	if err := ValidateResponseTimeout(defaultTimeout); err != nil {
+		return defaultTimeoutGatewayString, fmt.Errorf("invalid default timeout: %w", err)
+	}
+	effective := defaultTimeout
+
+	for _, candidate := range []time.Duration{candidateDuration(manifest), egConfigured} {
+		if candidate <= 0 {
+			continue
+		}
+		if err := ValidateResponseTimeout(candidate); err != nil {
+			return defaultTimeoutGatewayString, fmt.Errorf("invalid timeout %s: %w", candidate, err)
+		}
+		if candidate > effective {
+			effective = candidate
+		}
+	}
+
+	effective = ClampResponseTimeout(effective)
+	formatted, err := FormatSeconds(effective)
+	if err != nil {
+		return defaultTimeoutGatewayString, fmt.Errorf("format effective timeout: %w", err)
+	}
+	return formatted, nil
+}
+
+func ValidateResponseTimeout(d time.Duration) error {
+	if d > MaxResponseTimeout {
+		return fmt.Errorf("timeout %s exceeds max %s", d, MaxResponseTimeout)
+	}
+	return nil
+}
+
+func candidateDuration(manifest *metav1.Duration) time.Duration {
+	if manifest == nil {
+		return 0
+	}
+	return manifest.Duration
+}

--- a/framework/app-service/pkg/gateway/timeout/timeout_test.go
+++ b/framework/app-service/pkg/gateway/timeout/timeout_test.go
@@ -1,0 +1,194 @@
+package timeout
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseSeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "plain seconds", in: "600", want: 10 * time.Minute},
+		{name: "seconds suffix", in: "600s", want: 10 * time.Minute},
+		{name: "minutes rejected", in: "10m", wantErr: true},
+		{name: "millis rejected", in: "500ms", wantErr: true},
+		{name: "invalid", in: "bad", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSeconds(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSeconds(%q) err=nil, want error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSeconds(%q) err=%v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseSeconds(%q)=%s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClampResponseTimeout(t *testing.T) {
+	if got := ClampResponseTimeout(31 * time.Second); got != DefaultSharedBackendResponseTimeout {
+		t.Fatalf("ClampResponseTimeout(31s)=%s, want %s", got, DefaultSharedBackendResponseTimeout)
+	}
+	if got := ClampResponseTimeout(12 * time.Minute); got != 12*time.Minute {
+		t.Fatalf("ClampResponseTimeout(12m)=%s, want 12m", got)
+	}
+}
+
+func TestDefaultTimeout(t *testing.T) {
+	t.Run("use env value when valid", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "720")
+		got := DefaultTimeout()
+		if got != 12*time.Minute {
+			t.Fatalf("DefaultTimeout() = %s, want 12m", got)
+		}
+	})
+
+	t.Run("use env value with s suffix", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "720s")
+		got := DefaultTimeout()
+		if got != 12*time.Minute {
+			t.Fatalf("DefaultTimeout() = %s, want 12m", got)
+		}
+	})
+
+	t.Run("fallback when env is empty", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("clamp when env below minimum", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "31")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("fallback when env uses minutes", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "12m")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("fallback when env is invalid", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "bad-value")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+
+	t.Run("clamp when env is ten seconds", func(t *testing.T) {
+		t.Setenv(EnvDefaultResponseTimeout, "10")
+		got := DefaultTimeout()
+		if got != DefaultSharedBackendResponseTimeout {
+			t.Fatalf("DefaultTimeout() = %s, want %s", got, DefaultSharedBackendResponseTimeout)
+		}
+	})
+}
+
+func TestEffectiveResponseTimeout(t *testing.T) {
+	t.Run("max compose default manifest eg", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(10*time.Minute, &metav1.Duration{Duration: 20 * time.Minute}, 30*time.Minute)
+		if err != nil {
+			t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+		}
+		if got != "1800s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 1800s", got)
+		}
+	})
+
+	t.Run("clamp below minimum", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(45*time.Second, nil, 0)
+		if err != nil {
+			t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+		}
+		if got != "600s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 600s", got)
+		}
+	})
+
+	t.Run("above max still returns safe default", func(t *testing.T) {
+		got, err := EffectiveResponseTimeout(MaxResponseTimeout+time.Second, nil, 0)
+		if err == nil {
+			t.Fatal("EffectiveResponseTimeout() err = nil, want error")
+		}
+		if got != "600s" {
+			t.Fatalf("EffectiveResponseTimeout() = %q, want 600s", got)
+		}
+	})
+}
+
+var gatewaySecondsPattern = regexp.MustCompile(`^\d+s$`)
+
+func TestEffectiveTimeoutSecondsFormat(t *testing.T) {
+	cases := []struct {
+		name       string
+		def        time.Duration
+		manifest   *metav1.Duration
+		eg         time.Duration
+		wantResult string
+	}{
+		{name: "below minimum clamped", def: 30 * time.Second, wantResult: "600s"},
+		{name: "ten minutes", def: 10 * time.Minute, wantResult: "600s"},
+		{name: "twelve minutes", def: 12 * time.Minute, wantResult: "720s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := EffectiveResponseTimeout(tc.def, tc.manifest, tc.eg)
+			if err != nil {
+				t.Fatalf("EffectiveResponseTimeout() err = %v", err)
+			}
+			if got != tc.wantResult {
+				t.Fatalf("EffectiveResponseTimeout() = %q, want %q", got, tc.wantResult)
+			}
+			if !gatewaySecondsPattern.MatchString(got) {
+				t.Fatalf("result %q does not match seconds pattern", got)
+			}
+		})
+	}
+}
+
+func TestValidateResponseTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		d       time.Duration
+		wantErr bool
+	}{
+		{name: "min platform default", d: MinResponseTimeout, wantErr: false},
+		{name: "below platform default allowed", d: 31 * time.Second, wantErr: false},
+		{name: "max boundary", d: MaxResponseTimeout, wantErr: false},
+		{name: "above max", d: MaxResponseTimeout + time.Second, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateResponseTimeout(tc.d)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateResponseTimeout(%s) err=nil, want error", tc.d)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateResponseTimeout(%s) err=%v, want nil", tc.d, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
materialize timeouts.request / timeouts.backendRequest on Shared SRR HTTPRoutes so Envoy Gateway no longer applies the default 15s backend timeout.
 Adds pkg/gateway/timeout, updates routecontrol reconcile with fail-safe 10m fallback and EG floor protection, and exposes SHARED_BACKEND_RESPONSE_TIMEOUT in app-service deploy env (default 600s).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live gateway HTTPRoute specs and request duration behavior for shared ingress; mis-tuned timeouts could still cut off or over-hold long requests, though defaults and floors aim to reduce risk.
> 
> **Overview**
> Shared **SharedRouteRegistry** gateway reconcile now writes **`timeouts.request`** and **`timeouts.backendRequest`** on managed HTTPRoutes so Envoy Gateway no longer falls back to the default **15s** backend timeout.
> 
> A new **`pkg/gateway/timeout`** package resolves the effective value from **`SHARED_BACKEND_RESPONSE_TIMEOUT`** (deploy default **600s**), clamps below **10m** up to the platform minimum, caps at **24h**, and fail-safes to **600s** on invalid input. Reconcile **probes** non–app-service HTTPRoutes and **BackendTrafficPolicy** `requestTimeout` targets so externally configured longer timeouts are not shortened. Probe or compose errors log warnings and still apply the safe default.
> 
> Tests cover timeout helpers and reconcile paths (create, probe failure, timeout-only spec diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5898c1fc05c070c55f9f43209ec318fe49966a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->