### PR TITLE
system-frontend: bump image version to v1.10.52

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.51
+          image: beclab/system-frontend:v1.10.52
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Bump the `system-frontend` (olares-app-init) image in `system-apps` from `v1.10.51` to `v1.10.52`, shipping the latest frontend changes from TermiPass:
  - Fix system frontend bugs for compute, launchpad and profile

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1206

* **Other information**:
None

Made with [Cursor](https://cursor.com)