### PR TITLE
fix(files upload): correct chunked resume

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.183
+          image: beclab/files-server:v0.2.184
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: resume writes land at the requested offset
- fix: partials survive pod restart
- fix: gap chunks fail loudly

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/350

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy; upload behavior changes are scoped to the files service bugfix release.
> 
> **Overview**
> Bumps the **`files`** DaemonSet container image from `beclab/files-server:v0.2.183` to **`v0.2.184`** in `files_deploy.yaml`, rolling out the upstream upload fixes (related **beclab/files#350**).
> 
> That release is intended to fix **chunked upload resume**: writes at the requested offset, partial uploads surviving pod restarts, and clearer failures on gap chunks. No other deploy config changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4aaa537a611010622aeee9dda86eceb9f7c742e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->