### PR TITLE
fix: update baseURL in Paperclip OpenCode config to include app route ID

### DIFF
--- a/docs/use-cases/paperclip.md
+++ b/docs/use-cases/paperclip.md
@@ -231,12 +231,17 @@ This OpenCode runs inside the Paperclip container and is separate from the OpenC
            }
          },
          "options": {
-           "baseURL": "https://<your-olares-id>.olares.com/v1"
+           "baseURL": "https://2b46296c.<your-olares-id>.olares.com/v1"
          }
        }
      }
    }
    ```
+
+
+   :::info
+   `2b46296c` is your actual application route ID. If you are not using Gemma4 26B Q4_K_M (Ollama), replace it with your actual application route ID.
+   :::
 
 4. Restart the Paperclip container.
 5. In Paperclip, go to **Agents** > **Configuration** > **Permissions & Configuration** to verify the newly added local model.

--- a/docs/use-cases/paperclip.md
+++ b/docs/use-cases/paperclip.md
@@ -215,6 +215,7 @@ This OpenCode runs inside the Paperclip container and is separate from the OpenC
    c. Replace the default configuration with the following example (using gemma4:26b as the model):
 
    - Replace `<your-olares-id>` in the configuration with your specific Olares ID.
+   - If you are not using Gemma4 26B Q4_K_M (Ollama), replace `2b46296c` with your actual application route ID.
    - Ensure that the `baseURL` ends with `/v1` to provide OpenAI-compatible API access through Ollama.
 
    ```json {wrap}
@@ -237,11 +238,6 @@ This OpenCode runs inside the Paperclip container and is separate from the OpenC
      }
    }
    ```
-
-
-   :::info
-   `2b46296c` is your actual application route ID. If you are not using Gemma4 26B Q4_K_M (Ollama), replace it with your actual application route ID.
-   :::
 
 4. Restart the Paperclip container.
 5. In Paperclip, go to **Agents** > **Configuration** > **Permissions & Configuration** to verify the newly added local model.


### PR DESCRIPTION
Update the baseURL in the Paperclip OpenCode configuration example to include the application route ID.

Changes:
- Changed `baseURL` from `https://<your-olares-id>.olares.com/v1` to `https://2b46296c.<your-olares-id>.olares.com/v1`
- Added info note explaining that `2b46296c` is the application route ID for Gemma4 26B Q4_K_M (Ollama), and users should replace it with their actual route ID if using a different model

See: https://github.com/beclab/Olares/blob/main/docs/use-cases/paperclip.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example URL and setup note; no runtime or application code is affected.
> 
> **Overview**
> Updates the **Paperclip** guide’s embedded OpenCode local-model example so the `baseURL` matches Olares’ per-app routing (`https://2b46296c.<your-olares-id>.olares.com/v1` instead of omitting the route segment).
> 
> Adds a bullet telling readers to swap `2b46296c` when they are not on Gemma4 26B Q4_K_M (Ollama). Also fixes a trailing newline on the **Learn more** link to OpenCode setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51685df01295c3c341014517ab330ef8057d291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->