### PR TITLE
fix(app-service): preserve shared HTTPRoute timeout floor

### DIFF
--- a/framework/app-service/pkg/gateway/routecontrol/reconcile.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,7 @@ const (
 	ManagedByLabel         = "app.kubernetes.io/managed-by"
 	ManagedByValue         = "app-service"
 	InstanceLabel          = "app.kubernetes.io/instance"
+	TimeoutFloorAnnotation = "app-service.olares.com/timeout-floor"
 	NetworkPolicyName      = "app-gateway-shared-ingress-np"
 	defaultGatewayNS       = "os-gateway"
 	defaultGatewayName     = "app-gateway"
@@ -215,7 +217,7 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	current := &unstructured.Unstructured{}
 	current.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
 	getErr := c.Get(ctx, types.NamespacedName{Namespace: srr.Namespace, Name: name}, current)
-	egConfigured := probeExternalSharedRouteTimeout(ctx, c, gw, srr, current)
+	egConfigured := probeExternalSharedRouteTimeout(ctx, c, gw, srr, current, getErr)
 	effective, err := gatewaytimeout.EffectiveResponseTimeout(gatewaytimeout.DefaultTimeout(), nil, egConfigured)
 	if err != nil {
 		klog.Warningf("effective timeout fell back to %q for srr=%s/%s: %v", effective, srr.Namespace, srr.Name, err)
@@ -284,6 +286,7 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 
 	switch {
 	case apierrors.IsNotFound(getErr):
+		applyTimeoutFloorAnnotation(desired, current, getErr)
 		if err := c.Create(ctx, desired); err != nil {
 			return "", err
 		}
@@ -291,15 +294,15 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	case getErr != nil:
 		return "", getErr
 	}
-	if !reflect.DeepEqual(current.Object["spec"], desired.Object["spec"]) {
+	specChanged := !reflect.DeepEqual(current.Object["spec"], desired.Object["spec"])
+	prevFloor := strings.TrimSpace(current.GetAnnotations()[TimeoutFloorAnnotation])
+	applyTimeoutFloorAnnotation(current, current, getErr)
+	metaChanged := mergeHTTPRouteMetadataForUpdate(current, desired)
+	annChanged := strings.TrimSpace(current.GetAnnotations()[TimeoutFloorAnnotation]) != prevFloor
+	if specChanged {
 		current.Object["spec"] = desired.Object["spec"]
-		labels := current.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		labels[ManagedByLabel] = ManagedByValue
-		labels[InstanceLabel] = srr.Name
-		current.SetLabels(labels)
+	}
+	if specChanged || metaChanged || annChanged {
 		if err := c.Update(ctx, current); err != nil {
 			return "", err
 		}
@@ -307,47 +310,67 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 	return name, nil
 }
 
-func probeExternalSharedRouteTimeout(ctx context.Context, c client.Client, gw GatewayRef, srr *srrv1alpha1.SharedRouteRegistry, current *unstructured.Unstructured) time.Duration {
+func probeExternalSharedRouteTimeout(ctx context.Context, c client.Client, gw GatewayRef, srr *srrv1alpha1.SharedRouteRegistry, current *unstructured.Unstructured, getErr error) time.Duration {
 	_ = gw
 	var floor time.Duration
 
-	if current != nil {
+	if current != nil && getErr == nil {
+		if ann := strings.TrimSpace(current.GetAnnotations()[TimeoutFloorAnnotation]); ann != "" {
+			d, err := gatewaytimeout.ParseSeconds(ann)
+			if err != nil {
+				klog.Warningf("parse annotation %s=%q failed for srr=%s/%s: %v", TimeoutFloorAnnotation, ann, srr.Namespace, srr.Name, err)
+			} else if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
+				klog.Warningf("invalid annotation %s=%q for srr=%s/%s: %v", TimeoutFloorAnnotation, ann, srr.Namespace, srr.Name, err)
+			} else if d > floor {
+				floor = d
+			}
+		}
+
 		labels := current.GetLabels()
 		if labels[ManagedByLabel] != ManagedByValue {
 			probed, err := extractRouteTimeoutFloor(current)
 			if err != nil {
 				klog.Warningf("probe current route timeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-				return 0
-			}
-			if probed > floor {
+			} else if probed > floor {
 				floor = probed
 			}
 		}
 	}
 
+	btpFloor, err := probeBTPTargetRouteTimeout(ctx, c, srr)
+	if err != nil {
+		klog.Warningf("probe BTP failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
+	} else if btpFloor > floor {
+		floor = btpFloor
+	}
+
+	return floor
+}
+
+func probeBTPTargetRouteTimeout(ctx context.Context, c client.Client, srr *srrv1alpha1.SharedRouteRegistry) (time.Duration, error) {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicyList"})
 	if err := c.List(ctx, list, client.InNamespace(srr.Namespace)); err != nil {
-		klog.Warningf("list BackendTrafficPolicy failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-		return 0
+		return 0, err
 	}
 
+	var floor time.Duration
 	for i := range list.Items {
 		item := &list.Items[i]
 		group, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "group")
 		if err != nil {
 			klog.Warningf("read BackendTrafficPolicy targetRef.group failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		kind, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "kind")
 		if err != nil {
 			klog.Warningf("read BackendTrafficPolicy targetRef.kind failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		name, _, err := unstructured.NestedString(item.Object, "spec", "targetRef", "name")
 		if err != nil {
 			klog.Warningf("read BackendTrafficPolicy targetRef.name failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		if group != "gateway.networking.k8s.io" || kind != "HTTPRoute" || name != httpRouteName(srr) {
 			continue
@@ -355,25 +378,83 @@ func probeExternalSharedRouteTimeout(ctx context.Context, c client.Client, gw Ga
 		raw, found, err := unstructured.NestedString(item.Object, "spec", "timeout", "http", "requestTimeout")
 		if err != nil {
 			klog.Warningf("read BackendTrafficPolicy requestTimeout failed for srr=%s/%s: %v", srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		if !found || raw == "" {
 			continue
 		}
-			d, err := gatewaytimeout.ParseSeconds(raw)
+		d, err := gatewaytimeout.ParseSeconds(raw)
 		if err != nil {
 			klog.Warningf("parse BackendTrafficPolicy requestTimeout=%q failed for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		if err := gatewaytimeout.ValidateResponseTimeout(d); err != nil {
 			klog.Warningf("invalid BackendTrafficPolicy requestTimeout=%q for srr=%s/%s: %v", raw, srr.Namespace, srr.Name, err)
-			return 0
+			continue
 		}
 		if d > floor {
 			floor = d
 		}
 	}
-	return floor
+	return floor, nil
+}
+
+func applyTimeoutFloorAnnotation(target, current *unstructured.Unstructured, getErr error) string {
+	if target == nil {
+		return ""
+	}
+	ann := target.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+
+	if getErr == nil && current != nil {
+		labels := current.GetLabels()
+		wasManaged := labels[ManagedByLabel] == ManagedByValue
+		if !wasManaged {
+			routeFloor, err := extractRouteTimeoutFloor(current)
+			if err != nil {
+				klog.Warningf("probe route floor for annotation failed for route=%s/%s: %v", current.GetNamespace(), current.GetName(), err)
+			} else if routeFloor > gatewaytimeout.DefaultTimeout() {
+				formatted, err := gatewaytimeout.FormatSeconds(routeFloor)
+				if err != nil {
+					klog.Warningf("format route floor for annotation failed for route=%s/%s: %v", current.GetNamespace(), current.GetName(), err)
+				} else {
+					ann[TimeoutFloorAnnotation] = formatted
+					target.SetAnnotations(ann)
+					return formatted
+				}
+			}
+		} else if existing := strings.TrimSpace(current.GetAnnotations()[TimeoutFloorAnnotation]); existing != "" {
+			ann[TimeoutFloorAnnotation] = existing
+			target.SetAnnotations(ann)
+			return existing
+		}
+	}
+
+	if existing := strings.TrimSpace(ann[TimeoutFloorAnnotation]); existing != "" {
+		ann[TimeoutFloorAnnotation] = existing
+		target.SetAnnotations(ann)
+		return existing
+	}
+	return ""
+}
+
+func mergeHTTPRouteMetadataForUpdate(current, desired *unstructured.Unstructured) bool {
+	changed := false
+	labels := current.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	desiredLabels := desired.GetLabels()
+	for _, k := range []string{ManagedByLabel, InstanceLabel} {
+		if want := desiredLabels[k]; want != "" && labels[k] != want {
+			labels[k] = want
+			changed = true
+		}
+	}
+	current.SetLabels(labels)
+	return changed
 }
 
 func extractRouteTimeoutFloor(route *unstructured.Unstructured) (time.Duration, error) {

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
@@ -586,3 +586,359 @@ func TestApplyHTTPRouteDiffOnlyTimeouts(t *testing.T) {
 		t.Fatalf("timeouts.request=%v, want 600s", got)
 	}
 }
+
+func mustRouteRequestTimeout(t *testing.T, route *unstructured.Unstructured) string {
+	t.Helper()
+	rule := mustHTTPRouteFirstRule(t, route)
+	timeouts, ok := rule["timeouts"].(map[string]any)
+	if !ok {
+		t.Fatalf("timeouts type=%T, want map[string]any", rule["timeouts"])
+	}
+	raw, ok := timeouts["request"].(string)
+	if !ok {
+		t.Fatalf("timeouts.request type=%T, want string", timeouts["request"])
+	}
+	return raw
+}
+
+func TestProbePreservesExternalFloorAcrossReconcile(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-probe-floor", Namespace: "demo-shared", UID: "uid-probe-floor"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"floor.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-probe-floor",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"floor.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+					"timeouts": map[string]any{
+						"backendRequest": "1800s",
+						"request":        "1800s",
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	for i := 0; i < 2; i++ {
+		if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+			t.Fatalf("ReconcileSharedRoute run=%d: %v", i+1, err)
+		}
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-probe-floor"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	if got := mustRouteRequestTimeout(t, route); got != "1800s" {
+		t.Fatalf("timeouts.request=%s, want 1800s", got)
+	}
+	if got := route.GetAnnotations()[TimeoutFloorAnnotation]; got != "1800s" {
+		t.Fatalf("annotation %s=%q, want 1800s", TimeoutFloorAnnotation, got)
+	}
+}
+
+func TestProbeBTPParseErrorKeepsRouteFloor(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-btp-parse", Namespace: "demo-shared", UID: "uid-btp-parse"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"btp.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-btp-parse",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"btp.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+					"timeouts": map[string]any{
+						"backendRequest": "1800s",
+						"request":        "1800s",
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	btp := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.envoyproxy.io/v1alpha1",
+		"kind":       "BackendTrafficPolicy",
+		"metadata": map[string]any{
+			"name":      "btp-shared-btp-parse",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"targetRef": map[string]any{
+				"group": "gateway.networking.k8s.io",
+				"kind":  "HTTPRoute",
+				"name":  "shared-btp-parse",
+			},
+			"timeout": map[string]any{
+				"http": map[string]any{
+					"requestTimeout": "bad",
+				},
+			},
+		},
+	}}
+	btp.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicy"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute, btp).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-btp-parse"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	if got := mustRouteRequestTimeout(t, route); got != "1800s" {
+		t.Fatalf("timeouts.request=%s, want 1800s", got)
+	}
+}
+
+func TestEffectiveRespectsAnnotationWhenManaged(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-annotation-floor", Namespace: "demo-shared", UID: "uid-annotation-floor"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"annotation.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-annotation-floor",
+			"namespace": "demo-shared",
+			"labels": map[string]any{
+				ManagedByLabel: ManagedByValue,
+				InstanceLabel:  "shared-annotation-floor",
+			},
+			"annotations": map[string]any{
+				TimeoutFloorAnnotation: "1800s",
+			},
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"annotation.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+					"timeouts": map[string]any{
+						"backendRequest": "600s",
+						"request":        "600s",
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-annotation-floor"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	if got := mustRouteRequestTimeout(t, route); got != "1800s" {
+		t.Fatalf("timeouts.request=%s, want 1800s", got)
+	}
+}
+
+func TestApplyHTTPRoutePersistsFloorAnnotationWhenSpecUnchanged(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-spec-unchanged", Namespace: "demo-shared", UID: "uid-spec-unchanged"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassShared,
+			HostPatterns:  []string{"spec-unchanged.shared.olares.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	existingRoute := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "shared-spec-unchanged",
+			"namespace": "demo-shared",
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":       "gateway.networking.k8s.io",
+					"kind":        "Gateway",
+					"namespace":   "os-gateway",
+					"name":        "app-gateway",
+					"sectionName": "http",
+				},
+			},
+			"hostnames": []any{"spec-unchanged.shared.olares.com"},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": "/"},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      "demo-svc",
+							"namespace": "demo-shared",
+							"port":      int64(8080),
+							"weight":    int64(1),
+						},
+					},
+					"timeouts": map[string]any{
+						"backendRequest": "1800s",
+						"request":        "1800s",
+					},
+				},
+			},
+		},
+	}}
+	existingRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr, existingRoute).Build()
+
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "shared-spec-unchanged"}, route); err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+	if got := route.GetLabels()[ManagedByLabel]; got != ManagedByValue {
+		t.Fatalf("managed-by label=%q, want %q", got, ManagedByValue)
+	}
+	if got := route.GetLabels()[InstanceLabel]; got != "shared-spec-unchanged" {
+		t.Fatalf("instance label=%q, want shared-spec-unchanged", got)
+	}
+	if got := route.GetAnnotations()[TimeoutFloorAnnotation]; got != "1800s" {
+		t.Fatalf("annotation %s=%q, want 1800s", TimeoutFloorAnnotation, got)
+	}
+	if got := mustRouteRequestTimeout(t, route); got != "1800s" {
+		t.Fatalf("timeouts.request=%s, want 1800s", got)
+	}
+}


### PR DESCRIPTION
Persist longer external HTTPRoute timeouts on first takeover via a timeout-floor annotation, and keep probe errors from discarding an already-collected floor.
Also trigger HTTPRoute Update when only annotation or labels change, so a second reconcile does not fall back from a longer external timeout to 600s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway HTTPRoute timeout reconciliation for shared ingress; wrong behavior could shorten or mis-apply timeouts for live traffic, though scope is limited to routecontrol with strong test coverage.
> 
> **Overview**
> Fixes a regression where app-service could **downgrade** shared `HTTPRoute` request timeouts (e.g. 1800s → 600s) after takeover or on a second reconcile.
> 
> Reconcile now records a longer pre-existing timeout on **`app-service.olares.com/timeout-floor`** when adopting an unmanaged route, and **uses that annotation** (plus route spec and matching **BackendTrafficPolicy** `requestTimeout`) as the effective timeout floor. BTP/list/parse failures **log and continue** instead of zeroing an already-known floor.
> 
> **HTTPRoute** updates run when **spec, managed-by/instance labels, or the floor annotation** change—not only when `spec` differs—so metadata-only fixes still persist the floor across repeated reconciles.
> 
> New reconcile tests cover multi-pass stability, bad BTP data, managed routes with annotation vs lower spec timeouts, and annotation persistence when spec is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cda5f40a54e2b1ec3445533ee7bea2604683bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->