### PR TITLE
docs: add google analytics

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -161,6 +161,21 @@ export default defineVersionedConfig2(withMermaid({
   },
   head: [
     [
+      "script",
+      {
+        async: "",
+        src: "https://www.googletagmanager.com/gtag/js?id=G-G98641Y6R0",
+      },
+    ],
+    [
+      "script",
+      {},
+      `window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-G98641Y6R0');`,
+    ],
+    [
       "meta",
       {
          name:"docsearch:version",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -128,7 +128,11 @@ export default defineVersionedConfig2(withMermaid({
         'meta',
         { name: 'robots', content: 'noindex, nofollow' },
       ]);
-      noindexPaths.add(pageData.relativePath.replace(/\.md$/, '.html'));
+      // Store the extensionless route so this matches the sitemap item.url
+      // regardless of `cleanUrls` (which drops the .html from item.url).
+      noindexPaths.add(
+        pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '')
+      );
     }
   },
 
@@ -139,11 +143,14 @@ export default defineVersionedConfig2(withMermaid({
       // them via the sitemap. The meta tag above is what ultimately removes
       // them from search engine indexes; this just avoids the extra hit.
       items.filter((item) => {
-        const p = item.url.replace(/^\/+/, '');
+        // Normalize to the extensionless route so the comparison holds whether
+        // or not cleanUrls is enabled.
+        const p = item.url.replace(/^\/+/, '').replace(/\.html$/, '');
         return !noindexPaths.has(p);
       }),
   },
   lastUpdated: true,
+  cleanUrls: true,
   base: process.env.BASE_URL || "/",
   vite: {
     build: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only analytics and URL/sitemap tweaks with no auth or application runtime impact; minor SEO risk if noindex filtering regressed, but the change explicitly addresses cleanUrls alignment.
> 
> **Overview**
> Adds **Google Analytics** (`G-G98641Y6R0`) site-wide via gtag scripts in the VitePress `head` config.
> 
> Enables **`cleanUrls: true`** in both VitePress and `vercel.json` so docs URLs drop the `.html` suffix on deploy.
> 
> Updates **noindex → sitemap** filtering to store and compare **extensionless routes** (including `index.md` handling), so pages with `noindex: true` still stay out of `sitemap.xml` after clean URLs change URL shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e112e893939df402880b3748a38ae32fd1d303a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->