### PR TITLE
chore(oac): add and rename accelerator modes

### DIFF
--- a/framework/app-service/pkg/utils/gpu_types.go
+++ b/framework/app-service/pkg/utils/gpu_types.go
@@ -13,14 +13,15 @@ const (
 )
 
 const (
-	CPUType              = "cpu"         // force to use CPU, no GPU
-	NvidiaCardType       = "nvidia"      // handling by HAMi
-	AmdGpuCardType       = "amd-gpu"     //
-	AmdApuCardType       = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
-	GB10ChipType         = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
-	AppleMChipType       = "apple-m"     // Apple M-series SoC
-	StrixHaloChipType    = "strix-halo"  // AMD Strix Halo GPU & unified system memory
-	MthreadsM100ChipType = "mthreads-m1000"
+	CPUType        = "cpu"         // force to use CPU, no GPU
+	NvidiaCardType = "nvidia"      // discrete NVIDIA card, handled by HAMi
+	GB10ChipType   = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
+	AppleMChipType = "apple-m"     // Apple M-series SoC (unified memory)
+	IntelType      = "intel"       // Intel integrated GPU
+	AMDType        = "amd"         // AMD integrated GPU
+	IntelGPUType   = "intel-gpu"   // Intel discrete GPU
+	AMDGPUType     = "amd-gpu"     // AMD discrete GPU
+	MooreSocType   = "moore-soc"   // Moore Threads SoC
 )
 
 // NodeGPUType returns the canonical GPU type string for a node by reading the

--- a/framework/oac/images.go
+++ b/framework/oac/images.go
@@ -31,8 +31,9 @@ var AllImageRenderModes = []string{
 	"apple-m",
 	"nvidia",
 	"nvidia-gb10",
-	"mthreads-m1000",
-	"strix-halo",
+	"moore-soc",
+	"amd",
+	"intel",
 }
 
 // ListImages returns the sorted, deduplicated set of container images used by

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -12,38 +12,48 @@ import (
 )
 
 const (
-	ResourceModeCPU           = "cpu"
-	ResourceModeAMDAPU        = "amd-apu"
-	ResourceModeAMDGPU        = "amd-gpu"
-	ResourceModeAppleM        = "apple-m"
-	ResourceModeNvidia        = "nvidia"
-	ResourceModeNvidiaGB10    = "nvidia-gb10"
-	ResourceModeMThreadsM1000 = "mthreads-m1000"
-	ResourceModeStrixHalo     = "strix-halo"
+	ResourceModeCPU        = "cpu"
+	ResourceModeNvidia     = "nvidia"
+	ResourceModeNvidiaGB10 = "nvidia-gb10"
+	ResourceModeAppleM     = "apple-m"
+	ResourceModeIntel      = "intel"     // Intel integrated GPU
+	ResourceModeAMD        = "amd"       // AMD integrated GPU
+	ResourceModeIntelGPU   = "intel-gpu" // Intel discrete GPU
+	ResourceModeAMDGPU     = "amd-gpu"   // AMD discrete GPU
+	ResourceModeMooreSoc   = "moore-soc" // Moore Threads SoC
 )
 
 var validResourceModes = []any{
 	ResourceModeCPU,
-	ResourceModeStrixHalo,
-	ResourceModeAMDGPU,
-	ResourceModeAppleM,
 	ResourceModeNvidia,
 	ResourceModeNvidiaGB10,
-	ResourceModeMThreadsM1000,
-	ResourceModeStrixHalo,
+	ResourceModeAppleM,
+	ResourceModeIntel,
+	ResourceModeAMD,
+	ResourceModeIntelGPU,
+	ResourceModeAMDGPU,
+	ResourceModeMooreSoc,
 }
 
 var modeArchRequirement = map[string]string{
-	ResourceModeAMDGPU:        "amd64",
-	ResourceModeNvidia:        "amd64",
-	ResourceModeNvidiaGB10:    "arm64",
-	ResourceModeMThreadsM1000: "arm64",
-	ResourceModeStrixHalo:     "amd64",
+	ResourceModeNvidia:     "amd64",
+	ResourceModeNvidiaGB10: "arm64",
+	ResourceModeAppleM:     "arm64",
+	ResourceModeIntel:      "amd64",
+	ResourceModeAMD:        "amd64",
+	ResourceModeIntelGPU:   "amd64",
+	ResourceModeAMDGPU:     "amd64",
+	ResourceModeMooreSoc:   "arm64",
 }
 
+// gpuMemoryModes are the modes that expose a standalone GPU memory pool, so a
+// manifest may declare requiredGpu / limitedGpu for them. These are the
+// discrete-GPU / HAMi flavors; the unified-memory SoCs (apple-m, intel, amd,
+// nvidia-gb10, moore-soc) draw from system RAM and must not.
 var gpuMemoryModes = map[string]struct{}{
-	ResourceModeNvidia: {},
-	ResourceModeAMDGPU: {},
+	ResourceModeNvidia:   {},
+	ResourceModeAMDGPU:   {},
+	ResourceModeIntelGPU: {},
 }
 
 var minResourcesManifestVersion = semver.MustParse("0.12.0")

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -184,7 +184,10 @@ func TestRule1_ModeArchRequirement(t *testing.T) {
 		{"nvidia ok with amd64", ResourceModeNvidia, []string{"amd64"}, false, ""},
 		{"amd-gpu needs amd64", ResourceModeAMDGPU, []string{"arm64"}, true, "amd64"},
 		{"nvidia-gb10 needs arm64", ResourceModeNvidiaGB10, []string{"amd64"}, true, "arm64"},
-		{"mthreads-m1000 needs arm64", ResourceModeMThreadsM1000, []string{"amd64"}, true, "arm64"},
+		{"moore-soc needs arm64", ResourceModeMooreSoc, []string{"amd64"}, true, "arm64"},
+		{"amd ok with amd64", ResourceModeAMD, []string{"amd64"}, false, ""},
+		{"intel ok with amd64", ResourceModeIntel, []string{"amd64"}, false, ""},
+		{"apple-m needs arm64", ResourceModeAppleM, []string{"amd64"}, true, "arm64"},
 		{"cpu has no arch constraint", ResourceModeCPU, []string{"amd64"}, false, ""},
 	}
 	for _, tc := range cases {
@@ -249,9 +252,9 @@ func TestRule2_NvidiaModeRequiresGPUPair(t *testing.T) {
 }
 
 func TestRule2_NonGPUModeAcceptsCompleteEnvelope(t *testing.T) {
-	// Non-GPU-memory modes (cpu / amd-apu / apple-m / nvidia-gb10 /
-	// mthreads-m1000) cannot declare standalone gpu fields. A fully
-	// populated cpu/memory/disk envelope therefore must validate cleanly.
+	// Non-GPU-memory modes (cpu / apple-m / nvidia-gb10 / intel / amd /
+	// moore-soc) cannot declare standalone gpu fields. A fully populated
+	// cpu/memory/disk envelope therefore must validate cleanly.
 	c := newResourcesConfig(ResourceMode{
 		Mode:                ResourceModeCPU,
 		ResourceRequirement: fullCPUMemoryDisk(),
@@ -280,12 +283,12 @@ func TestRule2_InlineMissingFieldRejected(t *testing.T) {
 	}
 }
 
-// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu)
-// cannot declare gpu fields. Disk is allowed on every mode after the
-// relaxation of the old "cpu+memory only" constraint.
+// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu /
+// intel-gpu) cannot declare gpu fields. Disk is allowed on every mode after
+// the relaxation of the old "cpu+memory only" constraint.
 func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	for _, mode := range []string{
-		ResourceModeCPU, ResourceModeStrixHalo, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMThreadsM1000,
+		ResourceModeCPU, ResourceModeAMD, ResourceModeIntel, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMooreSoc,
 	} {
 		mode := mode
 		t.Run(mode+"_disk_allowed", func(t *testing.T) {
@@ -325,8 +328,8 @@ func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	}
 }
 
-// Rule 4: nvidia and amd-gpu may declare a standalone gpu memory quantity;
-// every other mode must leave requiredGpu/limitedGpu empty.
+// Rule 4: nvidia, amd-gpu and intel-gpu may declare a standalone gpu memory
+// quantity; every other mode must leave requiredGpu/limitedGpu empty.
 func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	cases := []struct {
 		mode    string
@@ -334,8 +337,10 @@ func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	}{
 		{ResourceModeNvidia, false},
 		{ResourceModeAMDGPU, false},
-		{ResourceModeCPU, true},           // non-GPU family
-		{ResourceModeMThreadsM1000, true}, // GPU-family but not yet whitelisted
+		{ResourceModeIntelGPU, false},
+		{ResourceModeCPU, true},      // non-GPU family
+		{ResourceModeMooreSoc, true}, // GPU-family but not yet whitelisted
+		{ResourceModeAMD, true},      // integrated AMD: unified memory, no standalone gpu pool
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -409,8 +409,9 @@ func TestAllImageRenderModes_ContainsExpected(t *testing.T) {
 		"apple-m",
 		"nvidia",
 		"nvidia-gb10",
-		"mthreads-m1000",
-		"strix-halo",
+		"moore-soc",
+		"amd",
+		"intel",
 	}
 	if !reflect.DeepEqual(oac.AllImageRenderModes, want) {
 		t.Fatalf("AllImageRenderModes drift: got %v, want %v", oac.AllImageRenderModes, want)


### PR DESCRIPTION
* **Background**
Add and rename certain accelerator modes in OAC manifest schema

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Manifests or node labels still using removed mode names will fail validation or mismatch scheduling; new `intel-gpu` GPU-memory rules affect resource schema for app store manifests.
> 
> **Overview**
> **Renames and expands** the canonical accelerator / GPU type strings used for node labels (`gpu_types.go`), OAC manifest `resources[].mode` validation, and default helm image extraction (`AllImageRenderModes`).
> 
> **Removed** manifest and store modes `amd-apu`, `strix-halo`, and `mthreads-m1000`. **Added** `intel` and `amd` (integrated), `intel-gpu` (discrete), and `moore-soc` (Moore Threads SoC). Discrete pools `nvidia`, `amd-gpu`, and **`intel-gpu`** may declare `requiredGpu` / `limitedGpu`; unified-memory modes (`apple-m`, `intel`, `amd`, `nvidia-gb10`, `moore-soc`) must not.
> 
> **Arch rules** are updated: e.g. `apple-m` and `moore-soc` require `arm64`; `intel` / `amd` / discrete Intel and AMD modes require `amd64`. Tests pin the new mode lists and validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42740302a69a56fcbfe63ca4d20cd1757824dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->