### PR TITLE
fix: (files archive) honor preserve-symlinks and reject duplicate entry names

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.184
+          image: beclab/files-server:v0.2.185
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: Dereference symlinks when not preserving (incl. tar.gz/bz2/xz) and fail clearly on same-name sources instead of a raw 7z duplicate-name error.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/351

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no config changes; risk is limited to behavior in the new files-server build (archive edge cases).
> 
> **Overview**
> Bumps the **files** DaemonSet container image from `beclab/files-server:v0.2.184` to **`v0.2.185`** in `files_deploy.yaml`, rolling out the upstream files-server build that fixes archive behavior (per linked `beclab/files` PR).
> 
> No other manifest, env, or volume changes in this diff—only the image tag on the `files` container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55e6288bef3babcf3dfae407bb08de525e3eb1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->