### PR TITLE
refactor(appservice): support multi accelerator modes in single node

### DIFF
--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260611140302-a44523700b37
+	github.com/beclab/Olares/framework/oac v0.0.0-20260616125358-3d8fc9468ad0
 	github.com/beclab/api v0.0.18
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,10 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260611140302-a44523700b37 h1:TzA0GA11GK47VXvKRFxSGGFX1DZ2MiLLrU8dHKCDOxE=
-github.com/beclab/Olares/framework/oac v0.0.0-20260611140302-a44523700b37/go.mod h1:dpo6y8IYbmmE41+qKjZv2LfkuDUidAscpQ71TvbYPJ4=
-github.com/beclab/api v0.0.17 h1:N0w6MOUBcOtfKwHqZ7HYxx0GdID2E0F+CWyLZr7nI08=
-github.com/beclab/api v0.0.17/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/Olares/framework/oac v0.0.0-20260616125358-3d8fc9468ad0 h1:1qwobGs1u5kRWdRhNDbwjywSsnwegrAKHfwNkfOUtmU=
+github.com/beclab/Olares/framework/oac v0.0.0-20260616125358-3d8fc9468ad0/go.mod h1:dpo6y8IYbmmE41+qKjZv2LfkuDUidAscpQ71TvbYPJ4=
 github.com/beclab/api v0.0.18 h1:6qN86kZVJdHbQt1/hXppkLWn3hf9LYdCCOTldUaOpEQ=
 github.com/beclab/api v0.0.18/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -114,17 +114,17 @@ func (h *Handler) updateDeviceSupportType(req *restful.Request, resp *restful.Re
 		return
 	}
 
-	node, device, err := compute.FindDevice(ctx, h.ctrlClient, nodeName, deviceID)
+	_, device, err := compute.FindDevice(ctx, h.ctrlClient, nodeName, deviceID)
 	if err != nil {
 		api.HandleBadRequest(resp, req, err)
 		return
 	}
-	if !compute.IsHAMIMode(node.GPUType) {
-		api.HandleBadRequest(resp, req, fmt.Errorf("device mode switching is not supported for gpu type %s", node.GPUType))
+	if !compute.IsHAMIMode(device.Mode) {
+		api.HandleBadRequest(resp, req, fmt.Errorf("device mode switching is not supported for gpu type %s", device.Mode))
 		return
 	}
 	if !compute.SupportTypeAvailable(device.AvailableSupportTypes, body.SupportType) {
-		api.HandleBadRequest(resp, req, fmt.Errorf("support type %s is not available for gpu type %s", body.SupportType, node.GPUType))
+		api.HandleBadRequest(resp, req, fmt.Errorf("support type %s is not available for gpu type %s", body.SupportType, device.Mode))
 		return
 	}
 	if device.SupportType == body.SupportType {

--- a/framework/app-service/pkg/compute/auto_select.go
+++ b/framework/app-service/pkg/compute/auto_select.go
@@ -13,10 +13,12 @@ import (
 )
 
 // ErrAmbiguousComputeMode is returned by AutoSelectMode when more than one
-// non-cpu mode declared by the app is also runnable on the cluster, so the
-// caller must surface the ambiguity to the user (e.g. by returning the
-// install compute plan and asking for an explicit selectedGpuType).
-var ErrAmbiguousComputeMode = errors.New("multiple gpu types runnable on this cluster; please specify selectedGpuType")
+// mode declared by the app is runnable on the cluster. cpu is treated as a
+// first-class candidate, so an app that declares both cpu and a matching gpu
+// mode is ambiguous too; the caller must surface the choice to the user (e.g.
+// by returning the install compute plan and asking for an explicit
+// selectedGpuType).
+var ErrAmbiguousComputeMode = errors.New("multiple compute modes runnable on this cluster; please specify selectedGpuType")
 
 // AutoSelectMode picks a compute mode for `appCfg` when the install caller
 // did not supply one explicitly. It is meant to make the common cases
@@ -34,30 +36,30 @@ var ErrAmbiguousComputeMode = errors.New("multiple gpu types runnable on this cl
 //     See AppSupportedModes for the exact rules.
 //
 //  3. valid = (modes the app supports) ∩ (modes runnable on this cluster).
-//     - cpu is "runnable" iff app.modes contains cpu.
+//     - cpu is a first-class candidate: it is "runnable" iff app.modes
+//     contains cpu (every cluster can run cpu pods).
 //     - any non-cpu mode m is "runnable" iff m ∈ cluster.gpuTypes.
 //
-//  4. Decide:
-//     - exactly one non-cpu entry in valid → return that. (Single GPU
-//     candidate, no ambiguity even if cpu fallback is also valid.)
-//     - zero non-cpu entries in valid, but cpu ∈ valid → return cpu.
-//     (App is effectively cpu-only on this cluster.)
-//     - otherwise (multiple non-cpu candidates, or the intersection is
-//     empty) → return an error and let the caller require an explicit
-//     SelectedGpuType.
+//  4. Decide purely on len(valid):
+//     - exactly one entry → return it (the only choice; may be cpu).
+//     - zero entries → error (the app declares only gpu modes, none of
+//     which the cluster has).
+//     - more than one entry → ErrAmbiguousComputeMode; the caller surfaces
+//     the choice. cpu being one of the candidates does NOT auto-resolve it:
+//     {cpu, nvidia} is ambiguous and asks the user to pick.
 //
-// Worked examples (cluster has nvidia + cpu fallback):
+// Worked examples (cluster has nvidia, cpu always runnable):
 //
-//	app supports {nvidia, gb10, strix-halo}     -> nvidia
-//	app supports {nvidia, gb10, cpu}            -> nvidia (one non-cpu match)
-//	app supports {strix-halo, apple-m}          -> error (no overlap)
+//	app supports {nvidia, gb10, amd}            -> nvidia (only nvidia matches)
+//	app supports {nvidia, gb10, cpu}            -> error (ambiguous: nvidia + cpu)
+//	app supports {amd, apple-m}                 -> error (no overlap)
 //	app supports {cpu}                          -> cpu
 //
-// Worked examples (cluster has nvidia + strix-halo + cpu fallback):
+// Worked examples (cluster has nvidia + amd, cpu always runnable):
 //
 //	app supports {nvidia}                       -> nvidia
-//	app supports {strix-halo}                   -> strix-halo
-//	app supports {nvidia, strix-halo}           -> error (ambiguous)
+//	app supports {amd}                          -> amd
+//	app supports {nvidia, amd}                  -> error (ambiguous)
 //	app supports {cpu}                          -> cpu
 //	app supports {cpu, apple-m}                 -> cpu (apple-m not on cluster)
 func AutoSelectMode(ctx context.Context, c client.Client, appCfg *appcfg.ApplicationConfig) (string, error) {
@@ -122,25 +124,31 @@ func AutoSelectMode(ctx context.Context, c client.Client, appCfg *appcfg.Applica
 // out so unit tests can exercise the decision matrix without spinning up a
 // fake controller-runtime client. See AutoSelectMode for the contract.
 func autoSelectModeFromInputs(appModes []string, clusterGPUTypes map[string]struct{}) (string, error) {
-	var validNonCPU []string
-	var validCPU bool
+	seen := make(map[string]struct{})
+	var valid []string
+	add := func(mode string) {
+		if _, ok := seen[mode]; ok {
+			return
+		}
+		seen[mode] = struct{}{}
+		valid = append(valid, mode)
+	}
 	for _, mode := range appModes {
 		if mode == utils.CPUType {
-			validCPU = true
+			// cpu is a first-class candidate: every cluster can run cpu
+			// pods, so it always counts when the app declares it.
+			add(utils.CPUType)
 			continue
 		}
 		if _, ok := clusterGPUTypes[mode]; ok {
-			validNonCPU = append(validNonCPU, mode)
+			add(mode)
 		}
 	}
 
-	switch len(validNonCPU) {
+	switch len(valid) {
 	case 1:
-		return validNonCPU[0], nil
+		return valid[0], nil
 	case 0:
-		if validCPU {
-			return utils.CPUType, nil
-		}
 		return "", fmt.Errorf("The Olares cluster cannot meet the required resource specifications. No matching GPU type")
 	default:
 		return "", ErrAmbiguousComputeMode

--- a/framework/app-service/pkg/compute/auto_select_test.go
+++ b/framework/app-service/pkg/compute/auto_select_test.go
@@ -70,14 +70,14 @@ func mustParseQty(s string) *resource.Quantity {
 // design doc:
 //
 //	cluster A: a single nvidia node (cluster gpu types = {nvidia})
-//	cluster B: nvidia + strix-halo nodes (cluster gpu types = {nvidia, strix-halo})
+//	cluster B: nvidia + amd nodes (cluster gpu types = {nvidia, amd})
 //
 // In both clusters cpu is implicit — every node can run a cpu-mode pod —
 // so cpu is never enumerated in the cluster set itself; the auto-selector
 // only treats cpu as a valid choice when the app declares it.
 func TestAutoSelectModeFromInputs(t *testing.T) {
 	clusterNvidiaOnly := stringSet(utils.NvidiaCardType)
-	clusterNvidiaPlusStrix := stringSet(utils.NvidiaCardType, utils.StrixHaloChipType)
+	clusterNvidiaPlusAMD := stringSet(utils.NvidiaCardType, utils.AMDType)
 
 	tests := []struct {
 		name        string
@@ -88,20 +88,20 @@ func TestAutoSelectModeFromInputs(t *testing.T) {
 	}{
 		// case 1: cluster has only nvidia
 		{
-			name:     "case1/A: app supports nvidia/gb10/strix-halo, only nvidia matches",
-			appModes: []string{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType},
+			name:     "case1/A: app supports nvidia/gb10/amd, only nvidia matches",
+			appModes: []string{utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType},
 			cluster:  clusterNvidiaOnly,
 			wantMode: utils.NvidiaCardType,
 		},
 		{
-			name:     "case1/B: app supports nvidia/gb10/cpu, nvidia wins over cpu fallback",
-			appModes: []string{utils.NvidiaCardType, utils.GB10ChipType, utils.CPUType},
-			cluster:  clusterNvidiaOnly,
-			wantMode: utils.NvidiaCardType,
+			name:        "case1/B: app supports nvidia/gb10/cpu, nvidia + cpu both runnable, ambiguous",
+			appModes:    []string{utils.NvidiaCardType, utils.GB10ChipType, utils.CPUType},
+			cluster:     clusterNvidiaOnly,
+			wantErrFrag: "multiple compute modes",
 		},
 		{
-			name:        "case1/C: app supports strix-halo/apple-m, no overlap with cluster, errors",
-			appModes:    []string{utils.StrixHaloChipType, utils.AppleMChipType},
+			name:        "case1/C: app supports amd/apple-m, no overlap with cluster, errors",
+			appModes:    []string{utils.AMDType, utils.AppleMChipType},
 			cluster:     clusterNvidiaOnly,
 			wantErrFrag: "No matching GPU type",
 		},
@@ -112,35 +112,35 @@ func TestAutoSelectModeFromInputs(t *testing.T) {
 			wantMode: utils.CPUType,
 		},
 
-		// case 2: cluster has both nvidia and strix-halo
+		// case 2: cluster has both nvidia and amd
 		{
 			name:     "case2/A: app supports nvidia, picks nvidia",
 			appModes: []string{utils.NvidiaCardType},
-			cluster:  clusterNvidiaPlusStrix,
+			cluster:  clusterNvidiaPlusAMD,
 			wantMode: utils.NvidiaCardType,
 		},
 		{
-			name:     "case2/B: app supports strix-halo, picks strix-halo",
-			appModes: []string{utils.StrixHaloChipType},
-			cluster:  clusterNvidiaPlusStrix,
-			wantMode: utils.StrixHaloChipType,
+			name:     "case2/B: app supports amd, picks amd",
+			appModes: []string{utils.AMDType},
+			cluster:  clusterNvidiaPlusAMD,
+			wantMode: utils.AMDType,
 		},
 		{
-			name:        "case2/C: app supports both nvidia and strix-halo, ambiguous, errors",
-			appModes:    []string{utils.NvidiaCardType, utils.StrixHaloChipType},
-			cluster:     clusterNvidiaPlusStrix,
-			wantErrFrag: "multiple gpu types",
+			name:        "case2/C: app supports both nvidia and amd, ambiguous, errors",
+			appModes:    []string{utils.NvidiaCardType, utils.AMDType},
+			cluster:     clusterNvidiaPlusAMD,
+			wantErrFrag: "multiple compute modes",
 		},
 		{
 			name:     "case2/D: app supports cpu only, picks cpu",
 			appModes: []string{utils.CPUType},
-			cluster:  clusterNvidiaPlusStrix,
+			cluster:  clusterNvidiaPlusAMD,
 			wantMode: utils.CPUType,
 		},
 		{
 			name:     "case2/E: app supports cpu/apple-m on cluster without apple-m, picks cpu",
 			appModes: []string{utils.CPUType, utils.AppleMChipType},
-			cluster:  clusterNvidiaPlusStrix,
+			cluster:  clusterNvidiaPlusAMD,
 			wantMode: utils.CPUType,
 		},
 

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -39,19 +39,20 @@ func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnap
 func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot) []NodeOption {
 	out := make([]NodeOption, 0, len(nodes))
 	for _, node := range nodes {
-		if node.GPUType != req.Mode {
+		if !node.SupportsMode(req.Mode) {
 			out = append(out, NodeOption{
 				NodeName: node.NodeName,
-				GPUType:  node.GPUType,
+				GPUType:  node.primaryGPUType(),
 				Status:   NodeStatusNotMatch,
 			})
 			continue
 		}
+		view := node.viewForMode(req.Mode)
 		var option NodeOption
 		if req.Mode == utils.NvidiaCardType {
-			option = classifyNvidiaNode(req, node, pressure)
+			option = classifyNvidiaNode(req, view, pressure)
 		} else {
-			option = classifyNonNvidiaNode(req, node, pressure)
+			option = classifyNonNvidiaNode(req, view, pressure)
 		}
 		out = append(out, option)
 	}
@@ -62,7 +63,7 @@ func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) N
 	summary := summarizeNvidiaNode(req, node, pressure)
 	option := NodeOption{
 		NodeName: node.NodeName,
-		GPUType:  node.GPUType,
+		GPUType:  req.Mode,
 		Devices:  summary.devices,
 	}
 	if req.SupportMultiCards || req.SupportMultiNodes {
@@ -74,7 +75,7 @@ func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) N
 }
 
 func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
-	option := NodeOption{NodeName: node.NodeName, GPUType: node.GPUType}
+	option := NodeOption{NodeName: node.NodeName, GPUType: req.Mode}
 	if len(node.Devices) == 0 {
 		option.Status = NodeStatusNotAvailable
 		return option
@@ -168,10 +169,10 @@ func availabilityScope(req Requirement) string {
 	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
 		return AvailabilityScopeSingleNode
 	}
-	if req.Mode == utils.NvidiaCardType {
-		return AvailabilityScopeCard
-	}
-	return AvailabilityScopeNode
+	// Single-nvidia-card and every non-nvidia mode (cpu / amd / intel /
+	// apple-m / moore-soc — each modeled as one node-level device) share the
+	// per-card scope: the unit of scheduling is a single device.
+	return AvailabilityScopeCard
 }
 
 func markOperable(result *AvailabilityResult) {
@@ -436,7 +437,7 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 		if item.device.Health != "" && item.device.Health != deviceHealthYes {
 			return invalidBinding("device-unhealthy:" + item.device.ID)
 		}
-		if item.node.GPUType != req.Mode {
+		if item.device.Mode != req.Mode {
 			return invalidBinding("gpu-type-mismatch")
 		}
 		available := deviceAvailableMemory(item.device)

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -17,18 +17,18 @@ func TestCalculateInstallComputePlanUsesPureInputs(t *testing.T) {
 		Accelerator: []appcfg.ResourceMode{
 			resourceMode(utils.NvidiaCardType, "8Gi", "1Gi"),
 			resourceMode(utils.AppleMChipType, "", "1Gi"),
-			resourceMode(utils.StrixHaloChipType, "", "8Gi"),
+			resourceMode(utils.AMDType, "", "8Gi"),
 		},
 	}
 	nodes := []Node{
 		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
-		computeNode("strix-a", utils.StrixHaloChipType, 4*gi, SupportTypeExclusive),
+		computeNode("amd-a", utils.AMDType, 4*gi, SupportTypeExclusive),
 	}
 
 	plan := calculateInstallComputePlan(app, nodes)
 	assertModeStatus(t, plan, utils.NvidiaCardType, StatusInstallable)
 	assertModeStatus(t, plan, utils.AppleMChipType, StatusNoMatchingNode)
-	assertModeStatus(t, plan, utils.StrixHaloChipType, StatusInsufficientResources)
+	assertModeStatus(t, plan, utils.AMDType, StatusInsufficientResources)
 }
 
 func TestInstallComputePlanIgnoresCurrentBindings(t *testing.T) {
@@ -322,11 +322,11 @@ func TestAvailabilityCrossNodeSumsRawAvailableDespitePerNodePressure(t *testing.
 
 func TestAvailabilityNonNvidiaNodeBecomesNotAvailableUnderPressure(t *testing.T) {
 	req := Requirement{
-		Mode:           utils.StrixHaloChipType,
+		Mode:           utils.AMDType,
 		RequiredMemory: 4 * gi,
 		LimitedMemory:  4 * gi,
 	}
-	nodes := []Node{computeNode("strix-a", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive)}
+	nodes := []Node{computeNode("strix-a", utils.AMDType, 32*gi, SupportTypeExclusive)}
 
 	healthyResult := listAvailableForLaunch(req, nodes, PressureSnapshot{})
 	if len(healthyResult.Nodes) != 1 || healthyResult.Nodes[0].Status != NodeStatusAvailable {
@@ -350,13 +350,13 @@ func TestAvailabilityNonNvidiaNodeBecomesNotAvailableUnderPressure(t *testing.T)
 
 func TestValidateBindingSelectionNonNvidiaRequiresSingleSelection(t *testing.T) {
 	req := Requirement{
-		Mode:           utils.StrixHaloChipType,
+		Mode:           utils.AMDType,
 		RequiredMemory: 4 * gi,
 		LimitedMemory:  4 * gi,
 	}
 	nodes := []Node{
-		computeNode("strix-a", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive),
-		computeNode("strix-b", utils.StrixHaloChipType, 32*gi, SupportTypeExclusive),
+		computeNode("strix-a", utils.AMDType, 32*gi, SupportTypeExclusive),
+		computeNode("strix-b", utils.AMDType, 32*gi, SupportTypeExclusive),
 	}
 	result := ValidateBindingSelection(req, []BindingSelection{
 		{NodeName: "strix-a", DeviceID: "strix-a-device"},
@@ -476,9 +476,9 @@ func TestLegacyComputeMode(t *testing.T) {
 			name: "explicit SelectedGpuType wins even when requirement says cpu",
 			cfg: &appcfg.ApplicationConfig{
 				AppName:         "legacy-pinned-on-strix",
-				SelectedGpuType: utils.StrixHaloChipType,
+				SelectedGpuType: utils.AMDType,
 			},
-			want: utils.StrixHaloChipType,
+			want: utils.AMDType,
 		},
 	}
 	for _, tt := range cases {
@@ -509,12 +509,15 @@ func resourceMode(mode, requiredGPU, requiredMemory string) appcfg.ResourceMode 
 func nvidiaNode(name string, devices ...Device) Node {
 	node := Node{
 		NodeName:       name,
-		GPUType:        utils.NvidiaCardType,
+		GPUTypes:       []string{utils.NvidiaCardType},
 		memoryCapacity: 64 * gi,
 		Devices:        devices,
 	}
 	for i := range node.Devices {
 		node.Devices[i].NodeName = name
+		if node.Devices[i].Mode == "" {
+			node.Devices[i].Mode = utils.NvidiaCardType
+		}
 	}
 	return node
 }
@@ -522,11 +525,12 @@ func nvidiaNode(name string, devices ...Device) Node {
 func computeNode(name, gpuType string, memory int64, supportType string) Node {
 	return Node{
 		NodeName:       name,
-		GPUType:        gpuType,
+		GPUTypes:       []string{gpuType},
 		memoryCapacity: 64 * gi,
 		Devices: []Device{{
 			ID:          name + "-device",
 			NodeName:    name,
+			Mode:        gpuType,
 			Memory:      memory,
 			Health:      deviceHealthYes,
 			SupportType: supportType,

--- a/framework/app-service/pkg/compute/device_mode.go
+++ b/framework/app-service/pkg/compute/device_mode.go
@@ -32,15 +32,15 @@ func FindDevice(ctx context.Context, c client.Client, nodeName, deviceID string)
 // callers that have already torn the bindings down should use SwitchDeviceMode
 // directly.
 func UpdateDeviceSupportType(ctx context.Context, c client.Client, nodeName, deviceID, supportType string) (Device, error) {
-	node, device, err := FindDevice(ctx, c, nodeName, deviceID)
+	_, device, err := FindDevice(ctx, c, nodeName, deviceID)
 	if err != nil {
 		return Device{}, err
 	}
-	if !IsHAMIMode(node.GPUType) {
-		return Device{}, fmt.Errorf("device mode switching is not supported for gpu type %s", node.GPUType)
+	if !IsHAMIMode(device.Mode) {
+		return Device{}, fmt.Errorf("device mode switching is not supported for gpu type %s", device.Mode)
 	}
 	if !SupportTypeAvailable(device.AvailableSupportTypes, supportType) {
-		return Device{}, fmt.Errorf("support type %s is not available for gpu type %s", supportType, node.GPUType)
+		return Device{}, fmt.Errorf("support type %s is not available for gpu type %s", supportType, device.Mode)
 	}
 	if len(device.Bindings) > 0 {
 		return Device{}, fmt.Errorf("device %s still has %d compute bindings", deviceID, len(device.Bindings))

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -168,11 +168,14 @@ func PickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes
 	return pickSingleAllocation(appConfig, req, matching, pressure)
 }
 
+// matchingNodes returns the nodes that support `mode`, each projected onto that
+// single mode (Devices filtered to the mode) so the device-centric scheduling
+// helpers only ever see the relevant devices of a multi-mode node.
 func matchingNodes(mode string, nodes []Node) []Node {
 	out := make([]Node, 0)
 	for _, node := range nodes {
-		if node.GPUType == mode {
-			out = append(out, node)
+		if node.SupportsMode(mode) {
+			out = append(out, node.viewForMode(mode))
 		}
 	}
 	return out

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -201,38 +201,62 @@ func loadNodeResources(ctx context.Context, c client.Client) ([]Node, error) {
 	return out, nil
 }
 
+// buildNodeResource builds the compute view of a single physical node. A node
+// may advertise several accelerator modes at once (e.g. an Olares One exposing
+// both nvidia and intel): GPUTypes lists them all and Devices holds the devices
+// for every mode, each tagged with the Mode it serves. The scheduler /
+// availability code projects this down to a single mode via Node.viewForMode
+// when it needs a per-mode view. A node with no GPU mode is represented with a
+// single cpu memory-shared device, preserving the previous behavior for
+// pure-CPU and unlabeled nodes.
 func buildNodeResource(node *corev1.Node) Node {
 	totalMemory := node.Status.Capacity.Memory().Value()
-	mode := utils.NodeGPUType(node)
+	modes := utils.NodeSupportedGPUTypes(node)
 
 	n := Node{
 		NodeName:       node.Name,
-		GPUType:        mode,
+		GPUTypes:       modes,
 		Health:         nodeHealth(node),
 		memoryCapacity: totalMemory,
 	}
 
-	if IsHAMIMode(mode) {
-		n.Devices = decodeHAMINvidiaDevices(node)
-	} else {
-		supportType := SupportTypeExclusive
-		if mode == utils.CPUType {
-			supportType = SupportTypeMemoryShared
+	if len(modes) == 0 {
+		n.Devices = []Device{nonHAMIDevice(node, utils.CPUType, totalMemory)}
+		return n
+	}
+
+	for _, mode := range modes {
+		if IsHAMIMode(mode) {
+			n.Devices = append(n.Devices, decodeHAMINvidiaDevices(node, mode)...)
+			continue
 		}
-		n.Devices = []Device{{
-			ID:                    fmt.Sprintf("%s-%s-0", node.Name, mode),
-			NodeName:              node.Name,
-			Memory:                totalMemory * 75 / 100,
-			Health:                nodeHealth(node),
-			SupportType:           supportType,
-			AvailableSupportTypes: AvailableSupportTypes(mode),
-		}}
+		n.Devices = append(n.Devices, nonHAMIDevice(node, mode, totalMemory))
 	}
 
 	return n
 }
 
-func decodeHAMINvidiaDevices(node *corev1.Node) []Device {
+// nonHAMIDevice builds the single synthetic device used for unified-memory
+// modes (cpu, apple-m, amd, intel, moore-soc, …): the whole node is one
+// schedulable unit drawing from system memory. cpu is memory-shared; every
+// other such mode is exclusive (the Apple-Silicon path).
+func nonHAMIDevice(node *corev1.Node, mode string, totalMemory int64) Device {
+	supportType := SupportTypeExclusive
+	if mode == utils.CPUType {
+		supportType = SupportTypeMemoryShared
+	}
+	return Device{
+		ID:                    fmt.Sprintf("%s-%s-0", node.Name, mode),
+		NodeName:              node.Name,
+		Mode:                  mode,
+		Memory:                totalMemory * 75 / 100,
+		Health:                nodeHealth(node),
+		SupportType:           supportType,
+		AvailableSupportTypes: AvailableSupportTypes(mode),
+	}
+}
+
+func decodeHAMINvidiaDevices(node *corev1.Node, mode string) []Device {
 	raw := node.Annotations[constants.NodeNvidiaRegistryKey]
 	if !strings.Contains(raw, constants.OneContainerMultiDeviceSplitSymbol) {
 		return nil
@@ -249,10 +273,10 @@ func decodeHAMINvidiaDevices(node *corev1.Node) []Device {
 		}
 		devmem, _ := strconv.ParseInt(items[2], 10, 64)
 		healthy, _ := strconv.ParseBool(items[6])
-		mode := utils.NodeGPUType(node)
 		devices = append(devices, Device{
 			ID:                    items[0],
 			NodeName:              node.Name,
+			Mode:                  mode,
 			CardModel:             items[4],
 			Memory:                devmem * mib,
 			Health:                boolHealth(healthy),

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -1,0 +1,143 @@
+package compute
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func k8sNode(name string, memory string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(memory)},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func devicesForMode(n Node, mode string) []Device {
+	out := make([]Device, 0)
+	for _, d := range n.Devices {
+		if d.Mode == mode {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func TestBuildNodeResourcePureCPU(t *testing.T) {
+	n := buildNodeResource(k8sNode("cpu-a", "16Gi", nil))
+	if len(n.GPUTypes) != 0 {
+		t.Fatalf("pure-cpu node should advertise no gpu types, got %v", n.GPUTypes)
+	}
+	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.CPUType || n.Devices[0].SupportType != SupportTypeMemoryShared {
+		t.Fatalf("expected a single cpu memory-shared device, got %+v", n.Devices)
+	}
+	if !n.SupportsMode(utils.CPUType) {
+		t.Fatal("every node must support cpu")
+	}
+}
+
+func TestBuildNodeResourceMultiMode(t *testing.T) {
+	// Olares One style node: advertises both nvidia and intel, so it stays a
+	// single Node carrying both modes with per-mode devices.
+	node := k8sNode("olares-one", "32Gi", map[string]string{
+		utils.NodeGPUTypeLabelPrefix + utils.NvidiaCardType: "true",
+		utils.NodeGPUTypeLabelPrefix + utils.IntelType:      "true",
+	})
+	n := buildNodeResource(node)
+
+	if got, want := sortedStrings(n.GPUTypes), []string{utils.IntelType, utils.NvidiaCardType}; !equalStringSlices(got, want) {
+		t.Fatalf("expected GPUTypes %v, got %v", want, got)
+	}
+	if !n.SupportsMode(utils.NvidiaCardType) || !n.SupportsMode(utils.IntelType) || !n.SupportsMode(utils.CPUType) {
+		t.Fatalf("node should support nvidia, intel and cpu; GPUTypes=%v", n.GPUTypes)
+	}
+	if n.SupportsMode(utils.AMDType) {
+		t.Fatal("node must not claim support for amd")
+	}
+
+	// The intel mode follows the Apple-Silicon path: one exclusive device,
+	// tagged with its mode and the node-mode device id.
+	intelDevs := devicesForMode(n, utils.IntelType)
+	if len(intelDevs) != 1 || intelDevs[0].SupportType != SupportTypeExclusive {
+		t.Fatalf("expected one exclusive intel device, got %+v", intelDevs)
+	}
+	if intelDevs[0].ID != "olares-one-intel-0" {
+		t.Fatalf("unexpected intel device id %q", intelDevs[0].ID)
+	}
+
+	// viewForMode projects to a single mode so the scheduler only sees that
+	// mode's devices on this multi-mode node.
+	view := n.viewForMode(utils.IntelType)
+	if len(view.Devices) != 1 || view.Devices[0].Mode != utils.IntelType {
+		t.Fatalf("viewForMode(intel) should keep only intel devices, got %+v", view.Devices)
+	}
+}
+
+// TestBindingSelectionResolvesDeviceOnMultiModeNode guards the multi-mode node
+// binding path: a node that exposes both nvidia and intel must let callers
+// select either mode's device by (nodeName, deviceID). The single physical-node
+// model keeps every device under one NodeName so findNode/findDevice locate the
+// right one, and the validation keys the mode off the selected device.
+func TestBindingSelectionResolvesDeviceOnMultiModeNode(t *testing.T) {
+	node := Node{
+		NodeName:       "olares-one",
+		GPUTypes:       []string{utils.NvidiaCardType, utils.IntelType},
+		memoryCapacity: 32 * gi,
+		Devices: []Device{
+			{ID: "gpu0", NodeName: "olares-one", Mode: utils.NvidiaCardType, Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.NvidiaCardType)},
+			{ID: "olares-one-intel-0", NodeName: "olares-one", Mode: utils.IntelType, Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.IntelType)},
+		},
+	}
+	nodes := []Node{node}
+
+	resolved, err := resolveSelection([]BindingSelection{{NodeName: "olares-one", DeviceID: "olares-one-intel-0"}}, nodes)
+	if err != nil {
+		t.Fatalf("resolveSelection on multi-mode node: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0].device.ID != "olares-one-intel-0" || resolved[0].device.Mode != utils.IntelType {
+		t.Fatalf("expected the intel device resolved, got %+v", resolved)
+	}
+
+	reqIntel := Requirement{Mode: utils.IntelType, RequiredMemory: 4 * gi, LimitedMemory: 4 * gi}
+	if res := ValidateBindingSelection(reqIntel, []BindingSelection{{NodeName: "olares-one", DeviceID: "olares-one-intel-0"}}, nodes, PressureSnapshot{}); !res.OK {
+		t.Fatalf("intel device should be valid for an intel request, got %+v", res)
+	}
+
+	reqNvidia := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 4 * gi, LimitedGPU: 4 * gi}
+	if res := ValidateBindingSelection(reqNvidia, []BindingSelection{{NodeName: "olares-one", DeviceID: "olares-one-intel-0"}}, nodes, PressureSnapshot{}); res.OK {
+		t.Fatalf("intel device must not satisfy an nvidia request, got %+v", res)
+	}
+}
+
+// TestBuildNodeResourceDiscreteGPULabel documents that a node advertising a
+// discrete-GPU mode (amd-gpu / intel-gpu) is treated like any other advertised
+// mode now that there is no scheduling-time filter: it becomes a node-level
+// device for that mode. In practice olares-cli never writes these labels, so
+// this path is not exercised on real clusters.
+func TestBuildNodeResourceDiscreteGPULabel(t *testing.T) {
+	node := k8sNode("dgpu-a", "16Gi", map[string]string{
+		utils.NodeGPUTypeLabelPrefix + utils.AMDGPUType: "true",
+	})
+	n := buildNodeResource(node)
+	if len(n.GPUTypes) != 1 || n.GPUTypes[0] != utils.AMDGPUType {
+		t.Fatalf("expected node to advertise amd-gpu, got %v", n.GPUTypes)
+	}
+	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.AMDGPUType {
+		t.Fatalf("expected a single amd-gpu device, got %+v", n.Devices)
+	}
+}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -29,10 +29,17 @@ const (
 	hamiGPUBindingListKind   = "GPUBindingList"
 )
 
+// Node is a physical cluster node in the compute view. A node may support
+// several accelerator modes at once (e.g. an Olares One exposing both nvidia
+// and intel), so GPUTypes is a list rather than a single value; cpu is implicit
+// on every node and is not listed here. Each Device carries the Mode it serves,
+// so callers can filter a node's devices to a single mode (see Node.viewForMode
+// / matchingNodes) without losing the multi-mode view this struct exposes to
+// the API.
 type Node struct {
-	NodeName       string `json:"nodeName"`
-	GPUType        string `json:"gpuType"`
-	Health         string `json:"health,omitempty"`
+	NodeName       string   `json:"nodeName"`
+	GPUTypes       []string `json:"gpuTypes"`
+	Health         string   `json:"health,omitempty"`
 	memoryCapacity int64
 	Devices        []Device `json:"devices"`
 }
@@ -40,12 +47,53 @@ type Node struct {
 type Device struct {
 	ID                    string       `json:"id"`
 	NodeName              string       `json:"nodeName"`
+	Mode                  string       `json:"mode"`
 	CardModel             string       `json:"cardModel,omitempty"`
 	Memory                int64        `json:"memory"`
 	Health                string       `json:"health"`
 	SupportType           string       `json:"supportType"`
 	AvailableSupportTypes []string     `json:"availableSupportTypes,omitempty"`
 	Bindings              []Allocation `json:"bindings,omitempty"`
+}
+
+// SupportsMode reports whether the node can host a pod of the given mode. cpu
+// is universal — every node can run cpu workloads — while non-cpu modes must be
+// advertised in GPUTypes.
+func (n Node) SupportsMode(mode string) bool {
+	if mode == utils.CPUType {
+		return true
+	}
+	for _, m := range n.GPUTypes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// viewForMode returns a copy of the node projected onto a single mode: only the
+// devices serving that mode are retained. The device-centric scheduler /
+// availability code operates on these single-mode views so it never has to
+// reason about a node's other modes.
+func (n Node) viewForMode(mode string) Node {
+	view := n
+	devices := make([]Device, 0, len(n.Devices))
+	for _, d := range n.Devices {
+		if d.Mode == mode {
+			devices = append(devices, d)
+		}
+	}
+	view.Devices = devices
+	return view
+}
+
+// primaryGPUType returns a single representative mode for display on nodes that
+// don't match a requested mode (e.g. the availability "not-match" listing).
+func (n Node) primaryGPUType() string {
+	if len(n.GPUTypes) > 0 {
+		return n.GPUTypes[0]
+	}
+	return utils.CPUType
 }
 
 type Allocation struct {
@@ -85,7 +133,6 @@ const (
 	AvailabilityScopeCard          = "card"
 	AvailabilityScopeSingleNode    = "single-node-cards"
 	AvailabilityScopeCrossNode     = "cross-node-cards"
-	AvailabilityScopeNode          = "node"
 	FitLevelLimit                  = "limit"
 	FitLevelRequired               = "required"
 	BindingApplyStatusNotRequired  = "not-required"

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -895,7 +895,7 @@ func parseLegacyAppRequirement(cfg *appcfg.AppConfiguration, selectedGpu string)
 	if !oac.IsNewOlaresManifestVersion(cfg.ConfigVersion) {
 		// Default supportedGpu list when the manifest leaves it empty.
 		if len(cfg.Spec.SupportedGpu) == 0 {
-			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.StrixHaloChipType, utils.CPUType, utils.MthreadsM100ChipType, utils.AppleMChipType}
+			cfg.Spec.SupportedGpu = []interface{}{utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.CPUType, utils.MooreSocType, utils.AppleMChipType, utils.IntelType}
 		}
 
 		if selectedGpu != "" && gpu != nil && !gpu.IsZero() {

--- a/framework/app-service/pkg/utils/gpu_types.go
+++ b/framework/app-service/pkg/utils/gpu_types.go
@@ -3,7 +3,20 @@ package utils
 import corev1 "k8s.io/api/core/v1"
 
 const (
+	// NodeGPUTypeLabel is the legacy single-value node label
+	// (gpu.bytetrade.io/type=<mode>). Current olares-cli no longer writes it
+	// — it uses the existence-based per-mode labels below so a node can
+	// advertise several modes at once. It is still read so a historical
+	// nvidia node labeled by an older olares-cli keeps working: nvidia is the
+	// only pre-existing GPU type and its name is unchanged, so no alias
+	// mapping is needed.
 	NodeGPUTypeLabel = "gpu.bytetrade.io/type"
+
+	// NodeGPUTypeLabelPrefix is the prefix for the existence-based per-mode
+	// node labels. A node supports mode <m> iff it carries the label
+	// gpu.bytetrade.io/<m> (the value is ignored; olares-cli writes "true").
+	// cpu is never labeled — every node implicitly supports cpu workloads.
+	NodeGPUTypeLabelPrefix = "gpu.bytetrade.io/"
 
 	// noneGPUTypeLabel is the literal value some node-init paths write to
 	// gpu.bytetrade.io/type to mark a node that doesn't have a GPU. It's
@@ -13,40 +26,71 @@ const (
 )
 
 const (
-	CPUType              = "cpu"         // force to use CPU, no GPU
-	NvidiaCardType       = "nvidia"      // handling by HAMi
-	AmdGpuCardType       = "amd-gpu"     //
-	AmdApuCardType       = "amd-apu"     // AMD APU with integrated GPU , AI Max 395 etc.
-	GB10ChipType         = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
-	AppleMChipType       = "apple-m"     // Apple M-series SoC
-	StrixHaloChipType    = "strix-halo"  // AMD Strix Halo GPU & unified system memory
-	MthreadsM100ChipType = "mthreads-m1000"
+	CPUType        = "cpu"         // force to use CPU, no GPU
+	NvidiaCardType = "nvidia"      // discrete NVIDIA card, handled by HAMi
+	GB10ChipType   = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
+	AppleMChipType = "apple-m"     // Apple M-series SoC (unified memory)
+	IntelType      = "intel"       // Intel integrated GPU (unified memory)
+	AMDType        = "amd"         // AMD integrated GPU (Ryzen AI Max)
+	IntelGPUType   = "intel-gpu"   // Intel discrete GPU
+	AMDGPUType     = "amd-gpu"     // AMD discrete GPU
+	MooreSocType   = "moore-soc"   // Moore Threads SoC
 )
 
-// NodeGPUType returns the canonical GPU type string for a node by reading the
-// gpu.bytetrade.io/type label and folding the three "no GPU here" variants —
-// label missing, label set to the empty string, or label set to "none" —
-// into CPUType. Every other value is returned verbatim; the contract assumed
-// across the codebase is that other label values, OlaresManifest mode names,
-// and frontend GPU-type selections are already canonical (lowercased, no
-// whitespace), so no further normalization is necessary.
-//
-// Use this helper at any boundary that ingests a node's label, instead of
-// reading node.Labels[NodeGPUTypeLabel] directly: it keeps the cpu-fallback
-// semantics consistent across the package and is the single place that has
-// to be updated if more "no GPU" sentinel values ever get added.
-func NodeGPUType(node *corev1.Node) string {
-	if node == nil {
-		return CPUType
-	}
-	t, ok := node.Labels[NodeGPUTypeLabel]
-	if !ok || t == "" || t == noneGPUTypeLabel {
-		return CPUType
-	}
-	return t
+// canonicalGPUTypes is the ordered set of non-cpu modes the system recognizes
+// as node-labelable. It is the only set scanned for the existence-based
+// per-mode labels, so unrelated keys under the gpu.bytetrade.io/ prefix
+// (driver, cuda, cuda-supported, mode, …) are never mistaken for a GPU mode.
+var canonicalGPUTypes = []string{
+	NvidiaCardType,
+	GB10ChipType,
+	AppleMChipType,
+	IntelType,
+	AMDType,
+	IntelGPUType,
+	AMDGPUType,
+	MooreSocType,
 }
 
-// IsCPUOnlyNodeLabel reports whether the value read from a node's
+// NodeSupportedGPUTypes returns the deduplicated set of non-cpu GPU modes a
+// node supports, combining:
+//
+//   - the existence-based per-mode labels gpu.bytetrade.io/<mode> written by
+//     current olares-cli (a node may carry several at once), and
+//   - the legacy single-value gpu.bytetrade.io/type label, retained so a
+//     historical nvidia node labeled by an older olares-cli is still honored.
+//
+// cpu is never included (every node implicitly supports cpu). Results are
+// deduplicated. Declaration order follows canonicalGPUTypes with any extra
+// legacy-label value appended last.
+func NodeSupportedGPUTypes(node *corev1.Node) []string {
+	if node == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	add := func(mode string) {
+		if mode == "" || mode == CPUType {
+			return
+		}
+		if _, ok := seen[mode]; ok {
+			return
+		}
+		seen[mode] = struct{}{}
+		out = append(out, mode)
+	}
+	for _, mode := range canonicalGPUTypes {
+		if _, ok := node.Labels[NodeGPUTypeLabelPrefix+mode]; ok {
+			add(mode)
+		}
+	}
+	if t, ok := node.Labels[NodeGPUTypeLabel]; !IsCPUOnlyNodeLabel(t, ok) {
+		add(t)
+	}
+	return out
+}
+
+// IsCPUOnlyNodeLabel reports whether the value read from a node's legacy
 // gpu.bytetrade.io/type label denotes a cpu-only node. Use this at boundaries
 // where you've already extracted the label string and need to decide whether
 // to skip / fall back to CPUType, e.g. inside iteration over a NodeList.

--- a/framework/app-service/pkg/utils/gpu_types_test.go
+++ b/framework/app-service/pkg/utils/gpu_types_test.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func nodeWithLabels(labels map[string]string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: labels}}
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func TestNodeSupportedGPUTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   []string
+	}{
+		{
+			name:   "no labels -> cpu only (empty)",
+			labels: nil,
+			want:   []string{},
+		},
+		{
+			name:   "legacy single-value label",
+			labels: map[string]string{NodeGPUTypeLabel: NvidiaCardType},
+			want:   []string{NvidiaCardType},
+		},
+		{
+			name:   "legacy none label is cpu-only",
+			labels: map[string]string{NodeGPUTypeLabel: "none"},
+			want:   []string{},
+		},
+		{
+			name: "multiple existence labels (Olares One: nvidia + intel)",
+			labels: map[string]string{
+				NodeGPUTypeLabelPrefix + NvidiaCardType: "true",
+				NodeGPUTypeLabelPrefix + IntelType:      "true",
+			},
+			want: []string{NvidiaCardType, IntelType},
+		},
+		{
+			name: "legacy + new labels are deduped",
+			labels: map[string]string{
+				NodeGPUTypeLabel:                        NvidiaCardType,
+				NodeGPUTypeLabelPrefix + NvidiaCardType: "true",
+				NodeGPUTypeLabelPrefix + AMDType:        "true",
+			},
+			want: []string{NvidiaCardType, AMDType},
+		},
+		{
+			name:   "legacy single-value label is read verbatim (no alias folding)",
+			labels: map[string]string{NodeGPUTypeLabel: AMDType},
+			want:   []string{AMDType},
+		},
+		{
+			name: "unrelated gpu.bytetrade.io keys are ignored",
+			labels: map[string]string{
+				"gpu.bytetrade.io/driver":               "570.x",
+				"gpu.bytetrade.io/cuda-supported":       "true",
+				NodeGPUTypeLabelPrefix + NvidiaCardType: "true",
+			},
+			want: []string{NvidiaCardType},
+		},
+		{
+			name: "discrete gpu existence labels are still reported as supported",
+			labels: map[string]string{
+				NodeGPUTypeLabelPrefix + AMDGPUType:   "true",
+				NodeGPUTypeLabelPrefix + IntelGPUType: "true",
+			},
+			want: []string{IntelGPUType, AMDGPUType},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NodeSupportedGPUTypes(nodeWithLabels(tt.labels))
+			if !reflect.DeepEqual(sortedCopy(got), sortedCopy(tt.want)) {
+				t.Fatalf("NodeSupportedGPUTypes = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAllGpuTypesFromNodesMultiMode(t *testing.T) {
+	list := &corev1.NodeList{Items: []corev1.Node{
+		// Olares One: nvidia + intel
+		*nodeWithLabels(map[string]string{
+			NodeGPUTypeLabelPrefix + NvidiaCardType: "true",
+			NodeGPUTypeLabelPrefix + IntelType:      "true",
+		}),
+		// legacy single-value node (read verbatim, no alias folding)
+		*nodeWithLabels(map[string]string{NodeGPUTypeLabel: AMDType}),
+		// pure cpu node contributes nothing
+		*nodeWithLabels(nil),
+	}}
+	got, err := GetAllGpuTypesFromNodes(list)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]struct{}{NvidiaCardType: {}, IntelType: {}, AMDType: {}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetAllGpuTypesFromNodes = %v, want %v", got, want)
+	}
+}

--- a/framework/app-service/pkg/utils/k8sutil.go
+++ b/framework/app-service/pkg/utils/k8sutil.go
@@ -125,25 +125,25 @@ func GetAllNodesTunnelIPCIDRs() (cidrs []string) {
 // 	return gpuType, nil
 // }
 
-// GetAllGpuTypesFromNodes returns the set of explicit GPU types declared by
-// node labels (gpu.bytetrade.io/type). Nodes without the label, or with the
-// label set to an empty string / "none", contribute nothing to the result,
-// so a pure-CPU cluster returns an empty map. Callers that need to surface
-// "CPU" as a user-selectable option should add it on top of this set
-// themselves; mixing it in here would break the chart-render auto-detect
-// path which expects len(gpuTypes)==1 to mean "this cluster has exactly
-// one GPU flavour".
+// GetAllGpuTypesFromNodes returns the set of non-cpu GPU modes declared across
+// the cluster's nodes. Each node may advertise several modes at once via the
+// existence-based per-mode labels gpu.bytetrade.io/<mode> (and the legacy
+// single-value gpu.bytetrade.io/type label is still honored for backward
+// compatibility) — see NodeSupportedGPUTypes. Nodes without any GPU label
+// contribute nothing, so a pure-CPU cluster returns an empty map. Callers that
+// need to surface "CPU" as a user-selectable option should add it on top of
+// this set themselves; mixing it in here would break the chart-render
+// auto-detect path which expects len(gpuTypes)==1 to mean "this cluster has
+// exactly one GPU flavour".
 func GetAllGpuTypesFromNodes(nodes *corev1.NodeList) (map[string]struct{}, error) {
 	gpuTypes := make(map[string]struct{})
 	if nodes == nil {
 		return gpuTypes, errors.New("empty node list")
 	}
-	for _, n := range nodes.Items {
-		typeLabel, ok := n.Labels[NodeGPUTypeLabel]
-		if IsCPUOnlyNodeLabel(typeLabel, ok) {
-			continue
+	for i := range nodes.Items {
+		for _, mode := range NodeSupportedGPUTypes(&nodes.Items[i]) {
+			gpuTypes[mode] = struct{}{} // TODO: add driver version info
 		}
-		gpuTypes[typeLabel] = struct{}{} // TODO: add driver version info
 	}
 	return gpuTypes, nil
 }


### PR DESCRIPTION
* **Background**
Change the current single accelerator mode on single node to multiple accelerator modes on a single node and add some new modes

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core install scheduling, binding validation, and node labeling semantics; mis-selection or ambiguous auto-select can block installs or bind the wrong accelerator on multi-mode hardware.
> 
> **Overview**
> **Multi-mode nodes:** Compute nodes move from a single `gpuType` to `gpuTypes` plus per-device `Mode`, with `SupportsMode`, `viewForMode`, and `matchingNodes` projecting one mode at a time so scheduling and availability work on Olares One–style nodes (e.g. nvidia + intel on one machine). Node inventory is built from existence labels `gpu.bytetrade.io/<mode>` via `NodeSupportedGPUTypes`, with legacy `gpu.bytetrade.io/type` still honored.
> 
> **GPU taxonomy:** Canonical types are refreshed (`strix-halo` → `amd`, new `intel`, `moore-soc`, discrete `amd-gpu` / `intel-gpu`, etc.); legacy manifest default `supportedGpu` lists follow. HAMI device mode switching and binding validation key off **device** `Mode`, not the node’s primary type.
> 
> **Auto-select:** CPU is a first-class runnable mode; when both CPU and a matching GPU are valid, install auto-select returns ambiguity instead of preferring GPU. Availability scope drops the separate `node` scope in favor of per-card scheduling for unified-memory modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76caea5369df03582efa9601ff2f817a63560b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->