### PR TITLE
feat(cli): support multi gputypes in single node and rename some types

### DIFF
--- a/cli/pkg/bootstrap/precheck/tasks.go
+++ b/cli/pkg/bootstrap/precheck/tasks.go
@@ -412,13 +412,13 @@ func (r *RocmChecker) Check(runtime connector.Runtime) error {
 		return nil
 	}
 
-	// detect Strix-Halo presence
-	strixHaloExists, err := connector.HasStrixHalo(runtime)
+	// detect AMD Ryzen AI Max APU presence
+	ryzenAIMaxExists, err := connector.HasRyzenAIMax(runtime)
 	if err != nil {
 		return err
 	}
-	// no Strix-Halo found, no need to check rocm
-	if !strixHaloExists {
+	// no AMD Ryzen AI Max found, no need to check rocm
+	if !ryzenAIMaxExists {
 		return nil
 	}
 

--- a/cli/pkg/core/connector/amdgpu.go
+++ b/cli/pkg/core/connector/amdgpu.go
@@ -98,8 +98,8 @@ func HasAmdAPUOrGPU(execRuntime Runtime) (bool, error) {
 	})
 }
 
-func HasStrixHaloLocal() (bool, error) {
-	return hasStrixHaloChip(func(s string) (string, error) {
+func HasRyzenAIMaxLocal() (bool, error) {
+	return hasRyzenAIMax(func(s string) (string, error) {
 		out, err := exec.Command("sh", "-c", s).Output()
 		if err != nil {
 			return "", err
@@ -108,8 +108,8 @@ func HasStrixHaloLocal() (bool, error) {
 	})
 }
 
-func HasStrixHalo(execRuntime Runtime) (bool, error) {
-	return hasStrixHaloChip(func(s string) (string, error) {
+func HasRyzenAIMax(execRuntime Runtime) (bool, error) {
+	return hasRyzenAIMax(func(s string) (string, error) {
 		return execRuntime.GetRunner().SudoCmd(s, false, false)
 	})
 }
@@ -132,7 +132,9 @@ func RocmVersion() (*semver.Version, error) {
 	return cur, nil
 }
 
-func hasStrixHaloChip(cmdExec func(s string) (string, error)) (bool, error) {
+// hasRyzenAIMax detects an AMD "Ryzen AI Max" APU (the integrated-GPU part
+// labeled as the generic "amd" mode).
+func hasRyzenAIMax(cmdExec func(s string) (string, error)) (bool, error) {
 	target := "Ryzen AI Max"
 
 	// try lscpu first: extract 'Model name' field

--- a/cli/pkg/core/connector/intel.go
+++ b/cli/pkg/core/connector/intel.go
@@ -1,0 +1,36 @@
+package connector
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// hasIntelGPU reports whether the machine exposes an Intel GPU (PCI vendor
+// 8086) on a display-class controller.
+func hasIntelGPU(cmdExec func(s string) (string, error)) bool {
+	// lspci -nn prints the vendor:device id in brackets, e.g.
+	//   00:02.0 VGA compatible controller [0300]: Intel Corporation ... [8086:7d55]
+	out, err := cmdExec("lspci -nn 2>/dev/null | grep -iE 'VGA compatible controller|3D controller|Display controller' | grep -i '\\[8086:' || true")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// HasIntelGPULocal runs the Intel GPU detection against the local machine.
+func HasIntelGPULocal() bool {
+	return hasIntelGPU(func(s string) (string, error) {
+		out, err := exec.Command("sh", "-c", s).Output()
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	})
+}
+
+// HasIntelGPU runs the Intel GPU detection against the given runtime's host.
+func HasIntelGPU(execRuntime Runtime) bool {
+	return hasIntelGPU(func(s string) (string, error) {
+		return execRuntime.GetRunner().SudoCmd(s, false, false)
+	})
+}

--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -82,7 +82,8 @@ type Systems interface {
 	IsAmdGPU() bool
 	IsAmdGPUOrAPU() bool
 	IsMThreadsM1000() bool
-	IsStrixHalo() bool
+	IsRyzenAIMax() bool
+	IsIntelGPU() bool
 
 	IsUbuntu() bool
 	IsDebian() bool
@@ -255,8 +256,16 @@ func (s *SystemInfo) IsAmdGPU() bool {
 	return s.HasAmdGPU
 }
 
-func (s *SystemInfo) IsStrixHalo() bool {
-	return s.CpuInfo.IsStrixHalo
+// IsRyzenAIMax reports whether the node carries an AMD "Ryzen AI Max" APU
+// (integrated GPU). It drives ROCm install + the "amd" node mode label.
+func (s *SystemInfo) IsRyzenAIMax() bool {
+	return s.CpuInfo.IsRyzenAIMax
+}
+
+// IsIntelGPU reports whether the node exposes an Intel GPU (drives the "intel"
+// node mode label)
+func (s *SystemInfo) IsIntelGPU() bool {
+	return s.CpuInfo.IsIntelGPU
 }
 
 func (s *SystemInfo) IsAmdGPUOrAPU() bool {
@@ -480,7 +489,8 @@ type CpuInfo struct {
 	IsGB10Chip       bool   `json:"is_gb10_chip,omitempty"`
 	HasAmdAPU        bool   `json:"has_amd_apu,omitempty"`
 	IsMThreadsM1000  bool   `json:"is_mthreads_m1000,omitempty"`
-	IsStrixHalo      bool   `json:"is_strix_halo,omitempty"`
+	IsRyzenAIMax     bool   `json:"is_ryzen_ai_max,omitempty"`
+	IsIntelGPU       bool   `json:"is_intel_gpu,omitempty"`
 }
 
 // Not considering the case where AMD GPU and AMD APU coexist.
@@ -549,19 +559,23 @@ func getCpu() *CpuInfo {
 		hasAmdAPU = false
 	}
 
-	// check if it is Strix Halo
-	isStrixHalo, err := HasStrixHaloLocal()
+	// check if it is an AMD Ryzen AI Max APU
+	isRyzenAIMax, err := HasRyzenAIMaxLocal()
 	if err != nil {
-		fmt.Printf("Error checking Strix Halo: %v\n", err)
-		isStrixHalo = false
+		fmt.Printf("Error checking AMD Ryzen AI Max: %v\n", err)
+		isRyzenAIMax = false
 	}
+
+	// check if it has an Intel GPU
+	isIntelGPU := HasIntelGPULocal()
 
 	// check if it is mthreads m1000
 	ret.IsMThreadsM1000 = IsMThreadsAIBookM1000Local()
 
 	ret.IsGB10Chip = isGB10Chip
 	ret.HasAmdAPU = hasAmdAPU
-	ret.IsStrixHalo = isStrixHalo
+	ret.IsRyzenAIMax = isRyzenAIMax
+	ret.IsIntelGPU = isIntelGPU
 
 	return ret
 }

--- a/cli/pkg/gpu/amdgpu/module.go
+++ b/cli/pkg/gpu/amdgpu/module.go
@@ -79,8 +79,8 @@ func (m *InstallAmdPluginModule) Init() {
 
 	// update node with AMD GPU labels
 	updateNode := &task.LocalTask{
-		Name:   "UpdateNodeStrixHaloInfo",
-		Action: new(UpdateNodeStrixHaloInfo),
+		Name:   "UpdateNodeAMDInfo",
+		Action: new(UpdateNodeAMDInfo),
 		Retry:  1,
 	}
 

--- a/cli/pkg/gpu/amdgpu/tasks.go
+++ b/cli/pkg/gpu/amdgpu/tasks.go
@@ -56,12 +56,12 @@ func (t *InstallAmdRocm) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 
-	strixHaloExists, err := connector.HasStrixHalo(runtime)
+	ryzenAIMaxExists, err := connector.HasRyzenAIMax(runtime)
 	if err != nil {
 		return err
 	}
 	// skip rocm install
-	if !strixHaloExists {
+	if !ryzenAIMaxExists {
 		return nil
 	}
 	rocmV, _ := connector.RocmVersion()
@@ -218,24 +218,25 @@ func (t *GenerateAndValidateAmdCDI) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-// UpdateNodeStrixHaloInfo updates Kubernetes node labels with Strix-Halo information.
-type UpdateNodeStrixHaloInfo struct {
+// UpdateNodeAMDInfo labels the node as supporting the "amd" mode (AMD
+// integrated GPU / Ryzen AI Max) once ROCm is present.
+type UpdateNodeAMDInfo struct {
 	common.KubeAction
 }
 
-func (u *UpdateNodeStrixHaloInfo) Execute(runtime connector.Runtime) error {
+func (u *UpdateNodeAMDInfo) Execute(runtime connector.Runtime) error {
 	client, err := clientset.NewKubeClient()
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 	}
 
-	// Check if Strix-Halo exists
-	strixHaloExists, err := connector.HasStrixHalo(runtime)
+	// Check if an AMD Ryzen AI Max APU is present
+	ryzenAIMaxExists, err := connector.HasRyzenAIMax(runtime)
 	if err != nil {
 		return err
 	}
-	if !strixHaloExists {
-		logger.Info("Strix-Halo is not detected")
+	if !ryzenAIMaxExists {
+		logger.Info("AMD Ryzen AI Max APU is not detected")
 		return nil
 	}
 
@@ -248,10 +249,8 @@ func (u *UpdateNodeStrixHaloInfo) Execute(runtime connector.Runtime) error {
 
 	rocmVersion := rocmV.Original()
 
-	gpuType := gpu.StrixHaloChipType
-
-	// Use ROCm version as both driver and "cuda" version for AMD
-	return gpu.UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), &rocmVersion, nil, nil, &gpuType)
+	// Use the ROCm version as the driver label for the "amd" mode.
+	return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.AMDType, &rocmVersion, nil, nil)
 }
 
 // InstallAmdPlugin installs the AMD GPU device plugin DaemonSet.

--- a/cli/pkg/gpu/intelgpu/module.go
+++ b/cli/pkg/gpu/intelgpu/module.go
@@ -1,0 +1,34 @@
+package intelgpu
+
+import (
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+// InstallIntelPluginModule advertises Intel integrated-GPU support on the node.
+// There is no device plugin to install in this version (Intel iGPUs use unified
+// system memory and are scheduled like Apple Silicon), so the module only
+// updates the node's mode label.
+type InstallIntelPluginModule struct {
+	common.KubeModule
+	Skip bool // conditional execution based on Intel GPU detection
+}
+
+func (m *InstallIntelPluginModule) IsSkip() bool {
+	return m.Skip
+}
+
+func (m *InstallIntelPluginModule) Init() {
+	m.Name = "InstallIntelPlugin"
+
+	// update node with Intel GPU label
+	updateNode := &task.LocalTask{
+		Name:   "UpdateNodeIntelGPUInfo",
+		Action: new(UpdateNodeIntelGPUInfo),
+		Retry:  1,
+	}
+
+	m.Tasks = []task.Interface{
+		updateNode,
+	}
+}

--- a/cli/pkg/gpu/intelgpu/tasks.go
+++ b/cli/pkg/gpu/intelgpu/tasks.go
@@ -1,0 +1,33 @@
+package intelgpu
+
+import (
+	"context"
+
+	"github.com/beclab/Olares/cli/pkg/clientset"
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/gpu"
+
+	"github.com/pkg/errors"
+)
+
+// UpdateNodeIntelGPUInfo labels the node as supporting the "intel" mode (Intel
+// integrated GPU)
+type UpdateNodeIntelGPUInfo struct {
+	common.KubeAction
+}
+
+func (u *UpdateNodeIntelGPUInfo) Execute(runtime connector.Runtime) error {
+	client, err := clientset.NewKubeClient()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
+	}
+
+	if !connector.HasIntelGPU(runtime) {
+		logger.Info("Intel GPU is not detected")
+		return nil
+	}
+
+	return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelType, nil, nil, nil)
+}

--- a/cli/pkg/gpu/mtgpu/tasks.go
+++ b/cli/pkg/gpu/mtgpu/tasks.go
@@ -8,7 +8,6 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/gpu"
-	"k8s.io/utils/ptr"
 
 	"github.com/pkg/errors"
 )
@@ -32,7 +31,7 @@ func (u *UpdateNodeMThreadsGPUInfo) Execute(runtime connector.Runtime) error {
 	}
 
 	if runtime.GetSystemInfo().IsMThreadsM1000() {
-		return gpu.UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), nil, nil, nil, ptr.To(gpu.MThreadsM1000Type))
+		return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.MooreSocType, nil, nil, nil)
 	}
 
 	return nil

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -380,7 +380,7 @@ func (u *UpdateNodeGPUInfo) Execute(runtime connector.Runtime) error {
 		gpuType = GB10ChipType
 	}
 
-	return UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), &driverVersion, &st.CudaVersion, &supported, &gpuType)
+	return SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpuType, &driverVersion, &st.CudaVersion, &supported)
 }
 
 type RemoveNodeLabels struct {
@@ -393,13 +393,13 @@ func (u *RemoveNodeLabels) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 	}
 
-	return UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), nil, nil, nil, nil)
+	return RemoveAllNodeGpuLabels(context.Background(), client.Kubernetes())
 }
 
-// update k8s node labels gpu.bytetrade.io/driver and gpu.bytetrade.io/cuda.
-// if labels are not exists, create it.
-func UpdateNodeGpuLabel(ctx context.Context, client kubernetes.Interface, driver, cuda *string, supported *string, gpuType *string) error {
-	// get node name from hostname
+// updateCurrentNodeLabels reads the node matching the local hostname, hands its
+// label map to mutate (which returns whether it changed anything) and persists
+// the result with conflict retries when needed.
+func updateCurrentNodeLabels(ctx context.Context, client kubernetes.Interface, mutate func(labels map[string]string) bool) error {
 	nodeName, err := os.Hostname()
 	if err != nil {
 		logger.Error("get hostname error, ", err)
@@ -417,50 +417,61 @@ func UpdateNodeGpuLabel(ctx context.Context, client kubernetes.Interface, driver
 		labels = make(map[string]string)
 	}
 
-	update := false
-	for _, label := range []struct {
-		key   string
-		value *string
-	}{
-		{GpuDriverLabel, driver},
-		{GpuCudaLabel, cuda},
-		{GpuCudaSupportedLabel, supported},
-		{GpuType, gpuType},
-	} {
-		old, ok := labels[label.key]
-		switch {
-		case ok && label.value == nil: // delete label
-			delete(labels, label.key)
-			update = true
-
-		case ok && *label.value != "" && old != *label.value: // update label
-			labels[label.key] = *label.value
-			update = true
-
-		case !ok && label.value != nil && *label.value != "": // create label
-			labels[label.key] = *label.value
-			update = true
-		}
+	if !mutate(labels) {
+		return nil
 	}
 
-	if update {
-		node.SetLabels(labels)
-		safeString := func(s *string) string {
-			if s == nil {
-				return "nil"
-			}
-			return *s
-		}
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			logger.Infof("updating node gpu labels, %s, %s", safeString(driver), safeString(cuda))
-			_, err := client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-			return err
-		})
+	node.SetLabels(labels)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		logger.Infof("updating node gpu labels for %s", nodeName)
+		_, err := client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		logger.Error("update node error, ", err)
+		return err
+	}
+	return nil
+}
 
-		if err != nil {
-			logger.Error("update node error, ", err)
-			return err
+// SetNodeGpuModeLabel marks the current node as supporting `mode` by setting
+// the existence label gpu.bytetrade.io/<mode>=true. The write is additive:
+// labels for other modes the node already advertises are left untouched, so a
+// node with several accelerators (e.g. nvidia + intel) accumulates one label
+// per mode. The optional driver / cuda / cudaSupported values refresh the
+// corresponding gpu.bytetrade.io/{driver,cuda,cuda-supported} labels (used by
+// the nvidia path); a nil pointer means "leave that label as-is". The legacy
+// gpu.bytetrade.io/type label is intentionally never written.
+func SetNodeGpuModeLabel(ctx context.Context, client kubernetes.Interface, mode string, driver, cuda, cudaSupported *string) error {
+	err := updateCurrentNodeLabels(ctx, client, func(labels map[string]string) bool {
+		update := false
+		if mode != "" && mode != CPUType {
+			key := GpuModeLabel(mode)
+			if labels[key] != "true" {
+				labels[key] = "true"
+				update = true
+			}
 		}
+		for _, label := range []struct {
+			key   string
+			value *string
+		}{
+			{GpuDriverLabel, driver},
+			{GpuCudaLabel, cuda},
+			{GpuCudaSupportedLabel, cudaSupported},
+		} {
+			if label.value == nil || *label.value == "" {
+				continue
+			}
+			if labels[label.key] != *label.value {
+				labels[label.key] = *label.value
+				update = true
+			}
+		}
+		return update
+	})
+	if err != nil {
+		return err
 	}
 
 	if cuda != nil && *cuda != "" {
@@ -471,6 +482,30 @@ func UpdateNodeGpuLabel(ctx context.Context, client kubernetes.Interface, driver
 	}
 
 	return nil
+}
+
+// RemoveAllNodeGpuLabels strips every gpu.bytetrade.io GPU label from the
+// current node: the driver / cuda / cuda-supported labels, all per-mode
+// existence labels (gpu.bytetrade.io/<mode>), and the legacy
+// gpu.bytetrade.io/type label.
+func RemoveAllNodeGpuLabels(ctx context.Context, client kubernetes.Interface) error {
+	return updateCurrentNodeLabels(ctx, client, func(labels map[string]string) bool {
+		update := false
+		del := func(key string) {
+			if _, ok := labels[key]; ok {
+				delete(labels, key)
+				update = true
+			}
+		}
+		del(GpuDriverLabel)
+		del(GpuCudaLabel)
+		del(GpuCudaSupportedLabel)
+		del(GpuType)
+		for _, mode := range AllGpuModeTypes {
+			del(GpuModeLabel(mode))
+		}
+		return update
+	})
 }
 
 func updateCudaVersionSystemEnv(ctx context.Context, cudaVersion string) error {

--- a/cli/pkg/gpu/types.go
+++ b/cli/pkg/gpu/types.go
@@ -8,14 +8,45 @@ var (
 	GpuDriverLabel        = GpuLabelGroup + "/driver"
 	GpuCudaLabel          = GpuLabelGroup + "/cuda"
 	GpuCudaSupportedLabel = GpuLabelGroup + "/cuda-supported"
-	GpuType               = GpuLabelGroup + "/type"
+
+	// GpuType is the legacy single-value node label (gpu.bytetrade.io/type).
+	// olares-cli no longer writes it: a node's supported modes are now
+	// advertised through the existence-based per-mode labels returned by
+	// GpuModeLabel. It is still cleaned up on unlabel so stale values left by
+	// older installs don't linger.
+	GpuType = GpuLabelGroup + "/type"
 )
 
 const (
-	NvidiaCardType    = "nvidia"         // handling by HAMi
-	AmdGpuCardType    = "amd-gpu"        //
-	AmdApuCardType    = "amd-apu"        // AMD APU with integrated GPU , AI Max 395 etc.
-	GB10ChipType      = "nvidia-gb10"    // NVIDIA GB10 Superchip & unified system memory
-	StrixHaloChipType = "strix-halo"     // AMD Strix Halo GPU & unified system memory
-	MThreadsM1000Type = "mthreads-m1000" // MThreads M1000 AI Book with integrated GPU
+	CPUType        = "cpu"         // force to use CPU, no GPU
+	NvidiaCardType = "nvidia"      // discrete NVIDIA card, handled by HAMi
+	GB10ChipType   = "nvidia-gb10" // NVIDIA GB10 Superchip & unified system memory
+	AppleMChipType = "apple-m"     // Apple M-series SoC
+	IntelType      = "intel"       // Intel integrated GPU (unified memory)
+	AMDType        = "amd"         // AMD integrated GPU (Ryzen AI Max)
+	IntelGpuType   = "intel-gpu"   // Intel discrete GPU (not handled yet)
+	AmdGpuType     = "amd-gpu"     // AMD discrete GPU (not handled yet)
+	MooreSocType   = "moore-soc"   // Moore Threads SoC
 )
+
+// AllGpuModeTypes is the set of non-cpu modes olares-cli knows how to label a
+// node with. It is used to strip every per-mode label on unlabel. cpu is never
+// labeled — every node implicitly supports cpu workloads.
+var AllGpuModeTypes = []string{
+	NvidiaCardType,
+	GB10ChipType,
+	AppleMChipType,
+	IntelType,
+	AMDType,
+	IntelGpuType,
+	AmdGpuType,
+	MooreSocType,
+}
+
+// GpuModeLabel returns the existence-based per-mode node label key for a mode,
+// e.g. GpuModeLabel(NvidiaCardType) == "gpu.bytetrade.io/nvidia". A node
+// supports the mode iff it carries this label (value is "true"); a node may
+// carry several at once.
+func GpuModeLabel(mode string) string {
+	return GpuLabelGroup + "/" + mode
+}

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -5,6 +5,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/gpu"
 	"github.com/beclab/Olares/cli/pkg/gpu/amdgpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/intelgpu"
 	"github.com/beclab/Olares/cli/pkg/gpu/mtgpu"
 	"github.com/beclab/Olares/cli/pkg/kubesphere/plugins"
 	"github.com/beclab/Olares/cli/pkg/manifest"
@@ -61,13 +62,19 @@ func (l *linuxInstallPhaseBuilder) installGpuPlugin() phase {
 		&gpu.RestartK3sServiceModule{Skip: !(l.runtime.Arg.Kubetype == common.K3s)},
 		&gpu.InstallPluginModule{Skip: skipGpuPlugin},
 		&amdgpu.InstallAmdPluginModule{Skip: func() bool {
-			if l.runtime.GetSystemInfo().IsStrixHalo() {
+			if l.runtime.GetSystemInfo().IsRyzenAIMax() {
 				return false
 			}
 			return true
 		}()},
 		&mtgpu.InstallMThreadsPluginModule{Skip: func() bool {
 			if l.runtime.GetSystemInfo().IsMThreadsM1000() {
+				return false
+			}
+			return true
+		}()},
+		&intelgpu.InstallIntelPluginModule{Skip: func() bool {
+			if l.runtime.GetSystemInfo().IsIntelGPU() {
 				return false
 			}
 			return true

--- a/cli/pkg/phase/system/linux.go
+++ b/cli/pkg/phase/system/linux.go
@@ -84,7 +84,7 @@ func (l *linuxPhaseBuilder) build() []module.Module {
 			return []module.Module{
 				&amdgpu.InstallAmdRocmModule{},
 				&amdgpu.InstallAmdContainerToolkitModule{Skip: func() bool {
-					if l.runtime.GetSystemInfo().IsStrixHalo() {
+					if l.runtime.GetSystemInfo().IsRyzenAIMax() {
 						return false
 					}
 					return true

--- a/cli/pkg/terminus/welcome.go
+++ b/cli/pkg/terminus/welcome.go
@@ -72,7 +72,7 @@ func (t *WelcomeMessage) Execute(runtime connector.Runtime) error {
 
 	// If AMD GPU on Ubuntu 22.04/24.04, print warning about reboot for ROCm
 	if si := runtime.GetSystemInfo(); si.IsUbuntu() && (si.IsUbuntuVersionEqual(connector.Ubuntu2204) || si.IsUbuntuVersionEqual(connector.Ubuntu2404)) {
-		if hasStrixHalo, _ := connector.HasStrixHalo(runtime); hasStrixHalo {
+		if hasRyzenAIMax, _ := connector.HasRyzenAIMax(runtime); hasRyzenAIMax {
 			logger.Warnf("\x1b[31mWarning: To enable ROCm, please reboot your machine after activation.\x1b[0m")
 			fmt.Println()
 		}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -399,7 +399,7 @@ func (a *upgradeGPUDriverIfNeeded) Execute(runtime connector.Runtime) error {
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 		}
-		err = gpu.UpdateNodeGpuLabel(context.Background(), client.Kubernetes(), &targetDriverVersionStr, ptr.To(common.CurrentVerifiedCudaVersion), ptr.To("true"), ptr.To(gpu.NvidiaCardType))
+		err = gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.NvidiaCardType, &targetDriverVersionStr, ptr.To(common.CurrentVerifiedCudaVersion), ptr.To("true"))
 		if err != nil {
 			return err
 		}
@@ -605,14 +605,27 @@ func (a *backfillAppGPUConfig) Execute(_ connector.Runtime) error {
 			return errors.Wrapf(errors.WithStack(err), "failed to unmarshal config for applicationmanager %s", am.Name)
 		}
 
-		if appCfg.RequiredGPU == "" {
-			continue
-		}
-
 		modified := false
 
-		if appCfg.SelectedGpuType == "" {
-			appCfg.SelectedGpuType = gpuType
+		if appCfg.RequiredGPU != "" {
+			// App declares a GPU requirement but was installed before
+			// SelectedGpuType was recorded: backfill it from the cluster's
+			// gpu type so the new compute model resolves the right mode.
+			if appCfg.SelectedGpuType == "" {
+				appCfg.SelectedGpuType = gpuType
+				modified = true
+			}
+		} else if appCfg.SelectedGpuType != "" && appCfg.SelectedGpuType != "cpu" {
+			// App declares no GPU requirement yet carries a stale GPU
+			// SelectedGpuType: older olares-cli auto-assigned the cluster's
+			// single gpu type to every app it installed, cpu-only ones
+			// included. It was harmless then (GPU scheduling was additionally
+			// gated on a non-zero GPU requirement), but in the new compute
+			// model a non-empty SelectedGpuType resolves the app to that gpu
+			// mode and forces a device binding on resume — wrong for an app
+			// that never needed a GPU. Clear it so the app falls back to cpu
+			// mode, matching the app's effective behavior on the old version.
+			appCfg.SelectedGpuType = ""
 			modified = true
 		}
 


### PR DESCRIPTION
* **Background**
Update node label schema to support declaration of multiple gpu types
Detect intel integrated GPU and update the node label accordingly
Fix legacy apps that got injected the `nvidia` gpu type regardless of whether they need GPU

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes node labels and ApplicationManager GPU fields used for scheduling; mis-migration could affect which compute mode apps bind to after upgrade.
> 
> **Overview**
> **Node GPU advertising** moves from a single legacy `gpu.bytetrade.io/type` value to **additive per-mode labels** `gpu.bytetrade.io/<mode>=true`, so one node can expose several modes (e.g. NVIDIA + Intel). `SetNodeGpuModeLabel` / `RemoveAllNodeGpuLabels` replace the old `UpdateNodeGpuLabel` clear-and-set behavior; driver/cuda labels still update on the NVIDIA path but `gpu.bytetrade.io/type` is no longer written.
> 
> **Hardware detection & naming:** Strix Halo detection is renamed to **Ryzen AI Max** (`HasRyzenAIMax`, `IsRyzenAIMax`, `amd` mode). **Intel integrated GPU** detection via PCI `8086` is new, with an `intelgpu` install module that only sets the `intel` mode label (no device plugin). MThreads labeling uses `moore-soc` instead of the old type constant.
> 
> **Install/upgrade wiring:** Linux cluster GPU phase runs the Intel label module when `IsIntelGPU()`. Upgrade **backfills** `SelectedGpuType` for apps that require GPU but lack it, and **clears** stale `SelectedGpuType` on CPU-only apps so the new compute model does not force GPU binding on resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ddea6bd1707d1eb1ed3481e4e42e267847a6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->