### PR TITLE
fix(app-service): address shared apps to the cluster owner

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -125,6 +125,13 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 			return
 		}
 	}
+	// For uploaded (non-market) apps record the uploading user as the chart
+	// owner so the chart source path survives even when the app owner is
+	// normalized to the cluster owner (shared apps). Market apps keep
+	// chartOwner empty and fall back to the installing user downstream.
+	if chartOwner == "" && insReq.Source != api.Market {
+		chartOwner = owner
+	}
 
 	apiVersion, err := apputils.GetAppConfigVersion(req.Request.Context(), &apputils.ConfigOptions{
 		App:          app,
@@ -378,12 +385,14 @@ func (h *Handler) getOriginChartVersion(rawAppName, owner string) (string, strin
 		isShared := appcfg.IsShared(&am)
 		if (am.Spec.AppName == rawAppName && am.Spec.AppOwner == owner) || (am.Spec.AppName == rawAppName && isShared) {
 			// For shared apps the caller (current admin) may differ from
-			// the user that originally installed the app; return that
-			// original install owner so the chart-repo lookup can be keyed
-			// off the user the chart was first uploaded under. v3 per-user
-			// apps fall through to the owner-equality branch above just
-			// like v1 apps.
-			return am.Annotations[api.AppVersionKey], am.Spec.AppOwner, nil
+			// the user that originally uploaded the chart, and AppOwner is
+			// normalized to the cluster owner — so we cannot key the
+			// chart-repo lookup off AppOwner. GetChartOwner reads the
+			// app.bytetrade.io/chart-owner label (the original uploader)
+			// and only falls back to AppOwner for legacy/market AMs. v3
+			// per-user apps fall through to the owner-equality branch above
+			// just like v1 apps.
+			return am.Annotations[api.AppVersionKey], appcfg.GetChartOwner(&am), nil
 		}
 	}
 	return "", "", fmt.Errorf("rawApp %s not found", rawAppName)
@@ -706,11 +715,11 @@ func (h *installHandlerHelper) applyAppMgr(name string, extraLabels map[string]s
 		images = h.insReq.Images
 	}
 	imagesStr, _ := json.Marshal(images)
-	// For v1/v2 appConfig.OwnerName == h.owner (the install caller). For
-	// v3 it is the cluster owner that GetAppConfig resolved at chart
-	// load time — independent of which admin is currently operating, so
-	// the AM stays addressed to a stable user across multi-admin
-	// install / upgrade cycles.
+	// For v1/v2 and v3+per-user apps appConfig.OwnerName == h.owner (the
+	// install caller). For shared apps it is the cluster owner that
+	// GetAppConfig resolved at chart load time — independent of which admin
+	// is currently operating, so the AM stays addressed to a stable user
+	// across multi-admin install / upgrade cycles.
 	appOwner := h.appConfig.OwnerName
 	appMgr := &v1alpha1.ApplicationManager{
 		ObjectMeta: metav1.ObjectMeta{

--- a/framework/app-service/pkg/event/event.go
+++ b/framework/app-service/pkg/event/event.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/beclab/Olares/framework/app-service/pkg/users/activeusers"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 
 	"github.com/nats-io/nats.go"
@@ -193,20 +192,20 @@ func PublishAppEventToQueue(p utils.EventParams) {
 	// rather than fall back to a single-owner publish: a per-user style
 	// publish to a shared app's nominal Owner would be silently
 	// misrouted for everyone else.
-	if p.IsShared {
-		recipients := activeusers.List()
-		if len(recipients) == 0 {
-			klog.Infof("shared-app fan-out: no activated users (cache empty), dropping event for app %s", p.Name)
-			return
-		}
-		for _, u := range recipients {
-			AppEventQueue.enqueue(&QueueEvent{
-				Subject: fmt.Sprintf("os.application.%s", u),
-				Data:    buildEvent(u),
-			})
-		}
-		return
-	}
+	//if p.IsShared {
+	//	recipients := activeusers.List()
+	//	if len(recipients) == 0 {
+	//		klog.Infof("shared-app fan-out: no activated users (cache empty), dropping event for app %s", p.Name)
+	//		return
+	//	}
+	//	for _, u := range recipients {
+	//		AppEventQueue.enqueue(&QueueEvent{
+	//			Subject: fmt.Sprintf("os.application.%s", u),
+	//			Data:    buildEvent(u),
+	//		})
+	//	}
+	//	return
+	//}
 
 	AppEventQueue.enqueue(&QueueEvent{
 		Subject: fmt.Sprintf("os.application.%s", p.Owner),

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils/files"
@@ -798,7 +799,20 @@ func GetAppConfig(ctx context.Context, options *ConfigOptions) (*appcfg.Applicat
 	}
 
 	appcfg.Namespace = namespace
-	appcfg.OwnerName = options.Owner
+	// Shared apps are addressed to the cluster owner (the olares "owner"
+	// role user) so OwnerName / Application.spec.owner stay stable across
+	// admins. This is the canonical write site referenced by the reload
+	// path pkg/appcfg.GetAppInstallationConfig. v1/v2 and v3+per-user apps
+	// keep the installing user.
+	if appcfg.IsShared() {
+		clusterOwner, cErr := kubesphere.GetClusterOwner(ctx)
+		if cErr != nil {
+			return nil, chartPath, cErr
+		}
+		appcfg.OwnerName = clusterOwner
+	} else {
+		appcfg.OwnerName = options.Owner
+	}
 	appcfg.ChartOwner = options.ChartOwner
 	appcfg.RepoURL = options.RepoURL
 	return appcfg, chartPath, nil


### PR DESCRIPTION




* **Background**
Shared apps must be owned by the Olares "owner"-role user, not whichever admin runs the install. GetAppConfig unconditionally wrote OwnerName = options.Owner (the install caller), and InstallingApp runs helm from the persisted AM.Spec.Config rather than the reload path, so the deployment owner label and Application.spec.owner ended up as the installing admin — inconsistent with the reload path (GetAppInstallationConfig) and the security controller's ns-owner, which already resolve to the cluster owner.

- GetAppConfig now sets OwnerName = kubesphere.GetClusterOwner() for shared apps (the canonical write site referenced by GetAppInstallationConfig); v1/v2 and v3+per-user apps keep the installing user.
- Record the uploading user as chart-owner for uploaded (non-market) installs so the chart source path survives the owner normalization.
- getOriginChartVersion resolves the clone source via GetChartOwner (the app.bytetrade.io/chart-owner label) instead of AppOwner, keeping the "A uploads / B clones" flow downloading from the original uploader.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core install ownership and AM/Application addressing for shared apps plus event delivery semantics; mis-routing could affect multi-admin installs and UI notifications until fan-out behavior is reconciled.
> 
> **Overview**
> **Shared app ownership** is normalized so `OwnerName`, `ApplicationManager.spec.appOwner`, and downstream owner labels use the Olares cluster **owner** role user when `IsShared()` is true, instead of whichever admin runs install. **`GetAppConfig`** is the canonical write site: shared apps call `kubesphere.GetClusterOwner()`; v1/v2 and v3 per-user apps still use the installing user.
> 
> **Chart sourcing** is decoupled from that normalization: non-market installs set **`chartOwner`** to the uploader when empty, and **`getOriginChartVersion`** resolves clone sources via **`GetChartOwner`** (chart-owner label) rather than **`AppOwner`**, so shared “A uploads / B clones” still downloads from the original uploader.
> 
> **NATS app events** no longer fan out shared lifecycle events to every activated user—the shared-app **`activeusers.List()`** path is commented out, so events publish only to **`p.Owner`** (the cluster owner for shared apps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c9dbec737181b95214e9398dfa3af017ebc70b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->