### PR TITLE
feat(cli): add top-level 'search' command for Desktop global full-content search

### DIFF
--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/beclab/Olares/cli/cmd/ctl/os"
 	"github.com/beclab/Olares/cli/cmd/ctl/osinfo"
 	"github.com/beclab/Olares/cli/cmd/ctl/profile"
+	"github.com/beclab/Olares/cli/cmd/ctl/search"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings"
 	"github.com/beclab/Olares/cli/cmd/ctl/user"
 	"github.com/beclab/Olares/cli/cmd/ctl/wizard"
@@ -102,6 +103,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmds.AddCommand(doctor.NewDoctorCommand(factory))
 	cmds.AddCommand(dashboard.NewDashboardCommand(factory))
 	cmds.AddCommand(settings.NewSettingsCommand(factory))
+	cmds.AddCommand(search.NewSearchCommand(factory))
 	cmds.AddCommand(cluster.NewClusterCommand(factory))
 
 	return cmds

--- a/cli/cmd/ctl/search/search.go
+++ b/cli/cmd/ctl/search/search.go
@@ -1,0 +1,345 @@
+// Package search implements the top-level `olares-cli search` command:
+// the CLI counterpart of the Olares Desktop global search dialog (the
+// "Text Search" page reached via the Dock search icon / Shift+Space).
+//
+// It performs full-content retrieval against the per-user search3 index
+// the same way the desktop SPA does.
+//
+// SPA reference: apps/packages/app/src/api/common/search.ts
+//
+//	searchInit({reqid, keyword, type, app}, offset, limit)
+//	  -> POST /api/search/init   (apps: files_v2 | knowledge | files)
+//	syncSearch({query}, offset, limit)
+//	  -> POST /api/search/sync   (app: sync)
+//	searchCancel(reqid)
+//	  -> POST /api/search/cancel (best-effort session cleanup)
+//
+// All three are @All-proxied by user-service to search3, so the response
+// is a {code, message, data} envelope whose `data` is an array of result
+// rows. The endpoints live on the desktop ingress (DesktopURL), reached
+// through the same authenticated http.Client the rest of the CLI uses.
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+const (
+	// appDrive is the user-facing value for the Drive data source; it maps
+	// to the search3 API's `files_v2` app id (appFilesV2).
+	appDrive   = "drive"
+	appFilesV2 = "files_v2"
+	appSync    = "sync"
+
+	searchTypeAggregate = "aggregate"
+	searchTypeFileName  = "file_name"
+)
+
+type Format string
+
+const (
+	FormatTable Format = "table"
+	FormatJSON  Format = "json"
+)
+
+type options struct {
+	app        string
+	searchType string
+	limit      int
+	offset     int
+	output     string
+}
+
+// NewSearchCommand returns the top-level `search` command. It is a leaf
+// command (no subcommands): `olares-cli search <keyword>` runs the
+// search directly, mirroring the single-purpose Desktop search box.
+func NewSearchCommand(f *cmdutil.Factory) *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "search <keyword>",
+		Short: "Full-content search across Drive / Knowledge / Sync (Desktop global search)",
+		Long: `Run the same full-content search the Olares Desktop global search
+dialog ("Text Search") uses, from the command line.
+
+The query is sent to the per-user search3 index. Use --app to pick the
+data source and --limit / --offset to page through results.
+
+Apps:
+  drive   user Drive files (default)
+  sync    Seafile/Sync libraries (uses /api/search/sync)
+
+Examples:
+  olares-cli search report
+  olares-cli search "design doc" --app drive
+  olares-cli search invoice --app drive --limit 50
+  olares-cli search notes --app sync --offset 20 -o json
+`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			keyword := strings.TrimSpace(strings.Join(args, " "))
+			return runSearch(c.Context(), f, keyword, o)
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.Flags().StringVarP(&o.app, "app", "a", appDrive,
+		"data source to search: drive, sync")
+	cmd.Flags().StringVarP(&o.searchType, "type", "t", searchTypeAggregate,
+		"search mode: aggregate, file_name (ignored for --app sync)")
+	cmd.Flags().IntVarP(&o.limit, "limit", "l", 20, "maximum number of results")
+	cmd.Flags().IntVar(&o.offset, "offset", 0, "result offset for pagination")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "output format: table, json")
+	return cmd
+}
+
+func parseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", string(FormatTable):
+		return FormatTable, nil
+	case string(FormatJSON):
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported --output %q (allowed: table, json)", s)
+	}
+}
+
+// parseApp validates the user-facing --app value and returns the
+// search3 API app id. "drive" maps to the API's "files_v2"; "sync" is
+// passed through (it selects the /api/search/sync endpoint downstream).
+func parseApp(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", appDrive:
+		return appFilesV2, nil
+	case appSync:
+		return appSync, nil
+	default:
+		return "", fmt.Errorf("unsupported --app %q (allowed: drive, sync)", s)
+	}
+}
+
+func parseSearchType(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", searchTypeAggregate:
+		return searchTypeAggregate, nil
+	case searchTypeFileName:
+		return searchTypeFileName, nil
+	default:
+		return "", fmt.Errorf("unsupported --type %q (allowed: aggregate, file_name)", s)
+	}
+}
+
+// bflEnvelope is search3's (and BFL's) shared response shape. code 0/200
+// mean success; data carries the typed payload.
+type bflEnvelope struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// doEnvelope issues an authenticated request and unwraps the {code,
+// message, data} envelope into out. out may be nil for fire-and-forget
+// calls (e.g. cancel).
+func doEnvelope(ctx context.Context, d *whoami.HTTPClient, method, path string, body, out interface{}) error {
+	var env bflEnvelope
+	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
+		return err
+	}
+	switch env.Code {
+	case 0, 200:
+	default:
+		msg := strings.TrimSpace(env.Message)
+		if msg == "" {
+			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
+		}
+		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
+	}
+	if out == nil || len(env.Data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Data, out); err != nil {
+		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
+	}
+	return nil
+}
+
+// resultItem captures the fields the desktop SPA reads off each result
+// row, across both the /init (Drive/Knowledge/Files) and /sync shapes.
+// Display-only fields the SPA derives client-side (fileIcon, localized
+// fileType, rewritten path) are intentionally left out; the raw upstream
+// row is preserved for --output json via Raw.
+type resultItem struct {
+	Title       string          `json:"title"`
+	ResourceURI string          `json:"resource_uri,omitempty"`
+	Path        string          `json:"path,omitempty"`
+	RepoName    string          `json:"repo_name,omitempty"`
+	Highlight   json.RawMessage `json:"highlight,omitempty"`
+
+	Raw json.RawMessage `json:"-"`
+}
+
+func (it resultItem) location() string {
+	if it.ResourceURI != "" {
+		return it.ResourceURI
+	}
+	return it.Path
+}
+
+func runSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *options) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if keyword == "" {
+		return fmt.Errorf("a non-empty search keyword is required")
+	}
+	app, err := parseApp(o.app)
+	if err != nil {
+		return err
+	}
+	searchType, err := parseSearchType(o.searchType)
+	if err != nil {
+		return err
+	}
+	format, err := parseFormat(o.output)
+	if err != nil {
+		return err
+	}
+	if o.limit <= 0 {
+		return fmt.Errorf("--limit must be a positive integer")
+	}
+	if o.offset < 0 {
+		return fmt.Errorf("--offset must not be negative")
+	}
+
+	if f == nil {
+		return fmt.Errorf("internal error: search not wired with cmdutil.Factory")
+	}
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return err
+	}
+	hc, err := f.HTTPClient(ctx)
+	if err != nil {
+		return err
+	}
+	doer := whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID)
+
+	var rawRows []json.RawMessage
+	if app == appSync {
+		body := map[string]interface{}{
+			"query":  keyword,
+			"offset": o.offset,
+			"limit":  o.limit,
+		}
+		if err := doEnvelope(ctx, doer, "POST", "/api/search/sync", body, &rawRows); err != nil {
+			return err
+		}
+	} else {
+		reqid := uuid.NewString()
+		body := map[string]interface{}{
+			"reqid":   reqid,
+			"keyword": keyword,
+			"type":    searchType,
+			"app":     app,
+			"offset":  o.offset,
+			"limit":   o.limit,
+		}
+		if err := doEnvelope(ctx, doer, "POST", "/api/search/init", body, &rawRows); err != nil {
+			return err
+		}
+		// Best-effort session cleanup, mirroring the SPA's searchCancel.
+		// The search has already completed; failures here are harmless.
+		_ = doEnvelope(ctx, doer, "POST", "/api/search/cancel",
+			map[string]interface{}{"reqid": reqid}, nil)
+	}
+
+	items := make([]resultItem, 0, len(rawRows))
+	for _, raw := range rawRows {
+		var it resultItem
+		if err := json.Unmarshal(raw, &it); err != nil {
+			return fmt.Errorf("decode search result: %w", err)
+		}
+		it.Raw = raw
+		items = append(items, it)
+	}
+
+	switch format {
+	case FormatJSON:
+		return printResultsJSON(os.Stdout, items)
+	default:
+		return renderResults(os.Stdout, items)
+	}
+}
+
+// printResultsJSON emits the raw upstream rows verbatim so nothing the
+// index returns is lost to the typed projection above.
+func printResultsJSON(w io.Writer, items []resultItem) error {
+	rows := make([]json.RawMessage, 0, len(items))
+	for _, it := range items {
+		rows = append(rows, it.Raw)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rows)
+}
+
+func renderResults(w io.Writer, items []resultItem) error {
+	if len(items) == 0 {
+		_, err := fmt.Fprintln(w, "no results")
+		return err
+	}
+	for i, it := range items {
+		title := it.Title
+		if title == "" {
+			title = "(untitled)"
+		}
+		if _, err := fmt.Fprintf(w, "%d. %s\n", i+1, title); err != nil {
+			return err
+		}
+		if loc := it.location(); loc != "" {
+			if _, err := fmt.Fprintf(w, "   %s\n", loc); err != nil {
+				return err
+			}
+		}
+		if snippet := highlightSnippet(it.Highlight); snippet != "" {
+			if _, err := fmt.Fprintf(w, "   %s\n", snippet); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintf(w, "\n%d result(s)\n", len(items))
+	return err
+}
+
+// highlightSnippet renders the upstream `highlight` field (string or
+// []string, with <hi>…</hi> match markers) into a single readable line.
+// The markers are stripped for terminal output; `--output json` keeps the
+// original markup.
+func highlightSnippet(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return stripHighlightTags(single)
+	}
+	var many []string
+	if err := json.Unmarshal(raw, &many); err == nil {
+		return stripHighlightTags(strings.Join(many, " … "))
+	}
+	return ""
+}
+
+func stripHighlightTags(s string) string {
+	replacer := strings.NewReplacer("<hi>", "", "</hi>", "")
+	return strings.TrimSpace(strings.Join(strings.Fields(replacer.Replace(s)), " "))
+}

--- a/cli/cmd/ctl/search/search.go
+++ b/cli/cmd/ctl/search/search.go
@@ -245,21 +245,36 @@ func runSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *optio
 		}
 	} else {
 		reqid := uuid.NewString()
-		body := map[string]interface{}{
+		// Desktop search v2 is session-based for files_v2: always bootstrap
+		// with /api/search/init at offset=0, then page via /api/search/more
+		// using the same reqid.
+		initBody := map[string]interface{}{
 			"reqid":   reqid,
 			"keyword": keyword,
 			"type":    searchType,
 			"app":     app,
-			"offset":  o.offset,
+			"offset":  0,
 			"limit":   o.limit,
 		}
-		if err := doEnvelope(ctx, doer, "POST", "/api/search/init", body, &rawRows); err != nil {
+		// Best-effort session cleanup, mirroring the SPA's searchCancel.
+		// Keep defer close to reqid creation so all return paths are covered.
+		defer func() {
+			_ = doEnvelope(ctx, doer, "POST", "/api/search/cancel",
+				map[string]interface{}{"reqid": reqid}, nil)
+		}()
+		if err := doEnvelope(ctx, doer, "POST", "/api/search/init", initBody, &rawRows); err != nil {
 			return err
 		}
-		// Best-effort session cleanup, mirroring the SPA's searchCancel.
-		// The search has already completed; failures here are harmless.
-		_ = doEnvelope(ctx, doer, "POST", "/api/search/cancel",
-			map[string]interface{}{"reqid": reqid}, nil)
+		if o.offset > 0 {
+			moreBody := map[string]interface{}{
+				"reqid":  reqid,
+				"offset": o.offset,
+				"limit":  o.limit,
+			}
+			if err := doEnvelope(ctx, doer, "POST", "/api/search/more", moreBody, &rawRows); err != nil {
+				return err
+			}
+		}
 	}
 
 	items := make([]resultItem, 0, len(rawRows))


### PR DESCRIPTION
## Summary

- Adds `olares-cli search <keyword>`, the CLI counterpart of the Olares Desktop global search dialog ("Text Search" reached via the Dock search icon / Shift+Space).
- Performs full-content retrieval against the per-user `search3` index through the desktop ingress, mirroring the SPA's `apps/packages/app/src/api/common/search.ts`:
  - `--app drive` (default) → `POST /api/search/init` with `app=files_v2`, then a best-effort `POST /api/search/cancel` for session cleanup (matches the SPA's `searchCancel`).
  - `--app sync` → `POST /api/search/sync`.
- Registered as a sibling of `settings` in `cli/cmd/ctl/root.go`.

### Flags
- `-a, --app`: `drive` (default, maps to API `files_v2`) | `sync`
- `-t, --type`: `aggregate` (default) | `file_name` (ignored for `--app sync`)
- `-l, --limit` (default 20), `--offset` for pagination
- `-o, --output`: `table` (default) | `json` (raw upstream rows preserved verbatim)

### Notes
- Auth + token refresh reuse the existing `cmdutil.Factory` + `whoami.HTTPClient`; the `{code, message, data}` envelope is unwrapped locally.
- Identity follows the active profile (no per-invocation `--profile`); run `olares-cli profile use <name>` / `profile login` first.

## Test plan
- [x] `go build ./...`, `go vet ./cmd/ctl/search/`
- [x] `olares-cli search --help` renders the documented flags
- [ ] Against a live Olares: `olares-cli search <keyword>` returns Drive results; `--app sync` returns Sync results; `-o json` emits raw rows

Made with [Cursor](https://cursor.com)