### PR TITLE
fix(l4):  disable metrics port and change probe port to 18081

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.30"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.32"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.30
+          value: v0.3.32
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.30
+      name: beclab/l4-bfl-proxy:v0.3.32
 # must have blank new line            

--- a/framework/l4-bfl-proxy/cmd/main.go
+++ b/framework/l4-bfl-proxy/cmd/main.go
@@ -38,8 +38,8 @@ const (
 	sslProxyServerPort  = 444
 	xdsServerPort       = 8794
 	resyncPeriod        = 60 * time.Minute
-	metricsAddr         = ":9001"
-	probeAddr           = ":8081"
+	metricsAddr         = "0"
+	probeAddr           = ":18081"
 )
 
 func main() {


### PR DESCRIPTION


* **Background**
 disable metrics port and change probe port to 18081
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the user-facing L4 proxy image and listening ports on a critical network path; probe port changes only appear in the binary in this diff, so existing Kubernetes HTTP probes must stay aligned or pods may fail health checks after rollout.
> 
> **Overview**
> Bumps **`l4-bfl-proxy`** from **v0.3.30** to **v0.3.32** everywhere it is pinned: Olares prebuilt output, BFL launcher env **`L4_PROXY_IMAGE_VERSION`**, and the CLI **`UpgradeL4BFLProxy`** upgrade task.
> 
> In **`l4-bfl-proxy`**, controller-runtime **metrics** binding moves from **`:9001`** to **`"0"`** (disabled), and **health/readiness** move from **`:8081`** to **`:18081`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a625d16af429d5712124be4a77d434b81bfe819a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->