### PR TITLE
system-apps: bump system-frontend to v1.10.53

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.52
+          image: beclab/system-frontend:v1.10.53
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  Bumps the `system-frontend` (LarePass/TermiPass desktop) system app image from `v1.10.52` to `v1.10.53`, rolling the following merged TermiPass frontend changes into Olares:
  - **Desktop dock & mobile dock** (beclab/TermiPass#1207): replaces the PC dock's interval-based drag animation with slot-based reordering and CSS transitions, adds cross-device layout stability during drags (`setLayoutDragLock` / discard-on-cancel), aligns dock opens with the launchpad (resolving live app state before opening), and adds horizontal scroll for long synced layouts on the mobile dock.
  - **Mobile/pad responsive adaptation** (beclab/TermiPass#1208): makes Vault, Files, Settings, and the Profile editor responsive on narrow viewports with landscape blocking, adds Files browser back/forward history sync, desktop marquee + mobile long-press/mosaic multi-select, and hardens resumable (resume-offset / per-file) uploads.
  - **Compute resources schema** (beclab/TermiPass#1210): adapts the frontend to the upgraded `GET /api/compute-resources` schema (per-device `mode`, node-level `gpuTypes`, integrated accelerators without `cardModel`) and refreshes compute-mode titles across the Settings GPU pages and Market app-detail resource evaluation.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1207
https://github.com/beclab/TermiPass/pull/1208
https://github.com/beclab/TermiPass/pull/1210

* **Other information**
https://github.com/beclab/TermiPass/compare/v1.10.52...v1.10.53

Made with [Cursor](https://cursor.com)