### PR TITLE
fix(cli): add upgrader for patch l4 probe port and upgrade node-exporter

### DIFF
--- a/cli/pkg/kubesphere/plugins/files/build/prometheus/node-exporter/node-exporter-daemonset.yaml
+++ b/cli/pkg/kubesphere/plugins/files/build/prometheus/node-exporter/node-exporter-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
         - --collector.netdev.address-info
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-        image: beclab/node-exporter:0.0.10
+        image: beclab/node-exporter:0.0.11
         name: node-exporter
         securityContext:
           privileged: true

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -81,6 +81,12 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		},
 	}
 	pre = append(pre, u.upgraderBase.UpgradeSystemComponents()...)
+	pre = append(pre, &task.LocalTask{
+		Name:   "PatchL4BFLProxyProbePort",
+		Action: new(patchL4BFLProxyProbePort),
+		Retry:  3,
+		Delay:  5 * time.Second,
+	})
 	return append(pre,
 		&task.LocalTask{
 			Name: "WaitForAppServiceReady",

--- a/cli/pkg/upgrade/1_12_7_20260617.go
+++ b/cli/pkg/upgrade/1_12_7_20260617.go
@@ -1,0 +1,113 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type upgrader_1_12_7_20260617 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260617) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260617")
+}
+
+func (u upgrader_1_12_7_20260617) UpgradeSystemComponents() []task.Interface {
+	tasks := make([]task.Interface, 0)
+	tasks = append(tasks, upgradeNodeExporter()...)
+
+	tasks = append(tasks, u.upgraderBase.UpgradeSystemComponents()...)
+	tasks = append(tasks, &task.LocalTask{
+		Name:   "PatchL4BFLProxyProbePort",
+		Action: new(patchL4BFLProxyProbePort),
+		Retry:  3,
+		Delay:  5 * time.Second,
+	})
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260617{})
+}
+
+// patchL4BFLProxyProbePort updates the livenessProbe and readinessProbe
+// httpGet port of the l4-bfl-proxy deployment in the os-network namespace
+// from the legacy 8081 to 18081 to match the probe address now exposed
+// by the new l4-bfl-proxy binary.
+type patchL4BFLProxyProbePort struct {
+	common.KubeAction
+}
+
+func (a *patchL4BFLProxyProbePort) Execute(_ connector.Runtime) error {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %v", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	patch := []byte(`{
+		"spec": {
+			"template": {
+				"spec": {
+					"containers": [
+						{
+							"name": "proxy",
+							"livenessProbe": {
+								"httpGet": {
+									"port": 18081
+								}
+							},
+							"readinessProbe": {
+								"httpGet": {
+									"port": 18081
+								}
+							}
+						}
+					]
+				}
+			}
+		}
+	}`)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err := client.AppsV1().Deployments("os-network").Patch(
+			ctx,
+			"l4-bfl-proxy",
+			types.StrategicMergePatchType,
+			patch,
+			metav1.PatchOptions{},
+		)
+		return err
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Infof("l4-bfl-proxy deployment not found in os-network, skipping probe port patch")
+			return nil
+		}
+		return fmt.Errorf("failed to patch l4-bfl-proxy deployment probe port: %v", err)
+	}
+
+	logger.Infof("patched l4-bfl-proxy deployment livenessProbe/readinessProbe port to 18081")
+	return nil
+}

--- a/platform/prometheus/.olares/Olares.yaml
+++ b/platform/prometheus/.olares/Olares.yaml
@@ -7,7 +7,7 @@ output:
     - 
       name: kubesphere/prometheus-operator:v0.55.1
     - 
-      name: beclab/node-exporter:0.0.10
+      name: beclab/node-exporter:0.0.11
     - 
       name: prom/prometheus:v2.34.0
 


### PR DESCRIPTION

* **Background**
break change for patch l4 probeport and upgrade node-exporter
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/node_exporter/pull/9
* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patches live `l4-bfl-proxy` probe ports during upgrade; mis-timed rollout could briefly mark the proxy unready, though retries and NotFound skip limit blast radius.
> 
> **Overview**
> Adds upgrade automation for a **breaking l4-bfl-proxy health-check port change** (8081 → **18081**) and rolls **node-exporter** to **0.0.11**.
> 
> The **1.12.6** system-component upgrade path now runs a **`PatchL4BFLProxyProbePort`** task after the base component upgrades. A new daily upgrader **`1.12.7-20260617`** reuses **`upgradeNodeExporter()`** and the same probe patch so clusters on that line get both fixes without a full main-line release only.
> 
> **`patchL4BFLProxyProbePort`** strategically merges the `os-network`/`l4-bfl-proxy` deployment so the `proxy` container’s liveness and readiness `httpGet` ports match the new binary; it retries on conflict, skips cleanly if the deployment is missing, and times out after two minutes.
> 
> Bundled image bumps: **`beclab/node-exporter:0.0.11`** in the Prometheus node-exporter DaemonSet manifest and **`platform/prometheus/.olares/Olares.yaml`** prebuilt container list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebf448af498fe2735a262f508a23b32321d3257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->