### PR TITLE
feat(app-gateway): pin Olares fork envoy-gateway for 100-year control-plane mTLS certs

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/eg-control-plane.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/eg-control-plane.yaml
@@ -46,7 +46,7 @@ data:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
         shutdownManager:
-          image: envoyproxy/gateway:v1.8.0
+          image: beclab/envoy-gateway@sha256:292a7f1ee559d022f6ed35aa86328bc5ff932543e327e5bfe09d5343bb13cb75
       type: Kubernetes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -429,7 +429,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: envoyproxy/gateway:v1.8.0
+        image: beclab/envoy-gateway@sha256:292a7f1ee559d022f6ed35aa86328bc5ff932543e327e5bfe09d5343bb13cb75
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -641,7 +641,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: envoyproxy/gateway:v1.8.0
+        image: beclab/envoy-gateway@sha256:292a7f1ee559d022f6ed35aa86328bc5ff932543e327e5bfe09d5343bb13cb75
         imagePullPolicy: IfNotPresent
         name: envoy-gateway-certgen
         securityContext:


### PR DESCRIPTION
Replace upstream envoyproxy/gateway:v1.8.0 with beclab/envoy-gateway digest-pinned image across control plane, deployment, and certgen. The fork sets certgen’s default internal mTLS certificate lifetime to 100 years (36500 days) instead of upstream’s 5 years, so long-lived user-owned clusters avoid control-plane xDS mTLS expiry without built-in rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-plane TLS issuance and a custom gateway image on critical gateway infrastructure; risk is mitigated by digest pinning but depends on fork correctness and supply chain for beclab/envoy-gateway.
> 
> **Overview**
> Swaps **upstream** `envoyproxy/gateway:v1.8.0` for a **digest-pinned** `beclab/envoy-gateway` image in `eg-control-plane.yaml` everywhere the control plane runs that binary: the main `envoy-gateway` deployment, the Helm **certgen** pre-install/upgrade job, and the **shutdownManager** image in the EnvoyGateway provider config.
> 
> The fork is intended so **certgen** issues internal control-plane xDS mTLS certificates with a much longer default lifetime than upstream (per product goal: avoid expiry on long-lived clusters without built-in rotation). No other manifests or gateway behavior are changed in this diff—only the container image reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e86b4bae8a92502257c8f7bb7a0372cabd08f2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->