### PR TITLE
docs: update Google Tag Manager ID in VitePress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -171,7 +171,7 @@ export default defineVersionedConfig2(withMermaid({
       "script",
       {
         async: "",
-        src: "https://www.googletagmanager.com/gtag/js?id=G-G98641Y6R0",
+        src: "https://www.googletagmanager.com/gtag/js?id=G-GMCVWRBP24",
       },
     ],
     [
@@ -180,7 +180,7 @@ export default defineVersionedConfig2(withMermaid({
       `window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-G98641Y6R0');`,
+      gtag('config', 'G-GMCVWRBP24');`,
     ],
     [
       "meta",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Analytics configuration only; no application logic, auth, or data handling.
> 
> **Overview**
> **Updates docs site analytics** to use measurement ID `G-GMCVWRBP24` instead of `G-G98641Y6R0`.
> 
> Both the async `gtag/js` script URL and the inline `gtag('config', …)` call in `docs/.vitepress/config.mts` are changed so page views report to the new property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be1c12f8aa8c1b69632c759d9e8ef9681249d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->