### PR TITLE
fix(cli): specify tag for amd gpu plugin and retag the existing one

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -80,6 +80,7 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 			Delay:  5 * time.Second,
 		},
 	}
+	pre = append(pre, retagLegacyAMDGPUImage()...)
 	pre = append(pre, u.upgraderBase.UpgradeSystemComponents()...)
 	pre = append(pre, &task.LocalTask{
 		Name:   "PatchL4BFLProxyProbePort",

--- a/cli/pkg/upgrade/1_12_7_20260617.go
+++ b/cli/pkg/upgrade/1_12_7_20260617.go
@@ -30,6 +30,7 @@ func (u upgrader_1_12_7_20260617) Version() *semver.Version {
 func (u upgrader_1_12_7_20260617) UpgradeSystemComponents() []task.Interface {
 	tasks := make([]task.Interface, 0)
 	tasks = append(tasks, upgradeNodeExporter()...)
+	tasks = append(tasks, retagLegacyAMDGPUImage()...)
 
 	tasks = append(tasks, u.upgraderBase.UpgradeSystemComponents()...)
 	tasks = append(tasks, &task.LocalTask{

--- a/cli/pkg/upgrade/retag_legacy_amdgpu_image.go
+++ b/cli/pkg/upgrade/retag_legacy_amdgpu_image.go
@@ -1,0 +1,58 @@
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+const (
+	// legacyAMDGPUDevicePluginImage is the repository of the AMD GPU device
+	// plugin. Earlier releases referenced it in the DaemonSet without a tag,
+	// which resolves to ":latest". Docker Hub has since re-pushed "latest" and
+	// garbage-collected the manifest that was originally cached, leaving the
+	// local image untagged (shown as "-" and counted as a reclaimable, unused
+	// image). The DaemonSet is now pinned to an immutable tag, but hosts
+	// upgraded from those releases still hold the orphaned image.
+	legacyAMDGPUDevicePluginImage = "docker.io/rocm/k8s-device-plugin"
+	// legacyAMDGPUDevicePluginImageTag is the immutable tag we attach to that
+	// orphaned image so it is no longer untagged.
+	legacyAMDGPUDevicePluginImageTag = legacyAMDGPUDevicePluginImage + ":1.31.0.9"
+)
+
+// retagLegacyAMDGPUImage gives the previously untagged AMD GPU device plugin
+// image a stable version tag (1.31.0.9) via ctr, so it is no longer an orphan
+// excluded from being recognized as a managed image.
+func retagLegacyAMDGPUImage() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "RetagLegacyAMDGPUImage",
+			Action: new(retagLegacyAMDGPUImageAction),
+		},
+	}
+}
+
+type retagLegacyAMDGPUImageAction struct {
+	common.KubeAction
+}
+
+func (a *retagLegacyAMDGPUImageAction) Execute(runtime connector.Runtime) error {
+	// the image only exists on Linux hosts that previously ran the AMD GPU
+	// device plugin; ctr is not available elsewhere (e.g. macOS/minikube).
+	if !runtime.GetSystemInfo().IsLinux() {
+		return nil
+	}
+
+	// the legacy image is stored under the bare repository name (untagged).
+	cmd := fmt.Sprintf("ctr -n k8s.io i tag --force %s %s", legacyAMDGPUDevicePluginImage, legacyAMDGPUDevicePluginImageTag)
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
+		// the image is absent on this host, nothing to do, do not fail the upgrade.
+		logger.Debugf("legacy AMD GPU device plugin image %s not found, skip retagging: %v", legacyAMDGPUDevicePluginImage, err)
+		return nil
+	}
+	logger.Infof("tagged legacy AMD GPU device plugin image %s as %s", legacyAMDGPUDevicePluginImage, legacyAMDGPUDevicePluginImageTag)
+	return nil
+}

--- a/infrastructure/gpu/.olares/config/gpu/nvidia/amdgpu-device-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/nvidia/amdgpu-device-plugin.yaml
@@ -20,7 +20,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       containers:
-        - image: rocm/k8s-device-plugin
+        - image: rocm/k8s-device-plugin:1.31.0.10
           name: amdgpu-dp-cntr
           securityContext:
             privileged: true


### PR DESCRIPTION
* **Background**
The current image for AMD GPU plugin specifies no tag and is not recognised by the CRI service, we specify the tag in the manifest and also retag the existing one with the correct tag.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to AMD GPU Linux nodes during upgrade; retagging is best-effort and non-fatal, with no auth or data-path changes.
> 
> **Overview**
> Pins the AMD GPU device plugin DaemonSet to **`rocm/k8s-device-plugin:1.31.0.10`** instead of an implicit **`:latest`**, so pulls and CRI image tracking are stable.
> 
> Adds a **`RetagLegacyAMDGPUImage`** upgrade step (wired into **1.12.6** and **1.12.7** system-component upgrades) that on Linux runs **`ctr -n k8s.io i tag --force`** to label hosts’ old untagged **`docker.io/rocm/k8s-device-plugin`** cache as **`:1.31.0.9`**. Missing images or errors are logged and do not fail the upgrade; non-Linux hosts skip the step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13886212215b865f9c33445dc53d0fae23904b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->