### PR TITLE
fix(cli): also correct hostname on install phase

### DIFF
--- a/cli/pkg/bootstrap/patch/module.go
+++ b/cli/pkg/bootstrap/patch/module.go
@@ -81,3 +81,20 @@ func (m *InstallDepsModule) Init() {
 		enableSSHTask,
 	}
 }
+
+type CorrectHostnameModule struct {
+	common.KubeModule
+}
+
+func (m *CorrectHostnameModule) Init() {
+	m.Name = "CorrectHostname"
+
+	correctHostname := &task.LocalTask{
+		Name:   "CorrectHostname",
+		Action: new(CorrectHostname),
+	}
+
+	m.Tasks = []task.Interface{
+		correctHostname,
+	}
+}

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/beclab/Olares/cli/pkg/bootstrap/patch"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/gpu"
@@ -109,6 +110,7 @@ func (l *linuxInstallPhaseBuilder) build() []module.Module {
 		addModule(fsModuleBuilder(func() []module.Module {
 			return l.storage()
 		}).withJuiceFS(l.runtime)...).
+		addModule(&patch.CorrectHostnameModule{}).
 		addModule(l.installCluster()...).
 		addModule(gpuModuleBuilder(func() []module.Module {
 			return l.installGpuPlugin()


### PR DESCRIPTION
* **Background**
Currently, olares-cli corrects a machine's hostname to a valid K8s node name if eligible, on the prepare phase. For `deb` based installation of Olares, the prepare phase is skipped, so we also execute the task on the installation phase.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses existing hostname logic on the install path only; no auth or data changes, limited to local bootstrap before cluster install.
> 
> **Overview**
> **Deb-based installs** skip the prepare phase, so hostname normalization (valid K8s node name) never ran for those paths.
> 
> This adds a **`CorrectHostnameModule`** that runs the existing **`CorrectHostname`** action as a **local** install task, and inserts it into the **Linux install phase** immediately **before** cluster creation—mirroring the prepare-phase behavior for installs that bypass prepare.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108a3411cef4390f119631c8120b3cd504633ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->