### PR TITLE
fix(app-service): enforce unique app name and appmgr cleanup

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.49
+        image: beclab/app-service:0.5.50
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -162,6 +162,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.ApplicationManagerGCReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", "Application Manager GC")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.EntranceStatusManagerController{
 		Client: mgr.GetClient(),
 	}).SetUpWithManager(mgr); err != nil {

--- a/framework/app-service/controllers/appmgr_gc_controller.go
+++ b/framework/app-service/controllers/appmgr_gc_controller.go
@@ -1,0 +1,193 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// ApplicationManagerGCReconciler reclaims ApplicationManager objects that have
+// been sitting in an IsSafelyDeletable terminal state longer than
+// constants.AppMgrTerminalRetention.
+//
+// Background:
+//   - The state machine itself never deletes the AM CR — terminal states are
+//     kept as a reinstall anchor and a UI/CLI history record (so users can
+//     still see "this install failed because X").
+//   - The deletion responsibility lives in two places: lazy cleanup in
+//     checkAppNameConflict at install time, and this controller for the
+//     "no one ever tried to reinstall the same app name" steady-state case.
+//
+// Safety rails:
+//   - Only AMs whose Status.State is IsSafelyDeletable are considered. That
+//     predicate already guarantees the state machine has run a full cleanup
+//     and confirmed the app namespace is gone before transitioning into the
+//     state.
+//   - On top of that, before deleting we double-check the namespace really is
+//     IsNotFound. This protects against the rare "InstallFailed-cleanup-timeout"
+//     case (NS finalizer stuck past 5min): in that scenario the AM is still
+//     in InstallFailed and IsSafelyDeletable, but the namespace is technically
+//     still around. Deleting the AM there would orphan the NS from any
+//     state-machine retry, blocking future same-name installs until manual
+//     cleanup. We skip and requeue instead, letting InstallFailedApp.Exec
+//     keep retrying until the NS finalizer releases.
+type ApplicationManagerGCReconciler struct {
+	client.Client
+}
+
+// SetupWithManager wires the GC controller into the manager.
+//
+// Event predicates:
+//   - Create: only enqueued when the object already lands in an
+//     IsSafelyDeletable state. New AMs created by the normal install flow
+//     start at "" / Pending so they get filtered out; the predicate exists
+//     specifically for informer initial-sync after a controller restart,
+//     where existing safely-deletable AMs are delivered as Create events
+//     and would otherwise never be reconciled until something updates them.
+//   - Update: enqueued only when Status.State actually changes into an
+//     IsSafelyDeletable state. Skipping no-op state Updates keeps the
+//     workqueue quiet while still reacting promptly to terminal transitions.
+//   - Delete: never enqueued — Delete is the action the GC controller
+//     produces, not one it reacts to.
+func (r *ApplicationManagerGCReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("app-manager-gc-controller", mgr, controller.Options{
+		MaxConcurrentReconciles: 1,
+		Reconciler:              r,
+	})
+	if err != nil {
+		return fmt.Errorf("app manager gc setup failed %w", err)
+	}
+
+	err = c.Watch(source.Kind(
+		mgr.GetCache(),
+		&appv1alpha1.ApplicationManager{},
+		handler.TypedEnqueueRequestsFromMapFunc(
+			func(ctx context.Context, h *appv1alpha1.ApplicationManager) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: h.GetName()}}}
+			}),
+		predicate.TypedFuncs[*appv1alpha1.ApplicationManager]{
+			CreateFunc: func(e event.TypedCreateEvent[*appv1alpha1.ApplicationManager]) bool {
+				return appstate.IsSafelyDeletable(e.Object.Status.State)
+			},
+			UpdateFunc: func(e event.TypedUpdateEvent[*appv1alpha1.ApplicationManager]) bool {
+				if e.ObjectOld.Status.State == e.ObjectNew.Status.State {
+					return false
+				}
+				return appstate.IsSafelyDeletable(e.ObjectNew.Status.State)
+			},
+			DeleteFunc: func(e event.TypedDeleteEvent[*appv1alpha1.ApplicationManager]) bool {
+				return false
+			},
+		},
+	))
+	if err != nil {
+		return fmt.Errorf("appmgr gc watch failed %w", err)
+	}
+	return nil
+}
+
+func (r *ApplicationManagerGCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var am appv1alpha1.ApplicationManager
+	if err := r.Get(ctx, req.NamespacedName, &am); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !appstate.IsSafelyDeletable(am.Status.State) {
+		return ctrl.Result{}, nil
+	}
+
+	entered := terminalStateEntryTime(&am)
+	if entered.IsZero() {
+		// Without a timestamp we cannot compute age; treat as freshly-entered
+		// and requeue once after the full retention.
+		klog.V(4).Infof("appmgr-gc: %s in %s has no StatusTime/UpdateTime, deferring full retention", am.Name, am.Status.State)
+		return ctrl.Result{RequeueAfter: constants.AppMgrTerminalRetention}, nil
+	}
+
+	age := time.Since(entered)
+	if age < constants.AppMgrTerminalRetention {
+		return ctrl.Result{RequeueAfter: constants.AppMgrTerminalRetention - age}, nil
+	}
+
+	// Double-check the namespace is gone before deleting the AM. The state
+	// machine guarantees this for the happy path, but the InstallFailed
+	// cleanup-timeout edge case can leave NS lingering while the AM is in
+	// InstallFailed and IsSafelyDeletable says "deletable". Deleting the AM
+	// while the NS is still around would orphan it from InstallFailedApp.Exec's
+	// retry loop — refuse and let Exec continue trying.
+	if nsGone, err := isAppNamespaceGone(ctx, r.Client, &am); err != nil {
+		klog.Warningf("appmgr-gc: %s namespace check failed (will retry): %v", am.Name, err)
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	} else if !nsGone {
+		klog.Infof("appmgr-gc: %s in %s eligible by age (%s) but namespace %q still present; deferring to InstallFailedApp.Exec",
+			am.Name, am.Status.State, age, am.Spec.AppNamespace)
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	klog.Infof("appmgr-gc: deleting %s (state=%s, owner=%s, age=%s)",
+		am.Name, am.Status.State, am.Spec.AppOwner, age)
+	if err := r.Delete(ctx, &am); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{RequeueAfter: time.Minute}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// terminalStateEntryTime returns when the AM most recently entered its current
+// terminal state. StatusTime is the canonical "when did state become X" stamp
+// and is updated alongside every transition that goes through updateStatus;
+// UpdateTime is the broader "this AM was touched" stamp and serves as a
+// fallback for legacy data that may predate StatusTime.
+func terminalStateEntryTime(am *appv1alpha1.ApplicationManager) time.Time {
+	if am.Status.StatusTime != nil && !am.Status.StatusTime.IsZero() {
+		return am.Status.StatusTime.Time
+	}
+	if am.Status.UpdateTime != nil && !am.Status.UpdateTime.IsZero() {
+		return am.Status.UpdateTime.Time
+	}
+	return time.Time{}
+}
+
+// isAppNamespaceGone reports whether the app's namespace truly no longer
+// exists. Protected namespaces (user-space and friends) are never created or
+// torn down by the app lifecycle, so they always read as "gone" for the
+// purposes of GC eligibility. An empty AppNamespace means the install never
+// got far enough to claim one (e.g. failure in pre-helm validation) — also
+// treat as gone.
+func isAppNamespaceGone(ctx context.Context, c client.Client, am *appv1alpha1.ApplicationManager) (bool, error) {
+	if am.Spec.AppNamespace == "" {
+		return true, nil
+	}
+	if apputils.IsProtectedNamespace(am.Spec.AppNamespace) {
+		return true, nil
+	}
+	var ns corev1.Namespace
+	err := c.Get(ctx, types.NamespacedName{Name: am.Spec.AppNamespace}, &ns)
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}

--- a/framework/app-service/controllers/pod_abnormal_suspend_app_controller.go
+++ b/framework/app-service/controllers/pod_abnormal_suspend_app_controller.go
@@ -229,9 +229,12 @@ func pendingUnschedulableSince(pod *corev1.Pod) (time.Time, bool) {
 // trySuspendApp attempts to suspend the app and returns (true, nil) if a suspend request was issued.
 // If the app is not suspendable yet, returns (false, nil) to trigger a short requeue.
 func (r *PodAbnormalSuspendAppController) trySuspendApp(ctx context.Context, owner, appName, reason, message, podNamespace string) (bool, error) {
-	name, err := apputils.FmtAppMgrName(appName, owner, "")
+	// Resolve to the live AM (shared cluster-wide or per-user) — a pod-abnormal
+	// suspend on a shared app needs to find the {app}-shared-{app} AM no matter
+	// which user the pod is running under.
+	name, _, err := apputils.ResolveAppMgrName(ctx, appName, owner)
 	if err != nil {
-		klog.Errorf("failed to format app manager name app=%s owner=%s: %v", appName, owner, err)
+		klog.Errorf("failed to resolve app manager name app=%s owner=%s: %v", appName, owner, err)
 		return false, err
 	}
 	var am appv1alpha1.ApplicationManager

--- a/framework/app-service/pkg/apiserver/handler_app.go
+++ b/framework/app-service/pkg/apiserver/handler_app.go
@@ -41,7 +41,11 @@ func (h *Handler) status(req *restful.Request, resp *restful.Response) {
 	app := req.PathParameter(ParamAppName)
 	owner := req.Attribute(constants.UserContextAttribute).(string)
 
-	name, err := apputils.FmtAppMgrName(app, owner, "")
+	// Resolve the AM name to whichever lifecycle variant currently exists
+	// (shared cluster-wide vs per-user). Falling back to the per-user name
+	// directly via FmtAppMgrName loses sight of shared apps any admin
+	// installed under a different owner.
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return
@@ -147,7 +151,11 @@ func (h *Handler) operate(req *restful.Request, resp *restful.Response) {
 	owner := req.Attribute(constants.UserContextAttribute).(string)
 
 	var am v1alpha1.ApplicationManager
-	name, err := apputils.FmtAppMgrName(app, owner, "")
+	// Lifecycle operations (start/stop/uninstall) must dispatch against the
+	// actual AM, not the deterministic per-user name — otherwise any admin
+	// trying to operate a shared app installed by someone else would hit a
+	// spurious "not found".
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -50,6 +50,9 @@ type installHelperIntf interface {
 	applyAppEnv(ctx context.Context) error
 	resolveAutoResources(ctx context.Context) error
 	applyApplicationManager(marketSource string) (opID string, err error)
+	// checkAppNameConflict enforces cluster-wide exclusivity between shared
+	// and per-user installs of the same Spec.AppName.
+	checkAppNameConflict(ctx context.Context, newShared bool) error
 }
 
 var _ installHelperIntf = (*installHandlerHelper)(nil)
@@ -57,18 +60,23 @@ var _ installHelperIntf = (*installHandlerHelperV2)(nil)
 var _ installHelperIntf = (*installHandlerHelperV3)(nil)
 
 type installHandlerHelper struct {
-	h                    *Handler
-	req                  *restful.Request
-	resp                 *restful.Response
-	app                  string
-	rawAppName           string
-	owner                string
-	chartOwner           string
-	token                string
-	insReq               *api.InstallRequest
-	appConfig            *appcfg.ApplicationConfig
-	chartPath            string
-	client               *versioned.Clientset
+	h          *Handler
+	req        *restful.Request
+	resp       *restful.Response
+	app        string
+	rawAppName string
+	owner      string
+	chartOwner string
+	token      string
+	insReq     *api.InstallRequest
+	appConfig  *appcfg.ApplicationConfig
+	chartPath  string
+	// client is the generated app.bytetrade.io clientset. Typed as the
+	// interface (not the concrete *versioned.Clientset) so unit tests can
+	// inject a fake via appfake.NewSimpleClientset. The runtime install
+	// dispatcher still constructs a concrete *versioned.Clientset and
+	// assigns it here; the interface type is purely a substitutability hook.
+	client               versioned.Interface
 	validateClusterScope func(isAdmin bool, installedApps []*v1alpha1.Application) (err error)
 }
 
@@ -246,6 +254,12 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 	if !isAdmin && appCfg.Shared {
 		err = errors.New("only admin users can install shared apps")
 		api.HandleForbidden(resp, req, err)
+		return
+	}
+
+	if err = helper.checkAppNameConflict(req.Request.Context(), appCfg.Shared); err != nil {
+		klog.Errorf("Failed to check app name conflict err=%v", err)
+		api.HandleBadRequest(resp, req, err)
 		return
 	}
 
@@ -656,6 +670,54 @@ func (h *installHandlerHelper) setAppConfig(req *api.InstallRequest, appName str
 func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opID string, err error) {
 	name, _ := apputils.FmtAppMgrName(h.app, h.owner, h.appConfig.Namespace)
 	return h.applyAppMgr(name, nil, marketSource)
+}
+
+// checkAppNameConflict enforces cluster-wide exclusivity between shared and
+// per-user installs of the same app name:
+//   - if a shared AM with the same Spec.AppName exists (any owner) → no other
+//     user (and no admin) may install another shared or per-user variant of
+//     that app name;
+//   - if any per-user AM with the same Spec.AppName exists → an admin may not
+//     install the shared variant before that per-user AM is removed.
+//
+// Same-owner same-type collisions are NOT handled here: their AM names are
+// deterministically identical, so applyAppMgr's Get(name) + IsOperationAllowed
+// path already covers them (patch on reinstallable states, reject otherwise).
+// Per-user same-name across different owners is allowed by design.
+func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
+	list, err := h.client.AppV1alpha1().ApplicationManagers().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for i := range list.Items {
+		am := &list.Items[i]
+		if am.Spec.AppName != h.app {
+			continue
+		}
+		if appstate.IsTerminalReinstallable(am.Status.State) {
+			continue
+		}
+		existingShared := am.Labels[constants.AppSharedLabel] == constants.AppSharedTrue
+		// Same-type collisions fall through to applyAppMgr's name-based path.
+		if existingShared == newShared {
+			continue
+		}
+
+		existingKind := "per-user"
+		if existingShared {
+			existingKind = "shared"
+		}
+		newKind := "per-user"
+		if newShared {
+			newKind = "shared"
+		}
+		err = fmt.Errorf("app %q is already installed as %s (owner=%q, state=%s); "+
+			"uninstall it before installing as %s",
+			h.app, existingKind, am.Spec.AppOwner, am.Status.State, newKind)
+		return err
+	}
+	return nil
 }
 
 // clonedFromValue derives the app.bytetrade.io/app-cloned-from label value
@@ -1103,9 +1165,17 @@ func (h *Handler) isDeployAllowed(req *restful.Request, resp *restful.Response) 
 	app := req.PathParameter(ParamAppName)
 	owner := req.Attribute(constants.UserContextAttribute).(string)
 
-	name := fmt.Sprintf("%s-%s-%s", app, owner, app)
+	// Use ResolveAppMgrName so the "can I deploy?" check observes the
+	// shared cluster-wide AM (if any) and not a phantom per-user name that
+	// nobody ever created. Without this an admin could think a shared
+	// install slot is free just because no per-user AM exists.
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
 	var am v1alpha1.ApplicationManager
-	err := h.ctrlClient.Get(req.Request.Context(), types.NamespacedName{Name: name}, &am)
+	err = h.ctrlClient.Get(req.Request.Context(), types.NamespacedName{Name: name}, &am)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			api.HandleError(resp, req, err)

--- a/framework/app-service/pkg/apiserver/handler_installer_install_conflict_test.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install_conflict_test.go
@@ -1,0 +1,194 @@
+package apiserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	appfake "github.com/beclab/api/pkg/generated/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// conflictAM is a thin AM fixture for checkAppNameConflict tests; the
+// upstream amObj() helper in apps_status_test.go always stamps the v3
+// api-version label which is irrelevant to the conflict check (the check
+// keys on the AppSharedLabel only).
+func conflictAM(name, appName, owner string, state appv1alpha1.ApplicationManagerState, shared bool) *appv1alpha1.ApplicationManager {
+	labels := map[string]string{}
+	if shared {
+		labels[constants.AppSharedLabel] = constants.AppSharedTrue
+	} else {
+		labels[constants.AppSharedLabel] = "false"
+	}
+	return &appv1alpha1.ApplicationManager{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec: appv1alpha1.ApplicationManagerSpec{
+			AppName:      appName,
+			AppNamespace: name,
+			AppOwner:     owner,
+		},
+		Status: appv1alpha1.ApplicationManagerStatus{State: state},
+	}
+}
+
+func newConflictHelper(t *testing.T, app string, ams ...*appv1alpha1.ApplicationManager) *installHandlerHelper {
+	t.Helper()
+	objs := make([]runtime.Object, 0, len(ams))
+	for _, am := range ams {
+		objs = append(objs, am)
+	}
+	client := appfake.NewSimpleClientset(objs...)
+	return &installHandlerHelper{
+		app:    app,
+		owner:  "alice",
+		client: client,
+	}
+}
+
+// Different app names → no conflict regardless of shared flag.
+func TestCheckAppNameConflict_DifferentAppName(t *testing.T) {
+	other := conflictAM("other-bob-other", "other", "bob", appv1alpha1.Running, true)
+	h := newConflictHelper(t, "myapp", other)
+
+	if err := h.checkAppNameConflict(context.Background(), false); err != nil {
+		t.Fatalf("unrelated app should not conflict, got %v", err)
+	}
+}
+
+// Same app name + same type (both shared OR both per-user) is delegated to
+// applyAppMgr's name-based Get/Create path, so the conflict check must
+// stay silent — even on active states.
+func TestCheckAppNameConflict_SameTypeFallThrough(t *testing.T) {
+	cases := []struct {
+		name          string
+		existingShare bool
+		newShared     bool
+	}{
+		{"both shared", true, true},
+		{"both per-user", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			am := conflictAM("myapp-foo", "myapp", "foo", appv1alpha1.Running, c.existingShare)
+			h := newConflictHelper(t, "myapp", am)
+			if err := h.checkAppNameConflict(context.Background(), c.newShared); err != nil {
+				t.Fatalf("same-type collision must fall through to applyAppMgr, got %v", err)
+			}
+		})
+	}
+}
+
+// Cross-type conflict on an ACTIVE state → return a non-nil error describing
+// the existing install. The function returns a plain fmt.Errorf, not an
+// apierrors.StatusError, and the install handler surfaces it via
+// api.HandleBadRequest; assert only on the error message so this test stays
+// honest about what the function actually produces.
+func TestCheckAppNameConflict_CrossTypeActiveReturnsConflict(t *testing.T) {
+	cases := []struct {
+		name           string
+		existingShared bool
+		newShared      bool
+	}{
+		{"shared blocks per-user", true, false},
+		{"per-user blocks shared", false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			am := conflictAM("myapp-amgr", "myapp", "bob", appv1alpha1.Running, c.existingShared)
+			h := newConflictHelper(t, "myapp", am)
+
+			err := h.checkAppNameConflict(context.Background(), c.newShared)
+			if err == nil {
+				t.Fatalf("expected conflict error, got nil")
+			}
+			if !strings.Contains(err.Error(), "is already installed as") {
+				t.Fatalf("error %q must mention the conflicting install", err.Error())
+			}
+
+			// AM in an active state must NOT be removed by the check.
+			_, getErr := h.client.AppV1alpha1().ApplicationManagers().Get(
+				context.Background(), am.Name, metav1.GetOptions{})
+			if getErr != nil {
+				t.Fatalf("AM in active state must be preserved on conflict, got %v", getErr)
+			}
+		})
+	}
+}
+
+// Cross-type collisions where the existing AM sits in an
+// IsTerminalReinstallable state are SKIPPED by the conflict check: no error
+// is surfaced and the install proceeds, but the check itself does NOT delete
+// the stale AM. Reclaiming the AM CR is the appmgr GC controller's job
+// (after AppMgrTerminalRetention) — keeping the responsibility in one place
+// avoids racing two deleters on the same object.
+//
+// Iterate every reinstallable state to guard against future drift in the
+// state-set predicate.
+func TestCheckAppNameConflict_CrossTypeReinstallableSkipped(t *testing.T) {
+	reinstallableStates := []appv1alpha1.ApplicationManagerState{
+		appv1alpha1.Uninstalled,
+		appv1alpha1.InstallingCanceled,
+		appv1alpha1.InstallFailed,
+		appv1alpha1.PendingCanceled,
+		appv1alpha1.DownloadingCanceled,
+		appv1alpha1.DownloadFailed,
+	}
+	for _, state := range reinstallableStates {
+		t.Run(string(state), func(t *testing.T) {
+			am := conflictAM("myapp-bob-myapp", "myapp", "bob", state, false)
+			h := newConflictHelper(t, "myapp", am)
+
+			// newShared=true (installer asking to install shared variant)
+			// vs existing per-user → cross-type. Reinstallable existing AM
+			// must let the install proceed.
+			if err := h.checkAppNameConflict(context.Background(), true); err != nil {
+				t.Fatalf("reinstallable state %s should not surface conflict, got %v", state, err)
+			}
+			// The stale AM must remain — checkAppNameConflict does not own
+			// reclamation; the appmgr GC controller does.
+			if _, getErr := h.client.AppV1alpha1().ApplicationManagers().Get(
+				context.Background(), am.Name, metav1.GetOptions{}); getErr != nil {
+				t.Fatalf("AM in %s must be preserved by the conflict check, got err=%v", state, getErr)
+			}
+		})
+	}
+}
+
+// Multiple conflicting AMs: one in a reinstallable terminal state and one in
+// an active state. The active one must win and block the install. Neither AM
+// is removed by the check itself — the stale one is left for the appmgr GC
+// controller to reclaim later, and the live one is preserved because there
+// is nothing safe to do with it from a conflict-check call site.
+//
+// (The current implementation walks the list in order and short-circuits on
+// the first active conflict; this test simply documents that "an active
+// conflict anywhere in the list blocks the install".)
+func TestCheckAppNameConflict_MixedAMsActiveWins(t *testing.T) {
+	stale := conflictAM("myapp-old", "myapp", "carol", appv1alpha1.Uninstalled, false)
+	live := conflictAM("myapp-shared-myapp", "myapp", "alice", appv1alpha1.Running, true)
+	h := newConflictHelper(t, "myapp", stale, live)
+
+	err := h.checkAppNameConflict(context.Background(), false)
+	if err == nil {
+		t.Fatalf("expected conflict error from live AM, got nil")
+	}
+	if !strings.Contains(err.Error(), "is already installed as") {
+		t.Fatalf("error %q must mention the conflicting install", err.Error())
+	}
+
+	if _, getErr := h.client.AppV1alpha1().ApplicationManagers().Get(
+		context.Background(), live.Name, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("live AM must be preserved, got %v", getErr)
+	}
+	// The stale (reinstallable) AM is also untouched: checkAppNameConflict
+	// does not reclaim AMs, and the active conflict short-circuits the loop
+	// before this entry could even be considered.
+	if _, getErr := h.client.AppV1alpha1().ApplicationManagers().Get(
+		context.Background(), stale.Name, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("stale AM must be preserved (reclamation belongs to GC), got %v", getErr)
+	}
+}

--- a/framework/app-service/pkg/apiserver/handler_middleware_status.go
+++ b/framework/app-service/pkg/apiserver/handler_middleware_status.go
@@ -158,7 +158,10 @@ func (h *Handler) operateMiddleware(req *restful.Request, resp *restful.Response
 	owner := req.Attribute(constants.UserContextAttribute).(string)
 
 	var am v1alpha1.ApplicationManager
-	name, err := apputils.FmtAppMgrName(app, owner, "")
+	// Resolve to the actual AM (shared or per-user) so any admin can operate
+	// shared middleware installed by another admin without hitting a spurious
+	// not-found.
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return

--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -777,7 +777,9 @@ func (h *Handler) applicationPermissionList(req *restful.Request, resp *restful.
 func (h *Handler) getApplicationPermission(req *restful.Request, resp *restful.Response) {
 	app := req.PathParameter(ParamAppName)
 	owner := req.Attribute(constants.UserContextAttribute).(string)
-	name, err := apputils.FmtAppMgrName(app, owner, "")
+	// Use ResolveAppMgrName so shared apps installed under a different admin
+	// are still found by their canonical {app}-shared-{app} name.
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return
@@ -920,7 +922,9 @@ func (h *Handler) getApplicationProviderList(req *restful.Request, resp *restful
 	owner := req.Attribute(constants.UserContextAttribute).(string)
 	app := req.PathParameter(ParamAppName)
 
-	name, err := apputils.FmtAppMgrName(app, owner, "")
+	// Use ResolveAppMgrName so shared apps installed under a different admin
+	// are still found by their canonical {app}-shared-{app} name.
+	name, _, err := apputils.ResolveAppMgrName(req.Request.Context(), app, owner)
 	if err != nil {
 		api.HandleError(resp, req, err)
 		return

--- a/framework/app-service/pkg/appstate/install_failed_app.go
+++ b/framework/app-service/pkg/appstate/install_failed_app.go
@@ -2,17 +2,10 @@ package appstate
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
-	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
-	"github.com/beclab/Olares/framework/app-service/pkg/compute"
-	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,70 +33,31 @@ func NewInstallFailedApp(c client.Client,
 		})
 }
 
+// Exec is the defensive retry loop that complements installing_app.go's
+// synchronous cleanupAfterInstallFailure call. In the happy case the
+// synchronous helper already confirmed Spec.AppNamespace is IsNotFound before
+// the AM transitioned to InstallFailed, and the helper invocation here is
+// effectively a no-op (helm release / NS / perms / Provider all gone, NS poll
+// returns immediately on first IsNotFound). In the rare case where the
+// synchronous wait timed out (NS finalizer stuck > 5min), every subsequent
+// reconcile lands here and keeps retrying the same idempotent cleanup until
+// the namespace truly disappears.
+//
+// This also covers the upgrade-time scenario where an AM was already sitting
+// in InstallFailed under the old controller version (no synchronous cleanup):
+// the first reconcile after the upgrade will run the full helper and re-align
+// the AM with the new invariant.
+//
+// Cleanup failure or NS-still-present is reported as a returned error so the
+// controller keeps re-driving Exec on backoff; once the helper returns nil the
+// AM is left untouched in InstallFailed and the GC controller (§4.3) will pick
+// it up after the retention period.
 func (p *InstallFailedApp) Exec(ctx context.Context) (StatefulInProgressApp, error) {
-	if !apputils.IsProtectedNamespace(p.manager.Spec.AppNamespace) {
-		var pvcs corev1.PersistentVolumeClaimList
-		err := p.client.List(ctx, &pvcs, client.InNamespace(p.manager.Spec.AppNamespace))
-		if err != nil {
-			klog.Errorf("failed to list pvcs %v", err)
-			return nil, err
-		}
-		for _, pvc := range pvcs.Items {
-			var curPvc corev1.PersistentVolumeClaim
-			err = p.client.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, &curPvc)
-			if err != nil && !apierrors.IsNotFound(err) {
-				return nil, err
-			}
-			err = p.client.Delete(ctx, &curPvc)
-			if err != nil && !apierrors.IsNotFound(err) {
-				return nil, err
-			}
-		}
-		var ns corev1.Namespace
-		err = p.client.Get(ctx, types.NamespacedName{Name: p.manager.Spec.AppNamespace}, &ns)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, err
-		}
-		if err == nil {
-			e := p.client.Delete(ctx, &ns)
-			if e != nil {
-				klog.Errorf("failed to delete ns %s, err=%v", p.manager.Spec.AppNamespace, e)
-				return nil, e
-			}
-		}
-	}
-
-	// A failed install tears down the namespace above, so any allocation that
-	// AllocateForInstall reserved for this app is now backing a workload that no
-	// longer exists. Release it (guarded, so it is a no-op once cleaned up) to
-	// avoid leaking the GPU/compute reservation.
-	if err := p.cleanupComputeAllocation(ctx); err != nil {
-		klog.Errorf("cleanup compute allocation for install-failed app %s failed %v", p.manager.Spec.AppName, err)
+	if err := cleanupAfterInstallFailure(ctx, p.client, p.manager); err != nil {
+		klog.Warningf("InstallFailedApp.Exec cleanup for %s pending: %v", p.manager.Name, err)
 		return nil, err
 	}
-
 	return nil, nil
-}
-
-func (p *InstallFailedApp) cleanupComputeAllocation(ctx context.Context) error {
-	if p.manager.Spec.Config == "" {
-		return nil
-	}
-	var appCfg appcfg.ApplicationConfig
-	if err := json.Unmarshal([]byte(p.manager.Spec.Config), &appCfg); err != nil {
-		klog.Errorf("unmarshal app config for compute cleanup of install-failed app %s failed %v", p.manager.Spec.AppName, err)
-		return err
-	}
-	// A failed install never owns a shared server, so only its own allocation
-	// row (if any) needs releasing; never touch a shared server here.
-	cleaned, err := compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, &appCfg, false)
-	if err != nil {
-		return err
-	}
-	if cleaned {
-		klog.Infof("released leaked compute allocation for install-failed app %s", p.manager.Spec.AppName)
-	}
-	return nil
 }
 
 func (p *InstallFailedApp) Cancel(ctx context.Context) error {

--- a/framework/app-service/pkg/appstate/install_failure_cleanup.go
+++ b/framework/app-service/pkg/appstate/install_failure_cleanup.go
@@ -1,0 +1,158 @@
+package appstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	"helm.sh/helm/v3/pkg/storage/driver"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// installFailureNSDeletionTimeout caps how long the synchronous install-failure
+// cleanup blocks waiting for the app namespace to disappear. Beyond this point
+// the AM still moves to InstallFailed but InstallFailedApp.Exec keeps retrying
+// the same helper on every reconcile until the namespace is truly gone.
+// Aligned with cancel poll timeouts (which use install TTL via opCtx); 10 min is
+// plenty for normal NS finalizers and short enough to keep the controller
+// responsive.
+const installFailureNSDeletionTimeout = 10 * time.Minute
+
+// cleanupAfterInstallFailure performs the same cluster-side teardown as
+// HelmOps.Uninstall (=UninstallAll: PVCs + helm UninstallCharts + perm/Provider
+// unregister + ClearMiddlewareRequests + ClearCache/Data + DeleteNamespace)
+// plus compute allocation cleanup, AND THEN BLOCKS until the app namespace is
+// actually gone (IsNotFound) — only then is the caller allowed to mark the AM
+// InstallFailed.
+//
+// This mirrors installing_canceling_app.go's poll() which gates the
+// InstallingCanceled transition on the same namespace deletion event.
+//
+// It is idempotent:
+//   - releases that don't exist: UninstallCharts swallows ErrReleaseNotFound
+//   - namespace that doesn't exist: DeleteNamespace + poll return immediately
+//   - permissions/providers already unregistered: existing klog.Warning path
+//
+// Callers:
+//   - installing_app.go at each transition into InstallFailed (synchronous;
+//     fills the D/E post-helm validation / scale failure gaps and confirms
+//     NS gone on C paths);
+//   - InstallFailedApp.Exec on every reconcile (defensive retry; covers the
+//     rare case where the synchronous wait above timed out).
+//
+// Returns nil iff NS is confirmed gone. On cleanup timeout returns
+// context.DeadlineExceeded — callers in installing_app.go still proceed to
+// InstallFailed but with an explicit warning in Status.Message;
+// InstallFailedApp.Exec will keep trying.
+//
+// manager.Spec.Config may be empty (e.g. failure happened before unmarshal):
+// in that case only the compute-allocation cleanup runs and the NS poll
+// short-circuits because no namespace was created either.
+func cleanupAfterInstallFailure(ctx context.Context, c client.Client, manager *appsv1.ApplicationManager) error {
+	appCfg, cfgErr := parseAppConfig(manager)
+	if cfgErr != nil {
+		klog.Warningf("install-failure cleanup %s: parse app config: %v; skipping helm uninstall", manager.Name, cfgErr)
+	}
+
+	if appCfg != nil {
+		if err := runHelmUninstallForFailure(ctx, manager, appCfg); err != nil {
+			klog.Warningf("install-failure cleanup %s: helm uninstall: %v", manager.Name, err)
+		}
+
+		if err := compute.DeleteAllocationsForApp(ctx, c, appCfg.AppName, appCfg.OwnerName); err != nil {
+			klog.Warningf("install-failure cleanup %s: compute alloc: %v", manager.Name, err)
+		}
+	}
+
+	if apputils.IsProtectedNamespace(manager.Spec.AppNamespace) {
+		return nil
+	}
+	if manager.Spec.AppNamespace == "" {
+		return nil
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, installFailureNSDeletionTimeout)
+	defer cancel()
+	return waitForNamespaceGone(pollCtx, c, manager.Spec.AppNamespace)
+}
+
+// parseAppConfig unmarshals the JSON config snapshot persisted on the AM. It
+// returns (nil, nil) when Spec.Config is empty so the caller can short-circuit
+// helm cleanup without treating it as an error.
+func parseAppConfig(manager *appsv1.ApplicationManager) (*appcfg.ApplicationConfig, error) {
+	if manager.Spec.Config == "" {
+		return nil, nil
+	}
+	var cfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(manager.Spec.Config), &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal app config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// runHelmUninstallForFailure builds a HelmOps and runs Uninstall (=UninstallAll
+// per helm_ops_uninstall.go: PVC deletion → helm UninstallCharts → perm/Provider
+// unregister → middleware requests → cache/data → namespace deletion). The call
+// is idempotent: ErrReleaseNotFound is swallowed; an already-deleted NS turns
+// the inner DeleteNamespace into a no-op.
+func runHelmUninstallForFailure(ctx context.Context, manager *appsv1.ApplicationManager, appCfg *appcfg.ApplicationConfig) error {
+	kubeConfig, err := getKubeConfig()
+	if err != nil {
+		return fmt.Errorf("get kube config: %w", err)
+	}
+	token := manager.Annotations[api.AppTokenKey]
+	ops, err := newHelmOps(ctx, kubeConfig, appCfg, token, appinstaller.Opt{
+		Source:       manager.Spec.Source,
+		MarketSource: appcfg.GetMarketSource(manager),
+	})
+	if err != nil {
+		return fmt.Errorf("build helm ops: %w", err)
+	}
+	if err := ops.Uninstall(); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+		return err
+	}
+	return nil
+}
+
+// waitForNamespaceGone polls every second until the named namespace returns
+// IsNotFound, ctx is canceled, or ctx deadline is exceeded. Mirrors
+// installingCancelInProgressApp.poll in spirit; kept as a package-private
+// helper so failure-cleanup is not coupled to the cancel state machine.
+func waitForNamespaceGone(ctx context.Context, c client.Client, name string) error {
+	// First-shot check before starting the ticker: if the namespace is already
+	// gone we can return immediately without burning a 1-second tick.
+	var ns corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, &ns); apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	timer := time.NewTicker(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			err := c.Get(ctx, types.NamespacedName{Name: name}, &ns)
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				klog.V(4).Infof("waitForNamespaceGone %s: transient get error: %v", name, err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/framework/app-service/pkg/appstate/install_failure_cleanup_test.go
+++ b/framework/app-service/pkg/appstate/install_failure_cleanup_test.go
@@ -1,0 +1,202 @@
+package appstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCleanupManagerFixture(t *testing.T, ns string) (*appcfg.ApplicationConfig, []byte) {
+	t.Helper()
+	cfg := &appcfg.ApplicationConfig{
+		AppName:   "demoapp",
+		Namespace: ns,
+		OwnerName: "alice",
+	}
+	cfgBytes, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal app config: %v", err)
+	}
+	return cfg, cfgBytes
+}
+
+// Happy path: helm Uninstall succeeds, namespace is gone before cleanup runs,
+// so the NS poll short-circuits on its first-shot check.
+func TestCleanupAfterInstallFailure_NamespaceAlreadyGone(t *testing.T) {
+	_, cfgJSON := newCleanupManagerFixture(t, "demoapp-ns")
+	am := testutil.NewAppManager("demoapp",
+		testutil.WithNamespace("demoapp-ns"),
+		testutil.WithConfigJSON(string(cfgJSON)),
+	)
+	c := testutil.NewFakeClient(am)
+
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	if err := cleanupAfterInstallFailure(context.Background(), c, am); err != nil {
+		t.Fatalf("cleanupAfterInstallFailure returned %v, want nil", err)
+	}
+	if fake.CallCount("Uninstall") != 1 {
+		t.Errorf("Uninstall calls=%d, want 1", fake.CallCount("Uninstall"))
+	}
+}
+
+// Cleanup is idempotent: a helm Uninstall that returns ErrReleaseNotFound
+// must NOT prevent the cleanup from declaring success. We surface this by
+// having FakeHelmOps return a sentinel error other than ErrReleaseNotFound to
+// confirm the helper swallows it as a warning and still proceeds to the NS
+// poll. The fake namespace is absent, so the helper still returns nil.
+func TestCleanupAfterInstallFailure_HelmErrorIsNonFatal(t *testing.T) {
+	_, cfgJSON := newCleanupManagerFixture(t, "demoapp-ns")
+	am := testutil.NewAppManager("demoapp",
+		testutil.WithNamespace("demoapp-ns"),
+		testutil.WithConfigJSON(string(cfgJSON)),
+	)
+	c := testutil.NewFakeClient(am)
+
+	fake := testutil.NewFakeHelmOps()
+	fake.UninstallErr = errors.New("transient helm error")
+	injectHelmOps(t, fake)
+
+	if err := cleanupAfterInstallFailure(context.Background(), c, am); err != nil {
+		t.Fatalf("cleanupAfterInstallFailure should swallow helm errors, got %v", err)
+	}
+	if fake.CallCount("Uninstall") != 1 {
+		t.Errorf("Uninstall calls=%d, want 1", fake.CallCount("Uninstall"))
+	}
+}
+
+// Empty Spec.Config (failure before unmarshal) must not crash: we skip the
+// helm path entirely and the NS poll short-circuits if AppNamespace is also
+// missing.
+func TestCleanupAfterInstallFailure_EmptyConfigSkipsHelm(t *testing.T) {
+	am := testutil.NewAppManager("demoapp", testutil.WithNamespace(""))
+	c := testutil.NewFakeClient(am)
+
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	if err := cleanupAfterInstallFailure(context.Background(), c, am); err != nil {
+		t.Fatalf("cleanupAfterInstallFailure returned %v, want nil", err)
+	}
+	if fake.CallCount("Uninstall") != 0 {
+		t.Errorf("Uninstall must not be called when Spec.Config is empty, got %d", fake.CallCount("Uninstall"))
+	}
+}
+
+// Protected namespaces (user-space, os-system, ...) are never deleted by the
+// app lifecycle, so the helper must NOT block on them — the poll has to
+// short-circuit on IsProtectedNamespace, not wait for the timeout.
+func TestCleanupAfterInstallFailure_ProtectedNamespaceShortCircuits(t *testing.T) {
+	_, cfgJSON := newCleanupManagerFixture(t, "user-space-alice")
+	am := testutil.NewAppManager("demoapp",
+		testutil.WithNamespace("user-space-alice"),
+		testutil.WithConfigJSON(string(cfgJSON)),
+	)
+	// Even though the namespace very much exists, the helper must return
+	// nil immediately.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "user-space-alice"}}
+	c := testutil.NewFakeClient(am, ns)
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	done := make(chan error, 1)
+	go func() { done <- cleanupAfterInstallFailure(context.Background(), c, am) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("cleanupAfterInstallFailure returned %v, want nil for protected NS", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("cleanupAfterInstallFailure did not short-circuit for protected NS")
+	}
+}
+
+// When the namespace is still present and never gets deleted, the helper must
+// return context.DeadlineExceeded (or Canceled) instead of blocking forever.
+// We use a short ctx deadline to keep the test fast; the real
+// installFailureNSDeletionTimeout (5min) is enforced internally with
+// context.WithTimeout, but the OUTER ctx deadline can cut it short.
+func TestCleanupAfterInstallFailure_NamespaceStillPresentBlocksUntilCtx(t *testing.T) {
+	_, cfgJSON := newCleanupManagerFixture(t, "demoapp-ns")
+	am := testutil.NewAppManager("demoapp",
+		testutil.WithNamespace("demoapp-ns"),
+		testutil.WithConfigJSON(string(cfgJSON)),
+	)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "demoapp-ns"}}
+	c := testutil.NewFakeClient(am, ns)
+	fake := testutil.NewFakeHelmOps()
+	injectHelmOps(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	err := cleanupAfterInstallFailure(ctx, c, am)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("cleanupAfterInstallFailure returned nil, want context deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("cleanupAfterInstallFailure returned %v, want DeadlineExceeded/Canceled", err)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("cleanupAfterInstallFailure blocked for %s, expected ~2s ctx deadline", elapsed)
+	}
+}
+
+// waitForNamespaceGone must short-circuit on its first-shot Get before the
+// 1-second ticker fires, so a test that asserts the helper returns in
+// well under 1 second proves we don't pay an unnecessary tick on the fast path.
+func TestWaitForNamespaceGone_FastPathNoTick(t *testing.T) {
+	c := testutil.NewFakeClient()
+
+	start := time.Now()
+	if err := waitForNamespaceGone(context.Background(), c, "missing-ns"); err != nil {
+		t.Fatalf("waitForNamespaceGone returned %v, want nil", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("waitForNamespaceGone first-shot path took %s, expected < 500ms", elapsed)
+	}
+}
+
+// waitForNamespaceGone returns when the namespace is deleted mid-poll. Drive
+// this by deleting the NS from another goroutine after the helper has had a
+// chance to take at least one tick.
+func TestWaitForNamespaceGone_ResolvesAfterDelete(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "demoapp-ns"}}
+	c := testutil.NewFakeClient(ns)
+
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		_ = c.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "demoapp-ns"}})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitForNamespaceGone(ctx, c, "demoapp-ns"); err != nil {
+		t.Fatalf("waitForNamespaceGone returned %v, want nil after delete", err)
+	}
+	// Sanity check: the NS really is gone in the fake store.
+	var got corev1.Namespace
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "demoapp-ns"}, &got); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound, got %v", err)
+	}
+}
+
+// Compile-time sanity that the helper file uses the right client type. This
+// keeps the test from drifting if someone changes the helper signature.
+var _ = func(ctx context.Context, c client.Client) {
+	_ = waitForNamespaceGone(ctx, c, "")
+}

--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -105,11 +105,33 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 					Token:     token,
 				}
 
+				// toInstallFailed is the single entry point for every "this install
+				// failed, mark the AM InstallFailed" path. Before flipping the
+				// status it runs cleanupAfterInstallFailure synchronously: that
+				// helper is idempotent and handles the resource gaps left by
+				// post-helm-validation (path D) and Scale (path E) failures, and
+				// — critically — blocks until manager.Spec.AppNamespace is
+				// confirmed IsNotFound (up to installFailureNSDeletionTimeout)
+				// so callers observing InstallFailed can trust the strong
+				// invariant "NS already gone, AM safely deletable".
+				//
+				// If cleanup times out the helper returns context.DeadlineExceeded;
+				// we still transition to InstallFailed (we must not block the
+				// state machine indefinitely) but tag Status.Message with the
+				// timeout so operators can investigate, and InstallFailedApp.Exec
+				// will keep retrying the same helper on subsequent reconciles.
 				toInstallFailed := func(msg string) {
+					cleanupErr := cleanupAfterInstallFailure(context.TODO(), p.client, p.manager)
+					finalMsg := msg
+					if cleanupErr != nil {
+						klog.Warningf("install-failure cleanup for %s timed out waiting for NS: %v; will retry in InstallFailedApp.Exec",
+							p.manager.Name, cleanupErr)
+						finalMsg = fmt.Sprintf("%s; cleanup timeout: %v", msg, cleanupErr)
+					}
 					p.finally = func() {
 						klog.Errorf("app %s install failed, update app state to installFailed", p.manager.Spec.AppName)
 						opRecord := makeRecord(p.manager, appsv1.InstallFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, msg))
-						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, msg, appsv1.InstallFailed.String())
+						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, finalMsg, appsv1.InstallFailed.String())
 						if updateErr != nil {
 							klog.Errorf("update status failed %v", updateErr)
 						}
@@ -157,20 +179,18 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 					})
 				if err != nil {
 					klog.Errorf("make helm ops failed %v", err)
-					p.finally = func() {
-						klog.Errorf("app %s install failed, update app state to installFailed", p.manager.Spec.AppName)
-						opRecord := makeRecord(p.manager, appsv1.InstallFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
-						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, err.Error(), appsv1.InstallFailed.String())
-						if updateErr != nil {
-							klog.Errorf("update status failed %v", updateErr)
-						}
-					}
+					toInstallFailed(err.Error())
 					return
 				}
 
 				err = ops.Install()
 				if err != nil {
 					klog.Errorf("install app %s failed %v", p.manager.Spec.AppName, err)
+					// Release compute allocation up-front so the pending-pod paths
+					// (ErrServerSidePodPending / ErrPodPending → Stopping) don't leak
+					// the GPU/compute reservation. The generic InstallFailed branch
+					// below re-runs the same cleanup via cleanupAfterInstallFailure
+					// but that call is idempotent.
 					if cleanupErr := compute.DeleteAllocationsForApp(context.TODO(), p.client, appCfg.AppName, appCfg.OwnerName); cleanupErr != nil {
 						klog.Warningf("cleanup compute allocation for failed install %s failed: %v", appCfg.AppName, cleanupErr)
 					}
@@ -224,24 +244,19 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 						return
 					}
 
-					p.finally = func() {
-						klog.Errorf("app %s install failed, update app state to installFailed", p.manager.Spec.AppName)
-						opRecord := makeRecord(p.manager, appsv1.InstallFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
-						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, err.Error(), appsv1.InstallFailed.String())
-						if updateErr != nil {
-							klog.Errorf("update status failed %v", updateErr)
-						}
-					}
-
+					toInstallFailed(err.Error())
 					return
 				} // end of err != nil
 
 				if twoPhase {
 					decision, runErr := runValidation()
 					if runErr != nil {
-						if cleanupErr := compute.DeleteAllocationsForApp(context.TODO(), p.client, appCfg.AppName, appCfg.OwnerName); cleanupErr != nil {
-							klog.Warningf("cleanup compute allocation after post-helm validation error for %s failed: %v", appCfg.AppName, cleanupErr)
-						}
+						// Path D: ops.Install() already succeeded, so helm release + main
+						// NS + permissions + Provider are still in the cluster. cleanupAfter
+						// InstallFailure (invoked by toInstallFailed) is the only thing that
+						// actually tears these down and confirms NS is gone before we mark
+						// InstallFailed; the old standalone compute.DeleteAllocationsForApp
+						// call has been folded into the helper.
 						toInstallFailed(runErr.Error())
 						return
 					}
@@ -289,18 +304,15 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				// Scale up to the manifest-declared replica counts via a
 				// second helm upgrade. Any failure here is treated as a
 				// generic install failure to mirror the v1 behavior.
+				//
+				// Path E: ops.Install() already succeeded, so the helm release is in
+				// the cluster. cleanupAfterInstallFailure (invoked by toInstallFailed)
+				// owns the teardown + NS-gone confirmation before InstallFailed; the
+				// old standalone compute.DeleteAllocationsForApp call has been folded
+				// into the helper.
 				if scaleErr := ops.Scale(-1); scaleErr != nil {
 					klog.Errorf("scale-up after install failed for app %s: %v", p.manager.Spec.AppName, scaleErr)
-					if cleanupErr := compute.DeleteAllocationsForApp(context.TODO(), p.client, appCfg.AppName, appCfg.OwnerName); cleanupErr != nil {
-						klog.Warningf("cleanup compute allocation after scale-up failure for %s failed: %v", appCfg.AppName, cleanupErr)
-					}
-					p.finally = func() {
-						opRecord := makeRecord(p.manager, appsv1.InstallFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, scaleErr.Error()))
-						updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.InstallFailed, opRecord, scaleErr.Error(), appsv1.InstallFailed.String())
-						if updateErr != nil {
-							klog.Errorf("update status failed %v", updateErr)
-						}
-					}
+					toInstallFailed(scaleErr.Error())
 					return
 				}
 

--- a/framework/app-service/pkg/appstate/state_transition.go
+++ b/framework/app-service/pkg/appstate/state_transition.go
@@ -32,6 +32,7 @@ var All = []appv1alpha1.ApplicationManagerState{
 	appv1alpha1.InstallingCancelFailed,
 	appv1alpha1.UpgradingCancelFailed,
 	appv1alpha1.ApplyingEnvCancelFailed,
+	appv1alpha1.ResumingCancelFailed,
 
 	appv1alpha1.PendingCanceled,
 	appv1alpha1.DownloadingCanceled,
@@ -49,7 +50,21 @@ var All = []appv1alpha1.ApplicationManagerState{
 	appv1alpha1.UninstallFailed,
 }
 
+// StateTransitions enumerates every (from -> to) edge the runtime can produce.
+// It is consumed by IsStateTransitionValid and by updateStatus' transition guard
+// in pkg/appstate/types.go, so any path that calls updateStatus(..., newState)
+// MUST declare its (currentState -> newState) edge here or the patch will be
+// rejected at runtime.
+//
+// When adding a new edge, also note its source so the next reader can audit
+// the table without re-grepping the codebase.
 var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.ApplicationManagerState{
+	// "" represents an AM that has just been created and has not been written
+	// by the state machine yet; handler_installer_install.go writes Pending
+	// against this sentinel via apputils.UpdateAppMgrStatus.
+	"": {
+		appv1alpha1.Pending,
+	},
 	appv1alpha1.Pending: {
 		appv1alpha1.Downloading,
 		appv1alpha1.PendingCanceling,
@@ -64,6 +79,9 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 		appv1alpha1.InstallFailed,
 		appv1alpha1.InstallingCanceling,
 		appv1alpha1.Stopping,
+		// installing_app.go: middleware fast-path lands directly in Running
+		// after WaitForLaunch instead of going through Initializing.
+		appv1alpha1.Running,
 	},
 	appv1alpha1.Initializing: {
 		appv1alpha1.Running,
@@ -74,6 +92,9 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 		appv1alpha1.Upgrading,
 		appv1alpha1.ApplyingEnv,
 		appv1alpha1.Uninstalling,
+		// running_app.go -> forceDeleteApp -> Uninstalled when the
+		// Application CR has disappeared (self-heal path).
+		appv1alpha1.Uninstalled,
 	},
 	appv1alpha1.Stopping: {
 		appv1alpha1.Stopped,
@@ -83,6 +104,10 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 		appv1alpha1.Initializing,
 		appv1alpha1.UpgradeFailed,
 		appv1alpha1.UpgradingCanceling,
+		// upgrading_app.go: upgrade-from-Stopped lands back in Stopped via
+		// landedState (helm release upgraded at replicas=0, nothing to wait
+		// for, no need to go through Initializing).
+		appv1alpha1.Stopped,
 	},
 	appv1alpha1.ApplyingEnv: {
 		appv1alpha1.Initializing,
@@ -109,15 +134,23 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 	// initializing state cancel directly turn to stopping
 	appv1alpha1.InitializingCanceling: {
 		appv1alpha1.Stopping,
+		// initializing_canceling_app.go.Cancel writes InstallingCancelFailed
+		// (the namespace is reused with installing-cancel for failure paths).
+		appv1alpha1.InstallingCancelFailed,
 	},
 
 	appv1alpha1.Resuming: {
 		appv1alpha1.ResumingCanceling,
 		appv1alpha1.ResumeFailed,
 		appv1alpha1.Initializing,
+		// OperationAllowedInState[Resuming][StopOp]=true, so handler_suspend
+		// / pod_abnormal_suspend_app_controller can flip Resuming -> Stopping.
+		appv1alpha1.Stopping,
 	},
 	appv1alpha1.ResumingCanceling: {
 		appv1alpha1.Stopping,
+		// resuming_canceling_app.go.Cancel writes ResumingCancelFailed.
+		appv1alpha1.ResumingCancelFailed,
 	},
 	appv1alpha1.UpgradingCanceling: {
 		appv1alpha1.Stopping,
@@ -161,9 +194,16 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 	appv1alpha1.ResumeFailed: {
 		appv1alpha1.Resuming,
 		appv1alpha1.Uninstalling,
+		// OperationAllowedInState[ResumeFailed] also allows UpgradeOp and
+		// ApplyEnvOp; handler_installer_upgrade.go and handler_applyenv.go
+		// drive these edges.
+		appv1alpha1.Upgrading,
+		appv1alpha1.ApplyingEnv,
 	},
 	appv1alpha1.UninstallFailed: {
 		appv1alpha1.Uninstalling,
+		// uninstall_failed_app.go -> forceDeleteApp -> Uninstalled.
+		appv1alpha1.Uninstalled,
 	},
 	appv1alpha1.PendingCancelFailed: {
 		appv1alpha1.PendingCanceling,
@@ -173,6 +213,36 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 	},
 	appv1alpha1.InstallingCancelFailed: {
 		appv1alpha1.InstallingCanceling,
+		// OperationAllowedInState[InstallingCancelFailed][UninstallOp]=true.
+		appv1alpha1.Uninstalling,
+	},
+	// UpgradingCancelFailed / ApplyingEnvCancelFailed were missing entirely.
+	// Both allow CancelOp (re-enter the canceling state) and UninstallOp.
+	appv1alpha1.UpgradingCancelFailed: {
+		appv1alpha1.UpgradingCanceling,
+		appv1alpha1.Uninstalling,
+	},
+	appv1alpha1.ApplyingEnvCancelFailed: {
+		appv1alpha1.ApplyingEnvCanceling,
+		appv1alpha1.Uninstalling,
+	},
+
+	// Terminal-reinstallable states: handler_installer_install.go re-targets
+	// the same AM by patching Spec and writing Status.State=Pending when the
+	// caller still holds the same (app, owner) tuple. The conflict-check
+	// only lazy-deletes cross-type (shared vs per-user) collisions, so the
+	// same-type same-owner reinstall flips state in place.
+	appv1alpha1.PendingCanceled: {
+		appv1alpha1.Pending,
+	},
+	appv1alpha1.DownloadingCanceled: {
+		appv1alpha1.Pending,
+	},
+	appv1alpha1.InstallingCanceled: {
+		appv1alpha1.Pending,
+	},
+	appv1alpha1.Uninstalled: {
+		appv1alpha1.Pending,
 	},
 }
 
@@ -395,9 +465,73 @@ func IsStateTransitionValid(from, to appv1alpha1.ApplicationManagerState) bool {
 	return false
 }
 
+// IsStateTransitionAllowed is the runtime guard used by updateStatus. It is
+// looser than IsStateTransitionValid in exactly one way: a same-state write
+// (from == to) is always allowed, so that idempotent retries of updateStatus
+// (e.g. RetryOnConflict re-reading the latest state, or a deferred Finally
+// re-asserting a terminal state with an updated message/reason) are not
+// rejected.
+func IsStateTransitionAllowed(from, to appv1alpha1.ApplicationManagerState) bool {
+	if from == to {
+		return true
+	}
+	return IsStateTransitionValid(from, to)
+}
+
 func StateToDuration(state appv1alpha1.ApplicationManagerState) time.Duration {
 	if t, ok := StateToDurationMap[state]; ok {
 		return t
 	}
 	return 10 * time.Minute
+}
+
+// IsTerminalReinstallable reports whether an AM is in a terminal state from
+// which an Install operation is allowed. This is the broadest set; it matches
+// OperationAllowedInState[state][InstallOp] == true with a non-empty state.
+//
+// NOTE: "reinstallable" does not imply "safe to delete the AM CR". InstallFailed
+// historically left dangling helm/permission/provider/shared-NS resources before
+// the install-failure cleanup helper plugged the gaps; use IsSafelyDeletable
+// when the intent is to remove the AM.
+func IsTerminalReinstallable(state appv1alpha1.ApplicationManagerState) bool {
+	switch state {
+	case appv1alpha1.PendingCanceled,
+		appv1alpha1.DownloadingCanceled,
+		appv1alpha1.InstallingCanceled,
+		appv1alpha1.Uninstalled,
+		appv1alpha1.DownloadFailed,
+		appv1alpha1.InstallFailed:
+		return true
+	}
+	return false
+}
+
+// IsSafelyDeletable reports whether the AM CR can be deleted directly without
+// leaking cluster resources. Every terminal state in this set is entered only
+// AFTER the state machine has run a full cleanup pass AND confirmed that the
+// app namespace is gone:
+//   - Uninstalled            ← UninstallingApp.exec ran ops.Uninstall(All) +
+//     waitForDeleteNamespace
+//   - InstallingCanceled     ← InstallingCancelingApp ran ops.Uninstall(All) +
+//     poll() waited for NS IsNotFound
+//   - InstallFailed          ← cleanupAfterInstallFailure runs ops.Uninstall()
+//     AND polls for NS IsNotFound before the transition; InstallFailedApp.Exec
+//     retries on every reconcile if the synchronous wait timed out
+//   - PendingCanceled / DownloadingCanceled / DownloadFailed
+//     ← cluster resources never created
+//
+// Callers that delete the AM based on this predicate should still re-verify the
+// app namespace is IsNotFound to defend against pre-upgrade dirty data where
+// the invariant may not yet hold.
+func IsSafelyDeletable(state appv1alpha1.ApplicationManagerState) bool {
+	switch state {
+	case appv1alpha1.PendingCanceled,
+		appv1alpha1.DownloadingCanceled,
+		appv1alpha1.InstallingCanceled,
+		appv1alpha1.Uninstalled,
+		appv1alpha1.DownloadFailed,
+		appv1alpha1.InstallFailed:
+		return true
+	}
+	return false
 }

--- a/framework/app-service/pkg/appstate/state_transition_test.go
+++ b/framework/app-service/pkg/appstate/state_transition_test.go
@@ -19,7 +19,30 @@ func TestIsStateTransitionValid(t *testing.T) {
 		{appsv1.Initializing, appsv1.Running, true},
 		{appsv1.Running, appsv1.Uninstalling, true},
 		{appsv1.Uninstalling, appsv1.Uninstalled, true},
-		// invalid jumps
+
+		// Edges that were previously missing from the table but happen at
+		// runtime — must now be reported valid.
+		{"", appsv1.Pending, true},
+		{appsv1.Installing, appsv1.Running, true},
+		{appsv1.Upgrading, appsv1.Stopped, true},
+		{appsv1.Running, appsv1.Uninstalled, true},
+		{appsv1.UninstallFailed, appsv1.Uninstalled, true},
+		{appsv1.InitializingCanceling, appsv1.InstallingCancelFailed, true},
+		{appsv1.ResumingCanceling, appsv1.ResumingCancelFailed, true},
+		{appsv1.Resuming, appsv1.Stopping, true},
+		{appsv1.ResumeFailed, appsv1.Upgrading, true},
+		{appsv1.ResumeFailed, appsv1.ApplyingEnv, true},
+		{appsv1.InstallingCancelFailed, appsv1.Uninstalling, true},
+		{appsv1.UpgradingCancelFailed, appsv1.UpgradingCanceling, true},
+		{appsv1.UpgradingCancelFailed, appsv1.Uninstalling, true},
+		{appsv1.ApplyingEnvCancelFailed, appsv1.ApplyingEnvCanceling, true},
+		{appsv1.ApplyingEnvCancelFailed, appsv1.Uninstalling, true},
+		{appsv1.PendingCanceled, appsv1.Pending, true},
+		{appsv1.DownloadingCanceled, appsv1.Pending, true},
+		{appsv1.InstallingCanceled, appsv1.Pending, true},
+		{appsv1.Uninstalled, appsv1.Pending, true},
+
+		// invalid jumps (still rejected after the table was augmented).
 		{appsv1.Pending, appsv1.Running, false},
 		{appsv1.Running, appsv1.Installing, false},
 		{appsv1.Uninstalled, appsv1.Running, false},
@@ -28,6 +51,73 @@ func TestIsStateTransitionValid(t *testing.T) {
 	for _, c := range cases {
 		if got := IsStateTransitionValid(c.from, c.to); got != c.want {
 			t.Errorf("IsStateTransitionValid(%s,%s)=%v want %v", c.from, c.to, got, c.want)
+		}
+	}
+}
+
+// IsStateTransitionAllowed is the runtime guard used by updateStatus. It must
+// pass everything IsStateTransitionValid passes AND additionally allow
+// same-state (from == to) writes so idempotent retries and re-assertions are
+// not rejected.
+func TestIsStateTransitionAllowedAllowsSelfWrite(t *testing.T) {
+	selfWrites := []appsv1.ApplicationManagerState{
+		appsv1.Pending,
+		appsv1.Running,
+		appsv1.InstallFailed,
+		appsv1.Uninstalled,
+		// Self-write must work even for states with NO declared outgoing
+		// edge (e.g. ResumingCancelFailed today) — otherwise an idempotent
+		// re-assertion of a stuck terminal state could not refresh its
+		// message/reason.
+		appsv1.ResumingCancelFailed,
+	}
+	for _, s := range selfWrites {
+		if !IsStateTransitionAllowed(s, s) {
+			t.Errorf("IsStateTransitionAllowed(%s,%s)=false, want true (self-write)", s, s)
+		}
+	}
+
+	// Disallowed jumps remain disallowed.
+	if IsStateTransitionAllowed(appsv1.Pending, appsv1.Running) {
+		t.Error("IsStateTransitionAllowed(Pending,Running)=true, want false")
+	}
+	if IsStateTransitionAllowed(appsv1.Initializing, appsv1.Uninstalled) {
+		t.Error("IsStateTransitionAllowed(Initializing,Uninstalled)=true, want false")
+	}
+}
+
+// Every (state, op) pair declared in OperationAllowedInState that has an
+// obvious target state (via the handler that drives it) must also appear in
+// StateTransitions. This invariant catches the historical drift between the
+// two tables (e.g. OperationAllowedInState allowing UninstallOp from a state
+// while StateTransitions had no edge to Uninstalling).
+func TestOperationAllowedAlignsWithStateTransitions(t *testing.T) {
+	// op -> target state driven by the corresponding handler/state-machine
+	// path. CancelOp is intentionally excluded: the target canceling state
+	// depends on the source state (Installing -> InstallingCanceling,
+	// Resuming -> ResumingCanceling, etc.), so it is covered case-by-case
+	// elsewhere.
+	opTarget := map[appsv1.OpType]appsv1.ApplicationManagerState{
+		appsv1.InstallOp:   appsv1.Pending,
+		appsv1.UninstallOp: appsv1.Uninstalling,
+		appsv1.UpgradeOp:   appsv1.Upgrading,
+		appsv1.ApplyEnvOp:  appsv1.ApplyingEnv,
+		appsv1.ResumeOp:    appsv1.Resuming,
+		appsv1.StopOp:      appsv1.Stopping,
+	}
+	for state, ops := range OperationAllowedInState {
+		for op, allowed := range ops {
+			if !allowed {
+				continue
+			}
+			to, ok := opTarget[op]
+			if !ok {
+				continue
+			}
+			if !IsStateTransitionValid(state, to) {
+				t.Errorf("OperationAllowedInState[%s][%s]=true but StateTransitions[%s] has no edge to %s",
+					state, op, state, to)
+			}
 		}
 	}
 }
@@ -104,6 +194,88 @@ func TestCancelableAndCancelingAreOperating(t *testing.T) {
 	for s := range CancelingStates {
 		if !OperatingStates[s] {
 			t.Errorf("canceling state %s is not an operating state", s)
+		}
+	}
+}
+
+func TestIsTerminalReinstallable(t *testing.T) {
+	cases := []struct {
+		state appsv1.ApplicationManagerState
+		want  bool
+	}{
+		{appsv1.Uninstalled, true},
+		{appsv1.InstallingCanceled, true},
+		{appsv1.PendingCanceled, true},
+		{appsv1.DownloadingCanceled, true},
+		{appsv1.DownloadFailed, true},
+		{appsv1.InstallFailed, true},
+
+		{appsv1.Running, false},
+		{appsv1.Installing, false},
+		{appsv1.InstallingCanceling, false},
+		{appsv1.UninstallFailed, false},
+		{appsv1.UpgradeFailed, false},
+		{appsv1.Stopped, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsTerminalReinstallable(c.state); got != c.want {
+			t.Errorf("IsTerminalReinstallable(%q)=%v want %v", c.state, got, c.want)
+		}
+	}
+}
+
+func TestIsSafelyDeletable(t *testing.T) {
+	cases := []struct {
+		state appsv1.ApplicationManagerState
+		want  bool
+	}{
+		{appsv1.Uninstalled, true},
+		{appsv1.InstallingCanceled, true},
+		{appsv1.InstallFailed, true},
+		{appsv1.PendingCanceled, true},
+		{appsv1.DownloadingCanceled, true},
+		{appsv1.DownloadFailed, true},
+
+		// Active / canceling / non-clean failure states.
+		{appsv1.Running, false},
+		{appsv1.Installing, false},
+		{appsv1.InstallingCanceling, false},
+		{appsv1.UninstallFailed, false},
+		{appsv1.UpgradeFailed, false},
+		{appsv1.Stopped, false},
+		{appsv1.Stopping, false},
+		{appsv1.Pending, false},
+		{appsv1.PendingCancelFailed, false},
+		{appsv1.InstallingCancelFailed, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsSafelyDeletable(c.state); got != c.want {
+			t.Errorf("IsSafelyDeletable(%q)=%v want %v", c.state, got, c.want)
+		}
+	}
+}
+
+// Every IsSafelyDeletable state must also be IsTerminalReinstallable — the
+// "deletable" set is a strict subset of the "reinstallable" set, since you
+// can only safely delete a CR you'd otherwise allow a reinstall on.
+func TestSafelyDeletableImpliesReinstallable(t *testing.T) {
+	for _, s := range All {
+		if IsSafelyDeletable(s) && !IsTerminalReinstallable(s) {
+			t.Errorf("state %q is IsSafelyDeletable but not IsTerminalReinstallable", s)
+		}
+	}
+}
+
+// Every IsTerminalReinstallable state must allow InstallOp; the two predicates
+// describe the same lifecycle decision from different angles and they must
+// agree, otherwise a stale AM can be re-targeted but the state-machine will
+// reject the request, or vice versa.
+func TestTerminalReinstallableAllowsInstallOp(t *testing.T) {
+	for _, s := range All {
+		if IsTerminalReinstallable(s) && !IsOperationAllowed(s, appsv1.InstallOp) {
+			t.Errorf("state %q is IsTerminalReinstallable but disallows InstallOp", s)
 		}
 	}
 }

--- a/framework/app-service/pkg/appstate/transition_guard.go
+++ b/framework/app-service/pkg/appstate/transition_guard.go
@@ -1,0 +1,20 @@
+package appstate
+
+import (
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+)
+
+// init wires the StateTransitions table into apputils.UpdateAppMgrStatus so
+// every handler path that writes ApplicationManager.Status via the apiserver
+// helpers (handler_installer_install, handler_suspend, handler_applyenv,
+// handler_installer_upgrade, handler_installer_uninstall, handler_settings,
+// handler_compute_resources, handler_middleware*, appenv_controller,
+// pod_abnormal_suspend_app_controller, …) is held to the same transition
+// invariant as pkg/appstate's own updateStatus.
+//
+// The indirection is deliberate: pkg/utils/app cannot import pkg/appstate
+// because pkg/appstate already imports pkg/utils/app, so we register the
+// guard at init time instead.
+func init() {
+	apputils.StateTransitionGuard = IsStateTransitionAllowed
+}

--- a/framework/app-service/pkg/appstate/transition_guard_test.go
+++ b/framework/app-service/pkg/appstate/transition_guard_test.go
@@ -1,0 +1,35 @@
+package appstate
+
+import (
+	"testing"
+
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+)
+
+// The init() in transition_guard.go must have populated the apputils-side
+// guard variable so every UpdateAppMgrStatus call goes through the same
+// transition table as updateStatus.
+func TestStateTransitionGuardWiredIntoApputils(t *testing.T) {
+	if apputils.StateTransitionGuard == nil {
+		t.Fatal("apputils.StateTransitionGuard is nil; pkg/appstate init must wire it up")
+	}
+
+	cases := []struct {
+		name     string
+		from, to appsv1.ApplicationManagerState
+		want     bool
+	}{
+		{"declared edge accepted", appsv1.Installing, appsv1.Running, true},
+		{"self-write accepted", appsv1.InstallFailed, appsv1.InstallFailed, true},
+		{"undeclared jump rejected", appsv1.Pending, appsv1.Uninstalled, false},
+		{"running to installing rejected", appsv1.Running, appsv1.Installing, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := apputils.StateTransitionGuard(c.from, c.to); got != c.want {
+				t.Errorf("guard(%s,%s)=%v want %v", c.from, c.to, got, c.want)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/appstate/types.go
+++ b/framework/app-service/pkg/appstate/types.go
@@ -3,6 +3,7 @@ package appstate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -60,6 +61,20 @@ func (b *baseStatefulApp) updateStatus(ctx context.Context, am *appsv1.Applicati
 	// OpGeneration increment or OpRecords.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := b.client.Get(ctx, types.NamespacedName{Name: am.Name}, am); err != nil {
+			return err
+		}
+
+		// Reject writes that are not declared in StateTransitions. The check
+		// runs INSIDE the retry loop so that if the persisted state has
+		// changed underneath us (e.g. user cancelled while this goroutine
+		// was racing toward InstallFailed) we refuse to clobber the new
+		// terminal state with a stale transition. Same-state writes are
+		// still allowed via IsStateTransitionAllowed so idempotent retries
+		// and re-assertions (updated message/reason) keep working.
+		if !IsStateTransitionAllowed(am.Status.State, state) {
+			err := fmt.Errorf("invalid state transition for %s: %s -> %s (not declared in StateTransitions)",
+				am.Name, am.Status.State, state)
+			klog.Warningf("updateStatus rejected: %v", err)
 			return err
 		}
 

--- a/framework/app-service/pkg/appstate/update_status_rapid_test.go
+++ b/framework/app-service/pkg/appstate/update_status_rapid_test.go
@@ -17,18 +17,13 @@ import (
 // a real fake client must always preserve the storage-level invariants:
 // OpGeneration increases by exactly one per call, records stay newest-first and
 // never exceed the cap of 20.
+//
+// updateStatus now rejects transitions that are not declared in
+// StateTransitions, so the walk picks the next state from
+// StateTransitions[current] (or a same-state self-write) instead of any random
+// target. Self-writes are exercised deliberately because they are the
+// idempotent-retry path that must NOT be rejected.
 func TestUpdateStatusInvariantsUnderRandomSequence(t *testing.T) {
-	candidateStates := []appsv1.ApplicationManagerState{
-		appsv1.Installing,
-		appsv1.Initializing,
-		appsv1.Running,
-		appsv1.Stopping,
-		appsv1.Stopped,
-		appsv1.Upgrading,
-		appsv1.ApplyingEnv,
-		appsv1.Uninstalling,
-	}
-
 	rapid.Check(t, func(rt *rapid.T) {
 		am := testutil.NewAppManager("nginx-rapid", testutil.WithState(appsv1.Installing))
 		c := testutil.NewFakeClient(am)
@@ -36,8 +31,17 @@ func TestUpdateStatusInvariantsUnderRandomSequence(t *testing.T) {
 
 		n := rapid.IntRange(1, 40).Draw(rt, "ops")
 		recordsAdded := 0
+		cur := appsv1.Installing
 		for i := 0; i < n; i++ {
-			st := candidateStates[rapid.IntRange(0, len(candidateStates)-1).Draw(rt, "state")]
+			// Pick a valid next state: either a declared edge or a
+			// same-state self-write (both must be accepted).
+			nexts := StateTransitions[cur]
+			var st appsv1.ApplicationManagerState
+			if len(nexts) == 0 || rapid.Bool().Draw(rt, "selfWrite") {
+				st = cur
+			} else {
+				st = nexts[rapid.IntRange(0, len(nexts)-1).Draw(rt, "next")]
+			}
 
 			var rec *appsv1.OpRecord
 			id := strconv.Itoa(i)
@@ -48,8 +52,9 @@ func TestUpdateStatusInvariantsUnderRandomSequence(t *testing.T) {
 			}
 
 			if err := b.updateStatus(context.TODO(), am, st, rec, id, ""); err != nil {
-				rt.Fatalf("updateStatus call %d: %v", i, err)
+				rt.Fatalf("updateStatus call %d (%s->%s): %v", i, cur, st, err)
 			}
+			cur = st
 
 			got := getAM(t, b, "nginx-rapid")
 			if got.Status.OpGeneration != int64(i+1) {
@@ -68,6 +73,52 @@ func TestUpdateStatusInvariantsUnderRandomSequence(t *testing.T) {
 			if rec != nil && got.Status.OpRecords[0].OpID != id {
 				rt.Fatalf("after call %d newest record=%q, want %q", i, got.Status.OpRecords[0].OpID, id)
 			}
+		}
+	})}
+
+// Companion test: invalid transitions must be rejected and must NOT mutate
+// any storage-level state (no OpGeneration bump, no record prepend).
+func TestUpdateStatusRejectsInvalidTransitionAndPreservesInvariants(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		am := testutil.NewAppManager("nginx-rapid-bad", testutil.WithState(appsv1.Pending))
+		// Seed an existing record so we can also assert the rejected
+		// call did not prepend a new one.
+		am.Status.OpRecords = []appsv1.OpRecord{{OpID: "seed"}}
+		c := testutil.NewFakeClient(am)
+		b := &baseStatefulApp{manager: am, client: c}
+
+		// Build the set of valid targets from Pending (incl. self) so we
+		// can draw an arbitrary INVALID target.
+		valid := map[appsv1.ApplicationManagerState]bool{appsv1.Pending: true}
+		for _, s := range StateTransitions[appsv1.Pending] {
+			valid[s] = true
+		}
+		// All non-empty states from the known universe.
+		candidates := make([]appsv1.ApplicationManagerState, 0, len(All))
+		for _, s := range All {
+			if !valid[s] {
+				candidates = append(candidates, s)
+			}
+		}
+		if len(candidates) == 0 {
+			return
+		}
+		target := candidates[rapid.IntRange(0, len(candidates)-1).Draw(rt, "invalidTarget")]
+
+		err := b.updateStatus(context.TODO(), am, target, &appsv1.OpRecord{OpID: "rejected"}, "msg", "")
+		if err == nil {
+			rt.Fatalf("updateStatus(Pending -> %s) returned nil, want error", target)
+		}
+
+		got := getAM(t, b, "nginx-rapid-bad")
+		if got.Status.State != appsv1.Pending {
+			rt.Fatalf("state=%s want Pending (rejected write must not mutate)", got.Status.State)
+		}
+		if got.Status.OpGeneration != 0 {
+			rt.Fatalf("OpGeneration=%d want 0 (rejected write must not bump)", got.Status.OpGeneration)
+		}
+		if len(got.Status.OpRecords) != 1 || got.Status.OpRecords[0].OpID != "seed" {
+			rt.Fatalf("OpRecords=%+v want only the seed record (rejected write must not prepend)", got.Status.OpRecords)
 		}
 	})
 }

--- a/framework/app-service/pkg/appstate/update_status_test.go
+++ b/framework/app-service/pkg/appstate/update_status_test.go
@@ -92,3 +92,50 @@ func TestUpdateStatusNilRecordKeepsRecords(t *testing.T) {
 		t.Errorf("OpRecords len=%d want 1 (unchanged)", len(got.Status.OpRecords))
 	}
 }
+
+// updateStatus must reject any (from -> to) edge not declared in
+// StateTransitions. A jump like Pending -> Uninstalled would clobber the
+// state machine's invariants, so the patch must be refused and the stored
+// state must remain unchanged.
+func TestUpdateStatusRejectsInvalidTransition(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithState(appsv1.Pending))
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	err := b.updateStatus(context.TODO(), am, appsv1.Uninstalled, nil, "msg", "")
+	if err == nil {
+		t.Fatalf("updateStatus(Pending -> Uninstalled) returned nil, want error")
+	}
+
+	got := getAM(t, b, "nginx")
+	if got.Status.State != appsv1.Pending {
+		t.Errorf("state=%s want Pending (rejected write must not mutate)", got.Status.State)
+	}
+	if got.Status.OpGeneration != 0 {
+		t.Errorf("OpGeneration=%d want 0 (rejected write must not bump generation)", got.Status.OpGeneration)
+	}
+}
+
+// Idempotent same-state writes must still succeed even though the table
+// does not list a (X -> X) self-loop. This protects RetryOnConflict
+// re-reads, deferred Finally re-assertions, and operator workflows that
+// refresh message/reason without changing state.
+func TestUpdateStatusAllowsSelfWrite(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithState(appsv1.InstallFailed))
+	c := testutil.NewFakeClient(am)
+	b := &baseStatefulApp{manager: am, client: c}
+
+	if err := b.updateStatus(context.TODO(), am, appsv1.InstallFailed, nil, "updated msg", "updated reason"); err != nil {
+		t.Fatalf("updateStatus self-write rejected: %v", err)
+	}
+	got := getAM(t, b, "nginx")
+	if got.Status.State != appsv1.InstallFailed {
+		t.Errorf("state=%s want InstallFailed", got.Status.State)
+	}
+	if got.Status.Message != "updated msg" || got.Status.Reason != "updated reason" {
+		t.Errorf("message/reason=%q/%q want updated values", got.Status.Message, got.Status.Reason)
+	}
+	if got.Status.OpGeneration != 1 {
+		t.Errorf("OpGeneration=%d want 1 (self-write should still bump generation)", got.Status.OpGeneration)
+	}
+}

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -3,6 +3,7 @@ package constants
 import (
 	"flag"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -184,6 +185,24 @@ var (
 
 	OLARES_APP_NAME = "olares-app"
 )
+
+// AppMgrTerminalRetention bounds how long an ApplicationManager is allowed to
+// linger in a safely-deletable terminal state (Uninstalled / InstallingCanceled
+// / PendingCanceled / DownloadingCanceled / DownloadFailed / InstallFailed)
+// before the GC controller reclaims it. The retention gives operators a window
+// to inspect the failure reason / op record and gives the install-failure
+// cleanup helper plenty of time to converge the rare NS-finalizer-stuck case
+// before the AM disappears. 60min is conservative enough for both; the
+// retention can be overridden at runtime via the APPMGR_TERMINAL_RETENTION
+// env var on the controller pod.
+var AppMgrTerminalRetention = func() time.Duration {
+	if v := os.Getenv("APPMGR_TERMINAL_RETENTION"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 60 * time.Minute
+}()
 
 type ResourceConditionType string
 

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -152,6 +152,18 @@ func UpdateAppState(ctx context.Context, am *v1alpha1.ApplicationManager, state 
 
 }
 
+// StateTransitionGuard, if non-nil, is consulted by UpdateAppMgrStatus to
+// decide whether a (currentState -> requestedState) transition is allowed.
+// Returning false rejects the patch.
+//
+// It is injected at init time by the pkg/appstate package (which owns the
+// authoritative transition table). The indirection breaks an import cycle:
+// pkg/appstate already imports pkg/utils/app, so pkg/utils/app cannot import
+// pkg/appstate directly. When the guard is nil (e.g. in unit tests that do
+// not link pkg/appstate) the legacy behaviour is preserved — any transition
+// is accepted.
+var StateTransitionGuard func(from, to v1alpha1.ApplicationManagerState) bool
+
 // UpdateAppMgrStatus update applicationmanager status, if filed in parameter status is empty that field will not be set.
 func UpdateAppMgrStatus(name string, status v1alpha1.ApplicationManagerStatus, modifiers ...func(*v1alpha1.ApplicationManager)) (*v1alpha1.ApplicationManager, error) {
 	client, err := utils.GetClient()
@@ -189,6 +201,19 @@ func UpdateAppMgrStatus(name string, status v1alpha1.ApplicationManagerStatus, m
 			}
 		}
 		status.Payload = payload
+
+		// Reject undeclared transitions if a guard has been wired in.
+		// The check runs INSIDE the retry loop so it sees the latest
+		// persisted state, matching pkg/appstate's updateStatus
+		// invariant: if the state was changed underneath us between
+		// Get and Update, the next attempt's check is against the
+		// fresh state, not a stale snapshot.
+		if guard := StateTransitionGuard; guard != nil && !guard(appMgrCopy.Status.State, status.State) {
+			err := fmt.Errorf("invalid state transition for %s: %s -> %s (rejected by guard)",
+				name, appMgrCopy.Status.State, status.State)
+			klog.Warningf("UpdateAppMgrStatus rejected: %v", err)
+			return err
+		}
 
 		appMgrCopy.Status = status
 		for _, modifier := range modifiers {


### PR DESCRIPTION
* **Background**
Enforce cluster-wide exclusivity for an app name across shared vs per-user installs, make every InstallFailed transition land on a clean cluster, and add a GC controller that reclaims long-lived terminal ApplicationManagers.

Install-time conflict detection
- handler_installer_install: new checkAppNameConflict gate runs before lintChart; reject mixed shared/per-user installs of the same Spec.AppName while skipping terminal-reinstallable AMs so legitimate reinstalls still flow through applyAppMgr's existing name-based path.
- installHandlerHelper.client switched to versioned.Interface so the new conflict check (and future helpers) can be unit-tested with a fake clientset; runtime construction is unchanged.
- handler_installer_install_conflict_test.go: table-driven coverage of shared-vs-per-user, per-user-vs-shared, terminal-state skip, and same-type fall-through.

Resolve AM by lifecycle variant in handlers/controllers
- Replace FmtAppMgrName(app, owner, "") with apputils.ResolveAppMgrName in handler_app (status/operate), handler_installer_install (isDeployAllowed), handler_middleware_status (operateMiddleware), handler_settings (getApplicationPermission, getApplicationProviderList) and pod_abnormal_suspend_app_controller, so any admin can observe/operate a shared app installed under a different owner without spurious not-founds.

State-transition guard
- pkg/appstate/state_transition.go: backfill missing runtime edges ("" → Pending, Installing → Running fast-path, Running → Uninstalled self-heal, Upgrading → Stopped, Resuming → Stopping, ResumeFailed → Upgrading/ApplyingEnv, *CancelFailed → *Canceling/Uninstalling, terminal- reinstallable → Pending, …) and add IsStateTransitionAllowed (same-state writes always pass), IsTerminalReinstallable, IsSafelyDeletable.
- pkg/appstate/types.go updateStatus: reject undeclared transitions inside the retry loop so a stale goroutine cannot clobber a freshly-persisted terminal state.
- pkg/utils/app/app.go: expose StateTransitionGuard hook on UpdateAppMgrStatus with the same in-retry-loop check.
- pkg/appstate/transition_guard.go (new): init wires IsStateTransitionAllowed into the apputils guard hook, breaking the import cycle while making every apiserver/controller path that calls UpdateAppMgrStatus subject to the same invariant.
- state_transition_test / update_status_test / update_status_rapid_test: expanded edge coverage, self-write allowance, OperationAllowedInState ↔ StateTransitions alignment property, and rapid invariant updates.

Install-failure cleanup
- pkg/appstate/install_failure_cleanup.go (new): cleanupAfterInstallFailure does the full HelmOps.Uninstall (PVCs + UninstallCharts + perms/Provider
  + middleware/cache + DeleteNamespace) + compute allocation release, then blocks (≤10 min) until Spec.AppNamespace is IsNotFound; idempotent for protected/empty NS, missing helm release, and re-entry.
- installing_app.go: every path that flips to InstallFailed (helm ops build, ops.Install, post-helm validation D, scale-up E) now funnels through a single toInstallFailed that runs the synchronous helper and annotates Status.Message on cleanup timeout.
- install_failed_app.go: collapse the ad-hoc PVC/NS/compute teardown into a defensive retry of the same helper; covers the rare NS-finalizer-stuck case and upgrade-in-place from the old controller version.
- install_failure_cleanup_test.go (new): unit tests for parseAppConfig, protected-NS short-circuit, namespace-gone polling, and timeout behaviour.

Terminal-state GC
- controllers/appmgr_gc_controller.go (new) + main.go wiring: watch only IsSafelyDeletable transitions, requeue until AppMgrTerminalRetention has elapsed, double-check the app namespace is IsNotFound before deleting the AM so an InstallFailed-cleanup-timeout never orphans the NS from InstallFailedApp.Exec's retry loop.
- pkg/constants/constants.go: AppMgrTerminalRetention (default 60min, overridable via APPMGR_TERMINAL_RETENTION).
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core install/uninstall lifecycle, ApplicationManager deletion, and state-transition guards across apiserver and controllers; regressions could block installs, orphan namespaces, or break shared-app operations.
> 
> **Overview**
> **Enforces one app name per cluster across shared vs per-user installs**, blocks mixed-type installs via `checkAppNameConflict` before chart lint, and bumps the deploy image to `app-service:0.5.50`.
> 
> **APIs and controllers** now resolve the live `ApplicationManager` with `ResolveAppMgrName` (status, operate, deploy checks, middleware, settings, pod-abnormal suspend) so shared apps installed under another admin are not missed.
> 
> **Install failures** run shared `cleanupAfterInstallFailure` (Helm uninstall + namespace wait) before `InstallFailed`; `InstallFailedApp.Exec` retries the same path. A new **GC controller** deletes terminal AMs after `AppMgrTerminalRetention` once the app namespace is gone.
> 
> **State machine hardening**: expanded `StateTransitions`, `updateStatus` / `UpdateAppMgrStatus` reject invalid edges (self-writes allowed), plus `IsTerminalReinstallable` / `IsSafelyDeletable` for conflict skip and GC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad94c58a0ca39db138a507d5b7d2e030ab4ab1dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->