### PR TITLE
fix: files handle symlinks in compress / extract / copy

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.185
+          image: beclab/files-server:v0.2.186
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: Compress: preserve directory symlinks; dereference when not preserving.
- fix: Extract: keep absolute-link targets and skip unsafe links without failing.
- fix: Copy: allow symlinks through (drop --safe-links, lchown, dangling = exists).

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/352

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys new files-server logic on user data paths (archive/copy); symlink handling changes can affect correctness of compress/extract/copy but scope is limited to a single image tag bump.
> 
> **Overview**
> Rolls out **`beclab/files-server:v0.2.186`** on the `files` DaemonSet container (was `v0.2.185`) in `files_deploy.yaml`, with no other manifest changes.
> 
> That image carries symlink fixes from the upstream files server: compress/extract/copy behavior around directory symlinks, absolute link targets, and relaxed copy safety for symlinks (`lchown`, dangling links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5463b31a37b08767001bcfaf44bc6a38454779f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->