### PR TITLE
fix(sys-event): restore v2 shared CoreDNS and narrow incluster view to pod CIDR

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -93,7 +93,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.24
+        image: beclab/sys-event:0.2.25
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/main.go
+++ b/platform/tapr/cmd/sys-event/main.go
@@ -35,6 +35,9 @@ func main() {
 	if err := watchers.RegisterCorefileSRRWatcher(w, kubeClient, dynamicClient); err != nil {
 		klog.Fatalf("register SharedRouteRegistry corefile watcher: %v", err)
 	}
+	if err := watchers.RegisterCorefileApplicationWatcher(w, kubeClient, dynamicClient); err != nil {
+		klog.Fatalf("register Application corefile watcher: %v", err)
+	}
 
 	// add event subscriber to watchers
 	watchers.AddToWatchers[application.Application](w, application.GVR,

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -2,18 +2,24 @@ package watchers
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
 	"net"
 	"os"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
 
+	"bytetrade.io/web3os/tapr/pkg/app/application"
 	"github.com/coredns/corefile-migration/migration/corefile"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -25,12 +31,25 @@ const (
 	labelDNSPassthrough     = "gateway.olares.io/dns-passthrough"
 	labelSRRAppID           = "gateway.olares.io/appid"
 	labelSRREntrance        = "gateway.olares.io/entrance"
+	labelAppShared          = "app.bytetrade.io/app-shared"
+	labelAppSharedTrue      = "true"
+	labelNSAppName          = "applications.app.bytetrade.io/name"
+	labelNSShared           = "bytetrade.io/ns-shared"
+	labelNSInstallUser      = "applications.app.bytetrade.io/install_user"
+	labelNSNamespace        = "bytetrade.io/namespace"
 	appGatewayNamespace     = "os-gateway"
 	appGatewayDataService   = "app-gateway-data"
 	srrRouteModeGateway     = "gateway"
 	corefileSizeWarnBytes   = 800 * 1024
 	corefileSizeRejectBytes = 950 * 1024
+	defaultPodCIDR          = "10.233.64.0/18"
 )
+
+var calicoIPPoolGVR = schema.GroupVersionResource{
+	Group:    "crd.projectcalico.org",
+	Version:  "v1",
+	Resource: "ippools",
+}
 
 var sharedRouteRegistryGVR = schema.GroupVersionResource{
 	Group:    "gateway.olares.io",
@@ -232,6 +251,11 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 		klog.V(2).Info("skip shared incluster CoreDNS templates: inClusterGatewayEnabled=false")
 	}
 
+	v2DirectSharedTemplatePlugins, v2Err := v2DirectSharedTemplatesFromCluster(ctx, kubeClient, dynamicClient, userList.Items)
+	if v2Err != nil {
+		klog.Errorf("degrade: skip v2 direct shared templates, scan applications error: %v", v2Err)
+	}
+
 	var adguardIp string
 	pods, err := kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: "applications.app.bytetrade.io/name=adguardhome"})
 	if err != nil {
@@ -242,12 +266,10 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 		}
 	}
 
-	inclusterExpr := "incidr(client_ip(), '10.233.0.0/16')"
-	if adguardIp != "" {
-		inclusterExpr = fmt.Sprintf("( %s && client_ip() != '%s' )", inclusterExpr, adguardIp)
-	}
-
-	vpnExpr := fmt.Sprintf("incidr(client_ip(), '100.64.0.0/16') || client_ip() == '%s'", masterNodeIp)
+	podCIDR := detectPodCIDR(ctx, kubeClient, dynamicClient)
+	clusterCIDR := clusterCIDRFromPod(podCIDR)
+	klog.Infof("CoreDNS view expr: podCIDR=%s clusterCIDR=%s masterNodeIp=%s", podCIDR, clusterCIDR, masterNodeIp)
+	inclusterExpr, vpnExpr := buildViewExprs(podCIDR, clusterCIDR, masterNodeIp, adguardIp)
 
 	inclusterView := &corefile.Plugin{
 		Name: "view",
@@ -271,18 +293,17 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 		},
 	}
 
-	// CoreDNS plugin chain orders `template` before `hosts`, and the user-zone
-	// wildcard template (e.g. \w*\.?brucedai\.olares\.com\.$) would shadow any
-	// `hosts` entry for shared FQDNs. Shared mappings are therefore emitted as
-	// exact-match `template` instances inserted BEFORE the user wildcards in
-	// the incluster server block, with fallthrough so other names still hit
-	// the wildcards.
+	// Incluster template order (dual-track):
+	//   v3 SRR exact templates → user-zone wildcards → v2 legacy shared templates.
+	// v3 must stay before wildcards so options.shared apps keep gateway FQDN precedence.
+	// v2 follows release-1.12.5 placement after wildcards.
 	inclusterPluginsWithSharedTemplates := inclusterTemplatesPlugins
-	if len(sharedInclusterTemplatePlugins) > 0 {
-		inclusterPluginsWithSharedTemplates = append(
-			append([]*corefile.Plugin{}, sharedInclusterTemplatePlugins...),
-			inclusterTemplatesPlugins...,
-		)
+	if len(sharedInclusterTemplatePlugins) > 0 || len(v2DirectSharedTemplatePlugins) > 0 {
+		var inclusterPluginChain []*corefile.Plugin
+		inclusterPluginChain = append(inclusterPluginChain, sharedInclusterTemplatePlugins...)
+		inclusterPluginChain = append(inclusterPluginChain, inclusterTemplatesPlugins...)
+		inclusterPluginChain = append(inclusterPluginChain, v2DirectSharedTemplatePlugins...)
+		inclusterPluginsWithSharedTemplates = inclusterPluginChain
 	}
 	inclusterPlugins := append(append([]*corefile.Plugin{}, defaultPlugins...), inclusterPluginsWithSharedTemplates...)
 
@@ -842,6 +863,300 @@ func normalizeReloadInDefaultPlugins(defaultPlugins []*corefile.Plugin) []*coref
 		})
 	}
 	return defaultPlugins
+}
+
+// appIDFromApplication mirrors appcfg.AppName(name).GetAppID() without a framework import.
+func appIDFromApplication(app *application.Application) string {
+	if app.Spec.IsSysApp {
+		return app.Spec.Name
+	}
+	sum := md5.Sum([]byte(app.Spec.Name))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// legacySharedEntrancePrefix matches release-1.12.5 v2 shared CoreDNS ID base.
+func legacySharedEntrancePrefix(appid string) string {
+	sum := md5.Sum([]byte(appid + "shared"))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// legacySharedEntranceID always appends the loop index (single entrance uses …0).
+func legacySharedEntranceID(appid string, entranceIndex int) string {
+	return fmt.Sprintf("%s%d", legacySharedEntrancePrefix(appid), entranceIndex)
+}
+
+func isV3SharedApp(app *application.Application) bool {
+	return app.GetLabels()[labelAppShared] == labelAppSharedTrue
+}
+
+func platformDomainFromUserZone(userZone string) (string, bool) {
+	tokens := strings.Split(userZone, ".")
+	if len(tokens) < 2 {
+		return "", false
+	}
+	return strings.Join(tokens[1:], "."), true
+}
+
+func escapeRegexLabel(s string) string {
+	return strings.ReplaceAll(s, ".", `\.`)
+}
+
+func legacySharedNamespacesForApp(app *application.Application, nsList []corev1.Namespace) []*corev1.Namespace {
+	var sharedNs []*corev1.Namespace
+	for i := range nsList {
+		ns := &nsList[i]
+		refAppName := ns.Labels[labelNSAppName]
+		sharedNamespace := ns.Labels[labelNSShared]
+		installedUser := ns.Labels[labelNSInstallUser]
+		if refAppName == app.Spec.Name && sharedNamespace == "true" && installedUser == app.Spec.Owner {
+			sharedNs = append(sharedNs, ns)
+		}
+	}
+	return sharedNs
+}
+
+func buildV2DirectSharedTemplate(prefix string, entranceIndex int, sharedZone, clusterIP string) *corefile.Plugin {
+	legacyID := fmt.Sprintf("%s%d", prefix, entranceIndex)
+	fqdn := fmt.Sprintf("%s.%s", legacyID, sharedZone)
+	match := fmt.Sprintf(`"%s%d.?(%s\.)$"`, prefix, entranceIndex, sharedZone)
+	return &corefile.Plugin{
+		Name: "template",
+		Args: []string{"IN", "A", fqdn},
+		Options: []*corefile.Option{
+			{Name: "match", Args: []string{match}},
+			{Name: "answer", Args: []string{fmt.Sprintf(`"{{ .Name }} 60 IN A %s"`, clusterIP)}},
+			{Name: "fallthrough"},
+		},
+	}
+}
+
+func v2DirectSharedTemplatesFromCluster(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	dynamicClient dynamic.Interface,
+	users []unstructured.Unstructured,
+) ([]*corefile.Plugin, error) {
+	if len(users) == 0 {
+		klog.Info("no users found, skip adding shared entrance dns records")
+		return nil, nil
+	}
+
+	zone := users[0].GetAnnotations()[UserAnnotationZoneKey]
+	if len(zone) == 0 {
+		klog.Info("no zone annotation found in user, skip adding shared entrance dns records")
+		return nil, nil
+	}
+	tokens := strings.Split(zone, ".")
+	if len(tokens) < 2 {
+		klog.Info("invalid zone annotation found in user, skip adding shared entrance dns records")
+		return nil, nil
+	}
+	tokens[0] = "shared"
+	sharedZone := strings.Join(tokens, ".")
+
+	appList, err := dynamicClient.Resource(application.GVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Error("get applications error, ", err)
+		return nil, err
+	}
+
+	nsList, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Error("list namespaces error, ", err)
+		return nil, err
+	}
+
+	var plugins []*corefile.Plugin
+	for i := range appList.Items {
+		var app application.Application
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(appList.Items[i].Object, &app); err != nil {
+			klog.Error("convert obj error, ", err)
+			continue
+		}
+		if len(app.Spec.SharedEntrances) == 0 {
+			continue
+		}
+		if isV3SharedApp(&app) {
+			continue
+		}
+
+		sharedNs := legacySharedNamespacesForApp(&app, nsList.Items)
+		prefix := legacySharedEntrancePrefix(app.Spec.Appid)
+		for entranceIndex, entrance := range app.Spec.SharedEntrances {
+			for _, ns := range sharedNs {
+				svc, err := kubeClient.CoreV1().Services(ns.Name).Get(ctx, entrance.Host, metav1.GetOptions{})
+				if err != nil {
+					klog.Error("get shared entrance service error, ", err)
+					continue
+				}
+				entranceIP := svc.Spec.ClusterIP
+				if entranceIP == "" {
+					klog.Info("shared entrance has no ingress ip, skip corefile update")
+					continue
+				}
+				plugins = append(plugins, buildV2DirectSharedTemplate(prefix, entranceIndex, sharedZone, entranceIP))
+			}
+		}
+	}
+	if len(plugins) == 0 {
+		return nil, nil
+	}
+	return plugins, nil
+}
+
+func buildViewExprs(podCIDR, clusterCIDR, masterNodeIp, adguardIp string) (inclusterExpr, vpnExpr string) {
+	inclusterExpr = fmt.Sprintf("incidr(client_ip(), '%s')", podCIDR)
+	if adguardIp != "" {
+		inclusterExpr = fmt.Sprintf("( %s && client_ip() != '%s' )", inclusterExpr, adguardIp)
+	}
+	vpnExpr = fmt.Sprintf(
+		"incidr(client_ip(), '100.64.0.0/16') || client_ip() == '%s' || incidr(client_ip(), '%s')",
+		masterNodeIp, clusterCIDR,
+	)
+	return inclusterExpr, vpnExpr
+}
+
+func clusterCIDRFromPod(podCIDR string) string {
+	ip, _, err := net.ParseCIDR(podCIDR)
+	if err != nil {
+		return clusterCIDRFromPod(defaultPodCIDR)
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return clusterCIDRFromPod(defaultPodCIDR)
+	}
+	return fmt.Sprintf("%d.%d.0.0/16", v4[0], v4[1])
+}
+
+func detectPodCIDR(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) string {
+	if cidr, ok := podCIDRFromIptablesProbe(); ok {
+		klog.V(2).Infof("detectPodCIDR: iptables KUBE-SERVICES %s", cidr)
+		return cidr
+	}
+	if cidr, ok := podCIDRFromCalicoIPPools(ctx, dynamicClient); ok {
+		klog.V(2).Infof("detectPodCIDR: Calico IPPool %s", cidr)
+		return cidr
+	}
+	if cidr, ok := podCIDRFromKubeClusterCIDRArg(ctx, kubeClient); ok {
+		klog.V(2).Infof("detectPodCIDR: kube --cluster-cidr %s", cidr)
+		return cidr
+	}
+	klog.V(2).Infof("detectPodCIDR: fallback %s", defaultPodCIDR)
+	return defaultPodCIDR
+}
+
+// podCIDRFromIptablesProbe is swapped in unit tests to avoid host iptables dependence.
+var podCIDRFromIptablesProbe = podCIDRFromIptables
+
+func podCIDRFromIptables() (string, bool) {
+	out, err := exec.Command("iptables", "-t", "nat", "-S", "KUBE-SERVICES").CombinedOutput()
+	if err != nil {
+		klog.V(4).Infof("detectPodCIDR: iptables unavailable: %v", err)
+		return "", false
+	}
+	return parsePodCIDRFromKubeServicesIPTables(string(out))
+}
+
+func parsePodCIDRFromKubeServicesIPTables(output string) (string, bool) {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "KUBE-SERVICES") || !strings.Contains(line, "KUBE-MARK-MASQ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i := 0; i < len(fields)-2; i++ {
+			if fields[i] != "!" || fields[i+1] != "-s" {
+				continue
+			}
+			cidr := fields[i+2]
+			if _, _, err := net.ParseCIDR(cidr); err == nil {
+				return cidr, true
+			}
+		}
+	}
+	return "", false
+}
+
+func podCIDRFromCalicoIPPools(ctx context.Context, dynamicClient dynamic.Interface) (string, bool) {
+	if dynamicClient == nil {
+		return "", false
+	}
+	list, err := dynamicClient.Resource(calicoIPPoolGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.V(4).Infof("detectPodCIDR: list Calico IPPools failed: %v", err)
+		return "", false
+	}
+	for _, item := range list.Items {
+		cidr, found, err := unstructured.NestedString(item.Object, "spec", "cidr")
+		if err != nil || !found || cidr == "" {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(cidr); err == nil {
+			return cidr, true
+		}
+	}
+	return "", false
+}
+
+func podCIDRFromKubeClusterCIDRArg(ctx context.Context, kubeClient kubernetes.Interface) (string, bool) {
+	if kubeClient == nil {
+		return "", false
+	}
+	pods, err := kubeClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.V(4).Infof("detectPodCIDR: list kube-system pods failed: %v", err)
+		return "", false
+	}
+	for _, pod := range pods.Items {
+		for _, c := range pod.Spec.Containers {
+			if cidr, ok := clusterCIDRArgFromCommand(c.Command, c.Args); ok {
+				return cidr, true
+			}
+			if cidr, ok := clusterCIDRFromK3SArgsEnv(c.Env); ok {
+				return cidr, true
+			}
+		}
+		for _, c := range pod.Spec.InitContainers {
+			if cidr, ok := clusterCIDRArgFromCommand(c.Command, c.Args); ok {
+				return cidr, true
+			}
+		}
+	}
+	return "", false
+}
+
+func clusterCIDRFromK3SArgsEnv(env []corev1.EnvVar) (string, bool) {
+	for _, e := range env {
+		if e.Name != "K3S_ARGS" || e.Value == "" {
+			continue
+		}
+		for _, token := range strings.Fields(e.Value) {
+			if strings.HasPrefix(token, "--cluster-cidr=") {
+				cidr := strings.TrimPrefix(token, "--cluster-cidr=")
+				if _, _, err := net.ParseCIDR(cidr); err == nil {
+					return cidr, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func clusterCIDRArgFromCommand(command, args []string) (string, bool) {
+	all := append(append([]string{}, command...), args...)
+	for i, arg := range all {
+		if strings.HasPrefix(arg, "--cluster-cidr=") {
+			cidr := strings.TrimPrefix(arg, "--cluster-cidr=")
+			if _, _, err := net.ParseCIDR(cidr); err == nil {
+				return cidr, true
+			}
+		}
+		if arg == "--cluster-cidr" && i+1 < len(all) {
+			if _, _, err := net.ParseCIDR(all[i+1]); err == nil {
+				return all[i+1], true
+			}
+		}
+	}
+	return "", false
 }
 
 // CorefileSRRSubscriber regenerates CoreDNS when SharedRouteRegistry changes.

--- a/platform/tapr/cmd/sys-event/watchers/corefile_application_subscriber.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_application_subscriber.go
@@ -1,0 +1,49 @@
+package watchers
+
+import (
+	"context"
+
+	"bytetrade.io/web3os/tapr/pkg/app/application"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CorefileApplicationSubscriber regenerates CoreDNS when Application shared
+// entrances or the app-shared label change.
+type CorefileApplicationSubscriber struct {
+	*Subscriber
+	kubeClient    kubernetes.Interface
+	dynamicClient dynamic.Interface
+}
+
+func (s *CorefileApplicationSubscriber) HandleEvent() cache.ResourceEventHandler {
+	enqueue := func(obj interface{}) {
+		s.Watchers.Enqueue(EnqueueObj{
+			Subscribe: s,
+			Obj:       obj,
+			Action:    UPDATE,
+		})
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    enqueue,
+		UpdateFunc: func(_, newObj interface{}) { enqueue(newObj) },
+		DeleteFunc: enqueue,
+	}
+}
+
+func (s *CorefileApplicationSubscriber) Do(ctx context.Context, obj interface{}, action Action) error {
+	_ = obj
+	_ = action
+	return RegenerateCorefile(ctx, s.kubeClient, s.dynamicClient)
+}
+
+// RegisterCorefileApplicationWatcher watches Application CRs and triggers RegenerateCorefile.
+func RegisterCorefileApplicationWatcher(w *Watchers, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) error {
+	sub := &CorefileApplicationSubscriber{
+		Subscriber:    NewSubscriber(w),
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+	}
+	return AddToWatchers[application.Application](w, application.GVR, sub.HandleEvent())
+}

--- a/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"bytetrade.io/web3os/tapr/pkg/app/application"
 	"github.com/coredns/corefile-migration/migration/corefile"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -646,6 +647,8 @@ func buildCorefileRegenerateHarness(t *testing.T, inClusterEnabled bool) (*kubef
 		map[schema.GroupVersionResource]string{
 			clusterConfigGVR:       "ClusterConfigList",
 			sharedRouteRegistryGVR: "SharedRouteRegistryList",
+			application.GVR:        "ApplicationList",
+			calicoIPPoolGVR:        "IPPoolList",
 			{Group: "iam.kubesphere.io", Version: "v1alpha2", Resource: "users"}: "UserList",
 		},
 		clusterConfig, user, srr,

--- a/platform/tapr/cmd/sys-event/watchers/corefile_v2_direct_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_v2_direct_test.go
@@ -1,0 +1,548 @@
+package watchers
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"bytetrade.io/web3os/tapr/pkg/app/application"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAppIDFromApplication(t *testing.T) {
+	t.Run("user app nginx", func(t *testing.T) {
+		app := &application.Application{Spec: application.ApplicationSpec{Name: "nginx"}}
+		got := appIDFromApplication(app)
+		sum := md5.Sum([]byte("nginx"))
+		want := hex.EncodeToString(sum[:])[:8]
+		if got != want {
+			t.Fatalf("appIDFromApplication(nginx)=%q want %q", got, want)
+		}
+		if got != appIDFromApplication(app) {
+			t.Fatal("appIDFromApplication is not deterministic")
+		}
+	})
+
+	t.Run("sys app uses name", func(t *testing.T) {
+		app := &application.Application{Spec: application.ApplicationSpec{Name: "market", IsSysApp: true}}
+		if got := appIDFromApplication(app); got != "market" {
+			t.Fatalf("sys app id=%q want market", got)
+		}
+	})
+}
+
+func TestLegacySharedEntranceID(t *testing.T) {
+	prefix := legacySharedEntrancePrefix("demo1234")
+	if got := legacySharedEntranceID("demo1234", 0); got != prefix+"0" {
+		t.Fatalf("single entrance id=%q want %s0", got, prefix)
+	}
+	if got := legacySharedEntranceID("demo1234", 1); got != prefix+"1" {
+		t.Fatalf("second entrance id=%q want %s1", got, prefix)
+	}
+}
+
+func TestIsV3SharedApp(t *testing.T) {
+	v2 := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+	}
+	if isV3SharedApp(v2) {
+		t.Fatal("app without app-shared label must not be v3 shared")
+	}
+	v3 := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelAppShared: labelAppSharedTrue}},
+	}
+	if !isV3SharedApp(v3) {
+		t.Fatal("app-shared=true must be v3 shared")
+	}
+}
+
+func TestBuildV2DirectSharedTemplate(t *testing.T) {
+	const (
+		appid      = "ee434023"
+		sharedZone = "shared.olares.com"
+	)
+	prefix := legacySharedEntrancePrefix(appid)
+	plugin := buildV2DirectSharedTemplate(prefix, 0, sharedZone, "10.233.32.202")
+	if plugin == nil {
+		t.Fatal("expected template plugin")
+	}
+	body := plugin.ToString()
+	wantFQDN := legacySharedEntranceID(appid, 0) + "." + sharedZone
+	if !strings.Contains(body, "IN A "+wantFQDN) {
+		t.Fatalf("missing fqdn %q in %q", wantFQDN, body)
+	}
+	wantMatch := fmt.Sprintf(`"%s0.?(%s\.)$"`, prefix, sharedZone)
+	if !strings.Contains(body, wantMatch) {
+		t.Fatalf("missing match %q in %q", wantMatch, body)
+	}
+	if !strings.Contains(body, `"{{ .Name }} 60 IN A 10.233.32.202"`) {
+		t.Fatalf("missing TTL 60 answer in %q", body)
+	}
+	if !strings.Contains(body, "fallthrough") {
+		t.Fatalf("missing fallthrough in %q", body)
+	}
+}
+
+func TestV2DirectSharedTemplatesFromCluster_TC_V2_01_singleEntrance(t *testing.T) {
+	const (
+		appName    = "nginx"
+		appOwner   = "brucedai"
+		serviceIP  = "10.233.32.202"
+		userZone   = "brucedai.olares.com"
+		entranceID = "ee434023"
+	)
+
+	kubeClient, dynamicClient := buildV2DirectHarness(t, buildV2HarnessOpts{
+		userZone: userZone,
+		apps: []application.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: appName},
+				Spec: application.ApplicationSpec{
+					Name:   appName,
+					Owner:  appOwner,
+					Appid:  entranceID,
+					Namespace: "nginx-ns",
+					SharedEntrances: []application.Entrance{
+						{Name: "web", Host: "nginx-svc"},
+					},
+				},
+			},
+		},
+		namespaces: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx-shared-ns",
+					Labels: map[string]string{
+						labelNSAppName:     appName,
+						labelNSShared:      "true",
+						labelNSInstallUser: appOwner,
+					},
+				},
+			},
+		},
+		services: map[string]corev1.Service{
+			"nginx-shared-ns/nginx-svc": {
+				ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "nginx-shared-ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+			},
+		},
+	})
+
+	users := []*unstructured.Unstructured{userWithZone("brucedai", userZone)}
+	plugins, err := v2DirectSharedTemplatesFromCluster(context.Background(), kubeClient, dynamicClient, toUnstructuredUsers(users))
+	if err != nil {
+		t.Fatalf("v2DirectSharedTemplatesFromCluster failed: %v", err)
+	}
+	if len(plugins) != 1 {
+		t.Fatalf("expected 1 v2 template, got %d", len(plugins))
+	}
+	wantLegacyID := legacySharedEntranceID(entranceID, 0)
+	wantMatch := fmt.Sprintf(`"%s0.?(shared.olares.com\.)$"`, legacySharedEntrancePrefix(entranceID))
+	if !templateMatchesRegex(plugins[0], wantMatch, serviceIP) {
+		t.Fatalf("template mismatch for %s: %s", wantLegacyID, plugins[0].ToString())
+	}
+	if !strings.Contains(plugins[0].ToString(), "IN A "+wantLegacyID+".shared.olares.com") {
+		t.Fatalf("expected fqdn %s.shared.olares.com in %s", wantLegacyID, plugins[0].ToString())
+	}
+}
+
+func TestV2DirectSharedTemplatesFromCluster_TC_V2_02_multiEntrance(t *testing.T) {
+	const (
+		appName   = "dual"
+		appOwner  = "brucedai"
+		userZone  = "brucedai.olares.com"
+		appid     = "58ea3080"
+		serviceIP = "10.233.44.55"
+	)
+
+	kubeClient, dynamicClient := buildV2DirectHarness(t, buildV2HarnessOpts{
+		userZone: userZone,
+		apps: []application.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: appName},
+				Spec: application.ApplicationSpec{
+					Name:  appName,
+					Owner: appOwner,
+					Appid: appid,
+					SharedEntrances: []application.Entrance{
+						{Name: "a", Host: "dual-a"},
+						{Name: "b", Host: "dual-b"},
+					},
+				},
+			},
+		},
+		namespaces: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dual-shared-ns",
+					Labels: map[string]string{
+						labelNSAppName:     appName,
+						labelNSShared:      "true",
+						labelNSInstallUser: appOwner,
+					},
+				},
+			},
+		},
+		services: map[string]corev1.Service{
+			"dual-shared-ns/dual-a": {
+				ObjectMeta: metav1.ObjectMeta{Name: "dual-a", Namespace: "dual-shared-ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+			},
+			"dual-shared-ns/dual-b": {
+				ObjectMeta: metav1.ObjectMeta{Name: "dual-b", Namespace: "dual-shared-ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+			},
+		},
+	})
+
+	users := []*unstructured.Unstructured{userWithZone("brucedai", userZone)}
+	plugins, err := v2DirectSharedTemplatesFromCluster(context.Background(), kubeClient, dynamicClient, toUnstructuredUsers(users))
+	if err != nil {
+		t.Fatalf("v2DirectSharedTemplatesFromCluster failed: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 v2 templates, got %d", len(plugins))
+	}
+	wantMatches := []string{
+		fmt.Sprintf(`"%s0.?(shared.olares.com\.)$"`, legacySharedEntrancePrefix(appid)),
+		fmt.Sprintf(`"%s1.?(shared.olares.com\.)$"`, legacySharedEntrancePrefix(appid)),
+	}
+	for i, want := range wantMatches {
+		if !templateMatchesRegex(plugins[i], want, serviceIP) {
+			t.Fatalf("template[%d] want %s got %s", i, want, plugins[i].ToString())
+		}
+	}
+}
+
+func TestV2DirectSharedTemplatesFromCluster_TC_V2_03_v3SharedSkipsV2(t *testing.T) {
+	const (
+		appName   = "ollamav3"
+		appOwner  = "brucedai"
+		userZone  = "brucedai.olares.com"
+		serviceIP = "10.233.66.77"
+	)
+
+	kubeClient, dynamicClient := buildV2DirectHarness(t, buildV2HarnessOpts{
+		userZone: userZone,
+		apps: []application.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: appName,
+					Labels: map[string]string{
+						labelAppShared: labelAppSharedTrue,
+					},
+				},
+				Spec: application.ApplicationSpec{
+					Name:  appName,
+					Owner: appOwner,
+					Appid: "a5be2268",
+					SharedEntrances: []application.Entrance{
+						{Name: "api", Host: "ollama-svc"},
+					},
+				},
+			},
+		},
+		namespaces: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ollama-shared-ns",
+					Labels: map[string]string{
+						labelNSAppName:     appName,
+						labelNSShared:      "true",
+						labelNSInstallUser: appOwner,
+					},
+				},
+			},
+		},
+		services: map[string]corev1.Service{
+			"ollama-shared-ns/ollama-svc": {
+				ObjectMeta: metav1.ObjectMeta{Name: "ollama-svc", Namespace: "ollama-shared-ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+			},
+		},
+	})
+
+	users := []*unstructured.Unstructured{userWithZone("brucedai", userZone)}
+	plugins, err := v2DirectSharedTemplatesFromCluster(context.Background(), kubeClient, dynamicClient, toUnstructuredUsers(users))
+	if err != nil {
+		t.Fatalf("v2DirectSharedTemplatesFromCluster failed: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("v3 shared app must not emit v2 templates, got %d: %v", len(plugins), plugins[0].ToString())
+	}
+}
+
+func TestV2DirectSharedTemplatesFromCluster_TC_V2_04_bareAppidEntranceIDExcluded(t *testing.T) {
+	const (
+		appName   = "nginx"
+		appOwner  = "brucedai"
+		userZone  = "brucedai.olares.com"
+		appid     = "ee434023"
+		serviceIP = "10.233.32.202"
+	)
+
+	legacySum := md5.Sum([]byte(appid + "shared"))
+	legacyPrefix := hex.EncodeToString(legacySum[:])[:8]
+	legacyID := legacyPrefix + "0"
+
+	kubeClient, dynamicClient := buildV2DirectHarness(t, buildV2HarnessOpts{
+		userZone: userZone,
+		apps: []application.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: appName},
+				Spec: application.ApplicationSpec{
+					Name:  appName,
+					Owner: appOwner,
+					Appid: appid,
+					SharedEntrances: []application.Entrance{
+						{Name: "web", Host: "nginx-svc"},
+					},
+				},
+			},
+		},
+		namespaces: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx-shared-ns",
+					Labels: map[string]string{
+						labelNSAppName:     appName,
+						labelNSShared:      "true",
+						labelNSInstallUser: appOwner,
+					},
+				},
+			},
+		},
+		services: map[string]corev1.Service{
+			"nginx-shared-ns/nginx-svc": {
+				ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "nginx-shared-ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+			},
+		},
+	})
+
+	users := []*unstructured.Unstructured{userWithZone("brucedai", userZone)}
+	plugins, err := v2DirectSharedTemplatesFromCluster(context.Background(), kubeClient, dynamicClient, toUnstructuredUsers(users))
+	if err != nil {
+		t.Fatalf("v2DirectSharedTemplatesFromCluster failed: %v", err)
+	}
+	if len(plugins) != 1 {
+		t.Fatalf("expected 1 v2 template, got %d", len(plugins))
+	}
+	body := plugins[0].ToString()
+	if !strings.Contains(body, legacyID) {
+		t.Fatalf("v2 template must use legacy id %q: %s", legacyID, body)
+	}
+	if strings.Contains(body, `"^`+appid+`\.shared\.`) {
+		t.Fatalf("v2 template must not use bare appid anchored match: %s", body)
+	}
+	wantMatch := fmt.Sprintf(`"%s0.?(shared.olares.com\.)$"`, legacyPrefix)
+	if !templateMatchesRegex(plugins[0], wantMatch, serviceIP) {
+		t.Fatalf("expected legacy match %s in %s", wantMatch, body)
+	}
+}
+
+func TestRegenerateCorefile_TC_V2_05_gatewayOffKeepsV2(t *testing.T) {
+	ctx := context.Background()
+	kubeClient, dynamicClient := buildV2RegenerateHarness(t, false)
+
+	if err := RegenerateCorefile(ctx, kubeClient, dynamicClient); err != nil {
+		t.Fatalf("RegenerateCorefile failed: %v", err)
+	}
+	body := mustReadCorefileConfigMap(t, ctx, kubeClient)
+	assertNotContainsSharedExactTemplate(t, body)
+	nginxAppid := appIDFromApplication(&application.Application{Spec: application.ApplicationSpec{Name: "nginx"}}) // harness sets same Appid
+	wantMatch := fmt.Sprintf(`"%s0.?(shared.olares.com\.)$"`, legacySharedEntrancePrefix(nginxAppid))
+	if !strings.Contains(body, wantMatch) {
+		t.Fatalf("expected v2 legacy template when gateway disabled, got:\n%s", body)
+	}
+}
+
+func TestRegenerateCorefile_TC_V2_06_upgradeStockV2Retained(t *testing.T) {
+	ctx := context.Background()
+	kubeClient, dynamicClient := buildV2RegenerateHarness(t, true)
+
+	if err := RegenerateCorefile(ctx, kubeClient, dynamicClient); err != nil {
+		t.Fatalf("RegenerateCorefile failed: %v", err)
+	}
+	body := mustReadCorefileConfigMap(t, ctx, kubeClient)
+	nginxAppid := appIDFromApplication(&application.Application{Spec: application.ApplicationSpec{Name: "nginx"}}) // harness sets same Appid
+	wantMatch := fmt.Sprintf(`"%s0.?(shared.olares.com\.)$"`, legacySharedEntrancePrefix(nginxAppid))
+	if !strings.Contains(body, wantMatch) {
+		t.Fatalf("upgrade stock v2 app must retain v2 legacy template, got:\n%s", body)
+	}
+	if !strings.Contains(body, "10.233.32.202") {
+		t.Fatalf("v2 template must answer Service ClusterIP, got:\n%s", body)
+	}
+}
+
+type buildV2HarnessOpts struct {
+	userZone   string
+	apps       []application.Application
+	namespaces []corev1.Namespace
+	services   map[string]corev1.Service
+}
+
+func buildV2DirectHarness(t *testing.T, opts buildV2HarnessOpts) (*kubefake.Clientset, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	objs := []runtime.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "coredns", Namespace: "kube-system"},
+			Data:       map[string]string{"Corefile": ".:53 { errors }"},
+		},
+	}
+	for i := range opts.namespaces {
+		objs = append(objs, &opts.namespaces[i])
+	}
+	for key, svc := range opts.services {
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) != 2 {
+			t.Fatalf("invalid service key %q", key)
+		}
+		s := svc
+		s.ObjectMeta.Namespace = parts[0]
+		s.ObjectMeta.Name = parts[1]
+		objs = append(objs, &s)
+	}
+
+	kubeClient := kubefake.NewSimpleClientset(objs...)
+
+	appObjs := make([]runtime.Object, 0, len(opts.apps))
+	for i := range opts.apps {
+		appObjs = append(appObjs, applicationUnstructured(&opts.apps[i]))
+	}
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			application.GVR: "ApplicationList",
+			calicoIPPoolGVR: "IPPoolList",
+		},
+		appObjs...,
+	)
+	return kubeClient, dynamicClient
+}
+
+func buildV2RegenerateHarness(t *testing.T, inClusterEnabled bool) (*kubefake.Clientset, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	const (
+		appName   = "nginx"
+		appOwner  = "brucedai"
+		sharedZone = "brucedai.olares.com"
+		serviceIP = "10.233.32.202"
+	)
+
+	kubeClient, dynamicClient := buildCorefileRegenerateHarness(t, inClusterEnabled)
+	ctx := context.Background()
+
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx-shared-ns",
+			Labels: map[string]string{
+				labelNSAppName:     appName,
+				labelNSShared:      "true",
+				labelNSInstallUser: appOwner,
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create shared namespace: %v", err)
+	}
+	if _, err := kubeClient.CoreV1().Services("nginx-shared-ns").Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "nginx-shared-ns"},
+		Spec:       corev1.ServiceSpec{ClusterIP: serviceIP},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create shared service: %v", err)
+	}
+	if _, err := dynamicClient.Resource(application.GVR).Create(ctx, applicationUnstructured(&application.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: appName},
+		Spec: application.ApplicationSpec{
+			Name:  appName,
+			Owner: appOwner,
+			Appid: appIDFromApplication(&application.Application{Spec: application.ApplicationSpec{Name: appName}}),
+			SharedEntrances: []application.Entrance{
+				{Name: "web", Host: "nginx-svc"},
+			},
+		},
+	}), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create application: %v", err)
+	}
+	return kubeClient, dynamicClient
+}
+
+func userWithZone(name, zone string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "iam.kubesphere.io/v1alpha2",
+			"kind":       "User",
+			"metadata": map[string]interface{}{
+				"name": name,
+				"annotations": map[string]interface{}{
+					UserAnnotationZoneKey: zone,
+					UserIndexAna:          "0",
+				},
+			},
+		},
+	}
+}
+
+func toUnstructuredUsers(users []*unstructured.Unstructured) []unstructured.Unstructured {
+	out := make([]unstructured.Unstructured, len(users))
+	for i, u := range users {
+		out[i] = *u
+	}
+	return out
+}
+
+func applicationUnstructured(app *application.Application) *unstructured.Unstructured {
+	metadata := map[string]interface{}{
+		"name": app.Name,
+	}
+	if len(app.Labels) > 0 {
+		labels := make(map[string]interface{}, len(app.Labels))
+		for k, v := range app.Labels {
+			labels[k] = v
+		}
+		metadata["labels"] = labels
+	}
+
+	entrances := make([]interface{}, len(app.Spec.SharedEntrances))
+	for i, e := range app.Spec.SharedEntrances {
+		entrances[i] = map[string]interface{}{
+			"name": e.Name,
+			"host": e.Host,
+		}
+	}
+
+	spec := map[string]interface{}{
+		"name":            app.Spec.Name,
+		"owner":           app.Spec.Owner,
+		"sharedEntrances": entrances,
+	}
+	if app.Spec.Appid != "" {
+		spec["appid"] = app.Spec.Appid
+	}
+	if app.Spec.Namespace != "" {
+		spec["namespace"] = app.Spec.Namespace
+	}
+	if app.Spec.IsSysApp {
+		spec["isSysApp"] = true
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "app.bytetrade.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   metadata,
+		"spec":       spec,
+	}}
+}

--- a/platform/tapr/cmd/sys-event/watchers/corefile_view_expr_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_view_expr_test.go
@@ -1,0 +1,123 @@
+package watchers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestBuildViewExprs_TC_EXPR_01_inclusterPodCIDR(t *testing.T) {
+	incluster, _ := buildViewExprs("10.233.64.0/18", "10.233.0.0/16", "192.168.50.230", "")
+	want := "incidr(client_ip(), '10.233.64.0/18')"
+	if incluster != want {
+		t.Fatalf("TC-EXPR-01 incluster=%q want %q", incluster, want)
+	}
+}
+
+func TestBuildViewExprs_TC_EXPR_02_vpnClusterCIDR(t *testing.T) {
+	_, vpn := buildViewExprs("10.233.64.0/18", "10.233.0.0/16", "192.168.50.230", "")
+	wantParts := []string{
+		"incidr(client_ip(), '100.64.0.0/16')",
+		"client_ip() == '192.168.50.230'",
+		"incidr(client_ip(), '10.233.0.0/16')",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(vpn, part) {
+			t.Fatalf("TC-EXPR-02 vpn=%q missing %q", vpn, part)
+		}
+	}
+}
+
+func TestBuildViewExprs_TC_EXPR_03_adguardExclusion(t *testing.T) {
+	incluster, _ := buildViewExprs("10.233.64.0/18", "10.233.0.0/16", "192.168.50.230", "10.233.3.99")
+	want := "( incidr(client_ip(), '10.233.64.0/18') && client_ip() != '10.233.3.99' )"
+	if incluster != want {
+		t.Fatalf("TC-EXPR-03 incluster=%q want %q", incluster, want)
+	}
+}
+
+func TestClusterCIDRFromPod_TC_EXPR_04(t *testing.T) {
+	if got := clusterCIDRFromPod("10.233.64.0/18"); got != "10.233.0.0/16" {
+		t.Fatalf("TC-EXPR-04 clusterCIDRFromPod=%q want 10.233.0.0/16", got)
+	}
+	if got := clusterCIDRFromPod("172.20.0.0/16"); got != "172.20.0.0/16" {
+		t.Fatalf("TC-EXPR-04 /16 pod CIDR clusterCIDR=%q want 172.20.0.0/16", got)
+	}
+}
+
+func TestDetectPodCIDR_TC_EXPR_05_fallback(t *testing.T) {
+	origProbe := podCIDRFromIptablesProbe
+	podCIDRFromIptablesProbe = func() (string, bool) { return "", false }
+	t.Cleanup(func() { podCIDRFromIptablesProbe = origProbe })
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		calicoIPPoolGVR: "IPPoolList",
+	})
+	got := detectPodCIDR(context.Background(), kubefake.NewSimpleClientset(), dynamicClient)
+	if got != defaultPodCIDR {
+		t.Fatalf("TC-EXPR-05 detectPodCIDR=%q want fallback %q", got, defaultPodCIDR)
+	}
+}
+
+func TestDetectPodCIDR_TC_EXPR_06_sources(t *testing.T) {
+	t.Run("iptables KUBE-SERVICES", func(t *testing.T) {
+		output := "-A KUBE-SERVICES ! -s 10.233.64.0/18 -m comment --comment \"kubernetes service portals\" -j KUBE-MARK-MASQ\n"
+		got, ok := parsePodCIDRFromKubeServicesIPTables(output)
+		if !ok || got != "10.233.64.0/18" {
+			t.Fatalf("TC-EXPR-06 iptables parse=%q ok=%v", got, ok)
+		}
+	})
+
+	t.Run("Calico IPPool", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+			calicoIPPoolGVR: "IPPoolList",
+		}, &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "crd.projectcalico.org/v1",
+				"kind":       "IPPool",
+				"metadata": map[string]interface{}{
+					"name": "default-ipv4-ippool",
+				},
+				"spec": map[string]interface{}{
+					"cidr": "10.233.64.0/18",
+				},
+			},
+		})
+		got, ok := podCIDRFromCalicoIPPools(context.Background(), dynamicClient)
+		if !ok || got != "10.233.64.0/18" {
+			t.Fatalf("TC-EXPR-06 Calico IPPool=%q ok=%v", got, ok)
+		}
+	})
+
+	t.Run("kube-apiserver cluster-cidr arg", func(t *testing.T) {
+		kubeClient := kubefake.NewSimpleClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-apiserver-node1",
+				Namespace: "kube-system",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "kube-apiserver",
+					Command: []string{
+						"kube-apiserver",
+						"--cluster-cidr=10.233.64.0/18",
+					},
+				}},
+			},
+		})
+		got, ok := podCIDRFromKubeClusterCIDRArg(context.Background(), kubeClient)
+		if !ok || got != "10.233.64.0/18" {
+			t.Fatalf("TC-EXPR-06 kube-apiserver arg=%q ok=%v", got, ok)
+		}
+	})
+}


### PR DESCRIPTION
Restore v2 direct shared CoreDNS templates and align v2 scan/plugin order with release-1.12.5, while keeping the v3 SRR shared path unchanged. Narrow the incluster view expression to the detected pod CIDR and add a vpn view cluster-CIDR fallback; ship as beclab/sys-event:0.2.25.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cluster-wide CoreDNS Corefile generation and client view routing; mis-detection of pod CIDR or template ordering could misroute in-cluster and VPN DNS for shared apps.
> 
> **Overview**
> Ships **sys-event** as `beclab/sys-event:0.2.25` and extends CoreDNS regeneration so legacy **v2** shared entrances work again alongside the existing **v3 SRR** path.
> 
> **Regeneration behavior:** `RegenerateCorefile` adds **v2 direct shared** `template` plugins (legacy MD5 entrance IDs → shared namespace Service ClusterIPs), skips apps labeled `app-shared=true`, and orders the incluster chain as **v3 SRR exact → user wildcards → v2 legacy**. An **Application** watcher triggers the same regeneration on app/shared-entrance changes.
> 
> **View plugins:** The **incluster** `view` expression uses a **detected pod CIDR** (iptables `KUBE-SERVICES`, Calico IPPools, kube `--cluster-cidr`, then default) instead of a fixed `/16`; the **vpn** view also matches a derived **cluster `/16`** plus the existing VPN/master rules, with AdGuard still excluded from incluster when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b75fb37b01c36a3d7a109fb5191d15eae81098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->