### PR TITLE
feat(gpu): seperate device allocation for multi pods of a single app across nodes

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.22"
+version: "v2.6.23"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.22
+      name: beclab/hami:v2.6.23
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Allow an app with multiple pods and multiple GPU bindings across nodes to allocate devices for each pod on each node.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/22

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GPU scheduler/device-plugin image changes affect workload placement and device binding; risk is limited here to a version bump, with behavior defined in the upstream HAMi release.
> 
> **Overview**
> Bumps the **HAMi** GPU virtualization stack from **`v2.6.22`** to **`v2.6.23`** so deployments pull the image that includes per-pod, per-node device allocation for multi-pod apps (per linked **HAMi** PR).
> 
> Updates **`version`** in `infrastructure/gpu/.olares/config/gpu/hami/values.yaml` (scheduler extender and device plugin use `beclab/hami`) and the prebuilt container pin in `platform/hami/.olares/Olares.yaml`. No other chart or config changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6f1b6d84d217d06da8fabfe923fa4ffc56c6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->