### PR TITLE
feat(system-apps): bump system-frontend to v1.10.54 and monitoring-server to v0.3.14

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.53
+          image: beclab/system-frontend:v1.10.54
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -23,7 +23,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.13
+        image: beclab/monitoring-server-v1:v0.3.14
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**

  Upgrade `system-frontend` to `v1.10.54` and `monitoring-server-v1` to `v0.3.14`. The `system-frontend` release rolls up a batch of frontend bug fixes and mobile/tablet adaptations from TermiPass:

  - **Disk overview** (beclab/TermiPass#1211): fix `pkname` assignment to fall back to `parent` when missing, and enhance `DiskLsblkTable` to render a tree prefix and emphasize top-level disk names for a clearer partition hierarchy.
  - **Application / market / cluster quota / domain** (beclab/TermiPass#1213): add custom route ID (third-level domain) validation, add cluster resource quota limit validation for sub-user resources, remove the duplicate block causing abnormal bottom UI on the mobile market log page (plus an empty state), correct application visibility for admins/owners, and fix the app card cancel-installation version reference.
  - **Files** (beclab/TermiPass#1214): make the folder/file picker device-aware so tablets (e.g. iPad) use the desktop dialog instead of the broken narrow mobile sheet, gate the "upload folder" entry to desktop, and make the mobile mosaic grid responsive.
  - **Share** (beclab/TermiPass#1212): adapt the Share app to mobile with a shared mobile header, switch the top-left header button to a confirm-then-logout flow, fix mobile file operations by threading `origin_id` through the pipeline, and fix share file downloads using the wrong raw endpoint.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1211
  https://github.com/beclab/TermiPass/pull/1213
  https://github.com/beclab/TermiPass/pull/1214
  https://github.com/beclab/TermiPass/pull/1212

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.54
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.53...v1.10.54

Made with [Cursor](https://cursor.com)