### PR TITLE
market: harden uploaded/shared chart upload and permission chain

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.35
+        image: beclab/dynamic-chart-repository:v0.3.36
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -131,7 +131,7 @@ spec:
           - name: APP_SERVICE_SERVICE_PORT
             value: "6755"
           - name: IMAGE_INFOS
-            value: /opt/app/data/v2/images-info
+            value: /opt/app/data/v3/images-info
           - name: NATS_HOST
             value: nats.os-platform
           - name: NATS_PORT
@@ -157,7 +157,7 @@ spec:
           - name: API_CHART_PATH
             value: /api/v1/applications/{chart_name}/chart
           - name: CHART_ROOT
-            value: /opt/app/data/v2
+            value: /opt/app/data
           - name: NATS_SUBJECT_SYSTEM_USER_STATE
             value: os.users
           - name: GO_ENV

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -215,7 +215,7 @@ spec:
           - name: API_DETAIL_PATH
             value: /api/v1/applications/info
           - name: CHART_ROOT
-            value: /opt/app/data/v2
+            value: /opt/app/data/v3
           - name: NATS_SUBJECT_SYSTEM_USER_STATE
             value: os.users
           - name: GO_ENV

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.57
+        image: beclab/market-backend:v0.6.58
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
market: harden uploaded/shared chart upload and permission chain and chart-repo migrate

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/297
https://github.com/beclab/market/pull/298
https://github.com/beclab/dynamic-chart-repository/pull/39
https://github.com/beclab/dynamic-chart-repository/pull/38


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk chart paths and paired service versions; a mismatched or partial rollout could break chart resolution until both deployments and any data migration complete.
> 
> **Overview**
> Rolls out newer **chart-repo** and **market-backend** images and retargets chart storage from the old **`/opt/app/data/v2`** layout to **v3**.
> 
> **chart-repo** (`dynamic-chart-repository` **v0.3.36**): `CHART_ROOT` is now **`/opt/app/data`** (was **`/opt/app/data/v2`**), and **`IMAGE_INFOS`** points at **`/opt/app/data/v3/images-info`** (was v2).
> 
> **market** (`market-backend` **v0.6.58**): **`CHART_ROOT`** is **`/opt/app/data/v3`** (was v2), aligning with the chart-repo migration referenced in the linked market/chart-repo PRs (upload/permission hardening lives there; this change only updates cluster deploy env and tags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278ec37a2da86f4f59ba92d5d4f0839c8a847996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->