### PR TITLE
chartrepo: point RenderedPackage at source dir so chart download

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.36
+        image: beclab/dynamic-chart-repository:v0.3.37
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix point RenderedPackage at source dir so chart download

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/dynamic-chart-repository/pull/40


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in a deployment manifest; behavior change is localized to chart packaging/download in chartrepo.
> 
> **Overview**
> Rolls out **dynamic-chart-repository v0.3.37** for the chartrepo deployment by updating the container image tag in `chart_repo_deploy.yaml` (`v0.3.36` → `v0.3.37`).
> 
> This picks up the upstream fix (beclab/dynamic-chart-repository#40) so **RenderedPackage** is resolved from the **source directory**, correcting chart download behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243231ecd26f769acea270d5242740e60b9badbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->