### PR TITLE
fix(daemon): support third level cusdomain use local url

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -11,6 +11,7 @@ replace (
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.0
 	k8s.io/client-go => k8s.io/client-go v0.34.0
 	kubesphere.io/api => ../../kubesphere-ext/staging/src/kubesphere.io/api/
+	olares.com/backups-sdk => github.com/Above-Os/backups-sdk v0.1.17
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.6
 )
 
@@ -20,7 +21,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/beclab/Olares/cli v0.0.0-20251230161135-5264df60cc33
 	github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82
-	github.com/beclab/api v0.0.17
+	github.com/beclab/api v0.0.21-0.20260618085457-f1a6694882f5
 	github.com/containerd/containerd v1.7.29
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
@@ -66,6 +67,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/cri-api v0.34.1
 	k8s.io/cri-client v0.34.1
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/mount-utils v0.31.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -48,8 +48,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82 h1:BE/T9N2OyH0ZKMTzK7RY/EvKy8pfr0dokDBINJHLE8g=
 github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82/go.mod h1:LYHBxvVI3cDiRa116LbDQ09Uiphi3i3tWX2Cjeoyi9w=
-github.com/beclab/api v0.0.17 h1:N0w6MOUBcOtfKwHqZ7HYxx0GdID2E0F+CWyLZr7nI08=
-github.com/beclab/api v0.0.17/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.21-0.20260618085457-f1a6694882f5 h1:97oJR2Gwd/MJQuVI/YkLa4dwnD9ldSCo40Fc+rUS3EE=
+github.com/beclab/api v0.0.21-0.20260618085457-f1a6694882f5/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/bfl v0.3.36 h1:PgeSPGc+XoONiwFsKq9xX8rqcL4kVM1G/ut0lYYj/js=
 github.com/beclab/bfl v0.3.36/go.mod h1:A82u38MxYk1C3Lqnm4iUUK4hBeY9HHIs+xU4V93OnJk=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
@@ -180,6 +180,7 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -811,6 +812,8 @@ k8s.io/cri-api v0.34.1 h1:n2bU++FqqJq0CNjP/5pkOs0nIx7aNpb1Xa053TecQkM=
 k8s.io/cri-api v0.34.1/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
 k8s.io/cri-client v0.34.1 h1:eq6FcEPDDL379w0WhPnItj2egsMZqOtU7nv1JaJmwP0=
 k8s.io/cri-client v0.34.1/go.mod h1:Dq6mKWV2ugO5tMv4xqVgcQ8vD7csP//e4KkzcFi2Pio=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hkbPJgdATINPMAxaynU2Ovg=

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/klog"
 	"net/url"
 	"os"
 	"strings"
@@ -23,13 +24,13 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	sysv1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
 	"github.com/beclab/api/manifest"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
@@ -575,15 +576,37 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 		klog.Error("list applications error, ", err)
 		return nil, err
 	}
-
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	uc, err := iamv1alpha2.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
 	for _, app := range apps.Items {
 		var entrances []appcfg.Entrance
 		var err error
+		zone, err := iamv1alpha2.GetUserZone(ctx, uc.Users, app.Spec.Owner)
+		if err != nil {
+			continue
+		}
 		if !appv1alpha1.IsShared(&app) {
 			entrances, err = appcfg.GenEntranceURL(ctx, &app)
 			if err != nil {
 				klog.Error("generate application entrance url error, ", err, ", ", app.Name)
 				continue
+			}
+			if zone == "" {
+				continue
+			}
+			// GenEntranceURL / BatchGenSharedAppEntranceURL only fill in the
+			// default appid-based URLs. User-customized third-level domains live
+			// in the "customDomain" setting, so without this the intranet (.local)
+			// layer never learns about custom subdomains and cannot resolve them.
+			thirdLevelURLs := app.ThirdLevelCusDomainURLs(zone, app.Spec.Owner)
+			for _, tl := range thirdLevelURLs {
+				entrances = append(entrances, appcfg.Entrance{URL: tl})
 			}
 		} else {
 
@@ -819,6 +842,14 @@ func BatchGenSharedAppEntranceURL(ctx context.Context, app *appv1alpha1.Applicat
 		}
 
 		entrances = append(entrances, a.Spec.Entrances...)
+		zone := u.GetAnnotations()["bytetrade.io/zone"]
+		if zone == "" {
+			continue
+		}
+		thirdLevelURLs := app.ThirdLevelCusDomainURLs(zone, u.GetName())
+		for _, tl := range thirdLevelURLs {
+			entrances = append(entrances, appcfg.Entrance{URL: tl})
+		}
 	}
 
 	return entrances, nil


### PR DESCRIPTION

* **Background**
support third level cusdomain use local url
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches intranet DNS configuration for all application URLs and adds IAM/K8s client calls on the hot path; behavior change is scoped to URL enumeration but wrong zone handling could skip or mis-register hosts.
> 
> **Overview**
> **Fixes local (.local / intranet) resolution for user-defined third-level custom domains** by feeding those URLs into the same path that builds application entrance lists for the intranet watcher.
> 
> `GetApplicationUrlAll` now resolves each app owner’s zone via the IAM client (`iamv1alpha2.GetUserZone`) and, for non-shared apps, appends URLs from `Application.ThirdLevelCusDomainURLs` after the default `GenEntranceURL` results—because custom subdomains live in `customDomain` settings and were previously omitted. Shared apps get the same treatment in `BatchGenSharedAppEntranceURL`, using each user’s `bytetrade.io/zone` annotation.
> 
> Dependency updates: **`github.com/beclab/api`** bumped to a pre-release that exposes `ThirdLevelCusDomainURLs`, plus **`olares.com/backups-sdk`** replace alias and **`k8s.io/klog` v1** (logging import switched from `k8s.io/klog/v2` to `k8s.io/klog` in `k8s.go`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d26c08e22b7b4d91305bad26d319b34b6c4ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->