### PR TITLE
refactor(app-service): unify MemoryShared into MemorySlice and set per-device default share modes

### DIFF
--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -61,7 +61,7 @@ func TestLegacyAppConfigIsMappedToComputeModes(t *testing.T) {
 		},
 	}
 	plan := calculateInstallComputePlan(cpuApp, []Node{
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	})
 	assertModeStatus(t, plan, utils.CPUType, StatusInstallable)
 
@@ -92,7 +92,7 @@ func TestCPUModeFallsBackToGPUTypeNodesWithoutUsingGPUMemory(t *testing.T) {
 		LimitedMemory:  8 * gi,
 	}
 	nodes := []Node{
-		computeNode("cpu-small", utils.CPUType, 4*gi, SupportTypeMemoryShared),
+		computeNode("cpu-small", utils.CPUType, 4*gi, SupportTypeMemorySlice),
 		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
 	}
 
@@ -121,7 +121,7 @@ func TestListAvailableForLaunchFiltersNotMatchAndMarksOperable(t *testing.T) {
 			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
 		),
 		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	}
 
 	result := listAvailableForLaunch(req, nodes, PressureSnapshot{})
@@ -145,7 +145,7 @@ func TestListAvailableForLaunchFiltersNotMatchAndMarksOperable(t *testing.T) {
 func TestListAvailableForLaunchReportsNoMatchingNode(t *testing.T) {
 	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: gi, LimitedGPU: gi}
 	result := listAvailableForLaunch(req, []Node{
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	}, PressureSnapshot{})
 
 	if result.Schedulable || result.Reason != "no-matching-node" || len(result.Nodes) != 0 {
@@ -396,10 +396,10 @@ func TestPickAggregateAllocationsAcrossNodes(t *testing.T) {
 // TestPickSingleAllocationGB10MemorySlice guards the GB10 single-card
 // allocation path: a GB10 node's device is decoded with the MemorySlice
 // support type by default (shareModeToSupportType), so PickAllocations must
-// offer MemorySlice in its support-type order. A regression here makes
-// supportTypeOrder fall back to the cpu-only [Exclusive, MemoryShared] set,
-// filters every GB10 candidate out, and surfaces as
-// "no available compute resource for type nvidia-gb10" at install time.
+// offer MemorySlice in its support-type order. GB10 shares the non-nvidia
+// [Exclusive, MemorySlice] order; dropping MemorySlice from it would filter
+// every GB10 candidate out and surface as "no available compute resource for
+// type nvidia-gb10" at install time.
 func TestPickSingleAllocationGB10MemorySlice(t *testing.T) {
 	app := &appcfg.ApplicationConfig{AppName: "ollama", OwnerName: "alice"}
 	req := Requirement{

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -405,21 +405,17 @@ func isWholeCardMode(mode, supportType string) bool {
 }
 
 func supportTypeOrder(mode string) []string {
-	switch mode {
-	case utils.NvidiaCardType:
+	if mode == utils.NvidiaCardType {
 		return []string{SupportTypeExclusive, SupportTypeMemorySlice, SupportTypeTimeSlice}
-	case utils.GB10ChipType:
-		// GB10 devices are decoded from the HAMI node-nvidia-register
-		// annotation and carry MemorySlice (the default) or Exclusive
-		// support types, matching AvailableSupportTypes(GB10ChipType).
-		// MemoryShared is a cpu-only support type and never appears on a
-		// GB10 device, so the default branch below would filter every
-		// candidate out and make AllocateForInstall report
-		// "no available compute resource for type nvidia-gb10".
-		return []string{SupportTypeExclusive, SupportTypeMemorySlice}
-	default:
-		return []string{SupportTypeExclusive, SupportTypeMemoryShared}
 	}
+	// Every non-nvidia mode (nvidia-gb10 plus the unified-memory accelerators:
+	// cpu / apple-m / intel / amd / moore-soc / discrete GPUs) only ever
+	// carries Exclusive or MemorySlice devices — TimeSlice is nvidia-only.
+	// Listing Exclusive first keeps the scheduler's preference for whole-device
+	// placement before it falls back to a memory slice, and including
+	// MemorySlice is what lets GB10 (decoded as MemorySlice by default) and the
+	// memory-slicing accelerators be scheduled at all.
+	return []string{SupportTypeExclusive, SupportTypeMemorySlice}
 }
 
 func deviceAvailableMemory(device Device) int64 {
@@ -429,7 +425,7 @@ func deviceAvailableMemory(device Device) int64 {
 			return 0
 		}
 		return device.Memory
-	case SupportTypeMemorySlice, SupportTypeMemoryShared:
+	case SupportTypeMemorySlice:
 		return remainingMemory(device)
 	case SupportTypeTimeSlice:
 		return device.Memory

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -238,20 +238,18 @@ func buildNodeResource(node *corev1.Node) Node {
 
 // nonHAMIDevice builds the single synthetic device used for unified-memory
 // modes (cpu, apple-m, amd, intel, moore-soc, …): the whole node is one
-// schedulable unit drawing from system memory. cpu is memory-shared; every
-// other such mode is exclusive (the Apple-Silicon path).
+// schedulable unit drawing from system memory. The support type is the mode's
+// default (defaultSupportType): cpu / intel / amd / moore-soc share the memory
+// via MemorySlice, while apple-m and any discrete-GPU / future mode take the
+// whole device exclusively.
 func nonHAMIDevice(node *corev1.Node, mode string, totalMemory int64) Device {
-	supportType := SupportTypeExclusive
-	if mode == utils.CPUType {
-		supportType = SupportTypeMemoryShared
-	}
 	return Device{
 		ID:                    fmt.Sprintf("%s-%s-0", node.Name, mode),
 		NodeName:              node.Name,
 		Mode:                  mode,
 		Memory:                totalMemory * 75 / 100,
 		Health:                nodeHealth(node),
-		SupportType:           supportType,
+		SupportType:           defaultSupportType(mode),
 		AvailableSupportTypes: AvailableSupportTypes(mode),
 	}
 }
@@ -303,6 +301,9 @@ func boolHealth(healthy bool) string {
 	return deviceHealthNo
 }
 
+// shareModeToSupportType maps a device's HAMI share-mode annotation to a
+// support type. An unset / unrecognized annotation falls back to the mode's
+// default (defaultSupportType): nvidia → TimeSlice, nvidia-gb10 → MemorySlice.
 func shareModeToSupportType(gpuType, shareMode string) string {
 	switch shareMode {
 	case "0":
@@ -310,10 +311,7 @@ func shareModeToSupportType(gpuType, shareMode string) string {
 	case "1":
 		return SupportTypeMemorySlice
 	default:
-		if gpuType == utils.GB10ChipType {
-			return SupportTypeMemorySlice
-		}
-		return SupportTypeTimeSlice
+		return defaultSupportType(gpuType)
 	}
 }
 
@@ -334,17 +332,33 @@ func shareModeAnnotationKey(deviceID string) string {
 	return fmt.Sprintf("sharemode.gpu.bytetrade.io/%s", deviceID)
 }
 
+// AvailableSupportTypes lists the support types a device of the given mode may
+// take. The first entry is the mode's default — the one assigned when no share
+// mode is configured (see defaultSupportType). nvidia can switch among all
+// three; nvidia-gb10 defaults to MemorySlice but may switch to Exclusive; cpu
+// and the unified-memory accelerators (intel / amd / moore-soc) only do
+// MemorySlice; apple-m and any discrete-GPU (intel-gpu / amd-gpu) or future
+// mode are Exclusive-only for now.
 func AvailableSupportTypes(mode string) []string {
 	switch mode {
 	case utils.NvidiaCardType:
 		return []string{SupportTypeTimeSlice, SupportTypeMemorySlice, SupportTypeExclusive}
 	case utils.GB10ChipType:
 		return []string{SupportTypeMemorySlice, SupportTypeExclusive}
-	case utils.CPUType:
-		return []string{SupportTypeMemoryShared}
+	case utils.CPUType, utils.IntelType, utils.AMDType, utils.MooreSocType:
+		return []string{SupportTypeMemorySlice}
 	default:
 		return []string{SupportTypeExclusive}
 	}
+}
+
+// defaultSupportType is the support type a device of the given mode receives
+// when its share mode has not been explicitly configured. It is, by contract,
+// the first entry of AvailableSupportTypes(mode): nvidia → TimeSlice,
+// nvidia-gb10 and the unified-memory modes (cpu / intel / amd / moore-soc) →
+// MemorySlice, apple-m and any discrete-GPU / future mode → Exclusive.
+func defaultSupportType(mode string) string {
+	return AvailableSupportTypes(mode)[0]
 }
 
 func attachBindings(nodes []Node, allocations []Allocation) {

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -43,8 +43,8 @@ func TestBuildNodeResourcePureCPU(t *testing.T) {
 	if len(n.GPUTypes) != 0 {
 		t.Fatalf("pure-cpu node should advertise no gpu types, got %v", n.GPUTypes)
 	}
-	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.CPUType || n.Devices[0].SupportType != SupportTypeMemoryShared {
-		t.Fatalf("expected a single cpu memory-shared device, got %+v", n.Devices)
+	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.CPUType || n.Devices[0].SupportType != SupportTypeMemorySlice {
+		t.Fatalf("expected a single cpu memory-slice device, got %+v", n.Devices)
 	}
 	if !n.SupportsMode(utils.CPUType) {
 		t.Fatal("every node must support cpu")
@@ -70,11 +70,11 @@ func TestBuildNodeResourceMultiMode(t *testing.T) {
 		t.Fatal("node must not claim support for amd")
 	}
 
-	// The intel mode follows the Apple-Silicon path: one exclusive device,
-	// tagged with its mode and the node-mode device id.
+	// Intel is a unified-memory accelerator: one MemorySlice device, tagged
+	// with its mode and the node-mode device id.
 	intelDevs := devicesForMode(n, utils.IntelType)
-	if len(intelDevs) != 1 || intelDevs[0].SupportType != SupportTypeExclusive {
-		t.Fatalf("expected one exclusive intel device, got %+v", intelDevs)
+	if len(intelDevs) != 1 || intelDevs[0].SupportType != SupportTypeMemorySlice {
+		t.Fatalf("expected one memory-slice intel device, got %+v", intelDevs)
 	}
 	if intelDevs[0].ID != "olares-one-intel-0" {
 		t.Fatalf("unexpected intel device id %q", intelDevs[0].ID)
@@ -100,7 +100,7 @@ func TestBindingSelectionResolvesDeviceOnMultiModeNode(t *testing.T) {
 		memoryCapacity: 32 * gi,
 		Devices: []Device{
 			{ID: "gpu0", NodeName: "olares-one", Mode: utils.NvidiaCardType, Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.NvidiaCardType)},
-			{ID: "olares-one-intel-0", NodeName: "olares-one", Mode: utils.IntelType, Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.IntelType)},
+			{ID: "olares-one-intel-0", NodeName: "olares-one", Mode: utils.IntelType, Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice, AvailableSupportTypes: AvailableSupportTypes(utils.IntelType)},
 		},
 	}
 	nodes := []Node{node}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -11,10 +11,9 @@ const (
 	StatusInsufficientResources = "insufficient-resources"
 	StatusNoMatchingNode        = "no-matching-node"
 
-	SupportTypeTimeSlice    = "TimeSlice"
-	SupportTypeMemorySlice  = "MemorySlice"
-	SupportTypeExclusive    = "Exclusive"
-	SupportTypeMemoryShared = "MemoryShared"
+	SupportTypeTimeSlice   = "TimeSlice"
+	SupportTypeMemorySlice = "MemorySlice"
+	SupportTypeExclusive   = "Exclusive"
 
 	allocationConfigMapNamespace = "os-framework"
 	allocationConfigMapName      = "app-gpu-allocations"


### PR DESCRIPTION
## Summary
- Drop the `SupportTypeMemoryShared` support type, which overlapped with `MemorySlice` (both partition device memory among pods). CPU and the unified-memory accelerators now use `MemorySlice`.
- Introduce `defaultSupportType` (the first entry of `AvailableSupportTypes`) as the single source of truth for the support type a device gets when its share mode is not configured:
  - `nvidia` → `TimeSlice`
  - `nvidia-gb10` → `MemorySlice`
  - `intel` / `amd` / `moore-soc` → `MemorySlice` (only mode supported for now)
  - `apple-m` → `Exclusive` (only mode supported for now)
- Keep the fallback path so `intel-gpu` / `amd-gpu` and any future mode remain supported (default to `Exclusive`).

## Changes
- `pkg/compute/types.go`: remove `SupportTypeMemoryShared` constant.
- `pkg/compute/store.go`: add `defaultSupportType`; route `nonHAMIDevice` and `shareModeToSupportType` through it; extend `AvailableSupportTypes` so intel/amd/moore-soc report `MemorySlice` and cpu switches from `MemoryShared` to `MemorySlice`.
- `pkg/compute/scheduler.go`: collapse `supportTypeOrder` non-nvidia branches into `[Exclusive, MemorySlice]`; drop `MemoryShared` from `deviceAvailableMemory`.
- Tests updated accordingly (`store_test.go`, `calculator_test.go`).

Note: `intel`/`amd`/`moore-soc` switch from whole-device `Exclusive` to `MemorySlice` by default; mode switching for non-HAMI devices remains gated by `IsHAMIMode`, so "only mode supported for now" holds. The CLI legacy-binding migration and the GPU dashboard label layer read HAMI's raw share mode directly and are unaffected.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/compute/...`
- [x] `go vet ./pkg/compute/...`

Made with [Cursor](https://cursor.com)