### PR TITLE
fix(dashboard-cli): add isPartitionOfDisk function and related tests

### DIFF
--- a/cli/pkg/dashboard/dashboard_test.go
+++ b/cli/pkg/dashboard/dashboard_test.go
@@ -681,6 +681,29 @@ func TestHasPknameLabels(t *testing.T) {
 	}
 }
 
+func TestIsPartitionOfDisk(t *testing.T) {
+	cases := []struct {
+		child, disk string
+		want        bool
+	}{
+		{"sda", "sda", true},        // disk itself
+		{"sda1", "sda", true},       // plain-suffix partition
+		{"sdaa", "sda", false},      // sibling device, not a partition
+		{"nvme0n1p1", "nvme0n1", true},  // digit-ending disk → "p" separator
+		{"nvme0n1", "nvme0n1", true},    // disk itself
+		{"nvme0n10", "nvme0n1", false},  // sibling, not a partition of nvme0n1
+		{"nvme0n1p", "nvme0n1", false},  // "p" without a number
+		{"olares--vg-root", "nvme0n1", false}, // LVM device (no prefix match)
+		{"", "sda", false},
+		{"sda1", "", false},
+	}
+	for _, c := range cases {
+		if got := isPartitionOfDisk(c.child, c.disk); got != c.want {
+			t.Errorf("isPartitionOfDisk(%q, %q) = %v, want %v", c.child, c.disk, got, c.want)
+		}
+	}
+}
+
 func TestCollectSubtreeByPkname_BFSRoot(t *testing.T) {
 	rows := []lsblkRow{
 		{Name: "sda"},

--- a/cli/pkg/dashboard/helpers_test.go
+++ b/cli/pkg/dashboard/helpers_test.go
@@ -101,6 +101,10 @@ func podDeploymentName(pod string) string { return PodDeploymentName(pod) }
 
 func hasPknameLabels(rows []LsblkRow) bool { return HasPknameLabels(rows) }
 
+func isPartitionOfDisk(childName, diskName string) bool {
+	return IsPartitionOfDisk(childName, diskName)
+}
+
 func collectSubtreeByPkname(allRows []LsblkRow, rootName string) []LsblkRow {
 	return CollectSubtreeByPkname(allRows, rootName)
 }

--- a/cli/pkg/dashboard/lsblk.go
+++ b/cli/pkg/dashboard/lsblk.go
@@ -49,6 +49,43 @@ func HasPknameLabels(rows []LsblkRow) bool {
 	return false
 }
 
+// IsPartitionOfDisk reports whether `childName` is a partition of the
+// disk `diskName` by the kernel naming convention (see `disk_name()` in
+// block/genhd.c), mirroring `isPartitionOfDisk` in
+// Overview2/Disk/config.ts:318. The partition name is the disk name plus
+// a `p` separator when the disk name ends in a digit (e.g. `nvme0n1` ->
+// `nvme0n1p1`, `mmcblk0` -> `mmcblk0p1`), or just the appended partition
+// number otherwise (e.g. `sda` -> `sda1`). A plain prefix check is not
+// disk-specific and would wrongly match siblings such as `nvme0n10`
+// against `nvme0n1`, or `sdaa` against `sda`.
+func IsPartitionOfDisk(childName, diskName string) bool {
+	if childName == "" || diskName == "" {
+		return false
+	}
+	if childName == diskName {
+		return true
+	}
+	if !strings.HasPrefix(childName, diskName) {
+		return false
+	}
+	suffix := childName[len(diskName):]
+	if last := diskName[len(diskName)-1]; last >= '0' && last <= '9' {
+		if !strings.HasPrefix(suffix, "p") {
+			return false
+		}
+		suffix = suffix[1:]
+	}
+	if suffix == "" {
+		return false
+	}
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // CollectSubtreeByPkname BFS-walks the pkname graph from `rootName`,
 // returning the rows in their original order. Mirrors
 // `collectSubtreeByPkname` in Overview2/Disk/config.ts:273.

--- a/cli/pkg/dashboard/overview/disk/default_test.go
+++ b/cli/pkg/dashboard/overview/disk/default_test.go
@@ -41,8 +41,8 @@ func TestBuildSectionsEnvelope_Smoke(t *testing.T) {
             {"metric":{"node":"olares-1","device":"sda"},"value":[1714600000,"35"]}
           ]}},
           {"metric_name":"node_disk_lsblk_info","data":{"result":[
-            {"metric":{"node":"olares-1","name":"sda","pkname":"","size":"1T","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
-            {"metric":{"node":"olares-1","name":"sda1","pkname":"sda","size":"100G","fstype":"ext4","mountpoint":"/","fsused":"50G","fsuse_percent":"50%"},"value":[1714600000,"1"]}
+            {"metric":{"node":"olares-1","name":"sda","pkname":"","size":"1099511627776","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
+            {"metric":{"node":"olares-1","name":"sda1","pkname":"sda","size":"107374182400","fstype":"ext4","mountpoint":"/","fsused":"53687091200","fsuse_percent":"50%"},"value":[1714600000,"1"]}
           ]}}
         ]}`))
 	}))

--- a/cli/pkg/dashboard/overview/disk/helpers.go
+++ b/cli/pkg/dashboard/overview/disk/helpers.go
@@ -26,7 +26,6 @@ import pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
 var (
 	sampleFloat       = pkgdashboard.SampleFloat
 	formatFloat       = pkgdashboard.FormatFloat
-	percentString     = pkgdashboard.PercentString
 	safeRatio         = pkgdashboard.SafeRatio
 	lastSampleFromRow = pkgdashboard.LastSampleFromRow
 )

--- a/cli/pkg/dashboard/overview/disk/main.go
+++ b/cli/pkg/dashboard/overview/disk/main.go
@@ -56,9 +56,14 @@ func RunMain(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.Commo
 // All queries are instant (`step=0s`) — the SPA passes
 // `step:'0s'` in IndexPage.vue:113.
 //
+// The table is a 1:1 of the SPA card's visible content: device /
+// type / health header + the contentData rows (total capacity,
+// model, serial, protocol, temperature, firmware, 4K-native, node,
+// power-on hours, data written). The SPA computes used / avail /
+// utilisation in headerData but does NOT render them, so they are
+// kept in Raw (for JSON consumers) but omitted from the table.
 // Per the user's policy decision the per-second IOPS / throughput
-// columns are intentionally NOT emitted; the table is otherwise a
-// 1:1 of the SPA card content.
+// columns are intentionally NOT emitted.
 func BuildMainEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashboard.CommonFlags, now time.Time) (pkgdashboard.Envelope, error) {
 	metrics := []string{
 		"node_disk_smartctl_info",
@@ -207,6 +212,7 @@ func BuildMainEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashb
 			"physical_block":     physicalBlk,
 			"is_4k_native":       is4K,
 			"temperature_c":      celsius,
+			"temperature_f":      format.ConvertTemperature(celsius, format.TempF),
 			"power_on_hours":     powerHours,
 			"data_bytes_written": written,
 		}
@@ -216,10 +222,7 @@ func BuildMainEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashb
 			"type":           typeStr,
 			"health":         healthStr,
 			"total":          format.GetDiskSize(capLabel),
-			"used":           format.GetDiskSize(formatFloat(usedSize)),
-			"avail":          format.GetDiskSize(formatFloat(availUsed)),
-			"util":           percentString(ratio),
-			"temperature":    renderDiskTemperature(celsius, cf.TempUnit),
+			"temperature":    renderDiskTemperature(celsius),
 			"model":          dispOrDash(s.labels["model"]),
 			"serial":         dispOrDash(s.labels["serial"]),
 			"protocol":       dispOrDash(s.labels["protocol"]),
@@ -237,15 +240,17 @@ func BuildMainEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pkgdashb
 	}, nil
 }
 
-// renderDiskTemperature mirrors `renderTemperature` but only emits
-// the active --temp-unit value (no dual celsius/fahrenheit display).
-// Empty/zero celsius prints "-" the way the SPA does (config.ts:219).
-// Private — only the disk-main row builder calls this.
-func renderDiskTemperature(celsius float64, target format.TempUnit) string {
+// renderDiskTemperature mirrors the SPA card's dual-unit temperature
+// cell (config.ts:218–223): always emit both Celsius and Fahrenheit
+// as "<c>°C/<f>°F" regardless of --temp-unit, and print "-/-" for an
+// empty/zero reading. Private — only the disk-main row builder calls
+// this.
+func renderDiskTemperature(celsius float64) string {
 	if celsius == 0 {
-		return "-"
+		return "-/-"
 	}
-	return pkgdashboard.RenderTemperature(celsius, target)
+	return pkgdashboard.RenderTemperature(celsius, format.TempC) + "/" +
+		pkgdashboard.RenderTemperature(celsius, format.TempF)
 }
 
 // renderHoursOrDash renders power-on hours as "Xh", or "-" when the
@@ -275,11 +280,11 @@ func ifYesNo(b bool) string {
 	return "No"
 }
 
-// WriteMainTable renders the per-disk summary. Per the user's
-// decision IOPS / throughput columns are dropped; everything that
-// fits the SPA card lives here in column form. Column order is
-// pinned: agents that scrape stdout rely on the index being stable
-// across releases.
+// WriteMainTable renders the per-disk summary. Columns mirror the
+// SPA card's visible fields 1:1 (used / avail / util are computed
+// but unrendered on the card, so they stay out of the table and
+// live only in Raw). Column order is pinned: agents that scrape
+// stdout rely on the index being stable across releases.
 func WriteMainTable(w io.Writer, env pkgdashboard.Envelope) error {
 	cols := []pkgdashboard.TableColumn{
 		{Header: "DEVICE", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "device") }},
@@ -287,9 +292,6 @@ func WriteMainTable(w io.Writer, env pkgdashboard.Envelope) error {
 		{Header: "TYPE", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "type") }},
 		{Header: "HEALTH", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "health") }},
 		{Header: "TOTAL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "total") }},
-		{Header: "USED", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "used") }},
-		{Header: "AVAIL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "avail") }},
-		{Header: "UTIL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "util") }},
 		{Header: "TEMP", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "temperature") }},
 		{Header: "MODEL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "model") }},
 		{Header: "SERIAL", Get: func(it pkgdashboard.Item) string { return pkgdashboard.DisplayString(it, "serial") }},

--- a/cli/pkg/dashboard/overview/disk/main_test.go
+++ b/cli/pkg/dashboard/overview/disk/main_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
-	"github.com/beclab/Olares/cli/pkg/dashboard/format"
 )
 
 // diskMainFixtureSrv stubs /v1alpha3/nodes returning two SMART
@@ -96,9 +95,18 @@ func TestBuildMainEnvelope_SortsAndJoinsAuxiliaries(t *testing.T) {
 		t.Errorf("health display = %v / %v, want Exception / Normal",
 			row0.Display["health"], row1.Display["health"])
 	}
-	// nvme0n1: cap=500e9, avail=125e9 → used=375e9; ratio = 0.75
-	if row0.Display["util"] != "75%" {
-		t.Errorf("nvme0n1 util = %v, want 75%% (used/cap)", row0.Display["util"])
+	// nvme0n1: cap=500e9, avail=125e9 → used=375e9; ratio = 0.75.
+	// The SPA card does not render utilisation, so it is absent from
+	// Display but preserved in Raw for JSON consumers.
+	if _, ok := row0.Display["util"]; ok {
+		t.Errorf("util should be absent from Display (SPA card does not render it)")
+	}
+	if r, _ := row0.Raw["used_ratio"].(float64); r != 0.75 {
+		t.Errorf("nvme0n1 used_ratio = %v, want 0.75 (used/cap)", row0.Raw["used_ratio"])
+	}
+	// temperature: dual-unit "<c>°C/<f>°F" like the SPA card.
+	if row0.Display["temperature"] != "42°C/107.6°F" {
+		t.Errorf("nvme0n1 temperature = %v, want 42°C/107.6°F", row0.Display["temperature"])
 	}
 	// power_on_hours: nvme0n1 has 500h, sda has no row → "-".
 	if poh, _ := row0.Display["power_on_hours"].(string); !strings.Contains(poh, "500") {
@@ -113,24 +121,19 @@ func TestBuildMainEnvelope_SortsAndJoinsAuxiliaries(t *testing.T) {
 	}
 }
 
-// TestRenderDiskTemperature_HonoursUnitAndDash pins the disk-area
-// "0 → '-'" wrapper around pkgdashboard.RenderTemperature. Empty
-// samples (Celsius == 0) render as a dash to mirror the SPA's
-// config.ts:219 behaviour; non-zero values pass through to the
-// pkg-root unit converter and pick up the active --temp-unit. This
-// test was migrated from the pkg-root dashboard_test.go (P7) so
-// it lives next to the production helper it exercises.
-func TestRenderDiskTemperature_HonoursUnitAndDash(t *testing.T) {
-	if got := renderDiskTemperature(0, format.TempC); got != "-" {
-		t.Errorf("zero celsius should print '-', got %q", got)
+// TestRenderDiskTemperature_DualUnitAndDash pins the disk-area
+// dual-unit temperature cell. Empty samples (Celsius == 0) render
+// as "-/-" to mirror the SPA's config.ts:218–223 behaviour; non-zero
+// values always emit both Celsius and Fahrenheit regardless of
+// --temp-unit, matching the SPA card which hardcodes "<c>°C/<f>°F".
+func TestRenderDiskTemperature_DualUnitAndDash(t *testing.T) {
+	if got := renderDiskTemperature(0); got != "-/-" {
+		t.Errorf("zero celsius should print '-/-', got %q", got)
 	}
-	if got := renderDiskTemperature(40, format.TempC); got != "40°C" {
-		t.Errorf("40C → %q, want 40°C", got)
+	if got := renderDiskTemperature(40); got != "40°C/104°F" {
+		t.Errorf("40C → %q, want 40°C/104°F", got)
 	}
-	if got := renderDiskTemperature(40, format.TempF); got != "104°F" {
-		t.Errorf("40C in F → %q, want 104°F", got)
-	}
-	if got := renderDiskTemperature(40, format.TempK); got != "313.1K" {
-		t.Errorf("40C in K → %q, want 313.1K", got)
+	if got := renderDiskTemperature(35); got != "35°C/95°F" {
+		t.Errorf("35C → %q, want 35°C/95°F", got)
 	}
 }

--- a/cli/pkg/dashboard/overview/disk/partitions.go
+++ b/cli/pkg/dashboard/overview/disk/partitions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	pkgdashboard "github.com/beclab/Olares/cli/pkg/dashboard"
+	"github.com/beclab/Olares/cli/pkg/dashboard/format"
 )
 
 // RunPartitions is the cmd-side entry point for `dashboard overview
@@ -89,10 +90,17 @@ func BuildPartitionsEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 			if e.Metric["name"] == device && node == "" {
 				node = e.Metric["node"]
 			}
+			// pkname falls back to the `parent` label when absent,
+			// mirroring `metricFromSample` (config.ts:254) — some exporter
+			// versions emit `parent` instead of `pkname`.
+			pkname := e.Metric["pkname"]
+			if pkname == "" {
+				pkname = e.Metric["parent"]
+			}
 			allRows = append(allRows, pkgdashboard.LsblkRow{
 				Name:         e.Metric["name"],
 				Node:         e.Metric["node"],
-				Pkname:       e.Metric["pkname"],
+				Pkname:       pkname,
 				Size:         e.Metric["size"],
 				Fstype:       e.Metric["fstype"],
 				Mountpoint:   e.Metric["mountpoint"],
@@ -109,16 +117,34 @@ func BuildPartitionsEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 		}
 	}
 
-	var subset []pkgdashboard.LsblkRow
-	if pkgdashboard.HasPknameLabels(scoped) {
-		subset = pkgdashboard.CollectSubtreeByPkname(scoped, device)
-	} else {
-		subset = subset[:0]
-		for _, r := range scoped {
-			if r.Name == device || strings.HasPrefix(r.Name, device) {
-				subset = append(subset, r)
-			}
+	// A row belongs to the selected disk if it is reachable via the
+	// pkname chain OR it is a partition of the disk by kernel naming
+	// convention. Using the union of both strategies (mirroring
+	// getDiskPartitionRows in config.ts:443) avoids dropping partitions
+	// whose pkname/parent chain is not populated — which the old
+	// all-or-nothing toggle on HasPknameLabels would otherwise omit —
+	// while still capturing chain-only descendants such as dm/LVM
+	// devices whose names don't share the disk prefix.
+	matchesByName := make([]pkgdashboard.LsblkRow, 0, len(scoped))
+	for _, r := range scoped {
+		if pkgdashboard.IsPartitionOfDisk(r.Name, device) {
+			matchesByName = append(matchesByName, r)
 		}
+	}
+	var candidates []pkgdashboard.LsblkRow
+	if pkgdashboard.HasPknameLabels(scoped) {
+		candidates = append(pkgdashboard.CollectSubtreeByPkname(scoped, device), matchesByName...)
+	} else {
+		candidates = matchesByName
+	}
+	seenNames := map[string]bool{}
+	subset := make([]pkgdashboard.LsblkRow, 0, len(candidates))
+	for _, r := range candidates {
+		if seenNames[r.Name] {
+			continue
+		}
+		seenNames[r.Name] = true
+		subset = append(subset, r)
 	}
 	flat := pkgdashboard.FlattenLsblkHierarchy(subset, device)
 
@@ -137,10 +163,10 @@ func BuildPartitionsEnvelope(ctx context.Context, c *pkgdashboard.Client, cf *pk
 		}
 		disp := map[string]any{
 			"name":          fr.TreePrefix + fr.Row.Name,
-			"size":          orDash(fr.Row.Size),
+			"size":          formatLsblkDiskValue(fr.Row.Size),
 			"fstype":        orDash(fr.Row.Fstype),
 			"mountpoint":    orDash(fr.Row.Mountpoint),
-			"fsused":        orDash(fr.Row.Fsused),
+			"fsused":        formatLsblkDiskValue(fr.Row.Fsused),
 			"fsuse_percent": orDash(fr.Row.FsusePercent),
 		}
 		items = append(items, pkgdashboard.Item{Raw: raw, Display: disp})
@@ -160,6 +186,20 @@ func orDash(v string) string {
 		return "-"
 	}
 	return t
+}
+
+// formatLsblkDiskValue mirrors `formatLsblkDiskValue(raw, 'auto')` in
+// Overview2/Disk/config.ts:49: empty / "-" / non-numeric inputs render
+// as "-", and a numeric byte count runs through the disk-unit converter
+// (getSuitableValue) so the size / used columns display "631.51 Gi"
+// instead of the raw byte string. The SPA's partition table applies the
+// same auto-unit conversion in DiskLsblkTable.vue.
+func formatLsblkDiskValue(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" || s == "-" {
+		return "-"
+	}
+	return format.GetSuitableValue(s, format.UnitTypeDisk, "-")
 }
 
 // WritePartitionsTable renders the lsblk subtree. NAME carries the

--- a/cli/pkg/dashboard/overview/disk/partitions_test.go
+++ b/cli/pkg/dashboard/overview/disk/partitions_test.go
@@ -23,13 +23,17 @@ func TestBuildPartitionsEnvelope_PknameTreeAndPrefix(t *testing.T) {
 			noUnexpectedPath(t, w, r.URL.Path)
 			return
 		}
+		// size / fsused are raw byte counts (lsblk -b style), as the real
+		// exporter emits — the table converts them to disk units.
+		// sda=1Ti, sda1=100Gi (fsused 50Gi), sda2=900Gi,
+		// sda2p1=500Gi (fsused 200Gi), nvme0n1=512Gi.
 		_, _ = w.Write([]byte(`{"results":[
           {"metric_name":"node_disk_lsblk_info","data":{"result":[
-            {"metric":{"node":"olares-1","name":"sda","pkname":"","size":"1T","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
-            {"metric":{"node":"olares-1","name":"sda1","pkname":"sda","size":"100G","fstype":"ext4","mountpoint":"/boot","fsused":"50G","fsuse_percent":"50%"},"value":[1714600000,"1"]},
-            {"metric":{"node":"olares-1","name":"sda2","pkname":"sda","size":"900G","fstype":"LVM2_member","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
-            {"metric":{"node":"olares-1","name":"sda2p1","pkname":"sda2","size":"500G","fstype":"ext4","mountpoint":"/","fsused":"200G","fsuse_percent":"40%"},"value":[1714600000,"1"]},
-            {"metric":{"node":"olares-2","name":"nvme0n1","pkname":"","size":"512G","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]}
+            {"metric":{"node":"olares-1","name":"sda","pkname":"","size":"1099511627776","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
+            {"metric":{"node":"olares-1","name":"sda1","pkname":"sda","size":"107374182400","fstype":"ext4","mountpoint":"/boot","fsused":"53687091200","fsuse_percent":"50%"},"value":[1714600000,"1"]},
+            {"metric":{"node":"olares-1","name":"sda2","pkname":"sda","size":"966367641600","fstype":"LVM2_member","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]},
+            {"metric":{"node":"olares-1","name":"sda2p1","pkname":"sda2","size":"536870912000","fstype":"ext4","mountpoint":"/","fsused":"214748364800","fsuse_percent":"40%"},"value":[1714600000,"1"]},
+            {"metric":{"node":"olares-2","name":"nvme0n1","pkname":"","size":"549755813888","fstype":"","mountpoint":"","fsused":"","fsuse_percent":""},"value":[1714600000,"1"]}
           ]}}
         ]}`))
 	}))
@@ -82,5 +86,20 @@ func TestBuildPartitionsEnvelope_PknameTreeAndPrefix(t *testing.T) {
 	}
 	if env.Items[1].Display["mountpoint"] != "/boot" {
 		t.Errorf("sda1 mountpoint = %v, want /boot", env.Items[1].Display["mountpoint"])
+	}
+	// size / fsused run through the disk-unit converter (matching the
+	// SPA's formatLsblkDiskValue auto mode): raw byte counts become
+	// "1 Ti" / "100 Gi" etc., and empty fsused stays "-".
+	if env.Items[0].Display["size"] != "1 Ti" {
+		t.Errorf("sda size = %v, want \"1 Ti\"", env.Items[0].Display["size"])
+	}
+	if env.Items[1].Display["size"] != "100 Gi" {
+		t.Errorf("sda1 size = %v, want \"100 Gi\"", env.Items[1].Display["size"])
+	}
+	if env.Items[1].Display["fsused"] != "50 Gi" {
+		t.Errorf("sda1 fsused = %v, want \"50 Gi\"", env.Items[1].Display["fsused"])
+	}
+	if env.Items[2].Display["fsused"] != "-" {
+		t.Errorf("sda2 fsused = %v, want \"-\" (empty)", env.Items[2].Display["fsused"])
 	}
 }


### PR DESCRIPTION
* **Background**
  - Implemented the isPartitionOfDisk function to determine if a given child device is a partition of a specified disk based on kernel naming conventions.
  - Added unit tests for isPartitionOfDisk to cover various cases, ensuring accurate functionality.
  - Updated related tests and helper functions to integrate the new logic.
  - Adjusted disk and partition display values in tests to reflect accurate byte sizes and formatting.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to dashboard disk display and lsblk row selection logic, with broad unit test coverage and no auth or data-mutation paths.
> 
> **Overview**
> Brings **`dashboard overview disk`** closer to the SPA by fixing how partitions are detected and how tables render.
> 
> Adds **`IsPartitionOfDisk`** (kernel-style naming: `sda1`, `nvme0n1p1`, excluding false prefix matches like `nvme0n10`) with unit tests. **Partition envelopes** now merge **pkname/parent BFS** with name-based partition matching, read **`parent`** when **`pkname`** is missing, and format **SIZE/FSUSED** from raw byte counts via the disk unit converter.
> 
> **Disk main** output matches the card: **USED/AVAIL/UTIL** drop from the stdout table (still in **Raw** JSON), temperature shows **dual °C/°F** (`-/-` when empty), and **`temperature_f`** is added to Raw. Test fixtures use numeric byte sizes where the exporter does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab65240ae7af638d318beaadb8ec2b24f3b97f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->