### PR TITLE
refactor(app-service): unify MemoryShared into MemorySlice and set per-device default share modes

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.51
+        image: beclab/app-service:0.5.52
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.50
+        image: beclab/app-service:0.5.51
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/node_alert_controller.go
+++ b/framework/app-service/controllers/node_alert_controller.go
@@ -53,7 +53,7 @@ type NodeAlertController struct {
 	lastAlertTime map[string]time.Time
 	// lastPressureState tracks the last known pressure state for each node and pressure type
 	lastPressureState map[string]bool
-	mutex sync.RWMutex
+	mutex             sync.RWMutex
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/framework/app-service/pkg/apiserver/handler_app.go
+++ b/framework/app-service/pkg/apiserver/handler_app.go
@@ -657,18 +657,6 @@ func (h *Handler) allUsersApps(req *restful.Request, resp *restful.Response) {
 		}
 	}
 
-	// allUsers is needed only when at least one v3 / shared app is present;
-	// computed lazily so the common (no-shared) path stays free.
-	var allUsers []string
-	var allUsersErr error
-	loadAllUsers := func() ([]string, error) {
-		if allUsers != nil || allUsersErr != nil {
-			return allUsers, allUsersErr
-		}
-		allUsers, allUsersErr = h.getAllUser()
-		return allUsers, allUsersErr
-	}
-
 	for _, app := range appsMap {
 		entrances, err := appcfg.GenEntranceURL(req.Request.Context(), app)
 		if err != nil {
@@ -687,30 +675,7 @@ func (h *Handler) allUsersApps(req *restful.Request, resp *restful.Response) {
 		if v, ok := appsEntranceMap[app.Name]; ok {
 			app.Status.EntranceStatuses = v.Status.EntranceStatuses
 		}
-		// Shared apps are cluster-wide singletons. Fan out one entry per
-		// iam user so consumers grouping by Owner see them under every
-		// account (matching the v1 per-user-AM shape). Every user may
-		// open the app; lifecycle is admin-only. v3 per-user apps fall
-		// through with the regular owner-scoped layout.
-		//
-		// For each fanned-out copy, overlay Spec.UserSettings[u] on top
-		// of Spec.Settings / Spec.Entrances so consumers see that user's
-		// effective customDomain / policy / authLevel.
-		if appcfg.IsShared(app) {
-			users, uErr := loadAllUsers()
-			if uErr != nil {
-				api.HandleError(resp, req, uErr)
-				return
-			}
-			for _, u := range users {
-				cp := *app
-				cp.Spec.Owner = u
-				cp.Spec.Settings = app.EffectiveSettings(u)
-				cp.Spec.Entrances = app.EffectiveEntrances(u)
-				filteredApps = append(filteredApps, cp)
-			}
-			continue
-		}
+
 		filteredApps = append(filteredApps, *app)
 	}
 

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -39,6 +39,16 @@ type depRequest struct {
 	Data []appcfg.Dependency `json:"data"`
 }
 
+// getAppClient is the seam used by call sites (e.g. checkAppNameConflict)
+// that need a cluster-wide app.bytetrade.io clientset constructed from the
+// in-cluster / KUBECONFIG context. It defaults to utils.GetClient; unit
+// tests in this package override it to inject an appfake.NewSimpleClientset.
+// The return type is the versioned.Interface so both the real
+// *versioned.Clientset and the generated *fake.Clientset satisfy it.
+var getAppClient = func() (versioned.Interface, error) {
+	return utils.GetClient()
+}
+
 type installHelperIntf interface {
 	getAdminUsers() (admin []string, isAdmin bool, err error)
 	getInstalledApps() (installed bool, app []*v1alpha1.Application, err error)
@@ -685,7 +695,7 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	clientset, err := utils.GetClient()
+	clientset, err := getAppClient()
 	if err != nil {
 		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
 		return err

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -685,13 +685,19 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	list, err := h.client.AppV1alpha1().ApplicationManagers().List(ctx, metav1.ListOptions{})
+	clientset, err := utils.GetClient()
 	if err != nil {
+		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
+		return err
+	}
+	apps, err := clientset.AppV1alpha1().ApplicationManagers().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("checkAppNameConflict: failed to get appmgr list %v", err)
 		return err
 	}
 
-	for i := range list.Items {
-		am := &list.Items[i]
+	for i := range apps.Items {
+		am := &apps.Items[i]
 		if am.Spec.AppName != h.app {
 			continue
 		}

--- a/framework/app-service/pkg/apiserver/handler_installer_install_conflict_test.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install_conflict_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"github.com/beclab/api/pkg/generated/clientset/versioned"
 	appfake "github.com/beclab/api/pkg/generated/clientset/versioned/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,16 @@ func newConflictHelper(t *testing.T, app string, ams ...*appv1alpha1.Application
 		objs = append(objs, am)
 	}
 	client := appfake.NewSimpleClientset(objs...)
+
+	// checkAppNameConflict obtains its clientset via the package-level
+	// getAppClient seam (which in production wraps utils.GetClient and
+	// requires in-cluster / KUBECONFIG access). Swap it for one that
+	// hands back the fake constructed above, and restore on teardown so
+	// later tests in the suite still see the production wiring.
+	origGetAppClient := getAppClient
+	getAppClient = func() (versioned.Interface, error) { return client, nil }
+	t.Cleanup(func() { getAppClient = origGetAppClient })
+
 	return &installHandlerHelper{
 		app:    app,
 		owner:  "alice",

--- a/framework/app-service/pkg/appstate/update_status_rapid_test.go
+++ b/framework/app-service/pkg/appstate/update_status_rapid_test.go
@@ -74,7 +74,8 @@ func TestUpdateStatusInvariantsUnderRandomSequence(t *testing.T) {
 				rt.Fatalf("after call %d newest record=%q, want %q", i, got.Status.OpRecords[0].OpID, id)
 			}
 		}
-	})}
+	})
+}
 
 // Companion test: invalid transitions must be rejected and must NOT mutate
 // any storage-level state (no OpGeneration bump, no record prepend).

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -61,7 +61,7 @@ func TestLegacyAppConfigIsMappedToComputeModes(t *testing.T) {
 		},
 	}
 	plan := calculateInstallComputePlan(cpuApp, []Node{
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	})
 	assertModeStatus(t, plan, utils.CPUType, StatusInstallable)
 
@@ -92,7 +92,7 @@ func TestCPUModeFallsBackToGPUTypeNodesWithoutUsingGPUMemory(t *testing.T) {
 		LimitedMemory:  8 * gi,
 	}
 	nodes := []Node{
-		computeNode("cpu-small", utils.CPUType, 4*gi, SupportTypeMemoryShared),
+		computeNode("cpu-small", utils.CPUType, 4*gi, SupportTypeMemorySlice),
 		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
 	}
 
@@ -121,7 +121,7 @@ func TestListAvailableForLaunchFiltersNotMatchAndMarksOperable(t *testing.T) {
 			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
 		),
 		nvidiaNode("nvidia-b", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	}
 
 	result := listAvailableForLaunch(req, nodes, PressureSnapshot{})
@@ -145,7 +145,7 @@ func TestListAvailableForLaunchFiltersNotMatchAndMarksOperable(t *testing.T) {
 func TestListAvailableForLaunchReportsNoMatchingNode(t *testing.T) {
 	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: gi, LimitedGPU: gi}
 	result := listAvailableForLaunch(req, []Node{
-		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemoryShared),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
 	}, PressureSnapshot{})
 
 	if result.Schedulable || result.Reason != "no-matching-node" || len(result.Nodes) != 0 {
@@ -396,10 +396,10 @@ func TestPickAggregateAllocationsAcrossNodes(t *testing.T) {
 // TestPickSingleAllocationGB10MemorySlice guards the GB10 single-card
 // allocation path: a GB10 node's device is decoded with the MemorySlice
 // support type by default (shareModeToSupportType), so PickAllocations must
-// offer MemorySlice in its support-type order. A regression here makes
-// supportTypeOrder fall back to the cpu-only [Exclusive, MemoryShared] set,
-// filters every GB10 candidate out, and surfaces as
-// "no available compute resource for type nvidia-gb10" at install time.
+// offer MemorySlice in its support-type order. GB10 shares the non-nvidia
+// [Exclusive, MemorySlice] order; dropping MemorySlice from it would filter
+// every GB10 candidate out and surface as "no available compute resource for
+// type nvidia-gb10" at install time.
 func TestPickSingleAllocationGB10MemorySlice(t *testing.T) {
 	app := &appcfg.ApplicationConfig{AppName: "ollama", OwnerName: "alice"}
 	req := Requirement{

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -405,21 +405,17 @@ func isWholeCardMode(mode, supportType string) bool {
 }
 
 func supportTypeOrder(mode string) []string {
-	switch mode {
-	case utils.NvidiaCardType:
+	if mode == utils.NvidiaCardType {
 		return []string{SupportTypeExclusive, SupportTypeMemorySlice, SupportTypeTimeSlice}
-	case utils.GB10ChipType:
-		// GB10 devices are decoded from the HAMI node-nvidia-register
-		// annotation and carry MemorySlice (the default) or Exclusive
-		// support types, matching AvailableSupportTypes(GB10ChipType).
-		// MemoryShared is a cpu-only support type and never appears on a
-		// GB10 device, so the default branch below would filter every
-		// candidate out and make AllocateForInstall report
-		// "no available compute resource for type nvidia-gb10".
-		return []string{SupportTypeExclusive, SupportTypeMemorySlice}
-	default:
-		return []string{SupportTypeExclusive, SupportTypeMemoryShared}
 	}
+	// Every non-nvidia mode (nvidia-gb10 plus the unified-memory accelerators:
+	// cpu / apple-m / intel / amd / moore-soc / discrete GPUs) only ever
+	// carries Exclusive or MemorySlice devices — TimeSlice is nvidia-only.
+	// Listing Exclusive first keeps the scheduler's preference for whole-device
+	// placement before it falls back to a memory slice, and including
+	// MemorySlice is what lets GB10 (decoded as MemorySlice by default) and the
+	// memory-slicing accelerators be scheduled at all.
+	return []string{SupportTypeExclusive, SupportTypeMemorySlice}
 }
 
 func deviceAvailableMemory(device Device) int64 {
@@ -429,7 +425,7 @@ func deviceAvailableMemory(device Device) int64 {
 			return 0
 		}
 		return device.Memory
-	case SupportTypeMemorySlice, SupportTypeMemoryShared:
+	case SupportTypeMemorySlice:
 		return remainingMemory(device)
 	case SupportTypeTimeSlice:
 		return device.Memory

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -238,20 +238,18 @@ func buildNodeResource(node *corev1.Node) Node {
 
 // nonHAMIDevice builds the single synthetic device used for unified-memory
 // modes (cpu, apple-m, amd, intel, moore-soc, …): the whole node is one
-// schedulable unit drawing from system memory. cpu is memory-shared; every
-// other such mode is exclusive (the Apple-Silicon path).
+// schedulable unit drawing from system memory. The support type is the mode's
+// default (defaultSupportType): cpu / intel / amd / moore-soc share the memory
+// via MemorySlice, while apple-m and any discrete-GPU / future mode take the
+// whole device exclusively.
 func nonHAMIDevice(node *corev1.Node, mode string, totalMemory int64) Device {
-	supportType := SupportTypeExclusive
-	if mode == utils.CPUType {
-		supportType = SupportTypeMemoryShared
-	}
 	return Device{
 		ID:                    fmt.Sprintf("%s-%s-0", node.Name, mode),
 		NodeName:              node.Name,
 		Mode:                  mode,
 		Memory:                totalMemory * 75 / 100,
 		Health:                nodeHealth(node),
-		SupportType:           supportType,
+		SupportType:           defaultSupportType(mode),
 		AvailableSupportTypes: AvailableSupportTypes(mode),
 	}
 }
@@ -303,6 +301,9 @@ func boolHealth(healthy bool) string {
 	return deviceHealthNo
 }
 
+// shareModeToSupportType maps a device's HAMI share-mode annotation to a
+// support type. An unset / unrecognized annotation falls back to the mode's
+// default (defaultSupportType): nvidia → TimeSlice, nvidia-gb10 → MemorySlice.
 func shareModeToSupportType(gpuType, shareMode string) string {
 	switch shareMode {
 	case "0":
@@ -310,10 +311,7 @@ func shareModeToSupportType(gpuType, shareMode string) string {
 	case "1":
 		return SupportTypeMemorySlice
 	default:
-		if gpuType == utils.GB10ChipType {
-			return SupportTypeMemorySlice
-		}
-		return SupportTypeTimeSlice
+		return defaultSupportType(gpuType)
 	}
 }
 
@@ -334,17 +332,33 @@ func shareModeAnnotationKey(deviceID string) string {
 	return fmt.Sprintf("sharemode.gpu.bytetrade.io/%s", deviceID)
 }
 
+// AvailableSupportTypes lists the support types a device of the given mode may
+// take. The first entry is the mode's default — the one assigned when no share
+// mode is configured (see defaultSupportType). nvidia can switch among all
+// three; nvidia-gb10 defaults to MemorySlice but may switch to Exclusive; cpu
+// and the unified-memory accelerators (intel / amd / moore-soc) only do
+// MemorySlice; apple-m and any discrete-GPU (intel-gpu / amd-gpu) or future
+// mode are Exclusive-only for now.
 func AvailableSupportTypes(mode string) []string {
 	switch mode {
 	case utils.NvidiaCardType:
 		return []string{SupportTypeTimeSlice, SupportTypeMemorySlice, SupportTypeExclusive}
 	case utils.GB10ChipType:
 		return []string{SupportTypeMemorySlice, SupportTypeExclusive}
-	case utils.CPUType:
-		return []string{SupportTypeMemoryShared}
+	case utils.CPUType, utils.IntelType, utils.AMDType, utils.MooreSocType:
+		return []string{SupportTypeMemorySlice}
 	default:
 		return []string{SupportTypeExclusive}
 	}
+}
+
+// defaultSupportType is the support type a device of the given mode receives
+// when its share mode has not been explicitly configured. It is, by contract,
+// the first entry of AvailableSupportTypes(mode): nvidia → TimeSlice,
+// nvidia-gb10 and the unified-memory modes (cpu / intel / amd / moore-soc) →
+// MemorySlice, apple-m and any discrete-GPU / future mode → Exclusive.
+func defaultSupportType(mode string) string {
+	return AvailableSupportTypes(mode)[0]
 }
 
 func attachBindings(nodes []Node, allocations []Allocation) {

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -43,8 +43,8 @@ func TestBuildNodeResourcePureCPU(t *testing.T) {
 	if len(n.GPUTypes) != 0 {
 		t.Fatalf("pure-cpu node should advertise no gpu types, got %v", n.GPUTypes)
 	}
-	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.CPUType || n.Devices[0].SupportType != SupportTypeMemoryShared {
-		t.Fatalf("expected a single cpu memory-shared device, got %+v", n.Devices)
+	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.CPUType || n.Devices[0].SupportType != SupportTypeMemorySlice {
+		t.Fatalf("expected a single cpu memory-slice device, got %+v", n.Devices)
 	}
 	if !n.SupportsMode(utils.CPUType) {
 		t.Fatal("every node must support cpu")
@@ -70,11 +70,11 @@ func TestBuildNodeResourceMultiMode(t *testing.T) {
 		t.Fatal("node must not claim support for amd")
 	}
 
-	// The intel mode follows the Apple-Silicon path: one exclusive device,
-	// tagged with its mode and the node-mode device id.
+	// Intel is a unified-memory accelerator: one MemorySlice device, tagged
+	// with its mode and the node-mode device id.
 	intelDevs := devicesForMode(n, utils.IntelType)
-	if len(intelDevs) != 1 || intelDevs[0].SupportType != SupportTypeExclusive {
-		t.Fatalf("expected one exclusive intel device, got %+v", intelDevs)
+	if len(intelDevs) != 1 || intelDevs[0].SupportType != SupportTypeMemorySlice {
+		t.Fatalf("expected one memory-slice intel device, got %+v", intelDevs)
 	}
 	if intelDevs[0].ID != "olares-one-intel-0" {
 		t.Fatalf("unexpected intel device id %q", intelDevs[0].ID)
@@ -100,7 +100,7 @@ func TestBindingSelectionResolvesDeviceOnMultiModeNode(t *testing.T) {
 		memoryCapacity: 32 * gi,
 		Devices: []Device{
 			{ID: "gpu0", NodeName: "olares-one", Mode: utils.NvidiaCardType, Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.NvidiaCardType)},
-			{ID: "olares-one-intel-0", NodeName: "olares-one", Mode: utils.IntelType, Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive, AvailableSupportTypes: AvailableSupportTypes(utils.IntelType)},
+			{ID: "olares-one-intel-0", NodeName: "olares-one", Mode: utils.IntelType, Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice, AvailableSupportTypes: AvailableSupportTypes(utils.IntelType)},
 		},
 	}
 	nodes := []Node{node}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -11,10 +11,9 @@ const (
 	StatusInsufficientResources = "insufficient-resources"
 	StatusNoMatchingNode        = "no-matching-node"
 
-	SupportTypeTimeSlice    = "TimeSlice"
-	SupportTypeMemorySlice  = "MemorySlice"
-	SupportTypeExclusive    = "Exclusive"
-	SupportTypeMemoryShared = "MemoryShared"
+	SupportTypeTimeSlice   = "TimeSlice"
+	SupportTypeMemorySlice = "MemorySlice"
+	SupportTypeExclusive   = "Exclusive"
 
 	allocationConfigMapNamespace = "os-framework"
 	allocationConfigMapName      = "app-gpu-allocations"

--- a/framework/app-service/pkg/gateway/producer.go
+++ b/framework/app-service/pkg/gateway/producer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
## Summary
- Drop the `SupportTypeMemoryShared` support type, which overlapped with `MemorySlice` (both partition device memory among pods). CPU and the unified-memory accelerators now use `MemorySlice`.
- Introduce `defaultSupportType` (the first entry of `AvailableSupportTypes`) as the single source of truth for the support type a device gets when its share mode is not configured:
  - `nvidia` → `TimeSlice`
  - `nvidia-gb10` → `MemorySlice`
  - `intel` / `amd` / `moore-soc` → `MemorySlice` (only mode supported for now)
  - `apple-m` → `Exclusive` (only mode supported for now)
- Keep the fallback path so `intel-gpu` / `amd-gpu` and any future mode remain supported (default to `Exclusive`).

## Changes
- `pkg/compute/types.go`: remove `SupportTypeMemoryShared` constant.
- `pkg/compute/store.go`: add `defaultSupportType`; route `nonHAMIDevice` and `shareModeToSupportType` through it; extend `AvailableSupportTypes` so intel/amd/moore-soc report `MemorySlice` and cpu switches from `MemoryShared` to `MemorySlice`.
- `pkg/compute/scheduler.go`: collapse `supportTypeOrder` non-nvidia branches into `[Exclusive, MemorySlice]`; drop `MemoryShared` from `deviceAvailableMemory`.
- Tests updated accordingly (`store_test.go`, `calculator_test.go`).

Note: `intel`/`amd`/`moore-soc` switch from whole-device `Exclusive` to `MemorySlice` by default; mode switching for non-HAMI devices remains gated by `IsHAMIMode`, so "only mode supported for now" holds. The CLI legacy-binding migration and the GPU dashboard label layer read HAMI's raw share mode directly and are unaffected.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/compute/...`
- [x] `go vet ./pkg/compute/...`

Made with [Cursor](https://cursor.com)