### PR TITLE
fix(app-service): allow uninstall from installFailed and fast-fail stuck installs

### DIFF
--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -629,6 +629,11 @@ func (h *HelmOps) WaitForStartUp() (bool, error) {
 		return true, nil
 	}
 	timer := time.NewTicker(1 * time.Second)
+	// unrecoverableSince records when an unrecoverable pod condition was first
+	// observed while the app is still not started. Once it persists past
+	// unrecoverableGrace, startup fails fast instead of polling until the outer
+	// installing TTL expires (which left CrashLoopBackOff apps stuck ~30m).
+	var unrecoverableSince time.Time
 	for {
 		select {
 		case <-timer.C:
@@ -644,6 +649,18 @@ func (h *HelmOps) WaitForStartUp() (bool, error) {
 			}
 			if errors.Is(err, errcode.ErrPodPending) || errors.Is(err, errcode.ErrServerSidePodPending) {
 				return false, err
+			}
+
+			if reason, ok := h.hasUnrecoverablePod(h.ctx); ok {
+				if unrecoverableSince.IsZero() {
+					unrecoverableSince = time.Now()
+					klog.Warningf("app %s has unrecoverable pod (%s); will fail startup if it persists for %s",
+						h.app.AppName, reason, unrecoverableGrace)
+				} else if time.Since(unrecoverableSince) > unrecoverableGrace {
+					return false, fmt.Errorf("app %s failed to start up: %s", h.app.AppName, reason)
+				}
+			} else {
+				unrecoverableSince = time.Time{}
 			}
 
 		case <-h.ctx.Done():

--- a/framework/app-service/pkg/appstate/state_transition.go
+++ b/framework/app-service/pkg/appstate/state_transition.go
@@ -172,6 +172,7 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 	},
 	appv1alpha1.InstallFailed: {
 		appv1alpha1.Pending,
+		appv1alpha1.Uninstalling,
 	},
 
 	appv1alpha1.StopFailed: {
@@ -313,7 +314,8 @@ var OperationAllowedInState = map[appv1alpha1.ApplicationManagerState]map[appv1a
 		appv1alpha1.InstallOp: true,
 	},
 	appv1alpha1.InstallFailed: {
-		appv1alpha1.InstallOp: true,
+		appv1alpha1.InstallOp:   true,
+		appv1alpha1.UninstallOp: true,
 	},
 	//appv1alpha1.InitialFailed: {
 	//	appv1alpha1.UpgradeOp:   true,

--- a/framework/app-service/pkg/appstate/state_transition_test.go
+++ b/framework/app-service/pkg/appstate/state_transition_test.go
@@ -16,6 +16,7 @@ func TestIsStateTransitionValid(t *testing.T) {
 		{appsv1.Downloading, appsv1.Installing, true},
 		{appsv1.Installing, appsv1.Initializing, true},
 		{appsv1.Installing, appsv1.InstallFailed, true},
+		{appsv1.InstallFailed, appsv1.Uninstalling, true},
 		{appsv1.Initializing, appsv1.Running, true},
 		{appsv1.Running, appsv1.Uninstalling, true},
 		{appsv1.Uninstalling, appsv1.Uninstalled, true},
@@ -146,6 +147,7 @@ func TestIsOperationAllowed(t *testing.T) {
 		{appsv1.Running, appsv1.InstallOp, false},
 		{appsv1.Uninstalling, appsv1.UninstallOp, false},
 		{appsv1.InstallFailed, appsv1.InstallOp, true},
+		{appsv1.InstallFailed, appsv1.UninstallOp, true},
 		{appsv1.Pending, appsv1.CancelOp, true},
 		{appsv1.Pending, appsv1.UninstallOp, false},
 	}

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"context"
 	"fmt"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"os"
 	"time"
 
@@ -110,6 +111,9 @@ func UninstallCharts(cfg *action.Configuration, releaseName string) error {
 	uninstall.KeepHistory = false
 	r, err := uninstall.Run(releaseName)
 	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return nil
+		}
 		if r != nil && r.Release != nil && r.Release.Info != nil &&
 			r.Release.Info.Status == release.StatusUninstalled {
 			return nil


### PR DESCRIPTION
## Summary
- `WaitForStartUp` now fast-fails when a workload is stuck on unrecoverable pod states (`CrashLoopBackOff` / `ImagePullBackOff`) past the grace window, instead of looping until the operation times out. The returned error drives the app into `Stopping` so it lands in a clean terminal state.
- `installFailed` now accepts `UninstallOp` (added the `InstallFailed -> Uninstalling` transition edge). A failed install can be uninstalled directly, instead of only being reinstallable or removable via `market delete`.

## Why
A chart that fails to start (e.g. a debug image in `CrashLoopBackOff`) used to leave the app wedged: the install hung, and once it failed the only way out was reinstall/delete — the namespace could linger. These two changes let a failed install be torn down cleanly and stop stuck installs from hanging.

## Test plan
- [x] `go build ./pkg/appstate/... ./pkg/apiserver/... ./pkg/appinstaller/...`
- [x] `go test ./pkg/appstate/` (state-transition tests, incl. new `installFailed` uninstall cases)
- [ ] Manual: upload a chart that crash-loops, confirm it reaches a terminal failed state and can be uninstalled directly with the namespace removed.

Made with [Cursor](https://cursor.com)