### PR TITLE
feat(cli/market): make uninstall fully remove in-flight apps

### DIFF
--- a/cli/cmd/ctl/market/uninstall.go
+++ b/cli/cmd/ctl/market/uninstall.go
@@ -2,14 +2,31 @@ package market
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/cmd/ctl/market/cancel"
 	"github.com/beclab/Olares/cli/cmd/ctl/market/uninstall"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
+
+// inFlightCancelableStates mirrors app-service's CancelableStates: while the
+// app is mid-operation, app-service rejects a direct uninstall and only
+// accepts a cancel. `market uninstall` orchestrates around this (cancel
+// first, then finish with a real uninstall if the cancel only stopped the
+// app) so "uninstall == fully remove" holds regardless of state.
+var inFlightCancelableStates = map[string]bool{
+	"pending":      true,
+	"downloading":  true,
+	"installing":   true,
+	"initializing": true,
+	"upgrading":    true,
+	"applyingEnv":  true,
+	"resuming":     true,
+}
 
 func NewCmdMarketUninstall(f *cmdutil.Factory) *cobra.Command {
 	opts := newMarketOptions(f)
@@ -95,6 +112,7 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 	// builder includes it only when non-empty; the 1.12.5 builder ignores it.
 	source := strings.TrimSpace(opts.Source)
 	version := strings.TrimSpace(opts.Version)
+	var curState string
 	row, lookupErr := lookupInstalledApp(ctx, mc, appName)
 	if lookupErr != nil {
 		return opts.failOp("uninstall", appName, lookupErr)
@@ -106,6 +124,7 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 		if version == "" {
 			version = strings.TrimSpace(row.Version)
 		}
+		curState = strings.TrimSpace(row.State)
 	}
 
 	cascadeExplicit := cmd != nil && cmd.Flags().Changed("cascade")
@@ -119,6 +138,15 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 		} else {
 			opts.info("--cascade auto-enabled: %s", why)
 		}
+	}
+
+	// In-flight app: app-service rejects a direct uninstall while an
+	// operation is in progress and only accepts cancel. Orchestrate the full
+	// removal from the CLI (cancel first, then a real uninstall if the cancel
+	// only stopped the app) so "uninstall == fully remove" holds regardless
+	// of state.
+	if row != nil && inFlightCancelableStates[curState] {
+		return runUninstallViaCancel(opts, mc, appName, source, version, cascade, curState, atLeast126)
 	}
 
 	opts.info("Uninstalling '%s' for user '%s'...", appName, mc.olaresID)
@@ -165,6 +193,93 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 	// once the backend cleans it up, so the watch target opts in to the
 	// "absent means success (provided we saw it earlier)" shortcut.
 	return runWithWatch(opts, mc, result, newWatchTarget(watchUninstall, appName, source))
+}
+
+// runUninstallViaCancel handles `uninstall` against an in-flight app.
+// app-service rejects a direct uninstall while an operation is in progress
+// and only accepts cancel, so we orchestrate the removal entirely from the
+// CLI:
+//
+//  1. cancel and block until the row settles;
+//  2. if the cancel tore the app down (the pending/downloading/installing
+//     flow cancels into a *Canceled state with the namespace deleted, or the
+//     row reaches uninstalled / vanishes) we are done — that is equivalent to
+//     uninstalled;
+//  3. if the cancel only stopped the app (initializing/upgrading/applyingEnv/
+//     resuming cancel into stopped, or a race left it running) the app is
+//     still present, so issue the real uninstall — now allowed from
+//     stopped/running — and finish under --watch.
+//
+// The cancel step always blocks (it must, to decide step 3) regardless of
+// --watch.
+func runUninstallViaCancel(opts *MarketOptions, mc *MarketClient, appName, source, version string, cascade bool, curState string, atLeast126 bool) error {
+	ctx := context.Background()
+
+	opts.info("'%s' is %s (operation in progress); canceling it first...", appName, curState)
+	cancelMethod, cancelPath, cancelBody := cancel.Build(atLeast126, appName, source, version)
+	if _, err := mc.doRequest(ctx, cancelMethod, cancelPath, cancelBody); err != nil {
+		return opts.failOp("uninstall", appName, fmt.Errorf("cancel in-progress operation: %w", err))
+	}
+
+	// watchCancel's success set is the widest in the tree (any "stopped
+	// moving" state); it fails only on *CancelFailed.
+	cancelRow, err := waitForTerminal(ctx, mc, opts, newWatchTarget(watchCancel, appName, source))
+	if err != nil {
+		return finishWatchError(opts, mc, "uninstall", appName, source, err)
+	}
+	settled := strings.TrimSpace(cancelRow.State)
+
+	// Install-flow cancel deletes the namespace -> the app is gone. Treat
+	// *Canceled / uninstalled / a vanished row as a completed uninstall.
+	if settled == "" || settled == "uninstalled" || canceledStates[settled] {
+		final := newOperationResult(mc, "uninstall", appName, source, "", "", nil)
+		final.Status = "success"
+		final.State = settled
+		final.FinalState = settled
+		final.Source = source
+		final.Message = fmt.Sprintf("uninstall completed via cancel (state=%s)", valueOrUnknown(settled))
+		if !opts.Quiet {
+			opts.printResult(final)
+		}
+		return nil
+	}
+
+	// Cancel only stopped the app (or raced and left it running); the app is
+	// still present, so finish the job with a real uninstall.
+	opts.info("'%s' settled at %s after cancel; issuing uninstall to fully remove it...", appName, settled)
+
+	method, path, body := uninstall.Build(atLeast126, appName, source, version, cascade, opts.DeleteData)
+	resp, err := mc.doRequest(ctx, method, path, body)
+	if err != nil {
+		return opts.failOp("uninstall", appName, err)
+	}
+	result := newOperationResult(mc, "uninstall", appName, source, "", "uninstall requested", resp)
+	return runWithWatch(opts, mc, result, newWatchTarget(watchUninstall, appName, source))
+}
+
+// finishWatchError renders a terminal watch error (failure / timeout) as a
+// failed OperationResult and returns errReported, mirroring runWithWatch's
+// error path so multi-step flows surface structured output too.
+func finishWatchError(opts *MarketOptions, mc *MarketClient, op, appName, source string, err error) error {
+	failed := newOperationResult(mc, op, appName, source, "", "", nil)
+	failed.Status = "failed"
+	failed.Message = err.Error()
+	var fail *watchFailureError
+	if errors.As(err, &fail) {
+		failed.State = fail.row.State
+		failed.Progress = fail.row.Progress
+		failed.FinalState = fail.row.State
+		failed.FinalOpType = fail.row.OpType
+	}
+	var to *watchTimeoutError
+	if errors.As(err, &to) && to.last != nil {
+		failed.State = to.last.State
+		failed.Progress = to.last.Progress
+		failed.FinalState = to.last.State
+		failed.FinalOpType = to.last.OpType
+	}
+	opts.printResult(failed)
+	return errReported
 }
 
 // resolveCascade computes the final value of the `all` flag for uninstall /

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -73,6 +73,16 @@ The JSON payload field is `all`. Default behavior mirrors the SPA's `csAppUninst
 - A short reason is printed on **stderr** when the auto-decision flips the default to true.
 - Probe errors (user count / app info) soft-fail to `--cascade=false`; the backend has the final say either way.
 
+### Uninstalling an in-flight app (auto-orchestrated)
+
+app-service only accepts `uninstall` from a settled state (`running` / `stopped` / a terminal `*Failed`, including `installFailed`); while an operation is in flight it accepts only `cancel`. `market uninstall` handles this for you so **`uninstall` always means "fully remove"** regardless of state:
+
+- If the app is **in-flight** (`pending` / `downloading` / `installing` / `initializing` / `upgrading` / `applyingEnv` / `resuming`), the CLI **cancels first**, then:
+  - the `pending` / `downloading` / `installing` flow cancels into a `*Canceled` state that **tears the partial install down (namespace deleted)** — equivalent to uninstalled, so the command finishes there;
+  - `initializing` / `upgrading` / `applyingEnv` / `resuming` cancel only **stops** the app (lands in `stopped`), so the CLI then issues the **real uninstall** to finish removing it.
+- The cancel step always blocks (it must, to decide the next step) even without `--watch`.
+- `installFailed` no longer needs this dance — `uninstall` is accepted directly.
+
 ## `clone`
 
 ```bash
@@ -112,6 +122,7 @@ olares-cli market cancel firefox --watch               # block until row stops m
 - **The widest watcher in the tree**: any "row stopped moving" state counts as success, including `*Canceled`, `*Failed` (the underlying op died, cancel "won by default"), and stable resting states `running` / `stopped` / `uninstalled` (cancel raced and lost, OR rollback landed).
 - Failure is ONLY surfaced for `*CancelFailed` (the cancel request itself was rejected).
 - The terminal row carries the **underlying op** (install / upgrade / ...) as its `opType`, not `cancel`. `matchOpType` is OFF — no race-tracking gate applies.
+- **Teardown vs stop**: cancel of the `pending` / `downloading` / `installing` flow **tears the partial install down (namespace deleted)** — functionally equivalent to uninstall. Cancel of `initializing` / `upgrading` / `applyingEnv` / `resuming` only **stops** the app (lands in `stopped`); the app is still installed. `market uninstall` relies on this split when auto-orchestrating (see `uninstall` above).
 
 ## `--watch` interaction with each verb
 
@@ -119,7 +130,7 @@ olares-cli market cancel firefox --watch               # block until row stops m
 |---|---|---|
 | `install` | `running` | App already installed → returns immediately |
 | `upgrade` | `running` (matchOpType=upgrade) | — (handled by pre-flight) |
-| `uninstall` | `uninstalled`, row disappears | App already uninstalled → returns immediately |
+| `uninstall` | `uninstalled`, row disappears (or `*Canceled` when an in-flight app was auto-canceled) | App already uninstalled → returns immediately; in-flight apps are canceled first, then uninstalled if still present |
 | `clone` | `running` on the new clone name | — |
 | `stop` | `stopped` | Already stopped → returns immediately |
 | `resume` | `running` | Already running → returns immediately |


### PR DESCRIPTION
## Summary
- `market uninstall` now detects an in-flight app from its per-user state row (`pending` / `downloading` / `installing` / `initializing` / `upgrading` / `applyingEnv` / `resuming`) and orchestrates the full teardown from the CLI, instead of firing a direct uninstall that app-service rejects.
- Flow: issue a `cancel` and block until the row settles; if it tore down (`*Canceled` / `uninstalled` / vanished row) the uninstall is complete; otherwise (cancel only stopped the app) issue the real `uninstall` and finish under `--watch`.
- Updated the `olares-market` skill docs (in-flight uninstall orchestration + cancel teardown-vs-stop note + `--watch` table).

## Why
app-service only accepts `cancel` (not `uninstall`) while an operation is in progress. Previously `market uninstall` against an in-flight app reported failure even though the user asked to remove it, and the app/namespace could linger — a confusing "looks uninstalled but isn't" state. This makes "uninstall == fully remove" hold regardless of the app's current state.

## Notes
- Re-based onto the current `main` `uninstall.go` (1.12.6 backend version-aware builder). Cancel is issued via `cancel.Build` + `doRequest`, matching `runCancel`. The change is purely additive (no existing behavior removed).

## Test plan
- [x] `go build ./cmd/ctl/market/...`
- [x] `go vet ./cmd/ctl/market/`
- [x] `go test ./cmd/ctl/market/`
- [ ] Manual: `market uninstall` an `installing` app → confirm it cancels, then fully removes (namespace gone), and `--watch` reports success.

Made with [Cursor](https://cursor.com)