### PR TITLE
docs(skills/olares-chart): document CAP_CHOWN limit, Helm empty-string env, and upgrade recovery

### DIFF
--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -82,6 +82,23 @@ Use [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`cluster p
 - Pod names for the Deployments are dynamic (`market-deployment-*`, `chartrepo-deployment-*`); resolve the exact name first with `olares-cli cluster pod list -n os-framework` (filter the output for `market` / `chartrepo`).
 - **Admin caveat:** `os-framework` system pods are typically visible only to an **admin** profile. If you get `HTTP 403` / `HTTP 404`, the active developer profile isn't admin — don't fight it; report that the platform logs need an admin and fall back to the app's own pod logs.
 
+## 4b. Upgrade recovery: `stopped` after upgrade
+
+After `market upgrade`, app-service orchestrates stop → deploy → start. If the sequence is interrupted mid-flight (e.g. watcher timeout, or a crashing initContainer that was later fixed and redeployed), the app can land in `state=stopped` even though the pod is actually `Running`:
+
+```bash
+olares-cli market status <app> -s upload   # state=stopped, op=upgrade
+olares-cli cluster application status <ns> # Deployment 1/1 Running
+```
+
+This is **not** a failure — it means stop succeeded but start was never issued. Recovery:
+
+```bash
+olares-cli market resume <app> --watch
+```
+
+`resume` transitions `stopped → resuming → running`. If the pod is already running it completes instantly and flips the market row to `running`.
+
 ## 5. Decide: fix the chart, or report back
 
 - **Problem is in the chart** (wrong image ref, missing/incorrect env, bad volume mount, entrance host/port, undeclared `permission` for a userspace mount, **uid/permission mismatch on userspace volumes**, ...): edit the manifest/templates per [`olares-chart-manifest.md`](olares-chart-manifest.md) and [`olares-chart-run-as-user.md`](olares-chart-run-as-user.md), re-run `chart lint`, and re-upload (the auto-loop continues). **No version bump needed to redeploy a fix** — `upload` requires the new version be **>= the stored** one, so re-uploading the *same* version overwrites the stored chart. Keep `Chart.yaml` `version` == `metadata.version` (lint enforces equality); bump only if you want to track iterations (a *lower* version is rejected).

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -84,20 +84,20 @@ Use [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`cluster p
 
 ## 4b. Upgrade recovery: `stopped` after upgrade
 
-After `market upgrade`, app-service orchestrates stop → deploy → start. If the sequence is interrupted mid-flight (e.g. watcher timeout, or a crashing initContainer that was later fixed and redeployed), the app can land in `state=stopped` even though the pod is actually `Running`:
+An upgrade can leave the **market row** in `state=stopped` while the **workload** is actually `Running`. Two paths land in `stopped`: upgrading an **already-stopped** app re-renders the chart at `replicas=0` and intentionally returns to `stopped` (by design); and **canceling an in-flight** op (`initializing` / `upgrading` / `applyingEnv` / `resuming`) only *stops* the app — so if a crashing initContainer was fixed and the workload later came up on its own, the row can read `stopped` while the pod is `1/1 Running`:
 
 ```bash
-olares-cli market status <app> -s upload   # state=stopped, op=upgrade
+olares-cli market status <app> -s upload   # state=stopped
 olares-cli cluster application status <ns> # Deployment 1/1 Running
 ```
 
-This is **not** a failure — it means stop succeeded but start was never issued. Recovery:
+This is **not** a failure — the market row just needs to be resumed. Recovery:
 
 ```bash
 olares-cli market resume <app> --watch
 ```
 
-`resume` transitions `stopped → resuming → running`. If the pod is already running it completes instantly and flips the market row to `running`.
+`resume` scales the workloads back up and waits for startup (`stopped → resuming → running`). If the pod is already running it completes quickly and flips the market row to `running`.
 
 ## 5. Decide: fix the chart, or report back
 

--- a/cli/skills/olares-chart/references/olares-chart-env.md
+++ b/cli/skills/olares-chart/references/olares-chart-env.md
@@ -118,3 +118,9 @@ Copy-pasteable examples (init admin credentials, reuse a user var, optional-with
 - **`valueFrom` inherits** `type`/`editable`/`regex` from the referenced var; local `default`/`options`/`type` are ignored.
 - **Install-time override.** A value can be supplied at install via the CLI `--env KEY=VALUE` (see [`olares-market`](../../olares-market/SKILL.md)).
 - **`applyOnChange: false`** means edits only take effect on upgrade/reinstall — stopping and starting the app does nothing.
+- **Helm renders unset optional env vars as empty strings.** When a user hasn't filled in an optional env (`required: false`, no `default`) and the template contains `value: "{{ .Values.olaresEnv.FOO }}"`, Helm renders this as `value: ""` — an empty string, not an absent env var. Apps that treat these as URLs (e.g. an HF endpoint, a proxy address) will receive `""` and fail with "missing protocol" or similar errors. Guard at app startup: unset any env var whose value is an empty string before the library reads it. Example (Python):
+  ```python
+  for var in ("HF_ENDPOINT", "HF_TOKEN"):
+      if not os.environ.get(var, "").strip():
+          os.environ.pop(var, None)
+  ```

--- a/cli/skills/olares-chart/references/olares-chart-env.md
+++ b/cli/skills/olares-chart/references/olares-chart-env.md
@@ -124,3 +124,4 @@ Copy-pasteable examples (init admin credentials, reuse a user var, optional-with
       if not os.environ.get(var, "").strip():
           os.environ.pop(var, None)
   ```
+  This `""` behavior applies only to a key **declared in `envs[]`** (so it exists in `.Values.olaresEnv`). A reference to a key that is *not declared at all* renders as `<no value>` instead — a different failure mode — so keep every env you template referenced in `envs[]`.

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -102,6 +102,13 @@ spec:
 
 Also set `spec.runAsUser: true` in `OlaresManifest.yaml`. Run `chown` for **each** userspace mount the app writes to (combine paths in one command if needed).
 
+> **CAP_CHOWN limitation — upgrade scenario.** Olares drops `CAP_CHOWN` from all containers at admission. This means:
+>
+> - **Fresh install:** the `hostPath` root dir is created empty by `DirectoryOrCreate` (owned by kubelet/root). The busybox initContainer runs as root and can `chown` it because root owns the directory. Works.
+> - **Upgrade:** if the main container previously created subdirectories as uid 1000, the busybox initContainer (root, no `CAP_CHOWN`) **cannot** chown those uid-1000-owned subdirs — `Operation not permitted`. The initContainer crash-loops and the pod stays in `Initializing` indefinitely.
+>
+> **Practical rule:** For `appData` / `appCache` with `permission.appData: true`, Olares already creates the root dir with uid 1000 ownership. If the app creates its own subdirectories at runtime (e.g. `os.makedirs("/data/models")` in Python), the whole tree stays uid 1000 and **no initContainer is needed**. Only reach for initContainer `chown` when the upstream image's entrypoint writes root-owned files before the process drops to uid 1000.
+
 ### C — image must start as root internally
 
 If the upstream entrypoint **requires** root for its own initialization, you cannot set `runAsUser: 1000` on the main container without breaking it.

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -102,10 +102,12 @@ spec:
 
 Also set `spec.runAsUser: true` in `OlaresManifest.yaml`. Run `chown` for **each** userspace mount the app writes to (combine paths in one command if needed).
 
-> **CAP_CHOWN limitation — upgrade scenario.** Olares drops `CAP_CHOWN` from all containers at admission. This means:
+> **`chown` of pre-owned subdirs can fail on upgrade.** A root initContainer can `chown` a root-owned directory, but has been observed to fail with `Operation not permitted` when `chown`-ing subdirectories the main container previously created as uid 1000 — as if `CAP_CHOWN` is unavailable. This means:
 >
 > - **Fresh install:** the `hostPath` root dir is created empty by `DirectoryOrCreate` (owned by kubelet/root). The busybox initContainer runs as root and can `chown` it because root owns the directory. Works.
-> - **Upgrade:** if the main container previously created subdirectories as uid 1000, the busybox initContainer (root, no `CAP_CHOWN`) **cannot** chown those uid-1000-owned subdirs — `Operation not permitted`. The initContainer crash-loops and the pod stays in `Initializing` indefinitely.
+> - **Upgrade:** if the main container previously created subdirectories as uid 1000, the busybox initContainer **fails to** `chown` those uid-1000-owned subdirs — `Operation not permitted` — crash-loops, and the pod stays in `Initializing` indefinitely.
+>
+> A plain root container normally keeps `CAP_CHOWN`, so the cap-dropping layer is environment-specific (likely enforced below the cluster at the node / container-runtime level). It is **not** the Olares OPA policy, which only denies untrusted-image + root/`privileged` pods (see [OPA and lint boundaries](#opa-and-lint-boundaries) below) and mutates nothing about capabilities. Treat the rule below as the safe pattern regardless of the exact mechanism.
 >
 > **Practical rule:** For `appData` / `appCache` with `permission.appData: true`, Olares already creates the root dir with uid 1000 ownership. If the app creates its own subdirectories at runtime (e.g. `os.makedirs("/data/models")` in Python), the whole tree stays uid 1000 and **no initContainer is needed**. Only reach for initContainer `chown` when the upstream image's entrypoint writes root-owned files before the process drops to uid 1000.
 


### PR DESCRIPTION
## Summary

Three gotchas discovered while porting real apps to Olares (PDF-Extract-Kit, OpenFang), added to the `olares-chart` skill references:

- **`olares-chart-run-as-user.md`**: Document that Olares drops `CAP_CHOWN` at admission. On upgrade, a busybox initContainer running as root still cannot `chown` subdirectories that were previously created by the main container as uid 1000 (EPERM). Clarify the practical rule: for `appData`/`appCache` volumes, let the app create its own subdirectories at runtime — no initContainer needed.

- **`olares-chart-env.md`**: Document that Helm renders unset optional env vars (`required: false`, no `default`) as empty strings `""`, not absent vars. Apps that consume these as URLs fail with "missing protocol". Add a guard pattern (Python example).

- **`olares-chart-deploy.md`**: Add upgrade recovery section (§4b). After a mid-flight upgrade interruption, the app can land in `state=stopped` with the pod actually `Running`. Fix: `market resume <app> --watch`.

## Test plan

- [ ] Read each updated section and verify the explanation matches observed behaviour
- [ ] Confirm the Python guard snippet is copy-pasteable and correct
- [ ] Confirm the `market resume` command syntax matches `olares-cli market resume --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to skill reference markdown; no application, CLI, or deployment behavior changes.
> 
> **Overview**
> Adds three operational gotchas to the **olares-chart** skill references (from real app ports), with no runtime or CLI code changes.
> 
> **`olares-chart-deploy.md`** — New **§4b** explains when the market row shows `stopped` while the workload is still `Running` (stopped-app upgrade by design, or cancel mid-flight after a fix). Recovery is `olares-cli market resume <app> --watch`.
> 
> **`olares-chart-env.md`** — Documents that Helm turns unset optional `envs[]` values into **`""` in the container**, not missing vars, and how that breaks URL-style settings; adds a Python startup guard and notes undeclared keys render as `<no value>`.
> 
> **`olares-chart-run-as-user.md`** — Warns that root initContainer **`chown` can EPERM on upgrade** when subdirs were created as uid 1000; recommends skipping initContainer when Olares already owns the volume root and the app creates subdirs at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3e016155357c6af72b761cd985956c2e317510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->