### PR TITLE
docs(skills/olares-chart): clarify userspace mount paths to prevent broken volumes

### DIFF
--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -101,6 +101,20 @@ olares-cli cluster pod logs <app>-<owner>/<pod> -c <main-container> --previous  
 
 `--previous` grabs the buffer from the instance that just died — usually where the real traceback is. Then jump to [§4 Diagnose by fetching logs](#4-diagnose-by-fetching-logs) and [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`--previous` is mutually exclusive with `-f`).
 
+**Empty logs across restarts? Read the exit code, not the (missing) traceback.** A container that emits nothing and still CrashLoopBackOffs did not crash on an exception — it either never started or exited cleanly. `cluster pod get -o json` **trims `lastState`** (and `securityContext`), so the terminated detail is invisible at rest; `workload restart` the deployment and poll `state` until you catch the `terminated` snapshot before it backs off again:
+
+```bash
+olares-cli cluster workload restart <ns>/<app> --kind deployment --yes
+# poll the main container's state until it shows terminated.{exitCode,reason}
+olares-cli cluster pod get <ns>/<pod> -o json   # status.containerStatuses[].state.terminated
+```
+
+Triage by what you find:
+
+- **`terminated.exitCode == 0` / `reason: Completed`** (often `startedAt == finishedAt`) → the process exited cleanly without serving — wrong/missing command, no long-lived server, the image's effective `CMD` is a no-op (e.g. bare `node` hitting EOF on a non-TTY stdin), or a **stale cached image** under a mutable tag (Olares renders `imagePullPolicy: IfNotPresent`, so a node that cached wrong bytes never re-pulls). Fix: set an explicit `command`/`args`, pin the image by digest. **Not** a permission issue — see [olares-chart-run-as-user.md](olares-chart-run-as-user.md).
+- **`terminated.exitCode != 0`** → a genuine crash; the traceback is in the `--previous` logs above.
+- **`state.waiting.reason == CreateContainerConfigError`** (the full text is in `state.waiting.message`) → securityContext / config mismatch (e.g. `runAsNonRoot` vs a non-numeric image `USER`), not an app bug.
+
 ## 4. Diagnose by fetching logs
 
 Use [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`cluster pod logs` / `cluster container logs`). The platform backends all live in namespace `os-framework`:
@@ -112,6 +126,7 @@ Use [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`cluster p
 | Install can't fetch the chart | Deployment `chartrepo-deployment`, container `chartrepo` | `olares-cli cluster container logs os-framework/<chartrepo-deployment-pod>/chartrepo` |
 | Install / orchestration failed | StatefulSet pod `app-service-0`, container `app-service` | `olares-cli cluster container logs os-framework/app-service-0/app-service` |
 | The app's own container crash-loops | the app's pods (usually `user-space-<id>` or the app namespace) | `olares-cli cluster application status <ns>` then `olares-cli cluster pod logs <ns>/<pod>` |
+| CrashLoopBackOff with **empty logs** + `exitCode 0` / `Completed` | main process exits immediately — wrong/missing command, no long-lived server, no-op image `CMD` (e.g. bare `node`), or a stale cached image under a mutable tag | set an explicit `command`/`args`, pin the image by digest — [olares-chart-run-as-user.md](olares-chart-run-as-user.md); **not** a permission fix (triage in §3) |
 | `Permission denied` / EACCES writing data, or data not persisting | uid ≠ 1000, root-owned dirs on userspace mount, missing `spec.runAsUser` | [olares-chart-run-as-user.md](olares-chart-run-as-user.md) — then back to refine + lint |
 | Admission denied: untrusted image + root | third-party main container runs as root | [olares-chart-run-as-user.md](olares-chart-run-as-user.md) — force uid 1000 or initContainer chown |
 

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -51,15 +51,22 @@ permission:
   - Home/Documents/MyApp/
 ```
 
-In the deployment template, replace the PVC mount with the injected host path (`appData`/`appCache` are host paths):
+In the deployment template, replace the PVC mount with the injected host path (`appData`/`appCache` are host paths). **The value already ends in `/<appName>` — mount it as-is; do not append the app name again:**
 
 ```yaml
       volumes:
       - name: app-data
         hostPath:
-          path: {{ .Values.userspace.appData }}/myapp
+          # appData/appCache already resolve to .../Data/<appName> / .../Cache/<appName>
+          # (owned by uid 1000). Mount the bare value — appending /<app> again would
+          # give .../Data/<app>/<app>.
+          path: {{ .Values.userspace.appData }}
           type: DirectoryOrCreate
 ```
+
+> **The value already includes `/<appName>` — don't re-append it.** `.Values.userspace.appData` / `.appCache` resolve to `.../Data/<appName>` / `.../Cache/<appName>`, created and `chown`ed to uid 1000. Mount the bare value. **`appCommon` is the exception** — it is a *bare* cross-app dir (no `appName` suffix), so you do append the reserved cache name, e.g. `{{ .Values.userspace.appCommon }}/huggingface`.
+
+> **If you append a subdir (or use `subPath`), you own its permissions.** Only the granted dir (`.../Data/<appName>`) is `chown`ed to uid 1000. A subdir you add via `path: {{ .Values.userspace.appData }}/sub` or a `volumeMounts.subPath` is created **root-owned** (by `DirectoryOrCreate` / kubelet) — so a process running as **uid 1000** (`spec.runAsUser: true`) hits `Permission denied` → CrashLoop. Either mount the bare value, let the app create the subdir at runtime (it inherits uid 1000), or `chown` it in an initContainer ([olares-chart-run-as-user.md](olares-chart-run-as-user.md) §B). Prefer not using `subPath` for userspace mounts.
 
 > Anything declared in a template (`.Values.userspace.appData/appCache/userData`) MUST have the matching `permission` field, or `lint`'s app-data cross-check fails. Drop leftover kompose PVCs.
 

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -131,6 +131,7 @@ If the upstream entrypoint **requires** root for its own initialization, you can
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | CrashLoop, `Permission denied` writing data dir | uid ≠ 1000 or dir owned by root | A or B above |
+| CrashLoop / `Permission denied` on an **appended subdir or `subPath`** under a userspace mount | only the granted dir (`.../Data/<appName>`) is chowned to 1000; the nested subdir was created root-owned (`DirectoryOrCreate`/kubelet) | Mount the bare `.Values.userspace.*` value (it already ends in `/<appName>`), or `chown` the subdir via initContainer B; avoid `subPath` for userspace mounts (see [olares-chart-manifest.md](olares-chart-manifest.md) §2) |
 | Install OK but config/data not persisted | Writes go to container-local path, or EACCES silently ignored | Check mount paths + run identity |
 | Admission denied: untrusted image + root | Third-party main container runs as root | A (force 1000) or B; never root main on third-party |
 | OPA OK but app still can't write | `spec.runAsUser` not set, or volume pre-dates chown | `spec.runAsUser: true` + B |

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -128,10 +128,13 @@ If the upstream entrypoint **requires** root for its own initialization, you can
 
 ## Symptoms → fix
 
+> **Not every CrashLoop is a permission problem.** Before reaching for `chown` / `runAsUser`, read the container's `terminated.exitCode` / `reason` (triage in [olares-chart-deploy.md](olares-chart-deploy.md) §3). A clean `exitCode 0` / `Completed` with **empty logs** is the main process exiting immediately — not a write-permission failure.
+
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | CrashLoop, `Permission denied` writing data dir | uid ≠ 1000 or dir owned by root | A or B above |
 | CrashLoop / `Permission denied` on an **appended subdir or `subPath`** under a userspace mount | only the granted dir (`.../Data/<appName>`) is chowned to 1000; the nested subdir was created root-owned (`DirectoryOrCreate`/kubelet) | Mount the bare `.Values.userspace.*` value (it already ends in `/<appName>`), or `chown` the subdir via initContainer B; avoid `subPath` for userspace mounts (see [olares-chart-manifest.md](olares-chart-manifest.md) §2) |
+| CrashLoopBackOff but `exitCode 0` / `reason: Completed` / **empty logs** | **NOT a permission problem** — the main process exits immediately (no long-lived server, wrong/missing command, the image's effective `CMD` is a no-op such as bare `node` reading EOF on a non-TTY stdin, or a stale cached image under a mutable tag) | Don't `chown`/`runAsUser`. Verify the image runs a long-lived server with the chart's exact command/env; set an explicit `command`/`args` (e.g. `command: ["node", "app.js"]` + `workingDir: /app`); pin the image by digest. Triage: [olares-chart-deploy.md](olares-chart-deploy.md) §3 |
 | Install OK but config/data not persisted | Writes go to container-local path, or EACCES silently ignored | Check mount paths + run identity |
 | Admission denied: untrusted image + root | Third-party main container runs as root | A (force 1000) or B; never root main on third-party |
 | OPA OK but app still can't write | `spec.runAsUser` not set, or volume pre-dates chown | `spec.runAsUser: true` + B |


### PR DESCRIPTION
## Summary
- The `olares-chart-manifest.md` §2 storage example mounted `{{ .Values.userspace.appData }}/myapp`, re-appending the app name. This contradicts `olares-chart-system-values.md` and the platform storage model, which state `appData`/`appCache` values **already end in `/<appName>`** (created and owned by uid 1000). Agents copying the example produced double-suffixed (`.../Data/<app>/<app>`) mounts.
- Fix the example to mount the **bare value**, and add two callouts: (1) the value already includes `/<appName>` — don't re-append; `appCommon` is the bare cross-app exception (append the reserved cache name, e.g. `/huggingface`); (2) an appended subdir or `subPath` is created **root-owned**, so a uid-1000 process (`spec.runAsUser: true`) hits `Permission denied` → CrashLoop — mount bare, create the subdir at runtime, or `chown` via initContainer; avoid `subPath` for userspace mounts.
- Add the matching symptom row to `olares-chart-run-as-user.md` "Symptoms → fix".

## Why
Doc-only consistency fix. The contradictory example was a recurring foot-gun for agents authoring charts.

## Test plan
- [ ] Render review of `olares-chart-manifest.md` §2 and `olares-chart-run-as-user.md` symptom table.

Made with [Cursor](https://cursor.com)