### PR TITLE
app-service: allow install to recover an app stuck in upgradeFailed

### DIFF
--- a/framework/app-service/pkg/appstate/state_transition.go
+++ b/framework/app-service/pkg/appstate/state_transition.go
@@ -186,6 +186,9 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 		appv1alpha1.Stopping,
 		appv1alpha1.Upgrading,
 		appv1alpha1.Uninstalling,
+		// OperationAllowedInState[UpgradeFailed][InstallOp]=true; the install
+		// handler re-targets the AM by writing Status.State=Pending.
+		appv1alpha1.Pending,
 	},
 	appv1alpha1.ApplyEnvFailed: {
 		appv1alpha1.Stopping,
@@ -339,6 +342,12 @@ var OperationAllowedInState = map[appv1alpha1.ApplicationManagerState]map[appv1a
 	appv1alpha1.UpgradeFailed: {
 		appv1alpha1.UninstallOp: true,
 		appv1alpha1.UpgradeOp:   true,
+		// An upgrade can leave the app with no usable helm release (e.g. the
+		// release was lost while the AM still believes the app is installed),
+		// in which case UpgradeOp keeps failing at GetDeployedReleaseVersion
+		// with "release: not found". Allow InstallOp as a recovery path so a
+		// fresh (re)install can reconcile the app, mirroring InstallFailed.
+		appv1alpha1.InstallOp: true,
 	},
 	appv1alpha1.ApplyEnvFailed: {
 		appv1alpha1.UninstallOp: true,
@@ -487,9 +496,14 @@ func StateToDuration(state appv1alpha1.ApplicationManagerState) time.Duration {
 	return 10 * time.Minute
 }
 
-// IsTerminalReinstallable reports whether an AM is in a terminal state from
-// which an Install operation is allowed. This is the broadest set; it matches
-// OperationAllowedInState[state][InstallOp] == true with a non-empty state.
+// IsTerminalReinstallable reports whether an AM is in a terminal state that is
+// known to hold no live cluster resources, so a re-install can re-target the
+// AM without first reconciling an existing deployment.
+//
+// It is a subset of "states that allow InstallOp": UpgradeFailed also allows
+// InstallOp (as a recovery path when the helm release was lost), but it may
+// still have a running previous release, so it is deliberately NOT listed here
+// — checkAppNameConflict must keep treating it as occupied.
 //
 // NOTE: "reinstallable" does not imply "safe to delete the AM CR". InstallFailed
 // historically left dangling helm/permission/provider/shared-NS resources before

--- a/framework/app-service/pkg/appstate/state_transition_test.go
+++ b/framework/app-service/pkg/appstate/state_transition_test.go
@@ -42,6 +42,8 @@ func TestIsStateTransitionValid(t *testing.T) {
 		{appsv1.DownloadingCanceled, appsv1.Pending, true},
 		{appsv1.InstallingCanceled, appsv1.Pending, true},
 		{appsv1.Uninstalled, appsv1.Pending, true},
+		// UpgradeFailed allows InstallOp as a recovery path (release lost).
+		{appsv1.UpgradeFailed, appsv1.Pending, true},
 
 		// invalid jumps (still rejected after the table was augmented).
 		{appsv1.Pending, appsv1.Running, false},
@@ -148,6 +150,8 @@ func TestIsOperationAllowed(t *testing.T) {
 		{appsv1.Uninstalling, appsv1.UninstallOp, false},
 		{appsv1.InstallFailed, appsv1.InstallOp, true},
 		{appsv1.InstallFailed, appsv1.UninstallOp, true},
+		{appsv1.UpgradeFailed, appsv1.InstallOp, true},
+		{appsv1.UpgradeFailed, appsv1.UpgradeOp, true},
 		{appsv1.Pending, appsv1.CancelOp, true},
 		{appsv1.Pending, appsv1.UninstallOp, false},
 	}


### PR DESCRIPTION
* **Background**

When an upgrade fails because the helm release is missing — e.g. the release was lost while the `ApplicationManager` still believes the app is installed (orphaned/incomplete prior install) — the app lands in `upgradeFailed`. Today that state only allows `UpgradeOp`/`UninstallOp`:

- `upgrade` keeps failing early at `GetDeployedReleaseVersion` with `release: not found`,
- `install` is rejected outright (`install operation is not allowed for upgradeFailed state`),
- `cancel` is not allowed either,

so the app is wedged with no CLI recovery path.

This PR mirrors the existing `InstallFailed` recovery: allow `InstallOp` from `upgradeFailed` and add the `upgradeFailed -> Pending` transition the install handler writes. `install()` already tolerates an existing release (`driver.ErrReleaseExists`), so when an old release is still present this is effectively a no-op; when the release is gone it reinstalls cleanly.

`IsTerminalReinstallable` intentionally still excludes `upgradeFailed` (it may hold a live previous release, so `checkAppNameConflict` must keep treating it as occupied); only its doc comment is updated.

Changes:
- `OperationAllowedInState[UpgradeFailed]`: add `InstallOp`.
- `StateTransitions[UpgradeFailed]`: add `Pending` (required by `TestOperationAllowedAlignsWithStateTransitions`).
- tests: `TestIsOperationAllowed` / `TestIsStateTransitionValid` cases for the new edges.

`go test ./pkg/appstate/...` passes.

* **Target Version for Merge**

main

* **Related Issues**

N/A

* **PRs Involving Sub-Systems**

This is approach **A** (minimal recovery-side fix). Approach **B** — #3438 — makes `upgrade` self-heal a missing release by installing it, so `upgradeFailed` never happens for a vanished release. The two are independent and can coexist; opened both so maintainers can pick the preferred direction (or take both).

* **Other information**:

app-service is a core component; the change takes effect after app-service is rebuilt/redeployed.