### PR TITLE
app-service: install on upgrade when the helm release is missing

### DIFF
--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -167,12 +168,22 @@ func (p *UpgradingApp) exec(ctx context.Context) error {
 	}
 	var appConfig *appcfg.ApplicationConfig
 	deployedVersion, _, err := apputils.GetDeployedReleaseVersion(actionConfig, p.manager.Spec.AppName)
+	releaseMissing := false
 	if err != nil {
-		klog.Errorf("Failed to get release revision err=%v", err)
-		return err
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			// The helm release is gone while the AM still considers the app
+			// installed (orphaned/incomplete prior install). Don't fail into
+			// upgradeFailed: let the flow continue so helm.UpgradeCharts can
+			// (re)install the release instead of erroring "release: not found".
+			klog.Warningf("helm release for %s not found during upgrade; will reinstall it", p.manager.Spec.AppName)
+			releaseMissing = true
+		} else {
+			klog.Errorf("Failed to get release revision err=%v", err)
+			return err
+		}
 	}
 
-	if !utils.MatchVersion(version, ">= "+deployedVersion) {
+	if !releaseMissing && !utils.MatchVersion(version, ">= "+deployedVersion) {
 		err = errors.New("upgrade version should great than deployed version")
 		return err
 	}

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -97,6 +97,18 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	if repoURL != "" {
 		client.RepoURL = repoURL
 	}
+	// helm's action.Upgrade.Run does not honor the `Install` field (the
+	// `helm upgrade --install` behavior lives in helm's CLI layer), so mirror
+	// it here: if the release does not exist, install it instead of failing
+	// with "release: not found". This self-heals an app whose helm release was
+	// lost while the ApplicationManager still considers it installed.
+	hist := action.NewHistory(actionConfig)
+	hist.Max = 1
+	if _, herr := hist.Run(appName); errors.Is(herr, driver.ErrReleaseNotFound) {
+		ctrl.Log.Info("helm release not found on upgrade; installing instead",
+			"appName", appName, "namespace", namespace)
+		return InstallCharts(ctx, actionConfig, settings, appName, chartName, repoURL, namespace, vals)
+	}
 	r, err := runUpgrade(ctx, []string{appName, chartName}, client, settings, vals)
 	if err != nil {
 		return err


### PR DESCRIPTION
* **Background**

When an app's helm release no longer exists but the `ApplicationManager` still believes the app is installed (orphaned/incomplete prior install), an `upgrade` fails early in `UpgradingApp.exec` at `GetDeployedReleaseVersion` with `release: not found` and drops the app into `upgradeFailed`. From there `upgrade` keeps hitting the same error and there is no clean CLI recovery path.

This PR makes `upgrade` self-heal a vanished release instead of erroring:

- `upgrading_app.go`: tolerate `driver.ErrReleaseNotFound` from `GetDeployedReleaseVersion` (don't return early), and skip the `>= deployed version` guard when there is no deployed release.
- `helm.UpgradeCharts`: mirror `helm upgrade --install`. helm's `action.Upgrade.Run` does **not** honor the `Install` field (that behavior lives in helm's CLI layer), so probe the release history and fall back to `InstallCharts` when it returns `driver.ErrReleaseNotFound`.

`go build ./...` and `go vet ./pkg/helm/... ./pkg/appstate/...` pass. (The helm path has no cluster-backed unit tests.)

* **Target Version for Merge**

main

* **Related Issues**

N/A

* **PRs Involving Sub-Systems**

This is approach **B** (root-cause fix: upgrade reinstalls a missing release, so `upgradeFailed` never happens for a vanished release). Approach **A** — #3437 — makes `upgradeFailed` recoverable via `install` from the state machine side. The two are independent and can coexist; opened both so maintainers can pick the preferred direction (or take both).

* **Other information**:

app-service is a core component; the change takes effect after app-service is rebuilt/redeployed.

Made with [Cursor](https://cursor.com)