### PR TITLE
fix(cli/market): allow same-version upgrade for the upload source

### DIFF
--- a/cli/cmd/ctl/market/preflight.go
+++ b/cli/cmd/ctl/market/preflight.go
@@ -208,7 +208,11 @@ func appLabels(appInfo map[string]interface{}) []string {
 //
 //  1. state ∈ isUpgradableStates  (`isUpgradable`)
 //  2. installed + target version both present
-//  3. target version > installed (strict semver)
+//  3. target version > installed (strict semver) — EXCEPT for the
+//     `upload` source, where target == installed is also allowed
+//     (re-uploading the same version overwrites the stored chart and
+//     app-service permits a same-version upgrade); a true downgrade is
+//     always rejected
 //  4. catalog row is NOT marked `suspend` / `remove` (`isAppSuspended`)
 //
 // Returns nil on pass. On any explicit gate failure returns a typed
@@ -255,11 +259,22 @@ func preflightUpgrade(ctx context.Context, opts *MarketOptions, mc *MarketClient
 		return fmt.Errorf("cannot upgrade '%s': target version is empty (internal error — version resolution did not produce a version string)", appName)
 	}
 
+	// The "upload" bucket (chartUploadSource) overwrites the stored
+	// chart in place when the same version is re-uploaded, and
+	// app-service accepts a same-version upgrade (it gates on
+	// `>= deployedVersion`, not strictly greater — see
+	// framework/app-service/pkg/appstate/upgrading_app.go). So for
+	// upload-source apps, `upgrade` to the SAME version is the
+	// sanctioned way to re-apply an edited chart (and to recover an
+	// app stuck in upgradeFailed) without an artificial version bump.
+	// We only relax the same-version no-op gate; a true downgrade
+	// (cmp < 0) is still rejected because app-service rejects it too.
+	isUpload := strings.TrimSpace(source) == chartUploadSource
 	cmp, err := compareSemver(targetVersion, row.Version)
 	if err != nil {
 		return fmt.Errorf("cannot upgrade '%s': version comparison failed: %w (installed %q, target %q)", appName, err, row.Version, targetVersion)
 	}
-	if cmp == 0 {
+	if cmp == 0 && !isUpload {
 		return fmt.Errorf("cannot upgrade '%s': target version '%s' is already installed — nothing to do", appName, targetVersion)
 	}
 	if cmp < 0 {

--- a/cli/cmd/ctl/market/preflight_test.go
+++ b/cli/cmd/ctl/market/preflight_test.go
@@ -360,6 +360,30 @@ func TestPreflightUpgrade(t *testing.T) {
 			wantErrSub: "is older than installed",
 		},
 		{
+			// upload bucket overwrites in place; re-applying the same
+			// version is the sanctioned re-deploy / recovery path, so
+			// the same-version no-op gate must NOT fire here.
+			name:    "upload source: target == installed → allowed (re-apply)",
+			appName: "psitransfer",
+			target:  "3.0.9",
+			source:  "upload",
+			setup: func(f *fakeMarketBackend) {
+				f.stateRows["upload"] = fakeStateRow{name: "psitransfer", state: "upgradeFailed", version: "3.0.9"}
+			},
+		},
+		{
+			// The upload carve-out is same-version only — a true
+			// downgrade is still rejected (app-service rejects it too).
+			name:    "upload source: target < installed → still bail (downgrade)",
+			appName: "psitransfer",
+			target:  "3.0.8",
+			source:  "upload",
+			setup: func(f *fakeMarketBackend) {
+				f.stateRows["upload"] = fakeStateRow{name: "psitransfer", state: "upgradeFailed", version: "3.0.9"}
+			},
+			wantErrSub: "is older than installed",
+		},
+		{
 			name:    "invalid installed version → comparison error",
 			appName: "firefox",
 			target:  "1.0.12",

--- a/cli/cmd/ctl/market/upgrade.go
+++ b/cli/cmd/ctl/market/upgrade.go
@@ -34,7 +34,14 @@ still surfaces the exit code). Four gates:
   3. Strict semver newer          — target > installed via
                                     Masterminds/semver/v3 strict parse;
                                     rejects downgrade and same-version
-                                    no-ops.
+                                    no-ops. EXCEPTION: for source
+                                    'upload', target == installed is
+                                    allowed — re-uploading the same
+                                    version overwrites the stored chart
+                                    and app-service permits a
+                                    same-version upgrade, so this is the
+                                    way to re-apply an edited chart or
+                                    recover an upgradeFailed upload app.
   4. Not suspended / withdrawn    — catalog labels exclude both
                                     'suspend' and 'remove' (verbatim
                                     suspendApp predicate). Soft-fails
@@ -97,8 +104,9 @@ func runUpgrade(opts *MarketOptions, appName string) error {
 	ctx := context.Background()
 	// Pre-flight gate mirroring the SPA's canUpgrade(): refuse early
 	// (with an actionable message) when the state row is missing, in a
-	// non-upgradable state, when the target version is not strictly
-	// newer than the installed version, or when the catalog row is
+	// non-upgradable state, when the target version is not newer than
+	// the installed version (same version is allowed for the 'upload'
+	// source — see preflightUpgrade gate 3), or when the catalog row is
 	// marked suspend / remove. Soft-fails on transient catalog probe
 	// errors — see preflightUpgrade for rationale.
 	if err := preflightUpgrade(ctx, opts, mc, appName, version, source); err != nil {

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -13,8 +13,12 @@ flowchart TD
   login -->|no| tell["tell developer: run 'olares-cli profile login --olares-id ID' then re-invoke"]
   login -->|yes| pkg["chart package -> .tgz"]
   pkg --> up["market upload"]
-  up --> inst["market install -s upload --watch -o json"]
+  up --> exists{"app already exists on this Olares?"}
+  exists -->|"no (first deploy / installFailed / uninstalled)"| inst["market install -s upload --watch -o json"]
+  exists -->|"yes (running / stopped / upgradeFailed / applyEnvFailed / stopFailed)"| upg["market upgrade -s upload --version SAME --watch -o json"]
   inst -->|running| done["deployed -> cleanup or keep"]
+  upg -->|running| done
+  upg -->|failed/stuck| diag
   inst -->|failed/stuck| diag["fetch logs"]
   diag --> isChart{"chart problem?"}
   isChart -->|yes| fix["fix chart -> back to refine + lint -> retry loop"]
@@ -58,6 +62,12 @@ Upload only stores the chart; installing it is what proves it runs:
 olares-cli market install <app> -s upload --version <version> --watch -o json
 ```
 
+- **`install` is for an app that does NOT yet exist on this Olares** (first deploy, or after `uninstall`, or retrying an `installFailed`). If the app already exists in a settled state (`running` / `stopped` / `upgradeFailed` / `applyEnvFailed` / `stopFailed`), `install` is rejected by app-service — **re-apply with `upgrade` instead** (next bullet). When in doubt, `olares-cli market get <app> -s upload -o json` and read `.state`.
+- **Re-apply an edited chart to an already-deployed app → `upgrade`, same version:**
+  ```bash
+  olares-cli market upgrade <app> -s upload --version <SAME version> --watch -o json
+  ```
+  Re-uploading the same version overwrites the stored chart, and `-s upload` allows a **same-version** upgrade (the CLI's strict-newer gate is waived for the upload source; app-service gates on `>= deployed`). This is the canonical loop for iterating on an installed app and for recovering one stuck in `upgradeFailed` — no version bump required.
 - Parse `.finalState`: `running` = deployed. `*Failed` / a watcher stuck near `*Failed` = go diagnose. See [`../../olares-market/references/olares-market-lifecycle.md`](../../olares-market/references/olares-market-lifecycle.md) for the state machine and `missing required env var(s)` (re-run with `--env KEY=VALUE`).
 - **Hydration race — `HTTP 404: App not found` right after upload is transient, NOT a chart problem.** `upload` lands the package in the chart repo immediately, but the app only becomes installable after the market backend indexes ("hydrates") it a few seconds later. Installing in that window 404s. This is the one install failure you *should* retry: wait for hydration, then re-run the same `install`. No need to re-`upload` or bump the version — the chart is already stored; re-uploading the same bytes wouldn't speed up hydration. Confirm hydration finished via the `appstore-backend` log (`isAppHydrationComplete RETURNING TRUE ... appID=<app>` → `Added new app to latest: <app>` → `new_app_ready`), or poll `olares-cli market get <app> -s upload` until it resolves:
   ```bash
@@ -135,9 +145,11 @@ olares-cli market resume <app> --watch
 
 `resume` scales the workloads back up and waits for startup (`stopped → resuming → running`). If the pod is already running it completes quickly and flips the market row to `running`.
 
+If an upgrade instead left the app in **`upgradeFailed`** (the upgrade itself errored, not a `stopped` row), recover by fixing the chart, re-uploading the **same version**, and re-running `market upgrade <app> -s upload --version <SAME> --watch` — `upgradeFailed` is an upgradable state and the upload source permits a same-version upgrade (see §3). Do **not** fall back to `install`: app-service rejects `install` from `upgradeFailed`, which only re-wedges the row.
+
 ## 5. Decide: fix the chart, or report back
 
-- **Problem is in the chart** (wrong image ref, missing/incorrect env, bad volume mount, entrance host/port, undeclared `permission` for a userspace mount, **uid/permission mismatch on userspace volumes**, ...): edit the manifest/templates per [`olares-chart-manifest.md`](olares-chart-manifest.md) and [`olares-chart-run-as-user.md`](olares-chart-run-as-user.md), re-run `chart lint`, and re-upload (the auto-loop continues). **No version bump needed to redeploy a fix** — `upload` requires the new version be **>= the stored** one, so re-uploading the *same* version overwrites the stored chart. Keep `Chart.yaml` `version` == `metadata.version` (lint enforces equality); bump only if you want to track iterations (a *lower* version is rejected).
+- **Problem is in the chart** (wrong image ref, missing/incorrect env, bad volume mount, entrance host/port, undeclared `permission` for a userspace mount, **uid/permission mismatch on userspace volumes**, ...): edit the manifest/templates per [`olares-chart-manifest.md`](olares-chart-manifest.md) and [`olares-chart-run-as-user.md`](olares-chart-run-as-user.md), re-run `chart lint`, and re-upload (the auto-loop continues). **No version bump needed to redeploy a fix** — `upload` requires the new version be **>= the stored** one, so re-uploading the *same* version overwrites the stored chart. Keep `Chart.yaml` `version` == `metadata.version` (lint enforces equality); bump only if you want to track iterations (a *lower* version is rejected). **After re-upload, re-apply with the right verb:** if the app no longer exists / is `installFailed` → `market install -s upload`; if it already exists in a settled state (`running` / `stopped` / `upgradeFailed` / `applyEnvFailed` / `stopFailed`) → `market upgrade -s upload --version <SAME>` (same-version upgrade is allowed for the upload source — see §3). Re-running `install` against an already-existing app is rejected by app-service and leaves the row in `upgradeFailed`/`installFailed`; `upgrade` is the recovery path.
 - **Problem is not in the chart, or unclear:** break out of the auto-loop — summarize the failing state and the relevant log excerpts in plain language, suggest likely causes, and **ask the developer how to proceed.** Do not silently retry install in a loop — install/auth failures are deterministic (see olares-market / olares-shared error tables). The lone exception is the post-upload hydration `404` in section 3, which is transient and meant to be retried once hydration completes.
 
 ## 6. Clean up the test install

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -55,7 +55,7 @@ Mirrors the SPA's `canUpgrade()`. Bails locally with a self-contained error (for
 
 1. **Row exists** — state row found via `Name` or `RawName` (clones included)
 2. **State is upgradable** — `running` / `stopped` / `stopFailed` / `upgradeFailed` / `applyEnvFailed`
-3. **Newer chart available** — `targetVersion > installedVersion` (semver compare)
+3. **Newer chart available** — `targetVersion > installedVersion` (semver compare). **Exception for `-s upload`:** `targetVersion == installedVersion` is allowed — re-uploading the same version overwrites the stored chart, and app-service permits a same-version upgrade (it gates on `>= deployed`). This is the sanctioned way to re-apply an edited upload chart or recover an `upgradeFailed` upload app **without** bumping the version. A true downgrade (`target < installed`) is still rejected for every source.
 4. **App labels don't forbid upgrade** — `disabled-upgrade`, `suspend`, `remove` labels
 
 ## `uninstall`
@@ -143,6 +143,7 @@ olares-cli market cancel firefox --watch               # block until row stops m
 
 - **For "install X and tell me when it's running"** → `market install X --watch -o json`, then parse `.finalState`.
 - **For "upgrade X if there's a newer version"** → `market get X -o json` to check version, then `market upgrade X --watch`. The pre-flight will short-circuit if there's no newer chart.
+- **For "re-apply an upload chart I just re-uploaded"** → `market upgrade X -s upload --version <same-version> --watch`. The same-version upgrade is allowed for `-s upload` (gate 3 exception) and is the right verb once the app already exists (`running` / `upgradeFailed` / ...) — `install` would be rejected by app-service in those states.
 - **For "stop everything for this user"** → `market list --mine -o json | jq -r '.[].name'` + a shell loop calling `market stop`. The cluster doesn't expose a bulk-stop verb.
 - **For "install a custom chart"** → `market upload ./mychart.tgz` (always lands in source `upload`), then `market install <name> -s upload`.
 - **For ambiguous source rows on uninstall/stop/resume**: the verb already resolves automatically. Don't pass `-s` even when the SPA shows it under multiple sources.
@@ -153,7 +154,7 @@ olares-cli market cancel firefox --watch               # block until row stops m
 |---|---|---|
 | `missing required env var(s): KEY1, KEY2 ...` (install) | App declares required envs | Re-run with `--env KEY=VALUE` per missing var |
 | `app 'X' is not in an upgradable state (current: Y)` | Pre-flight gate 2 | Wait for terminal state, or run `cancel` first |
-| `no newer version available (installed: 1.2.3, latest: 1.2.3)` | Pre-flight gate 3 | Nothing to upgrade |
+| `target version '1.2.3' is already installed — nothing to do` | Pre-flight gate 3 | Nothing to upgrade. **Does NOT fire for `-s upload`** — same-version upgrade is allowed there to re-apply an overwritten chart |
 | `app labels forbid upgrade (suspend / remove / disabled-upgrade)` | Pre-flight gate 4 | App is marked non-upgradable in the catalog; contact app maintainer |
 | `app 'X' is not cloneable` | `clone` against an app that is neither multi-instance nor a template | Check `market get X -o json` for `allowMultipleInstall` / `templateOnly` |
 | `--title is required` | `clone` without `--title` | Add `--title "..."` |


### PR DESCRIPTION
## Summary

- `olares-cli market upgrade` pre-flight **gate 3** rejected `target == installed` as a no-op for *every* source. For the `upload` bucket this is wrong: re-uploading the same version **overwrites the stored chart in place**, and app-service permits a same-version upgrade (it gates on `>= deployed`, not strictly greater — `framework/app-service/pkg/appstate/upgrading_app.go`).
- Net effect for an already-installed upload app (`running` / `upgradeFailed` / ...): `install` is rejected by app-service (InstallOp not allowed from those states), while the *only* sanctioned re-apply / recovery path — `upgrade` to the **same** version — was blocked by the CLI itself. This is the wedge seen in the `psitransfer` recovery flow.
- Fix: relax gate 3 to allow `cmp == 0` **only when `source == upload`**. A true downgrade (`cmp < 0`) is still rejected for every source (app-service rejects it too). Backend is unchanged — market only forwards, and app-service already accepts same-version.

## Changes

- `cli/cmd/ctl/market/preflight.go` — `preflightUpgrade` gate 3 upload carve-out + doc comment.
- `cli/cmd/ctl/market/upgrade.go` — `Long` help text + inline comment reflect the upload same-version exception.
- `cli/cmd/ctl/market/preflight_test.go` — new cases: upload same-version → allowed; upload downgrade → still rejected (non-upload same-version no-op already covered).
- `cli/skills/olares-market/references/olares-market-lifecycle.md` — gate 3 exception, error-table note, "re-apply an upload chart" guidance.
- `cli/skills/olares-chart/references/olares-chart-deploy.md` — iterate/recovery loop branches `install` (first deploy / installFailed / uninstalled) vs `upgrade -s upload --version <same>` (app already exists); §4b `upgradeFailed` recovery note.

## Test plan

- [x] `go build ./...` (cli)
- [x] `go test ./cmd/ctl/market/...` — all pass, incl. the two new upload pre-flight cases
- [ ] Manual: `market upgrade <app> -s upload --version <same>` re-applies an edited chart and recovers an `upgradeFailed` upload app

Made with [Cursor](https://cursor.com)