### PR TITLE
market: bump market-backend to v0.6.63

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.62
+        image: beclab/market-backend:v0.6.63
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
Bump the framework cluster deploy image so clusters pick up market-backend v0.6.63.

v0.6.63 adds a guard to the task-failure state write: terminal-failure writes from the install / upgrade / clone path now overwrite the `user_application_states` row only when it is still `pending`. This stops an `install` rejected by app-service from clobbering an `upgradeFailed` row into `installFailed` (the divergence between Market's PG state and the app-service AM that wedged recovery of upload apps).

* **Target Version for Merge**
v1.12.7

* **Related Issues**

* **PRs Involving Sub-Systems**
https://github.com/beclab/market/pull/309

* **Other information**:
`market_deploy.yaml`: `beclab/market-backend` **v0.6.62 → v0.6.63**. No manifest structure, env, or wiring changes — only the container image tag.

Made with [Cursor](https://cursor.com)