### PR TITLE
feat(appservice): add app accelerator spec in resource list API

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -314,6 +314,10 @@ func (h *Handler) listComputeResources(req *restful.Request, resp *restful.Respo
 		api.HandleError(resp, req, err)
 		return
 	}
+	if err := compute.AttachBoundAppSpecs(req.Request.Context(), h.ctrlClient, nodes); err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
 	resp.WriteAsJson(ComputeResourcesResponse{
 		Response: api.Response{Code: api.CodeSuccess},
 		Data:     nodes,

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -375,3 +375,44 @@ func attachBindings(nodes []Node, allocations []Allocation) {
 		}
 	}
 }
+
+// AttachBoundAppSpecs enriches every device binding with the bound app's
+// currently-selected resource-mode requirement (Allocation.Spec), so callers
+// listing compute resources can see each app's require/limit and multi-card /
+// multi-node support without a second round of lookups. The requirement is
+// resolved once per unique (appName, owner) pair from the app's
+// ApplicationManager config and shared across that app's bindings. If any
+// bound app's config can't be loaded or its selected mode can't be resolved,
+// the whole listing fails with an error.
+func AttachBoundAppSpecs(ctx context.Context, c client.Client, nodes []Node) error {
+	specs := make(map[string]*Requirement)
+	resolve := func(appName, owner string) (*Requirement, error) {
+		key := owner + "/" + appName
+		if spec, ok := specs[key]; ok {
+			return spec, nil
+		}
+		cfg, err := loadAppConfigForOwner(ctx, c, appName, owner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load app config for %s/%s: %w", owner, appName, err)
+		}
+		req, ok := SelectedRequirement(cfg)
+		if !ok {
+			return nil, fmt.Errorf("failed to resolve selected resource mode for %s/%s", owner, appName)
+		}
+		specs[key] = &req
+		return specs[key], nil
+	}
+	for ni := range nodes {
+		for di := range nodes[ni].Devices {
+			bindings := nodes[ni].Devices[di].Bindings
+			for bi := range bindings {
+				spec, err := resolve(bindings[bi].AppName, bindings[bi].Owner)
+				if err != nil {
+					return err
+				}
+				bindings[bi].Spec = spec
+			}
+		}
+	}
+	return nil
+}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -103,6 +103,12 @@ type Allocation struct {
 	NodeName string `json:"nodeName"`
 	DeviceID string `json:"deviceId"`
 	Memory   int64  `json:"memory"`
+	// Spec carries the bound app's currently-selected resource-mode
+	// requirement (require/limit GPU & memory, multi-card / multi-node
+	// support). It is resolved at read time for the compute-resources
+	// listing (see AttachBoundAppSpecs) and is never persisted to the
+	// allocation config map.
+	Spec *Requirement `json:"spec,omitempty"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
* **Background**
Add each bound app's accelerator spec in the compute resource list API for frontend to show more info.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The listing path now depends on ApplicationManager config reads for every distinct bound app and fails the whole response on any resolution error, which can affect admin compute views when configs are missing or invalid.
> 
> **Overview**
> The compute resources list API now returns each device binding’s **currently selected resource-mode requirement** (CPU/GPU/memory require & limits, multi-card / multi-node flags) inline on `Allocation.spec`, so the UI can show accelerator details without extra lookups.
> 
> A new read-time step **`AttachBoundAppSpecs`** resolves that requirement once per unique `(owner, appName)` from the app’s ApplicationManager config and attaches it to every binding on the node tree. **`Spec` is not stored** in the allocation config map. If any bound app’s config cannot be loaded or its selected mode cannot be resolved, the **entire list request fails** with an error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc269e4aaf33d39d56a6e6f388161f7ccd299b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->