### PR TITLE
fix(appservice): check reference before delete system/user env

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_systemenv.go
+++ b/framework/app-service/pkg/apiserver/handler_systemenv.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,40 @@ type AppEnvReferrer struct {
 	AppName   string `json:"appName"`
 	AppOwner  string `json:"appOwner"`
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// collectAppEnvReferrers builds a map from a referenced env name to the apps
+// that reference it via AppEnv.ValueFrom. When ownerFilter is non-empty, only
+// AppEnvs owned by that user are considered (used for user envs); an empty
+// ownerFilter considers every app (used for system envs).
+func (h *Handler) collectAppEnvReferrers(ctx context.Context, ownerFilter string) (map[string][]AppEnvReferrer, error) {
+	var appEnvList sysv1alpha1.AppEnvList
+	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+		return nil, err
+	}
+	refMap := make(map[string][]AppEnvReferrer)
+	for _, ae := range appEnvList.Items {
+		if ownerFilter != "" && ae.AppOwner != ownerFilter {
+			continue
+		}
+		seen := make(map[string]struct{})
+		for _, envVar := range ae.Envs {
+			if envVar.ValueFrom == nil || envVar.ValueFrom.EnvName == "" {
+				continue
+			}
+			envName := envVar.ValueFrom.EnvName
+			if _, ok := seen[envName]; ok {
+				continue
+			}
+			seen[envName] = struct{}{}
+			refMap[envName] = append(refMap[envName], AppEnvReferrer{
+				AppName:   ae.AppName,
+				AppOwner:  ae.AppOwner,
+				Namespace: ae.Namespace,
+			})
+		}
+	}
+	return refMap, nil
 }
 
 func (h *Handler) ensureAdmin(req *restful.Request, resp *restful.Response) (string, bool) {
@@ -184,6 +219,16 @@ func (h *Handler) deleteSystemEnv(req *restful.Request, resp *restful.Response) 
 		return
 	}
 
+	refMap, err := h.collectAppEnvReferrers(ctx, "")
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if refs := refMap[current.EnvName]; len(refs) > 0 {
+		api.HandleBadRequest(resp, req, fmt.Errorf("systemenv '%s' is referenced by %d app(s) and cannot be deleted", current.EnvName, len(refs)))
+		return
+	}
+
 	if err := h.ctrlClient.Delete(ctx, &current); err != nil {
 		if !apierrors.IsNotFound(err) {
 			api.HandleError(resp, req, err)
@@ -194,17 +239,39 @@ func (h *Handler) deleteSystemEnv(req *restful.Request, resp *restful.Response) 
 	resp.WriteEntity(api.Response{Code: 200})
 }
 
-// listSystemEnvs returns all system env specs
+// listSystemEnvs returns all system env specs. The referencedBy field is only
+// populated for admin users.
 func (h *Handler) listSystemEnvs(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
 	var list sysv1alpha1.SystemEnvList
-	if err := h.ctrlClient.List(req.Request.Context(), &list); err != nil {
+	if err := h.ctrlClient.List(ctx, &list); err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
 
-	result := make([]sysv1alpha1.EnvVarSpec, 0, len(list.Items))
+	owner := getCurrentUser(req)
+	isAdmin, err := kubesphere.IsAdmin(ctx, h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	var refMap map[string][]AppEnvReferrer
+	if isAdmin {
+		refMap, err = h.collectAppEnvReferrers(ctx, "")
+		if err != nil {
+			api.HandleError(resp, req, err)
+			return
+		}
+	}
+
+	result := make([]SystemEnvDetail, 0, len(list.Items))
 	for _, item := range list.Items {
-		result = append(result, item.EnvVarSpec)
+		detail := SystemEnvDetail{EnvVarSpec: item.EnvVarSpec}
+		if isAdmin {
+			detail.ReferencedBy = refMap[item.EnvName]
+		}
+		result = append(result, detail)
 	}
 	resp.WriteAsJson(result)
 }
@@ -237,23 +304,12 @@ func (h *Handler) getSystemEnvDetail(req *restful.Request, resp *restful.Respons
 
 	detail := SystemEnvDetail{EnvVarSpec: current.EnvVarSpec}
 
-	var appEnvList sysv1alpha1.AppEnvList
-	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+	refMap, err := h.collectAppEnvReferrers(ctx, "")
+	if err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
-	for _, ae := range appEnvList.Items {
-		for _, envVar := range ae.Envs {
-			if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == current.EnvName {
-				detail.ReferencedBy = append(detail.ReferencedBy, AppEnvReferrer{
-					AppName:   ae.AppName,
-					AppOwner:  ae.AppOwner,
-					Namespace: ae.Namespace,
-				})
-				break
-			}
-		}
-	}
+	detail.ReferencedBy = refMap[current.EnvName]
 
 	resp.WriteAsJson(detail)
 }

--- a/framework/app-service/pkg/apiserver/handler_userenv.go
+++ b/framework/app-service/pkg/apiserver/handler_userenv.go
@@ -164,6 +164,16 @@ func (h *Handler) deleteUserEnv(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if refs := refMap[current.EnvName]; len(refs) > 0 {
+		api.HandleBadRequest(resp, req, fmt.Errorf("userenv '%s' is referenced by %d app(s) and cannot be deleted", current.EnvName, len(refs)))
+		return
+	}
+
 	if err := h.ctrlClient.Delete(ctx, &current); err != nil {
 		if !apierrors.IsNotFound(err) {
 			api.HandleError(resp, req, err)
@@ -174,20 +184,31 @@ func (h *Handler) deleteUserEnv(req *restful.Request, resp *restful.Response) {
 	resp.WriteEntity(api.Response{Code: 200})
 }
 
-// listUserEnvs returns all user env specs for the current user
+// listUserEnvs returns all user env specs for the current user, along with the
+// current user's apps that reference each env.
 func (h *Handler) listUserEnvs(req *restful.Request, resp *restful.Response) {
 	username := getCurrentUser(req)
 
+	ctx := req.Request.Context()
 	userNamespace := utils.UserspaceName(username)
 	var list sysv1alpha1.UserEnvList
-	if err := h.ctrlClient.List(req.Request.Context(), &list, client.InNamespace(userNamespace)); err != nil {
+	if err := h.ctrlClient.List(ctx, &list, client.InNamespace(userNamespace)); err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
 
-	result := make([]sysv1alpha1.EnvVarSpec, 0, len(list.Items))
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	result := make([]UserEnvDetail, 0, len(list.Items))
 	for _, item := range list.Items {
-		result = append(result, item.EnvVarSpec)
+		result = append(result, UserEnvDetail{
+			EnvVarSpec:   item.EnvVarSpec,
+			ReferencedBy: refMap[item.EnvName],
+		})
 	}
 	resp.WriteAsJson(result)
 }
@@ -218,27 +239,12 @@ func (h *Handler) getUserEnvDetail(req *restful.Request, resp *restful.Response)
 
 	detail := UserEnvDetail{EnvVarSpec: current.EnvVarSpec}
 
-	var appEnvList sysv1alpha1.AppEnvList
-	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
-	for _, ae := range appEnvList.Items {
-		// Only check AppEnvs that belong to the same user
-		if ae.AppOwner != username {
-			continue
-		}
-		for _, envVar := range ae.Envs {
-			if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == current.EnvName {
-				detail.ReferencedBy = append(detail.ReferencedBy, AppEnvReferrer{
-					AppName:   ae.AppName,
-					AppOwner:  ae.AppOwner,
-					Namespace: ae.Namespace,
-				})
-				break
-			}
-		}
-	}
+	detail.ReferencedBy = refMap[current.EnvName]
 
 	resp.WriteAsJson(detail)
 }


### PR DESCRIPTION
* **Background**
when listing system & user envs, also return whether each env is referenced by application envs and what applications
when requested to delete any system & user env, check whether it's referenced by any application envs and block the request if any.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> List API responses now embed `referencedBy` (and use detail types), which may break clients expecting bare `EnvVarSpec` arrays; deletion rules are stricter and affect app configuration lifecycle.
> 
> **Overview**
> Prevents **orphaned app env references** by refusing to delete system or user envs that any `AppEnv` still pulls via `ValueFrom`, and surfaces which apps reference each env in list/detail responses.
> 
> A new **`collectAppEnvReferrers`** helper centralizes scanning all `AppEnv` resources (optionally scoped to an app owner for user envs). **Delete** handlers for system and user envs call it before delete and return a bad request when references exist. **List** endpoints change shape: `listUserEnvs` always returns `UserEnvDetail` with `referencedBy` for the current user’s apps; `listSystemEnvs` returns `SystemEnvDetail` and fills `referencedBy` only for **admin** callers. Detail endpoints reuse the same helper instead of inline listing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518a7b2efbad8b4d681aa9ae3c9d3c3cd8803100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->