### PR TITLE
chore: update NVIDIA driver version to 595.84 in configuration and tests

### DIFF
--- a/cli/pkg/dashboard/overview/gpu/format_test.go
+++ b/cli/pkg/dashboard/overview/gpu/format_test.go
@@ -167,7 +167,7 @@ func TestGpuDetailDisplayCopy_SPAFieldWhitelist(t *testing.T) {
 		"powerLimit":     0,
 		"temperature":    0,
 		"device_no":      "nvidia0",
-		"driver_version": "595.80",
+		"driver_version": "595.84",
 		"health":         true,
 	}
 	got := gpuDetailDisplayCopy(src)

--- a/cli/pkg/upgrade/1_12_7_20260622.go
+++ b/cli/pkg/upgrade/1_12_7_20260622.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260622 struct {
+	upgrader_1_12_7_20260513
+}
+
+func (u upgrader_1_12_7_20260622) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260622")
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260622{})
+}

--- a/infrastructure/cuda/.olares/Olares.yaml
+++ b/infrastructure/cuda/.olares/Olares.yaml
@@ -4,9 +4,9 @@ output:
   binaries:
     - 
       id: cuda-driver
-      name: cuda-driver-595.80.run
-      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.80/NVIDIA-Linux-x86_64-595.80.run
-      arm64: https://us.download.nvidia.com/XFree86/aarch64/595.80/NVIDIA-Linux-aarch64-595.80.run
+      name: cuda-driver-595.84.run
+      amd64: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.84/NVIDIA-Linux-x86_64-595.84.run
+      arm64: https://us.download.nvidia.com/XFree86/aarch64/595.84/NVIDIA-Linux-aarch64-595.84.run
     - 
       id: libnvidia-gpgkey 
       name: libnvidia-gpgkey


### PR DESCRIPTION
* **Background**
Bump NVIDIA driver to latest version 595.84 

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Driver upgrades touch node GPU stacks and can trigger reboots via the inherited upgrader tasks; scope is a minor vendor bump on an established upgrade pattern.
> 
> **Overview**
> Bumps the bundled **NVIDIA Linux driver** from **595.80** to **595.84** in `infrastructure/cuda/.olares/Olares.yaml`, including the prebuilt `.run` artifact name and amd64/arm64 download URLs.
> 
> Adds daily upgrader **`1.12.7-20260622`** that inherits the existing **`1.12.7-20260513`** upgrade path (GPU driver upgrade when needed and reboot), so clusters on the new build can pick up the driver bump through the normal Olares upgrade flow.
> 
> Updates the GPU dashboard test fixture **`driver_version`** to **595.84** so CLI display whitelist tests stay aligned with the shipped driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65aec0071ac90af6e4ebc8f68f870c95d39f6609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->