### PR TITLE
feat(appservice): return detailed resource stat upon node pressure

### DIFF
--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -484,11 +484,13 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 		if req.Mode == utils.NvidiaCardType && hasTimeSlice {
 			addedGPU = req.LimitedGPU
 		}
-		if pressure.WouldPressure(node, AddedResources{
+		if dims := pressure.PressuredDimensions(node, AddedResources{
 			CPU:    req.RequiredCPU,
 			Memory: req.RequiredMemory + addedGPU,
-		}) {
-			return invalidBinding("node-pressure:" + nodeName)
+		}); len(dims) > 0 {
+			result := invalidBinding("node-pressure:" + nodeName)
+			result.NodePressure = &NodePressureDetail{NodeName: nodeName, Dimensions: dims}
+			return result
 		}
 	}
 	return &BindingValidationResult{OK: true, Code: BindingValidationReasonValid}

--- a/framework/app-service/pkg/compute/pressure.go
+++ b/framework/app-service/pkg/compute/pressure.go
@@ -9,6 +9,33 @@ import (
 
 const defaultPressureThreshold = 0.90
 
+const (
+	PressureResourceCPU    = "cpu"
+	PressureResourceMemory = "memory"
+	PressureResourceDisk   = "disk"
+)
+
+// DimensionPressure describes, for a single resource dimension, how the
+// node's current usage plus the app's requested amount compares against
+// the pressure threshold:
+//
+//   - Required is how much the app wants to add on this dimension.
+//   - Used / Capacity are the node's current consumption and total.
+//   - Available is the remaining headroom UNDER the threshold before the
+//     request is added (capacity*threshold - used), clamped to >= 0. This
+//     is the "how much can still be placed" figure the frontend renders.
+//   - Pressured reports whether adding Required would push the dimension
+//     past the threshold (or the node reports unusable capacity for a
+//     dimension the app needs).
+type DimensionPressure struct {
+	Resource  string `json:"resource"`
+	Required  int64  `json:"required"`
+	Used      int64  `json:"used"`
+	Capacity  int64  `json:"capacity"`
+	Available int64  `json:"available"`
+	Pressured bool   `json:"pressured"`
+}
+
 func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
 	usage, err := prometheus.GetNodeResourceUsage(ctx)
 	if err != nil {
@@ -20,24 +47,16 @@ func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
 	}, nil
 }
 
-func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
+// Evaluate returns the per-dimension pressure breakdown (cpu, memory,
+// disk) for adding `added` to `node`. WouldPressure is the boolean
+// reduction of this, and PressuredDimensions filters it down to the
+// dimensions that actually block the placement.
+func (p PressureSnapshot) Evaluate(node Node, added AddedResources) []DimensionPressure {
 	threshold := p.Threshold
 	if threshold == 0 {
 		threshold = defaultPressureThreshold
 	}
 	usage, known := p.UsageByNode[node.NodeName]
-	// A node we have metrics for but that reports non-positive capacity on a
-	// dimension the app actually needs (e.g. a NotReady node or a stale/zeroed
-	// metric) cannot host the app. Without this, exceedsPressure's `total <= 0`
-	// short-circuit would report "no pressure" and nodePressureValidator would
-	// treat the node as infinite headroom and schedule onto it.
-	if known {
-		if (added.CPU > 0 && usage.CPUCapacity <= 0) ||
-			(added.Memory > 0 && usage.MemoryCapacity <= 0) ||
-			(added.Disk > 0 && usage.DiskCapacity <= 0) {
-			return true
-		}
-	}
 	// Sanitise the CPU utilisation before converting to a used-core count. A
 	// 0/0 monitoring ratio yields NaN (and a misbehaving exporter can produce
 	// Inf or a negative value); int64(NaN) is implementation-defined in Go, so
@@ -60,9 +79,58 @@ func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
 	if usedDisk < 0 {
 		usedDisk = 0
 	}
-	return exceedsPressure(usedCPU+added.CPU, usage.CPUCapacity, threshold) ||
-		exceedsPressure(usedMemory+added.Memory, usage.MemoryCapacity, threshold) ||
-		exceedsPressure(usedDisk+added.Disk, usage.DiskCapacity, threshold)
+	return []DimensionPressure{
+		evaluateDimension(PressureResourceCPU, added.CPU, usedCPU, usage.CPUCapacity, threshold, known),
+		evaluateDimension(PressureResourceMemory, added.Memory, usedMemory, usage.MemoryCapacity, threshold, known),
+		evaluateDimension(PressureResourceDisk, added.Disk, usedDisk, usage.DiskCapacity, threshold, known),
+	}
+}
+
+func evaluateDimension(resource string, required, used, capacity int64, threshold float64, known bool) DimensionPressure {
+	d := DimensionPressure{
+		Resource: resource,
+		Required: required,
+		Used:     used,
+		Capacity: capacity,
+	}
+	if headroom := float64(capacity)*threshold - float64(used); headroom > 0 {
+		d.Available = int64(headroom)
+	}
+	// A node we have metrics for but that reports non-positive capacity on a
+	// dimension the app actually needs (e.g. a NotReady node or a stale/zeroed
+	// metric) cannot host the app. Without this, exceedsPressure's `total <= 0`
+	// short-circuit would report "no pressure" and the node would look like it
+	// had infinite headroom.
+	if known && required > 0 && capacity <= 0 {
+		d.Pressured = true
+		return d
+	}
+	d.Pressured = exceedsPressure(used+required, capacity, threshold)
+	return d
+}
+
+func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
+	for _, d := range p.Evaluate(node, added) {
+		if d.Pressured {
+			return true
+		}
+	}
+	return false
+}
+
+// PressuredDimensions returns only the dimensions that would exceed the
+// pressure threshold when `added` is placed on `node`. It is non-empty
+// exactly when WouldPressure is true, so callers can use its length as
+// the rejection signal while also surfacing which resource(s) fell short
+// and by how much.
+func (p PressureSnapshot) PressuredDimensions(node Node, added AddedResources) []DimensionPressure {
+	var out []DimensionPressure
+	for _, d := range p.Evaluate(node, added) {
+		if d.Pressured {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 func exceedsPressure(used, total int64, threshold float64) bool {

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -189,6 +189,20 @@ type BindingValidationResult struct {
 	OK     bool   `json:"ok"`
 	Code   string `json:"code,omitempty"`
 	Reason string `json:"reason,omitempty"`
+	// NodePressure is populated only when the binding is rejected because
+	// a selected node would be pushed past its resource pressure
+	// threshold (Code "node-pressure:<node>"). It breaks the rejection
+	// down per resource so the caller can tell whether cpu, memory, or
+	// both fell short, how much the app needs, and how much headroom the
+	// node still has.
+	NodePressure *NodePressureDetail `json:"nodePressure,omitempty"`
+}
+
+// NodePressureDetail carries the per-resource breakdown behind a
+// "node-pressure" binding rejection for a single node.
+type NodePressureDetail struct {
+	NodeName   string              `json:"nodeName"`
+	Dimensions []DimensionPressure `json:"dimensions"`
 }
 
 type BindingApplyResult struct {


### PR DESCRIPTION
* **Background**
When selecting compute resources to resume an app, if node pressure will be introduced by the selection, the detailed resource type and number of the pressure will returned.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the binding validation API and refactors pressure math; rejection still hinges on the same threshold logic, but clients depend on the new fields and edge cases (zero capacity, NaN CPU util) are now expressed per dimension.
> 
> **Overview**
> When compute binding validation rejects a selection because the node would exceed the **90% resource pressure threshold**, the API now returns a **per-dimension breakdown** (cpu, memory, disk) instead of only a `node-pressure:<node>` code.
> 
> **Pressure evaluation** is refactored: `PressureSnapshot.Evaluate` computes used/capacity, threshold headroom (`available`), and whether each dimension is pressured; `WouldPressure` is unchanged semantically but built on `Evaluate`, and new **`PressuredDimensions`** returns only the blocking dimensions.
> 
> **Binding validation** (`validateResolvedBindingSelection`) uses `PressuredDimensions` and sets **`BindingValidationResult.NodePressure`** with `NodePressureDetail` so the resume UI can show which resources are short and how much headroom remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58a4f0e3de5d164316aca78ea8624495b3ded3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->