### PR TITLE
system-apps: bump system-frontend image to v1.10.58

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.55
+          image: beclab/system-frontend:v1.10.58
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the `system-frontend` (`olares-app-init`) image from `v1.10.55` to `v1.10.58` in the system-apps Helm chart (`olares-app.yaml`) to pick up the latest TermiPass/system-frontend changes.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1223
https://github.com/beclab/TermiPass/pull/1224

* **Other information**:
None