### PR TITLE
feat(appservice):  return detailed resource stat upon node pressure

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.52
+        image: beclab/app-service:0.5.53
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/apiserver/handler_compute_resources.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_resources.go
@@ -314,6 +314,10 @@ func (h *Handler) listComputeResources(req *restful.Request, resp *restful.Respo
 		api.HandleError(resp, req, err)
 		return
 	}
+	if err := compute.AttachBoundAppSpecs(req.Request.Context(), h.ctrlClient, nodes); err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
 	resp.WriteAsJson(ComputeResourcesResponse{
 		Response: api.Response{Code: api.CodeSuccess},
 		Data:     nodes,

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -695,7 +695,7 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	clientset, err := getAppClient()
+	clientset, err := utils.GetClient()
 	if err != nil {
 		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
 		return err

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -695,7 +695,7 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	clientset, err := utils.GetClient()
+	clientset, err := getAppClient()
 	if err != nil {
 		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
 		return err

--- a/framework/app-service/pkg/apiserver/handler_systemenv.go
+++ b/framework/app-service/pkg/apiserver/handler_systemenv.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,40 @@ type AppEnvReferrer struct {
 	AppName   string `json:"appName"`
 	AppOwner  string `json:"appOwner"`
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// collectAppEnvReferrers builds a map from a referenced env name to the apps
+// that reference it via AppEnv.ValueFrom. When ownerFilter is non-empty, only
+// AppEnvs owned by that user are considered (used for user envs); an empty
+// ownerFilter considers every app (used for system envs).
+func (h *Handler) collectAppEnvReferrers(ctx context.Context, ownerFilter string) (map[string][]AppEnvReferrer, error) {
+	var appEnvList sysv1alpha1.AppEnvList
+	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+		return nil, err
+	}
+	refMap := make(map[string][]AppEnvReferrer)
+	for _, ae := range appEnvList.Items {
+		if ownerFilter != "" && ae.AppOwner != ownerFilter {
+			continue
+		}
+		seen := make(map[string]struct{})
+		for _, envVar := range ae.Envs {
+			if envVar.ValueFrom == nil || envVar.ValueFrom.EnvName == "" {
+				continue
+			}
+			envName := envVar.ValueFrom.EnvName
+			if _, ok := seen[envName]; ok {
+				continue
+			}
+			seen[envName] = struct{}{}
+			refMap[envName] = append(refMap[envName], AppEnvReferrer{
+				AppName:   ae.AppName,
+				AppOwner:  ae.AppOwner,
+				Namespace: ae.Namespace,
+			})
+		}
+	}
+	return refMap, nil
 }
 
 func (h *Handler) ensureAdmin(req *restful.Request, resp *restful.Response) (string, bool) {
@@ -184,6 +219,16 @@ func (h *Handler) deleteSystemEnv(req *restful.Request, resp *restful.Response) 
 		return
 	}
 
+	refMap, err := h.collectAppEnvReferrers(ctx, "")
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if refs := refMap[current.EnvName]; len(refs) > 0 {
+		api.HandleBadRequest(resp, req, fmt.Errorf("systemenv '%s' is referenced by %d app(s) and cannot be deleted", current.EnvName, len(refs)))
+		return
+	}
+
 	if err := h.ctrlClient.Delete(ctx, &current); err != nil {
 		if !apierrors.IsNotFound(err) {
 			api.HandleError(resp, req, err)
@@ -194,17 +239,39 @@ func (h *Handler) deleteSystemEnv(req *restful.Request, resp *restful.Response) 
 	resp.WriteEntity(api.Response{Code: 200})
 }
 
-// listSystemEnvs returns all system env specs
+// listSystemEnvs returns all system env specs. The referencedBy field is only
+// populated for admin users.
 func (h *Handler) listSystemEnvs(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
 	var list sysv1alpha1.SystemEnvList
-	if err := h.ctrlClient.List(req.Request.Context(), &list); err != nil {
+	if err := h.ctrlClient.List(ctx, &list); err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
 
-	result := make([]sysv1alpha1.EnvVarSpec, 0, len(list.Items))
+	owner := getCurrentUser(req)
+	isAdmin, err := kubesphere.IsAdmin(ctx, h.kubeConfig, owner)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	var refMap map[string][]AppEnvReferrer
+	if isAdmin {
+		refMap, err = h.collectAppEnvReferrers(ctx, "")
+		if err != nil {
+			api.HandleError(resp, req, err)
+			return
+		}
+	}
+
+	result := make([]SystemEnvDetail, 0, len(list.Items))
 	for _, item := range list.Items {
-		result = append(result, item.EnvVarSpec)
+		detail := SystemEnvDetail{EnvVarSpec: item.EnvVarSpec}
+		if isAdmin {
+			detail.ReferencedBy = refMap[item.EnvName]
+		}
+		result = append(result, detail)
 	}
 	resp.WriteAsJson(result)
 }
@@ -237,23 +304,12 @@ func (h *Handler) getSystemEnvDetail(req *restful.Request, resp *restful.Respons
 
 	detail := SystemEnvDetail{EnvVarSpec: current.EnvVarSpec}
 
-	var appEnvList sysv1alpha1.AppEnvList
-	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+	refMap, err := h.collectAppEnvReferrers(ctx, "")
+	if err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
-	for _, ae := range appEnvList.Items {
-		for _, envVar := range ae.Envs {
-			if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == current.EnvName {
-				detail.ReferencedBy = append(detail.ReferencedBy, AppEnvReferrer{
-					AppName:   ae.AppName,
-					AppOwner:  ae.AppOwner,
-					Namespace: ae.Namespace,
-				})
-				break
-			}
-		}
-	}
+	detail.ReferencedBy = refMap[current.EnvName]
 
 	resp.WriteAsJson(detail)
 }

--- a/framework/app-service/pkg/apiserver/handler_userenv.go
+++ b/framework/app-service/pkg/apiserver/handler_userenv.go
@@ -164,6 +164,16 @@ func (h *Handler) deleteUserEnv(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+	if refs := refMap[current.EnvName]; len(refs) > 0 {
+		api.HandleBadRequest(resp, req, fmt.Errorf("userenv '%s' is referenced by %d app(s) and cannot be deleted", current.EnvName, len(refs)))
+		return
+	}
+
 	if err := h.ctrlClient.Delete(ctx, &current); err != nil {
 		if !apierrors.IsNotFound(err) {
 			api.HandleError(resp, req, err)
@@ -174,20 +184,31 @@ func (h *Handler) deleteUserEnv(req *restful.Request, resp *restful.Response) {
 	resp.WriteEntity(api.Response{Code: 200})
 }
 
-// listUserEnvs returns all user env specs for the current user
+// listUserEnvs returns all user env specs for the current user, along with the
+// current user's apps that reference each env.
 func (h *Handler) listUserEnvs(req *restful.Request, resp *restful.Response) {
 	username := getCurrentUser(req)
 
+	ctx := req.Request.Context()
 	userNamespace := utils.UserspaceName(username)
 	var list sysv1alpha1.UserEnvList
-	if err := h.ctrlClient.List(req.Request.Context(), &list, client.InNamespace(userNamespace)); err != nil {
+	if err := h.ctrlClient.List(ctx, &list, client.InNamespace(userNamespace)); err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
 
-	result := make([]sysv1alpha1.EnvVarSpec, 0, len(list.Items))
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	result := make([]UserEnvDetail, 0, len(list.Items))
 	for _, item := range list.Items {
-		result = append(result, item.EnvVarSpec)
+		result = append(result, UserEnvDetail{
+			EnvVarSpec:   item.EnvVarSpec,
+			ReferencedBy: refMap[item.EnvName],
+		})
 	}
 	resp.WriteAsJson(result)
 }
@@ -218,27 +239,12 @@ func (h *Handler) getUserEnvDetail(req *restful.Request, resp *restful.Response)
 
 	detail := UserEnvDetail{EnvVarSpec: current.EnvVarSpec}
 
-	var appEnvList sysv1alpha1.AppEnvList
-	if err := h.ctrlClient.List(ctx, &appEnvList); err != nil {
+	refMap, err := h.collectAppEnvReferrers(ctx, username)
+	if err != nil {
 		api.HandleError(resp, req, err)
 		return
 	}
-	for _, ae := range appEnvList.Items {
-		// Only check AppEnvs that belong to the same user
-		if ae.AppOwner != username {
-			continue
-		}
-		for _, envVar := range ae.Envs {
-			if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == current.EnvName {
-				detail.ReferencedBy = append(detail.ReferencedBy, AppEnvReferrer{
-					AppName:   ae.AppName,
-					AppOwner:  ae.AppOwner,
-					Namespace: ae.Namespace,
-				})
-				break
-			}
-		}
-	}
+	detail.ReferencedBy = refMap[current.EnvName]
 
 	resp.WriteAsJson(detail)
 }

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -484,11 +484,13 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 		if req.Mode == utils.NvidiaCardType && hasTimeSlice {
 			addedGPU = req.LimitedGPU
 		}
-		if pressure.WouldPressure(node, AddedResources{
+		if dims := pressure.PressuredDimensions(node, AddedResources{
 			CPU:    req.RequiredCPU,
 			Memory: req.RequiredMemory + addedGPU,
-		}) {
-			return invalidBinding("node-pressure:" + nodeName)
+		}); len(dims) > 0 {
+			result := invalidBinding("node-pressure:" + nodeName)
+			result.NodePressure = &NodePressureDetail{NodeName: nodeName, Dimensions: dims}
+			return result
 		}
 	}
 	return &BindingValidationResult{OK: true, Code: BindingValidationReasonValid}

--- a/framework/app-service/pkg/compute/pressure.go
+++ b/framework/app-service/pkg/compute/pressure.go
@@ -9,6 +9,33 @@ import (
 
 const defaultPressureThreshold = 0.90
 
+const (
+	PressureResourceCPU    = "cpu"
+	PressureResourceMemory = "memory"
+	PressureResourceDisk   = "disk"
+)
+
+// DimensionPressure describes, for a single resource dimension, how the
+// node's current usage plus the app's requested amount compares against
+// the pressure threshold:
+//
+//   - Required is how much the app wants to add on this dimension.
+//   - Used / Capacity are the node's current consumption and total.
+//   - Available is the remaining headroom UNDER the threshold before the
+//     request is added (capacity*threshold - used), clamped to >= 0. This
+//     is the "how much can still be placed" figure the frontend renders.
+//   - Pressured reports whether adding Required would push the dimension
+//     past the threshold (or the node reports unusable capacity for a
+//     dimension the app needs).
+type DimensionPressure struct {
+	Resource  string `json:"resource"`
+	Required  int64  `json:"required"`
+	Used      int64  `json:"used"`
+	Capacity  int64  `json:"capacity"`
+	Available int64  `json:"available"`
+	Pressured bool   `json:"pressured"`
+}
+
 func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
 	usage, err := prometheus.GetNodeResourceUsage(ctx)
 	if err != nil {
@@ -20,24 +47,16 @@ func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
 	}, nil
 }
 
-func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
+// Evaluate returns the per-dimension pressure breakdown (cpu, memory,
+// disk) for adding `added` to `node`. WouldPressure is the boolean
+// reduction of this, and PressuredDimensions filters it down to the
+// dimensions that actually block the placement.
+func (p PressureSnapshot) Evaluate(node Node, added AddedResources) []DimensionPressure {
 	threshold := p.Threshold
 	if threshold == 0 {
 		threshold = defaultPressureThreshold
 	}
 	usage, known := p.UsageByNode[node.NodeName]
-	// A node we have metrics for but that reports non-positive capacity on a
-	// dimension the app actually needs (e.g. a NotReady node or a stale/zeroed
-	// metric) cannot host the app. Without this, exceedsPressure's `total <= 0`
-	// short-circuit would report "no pressure" and nodePressureValidator would
-	// treat the node as infinite headroom and schedule onto it.
-	if known {
-		if (added.CPU > 0 && usage.CPUCapacity <= 0) ||
-			(added.Memory > 0 && usage.MemoryCapacity <= 0) ||
-			(added.Disk > 0 && usage.DiskCapacity <= 0) {
-			return true
-		}
-	}
 	// Sanitise the CPU utilisation before converting to a used-core count. A
 	// 0/0 monitoring ratio yields NaN (and a misbehaving exporter can produce
 	// Inf or a negative value); int64(NaN) is implementation-defined in Go, so
@@ -60,9 +79,58 @@ func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
 	if usedDisk < 0 {
 		usedDisk = 0
 	}
-	return exceedsPressure(usedCPU+added.CPU, usage.CPUCapacity, threshold) ||
-		exceedsPressure(usedMemory+added.Memory, usage.MemoryCapacity, threshold) ||
-		exceedsPressure(usedDisk+added.Disk, usage.DiskCapacity, threshold)
+	return []DimensionPressure{
+		evaluateDimension(PressureResourceCPU, added.CPU, usedCPU, usage.CPUCapacity, threshold, known),
+		evaluateDimension(PressureResourceMemory, added.Memory, usedMemory, usage.MemoryCapacity, threshold, known),
+		evaluateDimension(PressureResourceDisk, added.Disk, usedDisk, usage.DiskCapacity, threshold, known),
+	}
+}
+
+func evaluateDimension(resource string, required, used, capacity int64, threshold float64, known bool) DimensionPressure {
+	d := DimensionPressure{
+		Resource: resource,
+		Required: required,
+		Used:     used,
+		Capacity: capacity,
+	}
+	if headroom := float64(capacity)*threshold - float64(used); headroom > 0 {
+		d.Available = int64(headroom)
+	}
+	// A node we have metrics for but that reports non-positive capacity on a
+	// dimension the app actually needs (e.g. a NotReady node or a stale/zeroed
+	// metric) cannot host the app. Without this, exceedsPressure's `total <= 0`
+	// short-circuit would report "no pressure" and the node would look like it
+	// had infinite headroom.
+	if known && required > 0 && capacity <= 0 {
+		d.Pressured = true
+		return d
+	}
+	d.Pressured = exceedsPressure(used+required, capacity, threshold)
+	return d
+}
+
+func (p PressureSnapshot) WouldPressure(node Node, added AddedResources) bool {
+	for _, d := range p.Evaluate(node, added) {
+		if d.Pressured {
+			return true
+		}
+	}
+	return false
+}
+
+// PressuredDimensions returns only the dimensions that would exceed the
+// pressure threshold when `added` is placed on `node`. It is non-empty
+// exactly when WouldPressure is true, so callers can use its length as
+// the rejection signal while also surfacing which resource(s) fell short
+// and by how much.
+func (p PressureSnapshot) PressuredDimensions(node Node, added AddedResources) []DimensionPressure {
+	var out []DimensionPressure
+	for _, d := range p.Evaluate(node, added) {
+		if d.Pressured {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 func exceedsPressure(used, total int64, threshold float64) bool {

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -375,3 +375,44 @@ func attachBindings(nodes []Node, allocations []Allocation) {
 		}
 	}
 }
+
+// AttachBoundAppSpecs enriches every device binding with the bound app's
+// currently-selected resource-mode requirement (Allocation.Spec), so callers
+// listing compute resources can see each app's require/limit and multi-card /
+// multi-node support without a second round of lookups. The requirement is
+// resolved once per unique (appName, owner) pair from the app's
+// ApplicationManager config and shared across that app's bindings. If any
+// bound app's config can't be loaded or its selected mode can't be resolved,
+// the whole listing fails with an error.
+func AttachBoundAppSpecs(ctx context.Context, c client.Client, nodes []Node) error {
+	specs := make(map[string]*Requirement)
+	resolve := func(appName, owner string) (*Requirement, error) {
+		key := owner + "/" + appName
+		if spec, ok := specs[key]; ok {
+			return spec, nil
+		}
+		cfg, err := loadAppConfigForOwner(ctx, c, appName, owner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load app config for %s/%s: %w", owner, appName, err)
+		}
+		req, ok := SelectedRequirement(cfg)
+		if !ok {
+			return nil, fmt.Errorf("failed to resolve selected resource mode for %s/%s", owner, appName)
+		}
+		specs[key] = &req
+		return specs[key], nil
+	}
+	for ni := range nodes {
+		for di := range nodes[ni].Devices {
+			bindings := nodes[ni].Devices[di].Bindings
+			for bi := range bindings {
+				spec, err := resolve(bindings[bi].AppName, bindings[bi].Owner)
+				if err != nil {
+					return err
+				}
+				bindings[bi].Spec = spec
+			}
+		}
+	}
+	return nil
+}

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -189,6 +189,20 @@ type BindingValidationResult struct {
 	OK     bool   `json:"ok"`
 	Code   string `json:"code,omitempty"`
 	Reason string `json:"reason,omitempty"`
+	// NodePressure is populated only when the binding is rejected because
+	// a selected node would be pushed past its resource pressure
+	// threshold (Code "node-pressure:<node>"). It breaks the rejection
+	// down per resource so the caller can tell whether cpu, memory, or
+	// both fell short, how much the app needs, and how much headroom the
+	// node still has.
+	NodePressure *NodePressureDetail `json:"nodePressure,omitempty"`
+}
+
+// NodePressureDetail carries the per-resource breakdown behind a
+// "node-pressure" binding rejection for a single node.
+type NodePressureDetail struct {
+	NodeName   string              `json:"nodeName"`
+	Dimensions []DimensionPressure `json:"dimensions"`
 }
 
 type BindingApplyResult struct {

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -103,6 +103,12 @@ type Allocation struct {
 	NodeName string `json:"nodeName"`
 	DeviceID string `json:"deviceId"`
 	Memory   int64  `json:"memory"`
+	// Spec carries the bound app's currently-selected resource-mode
+	// requirement (require/limit GPU & memory, multi-card / multi-node
+	// support). It is resolved at read time for the compute-resources
+	// listing (see AttachBoundAppSpecs) and is never persisted to the
+	// allocation config map.
+	Spec *Requirement `json:"spec,omitempty"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
* **Background**
When selecting compute resources to resume an app, if node pressure will be introduced by the selection, the detailed resource type and number of the pressure will returned.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resume/binding API payloads and compute-resources listing failure modes; env delete is stricter when apps reference vars, which can surprise operators but avoids broken apps.
> 
> **Overview**
> When **resume / compute binding** validation rejects a node for resource pressure, the response now includes a **`nodePressure`** breakdown (per **cpu**, **memory**, **disk**: required, used, capacity, available under the threshold) instead of only a `node-pressure:<node>` code.
> 
> **Node pressure** evaluation is refactored to **`Evaluate` / `PressuredDimensions`** with shared **`DimensionPressure`** types; boolean **`WouldPressure`** is unchanged in behavior but built on that breakdown.
> 
> The **compute resources** list enriches each device **binding** with the bound app’s selected **resource-mode requirement** (`spec` on allocations via **`AttachBoundAppSpecs`**); the whole list **errors** if any bound app’s config or selected mode cannot be resolved.
> 
> **System and user env** APIs gain shared **`collectAppEnvReferrers`**: **delete** is blocked when apps still reference an env; **list** (and detail) return **`referencedBy`** apps—system env list only for **admins**. Deploy bumps **`beclab/app-service`** to **0.5.53**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636b44eba0c82b082f662a0d78dfdbab88f61963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->