### PR TITLE
fix(headscale): fix postStart readiness; api-wrapper restarts to recover

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -250,7 +250,7 @@ spec:
                               break
                           fi
                       done
-                      sleep 1
+                      sleep 2
                       headscale apikeys create -e 3650d > /etc/headscale/apikey
                       headscale users create default
                       USER_ID=$(headscale users list | awk '/default/ {print $1; exit}')

--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -250,6 +250,7 @@ spec:
                               break
                           fi
                       done
+                      sleep 1
                       headscale apikeys create -e 3650d > /etc/headscale/apikey
                       headscale users create default
                       USER_ID=$(headscale users list | awk '/default/ {print $1; exit}')
@@ -291,7 +292,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        image: beclab/headscale-api-wrapper:v0.1.8
+        image: beclab/headscale-api-wrapper:v0.1.9
         imagePullPolicy: IfNotPresent
         name: headscale-api-wrapper
         securityContext:


### PR DESCRIPTION

* **Background**
Fix a startup race where headscale's postStart ran before headscale was ready; bump api-wrapper so it restarts and recovers on its own.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm timing change and a patch-level sidecar image bump; no auth model or data-path changes.
> 
> **Overview**
> Addresses a **startup race** where the headscale container’s `postStart` hook could run CLI steps as soon as `headscale.sock` appeared, before the server was fully ready to handle `apikeys` / `users` / `preauthkeys`.
> 
> After the existing socket wait loop, the hook now **waits an extra 2 seconds** before creating the API key, default user, and preauth key files under `/etc/headscale`.
> 
> The **headscale-api-wrapper** sidecar image is bumped from `v0.1.8` to **`v0.1.9`** so it can restart and recover when those credentials are written late or missing on first boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71dad5a122c2d080d98d5664add57f33412d3bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->