### PR TITLE
docs: make language auto-redirect base-aware for /docs sub-path (1.12.2)

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -45,43 +45,51 @@ enhanceApp({ app, router }: { app: App; router: Router }) {
   setup() {
     const route = useRoute();
     const router = useRouter();
-    const { lang } = useData();
+    const { lang, site } = useData();
 
+    // Auto-redirect a fresh page load to the visitor's remembered language.
+    // router.route.path includes the site base (e.g. "/docs/" or
+    // "/docs/1.12.4/"); the version, when present, lives entirely in that base.
+    // We therefore strip the base first and match the language prefix on the
+    // base-relative path. (The previous implementation matched against the raw
+    // path without accounting for the base, so under a "/docs" deploy the
+    // default+en combination produced an empty prefix that matched everything
+    // and corrupted the URL, e.g. /docs/zh/... -> /zh/docs/zh/...).
     const routerRedirect = () => {
       let localLanguage = localStorage.getItem(LANGUAGE_LOCAL_KEY) || 'en';
-      
-      const versions = process.env.VERSIONS!.split(",") ||[];
-      versions.push('default');
 
-      const languages = process.env.LANGUAGES!.split(",") || [];
-      languages.push('en');
-      console.log(versions, languages,localLanguage)
+      const languages = process.env.LANGUAGES ? process.env.LANGUAGES.split(",") : [];
+      if (!languages.includes('en')) languages.push('en');
 
-      if(!languages?.includes(localLanguage) ){
+      if (!languages.includes(localLanguage)) {
         localLanguage = 'en';
       }
 
+      const base = site.value.base || '/';
+      const rawPath = router.route.path;
+      // Base-relative path without a leading slash, e.g. "zh/manual/x" or "manual/x".
+      const rel = rawPath.startsWith(base)
+        ? rawPath.slice(base.length)
+        : rawPath.replace(/^\//, '');
 
-      const currentPath = router.route.path;
-      
-      console.log('router.route.path', router.route.path);
-      for( const l of languages ) {
-        let localLanguagePath = (l === 'en' ? '' : `/${l}`);
-        for (const v of versions) {
-            let localVersionPath = (v === 'default' ? '' : `/${v}`);
-            const u = `${localVersionPath}${localLanguagePath}`;
-            console.log('checkPrefix', u);
-            if (currentPath.startsWith(u)) {
-                console.log('find localLanguage', localLanguage, l);
-                if( l !== localLanguage ) {
-                  let targetLanguagePath = (localLanguage === 'en' ? '' : `/${localLanguage}`);
-                  const nextUrl = `${localVersionPath}${targetLanguagePath}${route.path.replace(u, '')}`;
-                  router.go(nextUrl);
-                }            
-                return;
-            
-          }
+      // Detect the current language from the (non-en) prefix, if any.
+      let currentLanguage = 'en';
+      let pagePath = rel;
+      for (const l of languages) {
+        if (l === 'en') continue;
+        if (rel === l || rel.startsWith(`${l}/`)) {
+          currentLanguage = l;
+          pagePath = rel.slice(l.length).replace(/^\//, '');
+          break;
         }
+      }
+
+      if (currentLanguage === localLanguage) return;
+
+      const langPrefix = localLanguage === 'en' ? '' : `${localLanguage}/`;
+      const target = `${base}${langPrefix}${pagePath}`;
+      if (target !== rawPath) {
+        router.go(target);
       }
     };
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -67,10 +67,17 @@ enhanceApp({ app, router }: { app: App; router: Router }) {
 
       const base = site.value.base || '/';
       const rawPath = router.route.path;
-      // Base-relative path without a leading slash, e.g. "zh/manual/x" or "manual/x".
-      const rel = rawPath.startsWith(base)
-        ? rawPath.slice(base.length)
-        : rawPath.replace(/^\//, '');
+      // Base-relative path without a leading slash, e.g. "zh/manual/x" or
+      // "manual/x". Handle the base both with and without its trailing slash:
+      // router.route.path can be "/docs" as well as "/docs/".
+      let rel: string;
+      if (rawPath.startsWith(base)) {
+        rel = rawPath.slice(base.length);
+      } else if (base.endsWith('/') && rawPath === base.slice(0, -1)) {
+        rel = '';
+      } else {
+        rel = rawPath.replace(/^\//, '');
+      }
 
       // Detect the current language from the (non-en) prefix, if any.
       let currentLanguage = 'en';


### PR DESCRIPTION
## Summary

Make the docs language auto-redirect base-aware so it works under the `/docs` sub-path deploy.

`router.route.path` includes the site base (e.g. `/docs/` or `/docs/1.12.4/`), but the previous `routerRedirect` matched version/language prefixes without accounting for the base. Under `/docs`, the `default`+`en` combination produced an empty prefix that matched every path, so on refresh / language switch the URL got corrupted (e.g. `/docs/zh/manual/...` became `/zh/docs/zh/manual/...`, then `/docs/docs/...`).

The fix strips the base first, detects the current language on the base-relative path, and re-adds the base when redirecting.

## Test plan

- [ ] Build with `BASE_URL=/docs/`, open a zh page, refresh -> URL unchanged
- [ ] Switch EN/ZH -> `/docs` prefix and current page preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side docs routing only; no auth or data handling, with behavior change limited to remembered-language redirects on sub-path builds.
> 
> **Overview**
> Fixes **language auto-redirect** on docs refresh/switch when the site is deployed under a sub-path like `/docs/`.
> 
> `routerRedirect` in the VitePress theme now uses **`site.value.base`** from `useData()`, strips that base from `router.route.path`, detects the current locale on the remaining path, and rebuilds the URL as `base + optional lang prefix + page path`. The old logic matched version/language prefixes on the full path without the base, so `default`+`en` could match everything and corrupt URLs (e.g. `/docs/zh/...` → `/zh/docs/zh/...`).
> 
> The redirect path no longer loops over **`VERSIONS`** in theme code—version is assumed to live in the base. Debug **`console.log`** calls are removed, and **`LANGUAGES`** env parsing is guarded when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4da262829e5a72473aca6092d210ea1367d34d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->