### PR TITLE
fix(cli): clear bird route upon uninstallation

### DIFF
--- a/cli/pkg/bootstrap/os/tasks.go
+++ b/cli/pkg/bootstrap/os/tasks.go
@@ -440,6 +440,15 @@ var (
 		"iptables-save | grep -v KUBE- | grep -v CALICO- | iptables-restore",
 		"ip6tables-save | grep -v KUBE- | grep -v CALICO- | ip6tables-restore",
 		"ipset x",
+		// BIRD is configured with "persist", so the Calico-managed overlay routes
+		// (proto bird, via tunl0) are NOT removed when calico-node stops. They
+		// linger in the kernel FIB and, after re-joining a new master, a fresh
+		// BIRD won't overwrite a same-prefix route it learns on startup, leaving
+		// stale next-hops pointing at the old master. Flush them explicitly and
+		// drop the IPIP tunnel device so re-join starts from a clean state.
+		"ip route flush proto bird",
+		"ip route flush proto bird table all",
+		"ip link del tunl0",
 	}
 )
 


### PR DESCRIPTION
* **Background**
For multi-node environment, calico establishes bird route for pod's communications across nodes and they will be persisted after K8s uninstallation, and only cleared after a reboot, and a new calico instance won't fresh the old route, so a worker join right after an uninstallation without node reboot will cause error for cross node communication, we explicitly clear those routes upon uninstallation to avoid that case.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes node routing during uninstall; incorrect flush scope could affect non-Calico routes, though targeting `proto bird` and `tunl0` limits blast radius.
> 
> **Overview**
> Extends the **OS network reset** step run during Kubernetes uninstall so Calico overlay state is torn down on the node, not only CNI namespaces, iptables rules, and ipsets.
> 
> Three **sudo** commands are appended to `networkResetCmds`: flush routes with `proto bird` (main and all tables), then delete the `tunl0` IPIP device. That clears **persisted BIRD routes** that survive `calico-node` shutdown and can leave stale next-hops after a worker re-joins a new master without a reboot, breaking cross-node pod traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c230cfc81e603e6e5aafed313e27c56d2b52553d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->