### PR TITLE
fix(app-service): update network policy reconciliation 

### DIFF
--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -421,7 +421,11 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 			networkPolicy = security.NetworkPolicies{security.NPUnderLayerSystem.DeepCopy()}
 			networkPolicy.SetName("underlayer-system-np")
 			networkPolicy.SetNamespace(ns.Name)
-			npFix = nil
+			npFix = func(np *netv1.NetworkPolicy) {
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
+			}
 		} else if security.IsOSSystemNamespace(ns.Name) {
 			networkPolicy = security.NetworkPolicies{
 				security.NPOSSystem.DeepCopy(),
@@ -432,7 +436,11 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 			}
 			networkPolicy.SetName("os-system-np")
 			networkPolicy.SetNamespace(ns.Name)
-			npFix = nil
+			npFix = func(np *netv1.NetworkPolicy) {
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
+			}
 		} else if security.IsOSProtectedNamespace(ns.Name) {
 			networkPolicy = security.NetworkPolicies{security.NPOSProtected.DeepCopy(), security.NPSystemProvider.DeepCopy()}
 			networkPolicy.SetName("os-protected-np")
@@ -938,13 +946,24 @@ func (r *SecurityReconciler) namespacesShouldAllowNodeTunnel(ctx context.Context
 		return nil, err
 	}
 
-	reqs := []reconcile.Request{
-		{
+	var reqs []reconcile.Request
+
+	for _, n := range []string{
+		"os-network",
+		"os-platform",
+		"os-framework",
+		"os-gateway",
+		"kube-system",
+		"kubesphere-monitoring-system",
+		"kubesphere-system",
+	} {
+		reqs = append(reqs, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Name: "os-network",
+				Name: n,
 			},
-		},
+		})
 	}
+
 	for _, u := range users.Items {
 		reqs = append(reqs, reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -538,6 +538,9 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 						sel.MatchLabels[security.NamespaceOwnerLabel] = owner
 					}
 				}
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
 			}
 		} else if owner, ok := ns.Labels[security.NamespaceOwnerLabel]; ok && owner != "" {
 			// app namespace networkpolicy
@@ -590,6 +593,9 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 					}
 				}
 
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
 			}
 		} else if shared, ok := ns.Labels[security.NamespaceSharedLabel]; ok && shared != "false" {
 			// shared namespace networkpolicy
@@ -652,6 +658,10 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 						})
 					}
 				}
+
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
 
 			} // end of func npFix
 

--- a/framework/app-service/pkg/gateway/routecontrol/incluster_gateway_ingress_np.go
+++ b/framework/app-service/pkg/gateway/routecontrol/incluster_gateway_ingress_np.go
@@ -3,6 +3,7 @@ package routecontrol
 import (
 	"context"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/security"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,6 +99,9 @@ func desiredInClusterCallerIngressNP() *networkingv1.NetworkPolicy {
 							},
 						},
 					},
+				},
+				{
+					From: security.NodeTunnelRule(),
 				},
 			},
 		},


### PR DESCRIPTION
update network policy reconciliation to allow node tunnel in more namespaces

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster NetworkPolicy ingress across system, app, and gateway namespaces; scope is limited to dynamic node tunnel CIDRs but still broadens who can reach those pods.
> 
> **Overview**
> Extends **node tunnel** (Calico tunnel IP CIDRs via `NodeTunnelRule()`) ingress so workloads in additional namespaces can be reached from the overlay network when nodes change.
> 
> The security reconciler now **appends** a dedicated ingress rule with `NodeTunnelRule()` for underlayer and OS system namespaces (previously no `npFix`), and for v3 shared-app, per-owner app, and legacy shared namespace policies (alongside existing user-space behavior). On **node** events, reconciliation is enqueued for seven fixed platform/system namespaces (`os-platform`, `os-framework`, `os-gateway`, `kube-system`, etc.) in addition to `os-network` and each `user-space-<user>` namespace.
> 
> The gateway route-control reconciler also adds the same tunnel ingress rule to **`app-gateway-incluster-caller-ingress-np`** in `os-gateway`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b029c89e70d2fd861a8794f0529b75edf7d0861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->