### PR TITLE
feat(cli): add `settings compute` for AI accelerator resources (Olares >= 1.12.6)

### DIFF
--- a/cli/cmd/ctl/settings/compute/common.go
+++ b/cli/cmd/ctl/settings/compute/common.go
@@ -1,0 +1,298 @@
+// Package compute hosts `olares-cli settings compute` — the new-version
+// "Accelerator" surface (Olares PR #3118, TermiPass compute-resources
+// page). It mirrors the SPA's Settings -> Accelerator pages
+// (AcceleratorPage.vue / ManageNodePage.vue) backed by user-service's
+// compute.controller.ts, which relays app-service /compute-resources.
+//
+// This is the 1.12.6+ replacement for the legacy `settings gpu list`
+// (HAMI /api/gpu/list, 1.12.5). The two coexist: `gpu` stays for old
+// backends, `compute` is version-gated to >= 1.12.6.
+//
+// Display + behavior rules are deliberately kept identical to the SPA. The
+// pure helpers below are Go re-implementations of the TypeScript helpers in
+// TermiPass packages/app/src/constant/compute.ts so the CLI prints and
+// behaves the same way the web UI does.
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/credential"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// computeMinOlaresVersion is the first Olares line that exposes the
+// compute-resources wire surface (/api/compute-resources and friends).
+// On 1.12.5 those routes do not exist, so we fail fast with an actionable
+// upgrade message and point users at the legacy `settings gpu list`.
+const computeMinOlaresVersion = "1.12.6"
+
+type Format string
+
+const (
+	FormatTable Format = "table"
+	FormatJSON  Format = "json"
+)
+
+func parseFormat(s string) (Format, error) {
+	v := strings.ToLower(strings.TrimSpace(s))
+	switch v {
+	case "", string(FormatTable):
+		return FormatTable, nil
+	case string(FormatJSON):
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported --output %q (allowed: table, json)", s)
+	}
+}
+
+func addOutputFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVarP(target, "output", "o", "table", "output format: table, json")
+}
+
+type Doer interface {
+	DoJSON(ctx context.Context, method, path string, body, out interface{}) error
+}
+
+type preparedClient struct {
+	profile *credential.ResolvedProfile
+	doer    Doer
+}
+
+func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
+	if f == nil {
+		return nil, fmt.Errorf("internal error: settings compute not wired with cmdutil.Factory")
+	}
+	rp, err := f.ResolveProfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	hc, err := f.HTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &preparedClient{
+		profile: rp,
+		doer:    whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID),
+	}, nil
+}
+
+// requireComputeBackendVersion is the client-side version preflight for the
+// compute-resources surface. It mirrors TermiPass's `isLargeVersion12_6`
+// gate: compute-resources only exists on Olares >= 1.12.6, so on an older
+// (or undetectable) backend we reject up front with an actionable error
+// instead of letting the user hit an opaque 404 from /api/compute-resources.
+//
+// It is a thin wrapper that supplies this area's gate copy to the shared
+// preflight.RequireMinVersion helper.
+func requireComputeBackendVersion(ctx context.Context, f *cmdutil.Factory) error {
+	return preflight.RequireMinVersion(ctx, f, preflight.MinVersionGate{
+		Verb:       "settings compute",
+		MinVersion: computeMinOlaresVersion,
+		Reason:     "compute-resources APIs",
+		Fallback:   "upgrade the Olares system, or use the legacy `olares-cli settings gpu list` on 1.12.5",
+	})
+}
+
+type bflEnvelope struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
+	var env bflEnvelope
+	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
+		return err
+	}
+	switch env.Code {
+	case 0, 200:
+	default:
+		msg := strings.TrimSpace(env.Message)
+		if msg == "" {
+			return fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
+		}
+		return fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
+	}
+	if out == nil || len(env.Data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Data, out); err != nil {
+		return fmt.Errorf("GET %s: decode data: %w", path, err)
+	}
+	return nil
+}
+
+func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
+	var env bflEnvelope
+	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
+		return err
+	}
+	switch env.Code {
+	case 0, 200:
+	default:
+		msg := strings.TrimSpace(env.Message)
+		if msg == "" {
+			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
+		}
+		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
+	}
+	if out == nil || len(env.Data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Data, out); err != nil {
+		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
+	}
+	return nil
+}
+
+func printJSON(w io.Writer, v interface{}) error {
+	if w == nil {
+		w = os.Stdout
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func nonEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers re-implemented from TermiPass src/constant/compute.ts so the
+// CLI's display + behavior match the SPA exactly.
+// ---------------------------------------------------------------------------
+
+const giRoundEpsilon = 1e-6
+
+// computeMemoryValue mirrors formatComputeMemoryValue: bytes -> Gi, floored to
+// 2 decimals so it never overstates capacity. Returns the bare number string.
+func computeMemoryValue(bytes int64) string {
+	if bytes <= 0 {
+		return "0"
+	}
+	g := float64(bytes) / math.Pow(1024, 3)
+	floored := math.Floor(g*100+giRoundEpsilon) / 100
+	if floored == math.Trunc(floored) {
+		return fmt.Sprintf("%d", int64(floored))
+	}
+	return fmt.Sprintf("%.2f", floored)
+}
+
+// formatComputeMemory mirrors the TS formatComputeMemory: "<value> Gi".
+func formatComputeMemory(bytes int64) string {
+	return computeMemoryValue(bytes) + " Gi"
+}
+
+// formatComputeCpuCores mirrors the TS helper: millicores -> "<cores> Core".
+func formatComputeCpuCores(milli int64) string {
+	if milli <= 0 {
+		return "0 Core"
+	}
+	cores := float64(milli) / 1000
+	rounded := math.Round(cores*100) / 100
+	if rounded == math.Trunc(rounded) {
+		return fmt.Sprintf("%d Core", int64(rounded))
+	}
+	return fmt.Sprintf("%.2f Core", rounded)
+}
+
+// normalizeComputeMode mirrors the TS helper: lowercase, trim, `_` -> `-`.
+func normalizeComputeMode(mode string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(mode)), "_", "-")
+}
+
+// computeModeTitle mirrors COMPUTE_MODE_TITLE — brand display names, shown
+// identically in every locale. Unknown values fall back to the raw string.
+var computeModeTitleMap = map[string]string{
+	"cpu":         "CPU",
+	"nvidia":      "NVIDIA GPU",
+	"nvidia-gb10": "NVIDIA GB10",
+	"apple-m":     "Apple Silicon-M",
+	"intel":       "Intel",
+	"amd":         "AMD",
+	"intel-gpu":   "Intel GPU",
+	"amd-gpu":     "AMD GPU",
+	"moore-soc":   "Moore Threads",
+}
+
+func computeModeTitle(mode string) string {
+	if t, ok := computeModeTitleMap[normalizeComputeMode(mode)]; ok {
+		return t
+	}
+	return strings.TrimSpace(mode)
+}
+
+// vramComputeModes mirrors VRAM_COMPUTE_MODES: modes whose device memory is
+// dedicated VRAM (discrete GPUs). Integrated accelerators share system RAM.
+var vramComputeModes = map[string]struct{}{
+	"nvidia":    {},
+	"intel-gpu": {},
+	"amd-gpu":   {},
+}
+
+func isVramComputeMode(mode string) bool {
+	_, ok := vramComputeModes[normalizeComputeMode(mode)]
+	return ok
+}
+
+// acceleratorSupportTypeLabel mirrors ACCELERATOR_SUPPORT_TYPE_LABEL_KEY —
+// the wording shown on the Accelerator page.
+var acceleratorSupportTypeLabelMap = map[string]string{
+	"Exclusive":    "Exclusive",
+	"MemorySlice":  "Memory Slicing",
+	"TimeSlice":    "Time Slicing",
+	"MemoryShared": "Memory Shared",
+}
+
+func acceleratorSupportTypeLabel(t string) string {
+	if l, ok := acceleratorSupportTypeLabelMap[t]; ok {
+		return l
+	}
+	return t
+}
+
+// normalizeSupportTypeKey folds a support-type string for matching:
+// trimmed, lowercased, spaces removed. So "Memory Slicing", "MemorySlice"
+// and "  memoryslice " all compare equal-ish to their canonical key.
+func normalizeSupportTypeKey(s string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), " ", ""))
+}
+
+// canonicalSupportType resolves a user-supplied --type to its canonical
+// DeviceSupportType enum. It accepts BOTH the enum value (e.g. "MemorySlice")
+// and the human label shown by `list` (e.g. "Memory Slicing"), case- and
+// space-insensitively, so users can paste whichever form they see.
+func canonicalSupportType(input string) (string, bool) {
+	key := normalizeSupportTypeKey(input)
+	if key == "" {
+		return "", false
+	}
+	for _, enum := range validSupportTypes {
+		if normalizeSupportTypeKey(enum) == key {
+			return enum, true
+		}
+		if normalizeSupportTypeKey(acceleratorSupportTypeLabelMap[enum]) == key {
+			return enum, true
+		}
+	}
+	return "", false
+}
+
+func isExclusiveSupportType(t string) bool {
+	return t == "Exclusive"
+}

--- a/cli/cmd/ctl/settings/compute/compute_test.go
+++ b/cli/cmd/ctl/settings/compute/compute_test.go
@@ -1,0 +1,245 @@
+package compute
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestComputeMemoryValue(t *testing.T) {
+	const gib = int64(1) << 30
+	cases := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{"zero", 0, "0"},
+		{"negative", -5, "0"},
+		{"exact 12Gi", 12 * gib, "12"},
+		// Non-integer values keep 2 decimals (mirrors JS toFixed(2)).
+		{"half", 12*gib + gib/2, "12.50"},
+		// Floor (never overstate): 12.999 Gi -> 12.99, not 13.
+		{"floor never overstates", 12*gib + gib*999/1000, "12.99"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := computeMemoryValue(tc.bytes); got != tc.want {
+				t.Fatalf("computeMemoryValue(%d) = %q, want %q", tc.bytes, got, tc.want)
+			}
+		})
+	}
+	if got := formatComputeMemory(12 * gib); got != "12 Gi" {
+		t.Fatalf("formatComputeMemory = %q, want %q", got, "12 Gi")
+	}
+}
+
+func TestFormatComputeCpuCores(t *testing.T) {
+	cases := []struct {
+		milli int64
+		want  string
+	}{
+		{0, "0 Core"},
+		{-1, "0 Core"},
+		{1000, "1 Core"},
+		{150, "0.15 Core"},
+		{2500, "2.50 Core"},
+	}
+	for _, tc := range cases {
+		if got := formatComputeCpuCores(tc.milli); got != tc.want {
+			t.Fatalf("formatComputeCpuCores(%d) = %q, want %q", tc.milli, got, tc.want)
+		}
+	}
+}
+
+func TestComputeModeTitleAndVram(t *testing.T) {
+	titleCases := map[string]string{
+		"nvidia":      "NVIDIA GPU",
+		"NVIDIA":      "NVIDIA GPU",  // normalized (case)
+		"nvidia_gb10": "NVIDIA GB10", // normalized (_ -> -)
+		"apple-m":     "Apple Silicon-M",
+		"weird-thing": "weird-thing", // unknown falls back to raw
+	}
+	for in, want := range titleCases {
+		if got := computeModeTitle(in); got != want {
+			t.Fatalf("computeModeTitle(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	vram := []string{"nvidia", "intel-gpu", "amd-gpu", "INTEL_GPU"}
+	for _, m := range vram {
+		if !isVramComputeMode(m) {
+			t.Fatalf("isVramComputeMode(%q) = false, want true", m)
+		}
+	}
+	notVram := []string{"cpu", "intel", "apple-m", "nvidia-gb10", "moore-soc"}
+	for _, m := range notVram {
+		if isVramComputeMode(m) {
+			t.Fatalf("isVramComputeMode(%q) = true, want false", m)
+		}
+	}
+}
+
+func TestAcceleratorSupportTypeLabel(t *testing.T) {
+	want := map[string]string{
+		"Exclusive":    "Exclusive",
+		"MemorySlice":  "Memory Slicing",
+		"TimeSlice":    "Time Slicing",
+		"MemoryShared": "Memory Shared",
+		"Mystery":      "Mystery", // unknown falls back to raw
+	}
+	for in, exp := range want {
+		if got := acceleratorSupportTypeLabel(in); got != exp {
+			t.Fatalf("acceleratorSupportTypeLabel(%q) = %q, want %q", in, got, exp)
+		}
+	}
+}
+
+func TestCanonicalSupportType(t *testing.T) {
+	ok := map[string]string{
+		// enum forms (case / space insensitive)
+		"Exclusive":      "Exclusive",
+		"exclusive":      "Exclusive",
+		"MemorySlice":    "MemorySlice",
+		"  memoryslice ": "MemorySlice",
+		"TIMESLICE":      "TimeSlice",
+		"MemoryShared":   "MemoryShared",
+		// human labels shown by `list`
+		"Memory Slicing": "MemorySlice",
+		"memory slicing": "MemorySlice",
+		"Time Slicing":   "TimeSlice",
+		"Memory Shared":  "MemoryShared",
+	}
+	for in, want := range ok {
+		got, valid := canonicalSupportType(in)
+		if !valid || got != want {
+			t.Fatalf("canonicalSupportType(%q) = (%q,%v), want (%q,true)", in, got, valid, want)
+		}
+	}
+	for _, in := range []string{"", "   ", "bogus", "memory-slice", "exclusiveish"} {
+		if got, valid := canonicalSupportType(in); valid {
+			t.Fatalf("canonicalSupportType(%q) = (%q,true), want invalid", in, got)
+		}
+	}
+}
+
+func TestEffectiveUsedMemory(t *testing.T) {
+	const gib = int64(1) << 30
+
+	// Exclusive + bound app => full card capacity (mirrors the SPA).
+	exclusive := computeDevice{
+		Memory:      12 * gib,
+		SupportType: "Exclusive",
+		Bindings:    []computeBinding{{AppName: "comfyui", Memory: 3 * gib}},
+	}
+	if got := exclusive.effectiveUsedMemory(); got != 12*gib {
+		t.Fatalf("exclusive effectiveUsedMemory = %d, want %d", got, 12*gib)
+	}
+
+	// Exclusive without binding => falls back to summed usage (0).
+	exclusiveIdle := computeDevice{Memory: 12 * gib, SupportType: "Exclusive"}
+	if got := exclusiveIdle.effectiveUsedMemory(); got != 0 {
+		t.Fatalf("exclusive idle effectiveUsedMemory = %d, want 0", got)
+	}
+
+	// Non-exclusive => summed binding usage, capped at capacity.
+	shared := computeDevice{
+		Memory:      12 * gib,
+		SupportType: "MemorySlice",
+		Bindings: []computeBinding{
+			{AppName: "a", Memory: 8 * gib},
+			{AppName: "b", Memory: 8 * gib}, // sum 16Gi > 12Gi capacity => capped
+		},
+	}
+	if got := shared.effectiveUsedMemory(); got != 12*gib {
+		t.Fatalf("shared effectiveUsedMemory = %d, want %d (capped)", got, 12*gib)
+	}
+}
+
+func TestDeviceDisplayName(t *testing.T) {
+	if got := (computeDevice{Name: "GPU0", CardModel: "RTX", Mode: "nvidia", ID: "x"}).deviceDisplayName(); got != "GPU0" {
+		t.Fatalf("name priority = %q, want GPU0", got)
+	}
+	if got := (computeDevice{CardModel: "RTX 4090", Mode: "nvidia", ID: "x"}).deviceDisplayName(); got != "RTX 4090" {
+		t.Fatalf("cardModel priority = %q, want RTX 4090", got)
+	}
+	if got := (computeDevice{Mode: "nvidia", ID: "x"}).deviceDisplayName(); got != "NVIDIA GPU" {
+		t.Fatalf("mode-title priority = %q, want NVIDIA GPU", got)
+	}
+	if got := (computeDevice{ID: "dev-123"}).deviceDisplayName(); got != "dev-123" {
+		t.Fatalf("id fallback = %q, want dev-123", got)
+	}
+}
+
+func TestParseSupportTypeResult(t *testing.T) {
+	// Direct shape: {status, stoppedApps}.
+	direct := json.RawMessage(`{"status":"switched","stoppedApps":[{"appName":"a"}]}`)
+	if got := parseSupportTypeResult(direct); got.Status != "switched" || len(got.StoppedApps) != 1 {
+		t.Fatalf("direct parse = %+v", got)
+	}
+
+	// Discriminated blocked shape: {type:'computeDeviceSwitchBlocked', Data:{...}}.
+	wrapped := json.RawMessage(`{"type":"computeDeviceSwitchBlocked","Data":{"status":"bound-apps-stop-blocked","blockedApps":[{"appName":"b","reason":"running job"}]}}`)
+	got := parseSupportTypeResult(wrapped)
+	if got.Status != "bound-apps-stop-blocked" || len(got.BlockedApps) != 1 || got.BlockedApps[0].Reason != "running job" {
+		t.Fatalf("wrapped parse = %+v", got)
+	}
+
+	// Empty data => default to switched (success with no payload).
+	if got := parseSupportTypeResult(nil); got.Status != "switched" {
+		t.Fatalf("empty parse = %+v, want switched", got)
+	}
+}
+
+func TestAppBindings(t *testing.T) {
+	nodes := []computeNode{
+		{
+			NodeName: "node-a",
+			Devices: []computeDevice{
+				{ID: "d1", Bindings: []computeBinding{{AppName: "multi", Spec: &computeSpec{SupportMultiCards: true}}}},
+				{ID: "d2", Bindings: []computeBinding{{AppName: "multi", Spec: &computeSpec{SupportMultiCards: true}}}},
+				{ID: "d3", Bindings: []computeBinding{{AppName: "single"}}},
+			},
+		},
+	}
+
+	cards, multi := appBindings(nodes, "multi")
+	if len(cards) != 2 || !multi {
+		t.Fatalf("multi app bindings = %v multi=%v, want 2 cards multi=true", cards, multi)
+	}
+	cards, multi = appBindings(nodes, "single")
+	if len(cards) != 1 || multi {
+		t.Fatalf("single app bindings = %v multi=%v, want 1 card multi=false", cards, multi)
+	}
+	cards, _ = appBindings(nodes, "absent")
+	if len(cards) != 0 {
+		t.Fatalf("absent app bindings = %v, want empty", cards)
+	}
+}
+
+func TestFindDevice(t *testing.T) {
+	nodes := []computeNode{
+		{NodeName: "n1", Devices: []computeDevice{{ID: "d1"}, {ID: "d2"}}},
+		{NodeName: "n2", Devices: []computeDevice{{ID: "d3"}}},
+	}
+	if d := findDevice(nodes, "n1", "d2"); d == nil || d.ID != "d2" {
+		t.Fatalf("findDevice n1/d2 = %+v", d)
+	}
+	if d := findDevice(nodes, "n2", "d1"); d != nil {
+		t.Fatalf("findDevice n2/d1 = %+v, want nil (d1 is on n1)", d)
+	}
+	if d := findDevice(nodes, "nope", "d1"); d != nil {
+		t.Fatalf("findDevice nope/d1 = %+v, want nil", d)
+	}
+}
+
+func TestIsValidSupportType(t *testing.T) {
+	for _, v := range []string{"Exclusive", "MemorySlice", "TimeSlice", "MemoryShared"} {
+		if !isValidSupportType(v) {
+			t.Fatalf("isValidSupportType(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "exclusive", "memory-slice", "Bogus"} {
+		if isValidSupportType(v) {
+			t.Fatalf("isValidSupportType(%q) = true, want false", v)
+		}
+	}
+}

--- a/cli/cmd/ctl/settings/compute/list.go
+++ b/cli/cmd/ctl/settings/compute/list.go
@@ -1,0 +1,192 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings compute list`
+//
+// Backed by /api/compute-resources, which returns an array of nodes, each
+// with its accelerator devices and per-device app bindings. The table view
+// groups by node and mirrors the SPA Accelerator page (node summary +
+// per-device usage + bound apps). The DEVICE-ID column and the per-node
+// header are the two values `compute set-type <node> <device>` takes.
+func newListCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list nodes, accelerator devices (with DEVICE-ID) and per-app bindings",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "list compute resources"); err != nil {
+				return err
+			}
+			if err := requireComputeBackendVersion(ctx, f); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runList(ctx, f, output), "list compute resources")
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runList(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	var nodes []computeNode
+	if err := doGetEnvelope(ctx, pc.doer, "/api/compute-resources", &nodes); err != nil {
+		return err
+	}
+
+	switch format {
+	case FormatJSON:
+		return printJSON(os.Stdout, nodes)
+	default:
+		return renderResources(os.Stdout, nodes)
+	}
+}
+
+// renderResources groups output by node, mirroring the SPA Accelerator page:
+// a node header with the dedicated-VRAM / shared-RAM summary, then a table of
+// its devices (DEVICE-ID, support type, used/total memory, bound apps).
+func renderResources(w io.Writer, nodes []computeNode) error {
+	if len(nodes) == 0 {
+		_, err := fmt.Fprintln(w, "no accelerator found (connect a GPU or other accelerator to your cluster to get started)")
+		return err
+	}
+	for i, node := range nodes {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		header := nodeHeaderLine(node)
+		if _, err := fmt.Fprintln(w, header); err != nil {
+			return err
+		}
+		if summary := nodeSummaryLine(node); summary != "" {
+			if _, err := fmt.Fprintf(w, "  %s\n", summary); err != nil {
+				return err
+			}
+		}
+		if len(node.Devices) == 0 {
+			if _, err := fmt.Fprintln(w, "  no devices"); err != nil {
+				return err
+			}
+			continue
+		}
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(tw, "  DEVICE-ID\tNAME\tMODE\tSUPPORT-TYPE\tAVAILABLE\tMEM(Gi)\tHEALTH\tAPPS"); err != nil {
+			return err
+		}
+		for _, d := range node.Devices {
+			if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				nonEmpty(d.ID),
+				nonEmpty(d.deviceDisplayName()),
+				nonEmpty(computeModeTitle(d.Mode)),
+				nonEmpty(d.SupportType),
+				deviceAvailableCell(d),
+				fmt.Sprintf("%s / %s", computeMemoryValue(d.effectiveUsedMemory()), computeMemoryValue(d.Memory)),
+				nonEmpty(d.Health),
+				deviceAppsCell(d),
+			); err != nil {
+				return err
+			}
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nodeHeaderLine(node computeNode) string {
+	var b strings.Builder
+	b.WriteString("Node: ")
+	b.WriteString(nonEmpty(node.NodeName))
+	badges := make([]string, 0, len(node.GpuTypes))
+	for _, m := range node.GpuTypes {
+		if t := computeModeTitle(m); t != "" {
+			badges = append(badges, t)
+		}
+	}
+	if len(badges) > 0 {
+		b.WriteString("  [")
+		b.WriteString(strings.Join(badges, ", "))
+		b.WriteString("]")
+	}
+	if node.Health != "" {
+		b.WriteString("  health=")
+		b.WriteString(node.Health)
+	}
+	return b.String()
+}
+
+// nodeSummaryLine mirrors summaryTiles: Dedicated VRAM = sum of VRAM-mode
+// device memory; Shared RAM = sum of non-VRAM, non-CPU device memory.
+func nodeSummaryLine(node computeNode) string {
+	var vramTotal, sharedTotal int64
+	for _, d := range node.Devices {
+		total := d.Memory
+		if normalizeComputeMode(d.Mode) == "cpu" {
+			continue
+		}
+		if isVramComputeMode(d.Mode) {
+			vramTotal += total
+		} else {
+			sharedTotal += total
+		}
+	}
+	tiles := make([]string, 0, 2)
+	if vramTotal > 0 {
+		tiles = append(tiles, "Dedicated VRAM: "+formatComputeMemory(vramTotal))
+	}
+	if sharedTotal > 0 {
+		tiles = append(tiles, "Shared RAM: "+formatComputeMemory(sharedTotal))
+	}
+	return strings.Join(tiles, "  ")
+}
+
+// deviceAvailableCell lists the support types this device can switch to
+// (device.availableSupportTypes, enum values) — the valid `set-type --type`
+// arguments for this card. Not every device supports every type.
+func deviceAvailableCell(d computeDevice) string {
+	if len(d.AvailableSupportTypes) == 0 {
+		return "-"
+	}
+	return strings.Join(d.AvailableSupportTypes, ",")
+}
+
+func deviceAppsCell(d computeDevice) string {
+	if len(d.Bindings) == 0 {
+		return "no app bound"
+	}
+	names := make([]string, 0, len(d.Bindings))
+	for _, b := range d.Bindings {
+		names = append(names, nonEmpty(b.AppName))
+	}
+	return strings.Join(names, ", ")
+}

--- a/cli/cmd/ctl/settings/compute/root.go
+++ b/cli/cmd/ctl/settings/compute/root.go
@@ -1,0 +1,48 @@
+package compute
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewComputeCommand returns the `settings compute` parent — the new-version
+// "Accelerator" surface (compute-resources). Version-gated to
+// Olares >= 1.12.6; on older backends use `settings gpu list` instead.
+//
+// Subcommands are flat verbs that mirror the SPA's Accelerator pages:
+//
+//	list                            inspect nodes / devices (DEVICE-ID) / bindings
+//	unbind <app>                    unbind (and stop) an app's compute
+//	set-type <node> <device>        switch a device's support type
+func NewComputeCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compute",
+		Short: "AI compute (accelerator) resources — Settings -> Accelerator (Olares >= 1.12.6)",
+		Long: `Inspect and manage AI compute (accelerator) resources — the same surface the
+desktop SPA exposes under Settings -> Accelerator.
+
+Backed by the compute-resources APIs introduced in Olares 1.12.6; on a 1.12.5
+backend these routes do not exist — use the legacy "olares-cli settings gpu
+list" instead.
+
+Subcommands:
+  list                            list nodes, devices (with DEVICE-ID) and bindings
+  unbind <app>                    unbind an app from its device(s) (stops the app)
+  set-type <node> <device> ...    switch a device's support type
+
+Typical flow: run "list" first; its per-node header gives <node> and the
+DEVICE-ID column gives <device> for "set-type".
+
+Note: this differs from the top-level "olares-cli gpu" command (kubeconfig).
+"settings compute" is the profile-based edge-API surface that mirrors the SPA.
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(
+		newListCommand(f),
+		newUnbindCommand(f),
+		newSetTypeCommand(f),
+	)
+	return cmd
+}

--- a/cli/cmd/ctl/settings/compute/set_type.go
+++ b/cli/cmd/ctl/settings/compute/set_type.go
@@ -1,0 +1,252 @@
+package compute
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// validSupportTypes is the canonical DeviceSupportType set (compute.ts).
+var validSupportTypes = []string{"Exclusive", "MemorySlice", "TimeSlice", "MemoryShared"}
+
+func isValidSupportType(t string) bool {
+	for _, v := range validSupportTypes {
+		if v == t {
+			return true
+		}
+	}
+	return false
+}
+
+// `olares-cli settings compute set-type <node> <device> --type X`
+//
+// Backed by PUT /api/compute-resources/nodes/<node>/devices/<device>/support-type.
+// Mirrors the SPA's ManageNodePage support-type dropdown: switching a device
+// that has bound apps unbinds and STOPS those apps; the backend may also
+// refuse with a bound-apps-stop-blocked outcome (apps that cannot be stopped).
+//
+// <node> and <device> are the NODE header and DEVICE-ID column from
+// `olares-cli settings compute list`.
+func newSetTypeCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		supportType string
+		skipConfirm bool
+		output      string
+	)
+	cmd := &cobra.Command{
+		Use:   "set-type <node> <device>",
+		Short: "switch a device's support type (may stop bound apps)",
+		Long: fmt.Sprintf(`Switch an accelerator device's support type.
+
+<node> and <device> are the NODE (shown in each node header) and DEVICE-ID
+(first column) from "olares-cli settings compute list".
+
+Valid --type values: %s.
+The human labels shown by "list" are also accepted (e.g. "Memory Slicing"
+== "MemorySlice"). Not every device supports every type — see the AVAILABLE
+column in "list" for what a given device allows.
+
+This mirrors the SPA's support-type dropdown. If the device currently has
+bound apps, switching unbinds and STOPS those apps — you must type "yes" to
+confirm (or pass --yes). The backend may refuse the switch when a bound app
+cannot be stopped (bound-apps-stop-blocked); in that case nothing changes and
+the command exits non-zero, listing the blocking app(s).
+`, strings.Join(validSupportTypes, ", ")),
+		Args: cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "set compute support type"); err != nil {
+				return err
+			}
+			if err := requireComputeBackendVersion(ctx, f); err != nil {
+				return err
+			}
+			node := strings.TrimSpace(args[0])
+			device := strings.TrimSpace(args[1])
+			if node == "" || device == "" {
+				return fmt.Errorf("both <node> and <device> are required")
+			}
+			if !c.Flags().Changed("type") {
+				return fmt.Errorf("--type is required (one of: %s)", strings.Join(validSupportTypes, ", "))
+			}
+			target, ok := canonicalSupportType(supportType)
+			if !ok {
+				return fmt.Errorf("--type: invalid value %q (allowed: %s; labels like %q are also accepted)",
+					supportType, strings.Join(validSupportTypes, ", "), acceleratorSupportTypeLabel("MemorySlice"))
+			}
+			format, err := parseFormat(output)
+			if err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runSetType(ctx, f, node, device, target, skipConfirm, format), "set compute support type")
+		},
+	}
+	cmd.Flags().StringVar(&supportType, "type", "", fmt.Sprintf("target support type: %s", strings.Join(validSupportTypes, " | ")))
+	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "skip interactive confirmation when bound apps would be stopped")
+	addOutputFlag(cmd, &output)
+	cmd.Flags().SortFlags = false
+	return cmd
+}
+
+func runSetType(ctx context.Context, f *cmdutil.Factory, node, device, target string, skipConfirm bool, format Format) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	// Inspect the device first (same data the SPA dropdown is built from):
+	// short-circuit a no-op switch, validate against availableSupportTypes,
+	// and learn the bound apps so we can warn before stopping them.
+	var nodes []computeNode
+	if err := doGetEnvelope(ctx, pc.doer, "/api/compute-resources", &nodes); err != nil {
+		return err
+	}
+	dev := findDevice(nodes, node, device)
+	if dev == nil {
+		return fmt.Errorf("device %q not found on node %q (see `olares-cli settings compute list`)", device, node)
+	}
+	if dev.SupportType == target {
+		return printSetTypeOutcome(format, node, device, target, &supportTypeResult{Status: "unchanged"})
+	}
+	if len(dev.AvailableSupportTypes) > 0 && !containsStr(dev.AvailableSupportTypes, target) {
+		return fmt.Errorf("device %q does not support %q; available: %s",
+			device, target, strings.Join(dev.AvailableSupportTypes, ", "))
+	}
+
+	boundApps := make([]string, 0, len(dev.Bindings))
+	for _, b := range dev.Bindings {
+		boundApps = append(boundApps, b.AppName)
+	}
+	if len(boundApps) > 0 && !skipConfirm {
+		fmt.Fprintf(os.Stderr,
+			"Switching device %q to %q will unbind and STOP the following app(s):\n  %s\n"+
+				"Type 'yes' to continue: ",
+			device, acceleratorSupportTypeLabel(target), strings.Join(boundApps, ", "))
+		line, rerr := bufio.NewReader(os.Stdin).ReadString('\n')
+		if rerr != nil {
+			return rerr
+		}
+		if strings.TrimSpace(line) != "yes" {
+			return fmt.Errorf("aborting support-type switch: confirmation was not yes")
+		}
+	}
+
+	path := fmt.Sprintf("/api/compute-resources/nodes/%s/devices/%s/support-type",
+		url.PathEscape(node), url.PathEscape(device))
+	var raw json.RawMessage
+	if err := doMutateEnvelope(ctx, pc.doer, "PUT", path, map[string]string{"supportType": target}, &raw); err != nil {
+		return err
+	}
+	result := parseSupportTypeResult(raw)
+
+	if result.Status == "bound-apps-stop-blocked" {
+		// Mode was NOT switched; surface the blocking apps and fail.
+		return blockedError(result.BlockedApps)
+	}
+	return printSetTypeOutcome(format, node, device, target, result)
+}
+
+// parseSupportTypeResult decodes the discriminated wire shape: the inner data
+// is either a supportTypeResult directly, or wrapped as
+// {type: 'computeDeviceSwitchBlocked', Data: {...}}.
+func parseSupportTypeResult(raw json.RawMessage) *supportTypeResult {
+	if len(raw) == 0 {
+		return &supportTypeResult{Status: "switched"}
+	}
+	var env supportTypeEnvelope
+	if err := json.Unmarshal(raw, &env); err == nil && env.Type == "computeDeviceSwitchBlocked" && env.Data != nil {
+		return env.Data
+	}
+	var res supportTypeResult
+	if err := json.Unmarshal(raw, &res); err == nil && res.Status != "" {
+		return &res
+	}
+	return &supportTypeResult{Status: "switched"}
+}
+
+func blockedError(blocked []computeAppRef) error {
+	var b strings.Builder
+	b.WriteString("unable to switch support type: the following bound app(s) could not be stopped:")
+	if len(blocked) == 0 {
+		b.WriteString(" (no detail returned)")
+		return fmt.Errorf("%s", b.String())
+	}
+	for _, a := range blocked {
+		reason := strings.TrimSpace(a.Reason)
+		if reason == "" {
+			reason = "unable to switch mode"
+		}
+		b.WriteString(fmt.Sprintf("\n  - %s: %s", nonEmpty(a.AppName), reason))
+	}
+	return fmt.Errorf("%s", b.String())
+}
+
+func printSetTypeOutcome(format Format, node, device, target string, result *supportTypeResult) error {
+	stopped := make([]string, 0, len(result.StoppedApps))
+	for _, a := range result.StoppedApps {
+		stopped = append(stopped, a.AppName)
+	}
+	switch format {
+	case FormatJSON:
+		out := map[string]interface{}{
+			"node":        node,
+			"device":      device,
+			"supportType": target,
+			"status":      result.Status,
+		}
+		if len(stopped) > 0 {
+			out["stoppedApps"] = stopped
+		}
+		return printJSON(os.Stdout, out)
+	default:
+		switch result.Status {
+		case "unchanged":
+			_, err := fmt.Fprintf(os.Stdout, "device %q on node %q already uses %q; no change\n",
+				device, node, acceleratorSupportTypeLabel(target))
+			return err
+		default:
+			msg := fmt.Sprintf("switched device %q on node %q to %q", device, node, acceleratorSupportTypeLabel(target))
+			if len(stopped) > 0 {
+				msg += fmt.Sprintf(" (stopped app(s): %s)", strings.Join(stopped, ", "))
+			}
+			_, err := fmt.Fprintln(os.Stdout, msg)
+			return err
+		}
+	}
+}
+
+func findDevice(nodes []computeNode, node, device string) *computeDevice {
+	for ni := range nodes {
+		if nodes[ni].NodeName != node {
+			continue
+		}
+		for di := range nodes[ni].Devices {
+			if nodes[ni].Devices[di].ID == device {
+				return &nodes[ni].Devices[di]
+			}
+		}
+	}
+	return nil
+}
+
+func containsStr(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/ctl/settings/compute/types.go
+++ b/cli/cmd/ctl/settings/compute/types.go
@@ -1,0 +1,111 @@
+package compute
+
+// Wire types for the compute-resources surface. Field shapes mirror
+// TermiPass src/constant/compute.ts (ComputeResourceNode / Device / Binding,
+// ComputeSupportTypeResult) so the CLI decodes exactly what the SPA reads.
+
+// computeSpec is the per-binding requirement/capability spec.
+type computeSpec struct {
+	SupportMultiCards bool `json:"supportMultiCards"`
+	SupportMultiNodes bool `json:"supportMultiNodes"`
+}
+
+// computeBinding is a single app bound to a device.
+type computeBinding struct {
+	AppID    string       `json:"appId,omitempty"`
+	AppName  string       `json:"appName"`
+	Owner    string       `json:"owner,omitempty"`
+	Mode     string       `json:"mode,omitempty"`
+	NodeName string       `json:"nodeName,omitempty"`
+	DeviceID string       `json:"deviceId"`
+	Memory   int64        `json:"memory,omitempty"`
+	Spec     *computeSpec `json:"spec,omitempty"`
+}
+
+// computeDevice is a GPU/accelerator card on a node.
+type computeDevice struct {
+	ID                    string           `json:"id"`
+	NodeName              string           `json:"nodeName"`
+	Name                  string           `json:"name,omitempty"`
+	Mode                  string           `json:"mode,omitempty"`
+	CardModel             string           `json:"cardModel,omitempty"`
+	Memory                int64            `json:"memory"`
+	Health                string           `json:"health,omitempty"`
+	SupportType           string           `json:"supportType"`
+	AvailableSupportTypes []string         `json:"availableSupportTypes,omitempty"`
+	Bindings              []computeBinding `json:"bindings,omitempty"`
+}
+
+// computeNode is a node and all of its accelerator devices.
+type computeNode struct {
+	NodeName string          `json:"nodeName"`
+	GpuTypes []string        `json:"gpuTypes,omitempty"`
+	Health   string          `json:"health,omitempty"`
+	Devices  []computeDevice `json:"devices,omitempty"`
+}
+
+// deviceDisplayName mirrors the SPA deviceName(): name || cardModel ||
+// computeModeTitle(mode) || id.
+func (d computeDevice) deviceDisplayName() string {
+	if d.Name != "" {
+		return d.Name
+	}
+	if d.CardModel != "" {
+		return d.CardModel
+	}
+	if d.Mode != "" {
+		if t := computeModeTitle(d.Mode); t != "" {
+			return t
+		}
+	}
+	return d.ID
+}
+
+// usedMemory mirrors deviceUsedMemory: sum of allocated binding memory,
+// capped at the device capacity so used never exceeds total.
+func (d computeDevice) usedMemory() int64 {
+	var used int64
+	for _, b := range d.Bindings {
+		used += b.Memory
+	}
+	if d.Memory > 0 && used > d.Memory {
+		return d.Memory
+	}
+	return used
+}
+
+// effectiveUsedMemory mirrors effectiveDeviceUsedMemory: an Exclusive device
+// with a bound app reads as fully used (the whole card is dedicated);
+// otherwise it falls back to the summed binding usage.
+func (d computeDevice) effectiveUsedMemory() int64 {
+	if isExclusiveSupportType(d.SupportType) && len(d.Bindings) > 0 {
+		return d.Memory
+	}
+	return d.usedMemory()
+}
+
+// computeAppRef is an app reference inside a support-type switch result.
+type computeAppRef struct {
+	AppName string `json:"appName"`
+	Owner   string `json:"owner,omitempty"`
+	State   string `json:"state,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// supportTypeResult mirrors ComputeSupportTypeResult. `status` discriminates
+// the outcome regardless of the upstream business code (switched / unchanged /
+// bound-apps-stop-blocked).
+type supportTypeResult struct {
+	Status      string          `json:"status"`
+	Device      *computeDevice  `json:"device,omitempty"`
+	StoppedApps []computeAppRef `json:"stoppedApps,omitempty"`
+	BlockedApps []computeAppRef `json:"blockedApps,omitempty"`
+}
+
+// supportTypeEnvelope captures the discriminated wire shape used by the
+// support-type switch. The inner payload may arrive either directly as a
+// supportTypeResult, or wrapped as {type: 'computeDeviceSwitchBlocked', Data: {...}}.
+type supportTypeEnvelope struct {
+	Type string             `json:"type"`
+	Data *supportTypeResult `json:"Data"`
+}

--- a/cli/cmd/ctl/settings/compute/unbind.go
+++ b/cli/cmd/ctl/settings/compute/unbind.go
@@ -1,0 +1,144 @@
+package compute
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings compute unbind <app>`
+//
+// Backed by DELETE /api/apps/<app>/compute-resources/bindings. Mirrors the
+// SPA's UnbindAppDialog: unbinding releases the app from its device(s) and
+// stops the app. A multi-card app releases every linked card at once.
+//
+// (The per-app GET /api/apps/:name/compute-resources/bindings is unused by
+// the SPA — the Accelerator page reads bindings from /api/compute-resources,
+// so `compute list` is the inspection path here too.)
+func newUnbindCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		skipConfirm bool
+		output      string
+	)
+	cmd := &cobra.Command{
+		Use:   "unbind <app>",
+		Short: "unbind an app from its accelerator device(s) (stops the app)",
+		Long: `Unbind an app from its accelerator device(s).
+
+This mirrors the SPA's "Unbind" action: the app is unbound and stops
+simultaneously. A multi-card app releases every linked card at once; a
+single-card app releases only its one binding.
+
+By default you must type the whole word "yes" when prompted. Use --yes to
+skip confirmation (for scripting).
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "unbind compute bindings"); err != nil {
+				return err
+			}
+			if err := requireComputeBackendVersion(ctx, f); err != nil {
+				return err
+			}
+			app := strings.TrimSpace(args[0])
+			if app == "" {
+				return fmt.Errorf("app name is required")
+			}
+			format, err := parseFormat(output)
+			if err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runUnbind(ctx, f, app, skipConfirm, format), "unbind compute bindings")
+		},
+	}
+	cmd.Flags().BoolVar(&skipConfirm, "yes", false, "skip interactive confirmation (dangerous)")
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runUnbind(ctx context.Context, f *cmdutil.Factory, app string, skipConfirm bool, format Format) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	// Read current bindings from /compute-resources (same source the SPA
+	// uses) so the confirmation can state the real card count and whether
+	// this is a multi-card release.
+	var nodes []computeNode
+	if err := doGetEnvelope(ctx, pc.doer, "/api/compute-resources", &nodes); err != nil {
+		return err
+	}
+	cards, multiCard := appBindings(nodes, app)
+	if len(cards) == 0 {
+		return fmt.Errorf("app %q has no compute bindings to unbind (see `olares-cli settings compute list`)", app)
+	}
+
+	if !skipConfirm {
+		if multiCard {
+			fmt.Fprintf(os.Stderr,
+				"This will unbind app %q from ALL %d linked card(s) and stop the app.\n"+
+					"Type 'yes' to continue: ", app, len(cards))
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"This will unbind app %q from its accelerator device and stop the app.\n"+
+					"Type 'yes' to continue: ", app)
+		}
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(line) != "yes" {
+			return fmt.Errorf("aborting unbind: confirmation was not yes")
+		}
+	}
+
+	path := "/api/apps/" + url.PathEscape(app) + "/compute-resources/bindings"
+	if err := doMutateEnvelope(ctx, pc.doer, "DELETE", path, nil, nil); err != nil {
+		return err
+	}
+
+	switch format {
+	case FormatJSON:
+		return printJSON(os.Stdout, map[string]interface{}{
+			"app":            app,
+			"status":         "unbound",
+			"released_cards": len(cards),
+		})
+	default:
+		_, err := fmt.Fprintf(os.Stdout, "unbound app %q from compute (%d card(s) released; the app was stopped)\n", app, len(cards))
+		return err
+	}
+}
+
+// appBindings returns the device ids an app is bound to across all nodes, and
+// whether any of those bindings is a multi-card binding (spec.supportMultiCards).
+func appBindings(nodes []computeNode, app string) (cards []string, multiCard bool) {
+	for _, node := range nodes {
+		for _, d := range node.Devices {
+			for _, b := range d.Bindings {
+				if b.AppName != app {
+					continue
+				}
+				cards = append(cards, d.ID)
+				if b.Spec != nil && b.Spec.SupportMultiCards {
+					multiCard = true
+				}
+			}
+		}
+	}
+	return cards, multiCard
+}

--- a/cli/cmd/ctl/settings/gpu/list.go
+++ b/cli/cmd/ctl/settings/gpu/list.go
@@ -43,7 +43,7 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 				Verb:        "settings gpu list",
 				Detail:      "legacy HAMI /api/gpu/list",
 				RemovedIn:   "1.12.6",
-				Replacement: "olares-cli settings compute resources list",
+				Replacement: "olares-cli settings compute list",
 			}); err != nil {
 				return err
 			}

--- a/cli/cmd/ctl/settings/gpu/list.go
+++ b/cli/cmd/ctl/settings/gpu/list.go
@@ -19,15 +19,15 @@ import (
 // Backed by user-service's /api/gpu/list, which proxies HAMI. The body
 // is a BFL envelope around an array of GPUInfo:
 //
-//   {
-//     "nodeName": "...", "id": "...", "type": "...",
-//     "count": 1, "devmem": 12288, "devcore": 80,
-//     "mode": "exclusive" | "shared",
-//     "sharemode": "...",
-//     "health": true,
-//     "memoryAllocated": 0, "memoryAvailable": 0,
-//     "apps": [{"appName": "...", "memory": <int>}],
-//   }
+//	{
+//	  "nodeName": "...", "id": "...", "type": "...",
+//	  "count": 1, "devmem": 12288, "devcore": 80,
+//	  "mode": "exclusive" | "shared",
+//	  "sharemode": "...",
+//	  "health": true,
+//	  "memoryAllocated": 0, "memoryAvailable": 0,
+//	  "apps": [{"appName": "...", "memory": <int>}],
+//	}
 func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
@@ -37,6 +37,14 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 			if err := preflight.Gate(ctx, f, whoami.RoleAdmin, "list GPUs"); err != nil {
+				return err
+			}
+			if err := preflight.RejectIfRemoved(ctx, f, preflight.RemovedGate{
+				Verb:        "settings gpu list",
+				Detail:      "legacy HAMI /api/gpu/list",
+				RemovedIn:   "1.12.6",
+				Replacement: "olares-cli settings compute resources list",
+			}); err != nil {
 				return err
 			}
 			return preflight.Wrap(ctx, f, runList(ctx, f, output), "list GPUs")

--- a/cli/cmd/ctl/settings/internal/preflight/version_gate.go
+++ b/cli/cmd/ctl/settings/internal/preflight/version_gate.go
@@ -86,7 +86,7 @@ type RemovedGate struct {
 	// RemovedIn is the first Olares line that no longer ships the API, e.g. "1.12.6".
 	RemovedIn string
 	// Replacement is an optional replacement command to suggest, e.g.
-	// "olares-cli settings compute resources list".
+	// "olares-cli settings compute list".
 	Replacement string
 }
 

--- a/cli/cmd/ctl/settings/internal/preflight/version_gate.go
+++ b/cli/cmd/ctl/settings/internal/preflight/version_gate.go
@@ -1,0 +1,114 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// Version gates are the shared way every `olares-cli settings` verb expresses
+// an Olares-backend version requirement, so individual areas don't re-roll the
+// same OlaresBackendAtLeast + error-message boilerplate.
+//
+// Two opposite-direction gates are provided:
+//
+//   - RequireMinVersion — a verb that needs the backend to be at least some
+//     version (a feature introduced in release X). Fail-closed: an
+//     undetectable version is rejected, because the feature provably does not
+//     exist on anything older and the call would 404.
+//
+//   - RejectIfRemoved — a verb whose backing API was removed at some version
+//     (a legacy surface dropped in release X). Fail-open: an undetectable
+//     version is let through so the server stays authoritative and older
+//     backends where the endpoint still works keep behaving as before.
+//
+// Both consult the version cached by `profile login` / `profile whoami` (or
+// the --olares-version override), so in the common case they add no network
+// round-trip.
+
+// MinVersionGate describes a verb gated to a minimum Olares backend version.
+type MinVersionGate struct {
+	// Verb is the human command name, e.g. "settings compute". Rendered in
+	// backticks in the error.
+	Verb string
+	// MinVersion is the first Olares line that supports the verb, e.g. "1.12.6".
+	MinVersion string
+	// Reason is an optional short parenthetical, e.g. "compute-resources APIs".
+	Reason string
+	// Fallback is an optional trailing hint appended after the version error,
+	// e.g. "use the legacy `olares-cli settings gpu list` on 1.12.5".
+	Fallback string
+}
+
+// RequireMinVersion fails fast when the backend is below the gate's minimum,
+// or when the version is undetectable (fail-closed). The --olares-version flag
+// is suggested as the escape hatch for the undetectable case.
+func RequireMinVersion(ctx context.Context, f *cmdutil.Factory, gate MinVersionGate) error {
+	if f == nil {
+		return nil
+	}
+	reason := ""
+	if gate.Reason != "" {
+		reason = " (" + gate.Reason + ")"
+	}
+	ok, err := f.OlaresBackendAtLeast(ctx, gate.MinVersion)
+	if err != nil {
+		return fmt.Errorf(
+			"`%s` requires Olares >= %s%s, but the backend version could not be determined: %v; "+
+				"pass --%s <version> to set it manually (e.g. --%s %s)",
+			gate.Verb, gate.MinVersion, reason, err,
+			cmdutil.FlagOlaresVersion, cmdutil.FlagOlaresVersion, gate.MinVersion)
+	}
+	if !ok {
+		got := "unknown"
+		if v, verr := f.OlaresBackendVersion(ctx); verr == nil && v != nil {
+			got = v.Original()
+		}
+		msg := fmt.Sprintf("`%s` requires Olares >= %s%s, but this backend is %s",
+			gate.Verb, gate.MinVersion, reason, got)
+		if gate.Fallback != "" {
+			msg += "; " + gate.Fallback
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
+// RemovedGate describes a verb whose backing API was removed at a given Olares
+// backend version.
+type RemovedGate struct {
+	// Verb is the human command name, e.g. "settings gpu list".
+	Verb string
+	// Detail is an optional parenthetical naming the removed surface, e.g.
+	// "legacy HAMI /api/gpu/list".
+	Detail string
+	// RemovedIn is the first Olares line that no longer ships the API, e.g. "1.12.6".
+	RemovedIn string
+	// Replacement is an optional replacement command to suggest, e.g.
+	// "olares-cli settings compute resources list".
+	Replacement string
+}
+
+// RejectIfRemoved fails fast when the backend is at or after the version that
+// removed the verb, pointing the user at the replacement. Fail-open on an
+// undetectable version: the call is let through so the server stays
+// authoritative and older backends keep working.
+func RejectIfRemoved(ctx context.Context, f *cmdutil.Factory, gate RemovedGate) error {
+	if f == nil {
+		return nil
+	}
+	ok, err := f.OlaresBackendAtLeast(ctx, gate.RemovedIn)
+	if err != nil || !ok {
+		return nil
+	}
+	detail := ""
+	if gate.Detail != "" {
+		detail = " (" + gate.Detail + ")"
+	}
+	msg := fmt.Sprintf("`%s`%s was removed in Olares %s", gate.Verb, detail, gate.RemovedIn)
+	if gate.Replacement != "" {
+		msg += fmt.Sprintf("; use `%s` instead", gate.Replacement)
+	}
+	return fmt.Errorf("%s", msg)
+}

--- a/cli/cmd/ctl/settings/internal/preflight/version_gate_test.go
+++ b/cli/cmd/ctl/settings/internal/preflight/version_gate_test.go
@@ -76,7 +76,7 @@ func TestRejectIfRemoved(t *testing.T) {
 		Verb:        "settings gpu list",
 		Detail:      "legacy HAMI /api/gpu/list",
 		RemovedIn:   "1.12.6",
-		Replacement: "olares-cli settings compute resources list",
+		Replacement: "olares-cli settings compute list",
 	}
 
 	t.Run("at or after removal is rejected with replacement", func(t *testing.T) {

--- a/cli/cmd/ctl/settings/internal/preflight/version_gate_test.go
+++ b/cli/cmd/ctl/settings/internal/preflight/version_gate_test.go
@@ -1,0 +1,112 @@
+package preflight
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// factoryWithVersion returns a fresh Factory whose backend version resolves to
+// `v` via the --olares-version override (which short-circuits before any
+// profile/network lookup). Pass an unparseable string (e.g. "bad") to simulate
+// an undetectable version. The override is reset when the test finishes.
+func factoryWithVersion(t *testing.T, v string) *cmdutil.Factory {
+	t.Helper()
+	prev := viper.GetString(cmdutil.FlagOlaresVersion)
+	viper.Set(cmdutil.FlagOlaresVersion, v)
+	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, prev) })
+	return cmdutil.NewFactory()
+}
+
+func TestRequireMinVersion(t *testing.T) {
+	gate := MinVersionGate{
+		Verb:       "settings compute",
+		MinVersion: "1.12.6",
+		Reason:     "compute-resources APIs",
+		Fallback:   "use the legacy `olares-cli settings gpu list` on 1.12.5",
+	}
+
+	t.Run("at or above min passes", func(t *testing.T) {
+		if err := RequireMinVersion(context.Background(), factoryWithVersion(t, "1.12.6"), gate); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		// A daily build of the same line counts as >= the line.
+		if err := RequireMinVersion(context.Background(), factoryWithVersion(t, "1.12.6-20260603"), gate); err != nil {
+			t.Fatalf("daily build: expected nil, got %v", err)
+		}
+	})
+
+	t.Run("below min is rejected with reason + fallback", func(t *testing.T) {
+		err := RequireMinVersion(context.Background(), factoryWithVersion(t, "1.12.5"), gate)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		for _, want := range []string{"settings compute", "requires Olares >= 1.12.6", "compute-resources APIs", "1.12.5", gate.Fallback} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error %q missing %q", msg, want)
+			}
+		}
+	})
+
+	t.Run("undetectable version is fail-closed and suggests the flag", func(t *testing.T) {
+		err := RequireMinVersion(context.Background(), factoryWithVersion(t, "not-a-version"), gate)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "could not be determined") ||
+			!strings.Contains(err.Error(), cmdutil.FlagOlaresVersion) {
+			t.Fatalf("error %q should mention undetectable + --%s", err.Error(), cmdutil.FlagOlaresVersion)
+		}
+	})
+
+	t.Run("nil factory passes", func(t *testing.T) {
+		if err := RequireMinVersion(context.Background(), nil, gate); err != nil {
+			t.Fatalf("nil factory: expected nil, got %v", err)
+		}
+	})
+}
+
+func TestRejectIfRemoved(t *testing.T) {
+	gate := RemovedGate{
+		Verb:        "settings gpu list",
+		Detail:      "legacy HAMI /api/gpu/list",
+		RemovedIn:   "1.12.6",
+		Replacement: "olares-cli settings compute resources list",
+	}
+
+	t.Run("at or after removal is rejected with replacement", func(t *testing.T) {
+		err := RejectIfRemoved(context.Background(), factoryWithVersion(t, "1.12.6"), gate)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		for _, want := range []string{"settings gpu list", "legacy HAMI /api/gpu/list", "removed in Olares 1.12.6", gate.Replacement} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error %q missing %q", msg, want)
+			}
+		}
+	})
+
+	t.Run("before removal passes (legacy still works)", func(t *testing.T) {
+		if err := RejectIfRemoved(context.Background(), factoryWithVersion(t, "1.12.5"), gate); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("undetectable version is fail-open", func(t *testing.T) {
+		if err := RejectIfRemoved(context.Background(), factoryWithVersion(t, "not-a-version"), gate); err != nil {
+			t.Fatalf("undetectable should fail-open (nil), got %v", err)
+		}
+	})
+
+	t.Run("nil factory passes", func(t *testing.T) {
+		if err := RejectIfRemoved(context.Background(), nil, gate); err != nil {
+			t.Fatalf("nil factory: expected nil, got %v", err)
+		}
+	})
+}

--- a/cli/cmd/ctl/settings/root.go
+++ b/cli/cmd/ctl/settings/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/appearance"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/apps"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/backup"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/compute"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/gpu"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/integration"
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/me"
@@ -80,6 +81,7 @@ https://desktop.<terminus>; backup / restore use the same origin with a
 		vpn.NewVPNCommand(f),
 		network.NewNetworkCommand(f),
 		gpu.NewGPUCommand(f),
+		compute.NewComputeCommand(f),
 		video.NewVideoCommand(f),
 		search.NewSearchCommand(f),
 		backup.NewBackupCommand(f),

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -54,7 +54,7 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `backup` | [references/olares-settings-backup.md](references/olares-settings-backup.md) (plans / snapshots / password) |
 | `appearance` | `olares-cli settings appearance --help` (`get`, `language set`) |
 | `network` | `olares-cli settings network --help` (read-only reverse-proxy / frp / hosts-file; writes blocked by JWS gap — see below) |
-| `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute resources list`) |
+| `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute list`) |
 | `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
 | `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories (filenames are indexed broadly by default; full-text defaults to Drive `/Documents/` only — add more with `dirs add`). `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only today. Index coverage model lives in [`olares-search`](../olares-search/SKILL.md) |

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -54,7 +54,8 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `backup` | [references/olares-settings-backup.md](references/olares-settings-backup.md) (plans / snapshots / password) |
 | `appearance` | `olares-cli settings appearance --help` (`get`, `language set`) |
 | `network` | `olares-cli settings network --help` (read-only reverse-proxy / frp / hosts-file; writes blocked by JWS gap — see below) |
-| `gpu` | `olares-cli settings gpu --help` (read-only `list`) |
+| `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute resources list`) |
+| `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
 | `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories (filenames are indexed broadly by default; full-text defaults to Drive `/Documents/` only — add more with `dirs add`). `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only today. Index coverage model lives in [`olares-search`](../olares-search/SKILL.md) |
 | `restore` | `olares-cli settings restore --help` (read-only `plans list`) |
@@ -78,7 +79,7 @@ All three delegate to the same driver — same output, same caching, same `--ref
 
 | Floor | Verbs |
 |---|---|
-| **Admin (owner / admin)** | `users list / get / create / delete`; `network reverse-proxy get`, `network frp list`, `network hosts-file get`; `gpu list`; `advanced status / registries list / images list`; `vpn ssh status/enable/disable`, `vpn subroutes status`, `vpn acl all/get/add/remove`, `vpn public-domain-policy get` |
+| **Admin (owner / admin)** | `users list / get / create / delete`; `network reverse-proxy get`, `network frp list`, `network hosts-file get`; `gpu list`; `compute list`, `compute unbind`, `compute set-type`; `advanced status / registries list / images list`; `vpn ssh status/enable/disable`, `vpn subroutes status`, `vpn acl all/get/add/remove`, `vpn public-domain-policy get` |
 | **Normal (any authenticated user)** | `me whoami / version / check-update / sso list`; `apps list/get`, `apps entrances list`, `apps env get`, `apps domain get`, `apps policy get`; `vpn devices list / routes <id>`; `appearance get`, `appearance language set`; `integration accounts list / list-by-type / get / add / delete`; `video config get`; `search status / dirs list / rebuild`; `backup plans list`, `backup snapshots list`; `restore plans list`; `advanced env (system|user) list` |
 
 ### Soft preflight behavior
@@ -122,6 +123,7 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 | `vpn acl` | `add` / `remove` | VERIFIED |
 | `integration accounts` | `add awss3` / `add tencent` / `delete` | VERIFIED |
 | `apps` | `suspend [--cascade]` / `resume` (thin aliases over `market stop` / `market resume`), `env set`, `domain set/finish`, `policy set`, `auth-level set` | UNVERIFIED |
+| `compute` | `unbind <app>` (unbind + stop app), `set-type <node> <device> --type X` (may stop bound apps; handles `bound-apps-stop-blocked`) — **1.12.6+** | UNVERIFIED |
 | `backup` | `password set` | UNVERIFIED |
 
 **Not yet implemented** (and the CLI deliberately does NOT register them):


### PR DESCRIPTION
## Summary

Adds a new `olares-cli settings compute` command group that manages **AI compute / accelerator resources** (GPUs and other accelerators), mirroring the desktop SPA's *Settings -> Accelerator* pages. This is the 1.12.6+ replacement for the legacy `settings gpu list` (HAMI `/api/gpu/list`), backed by the new `compute-resources` APIs.

The command surface is intentionally flat and verb-style (Lark CLI conventions):

```
olares-cli settings compute
  list                                          list nodes / devices (with DEVICE-ID) / bindings
  unbind <app> [--yes]                          unbind an app from its device(s) and stop it
  set-type <node> <device> --type <T> [--yes]   switch a device's support type
```

Behavior, formatting, labels, and confirmation flows are deliberately kept identical to the SPA (`AcceleratorPage.vue` / `ManageNodePage.vue`, `compute.ts`) so the CLI and web UI behave the same way.

## What's included

- **`list`** — groups by node (header carries `Node:` name + mode badges + health), prints a per-device table with `DEVICE-ID`, `NAME`, `MODE`, `SUPPORT-TYPE` (enum value, copy-pasteable), `AVAILABLE` (the support types each device actually allows), `MEM(Gi)`, `HEALTH`, and bound `APPS`. Dedicated-VRAM / shared-RAM summary mirrors the SPA tiles.
- **`unbind <app>`** — `DELETE /api/apps/<app>/compute-resources/bindings`; mirrors the SPA's Unbind dialog (unbind + stop the app, all linked cards for a multi-card app). Interactive `yes` confirmation unless `--yes`.
- **`set-type <node> <device> --type <T>`** — `PUT /api/compute-resources/nodes/<node>/devices/<device>/support-type`. Validates against the device's `availableSupportTypes`, short-circuits no-op switches, warns/confirms when bound apps would be stopped, and handles the discriminated `bound-apps-stop-blocked` envelope (nothing changes, exits non-zero, lists the blocking app(s)). `--type` accepts both the enum (`MemorySlice`) and the human label shown by `list` (`Memory Slicing`), case/space-insensitive.
- **Version gating** — generic, reusable `preflight.RequireMinVersion` (fail-closed) and `preflight.RejectIfRemoved` (fail-open) helpers. `settings compute` requires Olares >= 1.12.6; on older backends `settings gpu list` still works, and on 1.12.6+ `gpu list` now reports it was removed and points users to `compute list`.
- Tests for the helpers (memory/CPU formatting, support-type normalization, discriminated envelope parsing, device lookup, version gates) and a minimal docs update to the `olares-settings` skill.

## Test plan

- [x] `CGO_ENABLED=0 go build ./...`
- [x] `go vet ./cmd/ctl/settings/...`
- [x] `go test ./cmd/ctl/settings/...`
- [x] `gofmt` clean, no linter errors
- [x] `settings compute -h` / `set-type -h` show the flattened verbs and parameter sourcing
- [ ] Manual verification against a live 1.12.6 backend (list / unbind / set-type, including `bound-apps-stop-blocked`)
- [ ] Manual verification that `gpu list` is rejected on 1.12.6 and still works on 1.12.5

Made with [Cursor](https://cursor.com)