### PR TITLE
docs: update sitemap URL in robots.txt to reflect new domain structure

### DIFF
--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.olares.com/sitemap.xml
+Sitemap: https://www.olares.com/docs/sitemap.xml


### PR DESCRIPTION
* **Background**
  The Olares documentation site has moved from the standalone subdomain docs.olares.com to the main site path www.olares.com/docs/. The VitePress sitemap hostname is already set to https://www.olares.com/docs/, but robots.txt still pointed crawlers at the old sitemap URL, https://docs.olares.com/sitemap.xml.
  
  That mismatch can cause search engines to fetch an outdated sitemap and miss pages under the new domain structure. This change updates the Sitemap directive to https://www.olares.com/docs/sitemap.xml so it matches the current deployment path and VitePress sitemap configuration.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SEO/crawler directive change with no application or security impact.
> 
> **Overview**
> Updates the **`Sitemap`** line in `docs/public/robots.txt` from `https://docs.olares.com/sitemap.xml` to **`https://www.olares.com/docs/sitemap.xml`**, matching the docs path on the main site and the VitePress sitemap **`hostname`** (`https://www.olares.com/docs/`).
> 
> Crawlers that read `robots.txt` are now pointed at the current sitemap location instead of the old subdomain URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4910170e455b76e898b93714843fc64aa1035d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->