### PR TITLE
fix(l4-bfl-proxy): route /api/archive/<node> to the data-local files pod

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.32
+          value: v0.3.33
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.32
+      name: beclab/l4-bfl-proxy:v0.3.33
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -47,6 +47,7 @@ var nodeLocationPrefixes = []string{
 	"/api/permission/cache/",
 	"/api/permission/external/",
 	"/api/task/",
+	"/api/archive/",
 }
 
 var masterLocationPrefixes = []string{


### PR DESCRIPTION
Background
- route /api/archive/<node> to the data-local files pod

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- none

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted addition to existing node-local file routing in l4-bfl-proxy with a version bump; no auth or data-model changes.
> 
> **Overview**
> **l4-bfl-proxy** now treats **`/api/archive/<node>/`** like other node-scoped file APIs: Envoy routes those requests to the **`files-<node>`** service on the node that owns the data, with the same Authelia ext-auth and headers as existing node-local paths.
> 
> The proxy image is bumped to **`v0.3.33`** in the BFL launcher (`L4_PROXY_IMAGE_VERSION`) and Olares prebuilt output so clusters pick up the routing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 296bd2f9ba321ab27c1a9554ffb45119cf387671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->