### PR TITLE
 feat(oac): normalize metadata.appid; reject reserved system appids and -1 on disk

### DIFF
--- a/framework/oac/appconfig.go
+++ b/framework/oac/appconfig.go
@@ -37,6 +37,13 @@ type AppConfiguration = apimanifest.AppConfiguration
 // manifests (<0.12.0) are template-rendered with the Checker's
 // owner/admin before parsing; modern (>=0.12.0) manifests are parsed
 // verbatim.
+//
+// metadata.appid is normalized to md5(metadata.name)[:8] before returning,
+// matching what framework/app-service derives at runtime
+// (appcfg.(AppName).GetAppID). Anything the manifest wrote into the field is
+// discarded; an empty metadata.name leaves the appid empty so the
+// downstream validation error keys off the missing name rather than a
+// meaningless hash.
 func (c *OAC) LoadAppConfiguration(oacPath string) (*AppConfiguration, error) {
 	m, err := c.LoadManifestFile(oacPath)
 	if err != nil {
@@ -46,11 +53,13 @@ func (c *OAC) LoadAppConfiguration(oacPath string) (*AppConfiguration, error) {
 	if !ok {
 		return nil, errAppConfigUnavailable
 	}
+	normalizeAppID(cfg)
 	return cfg, nil
 }
 
 // LoadAppConfigurationContent is the byte-slice counterpart of
-// LoadAppConfiguration.
+// LoadAppConfiguration. It applies the same metadata.appid normalization
+// (see LoadAppConfiguration for details).
 func (c *OAC) LoadAppConfigurationContent(content []byte) (*AppConfiguration, error) {
 	m, err := c.LoadManifestContent(content)
 	if err != nil {
@@ -60,7 +69,19 @@ func (c *OAC) LoadAppConfigurationContent(content []byte) (*AppConfiguration, er
 	if !ok {
 		return nil, errAppConfigUnavailable
 	}
+	normalizeAppID(cfg)
 	return cfg, nil
+}
+
+// normalizeAppID overwrites cfg.Metadata.AppID with the deterministic value
+// the platform derives from metadata.name. Centralised so both load entry
+// points behave identically and so the rule (and its empty-name edge case)
+// is documented exactly once.
+func normalizeAppID(cfg *AppConfiguration) {
+	if cfg == nil {
+		return
+	}
+	cfg.Metadata.AppID = olm.AppIDFromName(cfg.Metadata.Name)
 }
 
 // AsAppConfiguration unwraps a Manifest into the concrete

--- a/framework/oac/appconfig_fields_test.go
+++ b/framework/oac/appconfig_fields_test.go
@@ -67,6 +67,13 @@ func TestLoadAppConfiguration_PreservesAllYAMLFields(t *testing.T) {
 
 	var missing, mismatched []string
 	for path, want := range inputLeaves {
+		// metadata.appid is intentionally not preserved: LoadAppConfiguration
+		// normalizes it to md5(metadata.name)[:8] to align with the
+		// runtime-derived id (framework/app-service/pkg/appcfg.GetAppID), so
+		// whatever the YAML wrote there is discarded.
+		if path == "metadata.appid" {
+			continue
+		}
 		got, ok := lookupTestYAMLPath(outputNorm, path)
 		if !ok {
 			missing = append(missing, path)

--- a/framework/oac/appconfig_test.go
+++ b/framework/oac/appconfig_test.go
@@ -183,6 +183,75 @@ func TestValidateAppConfiguration_PackageLevelShortcut(t *testing.T) {
 	}
 }
 
+// TestLoadAppConfigurationContent_NormalizesAppID pins the loader contract
+// that metadata.appid is overwritten with md5(metadata.name)[:8] regardless
+// of what the manifest declared. The value matches
+// framework/app-service/pkg/appcfg.(AppName).GetAppID for non-system apps,
+// so callers can rely on the load layer producing the same id the runtime
+// computes downstream.
+func TestLoadAppConfigurationContent_NormalizesAppID(t *testing.T) {
+	const content = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: demo
+  title: Demo
+  version: 1.0.0
+  appid: whatever-user-wrote
+spec:
+  versionName: v1
+`
+	cfg, err := oac.LoadAppConfigurationContent([]byte(content))
+	if err != nil {
+		t.Fatalf("LoadAppConfigurationContent: %v", err)
+	}
+	// md5("demo") = "fe01ce2a7fbac8fafaed7c982a04e229" -> first 8 hex chars.
+	const want = "fe01ce2a"
+	if cfg.Metadata.AppID != want {
+		t.Fatalf("metadata.appid = %q, want %q (md5(metadata.name)[:8])", cfg.Metadata.AppID, want)
+	}
+}
+
+// TestLoadAppConfigurationContent_EmptyNameLeavesAppIDEmpty pins the
+// edge-case branch of normalizeAppID: when metadata.name is missing the
+// loader returns an empty appid rather than md5("")[:8] (a meaningless
+// constant). The follow-up validation error will then key off the missing
+// name instead of confusing the user with a synthetic hash.
+func TestLoadAppConfigurationContent_EmptyNameLeavesAppIDEmpty(t *testing.T) {
+	const content = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  title: Demo
+  version: 1.0.0
+spec:
+  versionName: v1
+`
+	cfg, err := oac.LoadAppConfigurationContent([]byte(content))
+	if err != nil {
+		t.Fatalf("LoadAppConfigurationContent: %v", err)
+	}
+	if cfg.Metadata.AppID != "" {
+		t.Fatalf("metadata.appid = %q, want empty when metadata.name is missing", cfg.Metadata.AppID)
+	}
+}
+
+// TestLoadAppConfiguration_NormalizesAppID exercises the file-based loader
+// against the firefox fixture: the manifest declares appid: firefox (see
+// testdata/firefox/OlaresManifest.yaml), which the load layer must
+// overwrite with md5("firefox")[:8].
+func TestLoadAppConfiguration_NormalizesAppID(t *testing.T) {
+	cfg, err := oac.LoadAppConfiguration(testdataFirefox, oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("LoadAppConfiguration: %v", err)
+	}
+	// md5("firefox") = "d6a5c9544eca9b5ce2266d1c34a93222" -> first 8 hex chars.
+	const want = "d6a5c954"
+	if cfg.Metadata.AppID != want {
+		t.Fatalf("metadata.appid = %q, want %q (md5(metadata.name)[:8])", cfg.Metadata.AppID, want)
+	}
+}
+
 // TestLoadAppConfiguration_PropagatesParseError ensures that file-IO and
 // parser errors surface via the convenience loader (we don't swallow them
 // or wrap them in errAppConfigUnavailable by mistake).

--- a/framework/oac/images.go
+++ b/framework/oac/images.go
@@ -31,8 +31,9 @@ var AllImageRenderModes = []string{
 	"apple-m",
 	"nvidia",
 	"nvidia-gb10",
-	"mthreads-m1000",
-	"strix-halo",
+	"moore-soc",
+	"amd",
+	"intel",
 }
 
 // ListImages returns the sorted, deduplicated set of container images used by

--- a/framework/oac/internal/manifest/appid.go
+++ b/framework/oac/internal/manifest/appid.go
@@ -1,0 +1,80 @@
+package manifest
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+)
+
+// reservedSystemAppIDs enumerates the metadata.appid values that the Olares
+// platform reserves for its built-in system apps. The list mirrors the
+// SYS_APPS environment value baked into the app-service deployment
+// (framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml)
+// so a third-party app cannot claim an identity that would collide with a
+// system app and silently shadow it at install / routing time.
+//
+// Membership is exact (case-sensitive after trimming); the platform compares
+// the raw appid string when deciding whether an install is a system upgrade,
+// so we mirror that contract here rather than fuzzy-matching.
+var reservedSystemAppIDs = map[string]struct{}{
+	"market":         {},
+	"auth":           {},
+	"citus":          {},
+	"desktop":        {},
+	"did":            {},
+	"docs":           {},
+	"files":          {},
+	"fsnotify":       {},
+	"headscale":      {},
+	"infisical":      {},
+	"intentprovider": {},
+	"ksserver":       {},
+	"message":        {},
+	"mongo":          {},
+	"monitoring":     {},
+	"notifications":  {},
+	"profile":        {},
+	"redis":          {},
+	"recommend":      {},
+	"seafile":        {},
+	"search":         {},
+	"search-admin":   {},
+	"settings":       {},
+	"systemserver":   {},
+	"tapr":           {},
+	"vault":          {},
+	"video":          {},
+	"zinc":           {},
+	"accounts":       {},
+	"control-hub":    {},
+	"dashboard":      {},
+	"nitro":          {},
+	"olares-app":     {},
+}
+
+// IsReservedSystemAppID reports whether s collides with a reserved system
+// appid. Surrounding whitespace is trimmed before lookup so a manifest that
+// accidentally writes "  market  " is treated the same as "market", matching
+// what the YAML parser would observe after the value goes through
+// downstream string normalization.
+func IsReservedSystemAppID(s string) bool {
+	_, ok := reservedSystemAppIDs[strings.TrimSpace(s)]
+	return ok
+}
+
+// AppIDFromName returns the deterministic appid the Olares platform derives
+// from an app name: the first 8 hex characters of md5(name). It mirrors
+// framework/app-service/pkg/appcfg.(AppName).GetAppID's user-app branch
+// (and framework/app-service/pkg/utils/app.GetAppID) so the loader's
+// normalization and the runtime's runtime-derived id agree byte-for-byte.
+//
+// An empty name yields an empty string -- the loader's normalization is a
+// no-op when metadata.name is missing, which keeps validation errors keyed
+// off the absent name rather than producing a meaningless hash.
+func AppIDFromName(name string) string {
+	if name == "" {
+		return ""
+	}
+	sum := md5.Sum([]byte(name))
+	return hex.EncodeToString(sum[:])[:8]
+}

--- a/framework/oac/internal/manifest/appid_test.go
+++ b/framework/oac/internal/manifest/appid_test.go
@@ -1,0 +1,117 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAppIDFromName pins the loader-normalization contract: a non-empty name
+// yields the first 8 hex characters of md5(name); an empty name yields the
+// empty string. Cross-checking against a couple of known md5 prefixes
+// guards against accidental hash-truncation bugs (e.g. taking the last 8
+// chars or hashing UTF-8 bytes differently).
+func TestAppIDFromName(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"", ""},
+		// md5("nginx")   = "ee434023cf89d7dfb21f63d64f0f9d74"
+		{"nginx", "ee434023"},
+		// md5("firefox") = "d6a5c9544eca9b5ce2266d1c34a93222"
+		{"firefox", "d6a5c954"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := AppIDFromName(tc.name)
+			if got != tc.want {
+				t.Fatalf("AppIDFromName(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppIDFromName_DeterministicAndLength(t *testing.T) {
+	id := AppIDFromName("my-app")
+	if len(id) != 8 {
+		t.Fatalf("non-empty name must yield an 8-char id, got %q (len=%d)", id, len(id))
+	}
+	if id != AppIDFromName("my-app") {
+		t.Fatal("AppIDFromName must be deterministic across calls")
+	}
+	if id == AppIDFromName("my-other-app") {
+		t.Fatal("distinct names must yield distinct ids")
+	}
+}
+
+// TestIsReservedSystemAppID covers a representative slice of the reserved
+// set (a head, a tail, and the hyphenated middle entry) plus a clearly
+// non-reserved name. Whitespace handling is pinned because the lint rule
+// trims before checking.
+func TestIsReservedSystemAppID(t *testing.T) {
+	for _, s := range []string{
+		"market", "auth", "search-admin", "olares-app", "control-hub",
+	} {
+		if !IsReservedSystemAppID(s) {
+			t.Errorf("IsReservedSystemAppID(%q) = false, want true", s)
+		}
+	}
+	if !IsReservedSystemAppID("  market  ") {
+		t.Error("IsReservedSystemAppID must trim surrounding whitespace")
+	}
+	for _, s := range []string{
+		"", "my-app", "MARKET", " market2", "marketing",
+	} {
+		if IsReservedSystemAppID(s) {
+			t.Errorf("IsReservedSystemAppID(%q) = true, want false", s)
+		}
+	}
+}
+
+// Lint rule: an empty metadata.appid is permitted (the loader will fill it
+// in deterministically). The baseline fixture omits the field, so it must
+// continue to pass.
+func TestValidateMetadataAppID_EmptyAllowed(t *testing.T) {
+	c := newValidConfig()
+	c.Metadata.AppID = ""
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("empty metadata.appid must be accepted, got: %v", err)
+	}
+}
+
+// Lint rule: a non-reserved metadata.appid (the existing "hand-author" shape
+// from olares-chart-from-compose -- appid==name) must pass even though the
+// loader will overwrite it later.
+func TestValidateMetadataAppID_CustomAccepted(t *testing.T) {
+	c := newValidConfig()
+	c.Metadata.AppID = "firefox"
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("non-reserved metadata.appid must be accepted, got: %v", err)
+	}
+}
+
+// Lint rule: every reserved system appid must be rejected, and the error
+// must mention metadata.appid plus the offending value so the user can
+// spot what to change.
+func TestValidateMetadataAppID_ReservedRejected(t *testing.T) {
+	for _, reserved := range []string{
+		"market", "auth", "settings", "search-admin", "olares-app", "control-hub", "nitro",
+	} {
+		reserved := reserved
+		t.Run(reserved, func(t *testing.T) {
+			c := newValidConfig()
+			c.Metadata.AppID = reserved
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("metadata.appid=%q must be rejected as reserved", reserved)
+			}
+			if !strings.Contains(err.Error(), "metadata.appid") {
+				t.Fatalf("error must mention metadata.appid, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), reserved) {
+				t.Fatalf("error must echo the offending value %q, got: %v", reserved, err)
+			}
+		})
+	}
+}

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -12,38 +12,48 @@ import (
 )
 
 const (
-	ResourceModeCPU           = "cpu"
-	ResourceModeAMDAPU        = "amd-apu"
-	ResourceModeAMDGPU        = "amd-gpu"
-	ResourceModeAppleM        = "apple-m"
-	ResourceModeNvidia        = "nvidia"
-	ResourceModeNvidiaGB10    = "nvidia-gb10"
-	ResourceModeMThreadsM1000 = "mthreads-m1000"
-	ResourceModeStrixHalo     = "strix-halo"
+	ResourceModeCPU        = "cpu"
+	ResourceModeNvidia     = "nvidia"
+	ResourceModeNvidiaGB10 = "nvidia-gb10"
+	ResourceModeAppleM     = "apple-m"
+	ResourceModeIntel      = "intel"     // Intel integrated GPU
+	ResourceModeAMD        = "amd"       // AMD integrated GPU
+	ResourceModeIntelGPU   = "intel-gpu" // Intel discrete GPU
+	ResourceModeAMDGPU     = "amd-gpu"   // AMD discrete GPU
+	ResourceModeMooreSoc   = "moore-soc" // Moore Threads SoC
 )
 
 var validResourceModes = []any{
 	ResourceModeCPU,
-	ResourceModeStrixHalo,
-	ResourceModeAMDGPU,
-	ResourceModeAppleM,
 	ResourceModeNvidia,
 	ResourceModeNvidiaGB10,
-	ResourceModeMThreadsM1000,
-	ResourceModeStrixHalo,
+	ResourceModeAppleM,
+	ResourceModeIntel,
+	ResourceModeAMD,
+	ResourceModeIntelGPU,
+	ResourceModeAMDGPU,
+	ResourceModeMooreSoc,
 }
 
 var modeArchRequirement = map[string]string{
-	ResourceModeAMDGPU:        "amd64",
-	ResourceModeNvidia:        "amd64",
-	ResourceModeNvidiaGB10:    "arm64",
-	ResourceModeMThreadsM1000: "arm64",
-	ResourceModeStrixHalo:     "amd64",
+	ResourceModeNvidia:     "amd64",
+	ResourceModeNvidiaGB10: "arm64",
+	ResourceModeAppleM:     "arm64",
+	ResourceModeIntel:      "amd64",
+	ResourceModeAMD:        "amd64",
+	ResourceModeIntelGPU:   "amd64",
+	ResourceModeAMDGPU:     "amd64",
+	ResourceModeMooreSoc:   "arm64",
 }
 
+// gpuMemoryModes are the modes that expose a standalone GPU memory pool, so a
+// manifest may declare requiredGpu / limitedGpu for them. These are the
+// discrete-GPU / HAMi flavors; the unified-memory SoCs (apple-m, intel, amd,
+// nvidia-gb10, moore-soc) draw from system RAM and must not.
 var gpuMemoryModes = map[string]struct{}{
-	ResourceModeNvidia: {},
-	ResourceModeAMDGPU: {},
+	ResourceModeNvidia:   {},
+	ResourceModeAMDGPU:   {},
+	ResourceModeIntelGPU: {},
 }
 
 var minResourcesManifestVersion = semver.MustParse("0.12.0")

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -396,7 +396,7 @@ func validateQuantities(prefix string, rr ResourceRequirement, templateOnly bool
 	}
 	var errs []error
 	for _, p := range pairs {
-		if p.value == "" || IsAutoResourceQuantity(p.value) {
+		if p.value == "" {
 			continue
 		}
 		if err := validateResourceQuantity(p.value, prefix+p.field, templateOnly, true); err != nil {

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -184,7 +184,10 @@ func TestRule1_ModeArchRequirement(t *testing.T) {
 		{"nvidia ok with amd64", ResourceModeNvidia, []string{"amd64"}, false, ""},
 		{"amd-gpu needs amd64", ResourceModeAMDGPU, []string{"arm64"}, true, "amd64"},
 		{"nvidia-gb10 needs arm64", ResourceModeNvidiaGB10, []string{"amd64"}, true, "arm64"},
-		{"mthreads-m1000 needs arm64", ResourceModeMThreadsM1000, []string{"amd64"}, true, "arm64"},
+		{"moore-soc needs arm64", ResourceModeMooreSoc, []string{"amd64"}, true, "arm64"},
+		{"amd ok with amd64", ResourceModeAMD, []string{"amd64"}, false, ""},
+		{"intel ok with amd64", ResourceModeIntel, []string{"amd64"}, false, ""},
+		{"apple-m needs arm64", ResourceModeAppleM, []string{"amd64"}, true, "arm64"},
 		{"cpu has no arch constraint", ResourceModeCPU, []string{"amd64"}, false, ""},
 	}
 	for _, tc := range cases {
@@ -249,9 +252,9 @@ func TestRule2_NvidiaModeRequiresGPUPair(t *testing.T) {
 }
 
 func TestRule2_NonGPUModeAcceptsCompleteEnvelope(t *testing.T) {
-	// Non-GPU-memory modes (cpu / amd-apu / apple-m / nvidia-gb10 /
-	// mthreads-m1000) cannot declare standalone gpu fields. A fully
-	// populated cpu/memory/disk envelope therefore must validate cleanly.
+	// Non-GPU-memory modes (cpu / apple-m / nvidia-gb10 / intel / amd /
+	// moore-soc) cannot declare standalone gpu fields. A fully populated
+	// cpu/memory/disk envelope therefore must validate cleanly.
 	c := newResourcesConfig(ResourceMode{
 		Mode:                ResourceModeCPU,
 		ResourceRequirement: fullCPUMemoryDisk(),
@@ -280,12 +283,12 @@ func TestRule2_InlineMissingFieldRejected(t *testing.T) {
 	}
 }
 
-// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu)
-// cannot declare gpu fields. Disk is allowed on every mode after the
-// relaxation of the old "cpu+memory only" constraint.
+// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu /
+// intel-gpu) cannot declare gpu fields. Disk is allowed on every mode after
+// the relaxation of the old "cpu+memory only" constraint.
 func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	for _, mode := range []string{
-		ResourceModeCPU, ResourceModeStrixHalo, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMThreadsM1000,
+		ResourceModeCPU, ResourceModeAMD, ResourceModeIntel, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMooreSoc,
 	} {
 		mode := mode
 		t.Run(mode+"_disk_allowed", func(t *testing.T) {
@@ -325,8 +328,8 @@ func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	}
 }
 
-// Rule 4: nvidia and amd-gpu may declare a standalone gpu memory quantity;
-// every other mode must leave requiredGpu/limitedGpu empty.
+// Rule 4: nvidia, amd-gpu and intel-gpu may declare a standalone gpu memory
+// quantity; every other mode must leave requiredGpu/limitedGpu empty.
 func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	cases := []struct {
 		mode    string
@@ -334,8 +337,10 @@ func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	}{
 		{ResourceModeNvidia, false},
 		{ResourceModeAMDGPU, false},
-		{ResourceModeCPU, true},           // non-GPU family
-		{ResourceModeMThreadsM1000, true}, // GPU-family but not yet whitelisted
+		{ResourceModeIntelGPU, false},
+		{ResourceModeCPU, true},      // non-GPU family
+		{ResourceModeMooreSoc, true}, // GPU-family but not yet whitelisted
+		{ResourceModeAMD, true},      // integrated AMD: unified memory, no standalone gpu pool
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -135,7 +135,32 @@ func validateAppMetaData(v interface{}) error {
 			validation.Required.Error("metadata.version is required"),
 			isSemver.Error("metadata.version must be a valid semantic version (e.g. 1.2.3)"),
 		),
+		validation.Field(&m.AppID,
+			validation.By(validateMetadataAppID),
+		),
 	)
+}
+
+// validateMetadataAppID rejects a metadata.appid value that collides with a
+// reserved built-in system app id. Empty appid is permitted -- the loader
+// normalizes it to md5(metadata.name)[:8] at LoadAppConfiguration time, and
+// downstream consumers that require a non-empty appid surface their own
+// errors (e.g. "market upload" rejects a missing field).
+func validateMetadataAppID(v interface{}) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("metadata.appid: unexpected type %T", v)
+	}
+	if s == "" {
+		return nil
+	}
+	if IsReservedSystemAppID(s) {
+		return fmt.Errorf(
+			"metadata.appid %q collides with a reserved system app id; choose a different value (the loader normalizes appid to md5(metadata.name)[:8] anyway, so leaving the field empty is also fine)",
+			s,
+		)
+	}
+	return nil
 }
 
 func validateEntranceValue(v interface{}) error {

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -409,8 +409,9 @@ func TestAllImageRenderModes_ContainsExpected(t *testing.T) {
 		"apple-m",
 		"nvidia",
 		"nvidia-gb10",
-		"mthreads-m1000",
-		"strix-halo",
+		"moore-soc",
+		"amd",
+		"intel",
 	}
 	if !reflect.DeepEqual(oac.AllImageRenderModes, want) {
 		t.Fatalf("AllImageRenderModes drift: got %v, want %v", oac.AllImageRenderModes, want)


### PR DESCRIPTION


* **Background**
     - Add reservedSystemAppIDs set + AppIDFromName helper in
      internal/manifest. The reserved list mirrors the SYS_APPS env baked
      into appservice_deploy.yaml; AppIDFromName mirrors
      framework/app-service/pkg/appcfg.(AppName).GetAppID for user apps so
      the load layer and the runtime agree byte-for-byte.
    - Lint metadata.appid: reject any value that collides with a reserved
      system app id (market / auth / ... / olares-app). Empty appid stays
      allowed because the loader fills it in deterministically.
    - LoadAppConfiguration / LoadAppConfigurationContent now overwrite
      cfg.Metadata.AppID with md5(metadata.name)[:8]. Empty metadata.name
      leaves appid empty rather than producing the meaningless md5("")[:8]
      constant, so the subsequent "metadata.name is required" validation
      error stays the one the user sees.
    - Fix validateQuantities short-circuiting on IsAutoResourceQuantity
      before validateResourceQuantity could fire: template-only manifests
      that set requiredDisk / limitedDisk to "-1" were silently accepted
      even though resourceQuantityValid already knew to reject them. Drop
      the early continue so the disk-vs-template-only rule reaches the
      validator (fixes TestResourceMode_TemplateOnlyRejectsAutoOnDisk).
    - TestLoadAppConfiguration_PreservesAllYAMLFields skips the
      metadata.appid leaf because it is now a derived field.
    - Tests: AppIDFromName + IsReservedSystemAppID coverage, lint rejection
      for every representative reserved id, and load-time normalization
      against both the firefox fixture and an in-memory content fixture
      (including the empty-name edge case).

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manifest validation and load-time app identity (affects install/routing semantics) and renames/removes resource modes, which can break existing manifests still declaring retired modes.
> 
> **Overview**
> **App identity at load time** is aligned with app-service: `LoadAppConfiguration` / `LoadAppConfigurationContent` now **overwrite** `metadata.appid` with `md5(metadata.name)[:8]` via `AppIDFromName`, ignoring manifest-authored values. If `metadata.name` is empty, **appid stays empty** so validation still surfaces the missing name.
> 
> **Lint** now rejects `metadata.appid` values that **collide with reserved system app IDs** (mirroring `SYS_APPS`); empty or non-reserved custom values remain allowed.
> 
> **Resource validation** refreshes the `spec.resources[].mode` enum and arch/GPU rules: legacy modes like `mthreads-m1000` / `strix-halo` / `amd-apu` give way to **`moore-soc`**, **`intel`**, **`amd`**, and discrete **`intel-gpu`**; standalone GPU memory is limited to **`nvidia`**, **`amd-gpu`**, and **`intel-gpu`**. **`AllImageRenderModes`** is updated in parallel (`moore-soc`, `amd`, `intel`).
> 
> **Template-only disk quantities**: `validateQuantities` no longer skips `"-1"` before validation, so **`requiredDisk` / `limitedDisk` cannot use auto-resolve** on template-only apps (fixes the prior silent accept).
> 
> Tests cover appid normalization, reserved-id lint, resource-mode behavior, and YAML round-trip skipping derived `metadata.appid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdaf29381ddf0dbb34d7eb8ddc6d48a95139fe16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->