### PR TITLE
feat(cli): add "node enable-juicefs" to migrate a single-node rootfs to JuiceFS in place

### DIFF
--- a/cli/cmd/ctl/node/enable_juicefs.go
+++ b/cli/cmd/ctl/node/enable_juicefs.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"log"
+	"time"
+
+	"github.com/beclab/Olares/cli/cmd/config"
+	"github.com/beclab/Olares/cli/pkg/pipelines"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdEnableJuiceFS() *cobra.Command {
+	var (
+		stopTimeout       time.Duration
+		stopCheckInterval time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "enable-juicefs",
+		Short: "convert a single-node master's local rootfs to a JuiceFS-backed shared rootfs",
+		Long: `Convert an already-installed single-node Olares master from a local-filesystem
+rootfs to a JuiceFS-backed shared rootfs, in place, without uninstalling.
+
+By default this installs the bundled object storage (MinIO) as the JuiceFS
+backend. To use an external S3-compatible object store instead, pass the
+storage flags (--storage-type s3/oss/cos, --s3-bucket, keys, etc.); in that
+case MinIO is not installed and the credentials are validated instead.
+
+It also installs the metadata engine (Redis), formats a JuiceFS filesystem,
+migrates the existing rootfs data into it (an online bulk copy followed by a
+brief offline incremental copy), swaps the rootfs directory for the JuiceFS
+mount, and regenerates the cluster services.
+
+After it completes, the master satisfies the JuiceFS precondition required to
+add worker nodes, so you can run "olares-cli node add" on the workers.
+
+The command is idempotent and resumable: if JuiceFS is already enabled it only
+ensures Olares is running.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.EnableJuiceFSPipeline(cmd.Context(), stopTimeout, stopCheckInterval); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+
+	flagSetter := config.NewFlagSetterFor(cmd)
+	config.AddVersionFlagBy(flagSetter)
+	config.AddBaseDirFlagBy(flagSetter)
+	config.AddStorageFlagsBy(flagSetter)
+	cmd.Flags().DurationVarP(&stopTimeout, "timeout", "t", 1*time.Minute, "Timeout for graceful container shutdown before using SIGKILL during the offline sync window")
+	cmd.Flags().DurationVarP(&stopCheckInterval, "check-interval", "i", 10*time.Second, "Interval between checks for remaining container processes")
+
+	return cmd
+}

--- a/cli/cmd/ctl/node/root.go
+++ b/cli/cmd/ctl/node/root.go
@@ -9,5 +9,6 @@ func NewNodeCommand() *cobra.Command {
 	}
 	cmd.AddCommand(NewCmdMasterInfo())
 	cmd.AddCommand(NewCmdAddNode())
+	cmd.AddCommand(NewCmdEnableJuiceFS())
 	return cmd
 }

--- a/cli/pkg/phase/cluster/enable_juicefs.go
+++ b/cli/pkg/phase/cluster/enable_juicefs.go
@@ -1,0 +1,434 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/container"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/module"
+	"github.com/beclab/Olares/cli/pkg/core/pipeline"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/k3s"
+	"github.com/beclab/Olares/cli/pkg/kubernetes"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+	"github.com/beclab/Olares/cli/pkg/storage"
+	"github.com/beclab/Olares/cli/pkg/terminus"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnableJuiceFS builds the pipeline that converts a single-node Olares master
+// from a local-filesystem rootfs to a JuiceFS-backed shared rootfs, in place,
+// without uninstalling. Once it completes, the master satisfies the JuiceFS
+// precondition required by `olares-cli node add`, so worker nodes can join.
+//
+// The whole operation is idempotent and resumable: if JuiceFS is already
+// enabled (the systemd unit exists, which only happens after the data has been
+// migrated and the rootfs swapped), it skips straight to ensuring Olares is
+// running and the rootfs type is set.
+func EnableJuiceFS(runtime *common.KubeRuntime, manifestMap manifest.InstallationManifest, stopTimeout, stopCheckInterval time.Duration) *pipeline.Pipeline {
+	manifestModule := manifest.ManifestModule{
+		Manifest: manifestMap,
+		BaseDir:  runtime.GetBaseDir(),
+	}
+
+	var modules []module.Module
+	if storage.IsJuiceFSEnabled() {
+		logger.Info("JuiceFS is already enabled on this node, ensuring Olares is started and the rootfs type is set")
+		modules = []module.Module{
+			&terminus.StartOlaresModule{},
+			&UpdateRootFSTypeModule{},
+			&ReRenderFsnotifyChartsModule{},
+		}
+	} else {
+		// the bundled MinIO is only installed when using the managed-minio
+		// backend; for external object storage (s3/oss/cos/external minio) we
+		// validate the provided credentials instead and JuiceFS is formatted
+		// against that remote bucket.
+		useManagedMinIO := runtime.Arg.Storage == nil || runtime.Arg.Storage.StorageType == common.ManagedMinIO
+		modules = []module.Module{
+			&MigratePrecheckModule{},
+			&storage.ValidateModule{Skip: useManagedMinIO},
+			&storage.InstallMinioModule{
+				ManifestModule: manifestModule,
+				Skip:           !useManagedMinIO,
+			},
+			&storage.InstallRedisModule{ManifestModule: manifestModule},
+			&MigrateRootFSToJuiceFSModule{
+				ManifestModule: manifestModule,
+				StopTimeout:    stopTimeout,
+				CheckInterval:  stopCheckInterval,
+			},
+			&terminus.StartOlaresModule{},
+			&UpdateRootFSTypeModule{},
+			&ReRenderFsnotifyChartsModule{},
+		}
+	}
+
+	return &pipeline.Pipeline{
+		Name:    "Enable JuiceFS on the master node and migrate rootfs",
+		Modules: modules,
+		Runtime: runtime,
+	}
+}
+
+// MigratePrecheckModule validates that the node can be migrated and that there
+// is enough disk space to do so.
+type MigratePrecheckModule struct {
+	common.KubeModule
+}
+
+func (m *MigratePrecheckModule) Init() {
+	m.Name = "MigratePrecheck"
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "CheckMigrationPrecheck",
+			Action: new(storage.CheckMigrationPrecheck),
+		},
+	}
+}
+
+// MigrateRootFSToJuiceFSModule installs the JuiceFS client, formats the
+// filesystem, syncs the local rootfs into it (online + a final offline
+// incremental pass), swaps the rootfs directory for the JuiceFS mount, and
+// regenerates the container runtime service so it gates on JuiceFS.
+type MigrateRootFSToJuiceFSModule struct {
+	common.KubeModule
+	manifest.ManifestModule
+	StopTimeout   time.Duration
+	CheckInterval time.Duration
+}
+
+func (m *MigrateRootFSToJuiceFSModule) Init() {
+	m.Name = "MigrateRootFSToJuiceFS"
+
+	// 1. install JuiceFS client + format the filesystem (no mount on rootfs yet)
+	getRedisConfig := &task.RemoteTask{
+		Name:   "GetRedisConfig",
+		Hosts:  m.Runtime.GetHostsByRole(common.Master),
+		Action: new(storage.GetOrSetRedisConfig),
+		Retry:  1,
+	}
+	// the osnode-init daemonset subPath-mounts /usr/local/bin/juicefs, so on a
+	// node that never had JuiceFS the path already exists as an empty directory;
+	// remove it so CheckJuiceFsExists doesn't mistake it for an installed binary.
+	cleanupStaleBinary := &task.LocalTask{
+		Name:   "CleanupStaleJuiceFsBinaryPath",
+		Action: new(storage.CleanupStaleJuiceFsBinaryPath),
+	}
+	installJuiceFs := &task.LocalTask{
+		Name:    "InstallJuiceFs",
+		Prepare: &storage.CheckJuiceFsExists{},
+		Action: &storage.InstallJuiceFs{
+			ManifestAction: manifest.ManifestAction{
+				BaseDir:  m.BaseDir,
+				Manifest: m.Manifest,
+			},
+		},
+		Retry: 1,
+	}
+	formatJuiceFs := &task.LocalTask{
+		Name:   "FormatJuiceFs",
+		Action: new(storage.ConfigJuiceFsMetaDB),
+		Retry:  1,
+	}
+
+	// 2. mount JuiceFS on a temp mount point and do the first (online) sync
+	mountForMigration := &task.LocalTask{
+		Name:   "MountJuiceFSForMigration",
+		Action: new(storage.MountJuiceFSForMigration),
+		Retry:  1,
+	}
+	firstSync := &task.LocalTask{
+		Name:   "SyncRootFSDataOnline",
+		Action: &storage.SyncRootFSData{Delete: false},
+		Retry:  1,
+	}
+
+	// 3. stop the workloads so nothing writes to the rootfs anymore.
+	// NOTE: we deliberately stop ONLY the kubernetes/container layer here, not
+	// the full StopOlares flow, because MinIO/Redis/JuiceFS must stay up to
+	// serve the second sync and the final mount.
+	m.Tasks = []task.Interface{
+		getRedisConfig,
+		cleanupStaleBinary,
+		installJuiceFs,
+		formatJuiceFs,
+		mountForMigration,
+		firstSync,
+	}
+	m.appendStopWorkloadsTasks()
+
+	// 4. final incremental sync, unmount temp, swap rootfs, mount JuiceFS on rootfs
+	secondSync := &task.LocalTask{
+		Name:   "SyncRootFSDataFinal",
+		Action: &storage.SyncRootFSData{Delete: true},
+		Retry:  1,
+	}
+	unmountMigration := &task.LocalTask{
+		Name:   "UnmountJuiceFSMigration",
+		Action: new(storage.UnmountJuiceFSMigration),
+		Retry:  3,
+	}
+	swapRootFS := &task.LocalTask{
+		Name:   "BackupAndSwapRootFS",
+		Action: new(storage.BackupAndSwapRootFS),
+		Retry:  1,
+	}
+	enableJuiceFs := &task.LocalTask{
+		Name:   "EnableJuiceFsService",
+		Action: new(storage.EnableJuiceFsService),
+		Retry:  1,
+	}
+	checkJuiceFs := &task.LocalTask{
+		Name:   "CheckJuiceFsState",
+		Action: new(storage.CheckJuiceFsState),
+		Retry:  5,
+		Delay:  5 * time.Second,
+	}
+	m.Tasks = append(m.Tasks, secondSync, unmountMigration, swapRootFS, enableJuiceFs, checkJuiceFs)
+
+	// 5. regenerate the container runtime service so it gains the JuiceFS
+	// pre-check (After=juicefs.service + ExecStartPre=juicefs summary) now that
+	// the unit exists.
+	m.appendRegenerateRuntimeServiceTasks()
+}
+
+func (m *MigrateRootFSToJuiceFSModule) appendStopWorkloadsTasks() {
+	stopUnits := []string{"k3s"}
+	if m.KubeConf.Arg.Kubetype == common.K8s {
+		stopUnits = []string{"kubelet"}
+	}
+	m.Tasks = append(m.Tasks,
+		&task.LocalTask{
+			Name: "StopKubernetes",
+			Action: &terminus.SystemctlCommand{
+				Command:   "stop",
+				UnitNames: stopUnits,
+			},
+			Retry: 3,
+		},
+		&task.LocalTask{
+			Name: "KillContainers",
+			Action: &container.KillContainerdProcess{
+				Signal:        "TERM",
+				Timeout:       m.StopTimeout,
+				CheckInterval: m.CheckInterval,
+			},
+			Retry: 3,
+		},
+		&task.LocalTask{
+			Name:   "ClearKubernetesMounts",
+			Action: new(kubernetes.UmountKubelet),
+			Retry:  3,
+		},
+	)
+}
+
+func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {
+	// Only the container-runtime *service* unit needs regenerating: now that
+	// juicefs.service exists, the template adds the JuiceFS pre-check
+	// (After=juicefs.service + ExecStartPre=juicefs summary). The service *env*
+	// file (e.g. k3s.service.env, which holds K3S_TOKEN) is unchanged by this
+	// migration, so we must NOT regenerate it - doing so would require the
+	// cluster status from the pipeline cache and risks clobbering the token.
+	if m.KubeConf.Arg.Kubetype == common.K8s {
+		m.Tasks = append(m.Tasks,
+			&task.LocalTask{
+				Name:   "RegenerateKubeletService",
+				Action: new(kubernetes.GenerateKubeletService),
+			},
+			&task.LocalTask{
+				Name:   "ReloadSystemdUnits",
+				Action: &terminus.SystemctlCommand{DaemonReloadPreExec: true},
+			},
+		)
+		return
+	}
+	m.Tasks = append(m.Tasks,
+		&task.LocalTask{
+			Name:   "RegenerateK3sService",
+			Action: new(k3s.GenerateK3sService),
+		},
+		// EnableK3sService does `systemctl daemon-reload && systemctl enable --now k3s`,
+		// which picks up the regenerated unit (with the JuiceFS pre-check).
+		&task.LocalTask{
+			Name:   "EnableK3sService",
+			Action: new(k3s.EnableK3sService),
+		},
+	)
+}
+
+// UpdateRootFSTypeModule flips OLARES_SYSTEM_ROOTFS_TYPE to "jfs". It runs after
+// Olares is back up, so it retries to give the kube-apiserver time to come back.
+type UpdateRootFSTypeModule struct {
+	common.KubeModule
+}
+
+func (m *UpdateRootFSTypeModule) Init() {
+	m.Name = "UpdateRootFSType"
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "UpdateRootFSTypeSystemEnv",
+			Action: new(storage.UpdateRootFSTypeSystemEnv),
+			Retry:  30,
+			Delay:  10 * time.Second,
+		},
+	}
+}
+
+// ReRenderFsnotifyChartsModule re-renders the charts whose templates branch on
+// fs_type so the JuiceFS-specific fsnotify components are deployed. Flipping the
+// SystemEnv alone is not enough: already-installed releases were rendered with
+// fs_type=fs and only re-render on a helm upgrade.
+type ReRenderFsnotifyChartsModule struct {
+	common.KubeModule
+}
+
+func (m *ReRenderFsnotifyChartsModule) Init() {
+	m.Name = "ReRenderFsnotifyCharts"
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "ReRenderFsnotifyCharts",
+			Action: new(ReRenderFsnotifyCharts),
+			Retry:  3,
+			Delay:  15 * time.Second,
+		},
+	}
+}
+
+// ReRenderFsnotifyCharts re-upgrades, with fs_type=jfs and --reuse-values:
+//   - the os-platform release, which carries the cluster-scoped fsnotify proxy
+//     and daemon (gated on fs_type==jfs);
+//   - each user's per-user fsnotify release (fsnotify for the admin/owner,
+//     fsnotify-<user> for others).
+//
+// Only the fs_type-gated templates change; everything else renders identically
+// thanks to --reuse-values, so this is effectively a no-op for the rest of the
+// release. fsnotify is the only consumer of fs_type that actually changes
+// behavior (the file-watch bridge needed because inotify does not work over the
+// JuiceFS FUSE mount).
+type ReRenderFsnotifyCharts struct {
+	common.KubeAction
+}
+
+func (t *ReRenderFsnotifyCharts) Execute(runtime connector.Runtime) error {
+	if !storage.IsJuiceFSEnabled() {
+		logger.Info("JuiceFS is not enabled, skipping fsnotify chart re-render")
+		return nil
+	}
+
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %w", err)
+	}
+
+	jfsVals := map[string]interface{}{"fs_type": "jfs"}
+
+	// 1. cluster-scoped fsnotify lives in the os-platform release
+	platformActionConfig, platformSettings, err := utils.InitConfig(config, common.NamespaceOsPlatform)
+	if err != nil {
+		return err
+	}
+	platformChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-platform")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	logger.Infof("re-rendering %s release with fs_type=jfs to deploy the cluster fsnotify components", common.ChartNameOSPlatform)
+	if err := utils.UpgradeCharts(ctx, platformActionConfig, platformSettings, common.ChartNameOSPlatform, platformChartPath, "", common.NamespaceOsPlatform, jfsVals, true); err != nil {
+		return fmt.Errorf("failed to re-render %s release: %w", common.ChartNameOSPlatform, err)
+	}
+
+	// 2. per-user fsnotify charts
+	users, adminUser, err := listOlaresUsers(config)
+	if err != nil {
+		// the cluster-level component is the critical one; don't fail the whole
+		// migration if user enumeration has a transient problem
+		logger.Warnf("failed to list users for per-user fsnotify re-render: %v", err)
+		return nil
+	}
+	fsnotifyChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "apps", "fsnotify")
+	for _, user := range users {
+		ns := fmt.Sprintf("user-space-%s", user)
+		releaseName := "fsnotify"
+		if user != adminUser {
+			releaseName = fmt.Sprintf("fsnotify-%s", user)
+		}
+		userActionConfig, userSettings, err := utils.InitConfig(config, ns)
+		if err != nil {
+			logger.Warnf("failed to init helm config for user %s: %v", user, err)
+			continue
+		}
+		// Explicitly pin bfl.username to this user. The per-user fsnotify chart
+		// derives its target namespace (user-system-<username>) from this value;
+		// relying on --reuse-values alone proved unreliable and could render a
+		// user's resources into another user's namespace.
+		userVals := map[string]interface{}{
+			"fs_type": "jfs",
+			"bfl":     map[string]interface{}{"username": user},
+		}
+		uctx, ucancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		logger.Infof("re-rendering fsnotify release %q in %s with fs_type=jfs", releaseName, ns)
+		if err := utils.UpgradeCharts(uctx, userActionConfig, userSettings, releaseName, fsnotifyChartPath, "", ns, userVals, true); err != nil {
+			logger.Warnf("failed to re-render fsnotify for user %s: %v", user, err)
+		}
+		ucancel()
+	}
+
+	return nil
+}
+
+// listOlaresUsers returns the names of all active Olares users (those with a
+// user-space namespace) and the name of the admin/owner user.
+func listOlaresUsers(config *rest.Config) (users []string, adminUser string, err error) {
+	scheme := kruntime.NewScheme()
+	if err := iamv1alpha2.AddToScheme(scheme); err != nil {
+		return nil, "", fmt.Errorf("failed to add user scheme: %w", err)
+	}
+	userClient, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create user client: %w", err)
+	}
+	k8sClient, err := k8sclientset.NewForConfig(config)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	var userList iamv1alpha2.UserList
+	if err := userClient.List(ctx, &userList); err != nil {
+		return nil, "", fmt.Errorf("failed to list users: %w", err)
+	}
+
+	for _, user := range userList.Items {
+		if user.Status.State == "Failed" || user.Status.State == "Deleting" || user.DeletionTimestamp != nil {
+			continue
+		}
+		nsCtx, nsCancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		_, nsErr := k8sClient.CoreV1().Namespaces().Get(nsCtx, fmt.Sprintf("user-space-%s", user.Name), metav1.GetOptions{})
+		nsCancel()
+		if nsErr != nil {
+			if apierrors.IsNotFound(nsErr) {
+				continue
+			}
+			return nil, "", fmt.Errorf("failed to get user-space namespace for %s: %w", user.Name, nsErr)
+		}
+		users = append(users, user.Name)
+		if role, ok := user.Annotations["bytetrade.io/owner-role"]; ok && role == "owner" {
+			adminUser = user.Name
+		}
+	}
+	return users, adminUser, nil
+}

--- a/cli/pkg/pipelines/enable_juicefs.go
+++ b/cli/pkg/pipelines/enable_juicefs.go
@@ -1,0 +1,53 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+	"github.com/beclab/Olares/cli/pkg/phase"
+	"github.com/beclab/Olares/cli/pkg/phase/cluster"
+	"github.com/beclab/Olares/cli/version"
+)
+
+func EnableJuiceFSPipeline(ctx context.Context, stopTimeout, stopCheckInterval time.Duration) error {
+	arg := common.NewArgument()
+	if !arg.SystemInfo.IsLinux() {
+		fmt.Println("error: enabling JuiceFS is only supported on Linux nodes")
+		os.Exit(1)
+	}
+
+	kubeType := phase.GetKubeType()
+	sysVersion, _ := phase.GetOlaresVersion()
+	if sysVersion == "" {
+		sysVersion = version.VERSION
+	}
+	arg.SetOlaresVersion(sysVersion)
+	arg.SetKubeVersion(kubeType)
+	arg.SetStorage(getStorageConfig())
+	arg.SetConsoleLog("enablejuicefs.log", true)
+
+	runtime, err := common.NewKubeRuntime(*arg)
+	if err != nil {
+		return fmt.Errorf("error creating runtime: %v", err)
+	}
+
+	manifestPath := path.Join(runtime.GetInstallerDir(), "installation.manifest")
+	runtime.Arg.SetManifest(manifestPath)
+	manifestMap, err := manifest.ReadAll(runtime.Arg.Manifest)
+	if err != nil {
+		return fmt.Errorf("error reading installation manifest: %v", err)
+	}
+
+	p := cluster.EnableJuiceFS(runtime, manifestMap, stopTimeout, stopCheckInterval)
+	if err := p.Start(ctx); err != nil {
+		logger.Errorf("failed to enable JuiceFS on the master node: %v", err)
+		return err
+	}
+	return nil
+}

--- a/cli/pkg/storage/migrate.go
+++ b/cli/pkg/storage/migrate.go
@@ -1,0 +1,395 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	v1alpha1 "github.com/beclab/Olares/framework/app-service/api/sys.bytetrade.io/v1alpha1"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/util"
+	"github.com/pkg/errors"
+	apixclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// MigrationTempMountPoint is a temporary mount point used to populate the newly
+// formatted JuiceFS filesystem with the data from the local rootfs before the
+// real rootfs directory is swapped out. It is intentionally a sibling of the
+// real rootfs (not a child of it) so the two never overlap.
+var MigrationTempMountPoint = path.Join(OlaresRootDir, ".rootfs-jfs-migrate")
+
+// RootFSLocalBackupDir is where the original local rootfs directory is moved to
+// after its content has been synced into JuiceFS. It is kept around (not
+// deleted) so that the migration can be rolled back manually if needed.
+var RootFSLocalBackupDir = path.Join(OlaresRootDir, "rootfs.local.bak")
+
+// IsJuiceFSEnabled reports whether this node has already been switched over to a
+// JuiceFS-backed rootfs.
+//
+// We deliberately key this off the existence of the juicefs systemd unit file
+// rather than whether /olares/rootfs is currently a JuiceFS mount. The unit
+// file is written by EnableJuiceFsService, which only runs AFTER the original
+// local rootfs has been backed up and swapped out. So its presence guarantees
+// the data migration already completed. Keying off "is currently mounted"
+// instead would be unsafe: a migrated-but-stopped node would look un-migrated
+// and could trigger a re-sync of an (empty) underlying directory into the live
+// JuiceFS with --delete, destroying all data.
+func IsJuiceFSEnabled() bool {
+	return util.IsExist(JuiceFsServiceFile)
+}
+
+// isPathMounted returns whether the given absolute path is currently a mount
+// point (of any filesystem type) by consulting /proc/self/mounts on the node.
+func isPathMounted(runtime connector.Runtime, target string) (bool, error) {
+	out, err := runtime.GetRunner().SudoCmd("cat /proc/self/mounts", false, false)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CheckMigrationPrecheck validates that the node is in a state where the
+// local rootfs can be migrated onto JuiceFS, and that there is enough free
+// space on the data disk to hold a second copy of the data (only relevant for
+// the bundled managed-MinIO backend, where the object data lives on the same
+// local disk).
+type CheckMigrationPrecheck struct {
+	common.KubeAction
+}
+
+func (t *CheckMigrationPrecheck) Execute(runtime connector.Runtime) error {
+	if !util.IsExist(OlaresJuiceFSRootDir) {
+		return fmt.Errorf("rootfs directory %s does not exist, is Olares installed on this node?", OlaresJuiceFSRootDir)
+	}
+
+	// rsync is required for the two-phase data sync. Olares only supports
+	// apt-based distros, so just install it if missing.
+	if _, err := runtime.GetRunner().SudoCmd("command -v rsync", false, false); err != nil {
+		logger.Info("rsync not found, installing it via apt")
+		if _, err := runtime.GetRunner().SudoCmd("apt-get update && apt-get install -y rsync", false, true); err != nil {
+			return errors.Wrap(err, "failed to install rsync, which is required for the rootfs data migration")
+		}
+	}
+
+	// For external object storage (S3/OSS/COS/external MinIO) the data is not
+	// written to the local disk, so the 2x space requirement does not apply.
+	if t.KubeConf.Arg.Storage == nil || t.KubeConf.Arg.Storage.StorageType != common.ManagedMinIO {
+		logger.Info("storage backend is not managed MinIO, skipping local disk space precheck")
+		return nil
+	}
+
+	used, err := dirUsageBytes(runtime, OlaresJuiceFSRootDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine the size of the current rootfs")
+	}
+	avail, err := availBytes(runtime, OlaresRootDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine the available space on the data disk")
+	}
+
+	// require a 10% margin on top of the current usage
+	required := used + used/10
+	if avail < required {
+		return fmt.Errorf("not enough free space to migrate rootfs onto the bundled MinIO: rootfs uses ~%d bytes, but only %d bytes are available on the disk holding %s (need ~%d). "+
+			"Free up space, attach a larger disk, or use an external S3-compatible object store instead",
+			used, avail, OlaresRootDir, required)
+	}
+	logger.Infof("disk space precheck passed: rootfs uses ~%d bytes, %d bytes available", used, avail)
+	return nil
+}
+
+func dirUsageBytes(runtime connector.Runtime, dir string) (int64, error) {
+	out, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("du -sb %s | awk '{print $1}'", dir), false, false)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+}
+
+func availBytes(runtime connector.Runtime, dir string) (int64, error) {
+	out, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("df -B1 --output=avail %s | tail -n 1", dir), false, false)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+}
+
+// CleanupStaleJuiceFsBinaryPath removes a stale /usr/local/bin/juicefs that was
+// auto-created as an (empty) directory by the osnode-init daemonset, which
+// hostPath-mounts /usr/local/bin and bind-mounts the juicefs binary into its
+// container via `subPath: juicefs`. On a single-node install that never had
+// JuiceFS, the binary doesn't exist, so kubelet's subPath handling MkdirAll's
+// the path into an empty directory.
+//
+// Left in place, CheckJuiceFsExists would treat that directory as an installed
+// binary and skip installation, and `juicefs format` would then fail with
+// "/usr/local/bin/juicefs: Is a directory". The path is only a bind-mount
+// source (not a host mount point), so removing it is safe; the running
+// osnode-init pod keeps its stale mount until it is restarted later in the
+// migration, after which subPath correctly mounts the real binary file.
+type CleanupStaleJuiceFsBinaryPath struct {
+	common.KubeAction
+}
+
+func (t *CleanupStaleJuiceFsBinaryPath) Execute(runtime connector.Runtime) error {
+	// Only remove it when it is a directory; never touch a real binary file.
+	cmd := fmt.Sprintf("if [ -d %s ]; then rm -rf %s; fi", JuiceFsFile, JuiceFsFile)
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
+		return errors.Wrap(err, "failed to remove stale juicefs binary directory")
+	}
+	return nil
+}
+
+// MountJuiceFSForMigration mounts the freshly formatted JuiceFS filesystem on a
+// temporary mount point so its content can be populated from the local rootfs.
+// It is idempotent: if the temp mount point is already mounted it does nothing.
+type MountJuiceFSForMigration struct {
+	common.KubeAction
+}
+
+func (t *MountJuiceFSForMigration) Execute(runtime connector.Runtime) error {
+	mounted, err := isPathMounted(runtime, MigrationTempMountPoint)
+	if err != nil {
+		return err
+	}
+	if mounted {
+		logger.Infof("%s is already mounted, skipping", MigrationTempMountPoint)
+		return nil
+	}
+
+	redisAddress, _ := t.PipelineCache.GetMustString(common.CacheHostRedisAddress)
+	redisPassword, _ := t.PipelineCache.GetMustString(common.CacheHostRedisPassword)
+	if redisAddress == "" || redisPassword == "" {
+		return errors.New("redis config is not available, cannot mount JuiceFS for migration")
+	}
+	metaURL := fmt.Sprintf("redis://:%s@%s:6379/1", redisPassword, redisAddress)
+
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s", MigrationTempMountPoint), false, false); err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf("%s mount --background --cache-dir %s %s %s", JuiceFsFile, JuiceFsCacheDir, metaURL, MigrationTempMountPoint)
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
+		return errors.Wrap(err, "failed to mount JuiceFS for migration")
+	}
+	return nil
+}
+
+// SyncRootFSData copies the content of the local rootfs into the JuiceFS
+// filesystem mounted at the migration temp mount point.
+//
+// It is meant to be run twice:
+//   - first (Delete=false) while Olares is still running, to copy the bulk of
+//     the data without downtime;
+//   - then (Delete=true) after the workloads have been stopped, to copy the
+//     incremental changes and remove anything deleted in the meantime.
+type SyncRootFSData struct {
+	common.KubeAction
+	Delete bool
+}
+
+func (t *SyncRootFSData) Execute(runtime connector.Runtime) error {
+	// Safety: the source must be the real local rootfs, never a JuiceFS mount.
+	// Otherwise a --delete sync from an (empty) JuiceFS into JuiceFS could wipe data.
+	srcMounted, err := isJuiceFSMounted(runtime, OlaresJuiceFSRootDir)
+	if err != nil {
+		return err
+	}
+	if srcMounted {
+		return fmt.Errorf("refusing to sync: source %s is already a JuiceFS mount", OlaresJuiceFSRootDir)
+	}
+	dstMounted, err := isPathMounted(runtime, MigrationTempMountPoint)
+	if err != nil {
+		return err
+	}
+	if !dstMounted {
+		return fmt.Errorf("refusing to sync: destination %s is not mounted", MigrationTempMountPoint)
+	}
+
+	flags := "-aHAX --numeric-ids"
+	// JuiceFS exposes internal control files at the mount root (.accesslog,
+	// .config, .stats, .trash, .control). They exist only on the destination
+	// (the JuiceFS mount), never in the local source, so a --delete pass would
+	// try to remove them and fail with "Operation not permitted". Exclude them
+	// (an excluded file is also protected from --delete by default).
+	flags += " --exclude=/.accesslog --exclude=/.config --exclude=/.stats --exclude=/.trash --exclude=/.control"
+	if t.Delete {
+		flags += " --delete"
+	}
+	// trailing slashes: copy the contents of the source into the destination
+	cmd := fmt.Sprintf("rsync %s %s/ %s/", flags, OlaresJuiceFSRootDir, MigrationTempMountPoint)
+	if _, err := runtime.GetRunner().SudoCmd(cmd, true, true); err != nil {
+		return errors.Wrap(err, "failed to sync rootfs data into JuiceFS")
+	}
+	return nil
+}
+
+// UnmountJuiceFSMigration unmounts and removes the temporary migration mount
+// point. It is idempotent.
+type UnmountJuiceFSMigration struct {
+	common.KubeAction
+}
+
+func (t *UnmountJuiceFSMigration) Execute(runtime connector.Runtime) error {
+	mounted, err := isPathMounted(runtime, MigrationTempMountPoint)
+	if err != nil {
+		return err
+	}
+	if mounted {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("umount %s", MigrationTempMountPoint), false, true); err != nil {
+			return errors.Wrap(err, "failed to unmount the migration mount point")
+		}
+	}
+	// best-effort cleanup of the now-empty temp dir
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rmdir %s", MigrationTempMountPoint), false, false)
+	return nil
+}
+
+// BackupAndSwapRootFS moves the original local rootfs aside and recreates an
+// empty rootfs directory that EnableJuiceFsService will then mount JuiceFS on.
+// It is idempotent: if the rootfs is already a JuiceFS mount it does nothing.
+type BackupAndSwapRootFS struct {
+	common.KubeAction
+}
+
+func (t *BackupAndSwapRootFS) Execute(runtime connector.Runtime) error {
+	if IsJuiceFSEnabled() {
+		logger.Info("JuiceFS is already enabled, skipping rootfs backup and swap")
+		return nil
+	}
+	mounted, err := isJuiceFSMounted(runtime, OlaresJuiceFSRootDir)
+	if err != nil {
+		return err
+	}
+	if mounted {
+		logger.Infof("%s is already a JuiceFS mount, skipping backup and swap", OlaresJuiceFSRootDir)
+		return nil
+	}
+
+	backup := RootFSLocalBackupDir
+	if util.IsExist(backup) {
+		backup = fmt.Sprintf("%s.%d", RootFSLocalBackupDir, time.Now().Unix())
+	}
+	logger.Infof("moving original rootfs %s to %s", OlaresJuiceFSRootDir, backup)
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mv %s %s", OlaresJuiceFSRootDir, backup), false, true); err != nil {
+		return errors.Wrap(err, "failed to back up the original rootfs")
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s", OlaresJuiceFSRootDir), false, false); err != nil {
+		return errors.Wrap(err, "failed to recreate the rootfs mount point")
+	}
+	return nil
+}
+
+func isJuiceFSMounted(runtime connector.Runtime, target string) (bool, error) {
+	out, err := runtime.GetRunner().SudoCmd("cat /proc/self/mounts", false, false)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[1] == target && strings.HasPrefix(fields[2], "fuse.juicefs") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// UpdateRootFSTypeSystemEnv flips the OLARES_SYSTEM_ROOTFS_TYPE system env from
+// "fs" to "jfs" so that subsequently installed apps are rendered for a shared
+// (JuiceFS) rootfs. Existing apps keep working regardless because their PVs are
+// hostPath PVs whose paths are unchanged.
+type UpdateRootFSTypeSystemEnv struct {
+	common.KubeAction
+}
+
+func (t *UpdateRootFSTypeSystemEnv) Execute(runtime connector.Runtime) error {
+	const envName = "OLARES_SYSTEM_ROOTFS_TYPE"
+	const value = "jfs"
+
+	common.SetSystemEnv(envName, value)
+
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %w", err)
+	}
+
+	apix, err := apixclientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create crd client: %w", err)
+	}
+
+	ctx := context.Background()
+	_, err = apix.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "systemenvs.sys.bytetrade.io", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Debugf("SystemEnv CRD not found, skipping rootfs type update")
+			return nil
+		}
+		return fmt.Errorf("failed to get SystemEnv CRD: %w", err)
+	}
+
+	scheme := kruntime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add systemenv scheme: %w", err)
+	}
+
+	c, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resourceName, err := apputils.EnvNameToResourceName(envName)
+	if err != nil {
+		return fmt.Errorf("invalid system env name: %s", envName)
+	}
+
+	var existingSystemEnv v1alpha1.SystemEnv
+	err = c.Get(ctx, types.NamespacedName{Name: resourceName}, &existingSystemEnv)
+	if err == nil {
+		if existingSystemEnv.Default != value {
+			existingSystemEnv.Default = value
+			if err := c.Update(ctx, &existingSystemEnv); err != nil {
+				return fmt.Errorf("failed to update SystemEnv %s: %w", resourceName, err)
+			}
+			logger.Infof("Updated SystemEnv %s default to %s", resourceName, value)
+		}
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get SystemEnv %s: %w", resourceName, err)
+	}
+
+	systemEnv := &v1alpha1.SystemEnv{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName,
+		},
+		EnvVarSpec: v1alpha1.EnvVarSpec{
+			EnvName: envName,
+			Default: value,
+		},
+	}
+	if err := c.Create(ctx, systemEnv); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create SystemEnv %s: %w", resourceName, err)
+	}
+	logger.Infof("Created SystemEnv: %s with default %s", envName, value)
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `olares-cli node enable-juicefs`, which converts an already-installed **single-node master** from a local-filesystem rootfs to a **JuiceFS-backed shared rootfs**, in place, without uninstalling. After it completes, the master satisfies the JuiceFS precondition required by `olares-cli node add`, so worker nodes can join.

The pipeline:
- Installs the metadata engine (Redis) and the object backend — bundled **MinIO** by default, or an **external S3/OSS/COS** store via the storage flags (in which case MinIO is skipped and the credentials are validated instead).
- Installs the JuiceFS client and formats a JuiceFS filesystem.
- Migrates the existing rootfs: an **online bulk `rsync`** (no downtime) followed by a **brief offline incremental pass** (`--delete`) after stopping only the kubernetes/container layer (MinIO/Redis/JuiceFS stay up).
- Backs up the original local rootfs, swaps the rootfs directory for the JuiceFS mount, and enables `juicefs.service`.
- Regenerates the container-runtime service so it gates on JuiceFS (`After=juicefs.service` + `ExecStartPre=juicefs summary`), ensuring correct ordering across reboots.
- Flips `OLARES_SYSTEM_ROOTFS_TYPE` to `jfs` and re-renders the fsnotify charts (cluster-scoped `os-platform` + per-user `fsnotify` releases).

The operation is **idempotent and resumable**: it keys off the existence of the juicefs systemd unit (only written after data migration + rootfs swap complete), so re-runs skip straight to ensuring Olares is up.

## Test plan

- [x] `go build ./...` passes in `cli/`
- [x] End-to-end on a single-node master (`192.168.31.16`, managed MinIO):
  - [x] `/olares/rootfs` is a `fuse.juicefs` mount after migration
  - [x] `juicefs` / `redis-server` / `minio` / `k3s` all active
  - [x] all 64 pods Running/Completed (a few restarted during the cutover and self-recovered)
  - [x] `OLARES_SYSTEM_ROOTFS_TYPE` SystemEnv default = `jfs`
  - [x] `k3s.service` regenerated with `After=juicefs.service` + `ExecStartPre=/usr/local/bin/juicefs summary /olares/rootfs`
- [ ] External S3/OSS/COS backend path
- [ ] Reboot test to confirm k3s waits for the JuiceFS mount
- [ ] Add a worker node after migration

## Notes

- The original local rootfs is preserved at `/olares/rootfs.local.bak` (not deleted) for manual rollback; it can be removed later to reclaim disk space.

Made with [Cursor](https://cursor.com)