### PR TITLE
fix(backup): include subPathTimestamp when building file restore path

### DIFF
--- a/framework/backup-server/pkg/modules/backup/v1/model.go
+++ b/framework/backup-server/pkg/modules/backup/v1/model.go
@@ -592,13 +592,23 @@ func parseResponseRestoreDetailFromBackupUrl(restore *sysv1.Restore) (*ResponseR
 		subPath = typeMap["subPath"].(string)
 	}
 
+	var subPathTimestamp int64
+	if v, ok := typeMap["subPathTimestamp"].(float64); ok {
+		subPathTimestamp = int64(v)
+	}
+
+	restoreFullPath := filepath.Join(restorePath, subPath)
+	if backupType == constant.BackupTypeFile {
+		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp))
+	}
+
 	result = &ResponseRestoreDetail{
 		BackupName:        backupName,
 		BackupPath:        backupPath,
 		BackupType:        backupType,
 		BackupAppTypeName: backupAppTypeName,
 		SnapshotTime:      util.ParseToInt64(snapshotTime),
-		RestorePath:       filepath.Join(restorePath, subPath),
+		RestorePath:       restoreFullPath,
 		Progress:          restore.Spec.Progress,
 		Status:            *restore.Spec.Phase,
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When fetching restore detail via `parseResponseRestoreDetailFromBackupUrl` (used by the `getRestore` API), the returned `RestorePath` was assembled as `filepath.Join(restorePath, subPath)`. This did not match the actual location where a file restore ends up on disk.

For file restores, the restore flow writes into a temporary directory `<path>/<subPath>.restore-<subPathTimestamp>` and, after the restore completes successfully, renames it by stripping the `.restore` segment, leaving the final directory `<path>/<subPath>-<subPathTimestamp>`. Because the API response omitted `subPathTimestamp`, the path reported to the client did not point to the real restored directory.

## Changes

- In `parseResponseRestoreDetailFromBackupUrl`, read `subPathTimestamp` from the restore type payload (it is serialized as a JSON number, decoded as `float64`).
- For `file` restores, build `RestorePath` as `<restorePath>/<subPath>-<subPathTimestamp>` so the API reflects the final on-disk directory.
- Non-file (app) restores keep the previous behavior, since they never set `subPath`/`subPathTimestamp` and do not perform the directory rename.

The `.restore` marker is intentionally left out of the API response: it is purely an internal marker of the restore flow and is removed during the post-restore rename. This endpoint only needs to report the final restore path.

## Notes

- Scope is limited to the single function originally reported; no shared helper was introduced and `parseResponseRestoreOne` was left untouched.
- Verified the `backup-server` backup module package builds successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20877701-a0b2-49b1-8d87-37b89ed9c8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20877701-a0b2-49b1-8d87-37b89ed9c8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

