### PR TITLE
fix(app-service): allow gateway shared apps without sharedEntrances

### DIFF
--- a/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
+++ b/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
@@ -9,9 +9,10 @@ import (
 
 // IsGatewaySharedApp reports whether the Application participates in the shared
 // Envoy Gateway path (SRR + HTTPRoute). Qualifying apps are shared cluster-wide
-// installs or v2 cluster-scoped apps that expose spec.sharedEntrances.
+// installs (options.shared) or cluster-scoped apps. sharedEntrances are optional;
+// apps with only spec.entrances still qualify and receive application-class SRRs.
 func IsGatewaySharedApp(app *appv1alpha1.Application) bool {
-	if app == nil || len(app.Spec.SharedEntrances) == 0 {
+	if app == nil {
 		return false
 	}
 	return IsShared(app) || IsClusterScoped(app)

--- a/framework/app-service/pkg/appcfg/helpers_gateway_shared_test.go
+++ b/framework/app-service/pkg/appcfg/helpers_gateway_shared_test.go
@@ -14,10 +14,23 @@ func TestIsGatewaySharedApp(t *testing.T) {
 		}
 	})
 
-	t.Run("no shared entrances", func(t *testing.T) {
+	t.Run("non shared app", func(t *testing.T) {
 		app := &appv1alpha1.Application{}
 		if IsGatewaySharedApp(app) {
-			t.Fatal("app without shared entrances must not be treated as gateway shared")
+			t.Fatal("app without shared or cluster-scoped label must not be treated as gateway shared")
+		}
+	})
+
+	t.Run("shared app without sharedEntrances", func(t *testing.T) {
+		app := &appv1alpha1.Application{
+			Spec: appv1alpha1.ApplicationSpec{
+				Entrances: []appv1alpha1.Entrance{{Name: "web", Host: "svc"}},
+			},
+		}
+		app.Labels = map[string]string{constants.AppSharedLabel: constants.AppSharedTrue}
+
+		if !IsGatewaySharedApp(app) {
+			t.Fatal("shared app without sharedEntrances should still qualify for gateway shared")
 		}
 	})
 

--- a/framework/app-service/pkg/gateway/route_mode_test.go
+++ b/framework/app-service/pkg/gateway/route_mode_test.go
@@ -123,12 +123,12 @@ func TestComputeRouteModePatch_skipsNonSharedApp(t *testing.T) {
 		t.Fatalf("non-shared app: got need=%v mode=%q err=%v, want no patch", need, mode, err)
 	}
 
-	// Shared label but no sharedEntrances.
+	// Shared label without sharedEntrances still qualifies (entrances-only shared singleton).
 	app = newSharedApp()
 	app.Spec.SharedEntrances = nil
 	need, mode, err = ComputeRouteModePatch(ctx, c, app)
-	if err != nil || need || mode != "" {
-		t.Fatalf("no sharedEntrances: got need=%v mode=%q err=%v, want no patch", need, mode, err)
+	if err != nil || !need || mode != AnnotationRouteModeGateway {
+		t.Fatalf("shared without sharedEntrances: got need=%v mode=%q err=%v, want gateway patch", need, mode, err)
 	}
 }
 


### PR DESCRIPTION
Allow shared gateway apps with UI-only entrances to auto opt into route-mode gateway without requiring sharedEntrances.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eligibility for shared gateway routing and automatic route-mode patching, which affects how traffic is routed for shared apps but is limited to apps already marked shared or cluster-scoped.
> 
> **Overview**
> **`IsGatewaySharedApp` no longer requires `spec.sharedEntrances`.** Shared (`options.shared`) or cluster-scoped applications now qualify for the shared Envoy Gateway path (SRR + HTTPRoute) even when they only define `spec.entrances`, matching apps that expose UI-only entrances.
> 
> Downstream **route-mode** logic picks this up: shared apps without `sharedEntrances` can receive an automatic **`gateway`** route-mode annotation when in-cluster gateway is enabled and the Gateway is ready, instead of being skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6162d699ac75cd701fdd4006c5d83a5e6ded52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->