### PR TITLE
docs: enable cleanUrls for docs-1.12.2

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineVersionedConfig2(withMermaid({
     hostname: "https://docs.olares.com/",
   },
   lastUpdated: true,
+  cleanUrls: true,
   base: process.env.BASE_URL || "/",
   vite: {
     build: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only hosting and URL configuration; no application logic, auth, or data handling changes.
> 
> **Overview**
> Enables **clean URLs** (paths without `.html`) for the Olares documentation site in both the build and hosting layers.
> 
> Adds `cleanUrls: true` to **VitePress** (`docs/.vitepress/config.mts`) so generated links and routes omit `.html` suffixes. Mirrors the same setting in **`docs/vercel.json`** so Vercel serves those extensionless URLs correctly in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655a894bcb931554bb5a9f32187542587714d9ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->