### PR TITLE
docs: enable cleanUrls for docs-1.12.4

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineVersionedConfig2(withMermaid({
     hostname: "https://docs.olares.com/",
   },
   lastUpdated: true,
+  cleanUrls: true,
   base: process.env.BASE_URL || "/",
   vite: {
     build: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only routing and hosting configuration with no application logic or security impact.
> 
> **Overview**
> Turns on **clean URLs** for the VitePress docs build and for Vercel hosting so pages are served without `.html` in the path.
> 
> `cleanUrls: true` is added in `docs/.vitepress/config.mts` and in `docs/vercel.json`, aligning static output and edge routing for extensionless doc URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fbdced6d8c70d3c4f1e18daf3d0ebf07c963f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->