### PR TITLE
docs: enable cleanUrls for docs-1.12.6

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -128,7 +128,11 @@ export default defineVersionedConfig2(withMermaid({
         'meta',
         { name: 'robots', content: 'noindex, nofollow' },
       ]);
-      noindexPaths.add(pageData.relativePath.replace(/\.md$/, '.html'));
+      // Store the extensionless route so this matches the sitemap item.url
+      // regardless of `cleanUrls` (which drops the .html from item.url).
+      noindexPaths.add(
+        pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '')
+      );
     }
   },
 
@@ -139,11 +143,14 @@ export default defineVersionedConfig2(withMermaid({
       // them via the sitemap. The meta tag above is what ultimately removes
       // them from search engine indexes; this just avoids the extra hit.
       items.filter((item) => {
-        const p = item.url.replace(/^\/+/, '');
+        // Normalize to the extensionless route so the comparison holds whether
+        // or not cleanUrls is enabled.
+        const p = item.url.replace(/^\/+/, '').replace(/\.html$/, '');
         return !noindexPaths.has(p);
       }),
   },
   lastUpdated: true,
+  cleanUrls: true,
   base: process.env.BASE_URL || "/",
   vite: {
     build: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only routing and sitemap filtering changes; no auth, data, or application runtime impact.
> 
> **Overview**
> Enables **clean URLs** (paths without `.html`) for the VitePress docs build and Vercel hosting by setting `cleanUrls: true` in both `docs/.vitepress/config.mts` and `docs/vercel.json`.
> 
> Because `cleanUrls` changes how routes appear in the sitemap, the **noindex → sitemap exclusion** logic is updated so paths are stored and compared as extensionless routes (including normalizing `index.md` and stripping `.html` from sitemap URLs). That keeps frontmatter `noindex` pages out of `sitemap.xml` after the URL shape change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd3e7f3866b5e16d2e1c0b5f7b3ec9fec74abeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->