### PR TITLE
fix: files open own SMB shares and route share proxy to data node

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.186
+          image: beclab/files-server:v0.2.187
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: authorize SMB shares for the owner, clearing the 403
- fix: route share proxy to the data node for remote external/cache shares

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/353

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in deployment config; behavior changes live in the container image from the linked files PR, with typical rollout risk for a patch release.
> 
> **Overview**
> Bumps the **`files`** container image in the cluster **`files` DaemonSet** from `beclab/files-server:v0.2.186` to **`v0.2.187`**, rolling out the upstream files-server build that addresses SMB share access and share-proxy behavior described in the PR (owner authorization for own shares and routing remote external/cache share proxy to the data node).
> 
> No other manifest, env, or service changes in this diff—only the image tag on the `files` container in `files_deploy.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936caef719e79aee8121b22a1b52c953cce99516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->