### PR TITLE
backup: fix include subPathTimestamp when building file restore path 

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.64" }}
+{{ $backupVersion := "0.3.65" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/pkg/modules/backup/v1/model.go
+++ b/framework/backup-server/pkg/modules/backup/v1/model.go
@@ -592,13 +592,23 @@ func parseResponseRestoreDetailFromBackupUrl(restore *sysv1.Restore) (*ResponseR
 		subPath = typeMap["subPath"].(string)
 	}
 
+	var subPathTimestamp int64
+	if v, ok := typeMap["subPathTimestamp"].(float64); ok {
+		subPathTimestamp = int64(v)
+	}
+
+	restoreFullPath := filepath.Join(restorePath, subPath)
+	if backupType == constant.BackupTypeFile {
+		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp))
+	}
+
 	result = &ResponseRestoreDetail{
 		BackupName:        backupName,
 		BackupPath:        backupPath,
 		BackupType:        backupType,
 		BackupAppTypeName: backupAppTypeName,
 		SnapshotTime:      util.ParseToInt64(snapshotTime),
-		RestorePath:       filepath.Join(restorePath, subPath),
+		RestorePath:       restoreFullPath,
 		Progress:          restore.Spec.Progress,
 		Status:            *restore.Spec.Phase,
 	}


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix include subPathTimestamp when building file restore path 

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/pull/3465


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API response fix for restore path display; deploy is a patch version bump with no auth or data-model changes.
> 
> **Overview**
> **File restore detail responses** now report the on-disk destination for backup-URL restores. For **file** backups, `restorePath` is built as `path/subPath-subPathTimestamp` instead of only `path/subPath`, by reading `subPathTimestamp` from the restore type JSON.
> 
> The cluster **backup-server** image version is bumped from **0.3.64** to **0.3.65** in the deploy template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa904c288a12698a99d5c0d54614ba15e6ba2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->