### PR TITLE
system-apps: bump system-frontend image to v1.10.60

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.58
+          image: beclab/system-frontend:v1.10.60
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Update the bundled `system-frontend` container image used by the system-apps Helm chart from `v1.10.58` to `v1.10.60`. This rolls the desktop/launcher frontend forward to the latest released build so deployments pick up the upstream system-frontend fixes and improvements shipped between these two tags. The change is limited to the `olares-app-init` init container image tag in `system-apps/templates/olares-app.yaml`; no chart logic, env, or runtime behavior is otherwise altered.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/icebergtsn

* **Other information**:
None

Made with [Cursor](https://cursor.com)