### PR TITLE
fix(docs): Remove unnecessary robots.txt and clean up build routes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -156,6 +156,17 @@ export default defineVersionedConfig2(withMermaid({
   },
   lastUpdated: true,
   cleanUrls: true,
+  // Snippet-only fragments and repo READMEs are pulled into real pages via
+  // `<!--@include-->` (which reads the raw file directly, so excluding them as
+  // routes does NOT break includes). Keeping them out of the build stops them
+  // from leaking into routes, search, and sitemap.xml as junk URLs.
+  srcExclude: [
+    "**/README.md",
+    "**/reusables/**",
+    "**/reusables.md",
+    "**/reusables-*.md",
+    "**/*.reusables.md",
+  ],
   base: process.env.BASE_URL || "/",
   vite: {
     build: {

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://www.olares.com/docs/sitemap.xml


### PR DESCRIPTION
* **Background**
The docs site now lives under https://www.olares.com/docs/. Some markdown files (e.g. README.md, reusables fragments) are only used via <!--@include--> but were still built as standalone routes, so junk URLs like /docs/README showed up in sitemap.xml. This change excludes those files from the build via srcExclude, and removes docs/public/robots.txt since site-level robots.txt already covers the sitemap.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs build and SEO surface-area only; includes still read raw files and are unaffected by srcExclude.
> 
> **Overview**
> **VitePress** now uses **`srcExclude`** so READMEs and reusables fragments (included via `<!--@include-->` only) are not built as standalone pages. That stops junk routes like `/docs/README` from appearing in **search**, **routes**, and **`sitemap.xml`**.
> 
> **`docs/public/robots.txt`** was removed because the main site already serves robots rules and the docs sitemap reference there was redundant under `https://www.olares.com/docs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13fae10398190620780ed43e261a3eb5202d6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->