### PR TITLE
fix(daemon): reliably detect pending shutdown/reboot via systemd D-Bus

### DIFF
--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/godbus/dbus/v5"
 	"github.com/joho/godotenv"
 	cpu "github.com/klauspost/cpuid/v2"
 	"github.com/mackerelio/go-osstat/uptime"
@@ -16,7 +17,148 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const (
+	// shutdownModeReboot indicates the system is going down for a reboot/kexec.
+	shutdownModeReboot = "reboot"
+	// shutdownModePoweroff indicates the system is powering off/halting.
+	shutdownModePoweroff = "shutdown"
+)
+
+// systemdShutdownUnits maps the systemd target units that drive a shutdown
+// transition to the mode they represent. When one of these targets has a
+// pending job, the system is going down.
+//
+// NOTE: we key off the *pending job*, not the unit's ActiveState. An immediate
+// `reboot`/`poweroff` enqueues a start job for the corresponding target via
+// logind (StartUnit(..., "replace-irreversibly")), but the target only becomes
+// "active" after its systemd-{reboot,poweroff}.service runs, and that service
+// never returns (it reboots/powers off the kernel). So in practice the target
+// stays "inactive (dead)" for the whole shutdown window while its start job is
+// queued. The job is therefore the only reliable pollable signal.
+var systemdShutdownUnits = map[string]string{
+	"reboot.target":   shutdownModeReboot,
+	"kexec.target":    shutdownModeReboot,
+	"poweroff.target": shutdownModePoweroff,
+	"halt.target":     shutdownModePoweroff,
+}
+
+// systemdJob mirrors the struct returned by
+// org.freedesktop.systemd1.Manager.ListJobs (a(usssoo)), i.e. the same job list
+// shown by `systemctl list-jobs`.
+type systemdJob struct {
+	ID       uint32
+	Unit     string
+	JobType  string
+	State    string
+	JobPath  dbus.ObjectPath
+	UnitPath dbus.ObjectPath
+}
+
+// GetSystemPendingShutdowm reports whether the system is about to shut down or
+// reboot, and in which mode ("reboot" or "shutdown").
+//
+// Relying on /run/systemd/shutdown/scheduled alone is not enough: that file is
+// only created by systemd-logind for *delayed* shutdowns (e.g. `shutdown +5`).
+// Immediate commands such as `reboot`, `reboot now`, `poweroff` or
+// `shutdown now` go straight through logind and never create it. Instead we
+// query systemd over D-Bus, combining:
+//  1. logind's ScheduledShutdown property (timed shutdowns), and
+//  2. pending systemd jobs for the shutdown target units (immediate and
+//     in-progress shutdowns).
+//
+// The legacy file-based check is kept as a fallback when D-Bus is unavailable.
 func GetSystemPendingShutdowm() (mode string, shuttingdown bool, err error) {
+	if !IsLinux() {
+		return "", false, nil
+	}
+
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		klog.Warningf("connect system dbus failed, fallback to file based shutdown check: %v", err)
+		return getPendingShutdownFromFile()
+	}
+
+	// 1. delayed/timed shutdown registered in logind
+	if m, ok := getScheduledShutdownFromLogind(conn); ok {
+		return m, true, nil
+	}
+
+	// 2. immediate or in-progress shutdown reflected by pending systemd jobs
+	m, ok, e := getActiveShutdownFromSystemd(conn)
+	if e != nil {
+		klog.Warningf("query systemd shutdown units failed, fallback to file based shutdown check: %v", e)
+		return getPendingShutdownFromFile()
+	}
+	if ok {
+		return m, true, nil
+	}
+
+	return "", false, nil
+}
+
+// getScheduledShutdownFromLogind reads logind's ScheduledShutdown property,
+// which is set for delayed shutdowns (the same source that backs
+// /run/systemd/shutdown/scheduled).
+func getScheduledShutdownFromLogind(conn *dbus.Conn) (mode string, scheduled bool) {
+	obj := conn.Object("org.freedesktop.login1", dbus.ObjectPath("/org/freedesktop/login1"))
+	v, err := obj.GetProperty("org.freedesktop.login1.Manager.ScheduledShutdown")
+	if err != nil {
+		klog.Warningf("read logind ScheduledShutdown property failed: %v", err)
+		return "", false
+	}
+
+	// the property is a struct (s: action, t: usec)
+	fields, ok := v.Value().([]interface{})
+	if !ok || len(fields) == 0 {
+		return "", false
+	}
+
+	action, _ := fields[0].(string)
+	action = strings.TrimSpace(action)
+	// empty action means nothing is scheduled; dry-run actions only send a wall
+	// message and do not actually power the machine down.
+	if action == "" || strings.HasPrefix(action, "dry-") {
+		return "", false
+	}
+
+	return normalizeShutdownMode(action), true
+}
+
+// getActiveShutdownFromSystemd checks whether systemd has a pending job for any
+// of the shutdown target units. This is the same list shown by
+// `systemctl list-jobs`: an immediate `reboot`/`poweroff`/`halt` enqueues a
+// start job for the corresponding target that stays queued for the whole
+// shutdown window (the target never reaches ActiveState=active before the
+// machine goes down), so the job is the reliable pollable signal.
+func getActiveShutdownFromSystemd(conn *dbus.Conn) (mode string, shuttingdown bool, err error) {
+	obj := conn.Object("org.freedesktop.systemd1", dbus.ObjectPath("/org/freedesktop/systemd1"))
+	var jobs []systemdJob
+	if err = obj.Call("org.freedesktop.systemd1.Manager.ListJobs", 0).Store(&jobs); err != nil {
+		return "", false, err
+	}
+
+	for _, j := range jobs {
+		if m, tracked := systemdShutdownUnits[j.Unit]; tracked {
+			return m, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// normalizeShutdownMode maps a logind/systemd action string to the coarse mode
+// used by callers ("reboot" or "shutdown").
+func normalizeShutdownMode(action string) string {
+	if strings.Contains(action, shutdownModeReboot) || strings.Contains(action, "kexec") {
+		return shutdownModeReboot
+	}
+	return shutdownModePoweroff
+}
+
+// getPendingShutdownFromFile is the legacy detection based on
+// /run/systemd/shutdown/scheduled, used only as a fallback when D-Bus cannot be
+// reached. It only detects delayed shutdowns.
+func getPendingShutdownFromFile() (mode string, shuttingdown bool, err error) {
 	path := "/run/systemd/shutdown/scheduled"
 	_, err = os.Stat(path)
 	if err != nil {
@@ -35,9 +177,10 @@ func GetSystemPendingShutdowm() (mode string, shuttingdown bool, err error) {
 		return
 	}
 
+	shuttingdown = true
 	mode, ok := envs["MODE"]
 	if !ok {
-		mode = "shutdown"
+		mode = shutdownModePoweroff
 	}
 
 	return


### PR DESCRIPTION
## Summary

`GetSystemPendingShutdowm` previously only checked `/run/systemd/shutdown/scheduled`. That file is written by `systemd-logind` **only for delayed shutdowns** (e.g. `shutdown +5`). Immediate commands — `reboot`, `reboot now`, `poweroff`, `shutdown now` — go straight through logind and never create it, so they were never detected. The function also never set `shuttingdown=true` even when the file did exist, so `IsSystemShuttingdown()` effectively always returned `false`.

This PR queries systemd over the system D-Bus (using the already-present `github.com/godbus/dbus/v5`) and combines two signals:

1. **Timed shutdowns** — logind's `org.freedesktop.login1.Manager.ScheduledShutdown` property (dry-run actions ignored).
2. **Immediate / in-progress shutdowns** — pending systemd jobs (`org.freedesktop.systemd1.Manager.ListJobs`, same as `systemctl list-jobs`) for `reboot.target` / `kexec.target` / `poweroff.target` / `halt.target`.

We key off the queued **start job** rather than the unit's `ActiveState`: `reboot.target`/`poweroff.target` stay `inactive (dead)` for the entire shutdown window because their `systemd-*.service` never returns (the kernel reboots/powers off first), so the job is the only reliable pollable signal.

The legacy file-based check is retained as a fallback when D-Bus is unavailable, and the `shuttingdown=true` bug in that path is fixed. On non-Linux the function short-circuits to "not shutting down".

`reboot`/`kexec` map to mode `reboot`; `poweroff`/`halt` map to `shutdown`. The public signature is unchanged, so callers `IsSystemShuttingdown` / `IsSystemRebooting` keep working as-is.

## Test plan

- [ ] `go build ./...` in `daemon/` (verified locally)
- [ ] On a host: `reboot` (no args) → daemon enters `Shutdown` state (previously missed)
- [ ] `shutdown +5` → detected via logind `ScheduledShutdown`; `shutdown -c` clears it
- [ ] `poweroff` → detected, mode `shutdown`
- [ ] Normal running state → reports not shutting down

Made with [Cursor](https://cursor.com)