### PR TITLE
feat(cli): inject git commit & build time into version output

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -89,7 +89,25 @@ jobs:
             echo "::error::binary version output '$actual' does not contain expected '$expected_stripped'"
             exit 1
           fi
-          echo "binary version OK: $actual"
+          # Assert build metadata (git commit / build time) was injected and is
+          # not the unknown/placeholder default baked into version.go.
+          if ! echo "$actual" | grep -qE '^Git commit: '; then
+            echo "::error::binary version output is missing the 'Git commit:' line"
+            echo "output: $actual"
+            exit 1
+          fi
+          if ! echo "$actual" | grep -qE '^Build time: '; then
+            echo "::error::binary version output is missing the 'Build time:' line"
+            echo "output: $actual"
+            exit 1
+          fi
+          if echo "$actual" | grep -qE '^(Git commit|Build time): unknown$'; then
+            echo "::error::build metadata still reports 'unknown'; ldflags did not take effect"
+            echo "output: $actual"
+            exit 1
+          fi
+          echo "binary version OK:"
+          echo "$actual"
 
       - name: Install coscmd
         run: pip install coscmd        

--- a/build/base-package/install.sh
+++ b/build/base-package/install.sh
@@ -100,7 +100,7 @@ else
     if [[ "$(basename "$REPO_PATH")" == "olares-one" ]]; then
         expected_vendor="OlaresOne"
     fi
-    if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
+    if command_exists olares-cli && [[ "$(olares-cli -v | awk 'NR==1{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
         INSTALL_OLARES_CLI=$(which olares-cli)
         echo "olares-cli already installed and is the expected version"
         echo ""

--- a/build/base-package/joincluster.sh
+++ b/build/base-package/joincluster.sh
@@ -186,7 +186,7 @@ expected_vendor="main"
 if [[ "$(basename "$REPO_PATH")" == "olares-one" ]]; then
     expected_vendor="OlaresOne"
 fi
-if command_exists olares-cli && [[ "$(olares-cli -v | awk '{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
+if command_exists olares-cli && [[ "$(olares-cli -v | awk 'NR==1{print $3}')" == "$VERSION" ]] && [[ "$(olares-cli --vendor)" == "$expected_vendor" ]]; then
     INSTALL_OLARES_CLI=$(which olares-cli)
     echo "olares-cli already installed and is the expected version"
     echo ""

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -23,6 +23,8 @@ builds:
       - -s
       - -w
       - -X github.com/beclab/Olares/cli/version.VERSION={{ .Version }}
+      - -X github.com/beclab/Olares/cli/version.GitCommit={{ .FullCommit }}
+      - -X github.com/beclab/Olares/cli/version.BuildTime={{ .Date }}
       - >-
         {{- if index .Env "OLARES_VENDOR_TYPE" }}
         -X github.com/beclab/Olares/cli/version.VENDOR={{ .Env.OLARES_VENDOR_TYPE }}

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,8 +1,13 @@
-BINARY  := olares-cli
-MODULE  := github.com/beclab/Olares/cli
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -s -w -X $(MODULE)/version.VERSION=$(VERSION)
-PREFIX  ?= /usr/local
+BINARY     := olares-cli
+MODULE     := github.com/beclab/Olares/cli
+VERSION    := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS    := -s -w \
+	-X $(MODULE)/version.VERSION=$(VERSION) \
+	-X $(MODULE)/version.GitCommit=$(GIT_COMMIT) \
+	-X $(MODULE)/version.BuildTime=$(BUILD_TIME)
+PREFIX     ?= /usr/local
 
 .PHONY: all build install uninstall clean
 

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -61,6 +61,15 @@ func NewDefaultCommand() *cobra.Command {
 	}
 	cmds.Flags().BoolVar(&showVendor, "vendor", false, "show the vendor type of olares-cli")
 
+	// Keep the first line byte-for-byte identical to Cobra's default
+	// ("olares-cli version <VERSION>") so existing parsers that read only
+	// the first line / the third whitespace-delimited token keep working,
+	// while appending the build metadata on following lines.
+	cmds.SetVersionTemplate(fmt.Sprintf(
+		"{{with .Name}}{{.}} {{end}}version {{.Version}}\nGit commit: %s\nBuild time: %s\n",
+		version.GitCommit, version.BuildTime,
+	))
+
 	// Version-compat controls (--olares-version / --refresh-version) live on
 	// the `profile` command tree, not here: backend version is a per-profile
 	// property (cached in config.json, eagerly fetched at login). Other

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -1,3 +1,12 @@
 package version
 
 var VERSION = "0.0.0-development"
+
+// GitCommit and BuildTime are injected at build time via -ldflags.
+// They default to "unknown" so a `go build`/`go run` without ldflags
+// (or any consumer parsing only the first line of the version output)
+// still behaves sensibly.
+var (
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)

--- a/daemon/pkg/commands/upgrade/utils.go
+++ b/daemon/pkg/commands/upgrade/utils.go
@@ -23,9 +23,13 @@ func getCurrentCliVersion() (*semver.Version, error) {
 		return nil, fmt.Errorf("failed to execute olares-cli -v: %v", err)
 	}
 
-	// parse version from output
-	// expected format: "olares-cli version ${VERSION}"
-	parts := strings.Split(string(output), " ")
+	// parse version from output.
+	// Only the first line carries the version and is stable across releases:
+	//   old format: "olares-cli version ${VERSION}"
+	//   new format: same first line, followed by extra "Git commit: ..." /
+	//               "Build time: ..." lines that we deliberately ignore here.
+	firstLine := strings.TrimSpace(strings.SplitN(string(output), "\n", 2)[0])
+	parts := strings.Fields(firstLine)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("unexpected version output format: %s", string(output))
 	}


### PR DESCRIPTION
## Summary
- Inject `GitCommit` and `BuildTime` into the `olares-cli` binary via ldflags, wired through both `goreleaser` (`.FullCommit` / `.Date`) and the `Makefile` (`git rev-parse HEAD` / UTC timestamp). They default to `"unknown"` so plain `go build`/`go run` still works.
- Surface the metadata on extra lines of `olares-cli -v` using a custom Cobra version template, while keeping the **first line byte-for-byte identical** (`olares-cli version <VERSION>`) so existing parsers stay compatible.
- Update all consumers that parse the version output:
  - `install.sh` / `joincluster.sh` now use `awk 'NR==1{print $3}'` (first line only).
  - daemon `getCurrentCliVersion` parses only the first line and ignores the new lines.
- CI (`release-cli.yaml`) now asserts the `Git commit:` / `Build time:` lines are present and not the `unknown` placeholder, confirming ldflags took effect.

## Test plan
- [x] `go build ./...` and `go vet` pass for the `cli` module
- [x] daemon `pkg/commands/upgrade` builds
- [x] Linux cross-build with ldflags succeeds
- [ ] CI release-cli version-assertion step passes on this PR

Made with [Cursor](https://cursor.com)