### PR TITLE
refactor(cli): simplify "node enable-juicefs" around a stopped Olares

### DIFF
--- a/cli/cmd/ctl/node/enable_juicefs.go
+++ b/cli/cmd/ctl/node/enable_juicefs.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"log"
-	"time"
 
 	"github.com/beclab/Olares/cli/cmd/config"
 	"github.com/beclab/Olares/cli/pkg/pipelines"
@@ -10,15 +9,16 @@ import (
 )
 
 func NewCmdEnableJuiceFS() *cobra.Command {
-	var (
-		stopTimeout       time.Duration
-		stopCheckInterval time.Duration
-	)
 	cmd := &cobra.Command{
 		Use:   "enable-juicefs",
 		Short: "convert a single-node master's local rootfs to a JuiceFS-backed shared rootfs",
 		Long: `Convert an already-installed single-node Olares master from a local-filesystem
 rootfs to a JuiceFS-backed shared rootfs, in place, without uninstalling.
+
+Olares must be stopped before running this command: run "olares-cli stop"
+first. If Olares is still running, the command aborts and asks you to stop it.
+With the cluster stopped the rootfs is quiescent, so the data is migrated in a
+single full sync.
 
 By default this installs the bundled object storage (MinIO) as the JuiceFS
 backend. To use an external S3-compatible object store instead, pass the
@@ -26,17 +26,16 @@ storage flags (--storage-type s3/oss/cos, --s3-bucket, keys, etc.); in that
 case MinIO is not installed and the credentials are validated instead.
 
 It also installs the metadata engine (Redis), formats a JuiceFS filesystem,
-migrates the existing rootfs data into it (an online bulk copy followed by a
-brief offline incremental copy), swaps the rootfs directory for the JuiceFS
-mount, and regenerates the cluster services.
+migrates the existing rootfs data into it, swaps the rootfs directory for the
+JuiceFS mount, regenerates the cluster services, and starts Olares back up.
 
 After it completes, the master satisfies the JuiceFS precondition required to
 add worker nodes, so you can run "olares-cli node add" on the workers.
 
-The command is idempotent and resumable: if JuiceFS is already enabled it only
-ensures Olares is running.`,
+If JuiceFS is already enabled, the command reports that the migration is
+already complete and exits without touching Olares.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := pipelines.EnableJuiceFSPipeline(cmd.Context(), stopTimeout, stopCheckInterval); err != nil {
+			if err := pipelines.EnableJuiceFSPipeline(cmd.Context()); err != nil {
 				log.Fatalf("error: %v", err)
 			}
 		},
@@ -46,8 +45,6 @@ ensures Olares is running.`,
 	config.AddVersionFlagBy(flagSetter)
 	config.AddBaseDirFlagBy(flagSetter)
 	config.AddStorageFlagsBy(flagSetter)
-	cmd.Flags().DurationVarP(&stopTimeout, "timeout", "t", 1*time.Minute, "Timeout for graceful container shutdown before using SIGKILL during the offline sync window")
-	cmd.Flags().DurationVarP(&stopCheckInterval, "check-interval", "i", 10*time.Second, "Interval between checks for remaining container processes")
 
 	return cmd
 }

--- a/cli/pkg/phase/cluster/enable_juicefs.go
+++ b/cli/pkg/phase/cluster/enable_juicefs.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/beclab/Olares/cli/pkg/common"
-	"github.com/beclab/Olares/cli/pkg/container"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/module"
@@ -34,47 +33,42 @@ import (
 // without uninstalling. Once it completes, the master satisfies the JuiceFS
 // precondition required by `olares-cli node add`, so worker nodes can join.
 //
-// The whole operation is idempotent and resumable: if JuiceFS is already
-// enabled (the systemd unit exists, which only happens after the data has been
-// migrated and the rootfs swapped), it skips straight to ensuring Olares is
-// running and the rootfs type is set.
-func EnableJuiceFS(runtime *common.KubeRuntime, manifestMap manifest.InstallationManifest, stopTimeout, stopCheckInterval time.Duration) *pipeline.Pipeline {
+// The caller must already have checked that JuiceFS is not yet enabled (the
+// "already migrated" case short-circuits earlier, before this pipeline is even
+// built). This pipeline therefore always performs the migration.
+//
+// The migration requires Olares to be stopped beforehand (it fails fast with a
+// hint to run `olares-cli stop` otherwise): with the kubernetes/container layer
+// down nothing writes to the rootfs, so a single full rsync migrates all the
+// data in one pass. The bundled object store (MinIO) and metadata engine
+// (Redis) are (re)started as part of the migration so they can serve the
+// JuiceFS mount during the sync. Olares is brought back up at the end so the
+// rootfs type and fsnotify charts can be updated.
+func EnableJuiceFS(runtime *common.KubeRuntime, manifestMap manifest.InstallationManifest) *pipeline.Pipeline {
 	manifestModule := manifest.ManifestModule{
 		Manifest: manifestMap,
 		BaseDir:  runtime.GetBaseDir(),
 	}
 
-	var modules []module.Module
-	if storage.IsJuiceFSEnabled() {
-		logger.Info("JuiceFS is already enabled on this node, ensuring Olares is started and the rootfs type is set")
-		modules = []module.Module{
-			&terminus.StartOlaresModule{},
-			&UpdateRootFSTypeModule{},
-			&ReRenderFsnotifyChartsModule{},
-		}
-	} else {
-		// the bundled MinIO is only installed when using the managed-minio
-		// backend; for external object storage (s3/oss/cos/external minio) we
-		// validate the provided credentials instead and JuiceFS is formatted
-		// against that remote bucket.
-		useManagedMinIO := runtime.Arg.Storage == nil || runtime.Arg.Storage.StorageType == common.ManagedMinIO
-		modules = []module.Module{
-			&MigratePrecheckModule{},
-			&storage.ValidateModule{Skip: useManagedMinIO},
-			&storage.InstallMinioModule{
-				ManifestModule: manifestModule,
-				Skip:           !useManagedMinIO,
-			},
-			&storage.InstallRedisModule{ManifestModule: manifestModule},
-			&MigrateRootFSToJuiceFSModule{
-				ManifestModule: manifestModule,
-				StopTimeout:    stopTimeout,
-				CheckInterval:  stopCheckInterval,
-			},
-			&terminus.StartOlaresModule{},
-			&UpdateRootFSTypeModule{},
-			&ReRenderFsnotifyChartsModule{},
-		}
+	// the bundled MinIO is only installed when using the managed-minio
+	// backend; for external object storage (s3/oss/cos/external minio) we
+	// validate the provided credentials instead and JuiceFS is formatted
+	// against that remote bucket.
+	useManagedMinIO := runtime.Arg.Storage == nil || runtime.Arg.Storage.StorageType == common.ManagedMinIO
+	modules := []module.Module{
+		&MigratePrecheckModule{},
+		&storage.ValidateModule{Skip: useManagedMinIO},
+		&storage.InstallMinioModule{
+			ManifestModule: manifestModule,
+			Skip:           !useManagedMinIO,
+		},
+		&storage.InstallRedisModule{ManifestModule: manifestModule},
+		&MigrateRootFSToJuiceFSModule{
+			ManifestModule: manifestModule,
+		},
+		&terminus.StartOlaresModule{},
+		&UpdateRootFSTypeModule{},
+		&ReRenderFsnotifyChartsModule{},
 	}
 
 	return &pipeline.Pipeline{
@@ -93,6 +87,12 @@ type MigratePrecheckModule struct {
 func (m *MigratePrecheckModule) Init() {
 	m.Name = "MigratePrecheck"
 	m.Tasks = []task.Interface{
+		// Olares must be stopped before we touch the rootfs; bail out early
+		// (with a hint to run `olares-cli stop`) if it is still running.
+		&task.LocalTask{
+			Name:   "CheckOlaresStopped",
+			Action: new(storage.CheckOlaresStopped),
+		},
 		&task.LocalTask{
 			Name:   "CheckMigrationPrecheck",
 			Action: new(storage.CheckMigrationPrecheck),
@@ -101,14 +101,13 @@ func (m *MigratePrecheckModule) Init() {
 }
 
 // MigrateRootFSToJuiceFSModule installs the JuiceFS client, formats the
-// filesystem, syncs the local rootfs into it (online + a final offline
-// incremental pass), swaps the rootfs directory for the JuiceFS mount, and
-// regenerates the container runtime service so it gates on JuiceFS.
+// filesystem, syncs the local rootfs into it in a single full pass (Olares is
+// already stopped, so the rootfs is quiescent), swaps the rootfs directory for
+// the JuiceFS mount, and regenerates the container runtime service so it gates
+// on JuiceFS.
 type MigrateRootFSToJuiceFSModule struct {
 	common.KubeModule
 	manifest.ManifestModule
-	StopTimeout   time.Duration
-	CheckInterval time.Duration
 }
 
 func (m *MigrateRootFSToJuiceFSModule) Init() {
@@ -145,38 +144,21 @@ func (m *MigrateRootFSToJuiceFSModule) Init() {
 		Retry:  1,
 	}
 
-	// 2. mount JuiceFS on a temp mount point and do the first (online) sync
+	// 2. mount JuiceFS on a temp mount point and do a single full sync. Olares
+	// is already stopped (enforced by the precheck), so nothing writes to the
+	// rootfs and one pass with --delete migrates everything.
 	mountForMigration := &task.LocalTask{
 		Name:   "MountJuiceFSForMigration",
 		Action: new(storage.MountJuiceFSForMigration),
 		Retry:  1,
 	}
-	firstSync := &task.LocalTask{
-		Name:   "SyncRootFSDataOnline",
-		Action: &storage.SyncRootFSData{Delete: false},
-		Retry:  1,
-	}
-
-	// 3. stop the workloads so nothing writes to the rootfs anymore.
-	// NOTE: we deliberately stop ONLY the kubernetes/container layer here, not
-	// the full StopOlares flow, because MinIO/Redis/JuiceFS must stay up to
-	// serve the second sync and the final mount.
-	m.Tasks = []task.Interface{
-		getRedisConfig,
-		cleanupStaleBinary,
-		installJuiceFs,
-		formatJuiceFs,
-		mountForMigration,
-		firstSync,
-	}
-	m.appendStopWorkloadsTasks()
-
-	// 4. final incremental sync, unmount temp, swap rootfs, mount JuiceFS on rootfs
-	secondSync := &task.LocalTask{
-		Name:   "SyncRootFSDataFinal",
+	syncRootFS := &task.LocalTask{
+		Name:   "SyncRootFSData",
 		Action: &storage.SyncRootFSData{Delete: true},
 		Retry:  1,
 	}
+
+	// 3. unmount temp, swap rootfs, mount JuiceFS on rootfs, verify
 	unmountMigration := &task.LocalTask{
 		Name:   "UnmountJuiceFSMigration",
 		Action: new(storage.UnmountJuiceFSMigration),
@@ -198,43 +180,23 @@ func (m *MigrateRootFSToJuiceFSModule) Init() {
 		Retry:  5,
 		Delay:  5 * time.Second,
 	}
-	m.Tasks = append(m.Tasks, secondSync, unmountMigration, swapRootFS, enableJuiceFs, checkJuiceFs)
+	m.Tasks = []task.Interface{
+		getRedisConfig,
+		cleanupStaleBinary,
+		installJuiceFs,
+		formatJuiceFs,
+		mountForMigration,
+		syncRootFS,
+		unmountMigration,
+		swapRootFS,
+		enableJuiceFs,
+		checkJuiceFs,
+	}
 
-	// 5. regenerate the container runtime service so it gains the JuiceFS
+	// 4. regenerate the container runtime service so it gains the JuiceFS
 	// pre-check (After=juicefs.service + ExecStartPre=juicefs summary) now that
 	// the unit exists.
 	m.appendRegenerateRuntimeServiceTasks()
-}
-
-func (m *MigrateRootFSToJuiceFSModule) appendStopWorkloadsTasks() {
-	stopUnits := []string{"k3s"}
-	if m.KubeConf.Arg.Kubetype == common.K8s {
-		stopUnits = []string{"kubelet"}
-	}
-	m.Tasks = append(m.Tasks,
-		&task.LocalTask{
-			Name: "StopKubernetes",
-			Action: &terminus.SystemctlCommand{
-				Command:   "stop",
-				UnitNames: stopUnits,
-			},
-			Retry: 3,
-		},
-		&task.LocalTask{
-			Name: "KillContainers",
-			Action: &container.KillContainerdProcess{
-				Signal:        "TERM",
-				Timeout:       m.StopTimeout,
-				CheckInterval: m.CheckInterval,
-			},
-			Retry: 3,
-		},
-		&task.LocalTask{
-			Name:   "ClearKubernetesMounts",
-			Action: new(kubernetes.UmountKubelet),
-			Retry:  3,
-		},
-	)
 }
 
 func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {

--- a/cli/pkg/pipelines/enable_juicefs.go
+++ b/cli/pkg/pipelines/enable_juicefs.go
@@ -5,25 +5,42 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
+	"strings"
 
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/manifest"
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/phase/cluster"
+	"github.com/beclab/Olares/cli/pkg/storage"
 	"github.com/beclab/Olares/cli/version"
 )
 
-func EnableJuiceFSPipeline(ctx context.Context, stopTimeout, stopCheckInterval time.Duration) error {
+func EnableJuiceFSPipeline(ctx context.Context) error {
 	arg := common.NewArgument()
 	if !arg.SystemInfo.IsLinux() {
 		fmt.Println("error: enabling JuiceFS is only supported on Linux nodes")
 		os.Exit(1)
 	}
 
+	// If JuiceFS has already been migrated/enabled on this node, there is
+	// nothing left to do. We deliberately do NOT start Olares here: the user
+	// manages the Olares lifecycle themselves now. This check runs before the
+	// console logger is initialized (SetConsoleLog below), so print directly.
+	if storage.IsJuiceFSEnabled() {
+		fmt.Println("JuiceFS is already enabled on this node, the rootfs migration is already complete, nothing to do")
+		return nil
+	}
+
 	kubeType := phase.GetKubeType()
-	sysVersion, _ := phase.GetOlaresVersion()
+	// The migration requires Olares to be stopped, so we can't rely on
+	// GetOlaresVersion() (which queries the cluster via kubectl). Read the
+	// installed version from the on-disk marker first; only fall back to the
+	// cluster query and then the binary's build version.
+	sysVersion := installedOlaresVersion(arg.BaseDir)
+	if sysVersion == "" {
+		sysVersion, _ = phase.GetOlaresVersion()
+	}
 	if sysVersion == "" {
 		sysVersion = version.VERSION
 	}
@@ -44,10 +61,28 @@ func EnableJuiceFSPipeline(ctx context.Context, stopTimeout, stopCheckInterval t
 		return fmt.Errorf("error reading installation manifest: %v", err)
 	}
 
-	p := cluster.EnableJuiceFS(runtime, manifestMap, stopTimeout, stopCheckInterval)
+	p := cluster.EnableJuiceFS(runtime, manifestMap)
 	if err := p.Start(ctx); err != nil {
 		logger.Errorf("failed to enable JuiceFS on the master node: %v", err)
 		return err
 	}
 	return nil
+}
+
+// installedOlaresVersion reads the Olares version from the on-disk install
+// marker (<baseDir>/.installed), whose content is "<version> <kubetype>".
+// It returns an empty string if the marker is missing or unreadable.
+func installedOlaresVersion(baseDir string) string {
+	if baseDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path.Join(baseDir, common.TerminusStateFileInstalled))
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }

--- a/cli/pkg/storage/migrate.go
+++ b/cli/pkg/storage/migrate.go
@@ -51,6 +51,39 @@ func IsJuiceFSEnabled() bool {
 	return util.IsExist(JuiceFsServiceFile)
 }
 
+// isOlaresRunning reports whether the kubernetes/container layer of Olares
+// (k3s or kubelet) is currently active on this node. `systemctl is-active`
+// prints exactly "active" on stdout (and exits 0) when the unit is running,
+// and a non-"active" word otherwise, regardless of exit code.
+func isOlaresRunning(runtime connector.Runtime) bool {
+	for _, unit := range []string{"k3s", "kubelet"} {
+		out, _ := runtime.GetRunner().SudoCmd(fmt.Sprintf("systemctl is-active %s", unit), false, false)
+		if strings.TrimSpace(out) == "active" {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckOlaresStopped aborts the migration if Olares is still running.
+//
+// The rootfs migration now requires Olares (the kubernetes/container layer) to
+// be stopped beforehand: with nothing writing to the rootfs, a single full
+// rsync captures all the data, so we no longer need the previous online +
+// offline two-phase sync. Rather than stopping Olares ourselves, we ask the
+// user to do it explicitly so they stay in control of the cluster lifecycle.
+type CheckOlaresStopped struct {
+	common.KubeAction
+}
+
+func (t *CheckOlaresStopped) Execute(runtime connector.Runtime) error {
+	if isOlaresRunning(runtime) {
+		return fmt.Errorf("Olares is still running; the rootfs migration requires it to be stopped first. " +
+			"Please run 'olares-cli stop' and then re-run this command")
+	}
+	return nil
+}
+
 // isPathMounted returns whether the given absolute path is currently a mount
 // point (of any filesystem type) by consulting /proc/self/mounts on the node.
 func isPathMounted(runtime connector.Runtime, target string) (bool, error) {
@@ -196,11 +229,9 @@ func (t *MountJuiceFSForMigration) Execute(runtime connector.Runtime) error {
 // SyncRootFSData copies the content of the local rootfs into the JuiceFS
 // filesystem mounted at the migration temp mount point.
 //
-// It is meant to be run twice:
-//   - first (Delete=false) while Olares is still running, to copy the bulk of
-//     the data without downtime;
-//   - then (Delete=true) after the workloads have been stopped, to copy the
-//     incremental changes and remove anything deleted in the meantime.
+// Because Olares is required to be stopped before the migration runs, the
+// rootfs is quiescent and a single full sync (Delete=true) captures all the
+// data in one pass, mirroring deletions as well.
 type SyncRootFSData struct {
 	common.KubeAction
 	Delete bool


### PR DESCRIPTION
## Summary

Reworks `olares-cli node enable-juicefs` so the operator owns the Olares start/stop lifecycle, which lets the rootfs migration be much simpler:

- **Already enabled** → report that the migration is already complete and exit immediately, without starting Olares (previously it force-started the whole cluster).
- **Not enabled, Olares running** → abort early with a hint to run `olares-cli stop`, instead of stopping the kubernetes/container layer ourselves.
- **Not enabled, Olares stopped** → with the rootfs quiescent, do a **single full `rsync --delete`** instead of the previous online + offline two-phase sync, then swap the rootfs, enable the JuiceFS service, regenerate the runtime service, and bring Olares back up to apply the rootfs type and re-render the fsnotify charts.

Supporting changes:
- Read the installed version from the on-disk `.installed` marker, since the cluster can't be queried for it while Olares is stopped.
- Drop the now-unused `--timeout` / `--check-interval` flags (they only governed the removed in-flight container-kill step).

## Test plan

Verified end-to-end on a real single-node Olares environment (k3s, Ubuntu):

- [x] **Already enabled**: prints "migration already complete", exits 0 in <1s, k3s not restarted.
- [x] **Not enabled + running**: aborts at the precheck with the "please run `olares-cli stop`" message, exit 1, nothing modified (no `juicefs.service` created).
- [x] **Not enabled + stopped**: single full sync migrates the rootfs onto JuiceFS, `/olares/rootfs` becomes a `fuse.juicefs` mount, Olares restarts healthy, rootfs-type SystemEnv flips to `jfs`, fsnotify charts re-rendered.
- [x] **Data integrity**: a marker file planted in the local rootfs survives intact in the JuiceFS-backed rootfs.
- [x] **Idempotency**: re-running on the migrated node reports "already complete" and does not restart Olares.

Made with [Cursor](https://cursor.com)