### PR TITLE
fix: files sync share upload

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.187
+          image: beclab/files-server:v0.2.188
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: materialize rebuilt body so seafile receives parent_dir

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/354

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy config; application logic change is isolated to the new files-server release.
> 
> **Overview**
> Rolls out **files-server `v0.2.188`** on the `files` DaemonSet container (was `v0.2.187`) in `files_deploy.yaml`. No other manifest, env, or volume changes.
> 
> This deploys the upstream fix for **files sync share upload** (rebuilt request body is materialized so Seafile gets `parent_dir`), per [beclab/files#354](https://github.com/beclab/files/pull/354). Target merge version: **1.12.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd3e5a07f41f21cf80f01513d5a90da4378c3278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->