### PR TITLE
daemon: increase timeout for overlay gateway enable/disable operations

### DIFF
--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_disable.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_disable.go
@@ -52,7 +52,7 @@ func (h *Handlers) DisableOverlayGateway(ctx *fiber.Ctx, cmd commands.Interface)
 		}
 
 		t := time.NewTicker(2 * time.Second)
-		timeout := time.NewTimer(10 * time.Second)
+		timeout := time.NewTimer(60 * time.Second)
 		defer t.Stop()
 		defer timeout.Stop()
 		for {

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_enable.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_enable.go
@@ -55,7 +55,7 @@ func (h *Handlers) EnableOverlayGateway(ctx *fiber.Ctx, cmd commands.Interface) 
 
 		// check if the overlay gateway is enabled
 		t := time.NewTicker(2 * time.Second)
-		timeout := time.NewTimer(10 * time.Second)
+		timeout := time.NewTimer(60 * time.Second)
 		defer t.Stop()
 		defer timeout.Stop()
 		for {


### PR DESCRIPTION

* **Background**
Increase timeout for overlay gateway enable/disable operations to 60 seconds

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in two handlers; only affects how long background polling runs before giving up, with no auth or data-path changes.
> 
> **Overview**
> Extends how long the daemon waits for overlay gateway **enable** and **disable** operations to reach the expected state after running the command.
> 
> In both async handlers, the status polling loop still ticks every 2 seconds, but the overall wait before logging a timeout is increased from **10 seconds** to **60 seconds**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46da2c63f5626d7e8250d4810b4eacfb9efaf3c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->