### PR TITLE
fix(authelia): format incorrect password message

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.55
+        image: beclab/auth:0.2.56
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION

* **Background**
format incorrect password message
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/57

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on the auth deployment with no manifest or secret changes; standard rollout risk only.
> 
> **Overview**
> Bumps the Authelia backend container image from **`beclab/auth:0.2.55`** to **`beclab/auth:0.2.56`** in `auth_backend_deploy.yaml`. No other deployment, config, or env changes are in this diff.
> 
> The new tag is intended to ship the incorrect-password message formatting fix from upstream Authelia (see beclab/authelia#57); that behavior lives in the image, not in this repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c387c1ac7cf56a02e0a8938ac8e4ada1a661540a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->