### PR TITLE
fix(app-service): not match app version

### DIFF
--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -449,19 +449,14 @@ func (r *ApplicationReconciler) updateApplication(ctx context.Context, req ctrl.
 		appCopy.Spec.TailScale = *tailScale
 	}
 
-	actionConfig, _, err := helm.InitConfig(r.Kubeconfig, appCopy.Spec.Namespace)
-	if err != nil {
-		ctrl.Log.Error(err, "init helm config error")
-	}
-
-	if !userspace.IsSysApp(app.Spec.Name) {
-		version, _, err := apputils.GetDeployedReleaseVersion(actionConfig, name)
-		if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-			ctrl.Log.Error(err, "get deployed release version error")
-		}
-		if err == nil {
-			appCopy.Spec.Settings["version"] = version
-		}
+	// Source the app version from the deployment annotation
+	// (applications.app.bytetrade.io/version) populated in settings by
+	// getAppSettings, so Spec.Settings["version"] stays consistent with the
+	// manifest version stamped on the workload. Skip the assignment when the
+	// annotation is missing/empty so we don't wipe a previously recorded
+	// version.
+	if v := settings["version"]; v != "" {
+		appCopy.Spec.Settings["version"] = v
 	}
 
 	// Record deployment resourceVersion to detect app-only modifications

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -261,6 +261,12 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
+	if appCfg.APIVersion == appcfg.V2 {
+		err = errors.New("app with apiVersion v2 is incompatible and cannot be install")
+		api.HandleForbidden(resp, req, err)
+		return
+	}
+
 	if !isAdmin && appCfg.Shared {
 		err = errors.New("only admin users can install shared apps")
 		api.HandleForbidden(resp, req, err)

--- a/framework/app-service/pkg/utils/app/provider.go
+++ b/framework/app-service/pkg/utils/app/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/client/clientset"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
@@ -110,16 +109,18 @@ func (c ProviderPermissionsConvertor) findProviderInMarket(ctx context.Context, 
 	var appCfg *appcfg.ApplicationConfig
 	for _, m := range marketSources {
 		o := ConfigOptions{
-			App:          appName,
-			RepoURL:      constants.CHART_REPO_URL,
-			Owner:        owner,
-			Version:      "",
-			Token:        token,
-			Admin:        owner,
-			MarketSource: m,
-			IsAdmin:      false,
-			RawAppName:   appName,
+			App:               appName,
+			RepoURL:           constants.CHART_REPO_URL,
+			Owner:             owner,
+			Version:           "",
+			Token:             token,
+			Admin:             owner,
+			MarketSource:      m,
+			IsAdmin:           false,
+			RawAppName:        appName,
+			NeedDownloadChart: true,
 		}
+
 		appCfg, _, err = GetAppConfig(ctx, &o)
 		if err != nil {
 			klog.Errorf("Failed to get app config for %s: %v", appName, err)


### PR DESCRIPTION

* **Background**
fix not match app version
fix need download provider ref char
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the version source on every Application reconcile can surface wrong versions if workload annotations are missing or stale; blocking v2 installs is a deliberate behavior change for those charts.
> 
> **Overview**
> **Application version** on the `Application` CR is no longer taken from the deployed Helm release during reconcile. `updateApplication` now copies `Spec.Settings["version"]` from the workload annotation path already filled by `getAppSettings`, and only when that value is non-empty so an existing stored version is not cleared.
> 
> **Install API** rejects manifests with `apiVersion` v2 after config load, returning **403 Forbidden** with an incompatibility message.
> 
> **Provider resolution** when looking up dependency providers in the market sets **`NeedDownloadChart: true`** on `GetAppConfig`, so the chart is fetched from the repo instead of assuming a local chart path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6ed332cc4a9be7e8d010a514be83da88491fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->