### PR TITLE
fix(app-service): not match app version

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.57
+        image: beclab/app-service:0.5.58
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,6 @@ spec:
       containers:
       - name: app-service
         image: beclab/app-service:0.5.56
-        image: beclab/app-service:0.5.53
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,6 +171,7 @@ spec:
       containers:
       - name: app-service
         image: beclab/app-service:0.5.56
+        image: beclab/app-service:0.5.53
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.5.56
+        image: beclab/app-service:0.5.57
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -449,19 +449,14 @@ func (r *ApplicationReconciler) updateApplication(ctx context.Context, req ctrl.
 		appCopy.Spec.TailScale = *tailScale
 	}
 
-	actionConfig, _, err := helm.InitConfig(r.Kubeconfig, appCopy.Spec.Namespace)
-	if err != nil {
-		ctrl.Log.Error(err, "init helm config error")
-	}
-
-	if !userspace.IsSysApp(app.Spec.Name) {
-		version, _, err := apputils.GetDeployedReleaseVersion(actionConfig, name)
-		if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-			ctrl.Log.Error(err, "get deployed release version error")
-		}
-		if err == nil {
-			appCopy.Spec.Settings["version"] = version
-		}
+	// Source the app version from the deployment annotation
+	// (applications.app.bytetrade.io/version) populated in settings by
+	// getAppSettings, so Spec.Settings["version"] stays consistent with the
+	// manifest version stamped on the workload. Skip the assignment when the
+	// annotation is missing/empty so we don't wipe a previously recorded
+	// version.
+	if v := settings["version"]; v != "" {
+		appCopy.Spec.Settings["version"] = v
 	}
 
 	// Record deployment resourceVersion to detect app-only modifications

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260623095738-fdaf29381ddf
+	github.com/beclab/Olares/framework/oac v0.0.0-20260624143729-4d08c058d606
 	github.com/beclab/api v0.0.18
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,8 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260623095738-fdaf29381ddf h1:kjUXLTlD8sKP7AUfJ/ZLlKr+Cl4J+CpalLrligj145o=
-github.com/beclab/Olares/framework/oac v0.0.0-20260623095738-fdaf29381ddf/go.mod h1:dpo6y8IYbmmE41+qKjZv2LfkuDUidAscpQ71TvbYPJ4=
+github.com/beclab/Olares/framework/oac v0.0.0-20260624143729-4d08c058d606 h1:IQK3YHYyexy3Uu4pzDwflnFwCNq9EZssWtieRTk+u/g=
+github.com/beclab/Olares/framework/oac v0.0.0-20260624143729-4d08c058d606/go.mod h1:dpo6y8IYbmmE41+qKjZv2LfkuDUidAscpQ71TvbYPJ4=
 github.com/beclab/api v0.0.18 h1:6qN86kZVJdHbQt1/hXppkLWn3hf9LYdCCOTldUaOpEQ=
 github.com/beclab/api v0.0.18/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -695,7 +695,7 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	clientset, err := getAppClient()
+	clientset, err := utils.GetClient()
 	if err != nil {
 		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
 		return err

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -261,6 +261,12 @@ func (h *Handler) install(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
+	if appCfg.APIVersion == appcfg.V2 {
+		err = errors.New("app with apiVersion v2 is incompatible and cannot be install")
+		api.HandleForbidden(resp, req, err)
+		return
+	}
+
 	if !isAdmin && appCfg.Shared {
 		err = errors.New("only admin users can install shared apps")
 		api.HandleForbidden(resp, req, err)

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -695,7 +695,7 @@ func (h *installHandlerHelper) applyApplicationManager(marketSource string) (opI
 // path already covers them (patch on reinstallable states, reject otherwise).
 // Per-user same-name across different owners is allowed by design.
 func (h *installHandlerHelper) checkAppNameConflict(ctx context.Context, newShared bool) error {
-	clientset, err := utils.GetClient()
+	clientset, err := getAppClient()
 	if err != nil {
 		klog.Errorf("checkAppNameConflict: failed to get clientset %v", err)
 		return err

--- a/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
@@ -116,7 +116,6 @@ func (h *HelmOps) Uninstall_(client kubernetes.Interface, actionConfig *action.C
 	permCfg, err := apputils.ProviderPermissionsConvertor(perm).ToPermissionCfg(h.ctx, h.app.OwnerName, h.options.MarketSource)
 	if err != nil {
 		klog.Errorf("Failed to convert app permissions for %s: %v", h.app.AppName, err)
-		return err
 	}
 
 	err = h.unregisterAppPerm(h.app.ServiceAccountName, h.app.OwnerName, permCfg)

--- a/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
@@ -116,6 +116,7 @@ func (h *HelmOps) Uninstall_(client kubernetes.Interface, actionConfig *action.C
 	permCfg, err := apputils.ProviderPermissionsConvertor(perm).ToPermissionCfg(h.ctx, h.app.OwnerName, h.options.MarketSource)
 	if err != nil {
 		klog.Errorf("Failed to convert app permissions for %s: %v", h.app.AppName, err)
+		return err
 	}
 
 	err = h.unregisterAppPerm(h.app.ServiceAccountName, h.app.OwnerName, permCfg)

--- a/framework/app-service/pkg/utils/app/provider.go
+++ b/framework/app-service/pkg/utils/app/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/client/clientset"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
@@ -110,16 +109,18 @@ func (c ProviderPermissionsConvertor) findProviderInMarket(ctx context.Context, 
 	var appCfg *appcfg.ApplicationConfig
 	for _, m := range marketSources {
 		o := ConfigOptions{
-			App:          appName,
-			RepoURL:      constants.CHART_REPO_URL,
-			Owner:        owner,
-			Version:      "",
-			Token:        token,
-			Admin:        owner,
-			MarketSource: m,
-			IsAdmin:      false,
-			RawAppName:   appName,
+			App:               appName,
+			RepoURL:           constants.CHART_REPO_URL,
+			Owner:             owner,
+			Version:           "",
+			Token:             token,
+			Admin:             owner,
+			MarketSource:      m,
+			IsAdmin:           false,
+			RawAppName:        appName,
+			NeedDownloadChart: true,
 		}
+
 		appCfg, _, err = GetAppConfig(ctx, &o)
 		if err != nil {
 			klog.Errorf("Failed to get app config for %s: %v", appName, err)


### PR DESCRIPTION

* **Background**
fix not match app version
fix need download provider ref char
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version metadata and install eligibility change behavior for all non-sys apps; provider lookups now always download charts, which affects network/repo failures during permission resolution.
> 
> **Overview**
> **Application version** on the `Application` CR now comes from the deployment’s `applications.app.bytetrade.io/version` annotation (via `getAppSettings`) instead of the Helm release version. Empty annotations no longer overwrite a previously stored `Spec.Settings["version"]`.
> 
> **Install API** rejects manifests with **apiVersion v2** with **403 Forbidden** after config is loaded, even when the install pipeline would otherwise use a v1/v3 helper.
> 
> **Provider permission resolution** sets **`NeedDownloadChart: true`** when loading provider app configs from the chart repo so referenced provider charts are fetched instead of assuming a local path only.
> 
> Deploy image **`beclab/app-service`** is bumped **0.5.56 → 0.5.58**; **`framework/oac`** dependency is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9828b75e92046fe26ad8e8c013f1bdd1641b004b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->