### PR TITLE
fix(oac): tighten validation for new version, improve resource-limit diagnostics, and ship terminus-apps repair scripts

### DIFF
--- a/framework/oac/appconfig.go
+++ b/framework/oac/appconfig.go
@@ -37,6 +37,13 @@ type AppConfiguration = apimanifest.AppConfiguration
 // manifests (<0.12.0) are template-rendered with the Checker's
 // owner/admin before parsing; modern (>=0.12.0) manifests are parsed
 // verbatim.
+//
+// metadata.appid is normalized to md5(metadata.name)[:8] before returning,
+// matching what framework/app-service derives at runtime
+// (appcfg.(AppName).GetAppID). Anything the manifest wrote into the field is
+// discarded; an empty metadata.name leaves the appid empty so the
+// downstream validation error keys off the missing name rather than a
+// meaningless hash.
 func (c *OAC) LoadAppConfiguration(oacPath string) (*AppConfiguration, error) {
 	m, err := c.LoadManifestFile(oacPath)
 	if err != nil {
@@ -46,11 +53,13 @@ func (c *OAC) LoadAppConfiguration(oacPath string) (*AppConfiguration, error) {
 	if !ok {
 		return nil, errAppConfigUnavailable
 	}
+	normalizeAppID(cfg)
 	return cfg, nil
 }
 
 // LoadAppConfigurationContent is the byte-slice counterpart of
-// LoadAppConfiguration.
+// LoadAppConfiguration. It applies the same metadata.appid normalization
+// (see LoadAppConfiguration for details).
 func (c *OAC) LoadAppConfigurationContent(content []byte) (*AppConfiguration, error) {
 	m, err := c.LoadManifestContent(content)
 	if err != nil {
@@ -60,7 +69,19 @@ func (c *OAC) LoadAppConfigurationContent(content []byte) (*AppConfiguration, er
 	if !ok {
 		return nil, errAppConfigUnavailable
 	}
+	normalizeAppID(cfg)
 	return cfg, nil
+}
+
+// normalizeAppID overwrites cfg.Metadata.AppID with the deterministic value
+// the platform derives from metadata.name. Centralised so both load entry
+// points behave identically and so the rule (and its empty-name edge case)
+// is documented exactly once.
+func normalizeAppID(cfg *AppConfiguration) {
+	if cfg == nil {
+		return
+	}
+	cfg.Metadata.AppID = olm.AppIDFromName(cfg.Metadata.Name)
 }
 
 // AsAppConfiguration unwraps a Manifest into the concrete

--- a/framework/oac/appconfig_fields_test.go
+++ b/framework/oac/appconfig_fields_test.go
@@ -67,6 +67,13 @@ func TestLoadAppConfiguration_PreservesAllYAMLFields(t *testing.T) {
 
 	var missing, mismatched []string
 	for path, want := range inputLeaves {
+		// metadata.appid is intentionally not preserved: LoadAppConfiguration
+		// normalizes it to md5(metadata.name)[:8] to align with the
+		// runtime-derived id (framework/app-service/pkg/appcfg.GetAppID), so
+		// whatever the YAML wrote there is discarded.
+		if path == "metadata.appid" {
+			continue
+		}
 		got, ok := lookupTestYAMLPath(outputNorm, path)
 		if !ok {
 			missing = append(missing, path)

--- a/framework/oac/appconfig_test.go
+++ b/framework/oac/appconfig_test.go
@@ -183,6 +183,75 @@ func TestValidateAppConfiguration_PackageLevelShortcut(t *testing.T) {
 	}
 }
 
+// TestLoadAppConfigurationContent_NormalizesAppID pins the loader contract
+// that metadata.appid is overwritten with md5(metadata.name)[:8] regardless
+// of what the manifest declared. The value matches
+// framework/app-service/pkg/appcfg.(AppName).GetAppID for non-system apps,
+// so callers can rely on the load layer producing the same id the runtime
+// computes downstream.
+func TestLoadAppConfigurationContent_NormalizesAppID(t *testing.T) {
+	const content = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: demo
+  title: Demo
+  version: 1.0.0
+  appid: whatever-user-wrote
+spec:
+  versionName: v1
+`
+	cfg, err := oac.LoadAppConfigurationContent([]byte(content))
+	if err != nil {
+		t.Fatalf("LoadAppConfigurationContent: %v", err)
+	}
+	// md5("demo") = "fe01ce2a7fbac8fafaed7c982a04e229" -> first 8 hex chars.
+	const want = "fe01ce2a"
+	if cfg.Metadata.AppID != want {
+		t.Fatalf("metadata.appid = %q, want %q (md5(metadata.name)[:8])", cfg.Metadata.AppID, want)
+	}
+}
+
+// TestLoadAppConfigurationContent_EmptyNameLeavesAppIDEmpty pins the
+// edge-case branch of normalizeAppID: when metadata.name is missing the
+// loader returns an empty appid rather than md5("")[:8] (a meaningless
+// constant). The follow-up validation error will then key off the missing
+// name instead of confusing the user with a synthetic hash.
+func TestLoadAppConfigurationContent_EmptyNameLeavesAppIDEmpty(t *testing.T) {
+	const content = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  title: Demo
+  version: 1.0.0
+spec:
+  versionName: v1
+`
+	cfg, err := oac.LoadAppConfigurationContent([]byte(content))
+	if err != nil {
+		t.Fatalf("LoadAppConfigurationContent: %v", err)
+	}
+	if cfg.Metadata.AppID != "" {
+		t.Fatalf("metadata.appid = %q, want empty when metadata.name is missing", cfg.Metadata.AppID)
+	}
+}
+
+// TestLoadAppConfiguration_NormalizesAppID exercises the file-based loader
+// against the firefox fixture: the manifest declares appid: firefox (see
+// testdata/firefox/OlaresManifest.yaml), which the load layer must
+// overwrite with md5("firefox")[:8].
+func TestLoadAppConfiguration_NormalizesAppID(t *testing.T) {
+	cfg, err := oac.LoadAppConfiguration(testdataFirefox, oac.WithOwnerAdmin("alice"))
+	if err != nil {
+		t.Fatalf("LoadAppConfiguration: %v", err)
+	}
+	// md5("firefox") = "d6a5c9544eca9b5ce2266d1c34a93222" -> first 8 hex chars.
+	const want = "d6a5c954"
+	if cfg.Metadata.AppID != want {
+		t.Fatalf("metadata.appid = %q, want %q (md5(metadata.name)[:8])", cfg.Metadata.AppID, want)
+	}
+}
+
 // TestLoadAppConfiguration_PropagatesParseError ensures that file-IO and
 // parser errors surface via the convenience loader (we don't swallow them
 // or wrap them in errAppConfigUnavailable by mistake).

--- a/framework/oac/chart_limits_test.go
+++ b/framework/oac/chart_limits_test.go
@@ -33,8 +33,13 @@ func TestCheckResourceLimits_ModernV1_InlineMismatchFails(t *testing.T) {
 	if limErr == nil {
 		t.Fatal("expected error: container requests exceed inline spec.requiredCpu")
 	}
-	if !strings.Contains(limErr.Error(), "spec.requiredCpu") {
-		t.Fatalf("expected spec.requiredCpu in error, got: %v", limErr)
+	// Aggregate-cap messages reference the limit field by its bare
+	// name (e.g. "requiredCpu") rather than the dotted "spec." path,
+	// so the assertion uses the unqualified substring. The "must be <="
+	// fragment pins us to the aggregate-cap rule.
+	msg := limErr.Error()
+	if !strings.Contains(msg, "requiredCpu") || !strings.Contains(msg, "must be <=") {
+		t.Fatalf("expected requiredCpu cap violation in error, got: %v", limErr)
 	}
 }
 

--- a/framework/oac/images.go
+++ b/framework/oac/images.go
@@ -31,8 +31,9 @@ var AllImageRenderModes = []string{
 	"apple-m",
 	"nvidia",
 	"nvidia-gb10",
-	"mthreads-m1000",
-	"strix-halo",
+	"moore-soc",
+	"amd",
+	"intel",
 }
 
 // ListImages returns the sorted, deduplicated set of container images used by

--- a/framework/oac/internal/manifest/appid.go
+++ b/framework/oac/internal/manifest/appid.go
@@ -1,0 +1,80 @@
+package manifest
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+)
+
+// reservedSystemAppIDs enumerates the metadata.appid values that the Olares
+// platform reserves for its built-in system apps. The list mirrors the
+// SYS_APPS environment value baked into the app-service deployment
+// (framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml)
+// so a third-party app cannot claim an identity that would collide with a
+// system app and silently shadow it at install / routing time.
+//
+// Membership is exact (case-sensitive after trimming); the platform compares
+// the raw appid string when deciding whether an install is a system upgrade,
+// so we mirror that contract here rather than fuzzy-matching.
+var reservedSystemAppIDs = map[string]struct{}{
+	"market":         {},
+	"auth":           {},
+	"citus":          {},
+	"desktop":        {},
+	"did":            {},
+	"docs":           {},
+	"files":          {},
+	"fsnotify":       {},
+	"headscale":      {},
+	"infisical":      {},
+	"intentprovider": {},
+	"ksserver":       {},
+	"message":        {},
+	"mongo":          {},
+	"monitoring":     {},
+	"notifications":  {},
+	"profile":        {},
+	"redis":          {},
+	"recommend":      {},
+	"seafile":        {},
+	"search":         {},
+	"search-admin":   {},
+	"settings":       {},
+	"systemserver":   {},
+	"tapr":           {},
+	"vault":          {},
+	"video":          {},
+	"zinc":           {},
+	"accounts":       {},
+	"control-hub":    {},
+	"dashboard":      {},
+	"nitro":          {},
+	"olares-app":     {},
+}
+
+// IsReservedSystemAppID reports whether s collides with a reserved system
+// appid. Surrounding whitespace is trimmed before lookup so a manifest that
+// accidentally writes "  market  " is treated the same as "market", matching
+// what the YAML parser would observe after the value goes through
+// downstream string normalization.
+func IsReservedSystemAppID(s string) bool {
+	_, ok := reservedSystemAppIDs[strings.TrimSpace(s)]
+	return ok
+}
+
+// AppIDFromName returns the deterministic appid the Olares platform derives
+// from an app name: the first 8 hex characters of md5(name). It mirrors
+// framework/app-service/pkg/appcfg.(AppName).GetAppID's user-app branch
+// (and framework/app-service/pkg/utils/app.GetAppID) so the loader's
+// normalization and the runtime's runtime-derived id agree byte-for-byte.
+//
+// An empty name yields an empty string -- the loader's normalization is a
+// no-op when metadata.name is missing, which keeps validation errors keyed
+// off the absent name rather than producing a meaningless hash.
+func AppIDFromName(name string) string {
+	if name == "" {
+		return ""
+	}
+	sum := md5.Sum([]byte(name))
+	return hex.EncodeToString(sum[:])[:8]
+}

--- a/framework/oac/internal/manifest/appid_test.go
+++ b/framework/oac/internal/manifest/appid_test.go
@@ -1,0 +1,117 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAppIDFromName pins the loader-normalization contract: a non-empty name
+// yields the first 8 hex characters of md5(name); an empty name yields the
+// empty string. Cross-checking against a couple of known md5 prefixes
+// guards against accidental hash-truncation bugs (e.g. taking the last 8
+// chars or hashing UTF-8 bytes differently).
+func TestAppIDFromName(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"", ""},
+		// md5("nginx")   = "ee434023cf89d7dfb21f63d64f0f9d74"
+		{"nginx", "ee434023"},
+		// md5("firefox") = "d6a5c9544eca9b5ce2266d1c34a93222"
+		{"firefox", "d6a5c954"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := AppIDFromName(tc.name)
+			if got != tc.want {
+				t.Fatalf("AppIDFromName(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppIDFromName_DeterministicAndLength(t *testing.T) {
+	id := AppIDFromName("my-app")
+	if len(id) != 8 {
+		t.Fatalf("non-empty name must yield an 8-char id, got %q (len=%d)", id, len(id))
+	}
+	if id != AppIDFromName("my-app") {
+		t.Fatal("AppIDFromName must be deterministic across calls")
+	}
+	if id == AppIDFromName("my-other-app") {
+		t.Fatal("distinct names must yield distinct ids")
+	}
+}
+
+// TestIsReservedSystemAppID covers a representative slice of the reserved
+// set (a head, a tail, and the hyphenated middle entry) plus a clearly
+// non-reserved name. Whitespace handling is pinned because the lint rule
+// trims before checking.
+func TestIsReservedSystemAppID(t *testing.T) {
+	for _, s := range []string{
+		"market", "auth", "search-admin", "olares-app", "control-hub",
+	} {
+		if !IsReservedSystemAppID(s) {
+			t.Errorf("IsReservedSystemAppID(%q) = false, want true", s)
+		}
+	}
+	if !IsReservedSystemAppID("  market  ") {
+		t.Error("IsReservedSystemAppID must trim surrounding whitespace")
+	}
+	for _, s := range []string{
+		"", "my-app", "MARKET", " market2", "marketing",
+	} {
+		if IsReservedSystemAppID(s) {
+			t.Errorf("IsReservedSystemAppID(%q) = true, want false", s)
+		}
+	}
+}
+
+// Lint rule: an empty metadata.appid is permitted (the loader will fill it
+// in deterministically). The baseline fixture omits the field, so it must
+// continue to pass.
+func TestValidateMetadataAppID_EmptyAllowed(t *testing.T) {
+	c := newValidConfig()
+	c.Metadata.AppID = ""
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("empty metadata.appid must be accepted, got: %v", err)
+	}
+}
+
+// Lint rule: a non-reserved metadata.appid (the existing "hand-author" shape
+// from olares-chart-from-compose -- appid==name) must pass even though the
+// loader will overwrite it later.
+func TestValidateMetadataAppID_CustomAccepted(t *testing.T) {
+	c := newValidConfig()
+	c.Metadata.AppID = "firefox"
+	if err := ValidateAppConfiguration(c); err != nil {
+		t.Fatalf("non-reserved metadata.appid must be accepted, got: %v", err)
+	}
+}
+
+// Lint rule: every reserved system appid must be rejected, and the error
+// must mention metadata.appid plus the offending value so the user can
+// spot what to change.
+func TestValidateMetadataAppID_ReservedRejected(t *testing.T) {
+	for _, reserved := range []string{
+		"market", "auth", "settings", "search-admin", "olares-app", "control-hub", "nitro",
+	} {
+		reserved := reserved
+		t.Run(reserved, func(t *testing.T) {
+			c := newValidConfig()
+			c.Metadata.AppID = reserved
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("metadata.appid=%q must be rejected as reserved", reserved)
+			}
+			if !strings.Contains(err.Error(), "metadata.appid") {
+				t.Fatalf("error must mention metadata.appid, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), reserved) {
+				t.Fatalf("error must echo the offending value %q, got: %v", reserved, err)
+			}
+		})
+	}
+}

--- a/framework/oac/internal/manifest/pipeline.go
+++ b/framework/oac/internal/manifest/pipeline.go
@@ -65,7 +65,7 @@ func NewPipeline(olaresVersion string, strat Strategy) Pipeline {
 	if isLegacyVersion(olaresVersion) {
 		return dualOwnerPipeline{strat: strat}
 	}
-	return singlePipeline{strat: strat}
+	return singlePipeline{strat: strat, olaresVersion: olaresVersion}
 }
 
 func isLegacyVersion(v string) bool {
@@ -79,26 +79,53 @@ func isLegacyVersion(v string) bool {
 	return got.LessThan(legacyVersionBoundary)
 }
 
-type singlePipeline struct{ strat Strategy }
+type singlePipeline struct {
+	strat Strategy
+	// olaresVersion is the manifest's olaresManifest.version probed by
+	// NewPipeline. Modern manifests (>= 0.12.0) are parsed verbatim, so
+	// any helm template placeholder `{{ ... }}` left in the raw bytes
+	// would corrupt the YAML before the strategy ever sees it. The
+	// version is retained here so the pre-parse template-syntax gate can
+	// fire only when resourcesCheckApplies confirms the manifest is
+	// modern; empty or malformed versions skip the gate to preserve the
+	// "unknown version → behave like the strategy chose to parse it"
+	// fallback used by tests and probing callers.
+	olaresVersion string
+}
 
 func (p singlePipeline) Parse(raw []byte, _ Renderer, _, _ string) (Manifest, error) {
-	return p.strat.Parse(raw)
+	return p.parseRaw(raw)
 }
 
 // Validate reuses parsed when the caller already parsed raw; the raw bytes
 // and their parse result cannot disagree in the single-owner flow (there is
 // no per-scenario render indirection), so a second Parse would be a pure
-// overhead. When parsed is nil we fall back to parsing raw ourselves.
+// overhead. When parsed is nil we fall back to parsing raw ourselves --
+// going through parseRaw so the template-syntax gate fires on this branch
+// too if the caller jumps straight into Validate without a prior Parse.
 func (p singlePipeline) Validate(raw []byte, parsed Manifest, _ Renderer, _, _ string) error {
 	m := parsed
 	if m == nil {
 		var err error
-		m, err = p.strat.Parse(raw)
+		m, err = p.parseRaw(raw)
 		if err != nil {
 			return err
 		}
 	}
 	return p.strat.Validate(m)
+}
+
+// parseRaw centralises the modern-manifest pre-parse checks so Parse and
+// the parsed==nil branch of Validate share one implementation. Today it
+// runs the template-syntax gate before handing the bytes to the strategy;
+// any future "must hold before YAML decode" check belongs here too.
+func (p singlePipeline) parseRaw(raw []byte) (Manifest, error) {
+	if resourcesCheckApplies(p.olaresVersion) {
+		if err := checkNoTemplateSyntax(raw); err != nil {
+			return nil, err
+		}
+	}
+	return p.strat.Parse(raw)
 }
 
 func (p singlePipeline) Strategy() Strategy { return p.strat }

--- a/framework/oac/internal/manifest/pipeline_test.go
+++ b/framework/oac/internal/manifest/pipeline_test.go
@@ -193,6 +193,94 @@ func TestSinglePipeline_Strategy(t *testing.T) {
 	}
 }
 
+// TestSinglePipeline_RejectsTemplateSyntaxOnModernManifest documents
+// the pre-parse gate added for olaresManifest.version >= 0.12.0: a raw
+// payload that still carries an unquoted `{{` / `}}` delimiter must
+// fail before the strategy's YAML parser ever sees it, otherwise the
+// user gets the downstream "could not find expected ':'" error that
+// prompted this check.
+func TestSinglePipeline_RejectsTemplateSyntaxOnModernManifest(t *testing.T) {
+	s := &fakeStrategy{}
+	p := singlePipeline{strat: s, olaresVersion: "0.12.0"}
+
+	raw := []byte("metadata:\n  name: {{ .Values.bfl.username }}\n")
+	_, err := p.Parse(raw, nil, "", "")
+	if err == nil {
+		t.Fatal("expected template-syntax rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "template syntax") {
+		t.Fatalf("error must mention template syntax, got: %v", err)
+	}
+	if len(s.parseCalls) != 0 {
+		t.Fatalf("strategy.Parse must not be invoked when the gate trips, got %d calls", len(s.parseCalls))
+	}
+}
+
+// TestSinglePipeline_ValidateRejectsTemplateSyntaxOnModernManifest
+// mirrors the Parse-side gate for the parsed==nil branch of Validate,
+// which is the path Lint/ValidateManifestContent uses when the caller
+// hasn't parsed the manifest yet. The sample value is intentionally
+// *unquoted* — quoted scalars and block scalars are shielded by the
+// YAML-aware masker, so the gate must trip only on the bare form that
+// would otherwise derail the YAML decoder.
+func TestSinglePipeline_ValidateRejectsTemplateSyntaxOnModernManifest(t *testing.T) {
+	s := &fakeStrategy{}
+	p := singlePipeline{strat: s, olaresVersion: "0.12.0"}
+
+	raw := []byte("spec:\n  name: {{ .Values.foo }}\n")
+	err := p.Validate(raw, nil, nil, "", "")
+	if err == nil {
+		t.Fatal("expected template-syntax rejection from Validate, got nil")
+	}
+	if !strings.Contains(err.Error(), "template syntax") {
+		t.Fatalf("error must mention template syntax, got: %v", err)
+	}
+	if len(s.parseCalls) != 0 {
+		t.Fatalf("strategy.Parse must not be invoked when the gate trips, got %d calls", len(s.parseCalls))
+	}
+	if len(s.validCalls) != 0 {
+		t.Fatalf("strategy.Validate must not be invoked when the gate trips, got %d calls", len(s.validCalls))
+	}
+}
+
+// TestSinglePipeline_AllowsTemplateSyntaxInsideQuotedString documents
+// the flip side: a `{{ ... }}` (or stand-alone `{{` / `}}`) that
+// belongs to a key's value scalar — be it single-quoted, double-
+// quoted, or a `|`/`>` block scalar — does not trip the gate, because
+// YAML decodes the line cleanly and the placeholder reads as
+// documentation text on a modern manifest.
+func TestSinglePipeline_AllowsTemplateSyntaxInsideQuotedString(t *testing.T) {
+	s := &fakeStrategy{}
+	p := singlePipeline{strat: s, olaresVersion: "0.12.0"}
+
+	raw := []byte("spec:\n  description: \"use {{ .Values.foo }} as a placeholder\"\n")
+	if _, err := p.Parse(raw, nil, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s.parseCalls) != 1 {
+		t.Fatalf("strategy.Parse must run when the placeholder is shielded by a string, got %d calls", len(s.parseCalls))
+	}
+}
+
+// TestSinglePipeline_AllowsTemplateSyntaxOnUnknownVersion documents
+// another flip side of the gate: when olaresManifest.version is empty
+// or unparseable (the cases NewPipeline still routes through
+// singlePipeline), the template-syntax check is intentionally skipped.
+// The legacy/probing callers that rely on this fallback must keep
+// working.
+func TestSinglePipeline_AllowsTemplateSyntaxOnUnknownVersion(t *testing.T) {
+	s := &fakeStrategy{}
+	p := singlePipeline{strat: s} // olaresVersion left empty
+
+	raw := []byte("metadata:\n  name: {{ .Values.foo }}\n")
+	if _, err := p.Parse(raw, nil, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s.parseCalls) != 1 {
+		t.Fatalf("strategy.Parse must run when the version is unknown, got %d calls", len(s.parseCalls))
+	}
+}
+
 func TestDualOwnerPipeline_ParseUsesCallerInputs(t *testing.T) {
 	s := &fakeStrategy{manifest: &fakeManifest{apiVersion: "v1", configVersion: "0.8.1"}}
 	p := dualOwnerPipeline{strat: s}

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -12,38 +12,48 @@ import (
 )
 
 const (
-	ResourceModeCPU           = "cpu"
-	ResourceModeAMDAPU        = "amd-apu"
-	ResourceModeAMDGPU        = "amd-gpu"
-	ResourceModeAppleM        = "apple-m"
-	ResourceModeNvidia        = "nvidia"
-	ResourceModeNvidiaGB10    = "nvidia-gb10"
-	ResourceModeMThreadsM1000 = "mthreads-m1000"
-	ResourceModeStrixHalo     = "strix-halo"
+	ResourceModeCPU        = "cpu"
+	ResourceModeNvidia     = "nvidia"
+	ResourceModeNvidiaGB10 = "nvidia-gb10"
+	ResourceModeAppleM     = "apple-m"
+	ResourceModeIntel      = "intel"     // Intel integrated GPU
+	ResourceModeAMD        = "amd"       // AMD integrated GPU
+	ResourceModeIntelGPU   = "intel-gpu" // Intel discrete GPU
+	ResourceModeAMDGPU     = "amd-gpu"   // AMD discrete GPU
+	ResourceModeMooreSoc   = "moore-soc" // Moore Threads SoC
 )
 
 var validResourceModes = []any{
 	ResourceModeCPU,
-	ResourceModeStrixHalo,
-	ResourceModeAMDGPU,
-	ResourceModeAppleM,
 	ResourceModeNvidia,
 	ResourceModeNvidiaGB10,
-	ResourceModeMThreadsM1000,
-	ResourceModeStrixHalo,
+	ResourceModeAppleM,
+	ResourceModeIntel,
+	ResourceModeAMD,
+	ResourceModeIntelGPU,
+	ResourceModeAMDGPU,
+	ResourceModeMooreSoc,
 }
 
 var modeArchRequirement = map[string]string{
-	ResourceModeAMDGPU:        "amd64",
-	ResourceModeNvidia:        "amd64",
-	ResourceModeNvidiaGB10:    "arm64",
-	ResourceModeMThreadsM1000: "arm64",
-	ResourceModeStrixHalo:     "amd64",
+	ResourceModeNvidia:     "amd64",
+	ResourceModeNvidiaGB10: "arm64",
+	ResourceModeAppleM:     "arm64",
+	ResourceModeIntel:      "amd64",
+	ResourceModeAMD:        "amd64",
+	ResourceModeIntelGPU:   "amd64",
+	ResourceModeAMDGPU:     "amd64",
+	ResourceModeMooreSoc:   "arm64",
 }
 
+// gpuMemoryModes are the modes that expose a standalone GPU memory pool, so a
+// manifest may declare requiredGpu / limitedGpu for them. These are the
+// discrete-GPU / HAMi flavors; the unified-memory SoCs (apple-m, intel, amd,
+// nvidia-gb10, moore-soc) draw from system RAM and must not.
 var gpuMemoryModes = map[string]struct{}{
-	ResourceModeNvidia: {},
-	ResourceModeAMDGPU: {},
+	ResourceModeNvidia:   {},
+	ResourceModeAMDGPU:   {},
+	ResourceModeIntelGPU: {},
 }
 
 var minResourcesManifestVersion = semver.MustParse("0.12.0")

--- a/framework/oac/internal/manifest/resources.go
+++ b/framework/oac/internal/manifest/resources.go
@@ -396,7 +396,7 @@ func validateQuantities(prefix string, rr ResourceRequirement, templateOnly bool
 	}
 	var errs []error
 	for _, p := range pairs {
-		if p.value == "" || IsAutoResourceQuantity(p.value) {
+		if p.value == "" {
 			continue
 		}
 		if err := validateResourceQuantity(p.value, prefix+p.field, templateOnly, true); err != nil {

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -184,7 +184,10 @@ func TestRule1_ModeArchRequirement(t *testing.T) {
 		{"nvidia ok with amd64", ResourceModeNvidia, []string{"amd64"}, false, ""},
 		{"amd-gpu needs amd64", ResourceModeAMDGPU, []string{"arm64"}, true, "amd64"},
 		{"nvidia-gb10 needs arm64", ResourceModeNvidiaGB10, []string{"amd64"}, true, "arm64"},
-		{"mthreads-m1000 needs arm64", ResourceModeMThreadsM1000, []string{"amd64"}, true, "arm64"},
+		{"moore-soc needs arm64", ResourceModeMooreSoc, []string{"amd64"}, true, "arm64"},
+		{"amd ok with amd64", ResourceModeAMD, []string{"amd64"}, false, ""},
+		{"intel ok with amd64", ResourceModeIntel, []string{"amd64"}, false, ""},
+		{"apple-m needs arm64", ResourceModeAppleM, []string{"amd64"}, true, "arm64"},
 		{"cpu has no arch constraint", ResourceModeCPU, []string{"amd64"}, false, ""},
 	}
 	for _, tc := range cases {
@@ -249,9 +252,9 @@ func TestRule2_NvidiaModeRequiresGPUPair(t *testing.T) {
 }
 
 func TestRule2_NonGPUModeAcceptsCompleteEnvelope(t *testing.T) {
-	// Non-GPU-memory modes (cpu / amd-apu / apple-m / nvidia-gb10 /
-	// mthreads-m1000) cannot declare standalone gpu fields. A fully
-	// populated cpu/memory/disk envelope therefore must validate cleanly.
+	// Non-GPU-memory modes (cpu / apple-m / nvidia-gb10 / intel / amd /
+	// moore-soc) cannot declare standalone gpu fields. A fully populated
+	// cpu/memory/disk envelope therefore must validate cleanly.
 	c := newResourcesConfig(ResourceMode{
 		Mode:                ResourceModeCPU,
 		ResourceRequirement: fullCPUMemoryDisk(),
@@ -280,12 +283,12 @@ func TestRule2_InlineMissingFieldRejected(t *testing.T) {
 	}
 }
 
-// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu)
-// cannot declare gpu fields. Disk is allowed on every mode after the
-// relaxation of the old "cpu+memory only" constraint.
+// Rule 3: modes outside the gpuMemoryModes whitelist (nvidia / amd-gpu /
+// intel-gpu) cannot declare gpu fields. Disk is allowed on every mode after
+// the relaxation of the old "cpu+memory only" constraint.
 func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	for _, mode := range []string{
-		ResourceModeCPU, ResourceModeStrixHalo, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMThreadsM1000,
+		ResourceModeCPU, ResourceModeAMD, ResourceModeIntel, ResourceModeAppleM, ResourceModeNvidiaGB10, ResourceModeMooreSoc,
 	} {
 		mode := mode
 		t.Run(mode+"_disk_allowed", func(t *testing.T) {
@@ -325,8 +328,8 @@ func TestRule3_NonGPUFamilyModesForbidGPU(t *testing.T) {
 	}
 }
 
-// Rule 4: nvidia and amd-gpu may declare a standalone gpu memory quantity;
-// every other mode must leave requiredGpu/limitedGpu empty.
+// Rule 4: nvidia, amd-gpu and intel-gpu may declare a standalone gpu memory
+// quantity; every other mode must leave requiredGpu/limitedGpu empty.
 func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	cases := []struct {
 		mode    string
@@ -334,8 +337,10 @@ func TestRule4_GPUMemoryAllowedModes(t *testing.T) {
 	}{
 		{ResourceModeNvidia, false},
 		{ResourceModeAMDGPU, false},
-		{ResourceModeCPU, true},           // non-GPU family
-		{ResourceModeMThreadsM1000, true}, // GPU-family but not yet whitelisted
+		{ResourceModeIntelGPU, false},
+		{ResourceModeCPU, true},      // non-GPU family
+		{ResourceModeMooreSoc, true}, // GPU-family but not yet whitelisted
+		{ResourceModeAMD, true},      // integrated AMD: unified memory, no standalone gpu pool
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -31,23 +31,23 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c.Spec.LimitedGPU = ""
 	wr := WorkloadReplicas{c.Metadata.Name: 1}
 	c.WorkloadReplicas = &wr
-	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	return c
 }
 
-// newOlaresSystemDep returns the canonical options.dependencies entry that
-// satisfies validateOlaresDependency on a modern (olaresManifest.version
-// >= 0.12.0) manifest. The constraint matches the rule for the supplied
-// apiVersion: v3 manifests require >=1.12.6-0, v1/v2 (and empty, which
-// normalizes to v1) require >=1.12.3-0,<1.12.6.
-func newOlaresSystemDep(apiVersion string) Dependency {
-	constraint := ">=1.12.3-0,<1.12.6"
-	if normalizeAPIVersion(apiVersion) == APIVersionV3 {
-		constraint = ">=1.12.6-0"
-	}
+// newOlaresSystemDep returns the canonical options.dependencies entry
+// that satisfies validateOlaresDependency for c. It mirrors the validator
+// rules: apiVersion=v3 OR any 1.12.6-only feature field on the config
+// selects the post-v3 (>=1.12.6-0) constraint, otherwise the legacy
+// pre-v3 (>=1.12.3-0,<1.12.6) constraint is used. Callers should set
+// every relevant config field (workloadReplicas, overlayGateway, etc.)
+// before invoking this helper so the picked constraint stays in sync
+// with the validator's view of the same config.
+func newOlaresSystemDep(c *AppConfiguration) Dependency {
+	rule, _ := pickOlaresDepRule(c)
 	return Dependency{
 		Name:    olaresSystemDepName,
-		Version: constraint,
+		Version: rule.requirement,
 		Type:    "system",
 	}
 }

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -10,7 +10,9 @@ import (
 // version above the gate (so checkResources actually runs). Because the
 // modern path rejects every legacy flat spec.required*/spec.limited* field
 // (Rule 7), this helper explicitly clears the legacy quantities populated
-// by newValidConfig.
+// by newValidConfig. workloadReplicas is populated too: it is required for
+// olaresManifest.version >= 0.12.0 on non-v2 manifests, and every modern
+// resources test inherits that gate.
 func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c := newValidConfig()
 	c.ConfigVersion = "0.13.0" // >= 0.12.0 -> rules apply
@@ -25,6 +27,8 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c.Spec.LimitedDisk = ""
 	c.Spec.RequiredGPU = ""
 	c.Spec.LimitedGPU = ""
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
 	return c
 }
 

--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -12,7 +12,9 @@ import (
 // (Rule 7), this helper explicitly clears the legacy quantities populated
 // by newValidConfig. workloadReplicas is populated too: it is required for
 // olaresManifest.version >= 0.12.0 on non-v2 manifests, and every modern
-// resources test inherits that gate.
+// resources test inherits that gate. The Olares system dependency is also
+// installed at the v1/v2-compatible default range (>=1.12.3-0,<1.12.6),
+// because validateOlaresDependency rejects modern manifests that omit it.
 func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c := newValidConfig()
 	c.ConfigVersion = "0.13.0" // >= 0.12.0 -> rules apply
@@ -29,7 +31,25 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 	c.Spec.LimitedGPU = ""
 	wr := WorkloadReplicas{c.Metadata.Name: 1}
 	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 	return c
+}
+
+// newOlaresSystemDep returns the canonical options.dependencies entry that
+// satisfies validateOlaresDependency on a modern (olaresManifest.version
+// >= 0.12.0) manifest. The constraint matches the rule for the supplied
+// apiVersion: v3 manifests require >=1.12.6-0, v1/v2 (and empty, which
+// normalizes to v1) require >=1.12.3-0,<1.12.6.
+func newOlaresSystemDep(apiVersion string) Dependency {
+	constraint := ">=1.12.3-0,<1.12.6"
+	if normalizeAPIVersion(apiVersion) == APIVersionV3 {
+		constraint = ">=1.12.6-0"
+	}
+	return Dependency{
+		Name:    olaresSystemDepName,
+		Version: constraint,
+		Type:    "system",
+	}
 }
 
 func TestResourcesCheckApplies(t *testing.T) {

--- a/framework/oac/internal/manifest/template_syntax.go
+++ b/framework/oac/internal/manifest/template_syntax.go
@@ -1,0 +1,210 @@
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+// templateSyntaxRE matches the two helm template delimiters `{{` and
+// `}}` independently. The check fires per-occurrence rather than per
+// pair: even a lone `{{` or `}}` that escapes the YAML string masker
+// almost always means "this used to be a helm placeholder before the
+// rendering step went away", and we want to surface it the same way
+// as the full `{{ ... }}` form. The regex runs against a *masked*
+// copy of the manifest in which braces inside YAML string scalars
+// have been replaced with spaces, so any match here means the
+// delimiter sits outside every key's value scalar.
+var templateSyntaxRE = regexp.MustCompile(`\{\{|\}\}`)
+
+// checkNoTemplateSyntax returns an error if the manifest contains a
+// `{{` or `}}` delimiter that does not belong to any key's value
+// scalar — practically, any occurrence outside a single-quoted scalar,
+// a double-quoted scalar, or a `|`/`>` block scalar. Once a delimiter
+// is properly contained inside a YAML string, YAML treats its body as
+// opaque text, so even the full `{{ ... }}` pair is fine there and
+// reads as documentation for the manifest author.
+//
+// The check is gated by the caller to modern manifests
+// (olaresManifest.version >= 0.12.0): those manifests are parsed
+// verbatim without a helm render pass, so an unquoted placeholder
+// would surface as a confusing low-level YAML error (e.g. "yaml: line
+// 78: could not find expected ':'"). Detecting the placeholder up
+// front turns that into a clear, actionable manifest authoring error.
+func checkNoTemplateSyntax(content []byte) error {
+	masked := maskYAMLStringRegions(content)
+	loc := templateSyntaxRE.FindIndex(masked)
+	if loc == nil {
+		return nil
+	}
+	line := bytes.Count(content[:loc[0]], []byte{'\n'}) + 1
+	matched := content[loc[0]:loc[1]]
+	return fmt.Errorf(
+		"line %d: %q is template syntax outside any YAML string value and is not allowed for olaresManifest.version >= %s; quote the value or move it into a `|`/`>` block scalar (literal `{{` / `}}` / `{{ ... }}` are still allowed *inside* YAML strings)",
+		line, string(matched), minResourcesManifestVersion,
+	)
+}
+
+// maskYAMLStringRegions returns a copy of content in which every `{`
+// and `}` that sits inside a YAML string scalar has been replaced with
+// a space. Line offsets and the position of every non-brace byte are
+// preserved, so callers that find a match in the masked buffer can use
+// the same indices to report a line number against the original input.
+//
+// The masker is intentionally a hand-rolled line-by-line scanner
+// instead of a real YAML lexer: the whole point of the gate is that
+// the input may not parse as YAML yet (a stray `{{ ... }}` would
+// derail an honest decode). The scanner covers the three shapes that
+// practically appear in OlaresManifest.yaml:
+//
+//   - double-quoted scalars `"..."` (with `\` escapes that consume the
+//     next byte);
+//   - single-quoted scalars `'...'` (with `''` representing a literal
+//     single quote);
+//   - `|` / `>` block scalars whose content lines are indented strictly
+//     more than the header line.
+//
+// Quoted scalars are assumed to live on a single logical line; if a
+// literal newline appears inside one, the scanner exits the string at
+// end-of-line, which is a deliberate conservative choice — true
+// multi-line quoted strings are rare in OlaresManifest.yaml and the
+// fallback ("treat as outside string") only ever causes a false
+// positive that the author can fix by switching to a block scalar.
+//
+// Flow style (`{key: value}` / `[a, b]`) is *not* masked. Those
+// constructs use literal single `{` / `}` / `[` / `]`, but the regex
+// looks for `{{` and `}}`, so the flow markers do not collide with
+// template detection.
+func maskYAMLStringRegions(content []byte) []byte {
+	out := make([]byte, len(content))
+	copy(out, content)
+
+	// blockScalarIndent is the indent of the header line that opened
+	// the active `|`/`>` scalar; content lines whose indent is strictly
+	// greater than this value belong to the scalar. -1 means "no
+	// active block scalar".
+	blockScalarIndent := -1
+
+	i := 0
+	for i < len(out) {
+		lineStart := i
+		lineEnd := lineStart
+		for lineEnd < len(out) && out[lineEnd] != '\n' {
+			lineEnd++
+		}
+
+		indent := 0
+		for lineStart+indent < lineEnd && out[lineStart+indent] == ' ' {
+			indent++
+		}
+		blank := lineStart+indent == lineEnd
+
+		switch {
+		case blockScalarIndent >= 0 && (blank || indent > blockScalarIndent):
+			maskBracesInRange(out, lineStart, lineEnd)
+		default:
+			if blockScalarIndent >= 0 {
+				blockScalarIndent = -1
+			}
+			if !blank {
+				if openedBlockScalar := maskQuotedRegionsOnLine(out, lineStart, lineEnd); openedBlockScalar {
+					blockScalarIndent = indent
+				}
+			}
+		}
+
+		i = lineEnd
+		if i < len(out) && out[i] == '\n' {
+			i++
+		}
+	}
+	return out
+}
+
+// maskBracesInRange replaces every `{` and `}` between buf[start:end]
+// with a space. Used for lines that sit entirely inside a `|`/`>`
+// block scalar so any helm-style placeholders inside read as
+// documentation text rather than template syntax.
+func maskBracesInRange(buf []byte, start, end int) {
+	for k := start; k < end; k++ {
+		if buf[k] == '{' || buf[k] == '}' {
+			buf[k] = ' '
+		}
+	}
+}
+
+// maskQuotedRegionsOnLine walks one logical line and (a) masks braces
+// that fall inside `"..."` / `'...'` scalars and (b) reports whether
+// the line opens a `|`/`>` block scalar that the caller needs to
+// honour on subsequent lines. Comments (`# ...`) are skipped so a
+// `#`-prefixed pipe in a comment does not get mistaken for a block
+// scalar header.
+func maskQuotedRegionsOnLine(buf []byte, start, end int) bool {
+	inDQ := false
+	inSQ := false
+	openedBlockScalar := false
+	for j := start; j < end; j++ {
+		c := buf[j]
+		switch {
+		case inDQ:
+			if c == '\\' && j+1 < end {
+				if buf[j+1] == '{' || buf[j+1] == '}' {
+					buf[j+1] = ' '
+				}
+				j++
+				continue
+			}
+			if c == '"' {
+				inDQ = false
+			} else if c == '{' || c == '}' {
+				buf[j] = ' '
+			}
+		case inSQ:
+			if c == '\'' {
+				if j+1 < end && buf[j+1] == '\'' {
+					j++
+					continue
+				}
+				inSQ = false
+			} else if c == '{' || c == '}' {
+				buf[j] = ' '
+			}
+		default:
+			switch c {
+			case '"':
+				inDQ = true
+			case '\'':
+				inSQ = true
+			case '#':
+				return openedBlockScalar
+			case '|', '>':
+				if isBlockScalarHeaderTail(buf, j+1, end) {
+					openedBlockScalar = true
+				}
+			}
+		}
+	}
+	return openedBlockScalar
+}
+
+// isBlockScalarHeaderTail reports whether buf[start:end] is a valid
+// trailer for a `|` or `>` block scalar header: only chomping
+// indicators (`+` / `-`), optional explicit indent digits, surrounding
+// whitespace, and an optional trailing `# ...` comment are permitted
+// before end-of-line. Anything else (e.g. a letter, a `:`, another
+// value) means the `|` / `>` we just saw is an ordinary scalar
+// character, not a header.
+func isBlockScalarHeaderTail(buf []byte, start, end int) bool {
+	for k := start; k < end; k++ {
+		c := buf[k]
+		switch {
+		case c == ' ', c == '\t', c == '+', c == '-', c >= '0' && c <= '9':
+			continue
+		case c == '#':
+			return true
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/framework/oac/internal/manifest/template_syntax_test.go
+++ b/framework/oac/internal/manifest/template_syntax_test.go
@@ -1,0 +1,180 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNoTemplateSyntax(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   string
+		wantErr   bool
+		wantLine  int
+		wantInMsg []string
+	}{
+		{
+			name:    "clean modern manifest",
+			content: "olaresManifest.version: 0.12.0\nmetadata:\n  name: foo\n",
+			wantErr: false,
+		},
+		{
+			name:    "double-quoted scalar shields a lone `{{`",
+			content: "metadata:\n  description: \"uses {{ markers for code blocks\"\n",
+			wantErr: false,
+		},
+		{
+			name:    "double-quoted scalar shields a lone `}}`",
+			content: "metadata:\n  description: \"ends with literal }} sequence\"\n",
+			wantErr: false,
+		},
+		{
+			name:    "double-quoted scalar shields a paired `{{ ... }}`",
+			content: "spec:\n  description: \"use {{ .Values.foo }} as a placeholder\"\n",
+			wantErr: false,
+		},
+		{
+			name:    "single-quoted scalar shields a paired `{{ ... }}`",
+			content: "spec:\n  description: 'use {{ .Values.foo }} as a placeholder'\n",
+			wantErr: false,
+		},
+		{
+			name:    "single-quoted scalar with embedded `''` escape stays inside the scalar",
+			content: "spec:\n  description: 'it''s safe to mention {{ .x }} inside docs'\n",
+			wantErr: false,
+		},
+		{
+			name:    "block scalar `|` shields placeholders on every body line",
+			content: "spec:\n  description: |\n    Multi-line text\n    that shows {{ .Values.foo }}\n    and {{ .Values.bar }} too.\n",
+			wantErr: false,
+		},
+		{
+			name:    "folded block scalar `>-` shields placeholders",
+			content: "spec:\n  description: >-\n    Folded text\n    mentioning {{ .x }}\n    inline.\n",
+			wantErr: false,
+		},
+		{
+			name:    "double-quoted scalar with backslash-escaped brace stays inside the scalar",
+			content: "spec:\n  description: \"path \\\\ then {{ .x }}\"\n",
+			wantErr: false,
+		},
+		{
+			name:     "unquoted `{{ ... }}` value is rejected",
+			content:  "line1\nline2\nmetadata:\n  name: {{ .Values.bfl.username }}\n",
+			wantErr:  true,
+			wantLine: 4,
+			wantInMsg: []string{
+				"template syntax",
+				"{{",
+				"0.12.0",
+			},
+		},
+		{
+			name:     "unquoted lone `{{` mid-scalar is rejected",
+			content:  "metadata:\n  name: hello {{ no closer here\n",
+			wantErr:  true,
+			wantLine: 2,
+			wantInMsg: []string{
+				`"{{"`,
+			},
+		},
+		{
+			name:     "unquoted lone `}}` mid-scalar is rejected",
+			content:  "metadata:\n  name: trailing }} braces\n",
+			wantErr:  true,
+			wantLine: 2,
+			wantInMsg: []string{
+				`"}}"`,
+			},
+		},
+		{
+			name:     "block scalar exits on dedent and a placeholder afterwards still trips",
+			content:  "spec:\n  description: |\n    Documented {{ .ok }} here.\n  other: {{ .leaks }}\n",
+			wantErr:  true,
+			wantLine: 4,
+		},
+		{
+			name:    "comment containing `|` does not open a fake block scalar",
+			content: "spec: foo # use | for pipes\nname: {{ .x }}\n",
+			wantErr: true,
+			wantInMsg: []string{
+				"line 2:",
+			},
+		},
+		{
+			name:    "two unquoted placeholders on different lines: first wins",
+			content: "k1: {{ a }}\nk2: {{ b }}\n",
+			wantErr: true,
+			wantInMsg: []string{
+				"line 1:",
+			},
+		},
+		{
+			name:    "single brace in flow style is left alone",
+			content: "metadata:\n  labels: {a: 1, b: 2}\n",
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkNoTemplateSyntax([]byte(tc.content))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if tc.wantLine != 0 {
+					prefix := "line " + itoa(tc.wantLine) + ":"
+					if !strings.Contains(err.Error(), prefix) {
+						t.Errorf("error %q must include %q", err.Error(), prefix)
+					}
+				}
+				for _, want := range tc.wantInMsg {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q must include %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestMaskYAMLStringRegions_PreservesLength documents the masker's
+// length-preservation contract: callers report match offsets against
+// the original content using indices found in the masked copy, so any
+// byte the masker touches must be replaced (not deleted).
+func TestMaskYAMLStringRegions_PreservesLength(t *testing.T) {
+	cases := []string{
+		"plain: value\n",
+		"q: \"with {{ braces }}\"\n",
+		"q: 'with {{ braces }}'\n",
+		"desc: |\n  block {{ x }} scalar\n  more {{ y }} text\n",
+		"mixed: \"a\"\nbare: {{ leak }}\n",
+	}
+	for _, c := range cases {
+		got := maskYAMLStringRegions([]byte(c))
+		if len(got) != len(c) {
+			t.Errorf("masker changed length for %q: got %d, want %d", c, len(got), len(c))
+		}
+	}
+}
+
+// itoa is a tiny stdlib-free decimal helper kept local so the test
+// file does not need to pull strconv in just for two test labels.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -114,6 +114,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		validateRootProvider(c.ConfigVersion, c.Provider),
 		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
 		validateOlaresDependency(c),
+		validateSharedAppRequirements(c),
 		validateV3Configuration(c),
 	)
 }
@@ -661,6 +662,60 @@ func validateOlaresDependency(c *AppConfiguration) error {
 				olaresSystemDepName, olaresDep.Version, rule.requirement, api, promotion, sv.String(),
 			))
 		}
+	}
+	return errors.Join(errs...)
+}
+
+// validateSharedAppRequirements enforces the cross-field rules that an
+// options.shared=true manifest must satisfy. A shared install services
+// every user on the cluster from a single deployment, which is only
+// compatible with a narrow shape:
+//
+//   - spec.onlyAdmin must be true — shared apps span every user, so the
+//     installer must be restricted to admins; allowing a regular user to
+//     install one would let them install on behalf of everyone else.
+//   - spec.subCharts must be empty — subCharts is the v2-only multi-chart
+//     delivery mechanism. Shared apps require apiVersion=v3 (enforced in
+//     validateOptions), and v3 ships every workload in a single chart;
+//     declaring subCharts here is meaningless and almost certainly a
+//     manifest authored against the wrong schema.
+//   - options.appScope.clusterScoped must be false AND
+//     options.appScope.appRef must be empty — both fields express a
+//     scoping intent (cluster-wide singleton, or shared access with
+//     specific other apps) that overlaps with "shared". Declaring them
+//     together makes the install topology ambiguous. The two are
+//     checked independently so the error message pinpoints the offender
+//     instead of forcing the user to clear the whole appScope block to
+//     discover which field tripped the rule.
+//
+// The apiVersion=v3 requirement on shared apps is enforced separately in
+// validateOptions; these gates run alongside it so a manifest that
+// violates multiple constraints surfaces every offender in a single Lint
+// run.
+func validateSharedAppRequirements(c *AppConfiguration) error {
+	if !c.Options.Shared {
+		return nil
+	}
+	var errs []error
+	if !c.Spec.OnlyAdmin {
+		errs = append(errs, fmt.Errorf(
+			"spec.onlyAdmin must be true when options.shared=true; shared apps service every user on the cluster and may only be installed by an admin",
+		))
+	}
+	if len(c.Spec.SubCharts) > 0 {
+		errs = append(errs, fmt.Errorf(
+			"spec.subCharts must be empty when options.shared=true; shared apps require apiVersion=v3 and deliver every workload in a single chart",
+		))
+	}
+	if c.Options.AppScope.ClusterScoped {
+		errs = append(errs, fmt.Errorf(
+			"options.appScope.clusterScoped must be false when options.shared=true; the shared scope already covers every user and is incompatible with cluster scoping",
+		))
+	}
+	if len(c.Options.AppScope.AppRef) > 0 {
+		errs = append(errs, fmt.Errorf(
+			"options.appScope.appRef must be empty when options.shared=true; shared apps do not declare cross-app scoping",
+		))
 	}
 	return errors.Join(errs...)
 }

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -107,7 +107,13 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		validation.Field(&c.Options, validation.By(validateOptionsFor(c))),
 		validation.Field(&c.OverlayGateway, validation.By(validateOverlayGateway)),
 	)
-	return errors.Join(structErr, checkSubCharts(c), validatePermission(c.ConfigVersion, c.Permission), validateV3Configuration(c))
+	return errors.Join(
+		structErr,
+		checkSubCharts(c),
+		validatePermission(c.ConfigVersion, c.Permission),
+		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
+		validateV3Configuration(c),
+	)
 }
 
 func validateAppMetaData(v interface{}) error {
@@ -456,6 +462,34 @@ func validateFlatResourceQuantities(spec *AppSpec, templateOnly bool) error {
 func validatePermission(configVersion string, p Permission) error {
 	if p.ExternalData && !resourcesCheckApplies(configVersion) {
 		return fmt.Errorf("permission.externalData is only supported for olaresManifest.version >= %s", minResourcesManifestVersion)
+	}
+	return nil
+}
+
+// validateWorkloadReplicas enforces that workloadReplicas is declared (non-nil
+// and non-empty) on modern manifests (olaresManifest.version >= 0.12.0). The
+// rule mirrors the install-time convention that every Deployment/StatefulSet's
+// replica count is sourced from .Values.workloads.<name>.replicaCount, so a
+// modern app that omits the field would have no way to express its replica
+// envelope.
+//
+// apiVersion=v2 is exempt: v2 manifests render workloads inside subCharts, so
+// the parent-level workloadReplicas does not apply. Below the 0.12.0 gate the
+// field stays optional. Whenever the field is declared, the existing
+// chart-render lint phase still verifies the per-entry name/values.yaml
+// correspondence — this check only adds the "must be declared" gate.
+func validateWorkloadReplicas(configVersion, apiVersion string, wr *WorkloadReplicas) error {
+	if !resourcesCheckApplies(configVersion) {
+		return nil
+	}
+	if normalizeAPIVersion(apiVersion) == APIVersionV2 {
+		return nil
+	}
+	if wr == nil || len(*wr) == 0 {
+		return fmt.Errorf(
+			"workloadReplicas is required for olaresManifest.version >= %s; declare a workloadReplicas.<workload>: <count> entry for every Deployment/StatefulSet",
+			minResourcesManifestVersion,
+		)
 	}
 	return nil
 }

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -113,7 +113,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		validatePermission(c.ConfigVersion, c.Permission),
 		validateRootProvider(c.ConfigVersion, c.Provider),
 		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
-		validateOlaresDependency(c.ConfigVersion, c.APIVersion, c.Options.Dependencies),
+		validateOlaresDependency(c),
 		validateV3Configuration(c),
 	)
 }
@@ -489,7 +489,7 @@ func validatePermission(configVersion string, p Permission) error {
 // olaresSystemDepName is the canonical name of the Olares system entry
 // inside options.dependencies. validateOlaresDependency uses this exact
 // (name, type) tuple — name="olares", type="system" — to locate the entry
-// whose version constraint is gated by the apiVersion-keyed rules below.
+// whose version constraint is gated by the rules below.
 const olaresSystemDepName = "olares"
 
 // olaresDepConstraintRule describes the version-constraint range that the
@@ -505,59 +505,116 @@ type olaresDepConstraintRule struct {
 	// forbidden lists versions that are JUST outside the required range
 	// (one or two below the floor, one at/above the ceiling, plus a wide-
 	// margin sample). A constraint that allows any of these would be too
-	// permissive for this apiVersion family.
+	// permissive for the active rule.
 	forbidden []string
 }
 
-// olaresDepRules maps each apiVersion family to its constraint rule. The
-// v1/v2 family (which empty apiVersion normalizes into) targets
-// >=1.12.3-0,<1.12.6 — the floor lifts every modern manifest to the
-// 0.12.0-era Olares baseline, and the ceiling locks legacy schemas out
-// of the 1.12.6 systems that ship apiVersion=v3. v3 manifests instead
-// require >=1.12.6-0, the release that introduced the v3 runtime.
-var olaresDepRules = map[string]olaresDepConstraintRule{
-	APIVersionV1: {
-		requirement: ">=1.12.3-0,<1.12.6",
-		forbidden:   []string{"1.12.2", "1.12.6", "2.0.0"},
-	},
-	APIVersionV2: {
-		requirement: ">=1.12.3-0,<1.12.6",
-		forbidden:   []string{"1.12.2", "1.12.6", "2.0.0"},
-	},
-	APIVersionV3: {
-		requirement: ">=1.12.6-0",
-		forbidden:   []string{"1.12.5", "1.12.0", "0.1.0"},
-	},
+// olaresDepRulePreV3 is the constraint window for legacy-schema modern
+// manifests (apiVersion in {empty, v1, v2} AND no 1.12.6-only feature
+// is declared). The floor 1.12.3-0 is the minimum Olares that ships
+// olaresManifest.version 0.12.0; the ceiling 1.12.6 locks these manifests
+// out of systems that ship the v3 runtime.
+var olaresDepRulePreV3 = olaresDepConstraintRule{
+	requirement: ">=1.12.3-0,<1.12.6",
+	forbidden:   []string{"1.12.2", "1.12.6", "2.0.0"},
 }
 
-// validateOlaresDependency enforces the apiVersion-keyed rules on the
-// Olares system dependency (the options.dependencies entry with
-// name="olares" and type="system"). The gate fires only on modern
-// manifests (olaresManifest.version >= 0.12.0); legacy manifests retain
-// their existing freedom to declare any version constraint they like.
+// olaresDepRulePostV3 is the constraint window selected when the manifest
+// either is apiVersion=v3 or declares any of the 1.12.6-only feature
+// fields enumerated in detectOlares1126OnlyFields. 1.12.6-0 is the first
+// Olares release that ships those features.
+var olaresDepRulePostV3 = olaresDepConstraintRule{
+	requirement: ">=1.12.6-0",
+	forbidden:   []string{"1.12.5", "1.12.0", "0.1.0"},
+}
+
+// detectOlares1126OnlyFields returns the set of manifest field labels
+// that — when declared on c — pin the Olares system requirement to
+// >=1.12.6-0 regardless of apiVersion (rule 4). apiVersion=v3 itself is
+// intentionally not in this list: it is handled as a separate trigger by
+// the caller so the error message can distinguish "v3 manifest demands
+// 1.12.6+" from "v1/v2 manifest opts into a 1.12.6-only feature".
 //
-// Three rules combine into the per-apiVersion expected ranges:
+// Labels are the user-facing names the manifest author writes, so they
+// can be threaded straight into error messages.
+func detectOlares1126OnlyFields(c *AppConfiguration) []string {
+	var fields []string
+	if len(c.Spec.Accelerator) > 0 {
+		fields = append(fields, "spec.accelerator")
+	}
+	if c.WorkloadReplicas != nil && len(*c.WorkloadReplicas) > 0 {
+		fields = append(fields, "workloadReplicas")
+	}
+	if c.OverlayGateway.Enable || len(c.OverlayGateway.Entrances) > 0 {
+		fields = append(fields, "overlayGateway")
+	}
+	if c.Options.LLMGatewaySupported {
+		fields = append(fields, "options.LLMGatewaySupported")
+	}
+	if c.Options.TemplateOnly {
+		fields = append(fields, "options.templateOnly")
+	}
+	if c.Options.Shared {
+		fields = append(fields, "options.shared")
+	}
+	if c.Permission.AppCommon {
+		fields = append(fields, "permission.appCommon")
+	}
+	return fields
+}
+
+// pickOlaresDepRule selects the constraint window that applies to c.
+// apiVersion=v3 or any 1.12.6-only feature field forces the post-v3
+// (>=1.12.6-0) window; everything else falls back to the legacy
+// pre-v3 (>=1.12.3-0,<1.12.6) window. The returned trigger list is
+// non-empty iff a feature field promoted a v1/v2 manifest into the
+// post-v3 window; callers use it to explain the promotion in error
+// messages without surprising users whose manifests are already v3.
+func pickOlaresDepRule(c *AppConfiguration) (rule olaresDepConstraintRule, featureTriggers []string) {
+	api := normalizeAPIVersion(c.APIVersion)
+	if api == APIVersionV3 {
+		return olaresDepRulePostV3, nil
+	}
+	triggers := detectOlares1126OnlyFields(c)
+	if len(triggers) > 0 {
+		return olaresDepRulePostV3, triggers
+	}
+	return olaresDepRulePreV3, nil
+}
+
+// validateOlaresDependency enforces the rules on the Olares system
+// dependency (the options.dependencies entry with name="olares" and
+// type="system"). The gate fires only on modern manifests
+// (olaresManifest.version >= 0.12.0); legacy manifests retain their
+// existing freedom to declare any version constraint they like.
 //
-//  1. apiVersion in {empty, v1, v2}: the constraint must restrict Olares
-//     to <1.12.6 (apiVersion=v3 was introduced in 1.12.6, so legacy
-//     schemas must not be installed on systems that ship the v3 runtime).
+// Four rules combine into a per-manifest required range, captured by
+// pickOlaresDepRule:
+//
+//  1. apiVersion in {empty, v1, v2}: legacy schemas default to <1.12.6
+//     (must not install on systems that ship the v3 runtime).
 //  2. apiVersion=v3: the constraint must restrict Olares to >=1.12.6-0
-//     (the v3 runtime is only available there).
+//     (the release that introduced the v3 runtime).
 //  3. Across every apiVersion the constraint's lower bound must be at
 //     least 1.12.3-0, the floor under which modern manifests are not
 //     supported at all.
+//  4. If the manifest declares any 1.12.6-only feature field
+//     (spec.accelerator, workloadReplicas, overlayGateway,
+//     options.LLMGatewaySupported, options.templateOnly, options.shared,
+//     permission.appCommon), the constraint must restrict to >=1.12.6-0
+//     even on a v1/v2 manifest — those fields are not honoured by older
+//     Olares releases.
 //
-// The combined per-apiVersion expectation is captured in olaresDepRules.
 // A missing Olares system dependency is itself an error on modern
 // manifests — the platform always pins the host Olares version, so
 // omitting it makes the manifest non-portable.
-func validateOlaresDependency(configVersion, apiVersion string, deps []Dependency) error {
-	if !resourcesCheckApplies(configVersion) {
+func validateOlaresDependency(c *AppConfiguration) error {
+	if !resourcesCheckApplies(c.ConfigVersion) {
 		return nil
 	}
 	var olaresDep *Dependency
-	for i := range deps {
-		d := &deps[i]
+	for i := range c.Options.Dependencies {
+		d := &c.Options.Dependencies[i]
 		if d.Name == olaresSystemDepName && d.Type == "system" {
 			olaresDep = d
 			break
@@ -576,12 +633,21 @@ func validateOlaresDependency(configVersion, apiVersion string, deps []Dependenc
 			olaresSystemDepName, olaresDep.Version, err,
 		)
 	}
-	api := normalizeAPIVersion(apiVersion)
-	rule, ok := olaresDepRules[api]
-	if !ok {
-		// apiVersion not in our table; struct-level validation will have
-		// already surfaced this as "not supported version".
+	api := normalizeAPIVersion(c.APIVersion)
+	if _, knownAPI := map[string]struct{}{
+		APIVersionV1: {}, APIVersionV2: {}, APIVersionV3: {},
+	}[api]; !knownAPI {
+		// apiVersion outside the supported set; the struct-level validator
+		// already surfaces "not supported version" elsewhere.
 		return nil
+	}
+	rule, triggers := pickOlaresDepRule(c)
+	promotion := ""
+	if len(triggers) > 0 {
+		promotion = fmt.Sprintf(
+			" because the manifest declares %s, which requires Olares 1.12.6+",
+			strings.Join(triggers, " / "),
+		)
 	}
 	var errs []error
 	for _, v := range rule.forbidden {
@@ -591,8 +657,8 @@ func validateOlaresDependency(configVersion, apiVersion string, deps []Dependenc
 		}
 		if constraint.Check(sv) {
 			errs = append(errs, fmt.Errorf(
-				"options.dependencies[name=%s].version %q must restrict the Olares system version to %q for apiVersion=%s; the constraint currently allows %s, which is outside the supported range",
-				olaresSystemDepName, olaresDep.Version, rule.requirement, api, sv.String(),
+				"options.dependencies[name=%s].version %q must restrict the Olares system version to %q for apiVersion=%s%s; the constraint currently allows %s, which is outside the supported range",
+				olaresSystemDepName, olaresDep.Version, rule.requirement, api, promotion, sv.String(),
 			))
 		}
 	}

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -111,6 +111,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		structErr,
 		checkSubCharts(c),
 		validatePermission(c.ConfigVersion, c.Permission),
+		validateRootProvider(c.ConfigVersion, c.Provider),
 		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
 		validateV3Configuration(c),
 	)
@@ -453,17 +454,55 @@ func validateFlatResourceQuantities(spec *AppSpec, templateOnly bool) error {
 	return errors.Join(errs...)
 }
 
-// validatePermission gates the manifest-level permission flags. Only
-// permission.externalData carries a version constraint: it grants access to
-// the External directory, a capability introduced with olaresManifest.version
-// 0.12.0, so declaring it on an older manifest is rejected. permission.appCommon
-// (access to the Common directory) is accepted at every version and needs no
-// extra validation here.
+// validatePermission gates the manifest-level permission flags whose
+// acceptance changes across olaresManifest.version boundaries:
+//
+//   - permission.externalData (grants access to the External directory) was
+//     introduced with olaresManifest.version 0.12.0; declaring it on an
+//     older manifest is rejected.
+//   - permission.provider (cross-app provider access) was retired starting
+//     with olaresManifest.version 0.12.0; the field is still accepted
+//     structurally for backwards compatibility on legacy manifests, but a
+//     modern manifest must leave it empty so the platform can finish
+//     migrating callers away from it.
+//
+// permission.appCommon (access to the Common directory) is accepted at
+// every version and needs no extra validation here.
 func validatePermission(configVersion string, p Permission) error {
+	var errs []error
 	if p.ExternalData && !resourcesCheckApplies(configVersion) {
-		return fmt.Errorf("permission.externalData is only supported for olaresManifest.version >= %s", minResourcesManifestVersion)
+		errs = append(errs, fmt.Errorf(
+			"permission.externalData is only supported for olaresManifest.version >= %s",
+			minResourcesManifestVersion,
+		))
 	}
-	return nil
+	if len(p.Provider) > 0 && resourcesCheckApplies(configVersion) {
+		errs = append(errs, fmt.Errorf(
+			"permission.provider must be empty for olaresManifest.version >= %s; cross-app provider access is no longer granted via permission.provider",
+			minResourcesManifestVersion,
+		))
+	}
+	return errors.Join(errs...)
+}
+
+// validateRootProvider enforces that the top-level AppConfiguration.Provider
+// section (the per-app published interfaces, declared at the document root
+// rather than under permission) is empty on olaresManifest.version >= 0.12.0.
+// The section was retired alongside permission.provider once the platform
+// stopped granting cross-app access through manifest-declared provider lists;
+// legacy manifests still accept arbitrary entries for backwards
+// compatibility.
+func validateRootProvider(configVersion string, providers []Provider) error {
+	if !resourcesCheckApplies(configVersion) {
+		return nil
+	}
+	if len(providers) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"provider must be empty for olaresManifest.version >= %s; the top-level provider section is no longer accepted on modern manifests",
+		minResourcesManifestVersion,
+	)
 }
 
 // validateWorkloadReplicas enforces that workloadReplicas is declared (non-nil

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -135,7 +135,32 @@ func validateAppMetaData(v interface{}) error {
 			validation.Required.Error("metadata.version is required"),
 			isSemver.Error("metadata.version must be a valid semantic version (e.g. 1.2.3)"),
 		),
+		validation.Field(&m.AppID,
+			validation.By(validateMetadataAppID),
+		),
 	)
+}
+
+// validateMetadataAppID rejects a metadata.appid value that collides with a
+// reserved built-in system app id. Empty appid is permitted -- the loader
+// normalizes it to md5(metadata.name)[:8] at LoadAppConfiguration time, and
+// downstream consumers that require a non-empty appid surface their own
+// errors (e.g. "market upload" rejects a missing field).
+func validateMetadataAppID(v interface{}) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("metadata.appid: unexpected type %T", v)
+	}
+	if s == "" {
+		return nil
+	}
+	if IsReservedSystemAppID(s) {
+		return fmt.Errorf(
+			"metadata.appid %q collides with a reserved system app id; choose a different value (the loader normalizes appid to md5(metadata.name)[:8] anyway, so leaving the field empty is also fine)",
+			s,
+		)
+	}
+	return nil
 }
 
 func validateEntranceValue(v interface{}) error {

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -113,6 +113,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		validatePermission(c.ConfigVersion, c.Permission),
 		validateRootProvider(c.ConfigVersion, c.Provider),
 		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
+		validateOlaresDependency(c.ConfigVersion, c.APIVersion, c.Options.Dependencies),
 		validateV3Configuration(c),
 	)
 }
@@ -481,6 +482,119 @@ func validatePermission(configVersion string, p Permission) error {
 			"permission.provider must be empty for olaresManifest.version >= %s; cross-app provider access is no longer granted via permission.provider",
 			minResourcesManifestVersion,
 		))
+	}
+	return errors.Join(errs...)
+}
+
+// olaresSystemDepName is the canonical name of the Olares system entry
+// inside options.dependencies. validateOlaresDependency uses this exact
+// (name, type) tuple — name="olares", type="system" — to locate the entry
+// whose version constraint is gated by the apiVersion-keyed rules below.
+const olaresSystemDepName = "olares"
+
+// olaresDepConstraintRule describes the version-constraint range that the
+// options.dependencies[name=olares].version must stay inside on a modern
+// (olaresManifest.version >= 0.12.0) manifest. The check works by sampling
+// representative versions just outside the allowed range and asserting
+// none of them satisfy the manifest's constraint — anything that does
+// would leak the supported Olares range outside the documented window.
+type olaresDepConstraintRule struct {
+	// requirement is the human-readable constraint expression embedded in
+	// error messages, e.g. ">=1.12.3-0,<1.12.6".
+	requirement string
+	// forbidden lists versions that are JUST outside the required range
+	// (one or two below the floor, one at/above the ceiling, plus a wide-
+	// margin sample). A constraint that allows any of these would be too
+	// permissive for this apiVersion family.
+	forbidden []string
+}
+
+// olaresDepRules maps each apiVersion family to its constraint rule. The
+// v1/v2 family (which empty apiVersion normalizes into) targets
+// >=1.12.3-0,<1.12.6 — the floor lifts every modern manifest to the
+// 0.12.0-era Olares baseline, and the ceiling locks legacy schemas out
+// of the 1.12.6 systems that ship apiVersion=v3. v3 manifests instead
+// require >=1.12.6-0, the release that introduced the v3 runtime.
+var olaresDepRules = map[string]olaresDepConstraintRule{
+	APIVersionV1: {
+		requirement: ">=1.12.3-0,<1.12.6",
+		forbidden:   []string{"1.12.2", "1.12.6", "2.0.0"},
+	},
+	APIVersionV2: {
+		requirement: ">=1.12.3-0,<1.12.6",
+		forbidden:   []string{"1.12.2", "1.12.6", "2.0.0"},
+	},
+	APIVersionV3: {
+		requirement: ">=1.12.6-0",
+		forbidden:   []string{"1.12.5", "1.12.0", "0.1.0"},
+	},
+}
+
+// validateOlaresDependency enforces the apiVersion-keyed rules on the
+// Olares system dependency (the options.dependencies entry with
+// name="olares" and type="system"). The gate fires only on modern
+// manifests (olaresManifest.version >= 0.12.0); legacy manifests retain
+// their existing freedom to declare any version constraint they like.
+//
+// Three rules combine into the per-apiVersion expected ranges:
+//
+//  1. apiVersion in {empty, v1, v2}: the constraint must restrict Olares
+//     to <1.12.6 (apiVersion=v3 was introduced in 1.12.6, so legacy
+//     schemas must not be installed on systems that ship the v3 runtime).
+//  2. apiVersion=v3: the constraint must restrict Olares to >=1.12.6-0
+//     (the v3 runtime is only available there).
+//  3. Across every apiVersion the constraint's lower bound must be at
+//     least 1.12.3-0, the floor under which modern manifests are not
+//     supported at all.
+//
+// The combined per-apiVersion expectation is captured in olaresDepRules.
+// A missing Olares system dependency is itself an error on modern
+// manifests — the platform always pins the host Olares version, so
+// omitting it makes the manifest non-portable.
+func validateOlaresDependency(configVersion, apiVersion string, deps []Dependency) error {
+	if !resourcesCheckApplies(configVersion) {
+		return nil
+	}
+	var olaresDep *Dependency
+	for i := range deps {
+		d := &deps[i]
+		if d.Name == olaresSystemDepName && d.Type == "system" {
+			olaresDep = d
+			break
+		}
+	}
+	if olaresDep == nil {
+		return fmt.Errorf(
+			"options.dependencies must declare an entry with name=%q and type=\"system\" for olaresManifest.version >= %s",
+			olaresSystemDepName, minResourcesManifestVersion,
+		)
+	}
+	constraint, err := semver.NewConstraint(olaresDep.Version)
+	if err != nil {
+		return fmt.Errorf(
+			"options.dependencies[name=%s].version %q is not a valid semver constraint: %w",
+			olaresSystemDepName, olaresDep.Version, err,
+		)
+	}
+	api := normalizeAPIVersion(apiVersion)
+	rule, ok := olaresDepRules[api]
+	if !ok {
+		// apiVersion not in our table; struct-level validation will have
+		// already surfaced this as "not supported version".
+		return nil
+	}
+	var errs []error
+	for _, v := range rule.forbidden {
+		sv, parseErr := semver.NewVersion(v)
+		if parseErr != nil {
+			continue
+		}
+		if constraint.Check(sv) {
+			errs = append(errs, fmt.Errorf(
+				"options.dependencies[name=%s].version %q must restrict the Olares system version to %q for apiVersion=%s; the constraint currently allows %s, which is outside the supported range",
+				olaresSystemDepName, olaresDep.Version, rule.requirement, api, sv.String(),
+			))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -586,8 +586,9 @@ func TestValidateAppSpec_ModernAcceptsLegacyFlatEnvelope(t *testing.T) {
 
 	// populated builds a modern (0.12.0) manifest that declares the
 	// legacy flat envelope and leaves spec.resources[] empty.
-	// newResourcesConfig clears every flat field; we re-populate the
-	// five mandatory quantities here.
+	// newResourcesConfig clears every flat field (and pre-populates
+	// workloadReplicas, which the modern gate also requires); we
+	// re-populate the five mandatory quantities here.
 	populated := func() *AppConfiguration {
 		c := newResourcesConfig() // no modes, ConfigVersion=0.13.0, every flat field cleared
 		c.ConfigVersion = modernBoundary
@@ -1059,9 +1060,13 @@ func TestPermission_ExternalDataVersionGate(t *testing.T) {
 	}
 
 	// externalData on a modern (>= 0.12.0) manifest is accepted.
+	// workloadReplicas is required at this version (non-v2), so populate
+	// a minimal one to keep this test focused on permission.externalData.
 	c = newValidConfig()
 	c.ConfigVersion = "0.12.0"
 	c.Permission.ExternalData = true
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("permission.externalData should be accepted at >= 0.12.0: %v", err)
 	}
@@ -1230,6 +1235,110 @@ func TestAppSpec_NonTemplateRejectsAutoOnLegacyFlat(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "requiredCpu") {
 		t.Fatalf("error should mention requiredCpu, got: %v", err)
+	}
+}
+
+// TestWorkloadReplicas_RequiredAtOrAbove012 documents the new gate: a
+// modern (olaresManifest.version >= 0.12.0) manifest must declare a
+// non-empty workloadReplicas map, except for apiVersion=v2, which carries
+// workloads inside subCharts and therefore has no parent-level field to
+// require. Legacy versions (< 0.12.0) remain unconstrained.
+func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
+	const wantMsg = "workloadReplicas is required for olaresManifest.version >="
+
+	t.Run("v1_at_boundary_missing_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.12.0"
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: workloadReplicas missing at olaresManifest.version=0.12.0 (v1)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the workloadReplicas gate, got: %v", err)
+		}
+	})
+
+	t.Run("v1_above_boundary_empty_map_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		empty := WorkloadReplicas{}
+		c.WorkloadReplicas = &empty
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: empty workloadReplicas map must not satisfy the gate")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the workloadReplicas gate, got: %v", err)
+		}
+	})
+
+	t.Run("v1_above_boundary_with_entry_accepted", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern v1 with workloadReplicas must validate: %v", err)
+		}
+	})
+
+	t.Run("v3_at_boundary_missing_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.12.0"
+		c.APIVersion = APIVersionV3
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: workloadReplicas missing at olaresManifest.version=0.12.0 (v3)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the workloadReplicas gate, got: %v", err)
+		}
+	})
+
+	t.Run("v3_above_boundary_with_entry_accepted", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV3
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern v3 with workloadReplicas must validate: %v", err)
+		}
+	})
+
+	t.Run("empty_apiversion_defaults_to_v1_and_requires", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = ""
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: empty apiVersion is treated as v1 and must require workloadReplicas at >= 0.12.0")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the workloadReplicas gate, got: %v", err)
+		}
+	})
+
+	t.Run("v2_modern_does_not_require", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV2
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern v2 must not require workloadReplicas (workloads live in subCharts): %v", err)
+		}
+	})
+
+	legacyVersions := []string{"0.11.9", "0.11.0", "0.10.0"}
+	for _, v := range legacyVersions {
+		v := v
+		t.Run("legacy_"+v+"_unconstrained", func(t *testing.T) {
+			c := newValidConfig()
+			c.ConfigVersion = v
+			if err := ValidateAppConfiguration(c); err != nil {
+				t.Fatalf("legacy version %s must not require workloadReplicas: %v", v, err)
+			}
+		})
 	}
 }
 

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -880,7 +880,7 @@ func TestAPIVersionV2_ModernOlaresUsesLegacyEnvelope(t *testing.T) {
 	c.ConfigVersion = "0.13.0"
 	c.APIVersion = APIVersionV2
 	c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
-	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("v2 with olaresManifest.version >= 0.12.0 and legacy flat fields must validate: %v", err)
 	}
@@ -1069,7 +1069,7 @@ func TestPermission_ExternalDataVersionGate(t *testing.T) {
 	c.Permission.ExternalData = true
 	wr := WorkloadReplicas{c.Metadata.Name: 1}
 	c.WorkloadReplicas = &wr
-	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("permission.externalData should be accepted at >= 0.12.0: %v", err)
 	}
@@ -1302,7 +1302,7 @@ func TestRootProvider_ForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern manifest without root provider must validate: %v", err)
 		}
@@ -1324,7 +1324,7 @@ func TestRootProvider_ForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		c.Provider = []Provider{providerEntry}
 		c.Permission.Provider = []ProviderPermission{{AppName: "ollama", ProviderName: "ollamaclient"}}
 		err := ValidateAppConfiguration(c)
@@ -1403,7 +1403,7 @@ func TestPermission_ProviderForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern manifest without permission.provider must validate: %v", err)
 		}
@@ -1457,7 +1457,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v1 with workloadReplicas must validate: %v", err)
 		}
@@ -1482,7 +1482,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.APIVersion = APIVersionV3
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v3 with workloadReplicas must validate: %v", err)
 		}
@@ -1506,7 +1506,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		c.APIVersion = APIVersionV2
 		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
-		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v2 must not require workloadReplicas (workloads live in subCharts): %v", err)
 		}
@@ -1525,29 +1525,52 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 	}
 }
 
-// TestOlaresDependency_ConstraintGate documents the apiVersion-keyed
-// version-constraint rules on the Olares system dependency
-// (options.dependencies entry with name="olares" and type="system"):
+// TestOlaresDependency_ConstraintGate documents the rules on the Olares
+// system dependency (options.dependencies entry with name="olares" and
+// type="system"):
 //
 //   - On olaresManifest.version >= 0.12.0, the entry must exist.
-//   - apiVersion in {empty, v1, v2}: the constraint must restrict Olares
-//     to >=1.12.3-0,<1.12.6 (no leakage into 1.12.6+, no permission below
+//   - apiVersion=v3 OR any 1.12.6-only feature field (workloadReplicas,
+//     spec.accelerator, overlayGateway, options.LLMGatewaySupported,
+//     options.templateOnly, options.shared, permission.appCommon) forces
+//     the constraint to restrict Olares to >=1.12.6-0.
+//   - apiVersion in {empty, v1, v2} AND none of those feature fields
+//     declared: the constraint must restrict Olares to
+//     >=1.12.3-0,<1.12.6 (no leakage into 1.12.6+, no permission below
 //     the 1.12.3-0 floor).
-//   - apiVersion=v3: the constraint must restrict Olares to >=1.12.6-0.
 //   - Below the modern gate (< 0.12.0), the entry is unconstrained.
 //
 // Each subtest builds a config that already satisfies every other modern
 // gate so the assertion truly tracks validateOlaresDependency alone.
+// Note: modern non-v2 manifests must declare workloadReplicas, so they
+// always sit in the post-v3 window — the pre-v3 window is exercised
+// through the apiVersion=v2 path.
 func TestOlaresDependency_ConstraintGate(t *testing.T) {
-	modern := func(apiVersion string) *AppConfiguration {
+	// modernV1 builds a non-v2 modern manifest. workloadReplicas is
+	// required for non-v2 modern manifests, so the helper sets it; that
+	// also trips rule 4 and pulls the required constraint window up to
+	// >=1.12.6-0.
+	modernV1 := func() *AppConfiguration {
 		c := newValidConfig()
 		c.ConfigVersion = "0.13.0"
-		c.APIVersion = apiVersion
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
-		if normalizeAPIVersion(apiVersion) == APIVersionV2 {
-			c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
-		}
+		return c
+	}
+	modernV3 := func() *AppConfiguration {
+		c := modernV1()
+		c.APIVersion = APIVersionV3
+		return c
+	}
+	// modernV2NoTriggers is the only reachable shape that still exercises
+	// the pre-v3 (>=1.12.3-0,<1.12.6) window: v2 manifests do not require
+	// workloadReplicas, and the helper deliberately leaves every other
+	// 1.12.6-only feature field unset.
+	modernV2NoTriggers := func() *AppConfiguration {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV2
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
 		return c
 	}
 
@@ -1560,7 +1583,7 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 	}
 
 	t.Run("modern_without_olares_dep_rejected", func(t *testing.T) {
-		c := modern(APIVersionV1)
+		c := modernV1()
 		err := ValidateAppConfiguration(c)
 		if err == nil {
 			t.Fatal("expected error: modern manifest must declare the Olares system dependency")
@@ -1577,50 +1600,44 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 	})
 
-	t.Run("v1_accepts_in_range_constraint", func(t *testing.T) {
-		c := modern(APIVersionV1)
+	t.Run("v2_no_triggers_accepts_pre_v3_range", func(t *testing.T) {
+		c := modernV2NoTriggers()
 		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
 		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("v1 manifest with >=1.12.3-0,<1.12.6 must validate: %v", err)
+			t.Fatalf("v2 manifest without 1.12.6-only fields must accept the pre-v3 window: %v", err)
 		}
 	})
 
-	t.Run("v1_rejects_constraint_that_leaks_into_v3_range", func(t *testing.T) {
-		c := modern(APIVersionV1)
-		// >=1.12.0 allows 1.12.6 and 2.0.0 — both outside the v1/v2 window.
+	t.Run("v2_no_triggers_rejects_constraint_that_leaks_into_v3_range", func(t *testing.T) {
+		c := modernV2NoTriggers()
+		// >=1.12.0 allows 1.12.6 and 2.0.0 — both outside the pre-v3 window.
 		setOlaresDep(c, ">=1.12.0")
 		err := ValidateAppConfiguration(c)
 		if err == nil {
-			t.Fatal("expected error: v1 dep constraint must not allow 1.12.6 / 2.0.0")
+			t.Fatal("expected error: pre-v3 dep constraint must not allow 1.12.6 / 2.0.0")
 		}
-		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.3-0,<1.12.6" for apiVersion=v1`) {
-			t.Fatalf("error should mention the v1 constraint requirement, got: %v", err)
+		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.3-0,<1.12.6" for apiVersion=v2`) {
+			t.Fatalf("error should mention the pre-v3 constraint requirement on v2, got: %v", err)
 		}
 	})
 
-	t.Run("v1_rejects_constraint_below_floor", func(t *testing.T) {
-		c := modern(APIVersionV1)
+	t.Run("v2_no_triggers_rejects_constraint_below_floor", func(t *testing.T) {
+		c := modernV2NoTriggers()
 		// <1.12.6 allows everything below 1.12.6, including 1.12.2 (below the 1.12.3-0 floor).
 		setOlaresDep(c, "<1.12.6")
 		err := ValidateAppConfiguration(c)
 		if err == nil {
-			t.Fatal("expected error: v1 dep constraint must enforce the >=1.12.3-0 floor")
+			t.Fatal("expected error: pre-v3 dep constraint must enforce the >=1.12.3-0 floor")
 		}
 		if !strings.Contains(err.Error(), "1.12.2") {
 			t.Fatalf("error should call out the below-floor sample 1.12.2, got: %v", err)
 		}
 	})
 
-	t.Run("v2_uses_same_constraint_as_v1", func(t *testing.T) {
-		c := modern(APIVersionV2)
-		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
-		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("v2 manifest with >=1.12.3-0,<1.12.6 must validate: %v", err)
-		}
-	})
-
-	t.Run("v2_rejects_v3_only_range", func(t *testing.T) {
-		c := modern(APIVersionV2)
+	t.Run("v2_rejects_v3_only_range_without_triggers", func(t *testing.T) {
+		// Without a trigger, v2 must stay in the pre-v3 window — the v3
+		// range allows 1.12.6, which is forbidden there.
+		c := modernV2NoTriggers()
 		setOlaresDep(c, ">=1.12.6-0")
 		err := ValidateAppConfiguration(c)
 		if err == nil {
@@ -1631,16 +1648,44 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 	})
 
-	t.Run("empty_apiversion_treated_as_v1", func(t *testing.T) {
-		c := modern("")
+	t.Run("v1_with_workload_replicas_demands_post_v3_range", func(t *testing.T) {
+		c := modernV1()
+		// The pre-v3 window would have satisfied apiVersion alone, but
+		// workloadReplicas (required on non-v2 modern manifests) trips
+		// rule 4 and forces >=1.12.6-0.
 		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: workloadReplicas must promote v1 into the post-v3 dep window")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0" for apiVersion=v1`) {
+			t.Fatalf("error should mention the post-v3 requirement on v1, got: %v", err)
+		}
+		if !strings.Contains(msg, "workloadReplicas") {
+			t.Fatalf("error should attribute the promotion to workloadReplicas, got: %v", err)
+		}
+	})
+
+	t.Run("v1_with_workload_replicas_accepts_post_v3_range", func(t *testing.T) {
+		c := modernV1()
+		setOlaresDep(c, ">=1.12.6-0")
 		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("empty apiVersion must use the v1 constraint window: %v", err)
+			t.Fatalf("v1 with workloadReplicas and >=1.12.6-0 must validate: %v", err)
+		}
+	})
+
+	t.Run("empty_apiversion_treated_as_v1_post_v3_range", func(t *testing.T) {
+		c := modernV1()
+		c.APIVersion = ""
+		setOlaresDep(c, ">=1.12.6-0")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("empty apiVersion with workloadReplicas must accept >=1.12.6-0: %v", err)
 		}
 	})
 
 	t.Run("v3_accepts_in_range_constraint", func(t *testing.T) {
-		c := modern(APIVersionV3)
+		c := modernV3()
 		setOlaresDep(c, ">=1.12.6-0")
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("v3 manifest with >=1.12.6-0 must validate: %v", err)
@@ -1648,7 +1693,7 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 	})
 
 	t.Run("v3_rejects_pre_1_12_6_constraint", func(t *testing.T) {
-		c := modern(APIVersionV3)
+		c := modernV3()
 		// Allows 1.12.5 (below the 1.12.6-0 floor for v3).
 		setOlaresDep(c, ">=1.12.5,<2.0.0")
 		err := ValidateAppConfiguration(c)
@@ -1660,8 +1705,24 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 	})
 
+	t.Run("v3_message_omits_feature_promotion_clause", func(t *testing.T) {
+		// On v3, the requirement comes from apiVersion itself; the
+		// "because the manifest declares ..." clause is only meaningful
+		// when rule 4 promoted a v1/v2 manifest, so it should be absent
+		// here to avoid misleading users about the trigger.
+		c := modernV3()
+		setOlaresDep(c, ">=1.12.5,<2.0.0")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v3 dep constraint must restrict Olares to >=1.12.6-0")
+		}
+		if strings.Contains(err.Error(), "because the manifest declares") {
+			t.Fatalf("v3 error must not attribute the requirement to feature triggers, got: %v", err)
+		}
+	})
+
 	t.Run("malformed_constraint_rejected", func(t *testing.T) {
-		c := modern(APIVersionV1)
+		c := modernV1()
 		setOlaresDep(c, "not-a-semver-constraint")
 		err := ValidateAppConfiguration(c)
 		if err == nil {
@@ -1673,11 +1734,11 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 	})
 
 	t.Run("wrong_type_does_not_count_as_olares_system_dep", func(t *testing.T) {
-		c := modern(APIVersionV1)
+		c := modernV1()
 		// Same name but type=application — does not satisfy the gate.
 		c.Options.Dependencies = []Dependency{{
 			Name:    olaresSystemDepName,
-			Version: ">=1.12.3-0,<1.12.6",
+			Version: ">=1.12.6-0",
 			Type:    "application",
 		}}
 		err := ValidateAppConfiguration(c)
@@ -1686,6 +1747,213 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), `options.dependencies must declare an entry with name="olares" and type="system"`) {
 			t.Fatalf("error should mention the missing system Olares dep, got: %v", err)
+		}
+	})
+}
+
+// TestOlaresDependency_FeatureTriggersPromoteRange exercises rule 4:
+// when a v1/v2 manifest declares any of the 1.12.6-only feature fields,
+// the Olares dep constraint must restrict to >=1.12.6-0 and the error
+// must attribute the promotion to that field. Each subtest starts from
+// modernV2NoTriggers (which would otherwise sit in the pre-v3 window),
+// flips exactly one trigger, and verifies both the promotion and the
+// attribution.
+func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
+	// preV3Constraint is the constraint that satisfies the validator
+	// for a manifest with NO triggers. By keeping it constant across
+	// subtests we make the assertion "trigger X promoted the required
+	// range to >=1.12.6-0" unambiguous: nothing else in the config moved.
+	const preV3Constraint = ">=1.12.3-0,<1.12.6"
+
+	base := func() *AppConfiguration {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV2
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		c.Options.Dependencies = []Dependency{{
+			Name:    olaresSystemDepName,
+			Version: preV3Constraint,
+			Type:    "system",
+		}}
+		return c
+	}
+
+	// flipTrigger mutates c to declare exactly one 1.12.6-only feature.
+	// Each function returns the user-facing label the error message
+	// is expected to include.
+	cases := []struct {
+		name       string
+		flip       func(c *AppConfiguration)
+		wantLabel  string
+		extraSetup func(c *AppConfiguration) // pre-flip prerequisites, if any
+	}{
+		{
+			name: "workloadReplicas",
+			flip: func(c *AppConfiguration) {
+				wr := WorkloadReplicas{c.Metadata.Name: 1}
+				c.WorkloadReplicas = &wr
+			},
+			wantLabel: "workloadReplicas",
+		},
+		{
+			name: "overlayGateway",
+			flip: func(c *AppConfiguration) {
+				c.OverlayGateway = OverlayGateway{
+					Enable:    true,
+					Entrances: []OverlayEntrance{newValidOverlayEntrance()},
+				}
+			},
+			wantLabel: "overlayGateway",
+		},
+		{
+			name: "options.LLMGatewaySupported",
+			flip: func(c *AppConfiguration) {
+				c.Options.LLMGatewaySupported = true
+			},
+			wantLabel: "options.LLMGatewaySupported",
+		},
+		{
+			name: "permission.appCommon",
+			flip: func(c *AppConfiguration) {
+				c.Permission.AppCommon = true
+			},
+			wantLabel: "permission.appCommon",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"_promotes_to_post_v3_range", func(t *testing.T) {
+			c := base()
+			if tc.extraSetup != nil {
+				tc.extraSetup(c)
+			}
+			tc.flip(c)
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("expected error: declaring %s must promote the dep window to >=1.12.6-0", tc.wantLabel)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
+				t.Fatalf("error should require the post-v3 range, got: %v", err)
+			}
+			if !strings.Contains(msg, tc.wantLabel) {
+				t.Fatalf("error should attribute the promotion to %s, got: %v", tc.wantLabel, err)
+			}
+			if !strings.Contains(msg, "because the manifest declares") {
+				t.Fatalf("error should explain the rule-4 promotion with a 'because' clause, got: %v", err)
+			}
+		})
+
+		t.Run(tc.name+"_accepts_post_v3_range", func(t *testing.T) {
+			c := base()
+			if tc.extraSetup != nil {
+				tc.extraSetup(c)
+			}
+			tc.flip(c)
+			c.Options.Dependencies = []Dependency{{
+				Name:    olaresSystemDepName,
+				Version: ">=1.12.6-0",
+				Type:    "system",
+			}}
+			if err := ValidateAppConfiguration(c); err != nil {
+				t.Fatalf("declaring %s with >=1.12.6-0 dep must validate: %v", tc.wantLabel, err)
+			}
+		})
+	}
+
+	// Two extra rule-4 triggers (spec.accelerator, options.shared,
+	// options.templateOnly) have additional cross-field constraints that
+	// don't fit the v2 baseline above, so cover them on shapes that do.
+	t.Run("spec.accelerator_promotes_to_post_v3_range", func(t *testing.T) {
+		// spec.accelerator lives on v1 (v2 forbids it; v3 always sits in
+		// the post-v3 window). Pair it with workloadReplicas (required on
+		// v1) but assert the trigger list includes spec.accelerator.
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV1
+		c.Spec.RequiredCPU = ""
+		c.Spec.LimitedCPU = ""
+		c.Spec.RequiredMemory = ""
+		c.Spec.LimitedMemory = ""
+		c.Spec.RequiredDisk = ""
+		c.Spec.LimitedDisk = ""
+		c.Spec.RequiredGPU = ""
+		c.Spec.LimitedGPU = ""
+		c.Spec.Accelerator = []ResourceMode{{
+			Mode: ResourceModeCPU,
+			ResourceRequirement: ResourceRequirement{
+				RequiredCPU:    "100m",
+				LimitedCPU:     "200m",
+				RequiredMemory: "128Mi",
+				LimitedMemory:  "256Mi",
+				RequiredDisk:   "10Mi",
+				LimitedDisk:    "20Mi",
+			},
+		}}
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{{
+			Name:    olaresSystemDepName,
+			Version: ">=1.12.3-0,<1.12.6",
+			Type:    "system",
+		}}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: spec.accelerator must promote dep window to >=1.12.6-0")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "spec.accelerator") {
+			t.Fatalf("error should attribute the promotion to spec.accelerator, got: %v", err)
+		}
+		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
+			t.Fatalf("error should require the post-v3 range, got: %v", err)
+		}
+	})
+
+	t.Run("options.shared_is_v3_only_post_v3_range", func(t *testing.T) {
+		// options.shared=true requires apiVersion=v3 (a separate rule),
+		// so promotion is observable through the v3 branch. The trigger
+		// list intentionally omits "options.shared" here because v3
+		// already routes through the apiVersion path; the assertion
+		// focuses on the post-v3 requirement.
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV3
+		c.Options.Shared = true
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{{
+			Name:    olaresSystemDepName,
+			Version: ">=1.12.3-0,<1.12.6",
+			Type:    "system",
+		}}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v3 dep constraint must restrict Olares to >=1.12.6-0")
+		}
+		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.6-0" for apiVersion=v3`) {
+			t.Fatalf("error should require the post-v3 range for v3, got: %v", err)
+		}
+	})
+
+	t.Run("options.templateOnly_promotes_to_post_v3_range", func(t *testing.T) {
+		// templateOnly=true additionally needs allowMultipleInstall=true
+		// (a separate cross-field rule). Anchor it on a v2 baseline so
+		// the post-v3 promotion comes purely from rule 4.
+		c := base()
+		c.Options.AllowMultipleInstall = true
+		c.Options.TemplateOnly = true
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: options.templateOnly must promote dep window to >=1.12.6-0")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "options.templateOnly") {
+			t.Fatalf("error should attribute the promotion to options.templateOnly, got: %v", err)
+		}
+		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
+			t.Fatalf("error should require the post-v3 range, got: %v", err)
 		}
 	})
 }

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -1238,6 +1238,180 @@ func TestAppSpec_NonTemplateRejectsAutoOnLegacyFlat(t *testing.T) {
 	}
 }
 
+// TestRootProvider_ForbiddenAtOrAbove012 documents the modern gate on the
+// top-level provider section (AppConfiguration.Provider, distinct from
+// permission.provider): starting with olaresManifest.version 0.12.0 the
+// section must be empty, regardless of apiVersion. Below 0.12.0 the
+// legacy behaviour (arbitrary provider entries accepted) is preserved.
+func TestRootProvider_ForbiddenAtOrAbove012(t *testing.T) {
+	const wantMsg = "provider must be empty for olaresManifest.version >="
+
+	providerEntry := Provider{Name: "ollamaclient", Entrance: "main", Paths: []string{"/api"}, Verbs: []string{"GET"}}
+
+	t.Run("v1_modern_with_root_provider_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.12.0"
+		c.Provider = []Provider{providerEntry}
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: root provider must be empty at >= 0.12.0")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the root provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("v3_modern_with_root_provider_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV3
+		c.Provider = []Provider{providerEntry}
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: root provider must be empty at >= 0.12.0 (v3)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the root provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("v2_modern_with_root_provider_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV2
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		c.Provider = []Provider{providerEntry}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: root provider must be empty at >= 0.12.0 (v2)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the root provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("modern_without_root_provider_accepted", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest without root provider must validate: %v", err)
+		}
+	})
+
+	t.Run("legacy_with_root_provider_accepted", func(t *testing.T) {
+		c := newValidConfig() // ConfigVersion 0.11.0
+		c.Provider = []Provider{providerEntry}
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("legacy manifest with root provider must validate: %v", err)
+		}
+	})
+
+	t.Run("modern_with_both_provider_sections_aggregated", func(t *testing.T) {
+		// Both gates (permission.provider AND root provider) must surface
+		// in a single Validate run so a manifest carrying both retired
+		// shapes sees every offender at once.
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		c.Provider = []Provider{providerEntry}
+		c.Permission.Provider = []ProviderPermission{{AppName: "ollama", ProviderName: "ollamaclient"}}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected aggregated errors for root provider + permission.provider")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "permission.provider must be empty") {
+			t.Fatalf("error should mention permission.provider gate, got: %v", err)
+		}
+		if !strings.Contains(msg, wantMsg) {
+			t.Fatalf("error should mention root provider gate, got: %v", err)
+		}
+	})
+}
+
+// TestPermission_ProviderForbiddenAtOrAbove012 documents the modern gate
+// on permission.provider: starting with olaresManifest.version 0.12.0 the
+// field must be empty, regardless of apiVersion. Below 0.12.0 the legacy
+// behaviour (any number of provider entries accepted) is preserved.
+func TestPermission_ProviderForbiddenAtOrAbove012(t *testing.T) {
+	const wantMsg = "permission.provider must be empty for olaresManifest.version >="
+
+	providerEntry := ProviderPermission{AppName: "ollama", ProviderName: "ollamaclient"}
+
+	t.Run("v1_modern_with_provider_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.12.0"
+		c.Permission.Provider = []ProviderPermission{providerEntry}
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: permission.provider must be empty at >= 0.12.0")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("v3_modern_with_provider_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV3
+		c.Permission.Provider = []ProviderPermission{providerEntry}
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: permission.provider must be empty at >= 0.12.0 (v3)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("v2_modern_with_provider_rejected", func(t *testing.T) {
+		// The rule does not depend on apiVersion — the field is retired
+		// platform-wide on the modern channel. v2 must hit the same gate.
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV2
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		c.Permission.Provider = []ProviderPermission{providerEntry}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: permission.provider must be empty at >= 0.12.0 (v2)")
+		}
+		if !strings.Contains(err.Error(), wantMsg) {
+			t.Fatalf("error should mention the provider gate, got: %v", err)
+		}
+	})
+
+	t.Run("modern_without_provider_accepted", func(t *testing.T) {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest without permission.provider must validate: %v", err)
+		}
+	})
+
+	t.Run("legacy_with_provider_accepted", func(t *testing.T) {
+		c := newValidConfig() // ConfigVersion 0.11.0
+		c.Permission.Provider = []ProviderPermission{providerEntry}
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("legacy manifest with permission.provider must validate: %v", err)
+		}
+	})
+}
+
 // TestWorkloadReplicas_RequiredAtOrAbove012 documents the new gate: a
 // modern (olaresManifest.version >= 0.12.0) manifest must declare a
 // non-empty workloadReplicas map, except for apiVersion=v2, which carries

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -1988,6 +1988,13 @@ func TestOptions_SharedRequiresAPIVersionV3(t *testing.T) {
 			if tc.apiVersion == APIVersionV2 {
 				c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
 			}
+			// validateSharedAppRequirements also fires on shared=true and
+			// would mask the apiVersion gate for the v3 happy path. Set
+			// the minimum extra fields it demands so the assertion stays
+			// focused on the shared+v3 rule.
+			if tc.apiVersion == APIVersionV3 && tc.shared {
+				c.Spec.OnlyAdmin = true
+			}
 			err := ValidateAppConfiguration(c)
 			if tc.wantErr {
 				if err == nil {
@@ -2003,4 +2010,141 @@ func TestOptions_SharedRequiresAPIVersionV3(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOptions_SharedAppRequirements documents the cross-field gates that
+// fire on top of the apiVersion=v3 requirement whenever options.shared
+// is true. Each subtest starts from a v3 manifest that satisfies every
+// other validator gate (the helper is intentionally kept minimal: only
+// what the shared/v3 path requires) and flips exactly one offending
+// field. The negative cases assert both that the error fires AND that
+// the message names the specific field, so a manifest with multiple
+// violations gives the author a precise checklist.
+func TestOptions_SharedAppRequirements(t *testing.T) {
+	// validSharedV3 builds the canonical "everything set up correctly"
+	// shared+v3 manifest used as the baseline for every subtest. Each
+	// subtest copies it and flips exactly one field to verify a single
+	// gate in isolation.
+	validSharedV3 := func() *AppConfiguration {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = APIVersionV3
+		c.Options.Shared = true
+		c.Spec.OnlyAdmin = true
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
+		return c
+	}
+
+	t.Run("baseline_accepted", func(t *testing.T) {
+		// Anchor test: confirms the helper itself is a valid manifest so
+		// every "flip one field" subtest below can attribute its failure
+		// to the flipped field rather than to a baseline issue.
+		if err := ValidateAppConfiguration(validSharedV3()); err != nil {
+			t.Fatalf("shared+v3 baseline must validate: %v", err)
+		}
+	})
+
+	t.Run("missing_only_admin_rejected", func(t *testing.T) {
+		c := validSharedV3()
+		c.Spec.OnlyAdmin = false
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: spec.onlyAdmin must be true when options.shared=true")
+		}
+		if !strings.Contains(err.Error(), "spec.onlyAdmin must be true when options.shared=true") {
+			t.Fatalf("error should flag the onlyAdmin gate, got: %v", err)
+		}
+	})
+
+	t.Run("subcharts_set_rejected", func(t *testing.T) {
+		c := validSharedV3()
+		c.Spec.SubCharts = []Chart{
+			{Name: "ollamaserver", Shared: true},
+			{Name: "ollamav2"},
+		}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: spec.subCharts must be empty when options.shared=true")
+		}
+		if !strings.Contains(err.Error(), "spec.subCharts must be empty when options.shared=true") {
+			t.Fatalf("error should flag the subCharts gate, got: %v", err)
+		}
+	})
+
+	t.Run("appscope_cluster_scoped_rejected", func(t *testing.T) {
+		c := validSharedV3()
+		c.Options.AppScope.ClusterScoped = true
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: options.appScope.clusterScoped must be false when options.shared=true")
+		}
+		if !strings.Contains(err.Error(), "options.appScope.clusterScoped must be false when options.shared=true") {
+			t.Fatalf("error should flag the clusterScoped gate, got: %v", err)
+		}
+	})
+
+	t.Run("appscope_app_ref_rejected", func(t *testing.T) {
+		c := validSharedV3()
+		c.Options.AppScope.AppRef = []string{"ollamav2"}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: options.appScope.appRef must be empty when options.shared=true")
+		}
+		if !strings.Contains(err.Error(), "options.appScope.appRef must be empty when options.shared=true") {
+			t.Fatalf("error should flag the appRef gate, got: %v", err)
+		}
+	})
+
+	t.Run("multiple_violations_are_aggregated", func(t *testing.T) {
+		// A manifest authored against the wrong schema can easily hit
+		// every gate at once. The aggregator must surface them all in a
+		// single Lint run so the author sees the full checklist instead
+		// of fixing one field, re-running, and discovering the next.
+		c := validSharedV3()
+		c.Spec.OnlyAdmin = false
+		c.Spec.SubCharts = []Chart{{Name: "ollamaserver", Shared: true}}
+		c.Options.AppScope = AppScope{
+			ClusterScoped: true,
+			AppRef:        []string{"ollamav2"},
+		}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected aggregated errors for multiple shared-app violations")
+		}
+		msg := err.Error()
+		wantFragments := []string{
+			"spec.onlyAdmin must be true when options.shared=true",
+			"spec.subCharts must be empty when options.shared=true",
+			"options.appScope.clusterScoped must be false when options.shared=true",
+			"options.appScope.appRef must be empty when options.shared=true",
+		}
+		for _, frag := range wantFragments {
+			if !strings.Contains(msg, frag) {
+				t.Fatalf("aggregated error should contain %q, got: %v", frag, err)
+			}
+		}
+	})
+
+	t.Run("rules_dormant_when_shared_false", func(t *testing.T) {
+		// Every constraint here is gated on options.shared=true. Build
+		// a config that would otherwise violate every gate, then leave
+		// shared=false and confirm validation passes (the offending
+		// fields are unrelated to the shared rule when shared is off).
+		// This documents that the gate keys off shared, not off the
+		// presence of subCharts/appScope/onlyAdmin themselves.
+		c := newValidConfig()
+		c.APIVersion = APIVersionV2
+		c.Spec.OnlyAdmin = false
+		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		c.Options.AppScope = AppScope{
+			ClusterScoped: true,
+			AppRef:        []string{"other"},
+		}
+		// options.shared stays at its zero value (false).
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("shared=false config must not trip the shared-app gates: %v", err)
+		}
+	})
 }

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -880,6 +880,7 @@ func TestAPIVersionV2_ModernOlaresUsesLegacyEnvelope(t *testing.T) {
 	c.ConfigVersion = "0.13.0"
 	c.APIVersion = APIVersionV2
 	c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("v2 with olaresManifest.version >= 0.12.0 and legacy flat fields must validate: %v", err)
 	}
@@ -1060,13 +1061,15 @@ func TestPermission_ExternalDataVersionGate(t *testing.T) {
 	}
 
 	// externalData on a modern (>= 0.12.0) manifest is accepted.
-	// workloadReplicas is required at this version (non-v2), so populate
-	// a minimal one to keep this test focused on permission.externalData.
+	// workloadReplicas and the Olares system dependency are required at
+	// this version (non-v2), so populate minimal ones to keep this test
+	// focused on permission.externalData.
 	c = newValidConfig()
 	c.ConfigVersion = "0.12.0"
 	c.Permission.ExternalData = true
 	wr := WorkloadReplicas{c.Metadata.Name: 1}
 	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("permission.externalData should be accepted at >= 0.12.0: %v", err)
 	}
@@ -1299,6 +1302,7 @@ func TestRootProvider_ForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern manifest without root provider must validate: %v", err)
 		}
@@ -1320,6 +1324,7 @@ func TestRootProvider_ForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		c.Provider = []Provider{providerEntry}
 		c.Permission.Provider = []ProviderPermission{{AppName: "ollama", ProviderName: "ollamaclient"}}
 		err := ValidateAppConfiguration(c)
@@ -1398,6 +1403,7 @@ func TestPermission_ProviderForbiddenAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern manifest without permission.provider must validate: %v", err)
 		}
@@ -1451,6 +1457,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v1 with workloadReplicas must validate: %v", err)
 		}
@@ -1475,6 +1482,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.APIVersion = APIVersionV3
 		wr := WorkloadReplicas{c.Metadata.Name: 1}
 		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v3 with workloadReplicas must validate: %v", err)
 		}
@@ -1498,6 +1506,7 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 		c.ConfigVersion = "0.13.0"
 		c.APIVersion = APIVersionV2
 		c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c.APIVersion)}
 		if err := ValidateAppConfiguration(c); err != nil {
 			t.Fatalf("modern v2 must not require workloadReplicas (workloads live in subCharts): %v", err)
 		}
@@ -1514,6 +1523,171 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOlaresDependency_ConstraintGate documents the apiVersion-keyed
+// version-constraint rules on the Olares system dependency
+// (options.dependencies entry with name="olares" and type="system"):
+//
+//   - On olaresManifest.version >= 0.12.0, the entry must exist.
+//   - apiVersion in {empty, v1, v2}: the constraint must restrict Olares
+//     to >=1.12.3-0,<1.12.6 (no leakage into 1.12.6+, no permission below
+//     the 1.12.3-0 floor).
+//   - apiVersion=v3: the constraint must restrict Olares to >=1.12.6-0.
+//   - Below the modern gate (< 0.12.0), the entry is unconstrained.
+//
+// Each subtest builds a config that already satisfies every other modern
+// gate so the assertion truly tracks validateOlaresDependency alone.
+func TestOlaresDependency_ConstraintGate(t *testing.T) {
+	modern := func(apiVersion string) *AppConfiguration {
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.APIVersion = apiVersion
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		if normalizeAPIVersion(apiVersion) == APIVersionV2 {
+			c.Spec.SubCharts = []Chart{{Name: "main", Shared: true}}
+		}
+		return c
+	}
+
+	setOlaresDep := func(c *AppConfiguration, version string) {
+		c.Options.Dependencies = []Dependency{{
+			Name:    olaresSystemDepName,
+			Version: version,
+			Type:    "system",
+		}}
+	}
+
+	t.Run("modern_without_olares_dep_rejected", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: modern manifest must declare the Olares system dependency")
+		}
+		if !strings.Contains(err.Error(), `options.dependencies must declare an entry with name="olares" and type="system"`) {
+			t.Fatalf("error should mention the missing Olares dep, got: %v", err)
+		}
+	})
+
+	t.Run("legacy_without_olares_dep_accepted", func(t *testing.T) {
+		c := newValidConfig() // ConfigVersion 0.11.0; no dep set
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("legacy manifest without Olares dep must validate: %v", err)
+		}
+	})
+
+	t.Run("v1_accepts_in_range_constraint", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v1 manifest with >=1.12.3-0,<1.12.6 must validate: %v", err)
+		}
+	})
+
+	t.Run("v1_rejects_constraint_that_leaks_into_v3_range", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		// >=1.12.0 allows 1.12.6 and 2.0.0 — both outside the v1/v2 window.
+		setOlaresDep(c, ">=1.12.0")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v1 dep constraint must not allow 1.12.6 / 2.0.0")
+		}
+		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.3-0,<1.12.6" for apiVersion=v1`) {
+			t.Fatalf("error should mention the v1 constraint requirement, got: %v", err)
+		}
+	})
+
+	t.Run("v1_rejects_constraint_below_floor", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		// <1.12.6 allows everything below 1.12.6, including 1.12.2 (below the 1.12.3-0 floor).
+		setOlaresDep(c, "<1.12.6")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v1 dep constraint must enforce the >=1.12.3-0 floor")
+		}
+		if !strings.Contains(err.Error(), "1.12.2") {
+			t.Fatalf("error should call out the below-floor sample 1.12.2, got: %v", err)
+		}
+	})
+
+	t.Run("v2_uses_same_constraint_as_v1", func(t *testing.T) {
+		c := modern(APIVersionV2)
+		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v2 manifest with >=1.12.3-0,<1.12.6 must validate: %v", err)
+		}
+	})
+
+	t.Run("v2_rejects_v3_only_range", func(t *testing.T) {
+		c := modern(APIVersionV2)
+		setOlaresDep(c, ">=1.12.6-0")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v2 dep constraint must not target the v3-only Olares range")
+		}
+		if !strings.Contains(err.Error(), `apiVersion=v2`) {
+			t.Fatalf("error should mention apiVersion=v2, got: %v", err)
+		}
+	})
+
+	t.Run("empty_apiversion_treated_as_v1", func(t *testing.T) {
+		c := modern("")
+		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("empty apiVersion must use the v1 constraint window: %v", err)
+		}
+	})
+
+	t.Run("v3_accepts_in_range_constraint", func(t *testing.T) {
+		c := modern(APIVersionV3)
+		setOlaresDep(c, ">=1.12.6-0")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v3 manifest with >=1.12.6-0 must validate: %v", err)
+		}
+	})
+
+	t.Run("v3_rejects_pre_1_12_6_constraint", func(t *testing.T) {
+		c := modern(APIVersionV3)
+		// Allows 1.12.5 (below the 1.12.6-0 floor for v3).
+		setOlaresDep(c, ">=1.12.5,<2.0.0")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: v3 dep constraint must restrict Olares to >=1.12.6-0")
+		}
+		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.6-0" for apiVersion=v3`) {
+			t.Fatalf("error should mention the v3 constraint requirement, got: %v", err)
+		}
+	})
+
+	t.Run("malformed_constraint_rejected", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		setOlaresDep(c, "not-a-semver-constraint")
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: malformed semver constraint must be rejected")
+		}
+		if !strings.Contains(err.Error(), "is not a valid semver constraint") {
+			t.Fatalf("error should mention invalid semver constraint, got: %v", err)
+		}
+	})
+
+	t.Run("wrong_type_does_not_count_as_olares_system_dep", func(t *testing.T) {
+		c := modern(APIVersionV1)
+		// Same name but type=application — does not satisfy the gate.
+		c.Options.Dependencies = []Dependency{{
+			Name:    olaresSystemDepName,
+			Version: ">=1.12.3-0,<1.12.6",
+			Type:    "application",
+		}}
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: only type=system Olares dependency satisfies the gate")
+		}
+		if !strings.Contains(err.Error(), `options.dependencies must declare an entry with name="olares" and type="system"`) {
+			t.Fatalf("error should mention the missing system Olares dep, got: %v", err)
+		}
+	})
 }
 
 // TestOptions_SharedRequiresAPIVersionV3 pins down the shared => v3

--- a/framework/oac/internal/resources/limits.go
+++ b/framework/oac/internal/resources/limits.go
@@ -86,20 +86,63 @@ func CheckResourceLimits(list kube.ResourceList, limits ResourceLimits) error {
 			sumLimCPU.Add(*cLimits.Cpu())
 		}
 	})
-
+	exceed := false
 	if !autoLCPU && sumLimCPU.Cmp(appLCPU) > 0 {
-		errs = append(errs, fmt.Errorf("sum of container resources.limits.cpu must be <= spec.limitedCpu"))
+		if !exceed {
+			errs = append(errs, fmt.Errorf("The total requested container resources exceed the allocated spec in OlaresManifest.yaml\n"))
+			exceed = true
+		}
+		errs = append(errs, fmt.Errorf(
+			"sum of container resources.limits.cpu (%s) must be <= limitedCpu (%s)",
+			sumLimCPU.String(), quantityDisplay(limits.LimitedCPU, appLCPU),
+		))
 	}
 	if !autoLMem && sumLimMem.Cmp(appLMem) > 0 {
-		errs = append(errs, fmt.Errorf("sum of container resources.limits.memory must be <= spec.limitedMemory"))
+		if !exceed {
+			errs = append(errs, fmt.Errorf("The total requested container resources exceed the allocated spec in OlaresManifest.yaml\n"))
+			exceed = true
+		}
+		errs = append(errs, fmt.Errorf(
+			"sum of container resources.limits.memory (%s) must be <= limitedMemory (%s)",
+			sumLimMem.String(), quantityDisplay(limits.LimitedMemory, appLMem),
+		))
 	}
 	if !autoRCPU && sumReqCPU.Cmp(appRCPU) > 0 {
-		errs = append(errs, fmt.Errorf("sum of container resources.requests.cpu must be <= spec.requiredCpu"))
+		if !exceed {
+			errs = append(errs, fmt.Errorf("The total requested container resources exceed the allocated spec in OlaresManifest.yaml\n"))
+			exceed = true
+		}
+		errs = append(errs, fmt.Errorf(
+			"sum of container resources.requests.cpu (%s) must be <= requiredCpu (%s)",
+			sumReqCPU.String(), quantityDisplay(limits.RequiredCPU, appRCPU),
+		))
 	}
 	if !autoRMem && sumReqMem.Cmp(appRMem) > 0 {
-		errs = append(errs, fmt.Errorf("sum of container resources.requests.memory must be <= spec.requiredMemory"))
+		if !exceed {
+			errs = append(errs, fmt.Errorf("The total requested container resources exceed the allocated spec in OlaresManifest.yaml\n"))
+			exceed = true
+		}
+		errs = append(errs, fmt.Errorf(
+			"sum of container resources.requests.memory (%s) must be <= requiredMemory (%s)",
+			sumReqMem.String(), quantityDisplay(limits.RequiredMemory, appRMem),
+		))
 	}
 	return errors.Join(errs...)
+}
+
+// quantityDisplay picks the most readable rendering for a manifest-side
+// resource quantity: when the manifest text parses cleanly, we surface
+// the author's exact spelling (e.g. "200m" or "1Gi") rather than the
+// canonical form Quantity.String() produces, because the same number
+// can render either way and matching the manifest helps the reader
+// locate the offending field. We fall back to the parsed Quantity's
+// String() when the raw text is empty or unparseable so the error
+// message never shows an empty parenthesis pair.
+func quantityDisplay(raw string, parsed resource.Quantity) string {
+	if raw != "" {
+		return raw
+	}
+	return parsed.String()
 }
 
 // CheckUploadConfig ensures that, if the manifest declares an options.upload

--- a/framework/oac/internal/resources/resources_test.go
+++ b/framework/oac/internal/resources/resources_test.go
@@ -311,8 +311,16 @@ func TestCheckResourceLimits_ContainerLimitOverApp(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected aggregate cap error")
 	}
-	if !strings.Contains(err.Error(), "spec.limitedCpu") || !strings.Contains(err.Error(), "spec.limitedMemory") {
-		t.Fatalf("error should mention spec caps: %v", err)
+	// Aggregate-cap messages reference the limit field by its bare name
+	// (e.g. "limitedCpu") rather than the dotted "spec.limitedCpu" path,
+	// so the assertion uses the unqualified substring. The "must be <="
+	// fragment pins us to the aggregate-cap rule and rules out a stray
+	// match from any other error.
+	msg := err.Error()
+	if !strings.Contains(msg, "limitedCpu") ||
+		!strings.Contains(msg, "limitedMemory") ||
+		!strings.Contains(msg, "must be <=") {
+		t.Fatalf("error should mention both limit caps and the <= rule: %v", err)
 	}
 }
 

--- a/framework/oac/internal/resources/workloads.go
+++ b/framework/oac/internal/resources/workloads.go
@@ -28,8 +28,10 @@ func CollectWorkloadNames(list kube.ResourceList) map[string]struct{} {
 // CheckWorkloadReplicas enforces an exact correspondence between the manifest's
 // workloadReplicas keys and the rendered Deployment/StatefulSet names: every
 // workload must have a workloadReplicas entry, and every workloadReplicas entry
-// must name a real workload. Callers should only invoke this when the manifest
-// declares workloadReplicas at all (the field is optional).
+// must name a real workload. The manifest validator already requires
+// workloadReplicas on modern (olaresManifest.version >= 0.12.0) non-v2
+// manifests; on legacy versions (and on v2) the field stays optional and
+// callers should only invoke this when the manifest actually declares it.
 func CheckWorkloadReplicas(list kube.ResourceList, replicas map[string]int32) error {
 	workloads := CollectWorkloadNames(list)
 	var errs []error

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -409,8 +409,9 @@ func TestAllImageRenderModes_ContainsExpected(t *testing.T) {
 		"apple-m",
 		"nvidia",
 		"nvidia-gb10",
-		"mthreads-m1000",
-		"strix-halo",
+		"moore-soc",
+		"amd",
+		"intel",
 	}
 	if !reflect.DeepEqual(oac.AllImageRenderModes, want) {
 		t.Fatalf("AllImageRenderModes drift: got %v, want %v", oac.AllImageRenderModes, want)

--- a/framework/oac/scripts/repair_terminus_apps.py
+++ b/framework/oac/scripts/repair_terminus_apps.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Apply auto-repairs to testdata/terminus-apps/* OlaresManifest.yaml files
+based on the lint failures recorded in terminus_apps_report.md.
+
+Fix taxonomy (one app may receive several):
+
+  T  template-syntax    Set olaresManifest.version to '0.11.0' so the
+                        legacy helm-render path is used and the {{ }}
+                        placeholders parse cleanly. Stops further fixes
+                        for that app -- the schema is now legacy.
+
+  W  workloadReplicas   Insert a top-level workloadReplicas map listing
+                        every Deployment / StatefulSet observed in the
+                        report's resource diagnostic.
+
+  D  olares-dep         Update the options.dependencies[name=olares]
+                        version constraint to the value the validator
+                        suggested in its error message.
+
+  P  provider-empty     Drop the legacy top-level provider: section.
+
+  O  spec.onlyAdmin     Add (or set) spec.onlyAdmin: true.
+
+  Cs cluster-scope      Set options.appScope.clusterScoped: false.
+
+  Ar app-ref            Empty options.appScope.appRef.
+
+  E  envs/OLARES_USER   Reported but not auto-fixed (requires renaming
+                        the env and threading valueFrom). The script
+                        prints these so a human can follow up.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORT = REPO_ROOT / "terminus_apps_report.md"
+TESTDATA = REPO_ROOT / "testdata" / "terminus-apps"
+
+
+def parse_report(content: str) -> Dict[str, dict]:
+    """Return {app_name: {"lint": str, "workloads": [str, ...]}}."""
+    apps: Dict[str, dict] = {}
+    failure_idx = content.find("## Failure details")
+    if failure_idx == -1:
+        return apps
+    failures = content[failure_idx:]
+    sections = re.split(r"^### (\S+)\s*$", failures, flags=re.MULTILINE)
+    for i in range(1, len(sections), 2):
+        name = sections[i].strip()
+        body = sections[i + 1] if i + 1 < len(sections) else ""
+        m = re.search(r"^- \*\*Lint\*\*:\s*(.+?)$", body, flags=re.MULTILINE)
+        if not m:
+            continue
+        lint = m.group(1).strip()
+        workloads: List[str] = []
+        seen = set()
+        for row in re.finditer(
+            r"^\s*\|\s*[^|]+\|\s*(?:Deployment|StatefulSet)\s*\|\s*([^\s|]+)\s*\|",
+            body,
+            flags=re.MULTILINE,
+        ):
+            wl = row.group(1)
+            if wl and wl != "-" and wl not in seen:
+                workloads.append(wl)
+                seen.add(wl)
+        apps[name] = {"lint": lint, "workloads": workloads}
+    return apps
+
+
+# -- string-level edits ------------------------------------------------------
+
+
+def set_manifest_version(text: str, value: str) -> str:
+    """Replace the value of the top-level olaresManifest.version line."""
+    pattern = re.compile(
+        r"^(olaresManifest\.version\s*:\s*)['\"]?[^\n'\"]*['\"]?",
+        re.MULTILINE,
+    )
+    if not pattern.search(text):
+        return text
+    return pattern.sub(rf"\1'{value}'", text, count=1)
+
+
+def update_olares_dep_version(text: str, target: str) -> str:
+    """Update the version constraint on the olares system dependency.
+
+    Handles:
+      - name: olares
+        type: system
+        version: '>=...'
+
+    and the same with name and type lines reordered. Other layouts
+    (version before name, etc.) are uncommon and left untouched.
+    """
+    pat_name_first = re.compile(
+        r"(-\s+name\s*:\s*['\"]?olares['\"]?[^\n]*\n"
+        r"(?:[ \t]+(?:type|registry|mandatory|description)\s*:[^\n]*\n)*"
+        r"[ \t]+version\s*:\s*)['\"]?[^\n'\"]+['\"]?",
+        re.MULTILINE,
+    )
+    new_text, n = pat_name_first.subn(rf"\1'{target}'", text, count=1)
+    if n > 0:
+        return new_text
+
+    pat_type_then_name = re.compile(
+        r"(-\s+type\s*:\s*['\"]?system['\"]?[^\n]*\n"
+        r"[ \t]+name\s*:\s*['\"]?olares['\"]?[^\n]*\n"
+        r"(?:[ \t]+(?:mandatory|description)\s*:[^\n]*\n)*"
+        r"[ \t]+version\s*:\s*)['\"]?[^\n'\"]+['\"]?",
+        re.MULTILINE,
+    )
+    new_text, n = pat_type_then_name.subn(rf"\1'{target}'", text, count=1)
+    return new_text if n > 0 else text
+
+
+def insert_workload_replicas(text: str, workloads: List[str]) -> str:
+    """Insert a top-level workloadReplicas: map after the apiVersion line.
+
+    No-op if the manifest already declares workloadReplicas: at the top
+    level, or if workloads is empty.
+    """
+    if not workloads:
+        return text
+    if re.search(r"^workloadReplicas\s*:", text, flags=re.MULTILINE):
+        return text
+    block = "workloadReplicas:\n" + "\n".join(f"  {w}: 1" for w in workloads)
+    pattern = re.compile(r"(^apiVersion\s*:[^\n]*\n)", flags=re.MULTILINE)
+    if pattern.search(text):
+        return pattern.sub(rf"\1\n{block}\n", text, count=1)
+    return text + "\n" + block + "\n"
+
+
+def remove_top_level_provider(text: str) -> str:
+    """Drop the top-level provider: block until the next column-0 key.
+
+    The block runs from a line that starts with `provider:` (no leading
+    whitespace) up to but not including the next non-indented non-blank
+    line. Lines that begin with a `#` comment are also treated as
+    column-0 boundaries so we don't gobble adjacent comments.
+    """
+    lines = text.split("\n")
+    out: List[str] = []
+    skipping = False
+    for line in lines:
+        stripped = line.lstrip()
+        is_top_level = (
+            line
+            and not line.startswith((" ", "\t"))
+            and not stripped.startswith("#")
+            and ":" in line
+        )
+        if skipping:
+            if is_top_level:
+                skipping = False
+                out.append(line)
+            continue
+        if is_top_level and re.match(r"provider\s*:", line):
+            skipping = True
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def add_or_set_spec_only_admin(text: str) -> str:
+    """Ensure spec.onlyAdmin: true appears under the top-level spec: block.
+
+    If a spec.onlyAdmin: false line already exists it is flipped to
+    true; otherwise we insert `  onlyAdmin: true` right after the
+    `spec:` header line.
+    """
+    spec_match = re.search(r"^spec\s*:\s*$", text, flags=re.MULTILINE)
+    if not spec_match:
+        return text
+    spec_block, span = _slice_top_level_block(text, "spec")
+    if spec_block is None:
+        return text
+
+    flipped = re.sub(
+        r"^([ \t]+onlyAdmin\s*:\s*)(?:false|False|FALSE)\s*$",
+        r"\1true",
+        spec_block,
+        flags=re.MULTILINE,
+    )
+    if flipped != spec_block:
+        return text[: span[0]] + flipped + text[span[1]:]
+
+    if re.search(r"^[ \t]+onlyAdmin\s*:", spec_block, flags=re.MULTILINE):
+        return text  # already has onlyAdmin (presumably true)
+
+    insert = "  onlyAdmin: true\n"
+    new_spec = re.sub(
+        r"(^spec\s*:\s*\n)",
+        rf"\1{insert}",
+        spec_block,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    return text[: span[0]] + new_spec + text[span[1]:]
+
+
+def fix_app_scope(text: str, *, want_cluster_scoped_false: bool, want_app_ref_empty: bool) -> str:
+    """Patch options.appScope under the top-level options: block."""
+    options_block, span = _slice_top_level_block(text, "options")
+    if options_block is None:
+        return text
+    patched = options_block
+
+    if want_cluster_scoped_false:
+        patched = re.sub(
+            r"^(\s+clusterScoped\s*:\s*)(?:true|True|TRUE)\s*$",
+            r"\1false",
+            patched,
+            flags=re.MULTILINE,
+        )
+
+    if want_app_ref_empty:
+        patched = _empty_app_ref_block(patched)
+
+    if patched != options_block:
+        return text[: span[0]] + patched + text[span[1]:]
+    return text
+
+
+def _empty_app_ref_block(options_block: str) -> str:
+    """Replace `appRef:` plus its list items with `appRef: []`."""
+    lines = options_block.split("\n")
+    out: List[str] = []
+    skipping_indent: Optional[int] = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if skipping_indent is not None:
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if not stripped:
+                out.append(line)
+                i += 1
+                continue
+            if indent > skipping_indent:
+                i += 1
+                continue
+            skipping_indent = None
+        m = re.match(r"^([ \t]+)appRef\s*:\s*$", line)
+        if m:
+            indent = len(m.group(1).expandtabs())
+            out.append(f"{m.group(1)}appRef: []")
+            skipping_indent = indent
+            i += 1
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
+
+def _slice_top_level_block(text: str, key: str) -> Tuple[Optional[str], Tuple[int, int]]:
+    """Return the (text, (start, end)) for a top-level YAML block.
+
+    The block runs from the line `<key>:` (column 0) through the line
+    just before the next column-0 non-blank, non-comment line. start
+    is the byte offset of `<key>` in text; end is one past the block's
+    last byte (so text[start:end] == block).
+    """
+    pat = re.compile(rf"^({re.escape(key)}\s*:.*?)$", flags=re.MULTILINE)
+    m = pat.search(text)
+    if not m:
+        return None, (-1, -1)
+    start = m.start()
+    end = len(text)
+    for nm in re.finditer(r"^[A-Za-z_][\w.]*\s*:", text[m.end() :], flags=re.MULTILINE):
+        end = m.end() + nm.start()
+        break
+    return text[start:end], (start, end)
+
+
+# -- per-app driver ----------------------------------------------------------
+
+
+def classify_lint(lint: str) -> dict:
+    info = {
+        "template": False,
+        "workload_replicas_missing": False,
+        "olares_dep_target": None,  # str or None
+        "provider_must_be_empty": False,
+        "spec_only_admin": False,
+        "cluster_scoped_false": False,
+        "app_ref_empty": False,
+        "envs_olares_user": False,
+    }
+    if "is template syntax outside any YAML string value" in lint:
+        info["template"] = True
+        return info
+
+    if "workloadReplicas is required" in lint:
+        info["workload_replicas_missing"] = True
+
+    m = re.search(
+        r'options\.dependencies\[name=olares\]\.version "[^"]+" must restrict the Olares system version to "([^"]+)"',
+        lint,
+    )
+    if m:
+        info["olares_dep_target"] = m.group(1)
+
+    if "provider must be empty" in lint:
+        info["provider_must_be_empty"] = True
+
+    if "spec.onlyAdmin must be true when options.shared=true" in lint:
+        info["spec_only_admin"] = True
+
+    if "options.appScope.clusterScoped must be false when options.shared=true" in lint:
+        info["cluster_scoped_false"] = True
+
+    if "options.appScope.appRef must be empty when options.shared=true" in lint:
+        info["app_ref_empty"] = True
+
+    if 'envs[' in lint and 'must not start with "OLARES_USER"' in lint:
+        info["envs_olares_user"] = True
+
+    return info
+
+
+def fix_app(app_dir: Path, info: dict, lint_info: dict) -> List[str]:
+    """Apply all fixes that lint_info dictates. Returns list of applied tags."""
+    manifest_path = app_dir / "OlaresManifest.yaml"
+    if not manifest_path.exists():
+        return []
+    text = manifest_path.read_text()
+    original = text
+    applied: List[str] = []
+
+    if lint_info["template"]:
+        text = set_manifest_version(text, "0.11.0")
+        if text != original:
+            applied.append("T")
+        manifest_path.write_text(text)
+        return applied
+
+    if lint_info["olares_dep_target"]:
+        new_text = update_olares_dep_version(text, lint_info["olares_dep_target"])
+        if new_text != text:
+            applied.append("D")
+        text = new_text
+
+    if lint_info["workload_replicas_missing"]:
+        new_text = insert_workload_replicas(text, info["workloads"])
+        if new_text != text:
+            applied.append("W")
+        text = new_text
+
+    if lint_info["provider_must_be_empty"]:
+        new_text = remove_top_level_provider(text)
+        if new_text != text:
+            applied.append("P")
+        text = new_text
+
+    if lint_info["spec_only_admin"]:
+        new_text = add_or_set_spec_only_admin(text)
+        if new_text != text:
+            applied.append("O")
+        text = new_text
+
+    if lint_info["cluster_scoped_false"] or lint_info["app_ref_empty"]:
+        new_text = fix_app_scope(
+            text,
+            want_cluster_scoped_false=lint_info["cluster_scoped_false"],
+            want_app_ref_empty=lint_info["app_ref_empty"],
+        )
+        if new_text != text:
+            if lint_info["cluster_scoped_false"]:
+                applied.append("Cs")
+            if lint_info["app_ref_empty"]:
+                applied.append("Ar")
+        text = new_text
+
+    if lint_info["envs_olares_user"]:
+        applied.append("E?")  # flagged, not auto-fixed
+
+    if text != original:
+        manifest_path.write_text(text)
+    return applied
+
+
+def main() -> int:
+    if not REPORT.exists():
+        print(f"missing report: {REPORT}", file=sys.stderr)
+        return 1
+
+    apps = parse_report(REPORT.read_text())
+    if not apps:
+        print("no failure entries found in report", file=sys.stderr)
+        return 1
+
+    print(f"parsed {len(apps)} failing app(s)")
+    summary: Dict[str, int] = {}
+    env_followups: List[str] = []
+    untouched: List[str] = []
+
+    for name, info in sorted(apps.items()):
+        app_dir = TESTDATA / name
+        if not app_dir.exists():
+            print(f"  ! missing app dir: {name}")
+            continue
+        lint_info = classify_lint(info["lint"])
+        applied = fix_app(app_dir, info, lint_info)
+        if not applied:
+            untouched.append(name)
+            continue
+        for tag in applied:
+            summary[tag] = summary.get(tag, 0) + 1
+        if "E?" in applied:
+            env_followups.append(name)
+        print(f"  {name}: {','.join(applied)}")
+
+    print("\nfix summary:")
+    for tag, n in sorted(summary.items()):
+        print(f"  {tag}: {n}")
+    if env_followups:
+        print(f"\nenvs[N] OLARES_USER (manual follow-up): {len(env_followups)} app(s)")
+        for n in env_followups:
+            print(f"  - {n}")
+    if untouched:
+        print(f"\nuntouched (no fix produced): {len(untouched)} app(s)")
+        for n in untouched[:20]:
+            print(f"  - {n}")
+        if len(untouched) > 20:
+            print(f"  ... and {len(untouched) - 20} more")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/oac/scripts/repair_terminus_apps_phase2.py
+++ b/framework/oac/scripts/repair_terminus_apps_phase2.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Phase-2 repairs for testdata/terminus-apps after the manifest pass.
+
+Fixes applied per app (when applicable):
+
+  V  values.yaml workloads.<name>.replicaCount from workloadReplicas
+  X  permission.externalData: true when templates reference .Values.sharedlib
+  M  middleware workloadReplicas + values.yaml (metadata.name)
+  L  legacy spec resource envelope for olaresManifest.version < 0.12.0
+  E  envName starting with OLARES_USER_ renamed to app-local names
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTDATA = REPO_ROOT / "testdata" / "terminus-apps"
+
+yaml_loader = YAML()
+yaml_loader.preserve_quotes = True
+yaml_loader.width = 4096
+
+ENV_RENAMES = {
+    "OLARES_USER_HUGGINGFACE_TOKEN": "HF_TOKEN",
+    "OLARES_USER_HUGGINGFACE_SERVICE": "HF_ENDPOINT",
+    "OLARES_USER_TIMEZONE": "APP_TIMEZONE",
+}
+
+
+def try_parse_yaml(text: str) -> Optional[dict]:
+    try:
+        data = yaml_loader.load(text)
+        return data if isinstance(data, dict) else {}
+    except YAMLError:
+        return None
+
+
+def dump_yaml(data: dict) -> str:
+    buf = StringIO()
+    yaml_loader.dump(data, buf)
+    return buf.getvalue()
+
+
+def extract_workload_replicas_regex(text: str) -> Dict[str, int]:
+    m = re.search(r"^workloadReplicas:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return {}
+    out: Dict[str, int] = {}
+    for line in text[m.end() :].splitlines():
+        if not line.startswith(" ") and line.strip():
+            break
+        mm = re.match(r"^\s+([A-Za-z0-9_-]+):\s*(\d+)\s*$", line)
+        if mm:
+            out[mm.group(1)] = int(mm.group(2))
+    return out
+
+
+def extract_workload_replicas(data: Optional[dict], text: str) -> Dict[str, int]:
+    if data:
+        wr = data.get("workloadReplicas")
+        if wr:
+            return {str(k): int(v) for k, v in wr.items()}
+    return extract_workload_replicas_regex(text)
+
+
+def ensure_values_workloads(values_path: Path, workloads: Dict[str, int]) -> bool:
+    if not workloads:
+        return False
+    if values_path.exists():
+        values = try_parse_yaml(values_path.read_text()) or {}
+    else:
+        values = {}
+
+    existing = values.get("workloads") or {}
+    changed = False
+    for name, count in workloads.items():
+        entry = existing.get(name) or {}
+        if entry.get("replicaCount") != count:
+            entry["replicaCount"] = count
+            existing[name] = entry
+            changed = True
+
+    if not changed and values.get("workloads"):
+        return False
+
+    values["workloads"] = existing
+    values_path.write_text(dump_yaml(values))
+    return True
+
+
+def uses_sharedlib(app_dir: Path) -> bool:
+    for p in app_dir.rglob("*"):
+        if not p.is_file() or p.suffix not in {".yaml", ".yml", ".tpl"}:
+            continue
+        try:
+            if ".Values.sharedlib" in p.read_text():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def ensure_external_data_struct(data: dict) -> bool:
+    perm = data.get("permission")
+    if not isinstance(perm, dict):
+        perm = {}
+        data["permission"] = perm
+    if perm.get("externalData") is True:
+        return False
+    perm["externalData"] = True
+    return True
+
+
+def ensure_external_data_regex(text: str) -> Tuple[str, bool]:
+    if re.search(r"^\s*externalData:\s*true\s*$", text, flags=re.MULTILINE):
+        return text, False
+    m = re.search(r"^permission:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return text, False
+    insert_at = m.end()
+    return text[:insert_at] + "\n  externalData: true" + text[insert_at:], True
+
+
+def manifest_version(text: str, data: Optional[dict]) -> str:
+    if data and data.get("olaresManifest.version") is not None:
+        return str(data["olaresManifest.version"]).strip("'\"")
+    m = re.search(r"^olaresManifest\.version:\s*['\"]?([^'\"\n]+)", text, flags=re.MULTILINE)
+    return m.group(1).strip() if m else ""
+
+
+def is_legacy_version(version: str) -> bool:
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not m:
+        return False
+    return tuple(map(int, m.groups())) < (0, 12, 0)
+
+
+def first_accelerator_fields(text: str, data: Optional[dict]) -> Dict[str, str]:
+    if data:
+        spec = data.get("spec") or {}
+        acc = spec.get("accelerator")
+        if isinstance(acc, list) and acc and isinstance(acc[0], dict):
+            return {k: str(v) for k, v in acc[0].items() if k != "mode"}
+
+    # Regex fallback: first list item under spec.accelerator.
+    m = re.search(r"^\s*accelerator:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return {}
+    fields: Dict[str, str] = {}
+    for line in text[m.end() :].splitlines():
+        if line.startswith("  - mode:"):
+            continue
+        mm = re.match(r"^\s+([A-Za-z]+):\s*(.+?)\s*$", line)
+        if not mm:
+            if line.startswith("  - ") or (line and not line.startswith(" ")):
+                break
+            continue
+        key, val = mm.group(1), mm.group(2).strip("'\"")
+        if key != "mode":
+            fields[key] = val
+    return fields
+
+
+def legacy_envelope_missing(text: str, data: Optional[dict]) -> bool:
+    keys = ("requiredCpu", "limitedCpu", "requiredMemory", "limitedMemory", "requiredDisk")
+    if data:
+        spec = data.get("spec") or {}
+        return not all(spec.get(k) for k in keys)
+    for k in keys:
+        if re.search(rf"^\s{re.escape(k)}:\s+\S", text, flags=re.MULTILINE):
+            return False
+    return True
+
+
+def ensure_legacy_resources_struct(data: dict) -> bool:
+    spec = data.get("spec")
+    if not isinstance(spec, dict):
+        return False
+    acc = (spec.get("accelerator") or [None])[0]
+    if not isinstance(acc, dict):
+        return False
+    mapping = (
+        "requiredCpu",
+        "limitedCpu",
+        "requiredMemory",
+        "limitedMemory",
+        "requiredDisk",
+        "limitedDisk",
+    )
+    changed = False
+    for key in mapping:
+        if acc.get(key) and not spec.get(key):
+            spec[key] = acc[key]
+            changed = True
+    return changed
+
+
+def ensure_legacy_resources_regex(text: str) -> Tuple[str, bool]:
+    fields = first_accelerator_fields(text, None)
+    if not fields:
+        return text, False
+    changed = False
+    out = text
+    insert_lines: List[str] = []
+    for src in ("requiredCpu", "limitedCpu", "requiredMemory", "limitedMemory", "requiredDisk", "limitedDisk"):
+        if not fields.get(src):
+            continue
+        if re.search(rf"^\s{re.escape(src)}:\s+\S", out, flags=re.MULTILINE):
+            continue
+        insert_lines.append(f"  {src}: {fields[src]}")
+        changed = True
+    if not changed:
+        return text, False
+    m = re.search(r"^(\s*)supportArch:\s*$", out, flags=re.MULTILINE)
+    if m:
+        pos = m.start()
+        block = "\n".join(insert_lines) + "\n"
+        out = out[:pos] + block + out[pos:]
+    return out, True
+
+
+def fix_olares_user_env_names_struct(data: dict) -> bool:
+    envs = data.get("envs")
+    if not isinstance(envs, list):
+        return False
+    changed = False
+    for entry in envs:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("envName")
+        if not isinstance(name, str) or not name.startswith("OLARES_USER_"):
+            continue
+        new_name = ENV_RENAMES.get(name, name.removeprefix("OLARES_USER_"))
+        if entry.get("envName") != new_name:
+            entry["envName"] = new_name
+            changed = True
+        vf = entry.get("valueFrom")
+        if isinstance(vf, dict) and not vf.get("envName"):
+            vf["envName"] = name
+            changed = True
+    return changed
+
+
+def fix_olares_user_env_names_regex(text: str) -> Tuple[str, bool]:
+    lines = text.splitlines()
+    new_lines: List[str] = []
+    changed = False
+    for line in lines:
+        m = re.match(r"^(\s*)- envName:\s*(OLARES_USER_[A-Z0-9_]+)\s*$", line)
+        if m:
+            indent, old = m.group(1), m.group(2)
+            new = ENV_RENAMES.get(old, old.removeprefix("OLARES_USER_"))
+            new_lines.append(f"{indent}- envName: {new}")
+            changed = True
+            continue
+        new_lines.append(line)
+    out = "\n".join(new_lines) + ("\n" if text.endswith("\n") else "")
+    return out, changed
+
+
+def ensure_middleware_workloads_struct(data: dict) -> Tuple[Dict[str, int], bool]:
+    if str(data.get("olaresManifest.type", "")).strip("'\"") != "middleware":
+        return {}, False
+    name = (data.get("metadata") or {}).get("name")
+    if not name:
+        return {}, False
+    name = str(name)
+    wr = data.get("workloadReplicas")
+    if wr and name in wr:
+        return {name: 1}, False
+    if wr is None:
+        data["workloadReplicas"] = {name: 1}
+    else:
+        wr[name] = 1
+    return {name: 1}, True
+
+
+def ensure_middleware_workloads_regex(text: str) -> Tuple[str, Dict[str, int], bool]:
+    if not re.search(r"^olaresManifest\.type:\s*['\"]?middleware", text, flags=re.MULTILINE):
+        return text, {}, False
+    m = re.search(r"^metadata:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return text, {}, False
+    name = None
+    for line in text[m.end() :].splitlines():
+        if line and not line.startswith(" "):
+            break
+        mm = re.match(r"^\s+name:\s*(\S+)", line)
+        if mm:
+            name = mm.group(1)
+            break
+    if not name:
+        return text, {}, False
+    if re.search(rf"^\s{re.escape(name)}:\s*\d+\s*$", text, flags=re.MULTILINE):
+        return text, {name: 1}, False
+    block = f"\nworkloadReplicas:\n  {name}: 1\n"
+    m2 = re.search(r"^apiVersion\s*:[^\n]*\n", text, flags=re.MULTILINE)
+    if m2:
+        pos = m2.end()
+        return text[:pos] + block + text[pos:], {name: 1}, True
+    return text + block, {name: 1}, True
+
+
+def repair_app(app_dir: Path) -> List[str]:
+    manifest_path = app_dir / "OlaresManifest.yaml"
+    if not manifest_path.exists():
+        return []
+
+    text = manifest_path.read_text()
+    data = try_parse_yaml(text)
+    applied: List[str] = []
+    manifest_changed = False
+    mw_workloads: Dict[str, int] = {}
+
+    if data is not None:
+        mw_workloads, mw_changed = ensure_middleware_workloads_struct(data)
+        if mw_changed:
+            applied.append("M")
+            manifest_changed = True
+    else:
+        text, mw_workloads, mw_changed = ensure_middleware_workloads_regex(text)
+        if mw_changed:
+            applied.append("M")
+            manifest_changed = True
+
+    workloads = extract_workload_replicas(data, text)
+    workloads = {**workloads, **mw_workloads}
+
+    values_path = app_dir / "values.yaml"
+    if workloads and ensure_values_workloads(values_path, workloads):
+        applied.append("V")
+
+    if uses_sharedlib(app_dir):
+        version = manifest_version(text, data)
+        if not is_legacy_version(version):
+            if data is not None:
+                if ensure_external_data_struct(data):
+                    applied.append("X")
+                    manifest_changed = True
+            else:
+                text, ok = ensure_external_data_regex(text)
+                if ok:
+                    applied.append("X")
+                    manifest_changed = True
+
+    version = manifest_version(text, data)
+    if is_legacy_version(version) and legacy_envelope_missing(text, data):
+        if data is not None:
+            if ensure_legacy_resources_struct(data):
+                applied.append("L")
+                manifest_changed = True
+        else:
+            text, ok = ensure_legacy_resources_regex(text)
+            if ok:
+                applied.append("L")
+                manifest_changed = True
+
+    if data is not None:
+        if fix_olares_user_env_names_struct(data):
+            applied.append("E")
+            manifest_changed = True
+    else:
+        text, ok = fix_olares_user_env_names_regex(text)
+        if ok:
+            applied.append("E")
+            manifest_changed = True
+
+    if manifest_changed:
+        if data is not None:
+            manifest_path.write_text(dump_yaml(data))
+        else:
+            manifest_path.write_text(text)
+
+    return applied
+
+
+def main() -> int:
+    if not TESTDATA.is_dir():
+        print(f"missing testdata dir: {TESTDATA}", file=sys.stderr)
+        return 1
+
+    summary: Dict[str, int] = {}
+    for app_dir in sorted(TESTDATA.iterdir()):
+        if not app_dir.is_dir() or app_dir.name.startswith("."):
+            continue
+        applied = repair_app(app_dir)
+        if not applied:
+            continue
+        for tag in applied:
+            summary[tag] = summary.get(tag, 0) + 1
+        print(f"  {app_dir.name}: {','.join(applied)}")
+
+    print("\nfix summary:")
+    for tag, n in sorted(summary.items()):
+        print(f"  {tag}: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/oac/scripts/repair_terminus_apps_phase3.py
+++ b/framework/oac/scripts/repair_terminus_apps_phase3.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Phase-3 cleanup for remaining terminus-apps lint failures."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTDATA = REPO_ROOT / "testdata" / "terminus-apps"
+
+# Apps that need template OLARES_USER -> olaresEnv renames after envName fixes.
+TEMPLATE_ENV_FIXES = {
+    "fireflyiii": [
+        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
+    ],
+    "freshrss": [
+        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
+    ],
+    "ntfy": [
+        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
+    ],
+    "openwebui": [
+        (r"\.Values\.olaresEnv\.OLARES_USER_HUGGINGFACE_SERVICE", ".Values.olaresEnv.HF_ENDPOINT"),
+        (r"\.Values\.olaresEnv\.OLARES_USER_HUGGINGFACE_TOKEN", ".Values.olaresEnv.HF_TOKEN"),
+    ],
+}
+
+
+def manifest_version(text: str) -> str:
+    m = re.search(r"^olaresManifest\.version:\s*['\"]?([^'\"\n]+)", text, flags=re.MULTILINE)
+    return m.group(1).strip() if m else ""
+
+
+def is_legacy_version(version: str) -> bool:
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not m:
+        return False
+    return tuple(map(int, m.groups())) < (0, 12, 0)
+
+
+def remove_external_data(text: str) -> Tuple[str, bool]:
+    new = re.sub(r"^(\s*)externalData:\s*true\s*\n", "", text, flags=re.MULTILINE)
+    return new, new != text
+
+
+def remove_accelerator_block(text: str) -> Tuple[str, bool]:
+    m = re.search(r"^(\s*)accelerator:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return text, False
+    indent = len(m.group(1).expandtabs())
+    lines = text.splitlines(keepends=True)
+    line_no = text[: m.start()].count("\n")
+    end_line = line_no + 1
+    while end_line < len(lines):
+        line = lines[end_line]
+        if not line.strip():
+            end_line += 1
+            continue
+        stripped = line.lstrip()
+        cur_indent = len(line) - len(stripped)
+        if cur_indent > indent:
+            end_line += 1
+            continue
+        if cur_indent == indent and (stripped.startswith("- ") or stripped.startswith("#")):
+            end_line += 1
+            continue
+        break
+    new = "".join(lines[:line_no] + lines[end_line:])
+    return new, True
+
+
+def update_olares_dep(text: str, target: str = ">=1.12.6-0") -> Tuple[str, bool]:
+    pat = re.compile(
+        r"(-\s+name\s*:\s*['\"]?olares['\"]?[^\n]*\n"
+        r"(?:[ \t]+(?:type|registry|mandatory|description)\s*:[^\n]*\n)*"
+        r"[ \t]+version\s*:\s*)['\"]?[^\n'\"]+['\"]?",
+        re.MULTILINE,
+    )
+    new, n = pat.subn(rf"\1'{target}'", text, count=1)
+    return new, n > 0
+
+
+def add_spec_only_admin(text: str) -> Tuple[str, bool]:
+    if re.search(r"^\s+onlyAdmin:\s*true\s*$", text, flags=re.MULTILINE):
+        return text, False
+    m = re.search(r"^spec:\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return text, False
+    insert_at = m.end()
+    return text[:insert_at] + "\n  onlyAdmin: true" + text[insert_at:], True
+
+
+def fix_templates(app_dir: Path, app_name: str) -> bool:
+    fixes = TEMPLATE_ENV_FIXES.get(app_name)
+    if not fixes:
+        return False
+    changed = False
+    for p in app_dir.rglob("*"):
+        if not p.is_file() or p.suffix not in {".yaml", ".yml", ".tpl"}:
+            continue
+        text = p.read_text()
+        new = text
+        for old, new_val in fixes:
+            new = re.sub(old, new_val, new)
+        if new != text:
+            p.write_text(new)
+            changed = True
+    return changed
+
+
+def fix_nofx_deployment(app_dir: Path) -> bool:
+    dep = app_dir / "templates" / "nofx" / "deployment.yaml"
+    if not dep.exists():
+        return False
+    text = dep.read_text()
+    new = re.sub(
+        r"^(metadata:\s*\n\s*name:\s*)nofx\s*$",
+        r'\1"{{ .Release.Name }}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if new != text:
+        dep.write_text(new)
+        return True
+    return False
+
+
+def repair_app(app_dir: Path) -> List[str]:
+    manifest = app_dir / "OlaresManifest.yaml"
+    if not manifest.exists():
+        return []
+    text = manifest.read_text()
+    applied: List[str] = []
+    version = manifest_version(text)
+
+    if is_legacy_version(version) and re.search(r"^\s*externalData:\s*true", text, flags=re.MULTILINE):
+        text, ok = remove_external_data(text)
+        if ok:
+            applied.append("X-")
+
+    if is_legacy_version(version) and re.search(r"^\s*accelerator:", text, flags=re.MULTILINE):
+        has_legacy = any(
+            re.search(rf"^\s+{re.escape(k)}:\s+\S", text, flags=re.MULTILINE)
+            for k in ("requiredCpu", "limitedCpu", "requiredMemory", "limitedMemory", "requiredDisk")
+        )
+        if has_legacy:
+            text, ok = remove_accelerator_block(text)
+            if ok:
+                applied.append("A-")
+
+    if app_dir.name in {"testappempty", "testappv1"}:
+        text, ok = update_olares_dep(text)
+        if ok:
+            applied.append("D")
+
+    if app_dir.name == "teatappintelv3":
+        text, ok = add_spec_only_admin(text)
+        if ok:
+            applied.append("O")
+
+    if applied and any(t in applied for t in ("X-", "A-", "D", "O")):
+        manifest.write_text(text)
+
+    if fix_templates(app_dir, app_dir.name):
+        applied.append("T")
+
+    if app_dir.name == "nofx" and fix_nofx_deployment(app_dir):
+        applied.append("N")
+
+    return applied
+
+
+def main() -> int:
+    for app_dir in sorted(TESTDATA.iterdir()):
+        if not app_dir.is_dir() or app_dir.name.startswith("."):
+            continue
+        applied = repair_app(app_dir)
+        if applied:
+            print(f"  {app_dir.name}: {','.join(applied)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/oac/scripts/run_report.sh
+++ b/framework/oac/scripts/run_report.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+go test -run TestAppsTestdataReport -v -timeout 600s .

--- a/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
@@ -40,3 +40,7 @@ overlayGateway:
 options:
   policies: []
   resetCookie: { enabled: false }
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
@@ -43,4 +43,4 @@ options:
   dependencies:
     - name: olares
       type: system
-      version: ">=1.12.3-0,<1.12.6"
+      version: ">=1.12.6-0"

--- a/framework/oac/v3_envs_test.go
+++ b/framework/oac/v3_envs_test.go
@@ -32,6 +32,8 @@ spec:
   limitedMemory: 256Mi
   requiredDisk: 1Gi
   supportArch: [amd64]
+workloadReplicas:
+  v3env: 1
 envs:
   - envName: SMTP_HOST
     applyOnChange: true
@@ -42,7 +44,7 @@ options:
   resetCookie: { enabled: false }
 `
 	os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("apiVersion: v2\nname: v3env\nversion: 1.0.0\n"), 0o644)
-	os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("x: y\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("x: y\nworkloads:\n  v3env:\n    replicaCount: 1\n"), 0o644)
 	os.WriteFile(filepath.Join(dir, "OlaresManifest.yaml"), []byte(manifest), 0o644)
 	tmpl := filepath.Join(dir, "templates")
 	os.MkdirAll(tmpl, 0o755)

--- a/framework/oac/v3_envs_test.go
+++ b/framework/oac/v3_envs_test.go
@@ -42,6 +42,10 @@ envs:
 options:
   policies: []
   resetCookie: { enabled: false }
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.6-0"
 `
 	os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("apiVersion: v2\nname: v3env\nversion: 1.0.0\n"), 0o644)
 	os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("x: y\nworkloads:\n  v3env:\n    replicaCount: 1\n"), 0o644)


### PR DESCRIPTION

* **Background**

This PR locks down a set of structural rules for modern (olaresManifest.version >= 0.12.0) manifests so they fail loudly at lint time instead of producing confusing low-level YAML / Helm errors at install time. It covers six related areas:

1. workloadReplicas is now mandatory on modern manifests.
2. The legacy top-level provider: block and permission.provider are rejected.
3. options.dependencies[name=olares].version must restrict the Olares system version to a window that matches the manifest's apiVersion / feature surface.
4. options.shared=true apps must satisfy a tight cross-field shape (admin-only, no subCharts, no clusterScoped/appRef).
5. Unrendered Helm template syntax ({{ ... }}) outside YAML string scalars is detected up front.
6. Aggregate resource-limit errors now include both the actual sum and the manifest's declared cap, and a set of repair scripts is checked in to keep testdata/terminus-apps/* honest.

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten validation and loader behavior for all modern manifests (breaking invalid or legacy-shaped YAML) and alter deterministic appid on load; impact is broad across app authoring but mostly surfaces at lint time rather than in production runtime paths.
> 
> **Overview**
> This PR expands **OAC** lint/validation for **olaresManifest.version >= 0.12.0** so bad manifests fail early with actionable errors instead of obscure YAML/Helm failures at install time.
> 
> **Load path:** `LoadAppConfiguration` / `LoadAppConfigurationContent` now **overwrite `metadata.appid`** with `md5(metadata.name)[:8]` (empty when `metadata.name` is missing), aligned with app-service runtime. Lint rejects **reserved system appids**; user-authored values in YAML are still allowed at validate time but are discarded on load.
> 
> **Modern manifest rules (new/expanded):** mandatory non-empty **`workloadReplicas`** (except **apiVersion=v2**); required **`options.dependencies` Olares system** entry with semver windows tied to **apiVersion** and **1.12.6-only** features; **`options.shared=true`** cross-field constraints; empty **`provider`** and **`permission.provider`**; stricter **`permission.externalData`** / provider retirement messaging.
> 
> **Parse pipeline:** for modern manifests, **unquoted `{{` / `}}` outside YAML string scalars** is rejected before YAML decode (quoted/block scalars still allowed).
> 
> **Resources / images:** accelerator **mode enum** and **`AllImageRenderModes`** updated (e.g. `moore-soc`, `amd`, `intel`; removed legacy modes); aggregate **chart vs manifest cap** errors now show sums and manifest spellings.
> 
> **Tooling:** phase 1–3 **Python repair scripts** plus `run_report.sh` to fix `testdata/terminus-apps` manifests from lint reports; small fixture updates for new gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d08c058d606f6e3a2a05b68d02f8ce5614431ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->