### PR TITLE
market: push first clone NATS event via definition-layer fallback

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.65
+        image: beclab/market-backend:v0.6.66
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
push first clone NATS event via definition-layer fallback, revert restore inherited templateOnly behavior on cloned instances

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/317
https://github.com/beclab/market/pull/318


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 29514882713809d3029cf4affc60f7bb3dff1114. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->