### PR TITLE
system-apps: bump app images for v1.12.6 and v1.12.7

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.60
+          image: beclab/system-frontend:v1.10.61
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.1
+          image: beclab/user-service:v0.1.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -23,7 +23,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.14
+        image: beclab/monitoring-server-v1:v0.3.15
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**
  This PR updates the system app image versions required for the v1.12.6 and v1.12.7 merge targets. It brings `system-frontend` to TermiPass v1.10.61, including fixes for SDK-only Material Symbols icon subsetting, profile QR code PNG download, intranet restore URL handling, invalid vue-i18n plural messages that could crash production rendering, and dashboard application entrance/search handling. It also updates `user-service` to v0.1.2 to initialize notification language correctly, parse locale strings such as `en-US`, and forward upstream error messages for token revocation and file controller failures. The monitoring server image is bumped to v0.3.15 together with these subsystem image updates.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1229
  https://github.com/beclab/TermiPass/pull/1230
  https://github.com/beclab/TermiPass/pull/1231
  https://github.com/beclab/user-service/pull/86

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.61
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.60...v1.10.61
  https://github.com/beclab/user-service/compare/v0.1.1...v0.1.2

Made with [Cursor](https://cursor.com)