### PR TITLE
chart-repo: oac update

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.43
+        image: beclab/dynamic-chart-repository:v0.3.44
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
oac update

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/dynamic-chart-repository/pull/50


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-container image tag bump with no config or wiring changes; risk is limited to whatever behavior changed in v0.3.44 of the chart repository service.
> 
> **Overview**
> **OAC / chart-repo image rollout** for the cluster chart-repo deployment: the `chartrepo` container image is bumped from `beclab/dynamic-chart-repository:v0.3.43` to **`v0.3.44`** in `chart_repo_deploy.yaml`. No other manifest fields (env, volumes, init containers, middleware) change in this diff.
> 
> This aligns the packaged Olares chart-repo deploy with the upstream **dynamic-chart-repository** release (see linked PR #50).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d922633655b203d085fb2527929fd58e9f70a542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->