### PR TITLE
system-apps: bump system-frontend image to v1.10.62

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.62
+          image: beclab/system-frontend:v1.10.63
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.61
+          image: beclab/system-frontend:v1.10.62
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
  This PR bumps the `system-frontend` image to TermiPass v1.10.62 for the v1.12.6 and v1.12.7 merge targets. The release fixes backup path encoding by base64-encoding the `create_backup/files/...` URL (decoding the raw path first) and decoding it back on the BackupNew page, so backup paths with special characters survive the round trip reliably. It also removes a leftover debug output on the BackupNew page, fixes the internal mobile share next-button disabled state on the base step, and only enables the mnemonic paste button over https where clipboard reading is available.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1232

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.62
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.61...v1.10.62

Made with [Cursor](https://cursor.com)