### PR TITLE
refactor(cli): default chart scaffold to 0.12.0 manifest schema

### DIFF
--- a/cli/cmd/ctl/chart/from_compose.go
+++ b/cli/cmd/ctl/chart/from_compose.go
@@ -10,12 +10,14 @@ import (
 )
 
 type fromComposeOpts struct {
-	Files     []string
-	Output    string
-	Name      string
-	Title     string
-	Type      string
-	NewSchema bool
+	Files  []string
+	Output string
+	Name   string
+	Title  string
+	Type   string
+	// newSchema is a deprecated no-op flag kept for backward compatibility;
+	// scaffolds always emit the 0.12.0 schema regardless of its value.
+	newSchema bool
 }
 
 func NewCmdChartFromCompose() *cobra.Command {
@@ -51,10 +53,13 @@ Validate your edits at any time with:
 
   olares-cli chart lint <output>
 
+The scaffolded OlaresManifest always uses the 0.12.0 schema (resources under
+spec.accelerator[mode=cpu]).
+
 Examples:
   olares-cli chart from-compose --name myapp -f docker-compose.yml
   olares-cli chart from-compose --name myapp -f compose.yml -o ./charts/myapp --title "My App"
-  olares-cli chart from-compose --name myapp -f a.yml -f b.yml --new-schema`,
+  olares-cli chart from-compose --name myapp -f a.yml -f b.yml`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFromCompose(o)
@@ -66,7 +71,8 @@ Examples:
 	fs.StringVar(&o.Name, "name", "", "Olares app name (lowercase alphanumeric, required)")
 	fs.StringVar(&o.Title, "title", "", "human-facing app title (default: name)")
 	fs.StringVar(&o.Type, "type", "app", "OlaresManifest type: app | recommend | middleware")
-	fs.BoolVar(&o.NewSchema, "new-schema", false, "emit the 0.12.0 schema (spec.accelerator) instead of legacy 0.8.0")
+	fs.BoolVar(&o.newSchema, "new-schema", false, "deprecated no-op: the 0.12.0 schema (spec.accelerator) is always emitted")
+	_ = fs.MarkHidden("new-schema")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -85,7 +91,6 @@ func runFromCompose(o *fromComposeOpts) error {
 		Name:         o.Name,
 		Title:        o.Title,
 		Type:         o.Type,
-		NewSchema:    o.NewSchema,
 	}); err != nil {
 		return err
 	}

--- a/cli/pkg/chart/scaffold.go
+++ b/cli/pkg/chart/scaffold.go
@@ -24,11 +24,16 @@ const (
 	defaultIcon    = "https://app.cdn.olares.com/appstore/default/defaulticon.webp"
 	appCfgFileName = "OlaresManifest.yaml"
 
-	// newSchemaConfigVersion projects resources into spec.accelerator[mode=cpu];
-	// legacySchemaConfigVersion writes the flat spec.requiredX/limitedX fields.
-	newSchemaConfigVersion    = "0.12.0"
-	legacySchemaConfigVersion = "0.8.0"
-	resourceModeCPU           = "cpu"
+	// configVersion is the olaresManifest.version every scaffold emits:
+	// resources live under spec.accelerator[mode=cpu].
+	configVersion   = "0.12.0"
+	resourceModeCPU = "cpu"
+
+	// olaresSystemDepName / olaresSystemDepVersion are the options.dependencies
+	// entry the 0.12.0 schema requires: spec.accelerator and workloadReplicas
+	// are 1.12.6-only features, so the constraint must restrict to >=1.12.6-0.
+	olaresSystemDepName    = "olares"
+	olaresSystemDepVersion = ">=1.12.6-0"
 
 	// entranceAnnotation marks the compose service the user wants exposed as
 	// the primary entrance (set via a compose label of the same name).
@@ -58,8 +63,6 @@ type Options struct {
 	Title string
 	// Type is the OlaresManifest type: app | recommend | middleware.
 	Type string
-	// NewSchema selects the 0.12.0 layout (spec.accelerator) over legacy 0.8.0.
-	NewSchema bool
 	// Profiles / NoInterpolate are passed straight to the kompose loader.
 	Profiles      []string
 	NoInterpolate bool
@@ -127,6 +130,7 @@ func writeChart(opts Options, resources []runtime.Object) error {
 	// selects it.
 	renamePrimaryWorkload(resources, opts.Name)
 
+	replicas := manifest.WorkloadReplicas{}
 	for i := range resources {
 		resource := resources[i]
 		addResourcesRequirements(resource)
@@ -142,8 +146,10 @@ func writeChart(opts Options, resources []runtime.Object) error {
 		switch obj := resource.(type) {
 		case *appsv1.Deployment:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
+			replicas[obj.GetName()] = 1
 		case *appsv1.StatefulSet:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
+			replicas[obj.GetName()] = 1
 		case *appsv1.DaemonSet:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
 		case *corev1.Pod:
@@ -165,7 +171,7 @@ func writeChart(opts Options, resources []runtime.Object) error {
 		}
 	}
 
-	return writeManifest(opts, host, port, totalRequests, totalLimits)
+	return writeManifest(opts, host, port, totalRequests, totalLimits, replicas)
 }
 
 // renamePrimaryWorkload renames one workload to appName so the chart has a
@@ -212,14 +218,14 @@ func renamePrimaryWorkload(resources []runtime.Object, appName string) {
 }
 
 // writeManifest assembles the OlaresManifest.yaml + Chart.yaml + values.yaml.
-func writeManifest(opts Options, entranceHost string, entrancePort int32, totalRequests, totalLimits corev1.ResourceList) error {
+func writeManifest(opts Options, entranceHost string, entrancePort int32, totalRequests, totalLimits corev1.ResourceList, replicas manifest.WorkloadReplicas) error {
 	cpuReq := totalRequests[corev1.ResourceCPU]
 	memReq := totalRequests[corev1.ResourceMemory]
 	cpuLim := totalLimits[corev1.ResourceCPU]
 	memLim := totalLimits[corev1.ResourceMemory]
 
 	appcfg := manifest.AppConfiguration{
-		ConfigVersion: configVersionFor(opts.NewSchema),
+		ConfigVersion: configVersion,
 		ConfigType:    opts.Type,
 		Metadata: manifest.AppMetaData{
 			Name:        opts.Name,
@@ -236,9 +242,17 @@ func writeManifest(opts Options, entranceHost string, entrancePort int32, totalR
 		},
 		Options: manifest.Options{
 			AppScope: manifest.AppScope{AppRef: []string{}},
+			Dependencies: []manifest.Dependency{{
+				Name:    olaresSystemDepName,
+				Version: olaresSystemDepVersion,
+				Type:    "system",
+			}},
 		},
 	}
-	applyAppResources(&appcfg.Spec, opts.NewSchema, oac.ManifestResourceLimits{
+	if len(replicas) > 0 {
+		appcfg.WorkloadReplicas = &replicas
+	}
+	applyAppResources(&appcfg.Spec, oac.ManifestResourceLimits{
 		RequiredCPU:    cpuReq.String(),
 		RequiredMemory: memReq.String(),
 		RequiredDisk:   "50Mi",
@@ -274,7 +288,26 @@ func writeManifest(opts Options, entranceHost string, entrancePort int32, totalR
 	if err := writeYAMLFile(filepath.Join(opts.OutputDir, "Chart.yaml"), meta); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(opts.OutputDir, "values.yaml"), []byte{}, 0644)
+	return writeValuesFile(filepath.Join(opts.OutputDir, "values.yaml"), replicas)
+}
+
+// writeValuesFile seeds values.yaml with workloads.<name>.replicaCount for
+// every workload in replicas. The 0.12.0 lint sources each workload's replica
+// count from .Values.workloads.<name>.replicaCount, so an empty values.yaml
+// would fail validation as soon as workloadReplicas is declared.
+func writeValuesFile(path string, replicas manifest.WorkloadReplicas) error {
+	if len(replicas) == 0 {
+		return os.WriteFile(path, []byte{}, 0644)
+	}
+	workloads := make(map[string]map[string]int32, len(replicas))
+	for name, count := range replicas {
+		workloads[name] = map[string]int32{"replicaCount": count}
+	}
+	out, err := yaml.Marshal(map[string]any{"workloads": workloads})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0644)
 }
 
 // detectEntrance picks the primary entrance for the scaffolded manifest:
@@ -336,27 +369,10 @@ func isSelectorMatch(podLabels, selector map[string]string) bool {
 	return true
 }
 
-// applyAppResources writes r into spec per the active schema. New schema
-// projects into spec.Accelerator[mode=cpu] (the v0.0.8 field; devbox's older
-// api used spec.Resources); legacy writes the flat spec.RequiredX/LimitedX.
-func applyAppResources(spec *manifest.AppSpec, newSchema bool, r oac.ManifestResourceLimits) {
-	if !newSchema {
-		spec.RequiredCPU = r.RequiredCPU
-		spec.LimitedCPU = r.LimitedCPU
-		spec.RequiredMemory = r.RequiredMemory
-		spec.LimitedMemory = r.LimitedMemory
-		spec.RequiredDisk = r.RequiredDisk
-		spec.LimitedDisk = r.LimitedDisk
-		return
-	}
-
-	spec.RequiredCPU = ""
-	spec.RequiredMemory = ""
-	spec.RequiredDisk = ""
-	spec.LimitedDisk = ""
-	spec.LimitedCPU = ""
-	spec.LimitedMemory = ""
-
+// applyAppResources projects r into spec.Accelerator[mode=cpu] (the modern
+// 0.12.0 resource envelope); the legacy flat spec.RequiredX/LimitedX fields
+// are intentionally left empty.
+func applyAppResources(spec *manifest.AppSpec, r oac.ManifestResourceLimits) {
 	mode := manifest.ResourceMode{
 		Mode: resourceModeCPU,
 		ResourceRequirement: manifest.ResourceRequirement{
@@ -375,13 +391,6 @@ func applyAppResources(spec *manifest.AppSpec, newSchema bool, r oac.ManifestRes
 		}
 	}
 	spec.Accelerator = append(spec.Accelerator, mode)
-}
-
-func configVersionFor(newSchema bool) string {
-	if newSchema {
-		return newSchemaConfigVersion
-	}
-	return legacySchemaConfigVersion
 }
 
 func addResourcesRequirements(resource runtime.Object) {

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-chart
-version: 4.5.0
+version: 4.6.0
 description: "Help a developer turn their own code or any open-source project into an app that runs on their own Olares. Two coupled axes: packaging the container image and authoring/refining the Olares app chart (OlaresManifest), then deploying it to the current Olares with an automatic upload + install + diagnose loop. Use when deploying a repo, docker-compose, or Helm chart to Olares, packaging an Olares app, wiring storage / system middleware / entrances / env / GPU, or fixing a failed install (ImagePullBackOff, permission denied / EACCES, app won't start). Publishing to the public Olares Market is the olares-publish skill."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only, deploy needs login
 metadata:
@@ -85,7 +85,7 @@ For deploying to your own Olares, **metadata can stay a stub** (`Utilities` cate
 | deployment | **Accelerator** | declare `spec.accelerator` modes (nvidia/amd-gpu/apple-m/cpu/…) per what the repo supports; set `requiredGPUMemory`; a sane CPU/memory envelope | GPU/accelerator app needs a resource envelope, or `lint` flags `spec.resources` | [accelerator.md](references/olares-chart-accelerator.md) |
 | packaging+deployment | **DinD** | a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`) while the main container stays non-privileged | a terminal/agent app must run `docker` / `docker compose` | [dind.md](references/olares-chart-dind.md) |
 | deployment | **Shared backend** | `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; consumers reach it over cross-namespace Service DNS; flag the admin-install to the user | a heavy/accelerator backend serves many users over shared data | [shared.md](references/olares-chart-shared.md) |
-| deployment | **Version rules** | `apiVersion: v3`; `olaresManifest.version` 0.8.0 vs 0.12.0; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`) | install rejects the manifest, or behavior differs by Olares version | [versioning.md](references/olares-chart-versioning.md) |
+| deployment | **Version rules** | `apiVersion: v3`; `olaresManifest.version` always `0.12.0`; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`) | install rejects the manifest, or behavior differs by Olares version | [versioning.md](references/olares-chart-versioning.md) |
 | deployment | **Metadata** | stub OK for local deploy (`Utilities`, default icon) as long as `lint` passes; full `metadata.*` + listing images only when publishing to the Market | `lint` flags missing metadata, or you want a public listing | [manifest.md](references/olares-chart-manifest.md) §1 |
 | deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
 | deploy | **Deploy** | `market upload` + `market install`, then diagnose from logs — automatic after `lint` passes (login required) | proving the chart actually runs on the developer's Olares | [deploy.md](references/olares-chart-deploy.md) |

--- a/cli/skills/olares-chart/references/olares-chart-accelerator.md
+++ b/cli/skills/olares-chart/references/olares-chart-accelerator.md
@@ -1,10 +1,10 @@
 # Accelerator resources (`spec.accelerator`) — modes & sizing
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first. This covers declaring accelerator modes and sizing the resource envelope on the modern schema (`olaresManifest.version >= 0.12.0`). Building the CUDA image and provisioning model weights are in [olares-chart-gpu.md](olares-chart-gpu.md).
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first. This covers declaring accelerator modes and sizing the resource envelope on the `0.12.0` schema (the schema every new app uses). Building the CUDA image and provisioning model weights are in [olares-chart-gpu.md](olares-chart-gpu.md).
 
 ## A. Declaring accelerator modes (`spec.accelerator`)
 
-On the modern schema (`olaresManifest.version >= 0.12.0`) an app that needs an accelerator declares one `spec.accelerator[]` entry **per compute mode** it supports. Without it the app is scheduled as plain `cpu` and never gets an accelerator device or GPU memory.
+On the `0.12.0` schema an app that needs an accelerator declares one `spec.accelerator[]` entry **per compute mode** it supports. Without it the app is scheduled as plain `cpu` and never gets an accelerator device or GPU memory.
 
 > **Naming gotchas (these bite):**
 > - The YAML key is `spec.accelerator`, but `lint` error messages call it **`spec.resources`** — same thing.

--- a/cli/skills/olares-chart/references/olares-chart-from-compose.md
+++ b/cli/skills/olares-chart/references/olares-chart-from-compose.md
@@ -9,7 +9,6 @@
 olares-cli chart from-compose --name myapp -f docker-compose.yml
 olares-cli chart from-compose --name myapp -f compose.yml -o ./charts/myapp --title "My App"
 olares-cli chart from-compose --name myapp -f base.yml -f override.yml      # merged in order
-olares-cli chart from-compose --name myapp -f docker-compose.yml --new-schema
 ```
 
 ## Before you run
@@ -36,7 +35,7 @@ olares-cli chart from-compose --name myapp -f docker-compose.yml --new-schema
 | `-o, --output` | chart root dir (default `./<name>`) |
 | `--title` | human title (default = name) |
 | `--type` | `app` (default) / `recommend` / `middleware` |
-| `--new-schema` | emit `olaresManifest.version: 0.12.0` with resources under `spec.accelerator[mode=cpu]` instead of legacy `0.8.0` flat fields |
+| `--new-schema` | **deprecated no-op** — every scaffold now emits `olaresManifest.version: 0.12.0` (resources under `spec.accelerator[mode=cpu]`) regardless |
 
 ## Reading the output
 

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -7,7 +7,7 @@ The scaffolded manifest is a stub. The four areas below are what kompose cannot 
 
 ## Schema version and apiVersion
 
-`olaresManifest.version` (the manifest **schema**: `0.8.0` default vs `0.12.0` via `--new-schema`) and the top-level `apiVersion` (skill sets **`v3`**) are separate axes from the chart/app versions. Use `0.12.0` when the app needs `spec.accelerator` or `permission.externalData`. The full schema-field table, the version-field map, and the `type: system` dependency are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
+`olaresManifest.version` (the manifest **schema**: always `0.12.0` for new apps) and the top-level `apiVersion` (skill sets **`v3`**) are separate axes from the chart/app versions. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The full schema description, the version-field map, and the `type: system` dependency are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
 
 ## 1. Metadata
 

--- a/cli/skills/olares-chart/references/olares-chart-versioning.md
+++ b/cli/skills/olares-chart/references/olares-chart-versioning.md
@@ -18,7 +18,7 @@ The semver scheme (stable / RC / daily), `.Values.sysVersion`, the `-0` prerelea
 >
 > ```yaml
 > apiVersion: v3
-> olaresManifest.version: '0.8.0'   # independent axis — see below
+> olaresManifest.version: '0.12.0'   # independent axis — see below
 > olaresManifest.type: app
 > metadata:
 >   name: myapp
@@ -34,7 +34,7 @@ What `v3` turns on (enforced by the toolchain only when `apiVersion: v3`):
   - Without `isShared: true` → installs into `<app>-<adminUsername>` (the admin's personal namespace). Use this when the app just needs admin-only install but manages its own users internally.
   - With `isShared: true` → installs into `<app>-shared` (cluster-wide, cross-namespace access enabled). Use this for heavy shared backends (GPU inference servers, shared databases) that other apps consume. See [olares-chart-shared.md](olares-chart-shared.md).
 
-`apiVersion` is independent of `olaresManifest.version` — `v3` works with both `0.8.0` and `0.12.0`.
+`apiVersion` is independent of `olaresManifest.version` — `v3` is the skill rule for the API axis, while the schema axis is always `0.12.0` (see below).
 
 ## The version fields in a chart (don't confuse them)
 
@@ -43,24 +43,24 @@ A chart carries several "version" fields with different jobs and different rules
 | Field | Where | What it is | Rule |
 |---|---|---|---|
 | `apiVersion` | `OlaresManifest.yaml` (top level) | manifest API generation | skill sets `v3` (toolchain allows `v1`/`v2`/`v3`, default `v1`) |
-| `olaresManifest.version` | `OlaresManifest.yaml` | manifest **schema** version | `0.8.0` (legacy) vs `0.12.0` (`--new-schema`); install minimum `>= 0.7.2` |
+| `olaresManifest.version` | `OlaresManifest.yaml` | manifest **schema** version | always `0.12.0` for new apps (`from-compose` emits it; install minimum `>= 0.7.2`, legacy `< 0.12.0` charts still install) |
 | `metadata.version` | `OlaresManifest.yaml` | **Chart version** (Market package) | must be semver and **equal `Chart.yaml` `version`** |
 | `version` | `Chart.yaml` | Helm chart version | `== metadata.version` |
 | `spec.versionName` | `OlaresManifest.yaml` | **upstream app** version (display) | tracks `Chart.yaml` `appVersion` — convention, not enforced |
 
 > **Name clash:** `Chart.yaml` also has its own `apiVersion` (`v2`) — that is the **Helm** chart API and is unrelated to the OlaresManifest `apiVersion`. Don't copy one into the other.
 
-### Schema version: 0.8.0 (legacy) vs 0.12.0 (`--new-schema`)
+### Schema version: 0.12.0
 
-`olaresManifest.version` declares which manifest schema the chart uses. `from-compose` emits **0.8.0** by default and **0.12.0** with `--new-schema`. The difference is not cosmetic — some fields only exist on 0.12.0:
+`olaresManifest.version` declares which manifest schema the chart uses. **New apps always use `0.12.0`** — `from-compose` emits it unconditionally (the old `--new-schema` flag is a deprecated no-op). The 0.12.0 schema:
 
-| | 0.8.0 (legacy, default) | 0.12.0 (`--new-schema`) |
-|---|---|---|
-| Resource envelope | flat `spec.requiredCpu` / `requiredMemory` / `requiredDisk` / `limitedCpu` / ... | `spec.resources[]` / `spec.accelerator[]` (mode-keyed: `cpu`, `nvidia`, ...) |
-| GPU / accelerator | not expressible cleanly | `spec.accelerator` with mode → arch cross-check at `lint` |
-| `permission.externalData` (`.Values.sharedlib`) | rejected | supported |
+- **Resource envelope** lives under `spec.resources[]` / `spec.accelerator[]` (mode-keyed: `cpu`, `nvidia`, ...), not the legacy flat `spec.requiredCpu` / `requiredMemory` / ... fields.
+- **GPU / accelerator** is declared via `spec.accelerator` with a mode → arch cross-check at `lint`.
+- **`permission.externalData`** (`.Values.sharedlib`) is supported.
 
-**Use 0.12.0 when** the app declares GPU/accelerator resources, needs `permission.externalData`, or you want the modern resource envelope (recommended for new Market apps). Otherwise 0.8.0 is fine. To switch an existing stub, re-scaffold with `from-compose --new-schema` (or edit `olaresManifest.version` and migrate the resource fields). Accelerator mode declaration and sizing are in [olares-chart-accelerator.md](olares-chart-accelerator.md).
+Accelerator mode declaration and sizing are in [olares-chart-accelerator.md](olares-chart-accelerator.md).
+
+> **Legacy `< 0.12.0` (e.g. `0.8.0`) charts** still install and validate (the install minimum is `>= 0.7.2`), and the validator reads their flat `spec.requiredCpu` / ... fields. You only meet them when reading old charts; do not author new ones on the legacy schema.
 
 ## Declaring system-version compatibility
 

--- a/cli/skills/olares-chart/references/olares-chart-workflow.md
+++ b/cli/skills/olares-chart/references/olares-chart-workflow.md
@@ -39,7 +39,7 @@ Step D1 produces a chart that **already passes `lint`** but is NOT yet a good ap
 <output>/
 ├── Chart.yaml              # helm chart metadata (name/version pinned to 0.0.1)
 ├── OlaresManifest.yaml     # Olares app manifest — the file you refine
-├── values.yaml             # empty; fill if you template values
+├── values.yaml             # seeded with workloads.<name>.replicaCount; add more as you template values
 └── templates/
     ├── deployment-<app>.yaml          # the primary workload, renamed to <app>
     ├── deployment-<svc>.yaml          # one per extra compose service
@@ -50,6 +50,7 @@ Step D1 produces a chart that **already passes `lint`** but is NOT yet a good ap
 - Every resource is namespaced with `namespace: '{{ .Release.Namespace }}'`.
 - Default CPU/memory requests+limits are stamped onto every container.
 - One **entrance** is auto-detected (the `olares.service.type: Entrance`-labeled service, else the first service with a port, else a `port: 80` placeholder).
-- `olaresManifest.version` is `0.8.0` (legacy) unless you pass `--new-schema` (`0.12.0`, resources under `spec.accelerator`) — see [olares-chart-manifest.md](olares-chart-manifest.md).
+- `olaresManifest.version` is always `0.12.0` (resources under `spec.accelerator`) — see [olares-chart-manifest.md](olares-chart-manifest.md).
+- For 0.12.0, the scaffold also emits `workloadReplicas.<workload>: 1` (with the matching `values.yaml` `workloads.<name>.replicaCount`) and the required `options.dependencies` `olares >=1.12.6-0` (`type: system`), so a fresh scaffold passes `lint`.
 
 > **Tip:** label the service you want exposed in the compose file with `labels: { olares.service.type: Entrance }` so the right workload becomes the entrance and gets renamed to the app name.

--- a/cli/skills/olares-publish/SKILL.md
+++ b/cli/skills/olares-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-publish
-version: 4.3.0
+version: 4.3.1
 description: "Publish an Olares app that already runs on your own Olares to the public Olares Market — the release-target requirements matrix, the market-ready metadata/image/arch checklist, the PR to beclab/apps (GitBot rules + lifecycle), and pay-to-download (paid) listings. Use when the user wants to submit / list / distribute / 上架 an app to the public Market, open a beclab/apps PR, or sell a paid app. Authoring and deploying the chart itself lives in olares-chart; this skill is the public-distribution step that comes after the app already installs and runs locally."
 compatibility: Requires olares-cli on PATH; PR submission needs a GitHub account
 metadata:

--- a/cli/skills/olares-publish/references/olares-publish-targets.md
+++ b/cli/skills/olares-publish/references/olares-publish-targets.md
@@ -21,7 +21,7 @@ Local deploy (in `olares-chart`) proves the app **runs**: `chart lint` OK, a pul
 | **`spec.featuredImage` / `promoteImage`** | Skip | Strongly recommended — see [promote-apps](https://docs.olares.com/developer/develop/promote-apps.html) |
 | **`spec.locale`** | Skip | Recommended (`en` at minimum) |
 | **`spec.supportArch`** | Optional (omit unless using accelerator modes) | Required — must match image platforms (`amd64`, `arm64`, or both) |
-| **`spec.accelerator` / GPU resources** | Only if the app needs GPU on **this** node | Fully declared when the app uses GPU/NPU; mode -> arch cross-check applies at `lint` for schema >= 0.12.0 |
+| **`spec.accelerator` / GPU resources** | Only if the app needs GPU on **this** node | Fully declared when the app uses GPU/NPU; mode -> arch cross-check applies at `lint` |
 | **`owners` file** | Not needed | Required in the OAC root for the `beclab/apps` PR |
 | **Validate** | `lint` + upload + install | Same, then the PR — [olares-publish-submit.md](olares-publish-submit.md) |
 
@@ -44,7 +44,7 @@ Complete **after** the app runs locally. Use this as a pre-PR gate.
 - [ ] **Listing assets:** `featuredImage`, `promoteImage[]` (URLs reachable by the Market CDN)
 - [ ] **Locale:** `spec.locale: [en]` (add more if translated)
 - [ ] **Architecture:** multi-arch images pushed; `spec.supportArch` lists every supported arch
-- [ ] **Resources:** if GPU/NPU needed, `spec.accelerator[]` complete with quantities; consider `--new-schema`
+- [ ] **Resources:** if GPU/NPU needed, `spec.accelerator[]` complete with quantities
 - [ ] **Versions:** `metadata.version` = `Chart.yaml` `version`; bump together for updates
 - [ ] **`owners` file** in the chart root with the submitter's GitHub username
 - [ ] **Folder name** valid for `beclab/apps` (lowercase alphanumeric, no hyphens, <=30 chars)


### PR DESCRIPTION
## Summary

- `olares-cli chart from-compose` now always emits `olaresManifest.version: 0.12.0` (resources under `spec.accelerator[mode=cpu]`). The `--new-schema` flag is kept as a **hidden, deprecated no-op** so existing scripts that pass it keep working.
- To keep a fresh scaffold lint-clean on the 0.12.0 schema, the scaffolder now also emits the required `workloadReplicas.<workload>: 1` map, the matching `values.yaml` `workloads.<name>.replicaCount` entries, and the `options.dependencies` `olares >=1.12.6-0` (`type: system`) dependency.
- The `framework/oac` validator is **untouched**: legacy `< 0.12.0` (e.g. `0.8.0`) charts still read, validate, and install.
- `olares-chart` / `olares-publish` skill docs are updated to present `0.12.0` as the only schema for new apps (skill versions bumped: olares-chart 4.5.0 -> 4.6.0, olares-publish 4.3.0 -> 4.3.1).

## Motivation

Apps targeting Olares >= 1.12.6 are authored on the v3 / modern resource envelope only. The legacy `0.8.0` flat resource schema is no longer a meaningful default for new apps, so the scaffolder and docs standardize on `0.12.0`.

## Test plan

- [x] `go build ./...` and `go vet ./pkg/chart/... ./cmd/ctl/chart/...` pass
- [x] `from-compose` (with and without `--new-schema`) emits `olaresManifest.version: 0.12.0` with `spec.accelerator`
- [x] `chart lint` returns `OK` on a fresh single-service and multi-service scaffold
- [ ] Confirm legacy `0.8.0` charts still install on a real Olares >= 1.12.6

Made with [Cursor](https://cursor.com)