### PR TITLE
feat(cli): backfill Intel/AMD GPU node labels on upgrade

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -82,6 +82,10 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		},
 	}
 	pre = append(pre, retagLegacyAMDGPUImage()...)
+	// backfill the per-mode (multi-mode) node labels for Intel/AMD GPUs so
+	// devices upgraded from before the per-mode labeling scheme advertise
+	// their GPU mode to the scheduler.
+	pre = append(pre, labelIntelAMDGPUNode()...)
 	pre = append(pre, u.upgraderBase.UpgradeSystemComponents()...)
 	pre = append(pre, &task.LocalTask{
 		Name:   "PatchL4BFLProxyProbePort",

--- a/cli/pkg/upgrade/1_12_7_20260625.go
+++ b/cli/pkg/upgrade/1_12_7_20260625.go
@@ -1,0 +1,28 @@
+package upgrade
+
+import (
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260625 struct {
+	upgrader_1_12_7_20260624
+}
+
+func (u upgrader_1_12_7_20260625) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260625")
+}
+
+func (u upgrader_1_12_7_20260625) UpgradeSystemComponents() []task.Interface {
+	tasks := u.upgrader_1_12_7_20260624.UpgradeSystemComponents()
+	// backfill the per-mode (multi-mode) node labels for Intel/AMD GPUs so
+	// devices upgraded from before the per-mode labeling scheme advertise
+	// their GPU mode to the scheduler.
+	tasks = append(tasks, labelIntelAMDGPUNode()...)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260625{})
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -23,6 +23,8 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/core/util"
 	"github.com/beclab/Olares/cli/pkg/gpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/amdgpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/intelgpu"
 	"github.com/beclab/Olares/cli/pkg/images"
 	"github.com/beclab/Olares/cli/pkg/k3s"
 	k3stemplates "github.com/beclab/Olares/cli/pkg/k3s/templates"
@@ -862,6 +864,32 @@ func (u *upgradeUserReverseProxyAgent) Execute(runtime connector.Runtime) error 
 	}
 
 	return nil
+}
+
+// labelIntelAMDGPUNode detects whether the current node carries an Intel
+// integrated GPU or an AMD Ryzen AI Max APU and, if so, sets the corresponding
+// gpu.bytetrade.io/<mode> existence label. Devices that gained Intel/AMD GPU
+// support before the per-mode (multi-mode) labeling scheme existed never got
+// these labels, so after an upgrade their GPU mode wouldn't be advertised to
+// the scheduler. Reusing the install-time actions here backfills the labels
+// without a fresh install. Both actions are idempotent and no-op on nodes
+// without the respective GPU (and the AMD one additionally requires ROCm to be
+// present, matching the install behavior).
+func labelIntelAMDGPUNode() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "LabelIntelGPUNode",
+			Action: new(intelgpu.UpdateNodeIntelGPUInfo),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+		&task.LocalTask{
+			Name:   "LabelAMDGPUNode",
+			Action: new(amdgpu.UpdateNodeAMDInfo),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	}
 }
 
 func upgradeUserReverseProxy() []task.Interface {


### PR DESCRIPTION
## Summary
- Add `labelIntelAMDGPUNode()` upgrade helper that reuses the install-time actions (`intelgpu.UpdateNodeIntelGPUInfo`, `amdgpu.UpdateNodeAMDInfo`) to detect Intel integrated GPUs / AMD Ryzen AI Max APUs and set the per-mode `gpu.bytetrade.io/<mode>` node labels. Actions are idempotent and no-op on nodes without the respective GPU.
- Wire it into the `1.12.6` upgrader (`UpgradeSystemComponents`, alongside the existing GPU migration/backfill tasks).
- Add tonight's `1.12.7-20260625` daily upgrader, which inherits `1.12.7-20260624` and appends the same labeling tasks.

This lets devices that gained Intel/AMD GPU support before the per-mode (multi-mode) labeling scheme existed advertise their GPU mode to the scheduler after an upgrade, without a fresh install. Only Intel and AMD are considered (NVIDIA already has its own labeling path).

## Test plan
- [ ] `go build ./...` in `cli/` (passes locally)
- [ ] Upgrade an Intel iGPU device to 1.12.6 / 1.12.7-20260625 and verify `gpu.bytetrade.io/intel=true` is set
- [ ] Upgrade an AMD Ryzen AI Max device (with ROCm) and verify `gpu.bytetrade.io/amd=true` is set
- [ ] Upgrade a non-GPU / NVIDIA device and verify no spurious Intel/AMD labels are added

Made with [Cursor](https://cursor.com)