### PR TITLE
fix(cli): wire scaffolded spec.replicas to workloadReplicas value

### DIFF
--- a/cli/pkg/chart/scaffold.go
+++ b/cli/pkg/chart/scaffold.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	oac "github.com/beclab/Olares/framework/oac"
@@ -143,13 +144,20 @@ func writeChart(opts Options, resources []runtime.Object) error {
 			obj.SetNamespace("{{ .Release.Namespace }}")
 		}
 
+		// wireReplica is set for the workload kinds whose spec.replicas must be
+		// driven by .Values.workloads.<name>.replicaCount (Deployment/StatefulSet).
+		wireReplica := false
 		switch obj := resource.(type) {
 		case *appsv1.Deployment:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
+			obj.Spec.Replicas = ptrInt32(1)
 			replicas[obj.GetName()] = 1
+			wireReplica = true
 		case *appsv1.StatefulSet:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
+			obj.Spec.Replicas = ptrInt32(1)
 			replicas[obj.GetName()] = 1
+			wireReplica = true
 		case *appsv1.DaemonSet:
 			accumulateContainerResources(obj.Spec.Template.Spec.Containers, totalRequests, totalLimits)
 		case *corev1.Pod:
@@ -163,6 +171,12 @@ func writeChart(opts Options, resources []runtime.Object) error {
 		yml, err := toYAML(resource)
 		if err != nil {
 			return err
+		}
+		if wireReplica {
+			// app-service drives replica counts (install/suspend/resume) purely
+			// through .Values.workloads.<name>.replicaCount, so the template must
+			// reference it instead of the literal kompose replica count.
+			yml = wireReplicasValue(yml, mobj.GetName())
 		}
 		kind := strings.ToLower(resource.GetObjectKind().GroupVersionKind().Kind)
 		filename := filepath.Join(templatesDir, fmt.Sprintf("%s-%s.yaml", kind, mobj.GetName()))
@@ -452,6 +466,19 @@ func accumulateContainerResources(containers []corev1.Container, totalRequests, 
 
 func toYAML(v any) ([]byte, error) {
 	return yaml.Marshal(v)
+}
+
+func ptrInt32(v int32) *int32 { return &v }
+
+var replicasLineRE = regexp.MustCompile(`(?m)^(\s*)replicas: \d+\s*$`)
+
+// wireReplicasValue rewrites a serialized Deployment/StatefulSet's literal
+// spec.replicas line into a Helm reference to .Values.workloads.<name>.replicaCount.
+// app-service installs and suspends/resumes apps by overriding that value, so a
+// hardcoded replicas count would make the lifecycle scale operations inert.
+func wireReplicasValue(yml []byte, name string) []byte {
+	repl := fmt.Sprintf("${1}replicas: {{ .Values.workloads.%s.replicaCount }}", name)
+	return replicasLineRE.ReplaceAll(yml, []byte(repl))
 }
 
 func writeYAMLFile(path string, v any) error {

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-chart
-version: 4.6.0
+version: 4.7.0
 description: "Help a developer turn their own code or any open-source project into an app that runs on their own Olares. Two coupled axes: packaging the container image and authoring/refining the Olares app chart (OlaresManifest), then deploying it to the current Olares with an automatic upload + install + diagnose loop. Use when deploying a repo, docker-compose, or Helm chart to Olares, packaging an Olares app, wiring storage / system middleware / entrances / env / GPU, or fixing a failed install (ImagePullBackOff, permission denied / EACCES, app won't start). Publishing to the public Olares Market is the olares-publish skill."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only, deploy needs login
 metadata:
@@ -86,6 +86,7 @@ For deploying to your own Olares, **metadata can stay a stub** (`Utilities` cate
 | packaging+deployment | **DinD** | a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`) while the main container stays non-privileged | a terminal/agent app must run `docker` / `docker compose` | [dind.md](references/olares-chart-dind.md) |
 | deployment | **Shared backend** | `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; consumers reach it over cross-namespace Service DNS; flag the admin-install to the user | a heavy/accelerator backend serves many users over shared data | [shared.md](references/olares-chart-shared.md) |
 | deployment | **Version rules** | `apiVersion: v3`; `olaresManifest.version` always `0.12.0`; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`) | install rejects the manifest, or behavior differs by Olares version | [versioning.md](references/olares-chart-versioning.md) |
+| deployment | **Workloads / replicas** | `workloadReplicas` lists every Deployment/StatefulSet → count (required on 0.12.0); each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` + matching `values.yaml` | `lint` rejects a missing map, or suspend/resume / staged install silently no-op on a hardcoded `replicas` | [manifest.md](references/olares-chart-manifest.md) Workloads & replicas |
 | deployment | **Metadata** | stub OK for local deploy (`Utilities`, default icon) as long as `lint` passes; full `metadata.*` + listing images only when publishing to the Market | `lint` flags missing metadata, or you want a public listing | [manifest.md](references/olares-chart-manifest.md) §1 |
 | deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
 | deploy | **Deploy** | `market upload` + `market install`, then diagnose from logs — automatic after `lint` passes (login required) | proving the chart actually runs on the developer's Olares | [deploy.md](references/olares-chart-deploy.md) |

--- a/cli/skills/olares-chart/references/olares-chart-from-compose.md
+++ b/cli/skills/olares-chart/references/olares-chart-from-compose.md
@@ -41,8 +41,8 @@ olares-cli chart from-compose --name myapp -f base.yml -f override.yml      # me
 
 The command prints the absolute chart path and a reminder to refine + lint. Then inspect:
 
-- `OlaresManifest.yaml` — the stub you will refine (see [olares-chart-manifest.md](olares-chart-manifest.md); metadata can stay a stub for local deploy).
-- `templates/deployment-<app>.yaml` — the primary workload (renamed to the app name; required by lint).
+- `OlaresManifest.yaml` — the stub you will refine (see [olares-chart-manifest.md](olares-chart-manifest.md); metadata can stay a stub for local deploy). It already carries `workloadReplicas` for every rendered Deployment/StatefulSet plus the `olares` system dependency.
+- `templates/deployment-<app>.yaml` — the primary workload (renamed to the app name; required by lint). Its `spec.replicas` is wired to `{{ .Values.workloads.<name>.replicaCount }}` (seeded in `values.yaml`) so app-service can scale it for install / suspend / resume.
 - `templates/service-*.yaml` — exposed services; the entrance `host` points at one of these service names.
 - `templates/persistentvolumeclaim-*.yaml` — one per compose volume; **these are the storage decisions you must revisit** (most should become userspace volumes; PVCs belonging to a bundled db must be deleted along with that db's workload — see middleware below).
 
@@ -52,6 +52,7 @@ The command prints the absolute chart path and a reminder to refine + lint. Then
 - **`hostPath` / bind mounts** (`./dir:/path`) are dropped by kompose with a warning — the host path won't exist on Olares. Re-model these as userspace volumes.
 - **Bundled db/queue services** (`postgres`/`redis`/`mongodb`/`mysql`/`mariadb`/`minio`/`rabbitmq`/`nats`) come through as plain workloads. **Delete them and wire to system middleware** — do not keep them just because they render (see manifest §3; this is the default, not optional).
 - **`depends_on`, healthchecks, restart policies** don't all map 1:1; verify the rendered templates.
+- **Workloads you add by hand** (extra Deployments/StatefulSets beyond what kompose rendered) must each be added to `workloadReplicas`, get a `values.yaml` `workloads.<name>.replicaCount`, and wire `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — otherwise suspend/resume won't control them (see manifest Workloads & replicas).
 - The conversion **always passes `lint` as-is** but is not production-ready — the four refinement areas in the parent skill are mandatory before the app will run well. Metadata (§1) can stay a stub for local deploy; functional refine (§2–§4) is always required.
 
 ## Next step

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -9,6 +9,22 @@ The scaffolded manifest is a stub. The four areas below are what kompose cannot 
 
 `olaresManifest.version` (the manifest **schema**: always `0.12.0` for new apps) and the top-level `apiVersion` (skill sets **`v3`**) are separate axes from the chart/app versions. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The full schema description, the version-field map, and the `type: system` dependency are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
 
+## Workloads & replicas (required on 0.12.0)
+
+On `0.12.0` the manifest **must** declare a top-level `workloadReplicas` map — one entry per **Deployment / StatefulSet** the chart renders → its replica count (`lint` rejects a modern non-v2 manifest that omits it). `from-compose` scaffolds this for you; you only touch it when you add or rename workloads.
+
+```yaml
+workloadReplicas:
+  myapp: 1          # every Deployment/StatefulSet name must appear here
+  worker: 1
+```
+
+Three rules that bite:
+
+- **Key = rendered workload name.** Each key must equal the rendered `metadata.name` of a Deployment/StatefulSet. **DaemonSets are excluded** (they are one-per-node, not replica-controlled).
+- **Template wiring contract.** Every listed workload's `spec.replicas` **must** be `{{ .Values.workloads.<name>.replicaCount }}`, and `values.yaml` must carry a matching `workloads.<name>.replicaCount`. The `.Values.workloads.*` value is documented in [olares-chart-system-values.md](olares-chart-system-values.md).
+- **Why it matters (non-obvious).** app-service drives the whole lifecycle through this Helm value: install is two-phase (helm renders at `replicas: 0`, then scales up), suspend scales every listed workload to `0`, resume scales back to the declared counts. If a template **hardcodes** `replicas`, `lint` may still pass but **suspend/resume and the staged install silently stop working** — the value override has nothing to drive. `from-compose` already wires the scaffolded workloads; any workload you add by hand must be wired the same way.
+
 ## 1. Metadata
 
 For deploying to your own Olares, metadata can stay a stub as long as `lint` passes. Full market-ready metadata (custom icon, dual-version categories, listing images, marketing spec) is only needed when **publishing to the public Market** — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).

--- a/cli/skills/olares-chart/references/olares-chart-system-values.md
+++ b/cli/skills/olares-chart/references/olares-chart-system-values.md
@@ -35,7 +35,7 @@ Populated in `BuildBaseHelmValues` for every install (mostly from app-service's 
 | `.Values.downloadCdnURL` | system CDN base (`OLARES_SYSTEM_CDN_SERVICE`) | URL |
 | `.Values.fs_type` | rootfs type (`OLARES_SYSTEM_ROOTFS_TYPE`) | `fs` (default, local) \| `jfs` (JuiceFS) — templates branch on `{{ if eq (.Values.fs_type \| default "fs") "jfs" }}` |
 | `.Values.sharedlib` | External storage base path (`/Files/External/<deviceName>/`) — the External area in [platform.md](../../olares-shared/references/olares-platform.md) (storage model) | path |
-| `.Values.workloads.<name>.replicaCount` | per-workload replica count; only when the manifest declares `WorkloadReplicas` | integer |
+| `.Values.workloads.<name>.replicaCount` | per-workload replica count; present whenever the manifest declares `workloadReplicas` (required on 0.12.0). Each listed Deployment/StatefulSet **must** wire `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — app-service overrides this value for install (staged at 0) and suspend/resume, so a hardcoded `replicas` makes those operations inert. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas). | integer |
 
 ```yaml
         env:

--- a/cli/skills/olares-chart/references/olares-chart-versioning.md
+++ b/cli/skills/olares-chart/references/olares-chart-versioning.md
@@ -57,6 +57,7 @@ A chart carries several "version" fields with different jobs and different rules
 - **Resource envelope** lives under `spec.resources[]` / `spec.accelerator[]` (mode-keyed: `cpu`, `nvidia`, ...), not the legacy flat `spec.requiredCpu` / `requiredMemory` / ... fields.
 - **GPU / accelerator** is declared via `spec.accelerator` with a mode → arch cross-check at `lint`.
 - **`permission.externalData`** (`.Values.sharedlib`) is supported.
+- **`workloadReplicas` is required** (non-v2): a map of every Deployment/StatefulSet → replica count, with each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}`. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas).
 
 Accelerator mode declaration and sizing are in [olares-chart-accelerator.md](olares-chart-accelerator.md).
 

--- a/cli/skills/olares-chart/references/olares-chart-workflow.md
+++ b/cli/skills/olares-chart/references/olares-chart-workflow.md
@@ -51,6 +51,6 @@ Step D1 produces a chart that **already passes `lint`** but is NOT yet a good ap
 - Default CPU/memory requests+limits are stamped onto every container.
 - One **entrance** is auto-detected (the `olares.service.type: Entrance`-labeled service, else the first service with a port, else a `port: 80` placeholder).
 - `olaresManifest.version` is always `0.12.0` (resources under `spec.accelerator`) — see [olares-chart-manifest.md](olares-chart-manifest.md).
-- For 0.12.0, the scaffold also emits `workloadReplicas.<workload>: 1` (with the matching `values.yaml` `workloads.<name>.replicaCount`) and the required `options.dependencies` `olares >=1.12.6-0` (`type: system`), so a fresh scaffold passes `lint`.
+- For 0.12.0, the scaffold also emits `workloadReplicas.<workload>: 1` (with the matching `values.yaml` `workloads.<name>.replicaCount`, and each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` so suspend/resume work) plus the required `options.dependencies` `olares >=1.12.6-0` (`type: system`), so a fresh scaffold passes `lint`.
 
 > **Tip:** label the service you want exposed in the compose file with `labels: { olares.service.type: Entrance }` so the right workload becomes the entrance and gets renamed to the app name.


### PR DESCRIPTION
## Summary

- `from-compose` already emits `workloadReplicas` + matching `values.yaml` on the 0.12.0 schema (#3495), but the kompose-generated Deployment/StatefulSet templates hardcoded `replicas: 1`. The scaffolder now rewrites each workload's `spec.replicas` to `{{ .Values.workloads.<name>.replicaCount }}`.
- This matters because app-service drives the whole lifecycle through that Helm value — install is staged (`replicas: 0` then scale up), suspend = `Scale(0)`, resume = `Scale(-1)` (`framework/app-service/pkg/appinstaller/helm_ops_scale.go`, `pkg/appstate/{installing,suspending,resuming}_app.go`). A hardcoded `replicas` passes `lint` but makes those scale operations inert.
- The `olares-chart` skill gains an explicit `workloadReplicas` rule: the required manifest field, the template-wiring contract (`spec.replicas` + `values.yaml` `workloads.<name>.replicaCount`), the key-equals-rendered-workload-name / DaemonSet-excluded rules, and the suspend/resume consequence. Updated across `manifest.md`, `system-values.md`, `versioning.md`, `from-compose.md`, `workflow.md`, and the SKILL decision table.
- `olares-chart` skill version bumped 4.6.0 -> 4.7.0.

## Test plan

- [x] `go build ./...` and `go vet ./pkg/chart/... ./cmd/ctl/chart/...` pass
- [x] `from-compose` renders `replicas: {{ .Values.workloads.<name>.replicaCount }}` for every Deployment/StatefulSet, with matching `values.yaml`
- [x] `chart lint` returns `OK` on a fresh single-service and multi-service scaffold
- [ ] On a real Olares >= 1.12.6, confirm a scaffolded app suspends (scales to 0) and resumes correctly

Made with [Cursor](https://cursor.com)