### PR TITLE
fix(backup): file restore path trailing slash & push canceled event when task exists

### DIFF
--- a/framework/backup-server/pkg/modules/backup/v1/model.go
+++ b/framework/backup-server/pkg/modules/backup/v1/model.go
@@ -599,7 +599,7 @@ func parseResponseRestoreDetailFromBackupUrl(restore *sysv1.Restore) (*ResponseR
 
 	restoreFullPath := filepath.Join(restorePath, subPath)
 	if backupType == constant.BackupTypeFile {
-		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp))
+		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp)) + "/"
 	}
 
 	result = &ResponseRestoreDetail{

--- a/framework/backup-server/pkg/worker/worker.go
+++ b/framework/backup-server/pkg/worker/worker.go
@@ -240,6 +240,7 @@ func (w *WorkerPool) ExistsTask(owner string, backupId, snapshotId string) error
 	})
 
 	if snapshotExists {
+		w.sendBackupCanceledEvent(owner, backupId, snapshotId, constant.MessageTaskExists)
 		return fmt.Errorf(constant.MessageTaskExists)
 	}
 
@@ -276,7 +277,7 @@ func (w *WorkerPool) CancelBackup(owner, backupId string) {
 	if activeTask != nil && *activeTask != nil {
 		backupTask := (*activeTask).(*BackupTask)
 		if backupTask.backupId == backupId {
-			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId, "")
 			backupTask.BaseTask.cancel()
 		}
 	}
@@ -312,7 +313,7 @@ func (w *WorkerPool) CancelSnapshot(owner, snapshotId string) {
 	if activeTask != nil && *activeTask != nil {
 		backupTask := (*activeTask).(*BackupTask)
 		if backupTask.snapshotId == snapshotId {
-			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId, "")
 			backupTask.BaseTask.cancel()
 		}
 	}
@@ -355,14 +356,14 @@ func (w *WorkerPool) CancelRestore(owner, restoreId string) {
 	}
 }
 
-func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snapshotId string) {
+func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snapshotId string, message string) {
 	var data = map[string]interface{}{
 		"id":       snapshotId,
 		"type":     constant.MessageTypeBackup,
 		"backupId": backupId,
 		"endat":    time.Now().Unix(),
 		"status":   constant.Canceled.String(),
-		"message":  "",
+		"message":  message,
 	}
 	notification.DataSender.Send(owner, data)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

Two fixes in the backup module.

## Changes

1. **`pkg/modules/backup/v1/model.go`** — `parseResponseRestoreDetailFromBackupUrl`
   - When `backupType == constant.BackupTypeFile`, `restoreFullPath` must end with a trailing `/`.
   - Since `filepath.Join` strips the trailing `/`, we explicitly append `/` for the file-type path.

2. **`pkg/worker/worker.go`** — `sendBackupCanceledEvent` / `ExistsTask`
   - Added a `message string` parameter to `sendBackupCanceledEvent`; the event's `message` field now uses this parameter.
   - In `ExistsTask`, when an existing task is detected, push a canceled event carrying the `constant.MessageTaskExists` message before returning the error.
   - The other call sites (`CancelBackup`, `CancelSnapshot`) pass an empty string as the last argument.

## Verification

- `go build ./pkg/worker/... ./pkg/modules/backup/...` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af717c2-ca08-460e-8c96-6e7e945b85ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af717c2-ca08-460e-8c96-6e7e945b85ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

