### PR TITLE
fix: verify workload replicas are sourced from values.yaml

### DIFF
--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -631,12 +631,17 @@ func (c *OAC) checkAllowMultipleInstall(oacPath string, m Manifest, sc ownerScen
 	return errors.Join(errs...)
 }
 
-// checkWorkloadReplicaValues verifies that values.yaml declares a
-// workloads.<name>.replicaCount entry for every workload named in
-// workloadReplicas. This mirrors the install-time convention that each
-// workload's replica count is driven from .Values.workloads.<name>.replicaCount,
-// so a missing entry would render the manifest's workloadReplicas value
-// unusable.
+// checkWorkloadReplicaValues verifies the two halves of the workloadReplicas
+// install convention:
+//
+//  1. values.yaml declares a workloads.<name>.replicaCount entry for every
+//     workload named in workloadReplicas, and
+//  2. every Deployment/StatefulSet template that sets spec.replicas sources the
+//     value from .Values.workloads.<name>.replicaCount (see
+//     checkWorkloadReplicaTemplates) rather than hardcoding it.
+//
+// Together they ensure the manifest's workloadReplicas value is actually
+// honoured at install time instead of being silently ignored.
 func checkWorkloadReplicaValues(oacPath string, replicas map[string]int32) error {
 	data, err := os.ReadFile(filepath.Join(oacPath, "values.yaml"))
 	if err != nil {
@@ -663,6 +668,9 @@ func checkWorkloadReplicaValues(oacPath string, replicas map[string]int32) error
 		if _, ok := wl["replicaCount"]; !ok {
 			errs = append(errs, fmt.Errorf("values.yaml must define workloads.%s.replicaCount", name))
 		}
+	}
+	if err := checkWorkloadReplicaTemplates(oacPath, replicas); err != nil {
+		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
 }

--- a/framework/oac/chartscan.go
+++ b/framework/oac/chartscan.go
@@ -2,6 +2,7 @@ package oac
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,24 @@ import (
 // chart files. v3 apps must reference app envs via .Values.olaresEnv.<envName>
 // instead of inlining OLARES_USER_* names in templates or values.yaml.
 var olaresUserChartRef = regexp.MustCompile(`\bOLARES_USER`)
+
+var (
+	// workloadReplicaCountDotRef matches the canonical replica-count reference
+	// {{ .Values.workloads.<name>.replicaCount }}.
+	workloadReplicaCountDotRef = regexp.MustCompile(`\.Values\.workloads\.([A-Za-z0-9_]+)\.replicaCount`)
+	// workloadReplicaCountIndexRef matches the index spelling
+	// {{ (index .Values.workloads "<name>").replicaCount }}, which is required
+	// when <name> contains characters (e.g. a hyphen) the dot accessor cannot
+	// express.
+	workloadReplicaCountIndexRef = regexp.MustCompile(`index\s+\.Values\.workloads\s+"([^"]+)"\s*\)\s*\.replicaCount`)
+
+	// workloadKindLine matches a `kind: Deployment` / `kind: StatefulSet` line.
+	workloadKindLine = regexp.MustCompile(`^\s*kind:\s*["']?(Deployment|StatefulSet)["']?\s*$`)
+	// replicasFieldLine matches a `replicas: <value>` line and captures the value.
+	replicasFieldLine = regexp.MustCompile(`^\s*replicas:\s*(\S.*?)\s*$`)
+	// yamlDocSeparator splits a multi-document YAML file on `---` lines.
+	yamlDocSeparator = regexp.MustCompile(`(?m)^---\s*$`)
+)
 
 func isChartYAMLFile(path string) bool {
 	lower := strings.ToLower(path)
@@ -103,4 +122,128 @@ func checkV3OLARESUserInChart(oacPath string) error {
 		)
 	}
 	return nil
+}
+
+// isUnderTemplatesDir reports whether path has a "templates" path segment, i.e.
+// the file is a chart template. This intentionally matches nested layouts
+// (templates/web/deployment.yaml) and subchart templates, not just files whose
+// immediate parent is templates/.
+func isUnderTemplatesDir(path string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == "templates" {
+			return true
+		}
+	}
+	return false
+}
+
+// checkWorkloadReplicaTemplates verifies that every Deployment/StatefulSet
+// template under oacPath that declares spec.replicas sources the value from
+// .Values.workloads.<name>.replicaCount, where <name> is a key declared in the
+// manifest's workloadReplicas map.
+//
+// It complements checkWorkloadReplicaValues: that function guarantees
+// values.yaml carries each workloads.<name>.replicaCount default, while this
+// one guarantees the templates actually consume it instead of hardcoding a
+// replica count. Documents that omit replicas: are left to helm's default and
+// to the rendered-name correspondence check.
+func checkWorkloadReplicaTemplates(oacPath string, replicas map[string]int32) error {
+	root := oacPath
+	if !strings.HasSuffix(root, string(filepath.Separator)) {
+		root += string(filepath.Separator)
+	}
+	var errs []error
+	walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info == nil || info.IsDir() || !isUnderTemplatesDir(path) || !isChartYAMLFile(path) {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("read %s: %w", path, readErr)
+		}
+		rel, relErr := filepath.Rel(oacPath, path)
+		if relErr != nil {
+			rel = filepath.Base(path)
+		}
+		errs = append(errs, scanWorkloadReplicaDoc(rel, string(data), replicas)...)
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	return errors.Join(errs...)
+}
+
+// scanWorkloadReplicaDoc splits content into YAML documents and returns one
+// error per Deployment/StatefulSet document whose replicas: field is hardcoded
+// (or otherwise not a .Values.workloads.<name>.replicaCount reference) or whose
+// reference names a workload absent from replicas. rel is the chart-relative
+// path used in error messages.
+func scanWorkloadReplicaDoc(rel, content string, replicas map[string]int32) []error {
+	var errs []error
+	for _, doc := range yamlDocSeparator.Split(content, -1) {
+		if !isWorkloadDoc(doc) {
+			continue
+		}
+		value, ok := findReplicasValue(doc)
+		if !ok {
+			continue
+		}
+		name, matched := workloadReplicaRefName(value)
+		if !matched {
+			errs = append(errs, fmt.Errorf(
+				"%s: Deployment/StatefulSet spec.replicas is set to %q; it must reference .Values.workloads.<name>.replicaCount so the replica count is sourced from values.yaml",
+				rel, value,
+			))
+			continue
+		}
+		if _, ok := replicas[name]; !ok {
+			errs = append(errs, fmt.Errorf(
+				"%s: spec.replicas references .Values.workloads.%s.replicaCount, but %q is not declared in workloadReplicas",
+				rel, name, name,
+			))
+		}
+	}
+	return errs
+}
+
+// isWorkloadDoc reports whether a YAML document declares a Deployment or
+// StatefulSet kind.
+func isWorkloadDoc(doc string) bool {
+	for _, line := range strings.Split(doc, "\n") {
+		if workloadKindLine.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// findReplicasValue returns the value of the first non-comment `replicas:` line
+// in doc. Deployments and StatefulSets carry exactly one such field (spec.replicas).
+func findReplicasValue(doc string) (string, bool) {
+	for _, line := range strings.Split(doc, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if m := replicasFieldLine.FindStringSubmatch(line); m != nil {
+			return strings.TrimSpace(m[1]), true
+		}
+	}
+	return "", false
+}
+
+// workloadReplicaRefName extracts the workload name from a replicas value that
+// references .Values.workloads.<name>.replicaCount in either the dot or index
+// spelling. It returns false when value is not such a reference.
+func workloadReplicaRefName(value string) (string, bool) {
+	if m := workloadReplicaCountDotRef.FindStringSubmatch(value); m != nil {
+		return m[1], true
+	}
+	if m := workloadReplicaCountIndexRef.FindStringSubmatch(value); m != nil {
+		return m[1], true
+	}
+	return "", false
 }

--- a/framework/oac/scripts/repair_terminus_apps_phase2.py
+++ b/framework/oac/scripts/repair_terminus_apps_phase2.py
@@ -7,7 +7,6 @@ Fixes applied per app (when applicable):
   X  permission.externalData: true when templates reference .Values.sharedlib
   M  middleware workloadReplicas + values.yaml (metadata.name)
   L  legacy spec resource envelope for olaresManifest.version < 0.12.0
-  E  envName starting with OLARES_USER_ renamed to app-local names
 """
 
 from __future__ import annotations
@@ -362,16 +361,6 @@ def repair_app(app_dir: Path) -> List[str]:
             if ok:
                 applied.append("L")
                 manifest_changed = True
-
-    if data is not None:
-        if fix_olares_user_env_names_struct(data):
-            applied.append("E")
-            manifest_changed = True
-    else:
-        text, ok = fix_olares_user_env_names_regex(text)
-        if ok:
-            applied.append("E")
-            manifest_changed = True
 
     if manifest_changed:
         if data is not None:

--- a/framework/oac/scripts/repair_terminus_apps_phase3.py
+++ b/framework/oac/scripts/repair_terminus_apps_phase3.py
@@ -11,24 +11,6 @@ from typing import List, Optional, Tuple
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTDATA = REPO_ROOT / "testdata" / "terminus-apps"
 
-# Apps that need template OLARES_USER -> olaresEnv renames after envName fixes.
-TEMPLATE_ENV_FIXES = {
-    "fireflyiii": [
-        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
-    ],
-    "freshrss": [
-        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
-    ],
-    "ntfy": [
-        (r"\.Values\.olaresEnv\.OLARES_USER_TIMEZONE", ".Values.olaresEnv.APP_TIMEZONE"),
-    ],
-    "openwebui": [
-        (r"\.Values\.olaresEnv\.OLARES_USER_HUGGINGFACE_SERVICE", ".Values.olaresEnv.HF_ENDPOINT"),
-        (r"\.Values\.olaresEnv\.OLARES_USER_HUGGINGFACE_TOKEN", ".Values.olaresEnv.HF_TOKEN"),
-    ],
-}
-
-
 def manifest_version(text: str) -> str:
     m = re.search(r"^olaresManifest\.version:\s*['\"]?([^'\"\n]+)", text, flags=re.MULTILINE)
     return m.group(1).strip() if m else ""
@@ -93,24 +75,6 @@ def add_spec_only_admin(text: str) -> Tuple[str, bool]:
     return text[:insert_at] + "\n  onlyAdmin: true" + text[insert_at:], True
 
 
-def fix_templates(app_dir: Path, app_name: str) -> bool:
-    fixes = TEMPLATE_ENV_FIXES.get(app_name)
-    if not fixes:
-        return False
-    changed = False
-    for p in app_dir.rglob("*"):
-        if not p.is_file() or p.suffix not in {".yaml", ".yml", ".tpl"}:
-            continue
-        text = p.read_text()
-        new = text
-        for old, new_val in fixes:
-            new = re.sub(old, new_val, new)
-        if new != text:
-            p.write_text(new)
-            changed = True
-    return changed
-
-
 def fix_nofx_deployment(app_dir: Path) -> bool:
     dep = app_dir / "templates" / "nofx" / "deployment.yaml"
     if not dep.exists():
@@ -164,9 +128,6 @@ def repair_app(app_dir: Path) -> List[str]:
 
     if applied and any(t in applied for t in ("X-", "A-", "D", "O")):
         manifest.write_text(text)
-
-    if fix_templates(app_dir, app_dir.name):
-        applied.append("T")
 
     if app_dir.name == "nofx" and fix_nofx_deployment(app_dir):
         applied.append("N")

--- a/framework/oac/scripts/wire_workload_replicas.py
+++ b/framework/oac/scripts/wire_workload_replicas.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Wire Deployment/StatefulSet spec.replicas to .Values.workloads.<name>.replicaCount.
+
+For every app under testdata/terminus-apps that declares workloadReplicas in
+OlaresManifest.yaml, find matching workloads in chart templates and replace
+hard-coded replica counts with the values.yaml indirection used by jellyfin
+and acestep15v3:
+
+  workloads:
+    jellyfin:
+      replicaCount: 1
+
+  spec:
+    replicas: {{ .Values.workloads.jellyfin.replicaCount }}
+
+A workload matches when its Deployment/StatefulSet metadata.name equals a
+workloadReplicas key, or when metadata.name is templated on
+{{ .Release.Name }} and the app directory name is listed in workloadReplicas.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTDATA = REPO_ROOT / "testdata" / "terminus-apps"
+
+RELEASE_NAME_RES = [
+    re.compile(r"^\s*name:\s*\{\{\s*\.Release\.Name\s*\}\}\s*$"),
+    re.compile(r'^\s*name:\s*["\']?\{\{\s*\.Release\.Name\s*\}\}["\']?\s*$'),
+]
+
+REPLICAS_ALREADY = re.compile(r"\.Values\.workloads\.")
+
+
+def parse_workload_replicas(manifest: Path) -> Dict[str, int]:
+    text = manifest.read_text()
+    if not re.search(r"^workloadReplicas:\s*$", text, flags=re.MULTILINE):
+        return {}
+    out: Dict[str, int] = {}
+    m = re.search(r"^workloadReplicas:\s*$", text, flags=re.MULTILINE)
+    for line in text[m.end() :].splitlines():
+        if line.strip() and not line.startswith(" "):
+            break
+        mm = re.match(r"^\s+([A-Za-z0-9_-]+):\s*(\d+)\s*$", line)
+        if mm:
+            out[mm.group(1)] = int(mm.group(2))
+    return out
+
+
+def split_yaml_docs(content: str) -> List[str]:
+    docs: List[str] = []
+    current: List[str] = []
+    for line in content.splitlines(keepends=True):
+        if line.strip() == "---":
+            if current:
+                docs.append("".join(current))
+                current = []
+            continue
+        current.append(line)
+    if current:
+        docs.append("".join(current))
+    return docs if docs else [content]
+
+
+def doc_kind(doc: str) -> Optional[str]:
+    m = re.search(r"^kind:\s*(\S+)\s*$", doc, flags=re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def doc_metadata_name(doc: str) -> Optional[str]:
+    # metadata.name may appear anywhere under metadata:
+    m = re.search(r"^metadata:\s*$", doc, flags=re.MULTILINE)
+    if not m:
+        return None
+    # scan until next top-level key (no leading whitespace) after metadata block
+    lines = doc[m.end() :].splitlines()
+    for line in lines:
+        if line and not line.startswith(" ") and not line.startswith("\t"):
+            break
+        mm = re.match(r"^\s+name:\s*(.+?)\s*$", line)
+        if mm:
+            val = mm.group(1).strip().strip("'\"")
+            return val
+    return None
+
+
+def is_release_name_template(name_line_value: str, raw_line: str) -> bool:
+    if "Release.Name" in raw_line or "Release.Name" in name_line_value:
+        return True
+    return False
+
+
+def resolve_workload_key(
+    doc: str, name: Optional[str], workloads: Dict[str, int], app_name: str
+) -> Optional[str]:
+    if not name:
+        return None
+    # Find the raw metadata name line for template detection.
+    raw = None
+    for line in doc.splitlines():
+        mm = re.match(r"^\s+name:\s*(.+?)\s*$", line)
+        if mm and mm.group(1).strip().strip("'\"") == name:
+            raw = line
+            break
+        if mm and "Release.Name" in line:
+            raw = line
+            break
+
+    if raw and is_release_name_template(name, raw):
+        if app_name in workloads:
+            return app_name
+        return None
+
+    if name in workloads:
+        return name
+
+    # Strip quotes from templated literal names.
+    if name in workloads:
+        return name
+
+    return None
+
+
+def replace_spec_replicas(doc: str, workload_key: str) -> Tuple[str, bool]:
+    target = f".Values.workloads.{workload_key}.replicaCount"
+    if target in doc:
+        return doc, False
+
+    # Replace the first replicas: under spec: (Deployment/StatefulSet level).
+    lines = doc.splitlines(keepends=True)
+    in_spec = False
+    spec_indent: Optional[int] = None
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if re.match(r"^spec:\s*$", stripped):
+            in_spec = True
+            spec_indent = indent
+            continue
+        if not in_spec:
+            continue
+        # Left spec block when dedented past spec.
+        if stripped and indent <= (spec_indent or 0):
+            break
+        mm = re.match(r"^(\s*)replicas:\s*(.+?)\s*$", line)
+        if mm and indent == (spec_indent or 0) + 2:
+            repl = f'{mm.group(1)}replicas: {{ {{ .Values.workloads.{workload_key}.replicaCount }} }}\n'
+            # fix double braces from f-string
+            repl_indent = mm.group(1)
+            if "-" in workload_key:
+                repl = f'{repl_indent}replicas: {{{{ (index .Values.workloads "{workload_key}").replicaCount }}}}\n'
+            else:
+                repl = f"{repl_indent}replicas: {{{{ .Values.workloads.{workload_key}.replicaCount }}}}\n"
+            if lines[i] != repl:
+                lines[i] = repl
+                return "".join(lines), True
+            return doc, False
+    return doc, False
+
+
+def patch_template_file(path: Path, workloads: Dict[str, int], app_name: str) -> List[str]:
+    content = path.read_text()
+    docs = split_yaml_docs(content)
+    changed_keys: List[str] = []
+    new_docs: List[str] = []
+    file_changed = False
+
+    for doc in docs:
+        kind = doc_kind(doc)
+        if kind not in {"Deployment", "StatefulSet"}:
+            new_docs.append(doc)
+            continue
+        name = doc_metadata_name(doc)
+        key = resolve_workload_key(doc, name, workloads, app_name)
+        if not key:
+            new_docs.append(doc)
+            continue
+        patched, ok = replace_spec_replicas(doc, key)
+        new_docs.append(patched)
+        if ok:
+            changed_keys.append(key)
+            file_changed = True
+
+    if not file_changed:
+        return []
+
+    # Reassemble with --- separators preserved.
+    out_parts: List[str] = []
+    for idx, doc in enumerate(new_docs):
+        if idx > 0 and not doc.startswith("---"):
+            # Original had --- between docs; rebuild conservatively.
+            out_parts.append("---\n")
+        out_parts.append(doc)
+    path.write_text("".join(out_parts))
+    return changed_keys
+
+
+def ensure_values_workloads(values_path: Path, workloads: Dict[str, int]) -> bool:
+    text = values_path.read_text() if values_path.exists() else ""
+    changed = False
+    lines = text.splitlines()
+    existing: Dict[str, bool] = {}
+    for w in workloads:
+        pat = re.compile(rf"^\s{re.escape(w)}:\s*$")
+        if any(pat.match(l) for l in lines if "workloads:" in text):
+            # deeper check below
+            pass
+
+    # Simple append-if-missing using ruamel-free text edit.
+    if "workloads:" not in text:
+        block = "workloads:\n" + "\n".join(
+            f"  {k}:\n    replicaCount: {v}" for k, v in sorted(workloads.items())
+        )
+        text = text.rstrip() + "\n\n" + block + "\n"
+        values_path.write_text(text)
+        return True
+
+    for w, count in workloads.items():
+        if re.search(rf"^\s{re.escape(w)}:\s*$", text, flags=re.MULTILINE):
+            if not re.search(
+                rf"^\s{re.escape(w)}:\s*\n\s+replicaCount:\s*{count}\s*$",
+                text,
+                flags=re.MULTILINE,
+            ):
+                # workload key exists; leave as-is unless replicaCount missing entirely
+                if not re.search(
+                    rf"^\s{re.escape(w)}:\s*\n\s+replicaCount:",
+                    text,
+                    flags=re.MULTILINE,
+                ):
+                    text = re.sub(
+                        rf"(^\s{re.escape(w)}:\s*\n)",
+                        rf"\1    replicaCount: {count}\n",
+                        text,
+                        count=1,
+                        flags=re.MULTILINE,
+                    )
+                    changed = True
+        else:
+            insert = f"  {w}:\n    replicaCount: {count}\n"
+            text = re.sub(
+                r"(^workloads:\s*\n)",
+                r"\1" + insert,
+                text,
+                count=1,
+                flags=re.MULTILINE,
+            )
+            changed = True
+
+    if changed:
+        values_path.write_text(text)
+    return changed
+
+
+def process_app(app_dir: Path) -> Tuple[List[str], List[str]]:
+    manifest = app_dir / "OlaresManifest.yaml"
+    if not manifest.exists():
+        return [], []
+    workloads = parse_workload_replicas(manifest)
+    if not workloads:
+        return [], []
+
+    values = app_dir / "values.yaml"
+    ensure_values_workloads(values, workloads)
+
+    templates_dir = app_dir / "templates"
+    if not templates_dir.is_dir():
+        return [], list(workloads.keys())
+
+    changed_files: List[str] = []
+    missing: List[str] = list(workloads.keys())
+
+    for tpl in sorted(templates_dir.rglob("*")):
+        if not tpl.is_file():
+            continue
+        if tpl.suffix not in {".yaml", ".yml", ".tpl"}:
+            continue
+        # Treat workloads already wired via .Values.workloads as matched.
+        try:
+            tpl_text = tpl.read_text()
+        except OSError:
+            continue
+        for w in list(missing):
+            if f".Values.workloads.{w}.replicaCount" in tpl_text or f'workloads "{w}"' in tpl_text:
+                missing.remove(w)
+            elif f'(index .Values.workloads "{w}")' in tpl_text:
+                missing.remove(w)
+        keys = patch_template_file(tpl, workloads, app_dir.name)
+        if keys:
+            changed_files.append(str(tpl.relative_to(app_dir)))
+            for k in keys:
+                if k in missing:
+                    missing.remove(k)
+
+    return changed_files, missing
+
+
+def main() -> int:
+    summary = {"apps": 0, "files": 0, "missing": 0}
+    for app_dir in sorted(TESTDATA.iterdir()):
+        if not app_dir.is_dir() or app_dir.name.startswith("."):
+            continue
+        changed, missing = process_app(app_dir)
+        if not changed and not missing:
+            continue
+        if changed:
+            summary["apps"] += 1
+            summary["files"] += len(changed)
+            print(f"{app_dir.name}: {', '.join(changed)}")
+        if missing:
+            summary["missing"] += len(missing)
+            print(f"  ! unmatched workloadReplicas keys: {', '.join(missing)}")
+
+    print(
+        f"\nupdated {summary['apps']} app(s), {summary['files']} template file(s); "
+        f"{summary['missing']} workload key(s) still unmatched"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/oac/v3_envs_test.go
+++ b/framework/oac/v3_envs_test.go
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   name: v3env
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.v3env.replicaCount }}
   selector:
     matchLabels:
       app: v3env

--- a/framework/oac/workloadrefs_internal_test.go
+++ b/framework/oac/workloadrefs_internal_test.go
@@ -16,6 +16,128 @@ func writeValues(t *testing.T, body string) string {
 	return dir
 }
 
+// writeTemplateFile writes name under dir/templates, creating the directory.
+func writeTemplateFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	tpl := filepath.Join(dir, "templates")
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(tpl, name)), 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tpl, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write template %s: %v", name, err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.workloads.web.replicaCount }}
+`)
+	if err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1}); err != nil {
+		t.Fatalf("valid replicas reference must pass: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_IndexForm(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "sts.yaml", `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  replicas: {{ (index .Values.workloads "my-redis").replicaCount }}
+`)
+	if err := checkWorkloadReplicaTemplates(dir, map[string]int32{"my-redis": 1}); err != nil {
+		t.Fatalf("index-form replicas reference must pass: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_Hardcoded(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+`)
+	err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1})
+	if err == nil {
+		t.Fatal("expected error for hardcoded spec.replicas")
+	}
+	if !strings.Contains(err.Error(), "must reference .Values.workloads") {
+		t.Fatalf("error should explain the values requirement, got: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_UnknownWorkload(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: {{ .Values.workloads.ghost.replicaCount }}
+`)
+	err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1})
+	if err == nil {
+		t.Fatal("expected error when referenced workload is not in workloadReplicas")
+	}
+	if !strings.Contains(err.Error(), "not declared in workloadReplicas") {
+		t.Fatalf("error should flag the unknown workload, got: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_NoReplicasFieldOK(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+`)
+	if err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1}); err != nil {
+		t.Fatalf("a workload without spec.replicas must pass: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_NonWorkloadIgnored(t *testing.T) {
+	dir := t.TempDir()
+	// A bare replicas: in a non-workload doc must not be flagged.
+	writeTemplateFile(t, dir, "other.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+data:
+  replicas: "3"
+`)
+	if err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1}); err != nil {
+		t.Fatalf("non-workload replicas must be ignored: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicaTemplates_NestedTemplate(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "web/deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+`)
+	err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1})
+	if err == nil {
+		t.Fatal("expected error for hardcoded replicas in a nested template")
+	}
+}
+
 func TestCheckWorkloadReplicaValues_AllPresent(t *testing.T) {
 	dir := writeValues(t, `
 workloads:


### PR DESCRIPTION

* **Background**
Extend checkWorkloadReplicaValues with checkWorkloadReplicaTemplates, which scans Deployment/StatefulSet templates and rejects any spec.replicas that is hardcoded instead of referencing .Values.workloads.<name>.replicaCount (both the dot and `index ... "name"` spellings), or that names a workload missing from workloadReplicas. Add internal tests covering valid/index/hardcoded/ unknown/no-replicas/non-workload/nested cases.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mandatory lint now fails charts that declare `workloadReplicas` but hardcode replicas, which can break CI until charts are updated; validation is regex-based on template text rather than full YAML/Helm parsing.
> 
> **Overview**
> OAC lint now enforces the **template** side of the `workloadReplicas` convention, not only `values.yaml` defaults. **`checkWorkloadReplicaValues`** still requires `workloads.<name>.replicaCount` for every manifest key, and it also calls new **`checkWorkloadReplicaTemplates`**, which walks chart templates and fails when a Deployment/StatefulSet sets `spec.replicas` to a literal or any expression that is not `.Values.workloads.<name>.replicaCount` (dot or `index` form for hyphenated names), or when the referenced workload is missing from `workloadReplicas`. Workloads without `replicas:` and non-workload YAML are left alone.
> 
> Supporting changes add **internal tests** for valid, index, hardcoded, unknown workload, and nested template paths; the v3 env fixture deployment now uses the values indirection. A new **`wire_workload_replicas.py`** bulk-rewires `testdata/terminus-apps` templates (and fills missing values entries), and the phase-2/phase-3 repair scripts drop the **`OLARES_USER_*` env rename** and per-app template env fix steps that those scripts used to perform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643eb89eddba653781d0046ee3dfac90fad4a76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->