### PR TITLE
fix(daemon): make olaresd aware of upgrade-triggered reboot

### DIFF
--- a/cli/pkg/daemon/state/constants.go
+++ b/cli/pkg/daemon/state/constants.go
@@ -30,6 +30,22 @@ const (
 	InProgress ProcessingState = "in-progress"
 )
 
+const (
+	// UpgradeRebootMarkFile is a tmpfs marker written by olares-cli when an
+	// upgrade has determined a reboot is required, before it flips the
+	// OlaresVersion CR to the target version. While this marker exists,
+	// olaresd keeps reporting the system as Upgrading (with the upgrade step
+	// set to UpgradeStepRebooting) instead of briefly reporting the upgrade
+	// as complete during the window between the version flip and the actual
+	// reboot. Being under /run (tmpfs), it is cleared automatically once the
+	// machine reboots.
+	UpgradeRebootMarkFile = "/run/olares-upgrade-rebooting"
+
+	// UpgradeStepRebooting is the UpgradingStep value reported while a
+	// post-upgrade reboot is pending.
+	UpgradeStepRebooting = "Rebooting"
+)
+
 // TerminusState is the high-level state machine value for the Olares
 // system as observed from this node. Use Describe() to obtain a
 // human-readable, one-line summary suitable for end-user output.

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -22,6 +22,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/core/util"
+	clistate "github.com/beclab/Olares/cli/pkg/daemon/state"
 	"github.com/beclab/Olares/cli/pkg/gpu"
 	"github.com/beclab/Olares/cli/pkg/images"
 	"github.com/beclab/Olares/cli/pkg/k3s"
@@ -408,6 +409,17 @@ func (a *upgradeGPUDriverIfNeeded) Execute(runtime connector.Runtime) error {
 
 	needReboot := changed || (status != nil && status.Mismatch)
 	a.PipelineCache.Set(cacheRebootNeeded, needReboot)
+	if needReboot {
+		// Drop a tmpfs marker now, before the OlaresVersion CR is flipped in
+		// the next task. While it exists, olaresd keeps reporting the system
+		// as upgrading-and-rebooting instead of briefly reporting the upgrade
+		// as complete during the window between the version flip and the
+		// actual reboot. The marker lives under /run and is cleared
+		// automatically once the machine reboots.
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("touch %s", clistate.UpgradeRebootMarkFile), false, false); err != nil {
+			logger.Warnf("failed to write upgrade reboot marker %s: %v", clistate.UpgradeRebootMarkFile, err)
+		}
+	}
 	return nil
 }
 

--- a/daemon/internel/watcher/upgrade/upgrade_watcher.go
+++ b/daemon/internel/watcher/upgrade/upgrade_watcher.go
@@ -3,13 +3,14 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"github.com/beclab/Olares/daemon/pkg/utils"
 	"math"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/daemon/pkg/utils"
 
 	"github.com/beclab/Olares/daemon/internel/watcher"
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
@@ -35,6 +36,31 @@ func NewUpgradeWatcher() watcher.Watcher {
 }
 
 func (w *upgradeWatcher) Watch(ctx context.Context) {
+	// A post-upgrade reboot can be in progress while the upgrade target file
+	// still exists: in the daemon-driven flow the target is only removed by a
+	// later phase that the reboot usually preempts, so we cannot rely on
+	// target == nil to detect it. Check this up front, regardless of the
+	// target: if olares-cli wrote the reboot marker (before flipping the
+	// OlaresVersion CR) and the system is actually shutting down, the upgrade
+	// is not really done yet - it only takes full effect after the reboot - so
+	// surface a dedicated "Rebooting" step instead of letting the rest of the
+	// watcher report it as complete. The marker stat is cheap and runs every
+	// tick; the shutdown probe (dbus) only runs when the marker is present.
+	// Gating on the real shutdown signal also means a stale marker left behind
+	// by a reboot that never happened cannot wedge the upgrade state.
+	if _, statErr := os.Stat(state.UpgradeRebootMarkFile); statErr == nil {
+		if shuttingDown, _ := state.IsSystemShuttingdown(); shuttingDown {
+			state.TerminusStateMu.Lock()
+			state.CurrentState.UpgradingState = state.InProgress
+			state.CurrentState.UpgradingStep = state.UpgradeStepRebooting
+			state.CurrentState.UpgradingRetryNum = 0
+			state.CurrentState.UpgradingNextRetryAt = nil
+			state.CurrentState.UpgradingError = ""
+			state.TerminusStateMu.Unlock()
+			return
+		}
+	}
+
 	var err error
 	w.target, err = state.GetOlaresUpgradeTarget()
 	if err != nil {

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -225,6 +225,18 @@ func CheckCurrentStatus(ctx context.Context) error {
 	if shutdown, err := IsSystemShuttingdown(); err != nil {
 		return err
 	} else if shutdown {
+		// If this shutdown is the reboot triggered at the end of an upgrade
+		// (olares-cli writes the reboot marker before flipping the
+		// OlaresVersion CR to the target), keep reporting the system as
+		// Upgrading rather than Shutdown, so the frontend keeps showing the
+		// upgrade as in progress (about to reboot) instead of briefly
+		// reporting it complete. Gating on the real shutdown signal here -
+		// instead of on the marker alone - means a stale marker left behind by
+		// a reboot that never happened cannot wedge the state in Upgrading.
+		if _, statErr := os.Stat(UpgradeRebootMarkFile); statErr == nil {
+			currentTerminusState = Upgrading
+			return nil
+		}
 		currentTerminusState = Shutdown
 		return nil
 	}

--- a/daemon/pkg/cluster/state/terminus.go
+++ b/daemon/pkg/cluster/state/terminus.go
@@ -45,6 +45,11 @@ const (
 	NetworkNotReady  = clistate.NetworkNotReady
 )
 
+const (
+	UpgradeRebootMarkFile = clistate.UpgradeRebootMarkFile
+	UpgradeStepRebooting  = clistate.UpgradeStepRebooting
+)
+
 // ValidateOp returns nil if the operation is allowed in the given
 // state, or a descriptive error otherwise. It replaces the previous
 // (TerminusState).ValidateOp method, since methods cannot be defined


### PR DESCRIPTION
## Summary

During an upgrade that requires a reboot, `olares-cli` flips the `OlaresVersion` CR to the target version **before** issuing `reboot now`. In the window before the reboot actually takes effect, `olaresd` saw the target version already applied, tore down the upgrade state, and briefly reported the upgrade as **complete** — even though the machine was about to restart. To the user this looked like "upgrade done", then the system unexpectedly rebooted.

This PR makes that pending reboot visible to `olaresd` so it keeps reporting the system as *upgrading and about to reboot*, with **no frontend changes required**.

### How it works
- **olares-cli** (`upgradeGPUDriverIfNeeded`): when a reboot is determined to be needed, write a tmpfs marker at `/run/olares-upgrade-rebooting` **before** the `OlaresVersion` CR is flipped (this task runs before `updateOlaresVersion` in every `NeedRestart` upgrader).
- **olaresd `CheckCurrentStatus`**: when a shutdown is actually pending **and** the marker exists, keep the overall `TerminusState` as `upgrading` instead of `shutdown`.
- **olaresd upgrade watcher**: independently of the upgrade target file (which, in the daemon-driven flow, is only removed by a later phase that the reboot usually preempts), when the marker exists and the system is shutting down, surface a dedicated `Rebooting` upgrade step.

### Design notes
- Gating on the **real shutdown signal** (not the marker alone) means a stale marker left behind by a reboot that never happened cannot wedge the state in `upgrading`.
- The marker lives on `/run` (tmpfs), so it is cleared automatically once the machine reboots — no cleanup code needed.
- The marker path / step label are defined once in the shared `cli/pkg/daemon/state` package and re-exported as aliases in the daemon's `state` package.

## Test plan
- [ ] Trigger an upgrade that requires a reboot (e.g. one with a GPU driver update) and confirm the status stays `upgrading` (step `Rebooting`) across the `reboot now` delay, rather than briefly flipping to complete/terminus-running.
- [ ] Confirm that after the reboot the marker is gone and the state transitions normally (`restarting` → `terminus-running`).
- [ ] Confirm an upgrade that does **not** require a reboot is unaffected (no marker written, state clears as before).
- [ ] Confirm a stale marker without an actual pending shutdown does not wedge the status in `upgrading`.

Made with [Cursor](https://cursor.com)