### PR TITLE
market: seed placeholders for present-but-failed app states on startup, oac update

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.44
+        image: beclab/dynamic-chart-repository:v0.3.45
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.66
+        image: beclab/market-backend:v0.6.67
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.67
+        image: beclab/market-backend:v0.6.68
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
seed placeholders for present-but-failed app states on startup, oac update

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/319


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches system-critical framework deployments (app store and chart repository); risk is mainly rollout/version skew rather than manifest logic changes in this PR.
> 
> **Overview**
> Rolls out newer **market** and **chart-repo** container images via OAC deployment manifests, aligning cluster deploys with upstream fixes (including startup seeding for present-but-failed app states per the linked market change).
> 
> **`chart-repo`**: `beclab/dynamic-chart-repository` **v0.3.44 → v0.3.45** in `chart_repo_deploy.yaml`.
> 
> **`market`**: `beclab/market-backend` **v0.6.66 → v0.6.68** in `market_deploy.yaml`. No env, RBAC, or wiring changes in this diff—only image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b9c1d0d698de5c506895f0ac268eab506c0ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->