### PR TITLE
docs(cli): make olares-chart skill version-neutral, add manifest skeleton

### DIFF
--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-chart
-version: 4.8.0
-description: "Help a developer turn their own code or any open-source project into an app that runs on their own Olares. Two coupled axes: packaging the container image and authoring/refining the Olares app chart (OlaresManifest), then deploying it to the current Olares with an automatic upload + install + diagnose loop. Use when deploying a repo, docker-compose, or Helm chart to Olares, packaging an Olares app, wiring storage / system middleware / entrances / env / GPU, or fixing a failed install (ImagePullBackOff, permission denied / EACCES, app won't start). Publishing to the public Olares Market is the olares-publish skill."
+version: 4.10.0
+description: "Use when deploying a repo, docker-compose, or generic Helm chart to your own Olares, packaging an Olares app image, authoring or validating an OlaresManifest, wiring storage / system middleware / entrances / env / GPU, or fixing a failed install (ImagePullBackOff, permission denied / EACCES, app won't start or won't reach running). Publishing to the public Olares Market is the olares-publish skill."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only, deploy needs login
 metadata:
   openclaw:
@@ -14,17 +14,15 @@ metadata:
 
 > **Source of truth for flags is always `olares-cli chart <verb> --help`.** This file only carries what `--help` cannot: the two coupled axes of a port, where to start on each, the per-axis concerns to get right, and the gotchas `lint` won't catch.
 
-> **Porting baseline: Olares >= 1.12.6.** This skill targets Olares >= 1.12.6 (other `olares-cli` features have no such floor). Check the target with `olares-cli profile list` (VERSION column). Full version rules — `apiVersion: v3`, the several chart version fields, `type: system` dependency — are in [references/olares-chart-versioning.md](references/olares-chart-versioning.md).
+> **Porting baseline: Olares >= 1.12.6.** Check the target with `olares-cli profile list` (VERSION column). Full version rules — `apiVersion: v3`, the chart version fields, the `olares` `type: system` dependency — are in [references/olares-chart-versioning.md](references/olares-chart-versioning.md).
 
-> **Platform model (read once, no login needed for authoring).** The porting decisions below rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). **Packaging an image and authoring/validating the chart need no profile login.** Only the final **deploy to your Olares** (`market upload` + `install`) requires login.
+> **Platform model (read once, no login needed for authoring).** Porting decisions rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). Packaging an image and authoring/validating the chart need no login; only **deploy to your Olares** (`market upload` + `install`) does.
 
 ## When to use
 
-- Turn a repo / docker-compose / generic Helm chart into an Olares app, or validate an OlaresManifest you authored
-- Package an Olares app image; wire storage / system middleware / entrances / env / GPU
-- Deploy / run the app on **your own** Olares (`market upload` + `install`)
+- Turn a repo / docker-compose / generic Helm chart into an Olares app, or validate an OlaresManifest; package its image; wire storage / middleware / entrances / env / GPU
+- Deploy / run the app on **your own** Olares (`market upload` + `install`), or fix a failed install (`ImagePullBackOff`, `EACCES`, app won't start)
 - Serve a specific LLM / embedding model (HF or Ollama) with no chart authoring — clone an `llm-init` base app and fill env ([llm-models.md](references/olares-chart-llm-models.md))
-- Fix a failed install (`ImagePullBackOff`, permission denied / `EACCES`, app won't start)
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
@@ -32,18 +30,16 @@ metadata:
 
 ## The shape of the work — two axes
 
-Porting an app is **not** a fixed `from-compose → lint → deploy` pipeline — it is driving two **orthogonal but coupled** axes each to its own *ready* state, looping back across the coupling edges as constraints surface (an image's baked-in uid/paths constrain the chart's mounts/permissions; a deploy constraint can send you back to rebuild the image). Start wherever your app already stands, not at a fixed step 1. Once both axes are ready, **deploy to the current Olares** — an automatic upload + install + diagnose loop.
+Porting an app is **not** a fixed `from-compose → lint → deploy` pipeline — it is driving two **orthogonal but coupled** axes each to its own *ready* state, looping back as constraints surface (an image's baked-in uid/paths constrain the chart's mounts/permissions; a deploy constraint can send you back to rebuild the image). Start wherever your app already stands, not at a fixed step 1. Once both axes are ready, **deploy to the current Olares** — an automatic upload + install + diagnose loop.
 
 - **Packaging — the image:** the app built into a pullable, arch-correct artifact. Olares only pulls, never builds.
 - **Deployment — the chart:** a `lint`-passing OlaresManifest + templates. `from-compose` is only **one** way in.
 
 **First move (not a pipeline):** locate where the app already sits on the packaging and deployment state tables → drive the concerns to ready, looping as constraints surface → deploy to your Olares.
 
-> **Publishing to the public Olares Market is out of scope here.** Once the app runs on your Olares, listing it publicly (market-ready metadata, multi-arch, the `beclab/apps` PR, paid apps) is the [`../olares-publish/SKILL.md`](../olares-publish/SKILL.md) skill.
-
 ## Axis 1 — Packaging (the image)
 
-Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and already logged in, then **build + push yourself** — only the credential entry (`docker login`) stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). No Olares login needed for this. Build for **this node's arch** (single-arch); multi-arch is only needed when publishing to the public Market (olares-publish).
+Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and logged in, then **build + push yourself** — only `docker login` stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). No Olares login needed. Build for **this node's arch** (single-arch); multi-arch is only for publishing.
 
 | Packaging state | Do this | Ready when |
 |---|---|---|
@@ -53,7 +49,7 @@ Olares **pulls images from a registry and never builds from source**, so every w
 
 ## Axis 2 — Deployment (the chart)
 
-The target is a `lint`-passing Olares chart. `from-compose` (kompose) is **just one entry method** for a compose-based start — a bare repo, a generic Helm chart, or an already-Olares chart each begin elsewhere. Local authoring (`from-compose` / `lint` / `package`) needs **no login**.
+The target is a `lint`-passing Olares chart. `from-compose` (kompose) is **just one entry method** — a bare repo, a generic Helm chart, or an already-Olares chart each begin elsewhere (see the state table below). Local authoring (`from-compose` / `lint` / `package`) needs **no login**.
 
 | Deployment state | Do this | Ready when |
 |---|---|---|
@@ -64,9 +60,9 @@ The target is a `lint`-passing Olares chart. `from-compose` (kompose) is **just 
 
 ## Deploy to your Olares (the done step)
 
-Both axes ready → **deploy to the current Olares automatically**. `lint` proves the chart is structurally valid; it does **not** prove the app pulls its images, wires its middleware, and reaches `running`. The deploy loop does — by pushing the chart to the developer's Olares and watching it install. **After `lint` passes, proceed without asking:** check login → package → `market upload` → `market install -s upload --watch` → on failure fetch logs → diagnose → fix chart + re-lint → retry. Only stop to ask when the profile is not logged in, or when a failure is clearly not a chart problem. Full procedure: [references/olares-chart-deploy.md](references/olares-chart-deploy.md).
+Both axes ready → **deploy to the current Olares automatically**. `lint` proves the chart is structurally valid; it does **not** prove the app pulls its images, wires its middleware, and reaches `running` — the deploy loop does. **After `lint` passes, proceed without asking:** check login → package → `market upload` → `market install -s upload --watch` → on failure fetch logs → diagnose → fix chart + re-lint → retry. Only stop to ask when the profile is not logged in, or a failure is clearly not a chart problem. Full procedure: [references/olares-chart-deploy.md](references/olares-chart-deploy.md).
 
-For deploying to your own Olares, **metadata can stay a stub** (`Utilities` category, default icon, empty `spec.developer`/`fullDescription`/…) as long as `lint` passes — functional refinement (storage / middleware / entrances) is still required.
+For deploying to your own Olares, **metadata can stay a stub** as long as `lint` passes; functional refinement (storage / middleware / entrances) is still required.
 
 ## The concerns to get right (reflect on these per axis)
 
@@ -74,20 +70,20 @@ For deploying to your own Olares, **metadata can stay a stub** (`Utilities` cate
 
 | Axis | Concern | Get this right | Loop back when | Reference |
 |---|---|---|---|---|
-| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for **this node** (multi-arch only when publishing) | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
-| packaging+deployment | **Run identity** | process runs as uid 1000; `spec.runAsUser: true`; initContainer `chown` for root-owned volumes; no root main on non-trusted images (OPA) | EACCES on appData/appCache/userData, admission denies a root third-party image | [run-as-user.md](references/olares-chart-run-as-user.md) |
-| deployment | **Storage** | every compose volume mapped to the right userspace area (Data / Cache / Home / Common / External), `permission` declared to match, leftover kompose PVCs deleted | a volume isn't persisting or lands in the wrong area | [manifest.md](references/olares-chart-manifest.md) §2 |
-| deployment | **Middleware & deps** | no bundled `postgres`/`redis`/`mongo`/…; wired to system middleware; SQLite→Postgres where supported; companion apps as `type: application` deps | a bundled db/queue is still in the chart, or a companion should be a dependency | [middleware.md](references/olares-chart-middleware.md) |
-| deployment | **Env** | app config in `envs[]` (v3 `valueFrom`, no inline `OLARES_USER`); install-time `required` prompts; middleware/system/user vars mapped via `.Values.olaresEnv`; platform render context (identity, domain, userspace, oidc, middleware) consumed via `.Values.*` | install fails on `appenv` 422, or config must be user-supplied | [env.md](references/olares-chart-env.md), [env-defaults.md](references/olares-chart-env-defaults.md), [system-values.md](references/olares-chart-system-values.md) |
+| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for **this node** | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
+| packaging+deployment | **Run identity** | uid 1000; `spec.runAsUser: true`; initContainer `chown` for root-owned volumes; no root main on non-trusted images (OPA) | EACCES on appData/appCache/userData; admission denies a root third-party image | [run-as-user.md](references/olares-chart-run-as-user.md) |
+| deployment | **Storage** | every compose volume → the right userspace area (Data/Cache/Home/Common/External), matching `permission`, leftover kompose PVCs deleted | a volume isn't persisting or lands in the wrong area | [manifest.md](references/olares-chart-manifest.md) §2 |
+| deployment | **Middleware & deps** | no bundled `postgres`/`redis`/`mongo`/…; wire to system middleware; SQLite→Postgres where supported; companion apps as `type: application` deps | a bundled db/queue remains, or a companion should be a dependency | [middleware.md](references/olares-chart-middleware.md) |
+| deployment | **Env** | app config in `envs[]` (v3 `valueFrom`, no inline `OLARES_USER`); install-time `required` prompts; middleware/system/user vars via `.Values.olaresEnv`; platform context via `.Values.*` | install fails on `appenv` 422, or config must be user-supplied | [env.md](references/olares-chart-env.md), [env-defaults.md](references/olares-chart-env-defaults.md), [system-values.md](references/olares-chart-system-values.md) |
 | deployment | **Entrances & ports** | ≥1 `entrances[]`; HTTP via entrances, non-HTTP via `ports[]`; internal-only services `invisible: true` | a service is unreachable, or an internal port is exposed as a desktop entrance | [manifest.md](references/olares-chart-manifest.md) §4 |
-| packaging+deployment | **GPU / models** | build a CUDA image without a local GPU (custom-kernel arch flags); download model weights via initContainer into the shared `appCommon` Hugging Face cache | AI app needs a CUDA build, model provisioning, or a shared model cache | [gpu.md](references/olares-chart-gpu.md) |
-| deployment | **LLM model serving** | serve any HF/Ollama model with no chart authoring — pick an engine by format, fill env, clone an `llm-init` base app (llama.cpp / Ollama / vLLM / SGLang); set the `MODEL_SUPPORTS` capability field from the model card (don't claim `vision` on a text-only GGUF) | user wants to run/serve/host a specific LLM or embedding model, not author a new app | [llm-models.md](references/olares-chart-llm-models.md) |
-| deployment | **Accelerator** | declare `spec.accelerator` modes (nvidia/amd-gpu/apple-m/cpu/…) per what the repo supports; set `requiredGPUMemory`; a sane CPU/memory envelope | GPU/accelerator app needs a resource envelope, or `lint` flags `spec.resources` | [accelerator.md](references/olares-chart-accelerator.md) |
-| packaging+deployment | **DinD** | a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`) while the main container stays non-privileged | a terminal/agent app must run `docker` / `docker compose` | [dind.md](references/olares-chart-dind.md) |
-| deployment | **Shared backend** | `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; consumers reach it over cross-namespace Service DNS; flag the admin-install to the user | a heavy/accelerator backend serves many users over shared data | [shared.md](references/olares-chart-shared.md) |
-| deployment | **Version rules** | `apiVersion: v3`; `olaresManifest.version` always `0.12.0`; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` `olares >=1.12.6-0` (`type: system`) | install rejects the manifest, or behavior differs by Olares version | [versioning.md](references/olares-chart-versioning.md) |
-| deployment | **Workloads / replicas** | `workloadReplicas` lists every Deployment/StatefulSet → count (required on 0.12.0, authored by you — never assume a scaffolder did it); each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` + matching `values.yaml` | every time you author/add/rename a 0.12.0 workload — run the three-point self-check; consequence of skipping: suspend/resume / staged install silently no-op on a hardcoded `replicas` | [manifest.md](references/olares-chart-manifest.md) Workloads & replicas |
-| deployment | **Metadata** | stub OK for local deploy (`Utilities`, default icon) as long as `lint` passes; full `metadata.*` + listing images only when publishing to the Market | `lint` flags missing metadata, or you want a public listing | [manifest.md](references/olares-chart-manifest.md) §1 |
+| packaging+deployment | **GPU / models** | build a CUDA image without a local GPU; download model weights via initContainer into the shared `appCommon` Hugging Face cache | AI app needs a CUDA build, model provisioning, or a shared model cache | [gpu.md](references/olares-chart-gpu.md) |
+| deployment | **LLM model serving** | serve any HF/Ollama model without authoring — pick an engine by format, fill env, clone an `llm-init` base app (llama.cpp / Ollama / vLLM / SGLang); set `MODEL_SUPPORTS` from the model card | user wants to run/serve a specific LLM or embedding model, not author a new app | [llm-models.md](references/olares-chart-llm-models.md) |
+| deployment | **Accelerator** | declare `spec.accelerator` modes per repo support; set `requiredGPUMemory`; a sane CPU/memory envelope | GPU/accelerator app needs a resource envelope, or `lint` flags `spec.resources` | [accelerator.md](references/olares-chart-accelerator.md) |
+| packaging+deployment | **DinD** | a privileged `beclab/docker` daemon sidecar (`ENABLE_DIND`, `DOCKER_HOST`); main container stays non-privileged | a terminal/agent app must run `docker` / `docker compose` | [dind.md](references/olares-chart-dind.md) |
+| deployment | **Shared backend** | `apiVersion: v3` ⇒ admin-only install into `<app>-shared`; consumers reach it via cross-namespace Service DNS; flag the admin-install | a heavy/accelerator backend serves many users over shared data | [shared.md](references/olares-chart-shared.md) |
+| deployment | **Version & deps fields** | fixed values every chart writes: `apiVersion: v3`; `olaresManifest.version: '0.12.0'`; `metadata.version` == `Chart.yaml` `version`; `options.dependencies` includes `olares >=1.12.6-0` (`type: system`) — authored by you | every manifest edit — confirm these fields + the `olares` system dep (`lint` rejects a missing system dep) | [versioning.md](references/olares-chart-versioning.md) |
+| deployment | **Workloads / replicas** | `workloadReplicas` lists every Deployment/StatefulSet → count (authored by you); each `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` + matching `values.yaml` | every time you author/add/rename a workload — run the three-point self-check; a hardcoded `replicas` silently no-ops suspend/resume / staged install | [manifest.md](references/olares-chart-manifest.md) Workloads & replicas |
+| deployment | **Metadata** | stub OK for local deploy (`Utilities`, default icon) while `lint` passes; full `metadata.*` + listing images only when publishing | `lint` flags missing metadata, or you want a public listing | [manifest.md](references/olares-chart-manifest.md) §1 |
 | deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
 | deploy | **Deploy** | `market upload` + `market install`, then diagnose from logs — automatic after `lint` passes (login required) | proving the chart actually runs on the developer's Olares | [deploy.md](references/olares-chart-deploy.md) |
 
@@ -116,12 +112,12 @@ gh search code --repo beclab/apps <keyword>      # find charts using a pattern (
 # then browse https://github.com/beclab/apps/tree/main/<app> — its OlaresManifest.yaml + templates/
 ```
 
-This is the canonical source for cross-app wiring (how a dependency app is reached, real `entrances`/`ports`, accelerator modes) that this skill intentionally does not hardcode.
+This is the canonical source for cross-app wiring this skill intentionally does not hardcode.
 
 **When picking a reference app, skip these — they mislead more than they help:**
 
 - **Apps with a `.suspend` (or `.remove`) control file in the OAC root** — suspended / no longer distributed; not a current, reliable pattern.
-- **Legacy v2 shared / cluster-scoped charts** that express sharing with `spec.subCharts[].shared: true` + `options.appScope.clusterScoped: true` + `appRef` (the `ollamaserver`/`ollamav2` shape). For Olares >= 1.12.6 this is superseded by `apiVersion: v3`; copy the shared-app pattern from a current `v3` app, not from these. See [shared.md](references/olares-chart-shared.md).
+- **Shared / cluster-scoped charts** that express sharing with `spec.subCharts[].shared: true` + `options.appScope.clusterScoped: true` + `appRef` (the `ollamaserver`/`ollamav2` shape). Copy the shared-app pattern from an `apiVersion: v3` app, not from these. See [shared.md](references/olares-chart-shared.md).
 
 ## Gotchas (what `lint` won't catch)
 

--- a/cli/skills/olares-chart/references/olares-chart-accelerator.md
+++ b/cli/skills/olares-chart/references/olares-chart-accelerator.md
@@ -1,14 +1,14 @@
 # Accelerator resources (`spec.accelerator`) — modes & sizing
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first. This covers declaring accelerator modes and sizing the resource envelope on the `0.12.0` schema (the schema every new app uses). Building the CUDA image and provisioning model weights are in [olares-chart-gpu.md](olares-chart-gpu.md).
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first. This covers declaring accelerator modes and sizing the resource envelope. Building the CUDA image and provisioning model weights are in [olares-chart-gpu.md](olares-chart-gpu.md).
 
 ## A. Declaring accelerator modes (`spec.accelerator`)
 
-On the `0.12.0` schema an app that needs an accelerator declares one `spec.accelerator[]` entry **per compute mode** it supports. Without it the app is scheduled as plain `cpu` and never gets an accelerator device or GPU memory.
+An app that needs an accelerator declares one `spec.accelerator[]` entry **per compute mode** it supports. Without it the app is scheduled as plain `cpu` and never gets an accelerator device or GPU memory.
 
 > **Naming gotchas (these bite):**
 > - The YAML key is `spec.accelerator`, but `lint` error messages call it **`spec.resources`** — same thing.
-> - The GPU-memory key inside an entry is **`requiredGPUMemory` / `limitedGPUMemory`** (the legacy flat field at `< 0.12.0` is `spec.requiredGpu` / `spec.limitedGpu` — also a memory quantity, not a card count). The two live at different levels: `requiredGPUMemory` sits inside an `accelerator[]` entry; `requiredGpu` is a top-level `spec.*` field — they are mutually exclusive (declare one shape, not both).
+> - The GPU-memory key inside an entry is **`requiredGPUMemory` / `limitedGPUMemory`** (a memory quantity, not a card count).
 > - `lint` error messages for a missing accelerator-entry GPU field still say **`requiredGpu` / `limitedGpu`**, even though the YAML key you must write in the entry is `requiredGPUMemory` / `limitedGPUMemory`. Don't let the message rename your field.
 > - Only **discrete-GPU** modes carry a GPU-memory field; unified/SoC modes (`nvidia-gb10`, `apple-m`, `intel`, `amd`, `moore-soc`) omit it and size via pod `requiredMemory` / `limitedMemory` instead.
 
@@ -28,14 +28,14 @@ The canonical mode set is the one the platform recognizes on nodes — `gpu.byte
 | `amd-gpu` | AMD discrete GPU (ROCm) | discrete — own GPU-memory quota | `amd64` |
 | `moore-soc` | Moore Threads SoC | unified — pod memory | per hardware |
 
-Rule of thumb: **discrete** cards (`nvidia`, `intel-gpu`, `amd-gpu`) take a standalone GPU-memory quota (`requiredGPUMemory`/`limitedGPUMemory`); **unified / SoC** modes (`nvidia-gb10`, `apple-m`, `intel`, `amd`, `moore-soc`) draw from pod memory and declare no GPU-memory field. (The legacy `spec.supportedGpu` list is superseded — on `0.12.0` use `spec.accelerator`.)
+Rule of thumb: **discrete** cards (`nvidia`, `intel-gpu`, `amd-gpu`) take a standalone GPU-memory quota (`requiredGPUMemory`/`limitedGPUMemory`); **unified / SoC** modes (`nvidia-gb10`, `apple-m`, `intel`, `amd`, `moore-soc`) draw from pod memory and declare no GPU-memory field. Declare modes with `spec.accelerator`.
 
-> **OAC `lint` currently lags `gpu_types.go`.** Today `olares-cli chart lint` validates the older set in `framework/oac/internal/manifest/resources.go` (`validResourceModes`): only `cpu`, `nvidia`, `nvidia-gb10`, `apple-m`, `amd-gpu`, plus the legacy names `strix-halo` / `mthreads-m1000`. So:
-> - `nvidia`, `nvidia-gb10`, `apple-m`, `amd-gpu`, `cpu` pass lint **and** match `gpu_types.go` — safe to use now.
-> - `intel`, `amd`, `intel-gpu`, `moore-soc` are real node modes but are **not yet accepted by `lint`** — declaring them fails validation until OAC is upgraded to the `gpu_types.go` set.
-> - `strix-halo` / `mthreads-m1000` are lint-only legacy names with no `gpu_types.go` equivalent; avoid them in new charts.
+> **Which modes `lint` accepts.** `olares-cli chart lint` accepts `cpu`, `nvidia`, `nvidia-gb10`, `apple-m`, `amd-gpu` (`validResourceModes` in `framework/oac/internal/manifest/resources.go`). So:
+> - `nvidia`, `nvidia-gb10`, `apple-m`, `amd-gpu`, `cpu` pass lint — safe to use.
+> - `intel`, `amd`, `intel-gpu`, `moore-soc` are real node modes but are **not accepted by `lint`** — declaring them fails validation.
+> - Avoid `strix-halo` / `mthreads-m1000`.
 >
-> `lint` also cross-checks mode → `spec.supportArch` for the arch-bound modes (`nvidia`/`amd-gpu` → `amd64`; `nvidia-gb10` → `arm64`), and only `nvidia`/`amd-gpu` are blessed for the GPU-memory fields (`gpuMemoryModes`). Both checks widen when OAC adopts `gpu_types.go`.
+> `lint` also cross-checks mode → `spec.supportArch` for the arch-bound modes (`nvidia`/`amd-gpu` → `amd64`; `nvidia-gb10` → `arm64`), and only `nvidia`/`amd-gpu` are blessed for the GPU-memory fields (`gpuMemoryModes`).
 
 ### Shape and semantics
 
@@ -68,7 +68,7 @@ spec:
 - `required*` is the **scheduling floor** (reserved); `limited*` is the **cap**. They map to Kubernetes container `requests` / `limits`.
 - **GPU is allocated by memory, not whole cards.** `requiredGPUMemory` is the vGPU memory the scheduler reserves (matched against device memory); a card count is not what you request here.
 - Each declared mode entry must be **complete** (all CPU/memory/disk pairs present); `lint` reports every missing field.
-- `spec.accelerator` is **mutually exclusive** with the legacy flat `spec.requiredCpu/...` fields, is **rejected on `apiVersion: v2`**, and only applies at `olaresManifest.version >= 0.12.0`.
+- The resource envelope lives entirely under `spec.accelerator[]` (mode-keyed) — there is no flat top-level `spec.requiredCpu/...`.
 
 ## B. Which modes to declare — local deploy vs publish
 

--- a/cli/skills/olares-chart/references/olares-chart-from-compose.md
+++ b/cli/skills/olares-chart/references/olares-chart-from-compose.md
@@ -35,7 +35,7 @@ olares-cli chart from-compose --name myapp -f base.yml -f override.yml      # me
 | `-o, --output` | chart root dir (default `./<name>`) |
 | `--title` | human title (default = name) |
 | `--type` | `app` (default) / `recommend` / `middleware` |
-| `--new-schema` | **deprecated no-op** — every scaffold now emits `olaresManifest.version: 0.12.0` (resources under `spec.accelerator[mode=cpu]`) regardless |
+| `--new-schema` | **deprecated no-op** — the scaffold always emits `olaresManifest.version: 0.12.0` (resources under `spec.accelerator[mode=cpu]`) |
 
 ## Reading the output
 

--- a/cli/skills/olares-chart/references/olares-chart-lint.md
+++ b/cli/skills/olares-chart/references/olares-chart-lint.md
@@ -55,7 +55,8 @@ By default lint renders the chart under **both** `owner==admin` (admin install) 
 | `Chart.yaml` vs manifest version mismatch | the two `version` fields differ | set them equal |
 | hostPath + rolling update | a template mounts a `hostPath` with a rolling-update workload | switch to a userspace volume, or set the workload strategy to `Recreate` if a host mount is truly required |
 | resource limit missing | a container has no CPU/memory limit | add `resources.limits` (or `--skip-resource` only for a quick check, not for market submit) |
-| `workloadReplicas is required` (or a workload not listed) | the 0.12.0 `workloadReplicas` map is missing, incomplete, or not wired | run the three-point self-check in [olares-chart-manifest.md](olares-chart-manifest.md) Workloads & replicas |
+| `workloadReplicas is required` (or a workload not listed) | the `workloadReplicas` map is missing, incomplete, or not wired | run the three-point self-check in [olares-chart-manifest.md](olares-chart-manifest.md) Workloads & replicas |
+| `options.dependencies must declare ... name="olares" ... type="system"` | the `olares` system dependency is missing from `options.dependencies` | add it per [olares-chart-manifest.md](olares-chart-manifest.md) System dependency: olares |
 | manifest structural error | required field missing/invalid | fix per [olares-chart-manifest.md](olares-chart-manifest.md) |
 | namespace check failed | a resource has a hardcoded namespace | use `namespace: '{{ .Release.Namespace }}'` |
 

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -3,15 +3,36 @@
 > **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
 > This is the field-by-field map from a raw `from-compose` stub to a working chart. After every change, re-run `olares-cli chart lint ./<app>` (see [olares-chart-lint.md](olares-chart-lint.md)).
 
-The scaffolded manifest is a stub. The four areas below are what kompose cannot decide. **§1 Metadata can stay a stub for deploying to your Olares; §2–§4 are functional and always required. Full market-ready metadata is only for publishing — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).**
+The scaffolded manifest is a stub. This doc covers, in order: the fixed **header fields**, the **two required manifest entries** every chart must author (`workloadReplicas` and the `olares` system dependency), then the **four refinement areas** kompose cannot decide (§1 Metadata can stay a stub for deploying to your Olares; §2–§4 are functional and always required). Full market-ready metadata is only for publishing — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).
 
-## Schema version and apiVersion
+## Header fields
 
-`olaresManifest.version` (the manifest **schema**: always `0.12.0` for new apps) and the top-level `apiVersion` (skill sets **`v3`**) are separate axes from the chart/app versions. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The full schema description, the version-field map, and the `type: system` dependency are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
+The manifest top sets `apiVersion: v3` and `olaresManifest.version: '0.12.0'`. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The fixed version-field values, the `olares` system dependency, and the field map are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
 
-## Workloads & replicas (required on 0.12.0)
+> **Two required manifest entries — author both yourself for every chart; `lint` rejects either if missing:** the `workloadReplicas` map (below) and the `olares` system dependency under `options.dependencies` (next section). Both live at the **top level of `OlaresManifest.yaml`** — siblings of `metadata`, `spec`, and `options`. In particular `workloadReplicas` is **not** nested under the manifest `spec`.
 
-A `0.12.0` chart **must** declare a top-level `workloadReplicas` map — one entry per **Deployment / StatefulSet** the chart renders → its replica count. **This is a mandatory part of authoring a v3 chart, and it is on you to get right: declare it and confirm it yourself for every chart, whether you scaffolded with `from-compose` or hand-authored, and re-check it whenever you add, rename, or remove a workload. Do not assume a scaffolder produced it correctly, and do not treat a passing `lint` as proof it is present and wired** — `lint` rejecting an omitted map is a backstop, not the reason you write it.
+## OlaresManifest skeleton (top-level keys)
+
+The top-level shape, in canonical order — every key below is a sibling (each at column 0). Field detail lives in the linked sections; this is just the map.
+
+```yaml
+# OlaresManifest.yaml — top-level keys, in order (all siblings)
+olaresManifest.version: '0.12.0'
+olaresManifest.type: app
+apiVersion: v3
+metadata: { ... }          # §1
+entrances: [ ... ]         # §4
+spec: { ... }              # §1 spec + resources/accelerator
+permission: { ... }        # §2 — only areas you mount
+middleware: { ... }        # §3 — only if wiring system middleware
+options: { ... }           # olares system dep (required) + middleware/app deps
+workloadReplicas: { ... }  # required; sibling of spec
+# optional/niche: ports, envs, overlayGateway, tailscale
+```
+
+## Workloads & replicas (required)
+
+Every chart **must** declare a top-level `workloadReplicas` map — one entry per **Deployment / StatefulSet** the chart renders → its replica count. **This is a mandatory part of authoring the chart, and it is on you to get right: declare it and confirm it yourself for every chart, whether you scaffolded with `from-compose` or hand-authored, and re-check it whenever you add, rename, or remove a workload. Do not assume a scaffolder produced it correctly, and do not treat a passing `lint` as proof it is present and wired** — `lint` rejecting an omitted map is a backstop, not the reason you write it.
 
 ```yaml
 workloadReplicas:
@@ -22,10 +43,24 @@ workloadReplicas:
 **Self-check (inspect the files directly — do not rely on any tool):**
 
 1. `OlaresManifest.yaml` top-level `workloadReplicas` lists **every** Deployment/StatefulSet the chart renders (by rendered `metadata.name`) → its replica count. **DaemonSets are excluded** (one-per-node, not replica-controlled).
-2. Every listed workload's template sets `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — **never a hardcoded number**.
+2. Every listed workload's template sets `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — **never a hardcoded number**. This `spec.replicas` is the Deployment/StatefulSet **template's** spec under `templates/`, a different field from the manifest's top-level `spec` — don't conflate the two.
 3. `values.yaml` carries a matching `workloads.<name>.replicaCount` for each. The `.Values.workloads.*` value is documented in [olares-chart-system-values.md](olares-chart-system-values.md).
 
 **Why the template wiring matters (non-obvious).** app-service drives the whole lifecycle through this Helm value: install is two-phase (helm renders at `replicas: 0`, then scales up), suspend scales every listed workload to `0`, resume scales back to the declared counts. If a template **hardcodes** `replicas`, **suspend/resume and the staged install silently stop working** — the value override has nothing to drive.
+
+## System dependency: olares (required)
+
+Every chart **must** declare the `olares` system dependency in `options.dependencies` — author it yourself, under the same "don't assume the scaffolder added it, don't treat a passing `lint` as proof" rule as `workloadReplicas` above.
+
+```yaml
+options:
+  dependencies:
+  - name: olares
+    version: '>=1.12.6-0'   # -0 covers daily/prerelease builds
+    type: system
+```
+
+The constraint and the `-0` prerelease rule are in [olares-chart-versioning.md](olares-chart-versioning.md).
 
 ## 1. Metadata
 
@@ -88,6 +123,8 @@ In the deployment template, replace the PVC mount with the injected host path (`
 > **Functional requirement, not cosmetic** — always required.
 
 Replace any bundled `postgres`/`redis`/`mongodb`/`mysql`/`mariadb`/`minio`/`rabbitmq`/`nats` workload with Olares **system middleware**, prefer Postgres over a bundled SQLite, and depend on an already-ported companion app instead of copying its workload. `lint` does **not** flag a bundled db, so this is on you. Full rules — the SQLite→Postgres decision, the `middleware:` block, the PostgreSQL extension catalog, `type: application` dependencies, and the self-hosted escape hatch — are in [olares-chart-middleware.md](olares-chart-middleware.md). Env wiring of the `.Values.<mw>.*` values is in [olares-chart-env.md](olares-chart-env.md).
+
+> The `olares` `type: system` dependency (see "System dependency: olares") is a **separate, always-required** entry in `options.dependencies` — keep it when you add or remove middleware / application dependencies.
 
 ## 4. Entrances & ports
 

--- a/cli/skills/olares-chart/references/olares-chart-middleware.md
+++ b/cli/skills/olares-chart/references/olares-chart-middleware.md
@@ -48,8 +48,8 @@ middleware:
     namespace: db0           # logical Redis db namespace for this app
 options:
   dependencies:
-  - name: olares
-    version: ">=1.0.0-0"
+  - name: olares             # required system dep — author per manifest.md (System dependency: olares)
+    version: ">=1.12.6-0"
     type: system
   - name: mysql              # middleware deps: set mandatory when install must wait for it
     version: ">=8.0.0-0"
@@ -108,8 +108,8 @@ Env wiring in the deployment (PostgreSQL example; Redis/Mongo/MySQL/MariaDB/MinI
    ```yaml
    options:
      dependencies:
-     - name: olares
-       version: ">=1.0.0-0"
+     - name: olares            # required system dep — author per manifest.md (System dependency: olares)
+       version: ">=1.12.6-0"
        type: system
      - name: searxng           # exact Market app name
        version: ">=1.0.0-0"    # semver constraint matched against the installed app

--- a/cli/skills/olares-chart/references/olares-chart-shared.md
+++ b/cli/skills/olares-chart/references/olares-chart-shared.md
@@ -11,21 +11,21 @@ Typical shape: a local model / inference backend (ollama, vLLM, an LLM gateway).
 
 ## What `apiVersion: v3` means
 
-In Olares >= 1.12.6 the install handler routes purely on `apiVersion`. `apiVersion: v3` ⇒:
+The install handler routes purely on `apiVersion`. `apiVersion: v3` ⇒:
 
 - **Admin-only install** — non-admin callers are rejected ("only admin users can install v3 / shared apps").
 - **Deterministic shared namespace** `<app>-shared` (not the per-user `<app>-<owner>`).
 - **Cluster-wide ApplicationManager** named `<app>-shared-<app>`.
 - **Cross-namespace shared access is force-enabled** so the app is a first-class destination for cross-namespace traffic (service-mesh sidecar + NetworkPolicy).
 
-So for ported apps targeting 1.12.6+, **`apiVersion: v3` is itself the "shared app" declaration** — there is no separate `subCharts shared:true` / `appScope.clusterScoped` wiring to add (that was the legacy v2 form, below).
+So **`apiVersion: v3` is itself the "shared app" declaration** — there is no separate sub-chart / app-scope wiring to add.
 
-> **There is no `sharedEntrances` in 1.12.6+.** Earlier shared apps exposed cross-user entrances on a `shared.<zone>` domain; a network redesign removed that. Consumers now reach the shared app's in-cluster Service directly (below). Do **not** add `sharedEntrances` — if you see it in an existing chart (e.g. a stray entry in `ollamav3`), treat it as a leftover and drop it.
+> **There is no `sharedEntrances`.** Consumers reach the shared app's in-cluster Service directly (below). Do **not** add `sharedEntrances` — if you see it in an existing chart, treat it as a leftover and drop it.
 
 ## Manifest (annotated, based on `ollamav3`)
 
 ```yaml
-olaresManifest.version: '0.12.0'      # modern schema (accelerator / externalData)
+olaresManifest.version: '0.12.0'      # accelerator / externalData
 olaresManifest.type: app
 apiVersion: 'v3'                       # => admin-installed, cluster-wide shared app
 metadata:
@@ -47,7 +47,7 @@ permission:
 options:
   allowMultipleInstall: true
   conflicts:
-    - name: ollamav2                   # conflict with the non-shared / v2 variant
+    - name: ollamav2                   # conflict with the non-shared variant
       type: application
   dependencies:
     - name: olares
@@ -72,7 +72,7 @@ Required / expected fields:
 |---|---|
 | `apiVersion: 'v3'` | makes it an admin-installed, cluster-wide shared app |
 | `olaresManifest.version: '0.12.0'` | needed for `spec.accelerator` / `permission.externalData` (see [manifest.md](olares-chart-manifest.md)) |
-| `options.dependencies` `olares` `>=1.12.6-0` (`type: system`) | **mandatory** — the shared/v3 model only exists on Olares >= 1.12.6 ([versioning.md](olares-chart-versioning.md)) |
+| `options.dependencies` `olares` `>=1.12.6-0` (`type: system`) | **mandatory** system dependency every chart declares ([versioning.md](olares-chart-versioning.md)) |
 | `spec.onlyAdmin: true` | explicit admin-only install (generally set on shared apps) |
 | `spec.accelerator` | GPU/accelerator envelope for the heavy backend — sizing in [olares-chart-accelerator.md](olares-chart-accelerator.md) |
 | `options.conflicts` | avoid co-installing the per-user / older variant of the same backend |
@@ -82,27 +82,9 @@ Required / expected fields:
 
 A shared app is consumed by **separate reference/client apps**, not by per-user copies of itself. The client declares an `options.dependencies` `type: application` on the shared app; app-service then injects the shared namespace's Services into the client's Helm values and grants cross-namespace reachability automatically. The full mechanism (`.Values.svcs.<svc>_host` = `<svc>.<app>-shared`, mesh sidecar + NetworkPolicy, no entrance/URL) is the platform **App, namespace & networking model** (loaded via the SKILL.md prerequisite).
 
-## Legacy v2 shared form (context only)
-
-Pre-v3 shared apps (still in the catalog: `ytdlp`, `searxngv2`, `vllm*`) expressed sharing inside an `apiVersion: 'v2'` app by marking one sub-chart shared:
-
-```yaml
-spec:
-  subCharts:
-    - name: <app>server   # the heavy/shared workload -> lands in <chart>-shared namespace
-      shared: true
-    - name: <app>         # the per-user part
-options:
-  appScope:
-    clusterScoped: true
-    appRef: [ "<consumer>.*" ]   # which apps may reference it
-```
-
-For new ports targeting 1.12.6+ use the `apiVersion: v3` form above instead; this is here only to read existing charts.
-
 ## Caveats
 
 - **Only an admin can install a v3 app** — surface this to the user; a normal user install will 403.
 - **`<app>-shared` namespace requires `isShared: true`** in the manifest. Without it, even a `apiVersion: v3` app installs into `<app>-<adminUsername>` (the admin's personal namespace). Add `isShared: true` when the app genuinely needs cluster-wide shared storage/services accessible across namespaces; omit it for apps that just need admin-only install but manage their own users internally.
-- Do not add `sharedEntrances` (removed in 1.12.6+).
+- Do not add `sharedEntrances` (not supported).
 - A shared app is still subject to the rest of the skill: run-as-user 1000 ([run-as-user.md](olares-chart-run-as-user.md)), pinned image tags, accelerator sizing ([accelerator.md](olares-chart-accelerator.md)), env rules ([env.md](olares-chart-env.md)).

--- a/cli/skills/olares-chart/references/olares-chart-system-values.md
+++ b/cli/skills/olares-chart/references/olares-chart-system-values.md
@@ -35,7 +35,7 @@ Populated in `BuildBaseHelmValues` for every install (mostly from app-service's 
 | `.Values.downloadCdnURL` | system CDN base (`OLARES_SYSTEM_CDN_SERVICE`) | URL |
 | `.Values.fs_type` | rootfs type (`OLARES_SYSTEM_ROOTFS_TYPE`) | `fs` (default, local) \| `jfs` (JuiceFS) — templates branch on `{{ if eq (.Values.fs_type \| default "fs") "jfs" }}` |
 | `.Values.sharedlib` | External storage base path (`/Files/External/<deviceName>/`) — the External area in [platform.md](../../olares-shared/references/olares-platform.md) (storage model) | path |
-| `.Values.workloads.<name>.replicaCount` | per-workload replica count; present whenever the manifest declares `workloadReplicas` (required on 0.12.0). Each listed Deployment/StatefulSet **must** wire `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — app-service overrides this value for install (staged at 0) and suspend/resume, so a hardcoded `replicas` makes those operations inert. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas). | integer |
+| `.Values.workloads.<name>.replicaCount` | per-workload replica count; present whenever the manifest declares `workloadReplicas` (required). Each listed Deployment/StatefulSet **must** wire `spec.replicas: {{ .Values.workloads.<name>.replicaCount }}` — app-service overrides this value for install (staged at 0) and suspend/resume, so a hardcoded `replicas` makes those operations inert. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas). | integer |
 
 ```yaml
         env:

--- a/cli/skills/olares-chart/references/olares-chart-versioning.md
+++ b/cli/skills/olares-chart/references/olares-chart-versioning.md
@@ -1,6 +1,6 @@
-# Version rules — Olares version, apiVersion, and the chart version fields
+# Chart version fields — the fixed values every chart writes
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md). This collects the version-related rules that bite when porting: the Olares system version, the porting baseline, the `apiVersion: v3` skill rule, and the several distinct "version" fields a chart carries.
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md). This collects the fixed version fields every chart writes — `apiVersion: v3`, `olaresManifest.version: '0.12.0'`, and the `olares` system-dependency floor — plus the several distinct "version" fields a chart carries and how they relate.
 
 ## Olares system version
 
@@ -10,76 +10,63 @@ The semver scheme (stable / RC / daily), `.Values.sysVersion`, the `-0` prerelea
 
 **This skill (porting apps) targets Olares >= 1.12.6.** This baseline applies only to porting — other `olares-cli` features have no such floor. The reason: the userspace backends a ported app commonly relies on — `drive/Common` (`appCommon`), archive, and NFS — are gated at `1.12.6`. Check the target before porting (`olares-cli profile list` VERSION column; `--refresh-version` or `settings me version` for a live re-fetch).
 
-## apiVersion: v3 (skill rule)
+## apiVersion: v3
 
-`OlaresManifest.yaml` carries a top-level `apiVersion`. The toolchain accepts `v1`, `v2`, or `v3` (empty defaults to `v1`); only unknown values are rejected by `lint`. `from-compose` does **not** write an `apiVersion`, so a freshly scaffolded chart is implicitly `v1`.
+Every chart sets `apiVersion: v3` at the top of `OlaresManifest.yaml`. `from-compose` does not write it, so hand-add it after scaffolding:
 
-> **Skill rule: set `apiVersion: v3` for every ported app.** Hand-add it after `from-compose` (it is not added or required by `lint` — this is a skill convention, not a CLI lock):
->
-> ```yaml
-> apiVersion: v3
-> olaresManifest.version: '0.12.0'   # independent axis — see below
-> olaresManifest.type: app
-> metadata:
->   name: myapp
->   ...
-> ```
+```yaml
+apiVersion: v3
+olaresManifest.version: '0.12.0'
+olaresManifest.type: app
+metadata:
+  name: myapp
+  ...
+```
 
-What `v3` turns on (enforced by the toolchain only when `apiVersion: v3`):
+What `apiVersion: v3` governs:
 
 - **Declarative env rules** — an app-local `envName` must not start with `OLARES_USER`; user/system variables are mapped via `valueFrom`. Full env model: [olares-chart-env.md](olares-chart-env.md).
 - **Chart scan** — `lint` rejects templates that inline `OLARES_USER...` env names.
-- **Admin-only install** — a normal-user install is rejected; only the admin can install a v3 app.
+- **Admin-only install** — a normal-user install is rejected; only the admin can install the app.
 - **Namespace depends on `isShared`** in the manifest:
   - Without `isShared: true` → installs into `<app>-<adminUsername>` (the admin's personal namespace). Use this when the app just needs admin-only install but manages its own users internally.
   - With `isShared: true` → installs into `<app>-shared` (cluster-wide, cross-namespace access enabled). Use this for heavy shared backends (GPU inference servers, shared databases) that other apps consume. See [olares-chart-shared.md](olares-chart-shared.md).
 
-`apiVersion` is independent of `olaresManifest.version` — `v3` is the skill rule for the API axis, while the schema axis is always `0.12.0` (see below).
-
 ## The version fields in a chart (don't confuse them)
 
-A chart carries several "version" fields with different jobs and different rules:
+A chart carries several "version" fields with different jobs. Their values are fixed for every app:
 
-| Field | Where | What it is | Rule |
+| Field | Where | What it is | Value |
 |---|---|---|---|
-| `apiVersion` | `OlaresManifest.yaml` (top level) | manifest API generation | skill sets `v3` (toolchain allows `v1`/`v2`/`v3`, default `v1`) |
-| `olaresManifest.version` | `OlaresManifest.yaml` | manifest **schema** version | always `0.12.0` for new apps (`from-compose` emits it; install minimum `>= 0.7.2`, legacy `< 0.12.0` charts still install) |
-| `metadata.version` | `OlaresManifest.yaml` | **Chart version** (Market package) | must be semver and **equal `Chart.yaml` `version`** |
+| `apiVersion` | `OlaresManifest.yaml` (top level) | manifest API generation | `v3` |
+| `olaresManifest.version` | `OlaresManifest.yaml` | manifest schema | `0.12.0` |
+| `metadata.version` | `OlaresManifest.yaml` | **Chart version** (Market package) | semver, **equal `Chart.yaml` `version`** |
 | `version` | `Chart.yaml` | Helm chart version | `== metadata.version` |
 | `spec.versionName` | `OlaresManifest.yaml` | **upstream app** version (display) | tracks `Chart.yaml` `appVersion` — convention, not enforced |
 
-> **Name clash:** `Chart.yaml` also has its own `apiVersion` (`v2`) — that is the **Helm** chart API and is unrelated to the OlaresManifest `apiVersion`. Don't copy one into the other.
+> **Name clash:** `Chart.yaml` has its own `apiVersion` (Helm's chart API) — unrelated to the OlaresManifest `apiVersion`. Don't copy one into the other.
 
-### Schema version: 0.12.0
+### olaresManifest.version: 0.12.0
 
-`olaresManifest.version` declares which manifest schema the chart uses. **New apps always use `0.12.0`** — `from-compose` emits it unconditionally (the old `--new-schema` flag is a deprecated no-op). The 0.12.0 schema:
+`0.12.0` is the manifest schema every chart uses (`from-compose` emits it). It defines:
 
-- **Resource envelope** lives under `spec.resources[]` / `spec.accelerator[]` (mode-keyed: `cpu`, `nvidia`, ...), not the legacy flat `spec.requiredCpu` / `requiredMemory` / ... fields.
-- **GPU / accelerator** is declared via `spec.accelerator` with a mode → arch cross-check at `lint`.
-- **`permission.externalData`** (`.Values.sharedlib`) is supported.
-- **`workloadReplicas` is required** (non-v2): a map of every Deployment/StatefulSet → replica count, with each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}`. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas).
+- **Resource envelope** under `spec.resources[]` / `spec.accelerator[]` (mode-keyed: `cpu`, `nvidia`, ...).
+- **GPU / accelerator** declared via `spec.accelerator` with a mode → arch cross-check at `lint`.
+- **`permission.externalData`** (`.Values.sharedlib`).
+- **`workloadReplicas`** — a required map of every Deployment/StatefulSet → replica count, with each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}`. See [olares-chart-manifest.md](olares-chart-manifest.md) (Workloads & replicas).
 
 Accelerator mode declaration and sizing are in [olares-chart-accelerator.md](olares-chart-accelerator.md).
 
-> **Legacy `< 0.12.0` (e.g. `0.8.0`) charts** still install and validate (the install minimum is `>= 0.7.2`), and the validator reads their flat `spec.requiredCpu` / ... fields. You only meet them when reading old charts; do not author new ones on the legacy schema.
+## System dependency: the constraint
 
-## Declaring system-version compatibility
+Every chart declares the `olares` `type: system` dependency in `options.dependencies` — the entry's shape and the "author it yourself" rule are in [olares-chart-manifest.md](olares-chart-manifest.md) (System dependency: olares). What this section adds is the **constraint semantics**:
 
-State the minimum Olares your app needs via `options.dependencies` with `type: system`:
+- At install, app-service matches the version constraint against the running Olares version (semver); a mismatch blocks install.
+- Declare exactly `>=1.12.6-0`. The `-0` prerelease suffix is required so daily/RC builds (e.g. `1.12.6-20260327`) match — without it they fail to match an otherwise-satisfied version.
 
-```yaml
-options:
-  dependencies:
-  - name: olares
-    version: ">=1.12.6-0"   # -0 includes daily/prerelease builds (e.g. 1.12.6-20260327)
-    type: system
-```
-
-At install, app-service matches the constraint against the running Terminus version (semver); a mismatch blocks install. `lint` only checks the dependency's structure, not the semver constraint. Given the porting baseline above, declare `>=1.12.6-0` (bump it higher if you use a feature from a later release).
+`lint` requires both this entry and `workloadReplicas` to be present.
 
 ## Caveats
 
 - The `>= 1.12.6` baseline is a **porting** concern; it does not apply to other `olares-cli` commands.
 - `profile list`'s version is **cached** — use `--refresh-version` (or `settings me version`) if the target was just upgraded.
-- `lint` does **not** enforce `apiVersion: v3` and does **not** validate the `type: system` semver constraint — both are only checked downstream (skill discipline / install time).
-- Use the `-0` prerelease suffix in system constraints, or daily/RC builds (which carry a prerelease segment) will fail to match an otherwise-satisfied version.

--- a/cli/skills/olares-chart/references/olares-chart-workflow.md
+++ b/cli/skills/olares-chart/references/olares-chart-workflow.md
@@ -50,7 +50,7 @@ Step D1 produces a chart that **already passes `lint`** but is NOT yet a good ap
 - Every resource is namespaced with `namespace: '{{ .Release.Namespace }}'`.
 - Default CPU/memory requests+limits are stamped onto every container.
 - One **entrance** is auto-detected (the `olares.service.type: Entrance`-labeled service, else the first service with a port, else a `port: 80` placeholder).
-- `olaresManifest.version` is always `0.12.0` (resources under `spec.accelerator`) — see [olares-chart-manifest.md](olares-chart-manifest.md).
-- For 0.12.0, the scaffold also emits `workloadReplicas.<workload>: 1` (with the matching `values.yaml` `workloads.<name>.replicaCount`, and each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` so suspend/resume work) plus the required `options.dependencies` `olares >=1.12.6-0` (`type: system`), so a fresh scaffold passes `lint`.
+- `olaresManifest.version` is `0.12.0` (resources under `spec.accelerator`) — see [olares-chart-manifest.md](olares-chart-manifest.md).
+- The scaffold also emits `workloadReplicas.<workload>: 1` (with the matching `values.yaml` `workloads.<name>.replicaCount`, and each workload's `spec.replicas` wired to `{{ .Values.workloads.<name>.replicaCount }}` so suspend/resume work) plus the required `options.dependencies` `olares >=1.12.6-0` (`type: system`), so a fresh scaffold passes `lint`.
 
 > **Tip:** label the service you want exposed in the compose file with `labels: { olares.service.type: Entrance }` so the right workload becomes the entrance and gets renamed to the app name.


### PR DESCRIPTION
## Summary
- Treats Olares 1.12.6 / `apiVersion: v3` / `olaresManifest.version: '0.12.0'` as the single fixed target and removes version-comparison / legacy framing across the `olares-chart` skill docs.
- Adds a top-level `OlaresManifest` key skeleton so `workloadReplicas` clearly reads as a sibling of `spec` (not nested under it), matching the `AppConfiguration` schema in `github.com/beclab/api@v0.0.17`.
- Dedupes the "two required entries" guidance (`workloadReplicas` + `olares` system dependency) and clarifies that the manifest top-level `spec` differs from a Deployment template's `spec.replicas`.
- Fixes `olares-chart-middleware.md` examples to declare the `olares` system-dep floor as `>=1.12.6-0` (was a contradictory `>=1.0.0-0`).
- Rewrites `olares-chart-versioning.md` in fixed-field voice.

## Background
A read-only pressure test (an agent authoring a chart using only the skill docs) surfaced the top failure point: the docs stated `workloadReplicas` is top-level but never showed the full top-level shape, making it easy to nest under `spec`. Verified against the canonical `manifest.AppConfiguration` struct that `workloadReplicas` is a top-level sibling of `spec`.

## Test plan
- [ ] Read `cli/skills/olares-chart/references/olares-chart-manifest.md` — confirm the skeleton keys sit at column 0 and the `§1`-`§4` pointers resolve.
- [ ] Confirm no remaining `>=1.0.0-0` on any `olares` `type: system` entry.
- [ ] Confirm no broken intra-skill markdown links.

Made with [Cursor](https://cursor.com)