### PR TITLE
backup: file restore path trailing slash & push canceled event when task exists

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.65" }}
+{{ $backupVersion := "0.3.66" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/pkg/modules/backup/v1/model.go
+++ b/framework/backup-server/pkg/modules/backup/v1/model.go
@@ -599,7 +599,7 @@ func parseResponseRestoreDetailFromBackupUrl(restore *sysv1.Restore) (*ResponseR
 
 	restoreFullPath := filepath.Join(restorePath, subPath)
 	if backupType == constant.BackupTypeFile {
-		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp))
+		restoreFullPath = filepath.Join(restorePath, fmt.Sprintf("%s-%d", subPath, subPathTimestamp)) + "/"
 	}
 
 	result = &ResponseRestoreDetail{

--- a/framework/backup-server/pkg/worker/worker.go
+++ b/framework/backup-server/pkg/worker/worker.go
@@ -240,6 +240,7 @@ func (w *WorkerPool) ExistsTask(owner string, backupId, snapshotId string) error
 	})
 
 	if snapshotExists {
+		w.sendBackupCanceledEvent(owner, backupId, snapshotId, constant.MessageTaskExists)
 		return fmt.Errorf(constant.MessageTaskExists)
 	}
 
@@ -276,7 +277,7 @@ func (w *WorkerPool) CancelBackup(owner, backupId string) {
 	if activeTask != nil && *activeTask != nil {
 		backupTask := (*activeTask).(*BackupTask)
 		if backupTask.backupId == backupId {
-			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId, "")
 			backupTask.BaseTask.cancel()
 		}
 	}
@@ -312,7 +313,7 @@ func (w *WorkerPool) CancelSnapshot(owner, snapshotId string) {
 	if activeTask != nil && *activeTask != nil {
 		backupTask := (*activeTask).(*BackupTask)
 		if backupTask.snapshotId == snapshotId {
-			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId, "")
 			backupTask.BaseTask.cancel()
 		}
 	}
@@ -355,14 +356,14 @@ func (w *WorkerPool) CancelRestore(owner, restoreId string) {
 	}
 }
 
-func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snapshotId string) {
+func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snapshotId string, message string) {
 	var data = map[string]interface{}{
 		"id":       snapshotId,
 		"type":     constant.MessageTypeBackup,
 		"backupId": backupId,
 		"endat":    time.Now().Unix(),
 		"status":   constant.Canceled.String(),
-		"message":  "",
+		"message":  message,
 	}
 	notification.DataSender.Send(owner, data)
 }


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
backup: file restore path trailing slash & push canceled event when task exists

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/pull/3499


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API presentation fix and notification wiring for duplicate-task rejection; no auth or data-model changes.
> 
> **Overview**
> Bumps the **backup-server** deployment image to **v0.3.66**.
> 
> For **file** restores, `restorePath` in restore detail responses now ends with a **trailing `/`** on the timestamped directory path so clients treat it consistently as a folder.
> 
> When a backup/snapshot is rejected because **another task for the same backup is already running or queued**, the worker now emits a **canceled** backup notification (via NATS) with message `MessageTaskExists` before returning the error—so the UI gets feedback instead of only an API failure. User-initiated cancel paths still send the same event with an empty message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a08cdd2e242ac659956df646ea8613b2230e20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->