### PR TITLE
docs(skills): stuck-install diagnosis and app namespace lookup

### DIFF
--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-market
-version: 4.3.0
+version: 4.4.0
 description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, upload chart."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -102,6 +102,12 @@ The same `State` can mean different things depending on which mutation is in fli
 - With `--watch`, the CLI blocks until the row reaches a terminal bucket (success OR failure) matching the OpType safety rules above.
 - **Idempotent**: `resume` against an already-`running` row returns immediately with success; `install` against an already-installed row returns immediately with `state=running`. Watcher never hangs on "no-op" mutations.
 - `--watch-iterations` / `--watch-interval` / `--watch-timeout` are **rejected without `--watch`**.
+
+### Don't just wait — diagnose a stuck install
+
+The `--watch` market row is **coarse**: `installing` / `initializing` can show no progress for a long time, because app-service only fast-fails on a few hard pod conditions and otherwise polls a long TTL. **Rule:** let `--watch` run for the first **1-2 minutes**; if the row is still `installing` / `initializing` with no progress, stop waiting and diagnose the app's own pods instead of sitting on the watch.
+
+For the app-service facts (TTLs, fast-fail conditions, the soft-hang / `Pending` → `Stopping` traps) see [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md#stuck-in-installing--initializing); for the actual pod/log commands see [`../olares-cluster/SKILL.md`](../olares-cluster/SKILL.md).
 
 ## "What apps do I have?" routing
 

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -166,6 +166,15 @@ olares-cli market cancel firefox --watch               # block until row stops m
 - **For "install a custom chart"** → `market upload ./mychart.tgz` (always lands in source `upload`), then `market install <name> -s upload`.
 - **For ambiguous source rows on uninstall/stop/resume**: the verb already resolves automatically. Don't pass `-s` even when the SPA shows it under multiple sources.
 
+## Stuck in installing / initializing
+
+The `--watch` market row is coarse: a long `installing` / `initializing` is NOT the same as a failure, but app-service can keep polling for a long time before it gives up. So after ~1-2 minutes with no progress, stop watching passively and inspect the app's own pods. Two non-obvious traps:
+
+- A soft hang (pod Running but the app never becomes serve-ready, without crashing) is never fast-failed — only the pod itself reveals it, not the row.
+- A scheduling failure (pod `Pending`) ends in `Stopping` / `stopped`, NOT `installFailed` — watching only for `*Failed` misses it.
+
+Once stalled, resolve the app's namespace (per [`../../olares-shared/references/olares-platform.md`](../../olares-shared/references/olares-platform.md#finding-an-apps-namespace) — shared apps use `<app>-shared` and a v2 app spans several namespaces, so don't assume `<app>-<owner>`) and diagnose its workload; for orchestration issues, also check the app-service pod `os-framework/app-service-0` — pod status, logs, and previous-instance logs are all via [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md). Note `os-framework` system pods are typically admin-only; if the active profile can't see them, fall back to the app's own pod logs. For the crash triage (exitCode / `CreateContainerConfigError` / permission), see [`../../olares-chart/references/olares-chart-deploy.md`](../../olares-chart/references/olares-chart-deploy.md).
+
 ## Common errors
 
 | Symptom | Cause | Fix |

--- a/cli/skills/olares-shared/references/olares-platform.md
+++ b/cli/skills/olares-shared/references/olares-platform.md
@@ -62,7 +62,21 @@ How Olares apps are placed in namespaces and reach each other:
 - **Dependency injection.** When app B declares a `type: application` dependency on a shared app A, app-service injects A's Services into B's Helm values as `.Values.svcs.<svcName>_host` (= `<svcName>.<app>-shared`) and `.Values.svcs.<svcName>_ports`.
 - **`sharedEntrances` was removed in 1.12.6+.** Do not add it; treat any leftover as stale.
 
-Used by: `chart` (authoring shared apps and `application` dependencies) and `cluster` (the application-space / namespace runtime view).
+### Finding an app's namespace
+
+`<owner>` is the Olares ID local part (e.g. `alice`). Given an app name, its namespace follows the install kind:
+
+- **Per-user app** → `<app>-<owner>` (the common case).
+- **Shared app** (`apiVersion: v3`) → `<app>-shared` (admin-only, cluster-wide).
+- **System app** → `user-space-<owner>` (NOT `<app>-<owner>`).
+- **v2 multi-chart app** → one namespace **per sub-chart**: `<chartName>-<owner>` (or `<chartName>-shared` for a shared sub-chart). Such an app **spans several namespaces** — do not assume a single one.
+- The ApplicationManager name encodes the namespace as `<namespace>-<app>` (per-user `<app>-<owner>-<app>`, shared `<app>-shared-<app>`).
+
+In practice: derive `<app>-<owner>`; for a shared app check `<app>-shared`; when unsure — or for any v2 app — run `olares-cli cluster application list` instead of guessing. See [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) for the list/get commands.
+
+System components are not per-app: framework services (app-service, market, chart-repo, ...) live in `os-framework`, and system middleware (PostgreSQL / Redis / NATS / MongoDB) in `os-platform`. Discover specifics live via the `cluster` skill (`cluster namespace list`, `cluster pod list -n <ns>`) rather than hardcoding service names.
+
+Used by: `chart` (authoring shared apps and `application` dependencies) and `cluster` (the application-space / namespace runtime view, and locating an app's namespace).
 
 ## System middleware model
 


### PR DESCRIPTION
## Summary

Improves the `olares-cli` agent skills so the agent stops passively `--watch`ing a stalled install and knows how to locate an app's namespace.

- **olares-market**: a watched install can sit in `installing` / `initializing` for a long time (app-service fast-fails only on a few hard pod conditions, otherwise polls a long TTL). Added a rule: after ~1-2 min with no progress, diagnose the app's own pods instead of waiting out the watch. The facts and traps (soft hang; `Pending` → `Stopping`, not `installFailed`) live in the lifecycle reference; `SKILL.md` keeps only the rule plus pointers (to the lifecycle reference and `olares-cluster`).
- **olares-shared**: documented how to resolve an app's namespace in the platform reference — per-user `<app>-<owner>`, shared v3 `<app>-shared`, system app `user-space-<owner>`, and v2 multi-chart spanning several `<chart>-<owner>` namespaces, plus the ApplicationManager name encoding. Diagnosis now points here instead of hardcoding `<app>-<owner>`.

Docs-only change under `cli/skills/`; no code paths touched.

## Test plan

- [ ] Verify the new `Stuck in installing / initializing` section renders and its anchor link from `olares-market/SKILL.md` resolves.
- [ ] Verify the `Finding an app's namespace` anchor in `olares-shared/references/olares-platform.md` resolves from the lifecycle reference.

Made with [Cursor](https://cursor.com)