### PR TITLE
docs(vitepress): add canonical links for indexable documentation pages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,16 @@ import _ from "lodash";
 // filter them out without re-reading frontmatter from disk.
 const noindexPaths = new Set<string>();
 
+// Archived (non-latest) versioned doc builds deploy under /docs/<version>/
+// (e.g. /docs/1.12.4/...) and duplicate the latest docs almost verbatim,
+// which is the main driver of the "duplicate content" / "missing canonical"
+// findings. Mark every page in such a build `noindex` so the versioned copies
+// drop out of search and consolidate onto the canonical latest /docs/... URLs.
+// Detected from the deploy base, the only signal reliably set for archived
+// builds: it always carries a version segment (e.g. "/docs/1.12.4/") and can
+// never match the latest deploy, whose base is "/docs/" or "/" (no version).
+const isArchivedVersionBuild = /\/\d+\.\d+/.test(process.env.BASE_URL || "");
+
  
 
 function defineVersionedConfig2(
@@ -127,7 +137,8 @@ export default defineVersionedConfig2(withMermaid({
     // to its frontmatter. Implemented here (rather than per-file `head`) so
     // we don't shift source line numbers, which would break `@include` ranges
     // in files that embed this one as a snippet.
-    if (pageData.frontmatter?.noindex) {
+    // Archived versioned builds noindex every page (see isArchivedVersionBuild).
+    if (isArchivedVersionBuild || pageData.frontmatter?.noindex) {
       pageData.frontmatter.head ??= [];
       pageData.frontmatter.head.push([
         'meta',
@@ -151,15 +162,20 @@ export default defineVersionedConfig2(withMermaid({
     const route = pageData.relativePath
       .replace(/(^|\/)index\.md$/, '$1')
       .replace(/\.md$/, '');
+    const canonicalHref = route
+      ? `https://www.olares.com/docs/${route}`
+      : 'https://www.olares.com/docs/';
     pageData.frontmatter.head ??= [];
     pageData.frontmatter.head.push([
       'link',
-      {
-        rel: 'canonical',
-        href: route
-          ? `https://www.olares.com/docs/${route}`
-          : 'https://www.olares.com/docs/',
-      },
+      { rel: 'canonical', href: canonicalHref },
+    ]);
+    // Keep og:url identical to the canonical URL. A mismatch between the two
+    // sends conflicting signals to crawlers and social scrapers about the
+    // page's authoritative address.
+    pageData.frontmatter.head.push([
+      'meta',
+      { property: 'og:url', content: canonicalHref },
     ]);
   },
 
@@ -173,6 +189,9 @@ export default defineVersionedConfig2(withMermaid({
         // Normalize to the extensionless route so the comparison holds whether
         // or not cleanUrls is enabled.
         const p = item.url.replace(/^\/+/, '').replace(/\.html$/, '');
+        // Repo READMEs are srcExclude'd above, but guard the sitemap too so a
+        // stray /docs/README (or nested README) can never leak back in.
+        if (p === 'README' || p.endsWith('/README')) return false;
         return !noindexPaths.has(p);
       }),
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -138,7 +138,29 @@ export default defineVersionedConfig2(withMermaid({
       noindexPaths.add(
         pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '')
       );
+      // Skip canonical on noindex pages: a self/duplicate canonical combined
+      // with `noindex` sends contradictory signals to crawlers.
+      return;
     }
+
+    // Self-referencing canonical for every indexable doc page. Built from the
+    // *unversioned* route on the production origin (matches the sitemap
+    // hostname below) so versioned (/docs/<version>/...) duplicates consolidate
+    // onto the latest /docs/... URL. `cleanUrls` is on, so the route is
+    // extensionless; directory indexes keep their trailing slash.
+    const route = pageData.relativePath
+      .replace(/(^|\/)index\.md$/, '$1')
+      .replace(/\.md$/, '');
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push([
+      'link',
+      {
+        rel: 'canonical',
+        href: route
+          ? `https://www.olares.com/docs/${route}`
+          : 'https://www.olares.com/docs/',
+      },
+    ]);
   },
 
   sitemap: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -9,6 +9,19 @@
           "value": "max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
* **Background**
Implemented self-referencing canonical links for indexable documentation pages to consolidate versioned URLs onto the latest unversioned route. This change ensures that noindex pages are correctly handled by skipping canonical links, preventing contradictory signals to crawlers.

* **Target Version for Merge**
v1.12.6, v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static docs build and deployment header changes only; SEO logic is additive with low runtime impact, though mis-detected `BASE_URL` could wrongly noindex or canonical URLs.
> 
> **Overview**
> Improves **docs SEO** in the VitePress build: **archived version deploys** (when `BASE_URL` includes a version segment like `/docs/1.12.4/`) now **noindex every page**, same as frontmatter `noindex`, so duplicate versioned copies drop out of search and the sitemap. **Indexable** pages get a **self-referencing canonical** and matching **`og:url`** on `https://www.olares.com/docs/...` (unversioned latest paths); **noindex pages skip canonical** to avoid conflicting crawler signals. The sitemap filter also **drops README routes** as a backup to `srcExclude`.
> 
> **`docs/vercel.json`** adds site-wide **`X-Frame-Options: SAMEORIGIN`** and **`X-Content-Type-Options: nosniff`** on all paths (in addition to existing asset cache headers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959cf6da0c30268fe88b8dbe2fa656e7748da73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->