### PR TITLE
fix(daemon): Fix LPVPN DNS resolution via drift-only SNAT reconcile

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/beclab/Olares/daemon/internel/watcher"
 	"github.com/beclab/Olares/daemon/internel/watcher/cert"
 	intranetwatcher "github.com/beclab/Olares/daemon/internel/watcher/intranet"
+	"github.com/beclab/Olares/daemon/internel/watcher/lpvpndns"
 	mountwatcher "github.com/beclab/Olares/daemon/internel/watcher/mount"
 	"github.com/beclab/Olares/daemon/internel/watcher/system"
 	"github.com/beclab/Olares/daemon/internel/watcher/systemenv"
@@ -109,6 +110,7 @@ func main() {
 		systemenv.NewSystemEnvWatcher(),
 		intranetwatcher.NewApplicationWatcher(),
 		mountwatcher.NewMountWatcher(),
+		lpvpndns.NewWatcher(),
 	}, func() {
 		if s != nil {
 			if err := s.Restart(); err != nil {

--- a/daemon/internel/watcher/lpvpndns/corefile.go
+++ b/daemon/internel/watcher/lpvpndns/corefile.go
@@ -1,0 +1,52 @@
+package lpvpndns
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// detectPodCIDR mirrors corefile.go's primary probe: parse the cluster Pod
+// CIDR from the kube-proxy KUBE-SERVICES chain. olaresd runs as root so the
+// iptables read works on host. Falls back to defaultPodCIDR.
+func detectPodCIDR(ctx context.Context, _ kubernetes.Interface) string {
+	if cidr, ok := podCIDRFromIptables(ctx); ok {
+		klog.V(2).Infof("lpvpndns: detectPodCIDR KUBE-SERVICES %s", cidr)
+		return cidr
+	}
+	klog.V(2).Infof("lpvpndns: detectPodCIDR fallback %s", defaultPodCIDR)
+	return defaultPodCIDR
+}
+
+func podCIDRFromIptables(ctx context.Context) (string, bool) {
+	out, err := runCmd(ctx, "iptables", "-t", natTable, "-S", "KUBE-SERVICES")
+	if err != nil {
+		klog.V(4).Infof("lpvpndns: detectPodCIDR iptables unavailable: %v", err)
+		return "", false
+	}
+	return parsePodCIDRFromKubeServicesIPTables(string(out))
+}
+
+// parsePodCIDRFromKubeServicesIPTables extracts the `! -s <cidr>` Pod CIDR from
+// the KUBE-SERVICES masquerade rule. Pure function for unit testing.
+func parsePodCIDRFromKubeServicesIPTables(output string) (string, bool) {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "KUBE-SERVICES") || !strings.Contains(line, "KUBE-MARK-MASQ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i := 0; i < len(fields)-2; i++ {
+			if fields[i] != "!" || fields[i+1] != "-s" {
+				continue
+			}
+			cidr := fields[i+2]
+			if _, _, err := net.ParseCIDR(cidr); err == nil {
+				return cidr, true
+			}
+		}
+	}
+	return "", false
+}

--- a/daemon/internel/watcher/lpvpndns/corefile_test.go
+++ b/daemon/internel/watcher/lpvpndns/corefile_test.go
@@ -1,0 +1,39 @@
+package lpvpndns
+
+import "testing"
+
+func TestParsePodCIDRFromKubeServicesIPTables(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "standard masq rule",
+			output: `-A KUBE-SERVICES ! -s 10.233.64.0/18 -d 10.233.0.1/32 -p tcp -j KUBE-MARK-MASQ`,
+			want:   "10.233.64.0/18",
+			wantOK: true,
+		},
+		{
+			name:   "no masq line",
+			output: `-A KUBE-SERVICES -d 10.233.0.1/32 -j KUBE-SVC-XYZ`,
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   "",
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parsePodCIDRFromKubeServicesIPTables(c.output)
+			if got != c.want || ok != c.wantOK {
+				t.Fatalf("parsePodCIDRFromKubeServicesIPTables = (%q,%v), want (%q,%v)", got, ok, c.want, c.wantOK)
+			}
+		})
+	}
+}

--- a/daemon/internel/watcher/lpvpndns/iptables.go
+++ b/daemon/internel/watcher/lpvpndns/iptables.go
@@ -1,0 +1,255 @@
+package lpvpndns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	chainName      = "OLARES-LPVPN-DNS"
+	natTable       = "nat"
+	postRouting    = "POSTROUTING"
+	dnsPort        = "53"
+	defaultPodCIDR = "10.233.64.0/18"
+)
+
+// runCmd / runCmdStdin are package-level command runners so unit tests can
+// replace them with mocks and assert exact command shape (the §4.1.1 red
+// lines: --noflush, single chain declaration, narrow conntrack, etc.).
+var runCmd = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = os.Environ()
+	return cmd.CombinedOutput()
+}
+
+var runCmdStdin = func(ctx context.Context, stdin, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = strings.NewReader(stdin)
+	return cmd.CombinedOutput()
+}
+
+var (
+	toSourceRe = regexp.MustCompile(`--to-source\s+(\S+)`)
+	dstRe      = regexp.MustCompile(`(?:^|\s)-d\s+(\S+)`)
+)
+
+// readChain returns the `iptables -t nat -S OLARES-LPVPN-DNS` lines and whether
+// the chain exists. A non-nil error from iptables (chain absent) yields
+// exists=false.
+func readChain(ctx context.Context) (lines []string, exists bool) {
+	out, err := runCmd(ctx, "iptables", "-t", natTable, "-S", chainName)
+	if err != nil {
+		if isIPTablesChainAbsent(out) {
+			klog.V(4).Infof("lpvpndns: chain %s absent", chainName)
+		} else {
+			klog.Warningf("lpvpndns: read chain %s failed: %v, out=%s", chainName, err, string(out))
+		}
+		return nil, false
+	}
+	for _, l := range strings.Split(string(out), "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines, true
+}
+
+// isIPTablesChainAbsent reports whether iptables -S failed because the chain
+// does not exist (expected on first install or after teardown).
+func isIPTablesChainAbsent(out []byte) bool {
+	return strings.Contains(string(out), "No chain/target/match")
+}
+
+// parseChain derives the SNAT target (--to-source), the destination CIDR (-d)
+// and the count of `-A OLARES-LPVPN-DNS` rules from the chain dump. Semantic
+// parsing avoids brittle string equality against iptables' normalized output.
+func parseChain(lines []string) (vpnIP, podCIDR string, ruleCount int) {
+	for _, l := range lines {
+		if !strings.HasPrefix(l, "-A "+chainName) {
+			continue
+		}
+		ruleCount++
+		if vpnIP == "" {
+			if m := toSourceRe.FindStringSubmatch(l); len(m) == 2 {
+				vpnIP = m[1]
+			}
+		}
+		if podCIDR == "" {
+			if m := dstRe.FindStringSubmatch(l); len(m) == 2 {
+				podCIDR = m[1]
+			}
+		}
+	}
+	return vpnIP, podCIDR, ruleCount
+}
+
+// reconcile is drift-only: it reads the actual state, compares against the
+// desired state, and writes iptables ONLY when there is a real difference.
+// In steady state it performs read-only probes and zero writes.
+func reconcile(ctx context.Context, vpnIP, podCIDR string) {
+	lines, exists := readChain(ctx)
+	oldVPNIP, curPodCIDR, ruleCount := parseChain(lines)
+
+	chainDrift := !exists || ruleCount != 2 || oldVPNIP != vpnIP || curPodCIDR != podCIDR
+	vpnChanged := exists && oldVPNIP != "" && oldVPNIP != vpnIP
+
+	if chainDrift {
+		klog.Infof("lpvpndns: rebuild chain %s vpnIP=%s podCIDR=%s (was vpnIP=%s podCIDR=%s rules=%d exists=%v)",
+			chainName, vpnIP, podCIDR, oldVPNIP, curPodCIDR, ruleCount, exists)
+		if out, err := rebuildChainAtomic(ctx, vpnIP, podCIDR); err != nil {
+			klog.Errorf("lpvpndns: rebuild chain failed: %v, out=%s", err, string(out))
+			// Fail-closed: do not ensureJump against a chain that may be missing or
+			// half-written; retry on the next tick after a successful rebuild.
+			return
+		}
+	}
+
+	if err := ensureJump(ctx); err != nil {
+		klog.V(4).Infof("lpvpndns: ensure POSTROUTING jump failed, retry next tick: %v", err)
+		return
+	}
+
+	if vpnChanged {
+		klog.Infof("lpvpndns: vpnIP changed %s -> %s, narrow conntrack flush", oldVPNIP, vpnIP)
+		cleanConntrack(ctx, oldVPNIP)
+	}
+}
+
+// rebuildChainAtomic replaces ONLY the OLARES-LPVPN-DNS chain in a single
+// iptables-restore --noflush transaction. Per iptables-restore(8), only the
+// chains declared with `:` are flushed and rebuilt; all other chains and
+// tables are retained. The POSTROUTING jump is never part of this input.
+func rebuildChainAtomic(ctx context.Context, vpnIP, podCIDR string) ([]byte, error) {
+	return runCmdStdin(ctx, buildRestoreInput(vpnIP, podCIDR), "iptables-restore", "--noflush")
+}
+
+func buildRestoreInput(vpnIP, podCIDR string) string {
+	return fmt.Sprintf(`*nat
+:%[1]s - [0:0]
+-A %[1]s -d %[2]s ! -s %[2]s -p udp --dport %[4]s -j SNAT --to-source %[3]s
+-A %[1]s -d %[2]s ! -s %[2]s -p tcp --dport %[4]s -j SNAT --to-source %[3]s
+COMMIT
+`, chainName, podCIDR, vpnIP, dnsPort)
+}
+
+// jumpRuleNumbers returns the 1-based rule numbers (in POSTROUTING) of every
+// `-j OLARES-LPVPN-DNS` jump, ascending. A read error is distinct from an
+// empty jump list so callers can fail-closed instead of treating errors as
+// "no jump".
+func jumpRuleNumbers(ctx context.Context) ([]int, error) {
+	out, err := runCmd(ctx, "iptables", "-t", natTable, "-S", postRouting)
+	if err != nil {
+		return nil, err
+	}
+	var nums []int
+	idx := 0
+	for _, l := range strings.Split(string(out), "\n") {
+		l = strings.TrimSpace(l)
+		if !strings.HasPrefix(l, "-A "+postRouting) {
+			continue
+		}
+		idx++ // rule number among -A POSTROUTING rules (1-based)
+		if strings.Contains(l, "-j "+chainName) {
+			nums = append(nums, idx)
+		}
+	}
+	sort.Ints(nums)
+	return nums, nil
+}
+
+// ensureJump keeps exactly one `-j OLARES-LPVPN-DNS` jump as the first rule of
+// POSTROUTING (ahead of KUBE-POSTROUTING). It is drift-only: no write when the
+// jump is already unique and on top. Insert-before-delete guarantees there is
+// never a window without a jump. Returns an error when POSTROUTING cannot be
+// read so callers fail-closed instead of inserting duplicate jumps.
+func ensureJump(ctx context.Context) error {
+	nums, err := jumpRuleNumbers(ctx)
+	if err != nil {
+		klog.Errorf("lpvpndns: read POSTROUTING jump state failed: %v", err)
+		return err
+	}
+	if len(nums) == 1 && nums[0] == 1 {
+		return nil
+	}
+
+	if out, err := runCmd(ctx, "iptables", "-t", natTable, "-I", postRouting, "1", "-j", chainName); err != nil {
+		klog.Errorf("lpvpndns: insert POSTROUTING jump failed: %v, out=%s", err, string(out))
+		return err
+	}
+
+	// Delete the remaining (now-redundant) jumps, keeping the new top one
+	// (number 1). Delete from highest number to lowest to keep indices valid.
+	again, err := jumpRuleNumbers(ctx)
+	if err != nil {
+		klog.Errorf("lpvpndns: re-read POSTROUTING jump state failed: %v", err)
+		return err
+	}
+	for i := len(again) - 1; i >= 0; i-- {
+		if again[i] == 1 {
+			continue
+		}
+		if out, err := runCmd(ctx, "iptables", "-t", natTable, "-D", postRouting, strconv.Itoa(again[i])); err != nil {
+			klog.Errorf("lpvpndns: delete redundant POSTROUTING jump #%d failed: %v, out=%s", again[i], err, string(out))
+		}
+	}
+	return nil
+}
+
+// cleanConntrack removes ONLY the reply-side conntrack entries previously SNAT
+// rewritten to oldVPNIP (reply-dst == oldVPNIP) on :53. It never touches
+// incluster Pod flows or external DNS flows. best-effort; a missing conntrack
+// tool degrades to 30s natural expiry.
+func cleanConntrack(ctx context.Context, oldVPNIP string) {
+	if net.ParseIP(oldVPNIP) == nil {
+		return
+	}
+	for _, proto := range []string{"udp", "tcp"} {
+		if _, err := runCmd(ctx, "conntrack", "-D", "--reply-dst", oldVPNIP, "-p", proto, "--dport", dnsPort); err != nil {
+			klog.V(4).Infof("lpvpndns: conntrack flush reply-dst=%s proto=%s: %v", oldVPNIP, proto, err)
+		}
+	}
+}
+
+// teardown removes the jump, flushes and deletes the chain, and narrow-cleans
+// conntrack. Fully idempotent: a missing chain/jump is a no-op.
+func teardown(ctx context.Context) {
+	lines, exists := readChain(ctx)
+	oldVPNIP, _, _ := parseChain(lines)
+
+	jumps, err := jumpRuleNumbers(ctx)
+	if err != nil {
+		klog.Errorf("lpvpndns: teardown read POSTROUTING jump state failed: %v", err)
+		return
+	}
+	for len(jumps) > 0 {
+		if out, err := runCmd(ctx, "iptables", "-t", natTable, "-D", postRouting, "-j", chainName); err != nil {
+			klog.Errorf("lpvpndns: teardown delete POSTROUTING jump failed: %v, out=%s", err, string(out))
+			break
+		}
+		jumps, err = jumpRuleNumbers(ctx)
+		if err != nil {
+			klog.Errorf("lpvpndns: teardown re-read POSTROUTING jump state failed: %v", err)
+			return
+		}
+	}
+
+	if exists {
+		if out, err := runCmd(ctx, "iptables", "-t", natTable, "-F", chainName); err != nil {
+			klog.Errorf("lpvpndns: teardown flush chain failed: %v, out=%s", err, string(out))
+		}
+		if out, err := runCmd(ctx, "iptables", "-t", natTable, "-X", chainName); err != nil {
+			klog.Errorf("lpvpndns: teardown delete chain failed: %v, out=%s", err, string(out))
+		}
+		cleanConntrack(ctx, oldVPNIP)
+	}
+}

--- a/daemon/internel/watcher/lpvpndns/iptables_test.go
+++ b/daemon/internel/watcher/lpvpndns/iptables_test.go
@@ -1,0 +1,373 @@
+package lpvpndns
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mockExec records every command and replies to read probes
+// (`iptables -t nat -S <chain>`) from configurable dumps.
+type mockExec struct {
+	chainDump       string // "" => chain absent (iptables returns error)
+	postroutingDump string
+	postroutingErr  error // when set, `-S POSTROUTING` fails
+	restoreErr      error // when set, iptables-restore fails
+
+	cmds   [][]string // every runCmd invocation (args joined)
+	stdins []string   // every runCmdStdin payload
+	stdcmd [][]string // every runCmdStdin invocation args
+}
+
+func (m *mockExec) run(_ context.Context, name string, args ...string) ([]byte, error) {
+	full := append([]string{name}, args...)
+	m.cmds = append(m.cmds, full)
+	joined := strings.Join(full, " ")
+
+	switch {
+	case strings.Contains(joined, "-S "+chainName):
+		if m.chainDump == "" {
+			return nil, errors.New("iptables: No chain/target/match by that name")
+		}
+		return []byte(m.chainDump), nil
+	case strings.Contains(joined, "-S "+postRouting):
+		if m.postroutingErr != nil {
+			return nil, m.postroutingErr
+		}
+		return []byte(m.postroutingDump), nil
+	}
+	return nil, nil
+}
+
+func (m *mockExec) runStdin(_ context.Context, stdin, name string, args ...string) ([]byte, error) {
+	m.stdcmd = append(m.stdcmd, append([]string{name}, args...))
+	m.stdins = append(m.stdins, stdin)
+	if m.restoreErr != nil {
+		return nil, m.restoreErr
+	}
+	return nil, nil
+}
+
+// install swaps the package runners with the mock and returns a restore func.
+func (m *mockExec) install() func() {
+	origRun, origStdin := runCmd, runCmdStdin
+	runCmd = m.run
+	runCmdStdin = m.runStdin
+	return func() { runCmd, runCmdStdin = origRun, origStdin }
+}
+
+// writeCmds returns iptables/conntrack commands that mutate state (everything
+// except read-only `-S` probes).
+func (m *mockExec) writeCmds() [][]string {
+	var w [][]string
+	for _, c := range m.cmds {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, " -S ") {
+			continue
+		}
+		w = append(w, c)
+	}
+	return w
+}
+
+func (m *mockExec) hasCmdContaining(sub string) bool {
+	for _, c := range m.cmds {
+		if strings.Contains(strings.Join(c, " "), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	testVPNIP   = "192.168.128.102"
+	testPodCIDR = "10.233.64.0/18"
+)
+
+func steadyChainDump(vpnIP, podCIDR string) string {
+	return strings.Join([]string{
+		"-N " + chainName,
+		"-A " + chainName + " -d " + podCIDR + " ! -s " + podCIDR + " -p udp -m udp --dport 53 -j SNAT --to-source " + vpnIP,
+		"-A " + chainName + " -d " + podCIDR + " ! -s " + podCIDR + " -p tcp -m tcp --dport 53 -j SNAT --to-source " + vpnIP,
+	}, "\n")
+}
+
+// jump on top of POSTROUTING followed by kube-proxy jump.
+const steadyPostrouting = "-P POSTROUTING ACCEPT\n" +
+	"-A POSTROUTING -j " + chainName + "\n" +
+	"-A POSTROUTING -m comment --comment kubernetes -j KUBE-POSTROUTING"
+
+func TestReconcile_SteadyState_NoWrites(t *testing.T) {
+	m := &mockExec{
+		chainDump:       steadyChainDump(testVPNIP, testPodCIDR),
+		postroutingDump: steadyPostrouting,
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	if w := m.writeCmds(); len(w) != 0 {
+		t.Fatalf("steady state must not write, got %v", w)
+	}
+	if len(m.stdcmd) != 0 {
+		t.Fatalf("steady state must not run iptables-restore, got %v", m.stdcmd)
+	}
+}
+
+func TestReconcile_VPNIPChange_RebuildAndNarrowConntrack(t *testing.T) {
+	oldIP := "192.168.128.106"
+	m := &mockExec{
+		chainDump:       steadyChainDump(oldIP, testPodCIDR),
+		postroutingDump: steadyPostrouting,
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	// exactly one atomic rebuild via iptables-restore --noflush
+	if len(m.stdcmd) != 1 {
+		t.Fatalf("want one iptables-restore, got %d (%v)", len(m.stdcmd), m.stdcmd)
+	}
+	restoreArgs := strings.Join(m.stdcmd[0], " ")
+	if !strings.Contains(restoreArgs, "iptables-restore") || !strings.Contains(restoreArgs, "--noflush") {
+		t.Fatalf("rebuild must use `iptables-restore --noflush`, got %q", restoreArgs)
+	}
+	assertRestoreInputRedlines(t, m.stdins[0])
+
+	// narrow conntrack on old IP, udp + tcp, never a broad flush
+	if !m.hasCmdContaining("conntrack -D --reply-dst " + oldIP + " -p udp --dport 53") {
+		t.Fatalf("missing narrow udp conntrack flush; cmds=%v", m.cmds)
+	}
+	if !m.hasCmdContaining("conntrack -D --reply-dst " + oldIP + " -p tcp --dport 53") {
+		t.Fatalf("missing narrow tcp conntrack flush; cmds=%v", m.cmds)
+	}
+	assertNoBroadConntrack(t, m)
+}
+
+func TestReconcile_PodCIDRDriftOnly_NoConntrack(t *testing.T) {
+	m := &mockExec{
+		chainDump:       steadyChainDump(testVPNIP, "10.244.0.0/16"), // wrong podCIDR, same vpnIP
+		postroutingDump: steadyPostrouting,
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	if len(m.stdcmd) != 1 {
+		t.Fatalf("podCIDR drift must rebuild once, got %d", len(m.stdcmd))
+	}
+	if m.hasCmdContaining("conntrack") {
+		t.Fatalf("podCIDR-only drift must NOT touch conntrack; cmds=%v", m.cmds)
+	}
+}
+
+func TestReconcile_FirstInstall_NoConntrack(t *testing.T) {
+	m := &mockExec{
+		chainDump:       "", // chain absent
+		postroutingDump: "-P POSTROUTING ACCEPT\n-A POSTROUTING -j KUBE-POSTROUTING",
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	if len(m.stdcmd) != 1 {
+		t.Fatalf("first install must rebuild once, got %d", len(m.stdcmd))
+	}
+	assertRestoreInputRedlines(t, m.stdins[0])
+	// jump absent -> must be inserted at top
+	if !m.hasCmdContaining("-I " + postRouting + " 1 -j " + chainName) {
+		t.Fatalf("first install must insert top jump; cmds=%v", m.cmds)
+	}
+	// first install relies on new-flow SNAT + 30s expiry, not a broad flush
+	if m.hasCmdContaining("conntrack") {
+		t.Fatalf("first install must NOT flush conntrack; cmds=%v", m.cmds)
+	}
+}
+
+func TestEnsureJump_FixesNonTopJump(t *testing.T) {
+	m := &mockExec{
+		// our jump is second, behind kube-proxy
+		postroutingDump: "-P POSTROUTING ACCEPT\n" +
+			"-A POSTROUTING -j KUBE-POSTROUTING\n" +
+			"-A POSTROUTING -j " + chainName,
+	}
+	defer m.install()()
+
+	if err := ensureJump(context.Background()); err != nil {
+		t.Fatalf("ensureJump: %v", err)
+	}
+
+	if !m.hasCmdContaining("-I " + postRouting + " 1 -j " + chainName) {
+		t.Fatalf("must insert jump on top; cmds=%v", m.cmds)
+	}
+	// only -C/-I/-D maintenance, never -F/-A on POSTROUTING
+	for _, c := range m.cmds {
+		j := strings.Join(c, " ")
+		if strings.Contains(j, "-A "+postRouting) || strings.Contains(j, "-F "+postRouting) {
+			t.Fatalf("jump must not be maintained via -A/-F: %q", j)
+		}
+	}
+}
+
+func TestEnsureJump_PostroutingReadError_NoWrites(t *testing.T) {
+	m := &mockExec{
+		postroutingErr: errors.New("iptables: read POSTROUTING failed"),
+	}
+	defer m.install()()
+
+	if err := ensureJump(context.Background()); err == nil {
+		t.Fatal("expected POSTROUTING read error")
+	}
+	if w := m.writeCmds(); len(w) != 0 {
+		t.Fatalf("POSTROUTING read error must not mutate iptables, got %v", w)
+	}
+}
+
+func TestReconcile_RebuildFailure_SkipsEnsureJump(t *testing.T) {
+	m := &mockExec{
+		chainDump:       "", // chain absent -> drift -> rebuild
+		postroutingDump: "-P POSTROUTING ACCEPT\n-A POSTROUTING -j KUBE-POSTROUTING",
+		restoreErr:      errors.New("iptables-restore: transaction failed"),
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	if len(m.stdcmd) != 1 {
+		t.Fatalf("rebuild failure must attempt one restore, got %d (%v)", len(m.stdcmd), m.stdcmd)
+	}
+	if m.hasCmdContaining("-I " + postRouting) {
+		t.Fatalf("rebuild failure must skip ensureJump; cmds=%v", m.cmds)
+	}
+	if m.hasCmdContaining("conntrack") {
+		t.Fatalf("rebuild failure must skip conntrack; cmds=%v", m.cmds)
+	}
+}
+
+func TestReconcile_PostroutingReadError_NoWrites(t *testing.T) {
+	m := &mockExec{
+		chainDump:      steadyChainDump(testVPNIP, testPodCIDR),
+		postroutingErr: errors.New("iptables: read POSTROUTING failed"),
+	}
+	defer m.install()()
+
+	reconcile(context.Background(), testVPNIP, testPodCIDR)
+
+	if w := m.writeCmds(); len(w) != 0 {
+		t.Fatalf("POSTROUTING read error must not mutate iptables, got %v", w)
+	}
+	if len(m.stdcmd) != 0 {
+		t.Fatalf("steady chain must not rebuild on POSTROUTING read error, got %v", m.stdcmd)
+	}
+}
+
+func TestTeardown_PostroutingReadError_NoChainMutation(t *testing.T) {
+	m := &mockExec{
+		chainDump:      steadyChainDump(testVPNIP, testPodCIDR),
+		postroutingErr: errors.New("iptables: read POSTROUTING failed"),
+	}
+	defer m.install()()
+
+	teardown(context.Background())
+
+	if m.hasCmdContaining("-F "+chainName) || m.hasCmdContaining("-X "+chainName) {
+		t.Fatalf("POSTROUTING read error must not flush/delete chain; cmds=%v", m.cmds)
+	}
+	if m.hasCmdContaining("-D " + postRouting) {
+		t.Fatalf("POSTROUTING read error must not delete jumps; cmds=%v", m.cmds)
+	}
+	if m.hasCmdContaining("conntrack") {
+		t.Fatalf("POSTROUTING read error must not flush conntrack; cmds=%v", m.cmds)
+	}
+}
+
+func TestTeardown_Idempotent_NoChain(t *testing.T) {
+	m := &mockExec{
+		chainDump:       "",
+		postroutingDump: "-P POSTROUTING ACCEPT\n-A POSTROUTING -j KUBE-POSTROUTING",
+	}
+	defer m.install()()
+
+	teardown(context.Background())
+
+	// no chain present -> must not attempt -F/-X or conntrack
+	if m.hasCmdContaining("-F "+chainName) || m.hasCmdContaining("-X "+chainName) {
+		t.Fatalf("teardown on absent chain must not flush/delete chain; cmds=%v", m.cmds)
+	}
+	if m.hasCmdContaining("conntrack") {
+		t.Fatalf("teardown on absent chain must not flush conntrack; cmds=%v", m.cmds)
+	}
+}
+
+func TestBuildRestoreInput_Redlines(t *testing.T) {
+	assertRestoreInputRedlines(t, buildRestoreInput(testVPNIP, testPodCIDR))
+}
+
+// assertRestoreInputRedlines enforces the §4.1.1 safety red lines on the
+// iptables-restore payload.
+func assertRestoreInputRedlines(t *testing.T, input string) {
+	t.Helper()
+	if !strings.Contains(input, ":"+chainName+" - [0:0]") {
+		t.Fatalf("restore input must declare own chain; got:\n%s", input)
+	}
+	if strings.Contains(input, ":"+postRouting) {
+		t.Fatalf("restore input must NOT declare built-in POSTROUTING; got:\n%s", input)
+	}
+	// exactly one chain declaration line (starts with ':')
+	chainDecls := 0
+	tables := 0
+	for _, line := range strings.Split(input, "\n") {
+		if strings.HasPrefix(line, ":") {
+			chainDecls++
+		}
+		if strings.HasPrefix(line, "*") {
+			tables++
+		}
+	}
+	if chainDecls != 1 {
+		t.Fatalf("restore input must declare exactly one chain, got %d:\n%s", chainDecls, input)
+	}
+	if tables != 1 || !strings.Contains(input, "*nat") {
+		t.Fatalf("restore input must be a single *nat table; got:\n%s", input)
+	}
+	if !strings.Contains(input, "COMMIT") {
+		t.Fatalf("restore input must COMMIT; got:\n%s", input)
+	}
+	if !strings.Contains(input, "--to-source "+testVPNIP) {
+		t.Fatalf("restore input must SNAT to vpnIP; got:\n%s", input)
+	}
+	if !strings.Contains(input, "! -s "+testPodCIDR) {
+		t.Fatalf("restore input must exclude podCIDR source; got:\n%s", input)
+	}
+}
+
+// assertNoBroadConntrack ensures no unfiltered node-wide --dport 53 flush.
+func assertNoBroadConntrack(t *testing.T, m *mockExec) {
+	t.Helper()
+	for _, c := range m.cmds {
+		j := strings.Join(c, " ")
+		if !strings.Contains(j, "conntrack") {
+			continue
+		}
+		if strings.Contains(j, "--dport 53") && !strings.Contains(j, "--reply-dst") {
+			t.Fatalf("broad conntrack flush detected (no --reply-dst): %q", j)
+		}
+	}
+}
+
+func TestIsIPTablesChainAbsent(t *testing.T) {
+	cases := []struct {
+		out  string
+		want bool
+	}{
+		{"iptables: No chain/target/match by that name", true},
+		{"iptables: Permission denied", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isIPTablesChainAbsent([]byte(c.out)); got != c.want {
+			t.Fatalf("isIPTablesChainAbsent(%q) = %v, want %v", c.out, got, c.want)
+		}
+	}
+}

--- a/daemon/internel/watcher/lpvpndns/watcher.go
+++ b/daemon/internel/watcher/lpvpndns/watcher.go
@@ -1,0 +1,69 @@
+// Package lpvpndns maintains a master-only deterministic SNAT chain so that
+// node / hostNetwork tailscale Pod DNS queries to CoreDNS are sourced from the
+// CoreDNS vpn view whitelist IP, making them hit the vpn view and resolve to
+// Tailnet IPs.
+package lpvpndns
+
+import (
+	"context"
+	"net"
+
+	"github.com/beclab/Olares/daemon/internel/watcher"
+	"github.com/beclab/Olares/daemon/pkg/cluster/state"
+	"github.com/beclab/Olares/daemon/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+var _ watcher.Watcher = &lpvpnDNSWatcher{}
+
+type lpvpnDNSWatcher struct{}
+
+func NewWatcher() *lpvpnDNSWatcher {
+	return &lpvpnDNSWatcher{}
+}
+
+// Watch reconciles the SNAT chain once per tick.
+//  1. master hard gate: non-master / role lookup failure -> teardown + return.
+//  2. running gate: not TerminusRunning -> skip (do NOT teardown, transient).
+//  3. vpnIP: master node InternalIP (same field corefile.go writes into vpn view).
+//  4. detect podCIDR.
+//  5. reconcile.
+func (w *lpvpnDNSWatcher) Watch(ctx context.Context) {
+	kube, err := utils.GetKubeClient()
+	if err != nil {
+		klog.Warning("lpvpndns: get kube client error, ", err)
+		return
+	}
+
+	// ① master hard gate (fail-closed): never default to master.
+	_, nodeIP, nodeRole, err := utils.GetThisNodeName(ctx, kube)
+	if err != nil {
+		klog.Warningf("lpvpndns: get node role failed: %v, teardown", err)
+		teardown(ctx)
+		return
+	}
+	if nodeRole != "master" {
+		klog.V(4).Infof("lpvpndns: not master (role=%q), teardown", nodeRole)
+		teardown(ctx)
+		return
+	}
+
+	// ② running gate: transient non-running states must not flap the chain.
+	if state.CurrentState.TerminusState != state.TerminusRunning {
+		return
+	}
+
+	// ③ vpnIP = master node InternalIP
+	vpnIP := nodeIP
+	if net.ParseIP(vpnIP) == nil {
+		klog.Warningf("lpvpndns: no valid vpn IP from node InternalIP=%q, teardown", nodeIP)
+		teardown(ctx)
+		return
+	}
+
+	// ④ detect podCIDR (SNAT anchor, drift-resistant to CoreDNS Pod IP changes).
+	podCIDR := detectPodCIDR(ctx, kube)
+
+	// ⑤ converge.
+	reconcile(ctx, vpnIP, podCIDR)
+}


### PR DESCRIPTION
Add a master-only lpvpndns watcher that reconciles OLARES-LPVPN-DNS so node and hostNetwork Tailscale DNS hits the CoreDNS vpn view and resolves Tailnet names reliably.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Mutates host nat POSTROUTING and a custom chain beside kube-proxy; mistakes could break cluster DNS or SNAT behavior cluster-wide on masters.
> 
> **Overview**
> Adds a new **`lpvpndns`** watcher to **terminusd** so node and hostNetwork Tailscale DNS toward CoreDNS is SNAT’d to the master’s **InternalIP** (CoreDNS vpn view whitelist), improving Tailnet name resolution.
> 
> On each **WatchStatus** tick, the watcher runs only when the node is **master** and **TerminusRunning**; otherwise it **teardown**s (non-master / role errors) or no-ops (transient non-running). It discovers **pod CIDR** from **KUBE-SERVICES** iptables (with fallback) and **drift-only** reconciles nat chain **`OLARES-LPVPN-DNS`**: atomic **`iptables-restore --noflush`**, a single top **POSTROUTING** jump ahead of **KUBE-POSTROUTING**, and narrow **conntrack** cleanup only when the vpn IP changes. Steady state avoids writes; read/restore failures are fail-closed. Unit tests cover parsing, reconcile/teardown edge cases, and restore “red lines.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e7462e4a7c26fc2d5f489cabe22e541b498ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->