### PR TITLE
system-apps: bump system-frontend image to v1.10.65

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.64
+          image: beclab/system-frontend:v1.10.65
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  Bumps the `system-frontend` (LarePass/TermiPass web) image from `v1.10.64` to `v1.10.65`.

  This release fixes WebSocket connections being blocked by Chrome's Local Network Access (LNA) checks when LarePass VPN is enabled. LarePass routes `*.olares.com` to CGNAT addresses (`100.64.0.0/10`), which Chrome classifies as `local`. A request from a `public` origin to a `local` address requires an LNA permission, but a SharedWorker context cannot trigger the permission prompt, so WebSocket connections created inside the SharedWorker always failed with `net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`.

  The fix introduces a Leader Tab pattern: the SharedWorker is reduced to a pure message bus, and a single elected leader tab creates the WebSocket on its main thread (which is LNA-exempt). Leadership transitions, message buffering/routing, fresh-credential reconnect, and new-tab state synchronization are hardened so connections and messages are not lost or duplicated across tabs, while per-application configuration (reconnect parameters, message handling) is preserved.

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1235

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.65
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.64...v1.10.65

Made with [Cursor](https://cursor.com)