### PR TITLE
perf(daemon): cache k8s clients and rest.Config

### DIFF
--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	bflconst "bytetrade.io/web3os/bfl/pkg/constants"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -23,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,8 +43,50 @@ const (
 	RoleOwner = "owner"
 )
 
-func GetKubeClient() (kubernetes.Interface, error) {
+// K8s clients and the rest.Config are safe for concurrent use and do not need
+// to be rebuilt on every call. olaresd's status loop reconstructs them many
+// times per 5s tick; caching them removes the repeated ctrl.GetConfig +
+// NewForConfig (REST/HTTP/TLS transport) churn. Each value is memoized only on
+// success, so a failure before the cluster is reachable is retried on the next
+// call instead of being cached permanently.
+var (
+	clientCacheMu       sync.Mutex
+	cachedConfig        *rest.Config
+	cachedKubeClient    kubernetes.Interface
+	cachedDynamicClient dynamic.Interface
+	cachedAppClientSet  *versioned.Clientset
+	cachedApixClient    apixclientset.Interface
+)
+
+// configLocked returns the cached rest.Config, loading it once on first
+// success. Callers must hold clientCacheMu.
+func configLocked() (*rest.Config, error) {
+	if cachedConfig != nil {
+		return cachedConfig, nil
+	}
 	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	cachedConfig = config
+	return config, nil
+}
+
+// GetConfig returns the cached rest.Config, loading it once on first success.
+func GetConfig() (*rest.Config, error) {
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	return configLocked()
+}
+
+func GetKubeClient() (kubernetes.Interface, error) {
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	if cachedKubeClient != nil {
+		return cachedKubeClient, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
 		klog.Error("get k8s config error, ", err)
 		return nil, err
@@ -54,11 +98,18 @@ func GetKubeClient() (kubernetes.Interface, error) {
 		return nil, err
 	}
 
+	cachedKubeClient = client
 	return client, nil
 }
 
 func GetDynamicClient() (dynamic.Interface, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	if cachedDynamicClient != nil {
+		return cachedDynamicClient, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
 		klog.Error("get k8s config error, ", err)
 		return nil, err
@@ -70,11 +121,18 @@ func GetDynamicClient() (dynamic.Interface, error) {
 		return nil, err
 	}
 
+	cachedDynamicClient = client
 	return client, nil
 }
 
 func GetAppClientSet() (versioned.Clientset, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	if cachedAppClientSet != nil {
+		return *cachedAppClientSet, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
 		klog.Error("get k8s config error, ", err)
 		return versioned.Clientset{}, err
@@ -86,6 +144,7 @@ func GetAppClientSet() (versioned.Clientset, error) {
 		return versioned.Clientset{}, err
 	}
 
+	cachedAppClientSet = client
 	return *client, nil
 }
 
@@ -576,7 +635,7 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 		klog.Error("list applications error, ", err)
 		return nil, err
 	}
-	config, err := ctrl.GetConfig()
+	config, err := GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +685,13 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 }
 
 func GetApixClient() (apixclientset.Interface, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	if cachedApixClient != nil {
+		return cachedApixClient, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
 		klog.Error("get k8s config error, ", err)
 		return nil, err
@@ -638,6 +703,7 @@ func GetApixClient() (apixclientset.Interface, error) {
 		return nil, err
 	}
 
+	cachedApixClient = client
 	return client, nil
 }
 

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -62,42 +62,55 @@ var (
 	cachedKubeconfigModTime time.Time
 )
 
-// kubeconfigPath resolves the kubeconfig file backing ctrl.GetConfig, mirroring
-// the env/default lookup. It returns "" when no file applies (e.g. in-cluster),
-// in which case the freshness check is skipped.
-func kubeconfigPath() string {
+// kubeconfigPaths resolves the kubeconfig files backing ctrl.GetConfig,
+// mirroring the env/default lookup. ctrl.GetConfig merges every file listed in
+// KUBECONFIG, so all of them are tracked for freshness. It returns nil when no
+// file applies (e.g. in-cluster), in which case the freshness check is skipped.
+func kubeconfigPaths() []string {
 	if v := os.Getenv("KUBECONFIG"); v != "" {
 		if parts := filepath.SplitList(v); len(parts) > 0 {
-			return parts[0]
+			return parts
 		}
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return nil
 	}
-	return filepath.Join(home, ".kube", "config")
+	return []string{filepath.Join(home, ".kube", "config")}
 }
 
-// ensureFreshLocked invalidates the cached config and clients when the
+// ensureFreshLocked invalidates the cached config and clients when any tracked
 // kubeconfig file changes (e.g. IP change or k3s cert rotation), so olaresd
 // recovers without a restart instead of pinning a stale config forever.
 // Callers must hold clientCacheMu.
 func ensureFreshLocked() {
-	path := kubeconfigPath()
-	if path == "" {
+	paths := kubeconfigPaths()
+	if len(paths) == 0 {
 		return
 	}
-	info, err := os.Stat(path)
-	if err != nil {
+	key := strings.Join(paths, string(os.PathListSeparator))
+	var modTime time.Time
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if mt := info.ModTime(); mt.After(modTime) {
+			modTime = mt
+		}
+	}
+	if modTime.IsZero() {
+		// None of the tracked files are readable right now; keep any cached
+		// clients. A momentarily-missing file (e.g. during an atomic rewrite)
+		// should not tear down a working in-memory client.
 		return
 	}
-	modTime := info.ModTime()
 	if cachedConfig == nil {
-		cachedKubeconfigPath = path
+		cachedKubeconfigPath = key
 		cachedKubeconfigModTime = modTime
 		return
 	}
-	if path == cachedKubeconfigPath && modTime.Equal(cachedKubeconfigModTime) {
+	if key == cachedKubeconfigPath && modTime.Equal(cachedKubeconfigModTime) {
 		return
 	}
 	klog.Info("kubeconfig changed, rebuilding k8s clients")
@@ -106,7 +119,7 @@ func ensureFreshLocked() {
 	cachedDynamicClient = nil
 	cachedAppClientSet = nil
 	cachedApixClient = nil
-	cachedKubeconfigPath = path
+	cachedKubeconfigPath = key
 	cachedKubeconfigModTime = modTime
 }
 

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -9,8 +9,10 @@ import (
 	"k8s.io/klog"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	bflconst "bytetrade.io/web3os/bfl/pkg/constants"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -50,13 +52,63 @@ const (
 // success, so a failure before the cluster is reachable is retried on the next
 // call instead of being cached permanently.
 var (
-	clientCacheMu       sync.Mutex
-	cachedConfig        *rest.Config
-	cachedKubeClient    kubernetes.Interface
-	cachedDynamicClient dynamic.Interface
-	cachedAppClientSet  *versioned.Clientset
-	cachedApixClient    apixclientset.Interface
+	clientCacheMu           sync.Mutex
+	cachedConfig            *rest.Config
+	cachedKubeClient        kubernetes.Interface
+	cachedDynamicClient     dynamic.Interface
+	cachedAppClientSet      *versioned.Clientset
+	cachedApixClient        apixclientset.Interface
+	cachedKubeconfigPath    string
+	cachedKubeconfigModTime time.Time
 )
+
+// kubeconfigPath resolves the kubeconfig file backing ctrl.GetConfig, mirroring
+// the env/default lookup. It returns "" when no file applies (e.g. in-cluster),
+// in which case the freshness check is skipped.
+func kubeconfigPath() string {
+	if v := os.Getenv("KUBECONFIG"); v != "" {
+		if parts := filepath.SplitList(v); len(parts) > 0 {
+			return parts[0]
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".kube", "config")
+}
+
+// ensureFreshLocked invalidates the cached config and clients when the
+// kubeconfig file changes (e.g. IP change or k3s cert rotation), so olaresd
+// recovers without a restart instead of pinning a stale config forever.
+// Callers must hold clientCacheMu.
+func ensureFreshLocked() {
+	path := kubeconfigPath()
+	if path == "" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	modTime := info.ModTime()
+	if cachedConfig == nil {
+		cachedKubeconfigPath = path
+		cachedKubeconfigModTime = modTime
+		return
+	}
+	if path == cachedKubeconfigPath && modTime.Equal(cachedKubeconfigModTime) {
+		return
+	}
+	klog.Info("kubeconfig changed, rebuilding k8s clients")
+	cachedConfig = nil
+	cachedKubeClient = nil
+	cachedDynamicClient = nil
+	cachedAppClientSet = nil
+	cachedApixClient = nil
+	cachedKubeconfigPath = path
+	cachedKubeconfigModTime = modTime
+}
 
 // configLocked returns the cached rest.Config, loading it once on first
 // success. Callers must hold clientCacheMu.
@@ -76,19 +128,20 @@ func configLocked() (*rest.Config, error) {
 func GetConfig() (*rest.Config, error) {
 	clientCacheMu.Lock()
 	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
 	return configLocked()
 }
 
 func GetKubeClient() (kubernetes.Interface, error) {
 	clientCacheMu.Lock()
 	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
 	if cachedKubeClient != nil {
 		return cachedKubeClient, nil
 	}
 
 	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -105,13 +158,13 @@ func GetKubeClient() (kubernetes.Interface, error) {
 func GetDynamicClient() (dynamic.Interface, error) {
 	clientCacheMu.Lock()
 	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
 	if cachedDynamicClient != nil {
 		return cachedDynamicClient, nil
 	}
 
 	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -128,13 +181,13 @@ func GetDynamicClient() (dynamic.Interface, error) {
 func GetAppClientSet() (versioned.Clientset, error) {
 	clientCacheMu.Lock()
 	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
 	if cachedAppClientSet != nil {
 		return *cachedAppClientSet, nil
 	}
 
 	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return versioned.Clientset{}, err
 	}
 
@@ -687,13 +740,13 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 func GetApixClient() (apixclientset.Interface, error) {
 	clientCacheMu.Lock()
 	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
 	if cachedApixClient != nil {
 		return cachedApixClient, nil
 	}
 
 	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Background
In olaresd's 5s `WatchStatus` loop, `GetKubeClient` / `GetDynamicClient` / `GetAppClientSet` / `GetApixClient` each call `ctrl.GetConfig()` + `NewForConfig(...)` on every invocation. They are called a dozen-plus times per tick, allocating a new REST/HTTP/TLS transport each time, which causes noticeable CPU and memory churn.

## Changes
- Memoize the rest.Config and the four clients process-wide in `daemon/pkg/utils/k8s.go` (guarded by a `sync.Mutex`).
- Cache only on success: when the cluster is not yet reachable the call returns an error and retries on the next call, so a failure is never cached permanently.
- Add `GetConfig()` to reuse the cached config (`GetApplicationUrlAll`'s `iamv1alpha2.NewClient` now uses it too).
- Function signatures are unchanged; call sites need no edits.

## Verification
- `GOOS=linux go build ./pkg/utils/ ./pkg/cluster/...` passes; `gofmt` / `go vet` clean.
- Suggested regression: state machine transitions, intranet, and the cert watcher still read/write correctly.

This is part 1/6 of the "reduce olaresd CPU load" PR series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes all daemon Kubernetes API connectivity; incorrect invalidation or stale caching could affect status, intranet, and cert watchers, though the design mirrors prior per-call behavior with added kubeconfig change handling.
> 
> **Overview**
> **Reduces olaresd CPU/memory churn** by memoizing `rest.Config` and the Kubernetes, dynamic, app, and API extensions clients in `daemon/pkg/utils/k8s.go`, instead of calling `ctrl.GetConfig()` and `NewForConfig` on every accessor invocation during the 5s status loop.
> 
> A mutex guards the cache; **only successful builds are stored**, so unreachable clusters still retry on the next call. **`GetConfig()`** exposes the shared config (e.g. `GetApplicationUrlAll` now uses it for IAM instead of a separate `ctrl.GetConfig()`). **Kubeconfig freshness** is tracked via `KUBECONFIG` / default `~/.kube/config` modtimes; when files change, caches are cleared and clients rebuilt so olaresd can pick up IP or cert updates without a restart. Unreadable kubeconfig during atomic rewrites does not tear down working clients.
> 
> Public getter signatures are unchanged—no call-site edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0439210dc988c0fdaf05233a72f97fa00279a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->