### PR TITLE
perf(daemon): cache static machine info, GPU and CPU name

### DIFF
--- a/daemon/pkg/cluster/state/utils.go
+++ b/daemon/pkg/cluster/state/utils.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -139,7 +140,27 @@ func IsIpChangeRunning() (bool, error) {
 	return running, err
 }
 
+var (
+	machineInfoMu     sync.Mutex
+	machineInfoCached bool
+	machineInfoCache  struct {
+		osType, osInfo, osArch, osVersion, osKernel string
+	}
+)
+
+// GetMachineInfo returns OS type/info/arch/version/kernel. These are static for
+// the lifetime of the process, but the underlying `olares-cli osinfo show` is a
+// subprocess fork that the status loop ran on every 5s tick. The result is
+// cached after the first successful read; if the CLI is not yet available the
+// call returns empty values and is retried on the next tick.
 func GetMachineInfo(ctx context.Context) (osType, osInfo, osArch, osVersion, osKernel string, err error) {
+	machineInfoMu.Lock()
+	defer machineInfoMu.Unlock()
+	if machineInfoCached {
+		c := machineInfoCache
+		return c.osType, c.osInfo, c.osArch, c.osVersion, c.osKernel, nil
+	}
+
 	cmd := exec.CommandContext(ctx, cli.TERMINUS_CLI, "osinfo", "show")
 
 	if output, err := cmd.Output(); err == nil {
@@ -162,6 +183,17 @@ func GetMachineInfo(ctx context.Context) (osType, osInfo, osArch, osVersion, osK
 				osKernel = kv[1]
 			}
 		}
+	}
+
+	// Cache only once we actually parsed something, so an early-boot read before
+	// olares-cli is ready does not get memoized as permanently empty.
+	if osType != "" || osInfo != "" || osArch != "" || osVersion != "" || osKernel != "" {
+		machineInfoCache.osType = osType
+		machineInfoCache.osInfo = osInfo
+		machineInfoCache.osArch = osArch
+		machineInfoCache.osVersion = osVersion
+		machineInfoCache.osKernel = osKernel
+		machineInfoCached = true
 	}
 
 	return

--- a/daemon/pkg/utils/gpu_linux.go
+++ b/daemon/pkg/utils/gpu_linux.go
@@ -9,26 +9,37 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/jaypipes/ghw"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
+// gpuEmptyRescanInterval bounds how often an empty GPU scan is retried, so a
+// node without a GPU does not re-scan the PCI bus on every status tick while a
+// GPU that only appears after boot is still eventually detected.
+const gpuEmptyRescanInterval = 5 * time.Minute
+
 var (
 	gpuInfoMu     sync.Mutex
 	gpuInfoCached bool
 	gpuInfoValue  *string
+	gpuLastScan   time.Time
 )
 
 // GetGpuInfo returns the primary GPU description. GPUs are not hot-plugged at
-// runtime, but scanning the PCI bus via ghw on every status tick is expensive,
-// so the result is cached after the first successful scan. A failed scan is not
-// cached and will be retried on the next call.
+// runtime, but scanning the PCI bus via ghw on every status tick is expensive.
+// A found GPU is cached for the process lifetime; an empty scan is retried at
+// most once per gpuEmptyRescanInterval, and a failed scan is retried on the
+// next call.
 func GetGpuInfo() (*string, error) {
 	gpuInfoMu.Lock()
 	defer gpuInfoMu.Unlock()
 	if gpuInfoCached {
+		return gpuInfoValue, nil
+	}
+	if !gpuLastScan.IsZero() && time.Since(gpuLastScan) < gpuEmptyRescanInterval {
 		return gpuInfoValue, nil
 	}
 
@@ -37,6 +48,7 @@ func GetGpuInfo() (*string, error) {
 		klog.Errorf("Error getting GPU info: %v", err)
 		return nil, err
 	}
+	gpuLastScan = time.Now()
 
 	var first string
 	var result *string
@@ -60,6 +72,8 @@ func GetGpuInfo() (*string, error) {
 	}
 
 	gpuInfoValue = result
-	gpuInfoCached = true
+	if result != nil {
+		gpuInfoCached = true
+	}
 	return result, nil
 }

--- a/daemon/pkg/utils/gpu_linux.go
+++ b/daemon/pkg/utils/gpu_linux.go
@@ -8,13 +8,30 @@ import (
 	"io"
 	"log"
 	"strings"
+	"sync"
 
 	"github.com/jaypipes/ghw"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
+var (
+	gpuInfoMu     sync.Mutex
+	gpuInfoCached bool
+	gpuInfoValue  *string
+)
+
+// GetGpuInfo returns the primary GPU description. GPUs are not hot-plugged at
+// runtime, but scanning the PCI bus via ghw on every status tick is expensive,
+// so the result is cached after the first successful scan. A failed scan is not
+// cached and will be retried on the next call.
 func GetGpuInfo() (*string, error) {
+	gpuInfoMu.Lock()
+	defer gpuInfoMu.Unlock()
+	if gpuInfoCached {
+		return gpuInfoValue, nil
+	}
+
 	gpu, err := ghw.GPU(ghw.WithAlerter(log.New(io.Discard, "", 0))) // discard warnings
 	if err != nil {
 		klog.Errorf("Error getting GPU info: %v", err)
@@ -22,13 +39,15 @@ func GetGpuInfo() (*string, error) {
 	}
 
 	var first string
+	var result *string
 	for _, card := range gpu.GraphicsCards {
 		if card.DeviceInfo == nil || card.DeviceInfo.Vendor == nil || card.DeviceInfo.Product == nil {
 			continue
 		}
 		info := fmt.Sprintf("%s %s", card.DeviceInfo.Vendor.Name, card.DeviceInfo.Product.Name)
 		if strings.Contains(strings.ToLower(info), "nvidia") {
-			return ptr.To(info), nil
+			first = info
+			break
 		}
 
 		if first == "" {
@@ -36,9 +55,11 @@ func GetGpuInfo() (*string, error) {
 		}
 	}
 
-	if first == "" {
-		return nil, nil
+	if first != "" {
+		result = ptr.To(first)
 	}
 
-	return ptr.To(first), nil
+	gpuInfoValue = result
+	gpuInfoCached = true
+	return result, nil
 }

--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -291,17 +291,21 @@ func GetBaseDirFromReleaseFile() (string, error) {
 }
 
 var (
-	cpuNameOnce  sync.Once
+	cpuNameMu    sync.Mutex
 	cpuNameValue string
 )
 
 // GetCPUName returns the CPU brand name. The result is static for the lifetime
-// of the process, so it is computed once and cached: the fallbacks below shell
-// out to lscpu/dmidecode, which is wasteful to repeat every status tick.
+// of the process, so it is cached to avoid the lscpu/dmidecode fallbacks below
+// running on every status tick. An empty result (e.g. a transient boot-time
+// failure) is not cached, so a later tick can still populate it.
 func GetCPUName() string {
-	cpuNameOnce.Do(func() {
-		cpuNameValue = computeCPUName()
-	})
+	cpuNameMu.Lock()
+	defer cpuNameMu.Unlock()
+	if cpuNameValue != "" {
+		return cpuNameValue
+	}
+	cpuNameValue = computeCPUName()
 	return cpuNameValue
 }
 

--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -289,7 +290,22 @@ func GetBaseDirFromReleaseFile() (string, error) {
 	return baseDir, nil
 }
 
+var (
+	cpuNameOnce  sync.Once
+	cpuNameValue string
+)
+
+// GetCPUName returns the CPU brand name. The result is static for the lifetime
+// of the process, so it is computed once and cached: the fallbacks below shell
+// out to lscpu/dmidecode, which is wasteful to repeat every status tick.
 func GetCPUName() string {
+	cpuNameOnce.Do(func() {
+		cpuNameValue = computeCPUName()
+	})
+	return cpuNameValue
+}
+
+func computeCPUName() string {
 	brandName := cpu.CPU.BrandName
 	if brandName == "" {
 		// cannot read info from /proc/cpuinfo, try to get from lscpu command

--- a/daemon/pkg/utils/utils_test.go
+++ b/daemon/pkg/utils/utils_test.go
@@ -72,6 +72,11 @@ func TestGetGpu(t *testing.T) {
 		return
 	}
 
+	if s == nil {
+		t.Log("no gpu info")
+		return
+	}
+
 	t.Log(*s)
 }
 


### PR DESCRIPTION
## Background
olaresd's 5s status loop re-collects host facts that are effectively static for the process lifetime, on every tick:
- `GetMachineInfo` forks `olares-cli osinfo show` (a subprocess).
- `GetGpuInfo` scans the PCI bus via ghw.
- `GetCPUName` may shell out to lscpu/dmidecode when the brand name is empty.

## Changes
- `GetMachineInfo` (`pkg/cluster/state/utils.go`): memoize the OS type/info/arch/version/kernel; cache only once a non-empty result is parsed so an early-boot read before olares-cli is ready is retried.
- `GetGpuInfo` (`pkg/utils/gpu_linux.go`): cache the result after the first successful scan; a failed scan is not cached and is retried.
- `GetCPUName` (`pkg/utils/system.go`): compute once via `sync.Once`.
- Cheap, possibly-changing fields (device name, disk size, hostname, memory) are intentionally left refreshing each tick.

## Verification
- `GOOS=linux go build ./pkg/utils/ ./pkg/cluster/...` passes; `gofmt` clean.

This is part 2/6 of the "reduce olaresd CPU load" PR series. Independent of the other parts.

Made with [Cursor](https://cursor.com)