### PR TITLE
perf(daemon): make BLE WiFi scan cadence adaptive

### DIFF
--- a/daemon/internel/ble/ble_common.go
+++ b/daemon/internel/ble/ble_common.go
@@ -34,6 +34,7 @@ func (s *service) scanInterval() time.Duration {
 func (s *service) Start() {
 	go func() {
 		defer s.cancel()
+		s.scanOnce()
 		for {
 			timer := time.NewTimer(s.scanInterval())
 			select {
@@ -42,14 +43,18 @@ func (s *service) Start() {
 				return
 
 			case <-timer.C:
-				s.getAPList()
-				s.getTerminusInfo()
-				if s.update != nil {
-					s.update()
-				}
+				s.scanOnce()
 			}
 		}
 	}()
+}
+
+func (s *service) scanOnce() {
+	s.getAPList()
+	s.getTerminusInfo()
+	if s.update != nil {
+		s.update()
+	}
 }
 
 func (s *service) Stop() {

--- a/daemon/internel/ble/ble_common.go
+++ b/daemon/internel/ble/ble_common.go
@@ -12,16 +12,36 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const (
+	// bleScanIntervalActive is used during onboarding (the node is not online
+	// yet), when the LarePass app needs a fresh WiFi AP list to connect.
+	bleScanIntervalActive = 2 * time.Second
+	// bleScanIntervalIdle is used once the node is online, when the AP list
+	// rarely matters. Backing off here removes the bulk of the periodic D-Bus
+	// WiFi scan CPU cost.
+	bleScanIntervalIdle = 30 * time.Second
+)
+
+// scanInterval picks the WiFi scan cadence based on network connectivity:
+// frequent while onboarding (no network), relaxed once the node is online.
+func (s *service) scanInterval() time.Duration {
+	if state.CurrentState.WiredConnected || state.CurrentState.WifiConnected {
+		return bleScanIntervalIdle
+	}
+	return bleScanIntervalActive
+}
+
 func (s *service) Start() {
-	ticker := time.NewTicker(2 * time.Second)
 	go func() {
+		defer s.cancel()
 		for {
+			timer := time.NewTimer(s.scanInterval())
 			select {
 			case <-s.ctx.Done():
-				s.cancel()
-				ticker.Stop()
+				timer.Stop()
+				return
 
-			case <-ticker.C:
+			case <-timer.C:
 				s.getAPList()
 				s.getTerminusInfo()
 				if s.update != nil {

--- a/daemon/internel/ble/ble_common.go
+++ b/daemon/internel/ble/ble_common.go
@@ -35,15 +35,22 @@ func (s *service) Start() {
 	go func() {
 		defer s.cancel()
 		s.scanOnce()
+		lastScan := time.Now()
+		// Poll at the active cadence so a connectivity drop is noticed within a
+		// couple of seconds, but only run the expensive D-Bus scan when due:
+		// every tick while offline, every bleScanIntervalIdle once online.
 		for {
-			timer := time.NewTimer(s.scanInterval())
+			timer := time.NewTimer(bleScanIntervalActive)
 			select {
 			case <-s.ctx.Done():
 				timer.Stop()
 				return
 
 			case <-timer.C:
-				s.scanOnce()
+				if time.Since(lastScan) >= s.scanInterval() {
+					s.scanOnce()
+					lastScan = time.Now()
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## Background
The BLE onboarding service (`internel/ble/ble_common.go`) scanned WiFi access points over D-Bus every 2s for the entire process lifetime. This scan only matters during onboarding, when the device is offline and the LarePass app needs a fresh AP list to set up WiFi. After the node is online it is pure overhead.

It also had a pre-existing bug: on `ctx.Done()` the loop called `cancel()`/`ticker.Stop()` but did not `return`, so it fell through into a busy loop.

## Changes
- Adaptive interval: 2s while offline (onboarding), 30s once wired or WiFi connectivity is up (`state.CurrentState.WiredConnected || WifiConnected`).
- Replace the fixed ticker with a per-iteration timer and return on `ctx.Done()`, fixing the busy loop on stop.

## Verification
- `gofmt` clean; `go build ./internel/ble/` passes natively.
- Suggested regression: BLE onboarding still lists/refreshes APs quickly while offline; after connecting, the AP list still updates (slower) and WiFi connect via BLE still works.

This is part 4/6 of the "reduce olaresd CPU load" PR series. Independent of the other parts.

Made with [Cursor](https://cursor.com)