### PR TITLE
perf(daemon): add shared informers and back pod reads with cache

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -60,6 +60,11 @@ func main() {
 
 	mainCtx, cancel := context.WithCancel(context.Background())
 
+	// Set up the shared informers' lifecycle context. The factory itself starts
+	// lazily once the cluster is reachable; readers fall back to live Lists
+	// until the cache has synced.
+	utils.InitInformers(mainCtx)
+
 	apis := apiserver.NewServer(mainCtx, port)
 
 	if err := state.CheckCurrentStatus(mainCtx); err != nil {

--- a/daemon/internel/watcher/intranet/watchers.go
+++ b/daemon/internel/watcher/intranet/watchers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/beclab/Olares/daemon/pkg/nets"
 	"github.com/beclab/Olares/daemon/pkg/utils"
 	"github.com/miekg/dns"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -185,13 +184,7 @@ var adguardHealth bool
 
 func (w *applicationWatcher) loadDnsPodConfig(ctx context.Context, o *intranet.ServerOptions) error {
 	// try to find adguard dns pod ip and mac
-	k8sClient, err := utils.GetKubeClient()
-	if err != nil {
-		klog.Error("get kube client error, ", err)
-		return err
-	}
-
-	dnsPods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	dnsPods, err := utils.ListPods(ctx)
 	if err != nil {
 		klog.Error("list pods error, ", err)
 		return err
@@ -199,7 +192,7 @@ func (w *applicationWatcher) loadDnsPodConfig(ctx context.Context, o *intranet.S
 
 	var dnsPodIp, dnsPodMac, calicoRouteIface string
 	const adguardDnsAppLabel = "applications.app.bytetrade.io/name"
-	for _, pod := range dnsPods.Items {
+	for _, pod := range dnsPods {
 		switch {
 		case pod.Labels[adguardDnsAppLabel] == "adguardhome":
 			dnsPodIp = pod.Status.PodIP

--- a/daemon/pkg/utils/informers.go
+++ b/daemon/pkg/utils/informers.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -29,8 +28,6 @@ const informerResyncPeriod = 10 * time.Minute
 var (
 	informerMu       sync.Mutex
 	informerCtx      context.Context
-	informerCancel   context.CancelFunc
-	informerClient   kubernetes.Interface
 	informerFactory  k8sinformers.SharedInformerFactory
 	podLister        corelisters.PodLister
 	podsSynced       cache.InformerSynced
@@ -53,12 +50,15 @@ func InitInformers(ctx context.Context) {
 	informerCtx = ctx
 }
 
-// ensureStartedLocked lazily creates and starts the shared informer factory,
-// rebuilding it if the underlying kube client was replaced (e.g. after a
-// kubeconfig change invalidated the cached client). Callers must hold
-// informerMu.
+// ensureStartedLocked lazily creates and starts the shared informer factory on
+// first use, once the cluster is reachable. Callers must hold informerMu.
+//
+// The factory is started once and left running for the process lifetime: it
+// stops only when informerCtx is canceled at shutdown. GetKubeClient builds a
+// fresh clientset on each call, so the factory must not be tied to client
+// identity; a kubeconfig change is instead handled by an olaresd restart.
 func ensureStartedLocked() {
-	if informerCtx == nil {
+	if informerCtx == nil || informersStarted {
 		return
 	}
 
@@ -68,42 +68,15 @@ func ensureStartedLocked() {
 		return
 	}
 
-	if informersStarted {
-		if client == informerClient {
-			return
-		}
-		// The cached kube client was rebuilt; stop the stale factory and
-		// recreate it against the new client so watches keep working.
-		resetInformersLocked()
-		klog.Info("kube client changed, restarting shared informers")
-	}
-
-	ctx, cancel := context.WithCancel(informerCtx)
 	factory := k8sinformers.NewSharedInformerFactory(client, informerResyncPeriod)
 	podInformer := factory.Core().V1().Pods()
 	podLister = podInformer.Lister()
 	podsSynced = podInformer.Informer().HasSynced
 
-	factory.Start(ctx.Done())
+	factory.Start(informerCtx.Done())
 	informerFactory = factory
-	informerCancel = cancel
-	informerClient = client
 	informersStarted = true
 	klog.Info("shared informers started")
-}
-
-// resetInformersLocked stops the running factory and clears the cached
-// listers so the next access rebuilds them. Callers must hold informerMu.
-func resetInformersLocked() {
-	if informerCancel != nil {
-		informerCancel()
-		informerCancel = nil
-	}
-	informerFactory = nil
-	informerClient = nil
-	podLister = nil
-	podsSynced = nil
-	informersStarted = false
 }
 
 // podListerIfSynced returns the pod lister only when its cache has synced,

--- a/daemon/pkg/utils/informers.go
+++ b/daemon/pkg/utils/informers.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -28,11 +29,20 @@ const informerResyncPeriod = 10 * time.Minute
 var (
 	informerMu       sync.Mutex
 	informerCtx      context.Context
+	informerCancel   context.CancelFunc
+	informerClient   kubernetes.Interface
 	informerFactory  k8sinformers.SharedInformerFactory
 	podLister        corelisters.PodLister
 	podsSynced       cache.InformerSynced
 	informersStarted bool
 )
+
+// logLiveFallback records (at debug verbosity) that a read bypassed the
+// informer cache and hit the API server directly, to help diagnose whether the
+// cache is actually serving reads in production.
+func logLiveFallback(resource string) {
+	klog.V(4).Infof("informer cache for %s not synced, falling back to live List", resource)
+}
 
 // InitInformers stores the lifecycle context for the shared informers. It
 // should be called once at startup before the informers are used. The factory
@@ -43,10 +53,12 @@ func InitInformers(ctx context.Context) {
 	informerCtx = ctx
 }
 
-// ensureStartedLocked lazily creates and starts the shared informer factory.
-// Callers must hold informerMu.
+// ensureStartedLocked lazily creates and starts the shared informer factory,
+// rebuilding it if the underlying kube client was replaced (e.g. after a
+// kubeconfig change invalidated the cached client). Callers must hold
+// informerMu.
 func ensureStartedLocked() {
-	if informersStarted || informerCtx == nil {
+	if informerCtx == nil {
 		return
 	}
 
@@ -56,15 +68,42 @@ func ensureStartedLocked() {
 		return
 	}
 
+	if informersStarted {
+		if client == informerClient {
+			return
+		}
+		// The cached kube client was rebuilt; stop the stale factory and
+		// recreate it against the new client so watches keep working.
+		resetInformersLocked()
+		klog.Info("kube client changed, restarting shared informers")
+	}
+
+	ctx, cancel := context.WithCancel(informerCtx)
 	factory := k8sinformers.NewSharedInformerFactory(client, informerResyncPeriod)
 	podInformer := factory.Core().V1().Pods()
 	podLister = podInformer.Lister()
 	podsSynced = podInformer.Informer().HasSynced
 
-	factory.Start(informerCtx.Done())
+	factory.Start(ctx.Done())
 	informerFactory = factory
+	informerCancel = cancel
+	informerClient = client
 	informersStarted = true
 	klog.Info("shared informers started")
+}
+
+// resetInformersLocked stops the running factory and clears the cached
+// listers so the next access rebuilds them. Callers must hold informerMu.
+func resetInformersLocked() {
+	if informerCancel != nil {
+		informerCancel()
+		informerCancel = nil
+	}
+	informerFactory = nil
+	informerClient = nil
+	podLister = nil
+	podsSynced = nil
+	informersStarted = false
 }
 
 // podListerIfSynced returns the pod lister only when its cache has synced,
@@ -84,10 +123,15 @@ func podListerIfSynced() corelisters.PodLister {
 // ListPods returns all pods across namespaces, preferring the synced informer
 // cache and falling back to a live List while the cache is warming up (or when
 // informers were never initialized, e.g. in tests).
+//
+// Cache reads are eventually consistent and may lag the API server by a watch
+// cycle; the live fallback only covers the not-yet-synced case, not a
+// synced-but-stale cache.
 func ListPods(ctx context.Context) ([]*corev1.Pod, error) {
 	if lister := podListerIfSynced(); lister != nil {
 		return lister.List(labels.Everything())
 	}
+	logLiveFallback("pods")
 
 	client, err := GetKubeClient()
 	if err != nil {

--- a/daemon/pkg/utils/informers.go
+++ b/daemon/pkg/utils/informers.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sinformers "k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// informerResyncPeriod is the shared informer resync period. The cache is kept
+// fresh by watches; the periodic resync is only a safety net.
+const informerResyncPeriod = 10 * time.Minute
+
+// Shared informers back the read-heavy parts of the status loop so that
+// olaresd reads Kubernetes objects from a local cache instead of doing a full
+// cluster-wide List + deserialize on every 5s tick.
+//
+// The factory is started lazily on first use, once the cluster is reachable.
+// Every accessor falls back to a live List while the cache is not yet synced,
+// so the status loop never misjudges cluster health during cache warm-up.
+var (
+	informerMu       sync.Mutex
+	informerCtx      context.Context
+	informerFactory  k8sinformers.SharedInformerFactory
+	podLister        corelisters.PodLister
+	podsSynced       cache.InformerSynced
+	informersStarted bool
+)
+
+// InitInformers stores the lifecycle context for the shared informers. It
+// should be called once at startup before the informers are used. The factory
+// itself is started lazily on first access, once the cluster is reachable.
+func InitInformers(ctx context.Context) {
+	informerMu.Lock()
+	defer informerMu.Unlock()
+	informerCtx = ctx
+}
+
+// ensureStartedLocked lazily creates and starts the shared informer factory.
+// Callers must hold informerMu.
+func ensureStartedLocked() {
+	if informersStarted || informerCtx == nil {
+		return
+	}
+
+	client, err := GetKubeClient()
+	if err != nil {
+		// Cluster not reachable yet; try again on the next access.
+		return
+	}
+
+	factory := k8sinformers.NewSharedInformerFactory(client, informerResyncPeriod)
+	podInformer := factory.Core().V1().Pods()
+	podLister = podInformer.Lister()
+	podsSynced = podInformer.Informer().HasSynced
+
+	factory.Start(informerCtx.Done())
+	informerFactory = factory
+	informersStarted = true
+	klog.Info("shared informers started")
+}
+
+// podListerIfSynced returns the pod lister only when its cache has synced,
+// otherwise nil so the caller falls back to a live List.
+func podListerIfSynced() corelisters.PodLister {
+	informerMu.Lock()
+	defer informerMu.Unlock()
+
+	ensureStartedLocked()
+
+	if podLister == nil || podsSynced == nil || !podsSynced() {
+		return nil
+	}
+	return podLister
+}
+
+// ListPods returns all pods across namespaces, preferring the synced informer
+// cache and falling back to a live List while the cache is warming up (or when
+// informers were never initialized, e.g. in tests).
+func ListPods(ctx context.Context) ([]*corev1.Pod, error) {
+	if lister := podListerIfSynced(); lister != nil {
+		return lister.List(labels.Everything())
+	}
+
+	client, err := GetKubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	pods := make([]*corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		pods = append(pods, &list.Items[i])
+	}
+	return pods, nil
+}

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -140,17 +140,17 @@ func IsTerminusInitializing(ctx context.Context, client dynamic.Interface) (bool
 }
 
 func IsTerminusRunning(ctx context.Context, client kubernetes.Interface) (bool, error) {
-	pods, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	pods, err := ListPods(ctx)
 	if err != nil {
 		klog.Error("list pods error, ", err)
 		return false, err
 	}
 
-	for _, pod := range pods.Items {
-		if isKeyPod(&pod) {
+	for _, pod := range pods {
+		if isKeyPod(pod) {
 			switch pod.Status.Phase {
 			case corev1.PodRunning:
-				if !isPodReady(&pod) {
+				if !isPodReady(pod) {
 					return false, nil
 				}
 				continue


### PR DESCRIPTION
## Background
olaresd has no informers today: it does a full cluster-wide `Pods("").List` and deserializes the result on every 5s status tick, at least twice per tick (`IsTerminusRunning` and the intranet DNS-pod lookup). On busy nodes this is the single biggest CPU cost of the daemon and also load on the apiserver.

## Changes
- New `pkg/utils/informers.go`: a lazily-started `SharedInformerFactory` with a pod lister.
  - Lifecycle bound to the daemon main context via `InitInformers(ctx)` (called from `main.go`).
  - Started lazily on first use, once the cluster is reachable.
  - `ListPods(ctx)` serves from the synced cache and **falls back to a live List** while the cache is warming up (or when informers were never initialized, e.g. tests), so the status loop never misjudges cluster health.
- `IsTerminusRunning` (`pkg/utils/k8s.go`) and the intranet `loadDnsPodConfig` (`internel/watcher/intranet/watchers.go`) now read via `utils.ListPods`.

## Notes
- Pairs with PR1 (client cache); both are independent and use the same cached config/client once merged.
- Trade-off: once synced, reads come from cache; a transient apiserver outage could briefly serve slightly stale pods (bounded, and resynced on reconnect).

## Verification
- `GOOS=linux go build ./pkg/utils/`, `go vet ./pkg/utils/`, native build of `internel/watcher/intranet/` all pass; `gofmt` clean. No go.mod/go.sum changes (client-go informers/listers already vendored).
- Suggested regression: NotInstalled -> Installing -> Running transitions, restart olaresd under load (cache warm-up fallback), intranet DNS resolution after adguard/coredns pod changes.

This is part 5/6 of the "reduce olaresd CPU load" PR series.

Made with [Cursor](https://cursor.com)