### PR TITLE
docs(skills): add doctor diagnosis skill and platform-appstate source of truth

### DIFF
--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
-> **Mental model:** this skill authors, validates, and **deploys your own chart to your own Olares**. Listing / selling it on the **public** Olares Market is [`../olares-publish/SKILL.md`](../olares-publish/SKILL.md); installing or managing an **already-published** catalog app is [`../olares-market/SKILL.md`](../olares-market/SKILL.md); inspecting pods/logs of an unrelated running app is [`../olares-cluster/SKILL.md`](../olares-cluster/SKILL.md).
+> **Mental model:** this skill authors, validates, and **deploys your own chart to your own Olares**, and owns the **fixes that mean editing your chart**. **Diagnosing a runtime failure** (won't install / start, crashes, `running` but unreachable, image won't pull) is [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md) — it finds the root cause and points back here for the chart edit. Listing / selling it on the **public** Olares Market is [`../olares-publish/SKILL.md`](../olares-publish/SKILL.md); installing or managing an **already-published** catalog app is [`../olares-market/SKILL.md`](../olares-market/SKILL.md); inspecting pods/logs of an unrelated running app is [`../olares-cluster/SKILL.md`](../olares-cluster/SKILL.md).
 
 ## The shape of the work — two axes
 
@@ -87,7 +87,7 @@ For deploying to your own Olares, **metadata can stay a stub** as long as `lint`
 | deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
 | deploy | **Deploy** | `market upload` + `market install`, then diagnose from logs — automatic after `lint` passes (login required) | proving the chart actually runs on the developer's Olares | [deploy.md](references/olares-chart-deploy.md) |
 
-> **Deploy** leans on sibling skills: [`olares-shared`](../olares-shared/SKILL.md) (login check), [`olares-market`](../olares-market/SKILL.md) (upload / install / cleanup), [`olares-cluster`](../olares-cluster/SKILL.md) (logs). **After `lint` passes, drive the deploy loop automatically without asking; never log in on the developer's behalf without asking.** One way to sequence the whole assembly (and the file tree `from-compose` emits) lives in [references/olares-chart-workflow.md](references/olares-chart-workflow.md) — a reference, not a required order.
+> **Deploy** leans on sibling skills: [`olares-shared`](../olares-shared/SKILL.md) (login check), [`olares-market`](../olares-market/SKILL.md) (upload / install / cleanup), [`olares-cluster`](../olares-cluster/SKILL.md) (logs), and [`olares-doctor`](../olares-doctor/SKILL.md) (runtime root-cause diagnosis when a deploy fails or the app won't start). **After `lint` passes, drive the deploy loop automatically without asking; never log in on the developer's behalf without asking.** One way to sequence the whole assembly (and the file tree `from-compose` emits) lives in [references/olares-chart-workflow.md](references/olares-chart-workflow.md) — a reference, not a required order.
 
 ## CLI verbs
 

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -77,62 +77,47 @@ olares-cli market install <app> -s upload --version <version> --watch -o json
   olares-cli market install <app> -s upload --version <version> --watch -o json
   ```
 
-### Watch a slow image pull (progress + speed)
-
-A `--watch` that sits in `downloading` for minutes is usually a **healthy but large image pull** (multi-GB AI / engine images — e.g. `ollama/ollama` is ~3.4GB), not a hang. `market list --mine` only shows the coarse state; byte-level progress + speed come from the per-node `image-service` DaemonSet (it pulls via containerd and logs each layer):
-
-```bash
-olares-cli cluster pod list -n os-framework | grep image-service        # one pod per node
-olares-cli cluster pod logs os-framework/<image-service-pod> -f | grep -E "progress=|downloading,ref:"
-```
-
-- `download image <ref> progress=<pct>, imageSize=<bytes>, offset=<bytes>` is the whole-image percent; `status: downloading,ref: layer-... offset:/Total:` is the active layer. Sample `offset` across two ticks ÷ the time gap = bytes/s. A **flat `offset` over many ticks = a stalled pull** (registry / mirror / network), not a slow one — go check the mirror / connectivity.
-- The same offset/total is mirrored into the `imagemanagers` CRD that drives the install %: on the host, `kubectl -n os-framework get imagemanagers -o yaml` (match the entry to your app instance) shows `.status.conditions[node][image]{offset,total}` without scraping logs.
-- The **model weights** download (engine pulling the model *after* its image is up) is a separate phase, NOT in image-service — watch it on the app's own llm-init container: `cluster pod logs <ns>/<app-pod> -c llm-init` or its `/api/progress` entrance.
-
 ### Don't just wait — diagnose the app's own pods in parallel
 
-The `--watch` market row (`downloading` / `initializing`) is a **coarse** signal. If you can multitask, kick off `market install ... --watch` AND, in parallel, watch the app's own workload directly — don't wait for app-service to flip the row.
+The `--watch` market row (`downloading` / `initializing`) is a **coarse** signal, and a crashlooping main container is NOT fast-failed for several minutes (the 5-minute `hasUnrecoverablePod` grace). If you can multitask, kick off `market install ... --watch` AND, in parallel, inspect the app's own workload directly rather than waiting for the row to flip.
 
-A crashlooping **main** container is NOT fast-failed while the row reads `initializing`. After the install scale-up, app-service moves the app to `Initializing` and polls **entrance TCP reachability** every 1s in `WaitForLaunch` (`framework/app-service/pkg/appstate/initializing_app.go:82` → `framework/app-service/pkg/appinstaller/helm_ops_install.go:1008`). It only gives up on a crashloop once `hasUnrecoverablePod` sees `CrashLoopBackOff` with `RestartCount >= 5` (`helm_ops_install.go:1118`, threshold `crashLoopRestartThreshold`) AND that condition persists past a **5-minute** grace (`unrecoverableGrace`, `helm_ops_install.go:1067`). So `initializing` legitimately persists for several minutes while the container is already CrashLoopBackOff. The fast signal is the pod's own container status + logs, not the market row.
+**The runtime diagnosis itself now lives in [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** — it owns the symptom→root-cause routing shared by catalog and dev apps:
 
-The app namespace is `<app>-<owner>` (e.g. `pdfextractkit-pptest03`). Catch the crash early:
+- A slow vs **stalled** image pull (byte-level progress from the per-node `image-service` DaemonSet / `imagemanagers` CRD; model-weights are a separate phase) → [olares-doctor-app-stuck.md](../../olares-doctor/references/olares-doctor-app-stuck.md).
+- A crashlooping / non-starting container (catch it early via `restartCount` / `state.waiting.reason`, read `--previous` logs) → [olares-doctor-app-crash.md](../../olares-doctor/references/olares-doctor-app-crash.md).
+- `running` but the entrance is unreachable / 504 → [olares-doctor-running-unhealthy.md](../../olares-doctor/references/olares-doctor-running-unhealthy.md).
 
-```bash
-# Container status of the app's pod — watch the MAIN container.
-olares-cli cluster pod list -n <app>-<owner> -o json   # status.containerStatuses[].{ready,restartCount,state}
-```
+Doctor diagnoses the root cause; **for a chart you author, it points back here** — the fix is a manifest/template edit (next section), then re-lint + re-deploy.
 
-- `restartCount` climbing or `state.waiting.reason == CrashLoopBackOff` on the main container = **start diagnosing now**, don't wait out the grace window.
+## 4. Diagnose: deploy-pipeline logs (chart-specific), then the app's runtime via doctor
 
-```bash
-# Crash traceback — current and (after a restart) the last failed start.
-olares-cli cluster pod logs <app>-<owner>/<pod> -c <main-container>
-olares-cli cluster pod logs <app>-<owner>/<pod> -c <main-container> --previous   # last crashed instance
-```
+### 4a. Deploy-pipeline log sources (specific to pushing your chart)
 
-`--previous` grabs the buffer from the instance that just died — usually where the real traceback is. Then jump to [§4 Diagnose by fetching logs](#4-diagnose-by-fetching-logs) and [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`--previous` is mutually exclusive with `-f`).
-
-## 4. Diagnose by fetching logs
-
-Use [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md) (`cluster pod logs` / `cluster container logs`). The platform backends all live in namespace `os-framework`:
+When the failure is in the **deploy pipeline** (not the app's own runtime), read the platform backend that rejected it. All live in `os-framework`; resolve dynamic pod names first with `olares-cli cluster pod list -n os-framework` (filter for `market` / `chartrepo`):
 
 | What you suspect | Where to look (`os-framework`) | Command |
 |---|---|---|
-| Image can't be pulled / wrong CPU arch (`ImagePullBackOff`, `no match for platform`, `exec format error`) | the app's own pods | `olares-cli cluster application status <ns>` then `olares-cli cluster pod logs <ns>/<pod>` — rebuild a pullable, node-arch image per [olares-chart-image.md](olares-chart-image.md) |
 | Upload / ingest rejected the chart | Deployment `market-deployment`, container `appstore-backend` | `olares-cli cluster container logs os-framework/<market-deployment-pod>/appstore-backend` |
 | Install can't fetch the chart | Deployment `chartrepo-deployment`, container `chartrepo` | `olares-cli cluster container logs os-framework/<chartrepo-deployment-pod>/chartrepo` |
-| Install failed (orchestration error, or the chart/manifest was rejected at install) | StatefulSet pod `app-service-0`, container `app-service` (cross-check the market backend `appstore-backend` row above) | `olares-cli cluster container logs os-framework/app-service-0/app-service` — read the error and fix the chart per [olares-chart-manifest.md](olares-chart-manifest.md) |
-| The app's own container crash-loops | the app's pods (usually `user-space-<id>` or the app namespace) | `olares-cli cluster application status <ns>` then `olares-cli cluster pod logs <ns>/<pod>` |
-| Main container `Completed` (exit 0) with **empty logs**, or app reads a bogus port/host | k8s service-link env collision — the Service name injects `<SVC>_PORT=tcp://...` that clobbers the app's own config env | set `spec.template.spec.enableServiceLinks: false` (see [olares-chart-env.md](olares-chart-env.md)) — then back to refine + lint |
-| Frontend request times out / 504 / connection closed at ~15s on a long request (LLM generation, big upload, slow report) — app pod healthy | entrance proxy route timeout `options.apiTimeout` defaults to 15s | set `options.apiTimeout: 0` (disable) or a large value in the manifest (see [olares-chart-manifest.md](olares-chart-manifest.md)) — then re-package + re-deploy |
-| `Permission denied` / EACCES writing data, or data not persisting | uid ≠ 1000, root-owned dirs on userspace mount, missing `spec.runAsUser` | [olares-chart-run-as-user.md](olares-chart-run-as-user.md) — then back to refine + lint |
-| Admission denied: untrusted image + root | third-party main container runs as root | [olares-chart-run-as-user.md](olares-chart-run-as-user.md) — force uid 1000 or initContainer chown |
+| Install failed (orchestration error, or the chart/manifest was rejected at install) | StatefulSet pod `app-service-0`, container `app-service` | `olares-cli cluster container logs os-framework/app-service-0/app-service` — read the error and fix the chart per [olares-chart-manifest.md](olares-chart-manifest.md) |
 
-- Pod names for the Deployments are dynamic (`market-deployment-*`, `chartrepo-deployment-*`); resolve the exact name first with `olares-cli cluster pod list -n os-framework` (filter the output for `market` / `chartrepo`).
-- **Admin caveat:** `os-framework` system pods are typically visible only to an **admin** profile. If you get `HTTP 403` / `HTTP 404`, the active developer profile isn't admin — don't fight it; report that the platform logs need an admin and fall back to the app's own pod logs.
+- **Admin caveat:** `os-framework` system pods are typically visible only to an **admin** profile. On `HTTP 403` / `HTTP 404`, the active developer profile isn't admin — fall back to the app's own pod logs.
 
-## 4b. Upgrade recovery: `stopped` after upgrade
+### 4b. The app's own runtime failure -> doctor, with the chart fix it points back to
+
+Once the app's container is the problem (it pulled, scheduled, and started but misbehaves), diagnose via [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md). The root causes most relevant to a chart you author, and the fix doctor routes you back to:
+
+| Root cause doctor identifies | Chart fix |
+|---|---|
+| Image can't be pulled / wrong CPU arch (`ImagePullBackOff`, `no match for platform`, `exec format error`) | rebuild a pullable, node-arch image — [olares-chart-image.md](olares-chart-image.md) |
+| Main container `Completed` (exit 0) with **empty logs**, or app reads a bogus port/host (k8s service-link env collision) | `spec.template.spec.enableServiceLinks: false` — [olares-chart-env.md](olares-chart-env.md) |
+| Frontend 504 / connection closed at ~15s on a long request, app pod healthy (entrance proxy `options.apiTimeout` defaults to 15s) | `options.apiTimeout: 0` or a large value — [olares-chart-manifest.md](olares-chart-manifest.md) |
+| `Permission denied` / EACCES writing data, or data not persisting (uid != 1000) | [olares-chart-run-as-user.md](olares-chart-run-as-user.md) |
+| Admission denied: untrusted image runs as root | force uid 1000 or initContainer chown — [olares-chart-run-as-user.md](olares-chart-run-as-user.md) |
+
+After the chart fix: re-lint, bump the version, re-package, re-upload, and re-apply with the right verb (§3 / §5).
+
+## 4c. Upgrade recovery: `stopped` after upgrade
 
 An upgrade can leave the **market row** in `state=stopped` while the **workload** is actually `Running`. Two paths land in `stopped`: upgrading an **already-stopped** app re-renders the chart at `replicas=0` and intentionally returns to `stopped` (by design); and **canceling an in-flight** op (`initializing` / `upgrading` / `applyingEnv` / `resuming`) only *stops* the app — so if a crashing initContainer was fixed and the workload later came up on its own, the row can read `stopped` while the pod is `1/1 Running`:
 

--- a/cli/skills/olares-chart/references/olares-chart-from-compose.md
+++ b/cli/skills/olares-chart/references/olares-chart-from-compose.md
@@ -63,4 +63,4 @@ Once refined, validate in a loop:
 olares-cli chart lint ./myapp      # see olares-chart-lint.md
 ```
 
-Then, with the developer's consent (confirm once), deploy to a real Olares — [olares-chart-deploy.md](olares-chart-deploy.md). To list it on the public Market afterwards, see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).
+Once `lint` passes, deploy to a real Olares automatically (no extra confirmation needed; stop only if not logged in or a failure is clearly not a chart problem) — [olares-chart-deploy.md](olares-chart-deploy.md). To list it on the public Market afterwards, see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).

--- a/cli/skills/olares-chart/references/olares-chart-gpu.md
+++ b/cli/skills/olares-chart/references/olares-chart-gpu.md
@@ -29,7 +29,7 @@ Watch out for:
    ENV TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9;9.0"
    ```
 2. **Arch is amd64.** Olares' `nvidia` GPU mode requires `amd64`, so GPU apps are single-arch: build `--platform linux/amd64` and declare `supportArch: [amd64]` — do NOT multi-arch. (arm64 NVIDIA is the niche `nvidia-gb10` mode.)
-3. **No local smoke test** — a CPU build box can't run the container. Validate on a GPU Olares node (Publish-local on a GPU host).
+3. **No local smoke test** — a CPU build box can't run the container. Validate by deploying to a GPU Olares node (the olares-chart deploy loop, run on a GPU host).
 
 > CUDA driver/toolkit version compatibility is not a concern here — Olares GPU nodes keep the driver current, so the image's CUDA version generally does not need to be pinned down to match the host.
 

--- a/cli/skills/olares-chart/references/olares-chart-llm-models.md
+++ b/cli/skills/olares-chart/references/olares-chart-llm-models.md
@@ -195,7 +195,7 @@ olares-cli market clone llamacppllmbasev3 -s upload \
 
 - `templateOnly` apps are created via `clone` (the CLI sends `templateClone:true` on 1.12.6+); `clone` mints a per-instance name and `--watch` tracks it. Single local test instance can also use `market install <base> -s upload --env ...`.
 - `lint` the chart first if you edited it: `olares-cli chart lint ./<base>`.
-- A long `downloading` state is the multi-GB engine image pull (then the model), not a hang — watch byte progress + speed via the `image-service` logs ([olares-chart-deploy.md](olares-chart-deploy.md) §3).
+- A long `downloading` state is the multi-GB engine image pull (then the model), not a hang — watch byte progress + speed via the `image-service` logs ([`../../olares-doctor/references/olares-doctor-app-stuck.md`](../../olares-doctor/references/olares-doctor-app-stuck.md)).
 
 ## 7. Manage / switch the model
 

--- a/cli/skills/olares-chart/references/olares-chart-manifest.md
+++ b/cli/skills/olares-chart/references/olares-chart-manifest.md
@@ -7,7 +7,7 @@ The scaffolded manifest is a stub. This doc covers, in order: the fixed **header
 
 ## Header fields
 
-The manifest top sets `apiVersion: v3` and `olaresManifest.version: '0.12.0'`. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The fixed version-field values, the `olares` system dependency, and the field map are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator sizing is in [olares-chart-gpu.md](olares-chart-gpu.md).
+The manifest top sets `apiVersion: v3` and `olaresManifest.version: '0.12.0'`. `0.12.0` carries `spec.accelerator` and `permission.externalData`. The fixed version-field values, the `olares` system dependency, and the field map are in [olares-chart-versioning.md](olares-chart-versioning.md); accelerator modes & sizing are in [olares-chart-accelerator.md](olares-chart-accelerator.md).
 
 > **Two required manifest entries — author both yourself for every chart; `lint` rejects either if missing:** the `workloadReplicas` map (below) and the `olares` system dependency under `options.dependencies` (next section). Both live at the **top level of `OlaresManifest.yaml`** — siblings of `metadata`, `spec`, and `options`. In particular `workloadReplicas` is **not** nested under the manifest `spec`.
 

--- a/cli/skills/olares-chart/references/olares-chart-shared.md
+++ b/cli/skills/olares-chart/references/olares-chart-shared.md
@@ -39,7 +39,7 @@ spec:
       limitedMemory: 40Gi
       requiredGPUMemory: 1Gi
       limitedGPUMemory: 24Gi
-    - mode: strix-halo
+    - mode: apple-m
       # ...
 permission:
   appData: true

--- a/cli/skills/olares-chart/references/olares-chart-system-values.md
+++ b/cli/skills/olares-chart/references/olares-chart-system-values.md
@@ -26,7 +26,7 @@ Populated in `BuildBaseHelmValues` for every install (mostly from app-service's 
 | `.Values.isAdmin` | `true` if the owner is an admin | `true` \| `false` |
 | `.Values.admin` | admin username (rewritten to the owner of an already-installed cluster-scoped instance when present) | free-form |
 | `.Values.sysVersion` | running Olares version, from the `Terminus` CR — see [platform.md](../../olares-shared/references/olares-platform.md) (version model) | semver, e.g. `1.12.6` |
-| `.Values.GPU.Type` / `.Values.gpu` | selected GPU flavour | `cpu` \| `nvidia` \| `amd-gpu` \| `amd-apu` \| `strix-halo` \| `nvidia-gb10` \| `apple-m` \| `mthreads-m1000` — the `spec.accelerator` mode names in [olares-chart-accelerator.md](olares-chart-accelerator.md) |
+| `.Values.GPU.Type` / `.Values.gpu` | selected GPU flavour the platform injected at install | `cpu` \| `nvidia` \| `amd-gpu` \| `amd-apu` \| `strix-halo` \| `nvidia-gb10` \| `apple-m` \| `mthreads-m1000` — the runtime flavour set is a **superset** of the `lint`-accepted `spec.accelerator` modes in [olares-chart-accelerator.md](olares-chart-accelerator.md) (some real node flavours aren't valid manifest modes) |
 | `.Values.GPU.Cuda` | CUDA version (`OLARES_SYSTEM_CUDA_VERSION`) | version string, may be empty on non-NVIDIA |
 | `.Values.cluster.arch` | node CPU arch | `amd64` \| `arm64` |
 | `.Values.nodes` | per-node hardware metadata; advanced, rarely templated. Each entry: `cudaVersion`, `cpu[]` (`coreNumber`/`arch`/`frequency`/`model`/`modelName`/`vendor`), `memory.total`, `gpus[]` (`vendor`/`arch`/`model`/`memory`/`modelName`) | list of NodeInfo |

--- a/cli/skills/olares-chart/references/olares-chart-workflow.md
+++ b/cli/skills/olares-chart/references/olares-chart-workflow.md
@@ -19,17 +19,17 @@
  D3. lint       olares-cli chart lint ./<app>        # loop D2<->D3 until OK
  D4. package    bump metadata.version (= Chart.yaml version), then olares-cli chart package ./<app>
 
- Deploy to your Olares (requires login; confirm once, then auto-loop):
+ Deploy to your Olares (requires login; automatic once lint passes):
  V1. logged-in? olares-cli profile list              # if not: tell developer, stop
- V2. ask once   confirm with the developer before the first upload — then run V3-V6 automatically
+ V2. auto       after lint passes + logged-in, run V3-V6 WITHOUT asking (stop only if not logged in, or a failure is clearly not a chart problem)
  V3. upload     olares-cli market upload ./<app>-<ver>.tgz
  V4. run        olares-cli market install <app> -s upload --version <ver> --watch -o json
- V5. on failure fetch market / chartrepo / app-service / app-pod logs and diagnose
+ V5. on failure diagnose via olares-doctor (symptom -> root cause), then loop back
  V6. decide     loop back: chart problem -> D2 ; image problem -> P3 ; uid/EACCES -> run-as-user.md ; not a chart problem -> break out, report & ask
  V7. cleanup    olares-cli market uninstall <app> --watch ; olares-cli market delete <app>
 ```
 
-Step D1 produces a chart that **already passes `lint`** but is NOT yet a good app: kompose translates containers literally and cannot make product decisions. The value you add is D2. Treat the generated `OlaresManifest.yaml` as a stub — for deploying to your own Olares, §1 Metadata can stay a stub. The V steps cross into sibling skills — full procedure in [olares-chart-deploy.md](olares-chart-deploy.md). Confirm once before the first upload, then drive the loop automatically.
+Step D1 produces a chart that **already passes `lint`** but is NOT yet a good app: kompose translates containers literally and cannot make product decisions. The value you add is D2. Treat the generated `OlaresManifest.yaml` as a stub — for deploying to your own Olares, §1 Metadata can stay a stub. The V steps cross into sibling skills — full procedure in [olares-chart-deploy.md](olares-chart-deploy.md); runtime diagnosis is [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md). Drive the loop automatically once `lint` passes (stop only if not logged in, or the failure is clearly not a chart problem); never log in on the developer's behalf without asking.
 
 > **Publishing to the public Market** (multi-arch build, full market-ready metadata, the `beclab/apps` PR, paid apps) is the [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md) skill — start there once the app runs on your Olares.
 

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -33,6 +33,8 @@ Against the cluster the active profile can see:
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
+> **Diagnosing *why* an app is broken** (stuck install, crash loop, `running` but unreachable, image won't pull, resource pressure) is [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md) — it orchestrates these `cluster` commands into symptom→root-cause routing. `cluster` stays the raw runtime view and the place that mutates K8s objects.
+
 > **Mental model:** if the question is *runtime state* of an existing cluster, you are here. If it's *lifecycle* of an Olares app or *day-zero* host setup, you are not.
 
 ## Core concepts
@@ -119,7 +121,7 @@ Every `list` verb under `pod` / `cronjob` / `job` / `namespace` / `node` / `work
 Two image-inventory commands ride on top of this:
 
 - `cluster workload images [IMAGE]` follows the same pagination contract. An IMAGE-argument lookup always full-scans the cluster, but the plain listing is NOT full-cluster unless `--all` is set. See [references/olares-cluster-workload.md](references/olares-cluster-workload.md).
-- For a local-image-vs-workload diagnostic, use the top-level `doctor images` instead — always full-scans (no pagination), annotates each local containerd image with its workload reference count, and takes `--unused` for zero-reference orphans. Its completeness/coverage caveats live in that same workload reference's Agent notes.
+- For a local-image-vs-workload diagnostic, use the top-level `doctor images` instead — always full-scans (no pagination), annotates each local containerd image with its workload reference count, and takes `--unused` for zero-reference orphans. It is owned by [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md); its completeness/coverage caveats live in [`../olares-doctor/references/olares-doctor-image.md`](../olares-doctor/references/olares-doctor-image.md).
 
 ### `--watch` / `--follow` semantics (uniform)
 
@@ -131,7 +133,7 @@ Two image-inventory commands ride on top of this:
 - TTY detection: clear-screen-redraw for table, raw stream for piped output, JSONL for `-o json`.
 - `--interval D` / `--timeout D` are **rejected with an error** when their gate flag (`-w` or `-f`) isn't also set — don't silently waste a flag.
 
-## Common errors → fixes
+## Common errors
 
 | Error message starts with | Meaning | Fix |
 |---|---|---|

--- a/cli/skills/olares-cluster/references/olares-cluster-middleware.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-middleware.md
@@ -11,7 +11,7 @@ Olares-managed databases / queues / object stores. **NOT a K8s native resource**
 |---|---|
 | `list` | TYPE / NAME / NAMESPACE / NODES / ADMIN-USER (read-only inventory) |
 
-> The CLI exposes **only** the read-only inventory verb today. Password rotation, instance creation, and other mutations are not in `olares-cli cluster middleware`; manage those from LarePass / ControlHub SPA, or the per-middleware admin tooling (psql, mongosh, redis-cli, etc.) once you know the connection details.
+> The CLI exposes **only** the read-only inventory verb. Password rotation, instance creation, and other mutations are not in `olares-cli cluster middleware`; manage those from LarePass / ControlHub SPA, or the per-middleware admin tooling (psql, mongosh, redis-cli, etc.) once you know the connection details.
 
 ## Sensitive-field handling on `list`
 

--- a/cli/skills/olares-cluster/references/olares-cluster-workload.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-workload.md
@@ -50,10 +50,8 @@ olares-cli cluster workload images --limit 50 --page 1
 # Where is a given image referenced? (tag/digest-normalized; full scan)
 olares-cli cluster workload images docker.io/library/nginx:latest
 
-# Local images + workload reference counts (full scan; pause excluded).
-olares-cli doctor images -o json
-# Only the orphans (zero refs), biggest first, with reclaimable-size footer.
-olares-cli doctor images --unused
+# For local-image-vs-workload reference counts / orphan pruning, use `doctor images`
+# (owned by the olares-doctor skill, not cluster).
 
 # Get + watch rollout to convergence.
 olares-cli cluster workload get user-system-alice/api --kind deploy
@@ -85,7 +83,7 @@ This combines the PATCH and the rollout-status poll into one invocation. The age
 - **`--kind` errors are the most common gotcha.** Always include it in `get` / `yaml` / mutating verbs. For `list`, omit it (or use `all`) when the user doesn't specify a type.
 - **`start <name> --replicas N` requires the user to know N.** If the user says "start this back up", ask what replica count they want before invoking. There is intentionally no "remember previous replicas" cache.
 - For "restart this app" requests, **prefer `pod delete` on a specific pod** when the user just wants a single pod to bounce; reach for `workload restart` only when they actually want every replica to recycle.
-- **`doctor images --unused` is a prune *hint*, not a green light.** Two limits: (1) it only lists images on the control node, so it's not a full-cluster census (but a listed image's verdict is checked cluster-wide and therefore safe); (2) references come only from Deployment/StatefulSet/DaemonSet/Job/CronJob specs, so an image used solely by a bare Pod / static pod / other-controller-owned Pod, or one a running container still pins by an old digest, can show as unused. Before telling a user to delete, cross-check running Pods.
+- **Local-image inventory / orphan pruning (`doctor images`) is owned by [`../../olares-doctor/references/olares-doctor-image.md`](../../olares-doctor/references/olares-doctor-image.md)** — including the prune-hint caveats (control-node-only census, reference-counting limits). Use `cluster workload images` for "where is THIS image referenced"; reach for `doctor images` for the reverse (local images + their reference counts).
 
 ## Common errors
 

--- a/cli/skills/olares-doctor/SKILL.md
+++ b/cli/skills/olares-doctor/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: olares-doctor
+version: 1.0.0
+description: "Runtime diagnosis for Olares apps and the system via olares-cli — symptom-to-root-cause routing for an app that won't install, won't start, crashes, is `running` but unreachable, or is slow; plus the `doctor` command tree (images). Use when an app or Olares is misbehaving and you need to find out why; both catalog (market) and dev (chart) apps hand runtime failures here."
+compatibility: Requires olares-cli on PATH and active Olares profile
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - olares-cli
+---
+
+# doctor (runtime diagnosis)
+
+**CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli doctor --help`.**
+
+> **Source of truth for flags is always `olares-cli doctor <verb> --help`.** This file only carries what `--help` cannot give: symptom-to-reference routing, the `doctor` command index, and which sibling skill owns each evidence-gathering command.
+
+> **This skill is a thin router.** It does not restate platform facts or duplicate sibling-skill commands — it maps a symptom to the right reference, then orchestrates `olares-cluster` / `olares-dashboard` / `olares-market` to gather evidence. Backend facts (state machine, TTLs, `running` semantics, download serialization) live once in [`../olares-shared/references/olares-platform-appstate.md`](../olares-shared/references/olares-platform-appstate.md).
+
+## When to use
+
+Diagnosing **why** an app or the system misbehaves — not performing lifecycle actions (that is `market`/`chart`) and not authoring charts (`chart`):
+
+- An install/upgrade is stuck or never reaches `running`; an app won't start.
+- An app crashes / restarts repeatedly (CrashLoopBackOff, exit codes, config errors).
+- An image won't pull (`ImagePullBackOff` / `ErrImagePull` / wrong arch), or you want to find unused local images.
+- An app is `running` but its entrance is unreachable / errors / times out.
+- The system or an app is slow, or a GPU/resource binding is rejected (`node-pressure`).
+
+**Both catalog apps (installed via `market`) and your own dev apps (deployed via `chart`) route runtime failures here.** Once the root cause is found, the *fix* for a dev app you authored is usually a chart edit — hand back to [`../olares-chart/SKILL.md`](../olares-chart/SKILL.md).
+
+> Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
+
+> **Mental model:** `doctor` answers *"why is this broken and what do I do next?"* It reads evidence, never mutates. The four-skill develop->deploy->debug combo is `chart` + `market` + `olares-shared` + `doctor`.
+
+## Symptom -> reference routing
+
+Pick the row that matches the reported symptom; each reference carries the locate-commands, the decision criteria, and the next step.
+
+| Symptom | Reference |
+|---|---|
+| Install/upgrade stuck; never reaches `running`; sits in `pending` / `downloading` / `installing` / `initializing`; a fresh install ended in `stopped` | [references/olares-doctor-app-stuck.md](references/olares-doctor-app-stuck.md) |
+| App crashes / restarts (CrashLoopBackOff, non-zero exit, `CreateContainerConfigError`, permission errors) | [references/olares-doctor-app-crash.md](references/olares-doctor-app-crash.md) |
+| Image won't pull (`ImagePullBackOff` / `ErrImagePull` / `InvalidImageName` / arch mismatch); finding unused local images | [references/olares-doctor-image.md](references/olares-doctor-image.md) |
+| App is `running` but the entrance is unreachable / 5xx / times out / blank | [references/olares-doctor-running-unhealthy.md](references/olares-doctor-running-unhealthy.md) |
+| System or app slow; resource pressure; GPU/compute binding rejected (`node-pressure`) | [references/olares-doctor-resources.md](references/olares-doctor-resources.md) |
+
+> **First, rule out the normal queue.** Before declaring an install stuck, check whether another app is `downloading` — app-service runs **one download at a time**, so a `pending` row is often just queuing (see the appstate reference and the app-stuck reference).
+
+## `olares-cli doctor` command tree
+
+`doctor` also hosts read-only diagnostic commands that combine multiple Olares API surfaces. **Source of truth for flags is always `olares-cli doctor <verb> --help`.** They mutate nothing.
+
+| Command | What it does | Reference |
+|---|---|---|
+| `doctor images` | Lists local containerd images annotated with how many workloads reference each one; `--unused` shows zero-reference prune candidates (largest-first, with reclaimable size). Always full-scans the control node; `-n` / `-l` scope the workload reference count. | [references/olares-doctor-image.md](references/olares-doctor-image.md) |
+
+## How doctor gathers evidence (orchestration, not ownership)
+
+`doctor` does not own these commands — it routes to the skill that does. The references spell out the exact invocations:
+
+| Need | Skill | Typical commands |
+|---|---|---|
+| App lifecycle state / source / watch | [`../olares-market/SKILL.md`](../olares-market/SKILL.md) | `market status <app> [-a]`, `market list --mine` |
+| Pod / container status, logs, events, workloads | [`../olares-cluster/SKILL.md`](../olares-cluster/SKILL.md) | `cluster application status <ns>`, `cluster pod list/get/logs/events`, `cluster workload ...` |
+| Resource usage / pressure / GPU | [`../olares-dashboard/SKILL.md`](../olares-dashboard/SKILL.md) | `dashboard overview [memory\|cpu\|disk\|gpu]`, `dashboard applications` |
+| The app's namespace (`<app>-<owner>` vs `<app>-shared`, v2 multi-namespace) | [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md#finding-an-apps-namespace) | — |
+
+> **Admin caveat:** `os-framework` / `os-platform` system pods are typically visible only to an **admin** profile. On `HTTP 403` / `404`, fall back to the app's own pod logs and report that platform logs need admin.
+
+## Common errors
+
+These are diagnosis-flow pitfalls, not CLI flag errors (those live in each sibling skill). Auth errors (`ErrTokenInvalidated` / 401 / 403 after refresh) are always [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md).
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Declared an install "stuck" while it's `pending` | Another app is `downloading` — app-service serializes downloads (one at a time) | Not stuck; it's queuing. Confirm with `market status -a`, then wait |
+| Treated a `--watch` timeout as a failure | A short foreground window expired; the op is still progressing (long backend TTLs) | Not a failure. Re-judge by STATE (`market status <app>`), not the timeout — see [olares-doctor-app-stuck.md](references/olares-doctor-app-stuck.md) |
+| `running` but the app doesn't work | `running` only proves entrance TCP-reachability, not health | Climb the health ladder — [olares-doctor-running-unhealthy.md](references/olares-doctor-running-unhealthy.md) |
+| A fresh install ended in `stopped` (no `*Failed`) | Scheduling failure tears down via `Stopping -> stopped`, never `installFailed` | Read pod events for the scheduling reason — [olares-doctor-resources.md](references/olares-doctor-resources.md) |
+| `HTTP 403` / `404` reading `os-framework` / `os-platform` pods | Active profile isn't admin | Fall back to the app's own pod logs; report that platform logs need an admin profile |
+| Found the root cause but unsure how to fix a dev app | The fix for an app you authored is a chart edit, not a CLI action | Hand back to [`../olares-chart/SKILL.md`](../olares-chart/SKILL.md) |

--- a/cli/skills/olares-doctor/references/olares-doctor-app-crash.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-app-crash.md
@@ -1,0 +1,41 @@
+# doctor: app crashes / restarts / won't start
+
+> **Prerequisite:** read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+> **Backend facts** (fast-fail grace, `running` semantics): [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md).
+
+Symptom: the app's container keeps restarting (CrashLoopBackOff), exits non-zero, or fails to start with a config/permission error.
+
+## Catch it early — don't wait out the grace window
+
+During `initializing`, app-service polls entrance TCP reachability and only declares failure once `hasUnrecoverablePod` sees `CrashLoopBackOff` with `RestartCount >= 5` **persisting past a 5-minute grace**. So the market row legitimately stays `initializing` for minutes while the container is already crashlooping — **the fast signal is the pod, not the row.** Resolve the namespace (`<app>-<owner>` / `<app>-shared`; see [finding an app's namespace](../../olares-shared/references/olares-platform.md#finding-an-apps-namespace)) and watch the **main** container directly:
+
+```bash
+olares-cli cluster pod list -n <ns> -o json    # status.containerStatuses[].{ready,restartCount,state.waiting.reason}
+```
+
+`restartCount` climbing or `state.waiting.reason == CrashLoopBackOff` on the main container = start diagnosing now.
+
+## Get the crash reason
+
+```bash
+# Current logs, and the buffer from the instance that just died (where the real traceback usually is).
+olares-cli cluster pod logs <ns>/<pod> -c <main-container>
+olares-cli cluster pod logs <ns>/<pod> -c <main-container> --previous   # mutually exclusive with -f
+olares-cli cluster pod get <ns>/<pod>          # exit code / reason / last state
+olares-cli cluster pod events <ns>/<pod>       # mount / config / pull events
+```
+
+(`cluster pod` flags & semantics: [`../../olares-cluster/references/olares-cluster-pod.md`](../../olares-cluster/references/olares-cluster-pod.md).)
+
+## Common root causes -> next step
+
+| What you see | Root cause | Next step |
+|---|---|---|
+| `CreateContainerConfigError` | Missing/!invalid env, secret, or configmap referenced by the container | Read events for the missing key; for a catalog app re-check required envs (`market install ... --env`); for a chart you author, fix the manifest env wiring |
+| `CrashLoopBackOff`, app traceback in logs | App-level error (bad config, missing dependency, unreachable middleware) | Read the traceback; wire middleware/env correctly |
+| Exit 0 / `Completed` with **empty logs**, or app reads a bogus port/host | k8s service-link env collision (`<SVC>_PORT=tcp://...` clobbers app config) | Chart fix: `enableServiceLinks: false` — [`../../olares-chart/references/olares-chart-env.md`](../../olares-chart/references/olares-chart-env.md) |
+| `Permission denied` / EACCES writing data, or data not persisting | uid != 1000 on userspace mounts (root-owned dirs, missing `runAsUser`) | Chart fix: [`../../olares-chart/references/olares-chart-run-as-user.md`](../../olares-chart/references/olares-chart-run-as-user.md) |
+| Admission denied: untrusted image runs as root | OPA blocks a root third-party main container | Chart fix: force uid 1000 / initContainer chown — [`../../olares-chart/references/olares-chart-run-as-user.md`](../../olares-chart/references/olares-chart-run-as-user.md) |
+| Image can't be pulled (`ImagePullBackOff` / arch) | Not a crash — a pull problem | [olares-doctor-image.md](olares-doctor-image.md) |
+
+> **Diagnosis vs fix:** this reference finds the root cause for any app. When the app is **one you are authoring**, the fix is a chart edit — hand back to [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) (then re-lint + re-deploy). For a published catalog app, the fix is config (`settings` / `market install --env`) or contacting the maintainer.

--- a/cli/skills/olares-doctor/references/olares-doctor-app-stuck.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-app-stuck.md
@@ -1,0 +1,58 @@
+# doctor: app stuck / won't install / never reaches running
+
+> **Prerequisite:** read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+> **Backend facts** (state machine, TTLs, single-download serialization, `Pending`->`stopped` trap): [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md). This reference is the diagnostic procedure on top of those facts.
+
+Symptom: an install/upgrade is stuck, or an app never reaches `running` — it sits in `pending` / `downloading` / `installing` / `initializing`, or a fresh install quietly ended in `stopped`.
+
+## Step 0 — read the state row, then rule out the normal queue
+
+```bash
+olares-cli market status <app> -o json     # STATE / OPERATION / SOURCE
+olares-cli market status -a                 # is ANY app currently downloading?
+```
+
+app-service admits **one `downloading` app at a time**; everything else waits in `pending`. So a `pending` row while another app downloads is **normal queuing, not stuck** — it advances when the in-flight download finishes. Only treat `pending` as a problem if nothing is downloading and it never moves.
+
+Then branch on STATE.
+
+## `downloading` — slow pull vs stalled pull
+
+A `downloading` row has a **30-day** backend TTL, so it will never self-fail — judge it by byte-level pull progress, not by waiting. The market PROGRESS field is unreliable; real progress is in the per-node `image-service` DaemonSet (it pulls via containerd):
+
+```bash
+olares-cli cluster pod list -n os-framework | grep image-service
+olares-cli cluster pod logs os-framework/<image-service-pod> -f | grep -E "progress=|downloading,ref:"
+```
+
+- `download image <ref> progress=<pct>, imageSize=<bytes>, offset=<bytes>` = whole-image percent; `status: downloading,ref: layer-... offset:/Total:` = active layer. Sample `offset` across two ticks: rising = healthy (large image), **flat over many ticks = a stalled pull** (registry/mirror/network) — check the mirror/connectivity.
+- Model weights (an engine downloading the model *after* its image is up) are a **separate** phase, not in image-service — watch the app's own init container, e.g. `cluster pod logs <ns>/<app-pod> -c llm-init`.
+- A stalled pull that can't be resolved → it's an image problem: [olares-doctor-image.md](olares-doctor-image.md).
+
+## `installing` / `initializing` stuck — two traps
+
+`installing` (30m TTL) and `initializing` (1h TTL) only fast-fail on hard pod conditions that persist past a 5-minute grace; otherwise they poll the long TTL. So a stuck row needs pod-level inspection, not more waiting. Resolve the namespace (`<app>-<owner>`, or `<app>-shared` for a shared app; a v2 app spans several namespaces — see [finding an app's namespace](../../olares-shared/references/olares-platform.md#finding-an-apps-namespace)), then:
+
+```bash
+olares-cli cluster application status <ns>          # workload readiness at a glance
+olares-cli cluster pod list -n <ns> -o json         # status.containerStatuses[].{ready,restartCount,state}
+olares-cli cluster pod events <ns>/<pod>            # scheduling / pull / mount events
+```
+
+Two non-obvious traps:
+
+- **Scheduling failure does NOT become `installFailed`.** A pod that can't schedule (stays `Pending`) is torn down via `Stopping -> stopped`. So **a fresh install that ended in `stopped` is the red flag** — read `cluster pod events` for the scheduling reason (insufficient CPU/memory/GPU, taints) and route to [olares-doctor-resources.md](olares-doctor-resources.md).
+- **Soft-hang:** the pod is `Running` but the app never becomes serve-ready (no crash). The row stays `initializing` and is never fast-failed — only the pod logs reveal it. If the container is up but the entrance never opens, route to [olares-doctor-running-unhealthy.md](olares-doctor-running-unhealthy.md).
+
+## Decision -> next step
+
+| Finding | Route to |
+|---|---|
+| Another app is downloading; this one is `pending` | Normal queue — wait, no action |
+| `downloading`, `offset` rising | Healthy large pull — keep polling |
+| `downloading`, `offset` flat | [olares-doctor-image.md](olares-doctor-image.md) (stalled pull) |
+| Pod `Pending` / fresh install in `stopped` | [olares-doctor-resources.md](olares-doctor-resources.md) (scheduling) |
+| Pod restarting / CrashLoopBackOff | [olares-doctor-app-crash.md](olares-doctor-app-crash.md) |
+| Pod Running but entrance never opens | [olares-doctor-running-unhealthy.md](olares-doctor-running-unhealthy.md) |
+
+For orchestration-level errors, also check `os-framework/app-service-0` (`cluster container logs os-framework/app-service-0/app-service`) — admin-only; fall back to the app's own pod logs if 403/404. **If this is a chart you are authoring**, fix per [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md).

--- a/cli/skills/olares-doctor/references/olares-doctor-image.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-image.md
@@ -1,0 +1,39 @@
+# doctor: image problems (pull failures, unused images)
+
+> **Prerequisite:** read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+
+Two distinct concerns: an image that **won't pull** (blocks an install), and local images that are **unused** (reclaim disk).
+
+## Image won't pull
+
+Symptom on a pod: `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, or a runtime arch error (`no match for platform`, `exec format error`). These are hard, never-self-healing conditions — app-service fast-fails them after the 5-minute grace.
+
+```bash
+olares-cli cluster pod list -n <ns> -o json     # state.waiting.reason on the failing container
+olares-cli cluster pod events <ns>/<pod>        # "Failed to pull image ...": the registry/auth/arch detail
+```
+
+| Reason | Root cause | Next step |
+|---|---|---|
+| `ImagePullBackOff` / `ErrImagePull` | Image missing, private without creds, or registry/mirror unreachable | Confirm the ref is public & pullable; if a mirror is down, that is a stalled-pull/network issue (see [olares-doctor-app-stuck.md](olares-doctor-app-stuck.md)) |
+| `InvalidImageName` | Malformed image ref in the workload spec | For a chart you author, fix the image ref — [`../../olares-chart/references/olares-chart-image.md`](../../olares-chart/references/olares-chart-image.md) |
+| `no match for platform` / `exec format error` | Image arch != node arch | Rebuild for this node's arch (`cluster node list` for arch) — [`../../olares-chart/references/olares-chart-image.md`](../../olares-chart/references/olares-chart-image.md) |
+
+A slow-but-progressing pull is NOT a failure — see the `downloading` section of [olares-doctor-app-stuck.md](olares-doctor-app-stuck.md) for distinguishing slow from stalled.
+
+## Unused local images (`doctor images`)
+
+`doctor images` lists local containerd images annotated with how many workloads reference each one. **Source of truth for flags: `olares-cli doctor images --help`.**
+
+```bash
+olares-cli doctor images                 # all local images + reference counts
+olares-cli doctor images --unused        # zero-reference prune candidates, largest-first, with reclaimable size
+olares-cli doctor images -n <ns>         # scope the reference count to one namespace
+olares-cli doctor images -o json
+```
+
+- Always full-scans the **control node**; the unused verdict for a listed image is cluster-wide-reference-checked, so it is safe — but images living only on a worker node won't appear (not a full-cluster census).
+- References are counted from Deployment / StatefulSet / DaemonSet / Job / CronJob **specs**, not from bare/static pods or the digest a running container is pinned to. A tag bumped to a new digest can leave the old, still-running image looking unused — **cross-check running pods before reclaiming.**
+- `pause`/sandbox images are excluded (runtime-pinned, never prunable).
+
+This command is read-only — it identifies candidates; pruning itself is a separate, deliberate action.

--- a/cli/skills/olares-doctor/references/olares-doctor-resources.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-resources.md
@@ -1,0 +1,41 @@
+# doctor: slow / resource pressure / scheduling rejected
+
+> **Prerequisite:** read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+
+Symptom: the system or an app feels slow, a pod can't schedule, or a GPU/compute binding is rejected with `node-pressure`. This reference orchestrates `dashboard` (usage) and `cluster` (scheduling) to locate the constrained resource.
+
+## Where is the pressure?
+
+```bash
+# System + per-user resource snapshot (physical / user / ranking sections).
+olares-cli dashboard overview -o json
+# Drill into one dimension.
+olares-cli dashboard overview memory -o json
+olares-cli dashboard overview cpu -o json
+olares-cli dashboard overview disk -o json
+# Which app/workload is consuming the most.
+olares-cli dashboard applications -o json
+```
+
+(Envelope shape, `--watch`, and empty-data semantics: [`../../olares-dashboard/SKILL.md`](../../olares-dashboard/SKILL.md).)
+
+## Pod can't schedule
+
+A pod stuck `Pending` (and a fresh install that ended in `stopped` — see the trap in [olares-doctor-app-stuck.md](olares-doctor-app-stuck.md)) is usually a scheduling constraint:
+
+```bash
+olares-cli cluster pod events <ns>/<pod>     # "Insufficient cpu/memory", taints, node affinity, no GPU
+olares-cli cluster node list -o json         # allocatable vs requested per node, arch
+```
+
+| Event reason | Root cause | Next step |
+|---|---|---|
+| `Insufficient memory` / `cpu` | Node lacks headroom | Free resources (stop other apps), or lower the app's requests in the chart ([`../../olares-chart/references/olares-chart-accelerator.md`](../../olares-chart/references/olares-chart-accelerator.md)) |
+| `Insufficient <gpu resource>` / no schedulable node | No matching GPU/accelerator capacity | Pick a node/device with capacity; check `settings compute list` |
+| `node-pressure` on a GPU `resume` (Memory/CPU/Disk Total/Used/Needed) | The compute binding can't fit | Free resources or pick different cards — see `market resume` `--compute-binding` ([`../../olares-market/references/olares-market-lifecycle.md`](../../olares-market/references/olares-market-lifecycle.md)) |
+
+## GPU / VRAM rejections
+
+GPU binding rejections (`aggregate-vram-insufficient`, `device-vram-insufficient`, `node-pressure`, `multi-card-not-supported`, `gpu-type-mismatch`) come back from `market install`/`resume`. The full reason matrix and how to re-pick devices live in [`../../olares-market/references/olares-market-lifecycle.md`](../../olares-market/references/olares-market-lifecycle.md); list operable devices with `olares-cli settings compute list`.
+
+> Pruning unused images to reclaim disk is in [olares-doctor-image.md](olares-doctor-image.md) (`doctor images --unused`).

--- a/cli/skills/olares-doctor/references/olares-doctor-running-unhealthy.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-running-unhealthy.md
@@ -1,0 +1,32 @@
+# doctor: running but unreachable / unhealthy
+
+> **Prerequisite:** read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+> **Backend fact:** `state=running` only proves entrance **TCP reachability**, not health — [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md#what-running-really-means-tcp-reachable-not-healthy).
+
+Symptom: `market status` shows `state=running`, but the app's page is blank, returns 5xx, times out, or the entrance doesn't respond. `running` was set the moment each entrance's host:port accepted a TCP connection — the L4 socket is open, but L7 (HTTP) may be broken. Climb the ladder to find which layer fails.
+
+## Health ladder
+
+```bash
+# 1. Market row — necessary, not sufficient.
+olares-cli market status <app> -o json                 # state=running ?
+
+# 2. Pod readiness — is the container actually Ready, restarts stable?
+olares-cli cluster application status <ns>             # Deployment X/Y Ready
+olares-cli cluster pod list -n <ns> -o json            # ready=true, restartCount stable
+
+# 3. App logs — fatal errors, panics, repeated restarts behind a still-open socket.
+olares-cli cluster pod logs <ns>/<pod> -c <main-container> --tail 200
+```
+
+(Namespace resolution: [finding an app's namespace](../../olares-shared/references/olares-platform.md#finding-an-apps-namespace).)
+
+| Finding | Root cause | Next step |
+|---|---|---|
+| Pod not `Ready` (`0/1`) but socket open | App listens but readiness/HTTP not up (soft-hang) | Read logs for startup blockers (waiting on middleware, slow migration) |
+| Pod restarting behind the open socket | Crash after the port opened | [olares-doctor-app-crash.md](olares-doctor-app-crash.md) |
+| Pod Ready, logs clean, but entrance 504 / closes at ~15s on a long request | Entrance proxy route timeout `options.apiTimeout` defaults to 15s | Chart fix: raise/disable `apiTimeout` — [`../../olares-chart/references/olares-chart-manifest.md`](../../olares-chart/references/olares-chart-manifest.md) |
+| Pod Ready, logs clean, entrance still wrong host/port | Entrance wired to the wrong service port | Chart fix: entrance host/port — [`../../olares-chart/references/olares-chart-manifest.md`](../../olares-chart/references/olares-chart-manifest.md) |
+| `StudioSource` (Devbox) app reads `running` immediately | Studio apps skip the launch probe entirely (`running` proves nothing about reachability) | Verify by pod readiness + HTTP directly |
+
+> **Diagnosis vs fix:** this reference locates the failing layer. Entrance/timeout fixes for an app **you author** are chart edits — hand back to [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md). For a catalog app, an entrance/domain tweak may be a `settings` change instead.

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -30,6 +30,10 @@ metadata:
 
 > **Finding files by name/content** (and what the index covers — filenames everywhere vs. full-text only in `/Documents/`) lives in [`olares-search`](../olares-search/SKILL.md); configure which directories get full-text indexing via `settings search dirs` in [`olares-settings`](../olares-settings/SKILL.md).
 
+## Mental model
+
+`files` is an **addressing layer** over the platform storage areas (which the [platform model](../olares-shared/references/olares-platform.md#userspace-storage-model) owns): you name a resource with a 3-segment frontend path and call a verb. Almost every surprise traces back to one of four things, so internalize them before reaching for a verb — (1) the **3-segment path** `fileType/extend[/subPath]` and which namespaces each verb accepts, (2) the **trailing-slash** dir-vs-file convention, (3) the **5 client-side quirks** that you respect rather than work around, and (4) the **>= 1.12.6 version gate** on the archive / `nfs` / `drive/Common` surface. Everything else is per-verb `--help`.
+
 ## Core concept: the 3-segment frontend path
 
 Every resource on the per-user files-backend is addressed by:
@@ -163,7 +167,7 @@ For flags, examples, and wire shapes, **always start with `olares-cli files <ver
 | `nfs` | [references/olares-files-nfs.md](references/olares-files-nfs.md) | Mount → `external/<node>/<entry>/`; bare host triggers export discovery; no credentials; shares the smb favorites book. Needs >= 1.12.6 |
 | `repos` | `olares-cli files repos --help` | List / create / rename / rm Seafile libraries; repo_id is the `<extend>` segment |
 
-## Common errors (cross-verb)
+## Common errors
 
 | Error fragment | Meaning | Fix |
 |---|---|---|

--- a/cli/skills/olares-files/references/olares-files-chown.md
+++ b/cli/skills/olares-files/references/olares-files-chown.md
@@ -67,4 +67,4 @@ olares-cli files chown cache/<node>/scratch/build/ --uid 1000 -r
 |---|---|---|
 | `chown is not supported for this namespace` | sync / external / cloud target | Use `files repos` (sync) or LarePass GUI (external) |
 | `refusing to chown a volume root` | `drive/Home/` / `drive/Data/` / `cache/<node>/` | Pick a sub-path |
-| 403 from server | Server-side ACL rejection | Confirm via `files ls -ld` (when available) or LarePass that the active user has permission |
+| 403 from server | Server-side ACL rejection | Confirm via `files ls --json` or LarePass that the active user has permission |

--- a/cli/skills/olares-files/references/olares-files-cp-mv.md
+++ b/cli/skills/olares-files/references/olares-files-cp-mv.md
@@ -11,7 +11,7 @@ Copy / move one or more entries between locations. Same wire endpoint (`PATCH /a
 - **`<dst> MUST end with `/` (drop-into-directory mode).** Each `<src>`'s basename is appended; preserves the dir / file marker.
 - **Renaming via `cp` / `mv` is not supported** — use `files rename` for in-place basename changes, or rename first and then `mv`.
 - **Directory sources require `-r`** (Unix-style refusal otherwise).
-- **`mv` source rejects protected names** ([quirk #4](../SKILL.md#4-drivehomepictures-music-movies-downloads-documents-code-cache-data-home-ollama-huggingface-are-system-managed)): `mv drive/Home/Pictures/ ...` is refused because moving would unlink a dir that apps depend on. **`cp` (copy) is intentionally NOT gated** — duplicating bytes (e.g. `cp -r drive/Home/Pictures/ drive/Home/Pictures-Backup/`) preserves the original and is fine.
+- **`mv` source rejects protected names** ([quirk #4](../SKILL.md#4-the-system-managed-drivehome-directories-are-protected)): `mv drive/Home/Pictures/ ...` is refused because moving would unlink a dir that apps depend on. **`cp` (copy) is intentionally NOT gated** — duplicating bytes (e.g. `cp -r drive/Home/Pictures/ drive/Home/Pictures-Backup/`) preserves the original and is fine.
 - **`external/<node>/` destinations are rejected** ([quirk #3](../SKILL.md#3-externalnode-is-a-virtual-volume-listing-layer-read-only)) — point at `external/<node>/<volume>/<sub>/`.
 
 ## Examples

--- a/cli/skills/olares-files/references/olares-files-rename.md
+++ b/cli/skills/olares-files/references/olares-files-rename.md
@@ -16,7 +16,7 @@ Rename a remote entry in place — same parent directory, new basename. Synchron
 
 - **Destructive (mutates the server) — confirm intent with the user.**
 - **`<new-name>` is a BARE basename** — no `/` or `\`. Empty, `.`, `..` are rejected.
-- **Protected names** ([quirk #4](../SKILL.md#4-drivehomepictures-music-movies-downloads-documents-code-cache-data-home-ollama-huggingface-are-system-managed)) refuse to be renamed at the first level under `drive/Home/`; deeper paths are fine.
+- **Protected names** ([quirk #4](../SKILL.md#4-the-system-managed-drivehome-directories-are-protected)) refuse to be renamed at the first level under `drive/Home/`; deeper paths are fine.
 - **Volume roots** (`drive/Home/`, `sync/<repo>/`, ...) are refused.
 - **`.` or `..` segments ANYWHERE in `<remote-path>`** are rejected (path-traversal blacklist on raw input).
 

--- a/cli/skills/olares-files/references/olares-files-rm.md
+++ b/cli/skills/olares-files/references/olares-files-rm.md
@@ -10,7 +10,7 @@ Delete one or more files / directories. Batch-aware: multiple targets that share
 - **Destructive verb — confirm intent with the user before invocation.** The CLI prompts y/N by default; `-f` skips the prompt.
 - **`-f` does NOT bypass the preflight existence check** — a missing path still aborts (safer-than-Unix `rm -f`). This means a typo cannot half-delete a batch.
 - **Trailing slash signals directory intent.** Without `-r`, `rm drive/Home/Foo/` errors with "<Foo> is a folder, pass -r". Without trailing slash AND target is actually a dir, errors with the same CTA.
-- **Protected names** ([quirk #4](../SKILL.md#4-drivehomepictures-music-movies-downloads-documents-code-cache-data-home-ollama-huggingface-are-system-managed)) are refused at the first level under `drive/Home/` only; deeper paths (`drive/Home/Pictures/Trip2024/`) are fully deletable.
+- **Protected names** ([quirk #4](../SKILL.md#4-the-system-managed-drivehome-directories-are-protected)) are refused at the first level under `drive/Home/` only; deeper paths (`drive/Home/Pictures/Trip2024/`) are fully deletable.
 
 ## Examples
 

--- a/cli/skills/olares-files/references/olares-files-task.md
+++ b/cli/skills/olares-files/references/olares-files-task.md
@@ -4,7 +4,7 @@
 > **Flags & wire shape:** `olares-cli files task --help`, `olares-cli files task cancel --help`.
 > **Needs Olares >= 1.12.6** (shares the archive surface).
 
-Control the per-node task queue that backs the asynchronous file verbs (`compress` / `extract` today). They return a `task_id`; this is how you act on it AFTER it's queued.
+Control the per-node task queue that backs the asynchronous file verbs (`compress` / `extract`). They return a `task_id`; this is how you act on it AFTER it's queued.
 
 ## Sub-commands
 

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 **CRITICAL — before doing anything, load the `olares-shared` skill first (profile selection, login, token refresh, auth-error recovery). Flag reference: `olares-cli market --help`.**
 
-> **Source of truth for flags is always `olares-cli market <verb> --help`.** This file only carries what `--help` cannot give: source resolution, the lifecycle state machine, OpType-vs-State race safety, the verb index, the `-s`/`-a` matrix, and the "what apps do I have" routing.
+> **Source of truth for flags is always `olares-cli market <verb> --help`.** This file only carries what `--help` cannot give: source resolution, the CLI's OpType-vs-State view of the lifecycle (the state machine itself lives in the appstate reference), OpType-vs-State race safety, the verb index, the `-s`/`-a` matrix, and the "what apps do I have" routing.
 
 > **Platform model:** app namespaces (`<app>-<owner>` vs the admin-only `<app>-shared`) and which system-middleware apps an admin installs are defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md#app-namespace--networking-model).
 
@@ -72,6 +72,8 @@ The market backend serves multiple "sources" of charts. The CLI resolves which o
 
 ## App lifecycle / state machine
 
+> **Backend facts (states, legal transitions, per-state allowed operations, fail TTLs, single-download serialization, `running` semantics, progress) live once in [`../olares-shared/references/olares-platform-appstate.md`](../olares-shared/references/olares-platform-appstate.md).** This section is only the CLI's view of them. Don't re-derive the state machine here.
+
 The backend tracks two orthogonal axes per app: **`State`** (where the row currently is) and **`OpType`** (which mutation is in flight). The CLI groups the full enum into four buckets:
 
 | Bucket | Examples | Meaning |
@@ -81,7 +83,7 @@ The backend tracks two orthogonal axes per app: **`State`** (where the row curre
 | **Terminal failure** | `installFailed`, `upgradeFailed`, `uninstallFailed`, `stopFailed`, `resumeFailed` | Mutation finished with a hard error |
 | **Canceled / cancel-failed** | `*Canceled`, `*CancelFailed` | A `cancel` request landed (or itself failed) |
 
-Each lifecycle verb maps to its own subset of terminal-success buckets — see the lifecycle reference.
+(Examples are illustrative, not exhaustive — the full state enum per bucket is in the [appstate reference](../olares-shared/references/olares-platform-appstate.md#lifecycle-state-machine).) Each lifecycle verb maps to its own subset of terminal-success buckets — see the lifecycle reference.
 
 ## OpType vs State (race-safety)
 
@@ -103,11 +105,14 @@ The same `State` can mean different things depending on which mutation is in fli
 - **Idempotent**: `resume` against an already-`running` row returns immediately with success; `install` against an already-installed row returns immediately with `state=running`. Watcher never hangs on "no-op" mutations.
 - `--watch-iterations` / `--watch-interval` / `--watch-timeout` are **rejected without `--watch`**.
 
-### Don't just wait — diagnose a stuck install
+### Agent watch discipline (don't block on a long watch)
 
-The `--watch` market row is **coarse**: `installing` / `initializing` can show no progress for a long time, because app-service only fast-fails on a few hard pod conditions and otherwise polls a long TTL. **Rule:** let `--watch` run for the first **1-2 minutes**; if the row is still `installing` / `initializing` with no progress, stop waiting and diagnose the app's own pods instead of sitting on the watch.
+`--watch` defaults to a 15-minute timeout, and progressing states have very long backend TTLs (`downloading` is **30 days** — see the appstate reference). A foreground `--watch` can therefore block far longer than an agent should sit idle. Discipline:
 
-For the app-service facts (TTLs, fast-fail conditions, the soft-hang / `Pending` → `Stopping` traps) see [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md#stuck-in-installing--initializing); for the actual pod/log commands see [`../olares-cluster/SKILL.md`](../olares-cluster/SKILL.md).
+1. **Use a short foreground window, not the 15m default.** Pass a small `--watch-timeout` sized to the verb (see [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md#per-op-foreground-watch-windows)): ~30s for `stop`/`cancel`/`resume`/`uninstall`, ~1m for the `install` deploy phase / `upgrade` / `clone`.
+2. **Timeout is NOT failure.** A `--watch` that times out only means "not terminal yet". Don't report failure — switch to polling `market status <app> --watch --watch-interval 5s` (or fire-and-forget + periodic `market status <app>`), or hand off to diagnosis.
+3. **Judge by STATE transitions, never the PROGRESS number** (it is unreliable — appstate reference). A long `downloading` is judged by image-pull progress, not by waiting for terminal.
+4. **When a short window expires with no STATE movement, stop waiting and diagnose** — route to [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md) (app stuck / won't start), which orchestrates the pod/log evidence.
 
 ## "What apps do I have?" routing
 

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -76,7 +76,7 @@ The JSON payload field is `all`. Behavior depends on the backend version:
 - **Olares 1.12.5:** `--cascade NOT passed` is **auto-decided** — single-user cluster AND v2 multi-chart bundle (`isCSV2`) defaults to `--cascade=true`, else false; an explicit value wins. A short reason is printed on stderr when the auto-decision flips to true.
 - Probe errors (user count / app info / simpleInfo) soft-fail to the user's value; the backend has the final say either way.
 
-> **1.12.6 caveat — cascade-cleanup after the row is gone:** once a prior uninstall has cleared the per-user row, 1.12.6's uninstall body has no source to send, so the CLI reports an idempotent `nothing to uninstall`. `market uninstall` does **not** expose `--source`, so re-running it to tear down leftover shared sub-charts is not reachable from the CLI today — clean those up from the Market SPA.
+> **1.12.6 caveat — cascade-cleanup after the row is gone:** once a prior uninstall has cleared the per-user row, 1.12.6's uninstall body has no source to send, so the CLI reports an idempotent `nothing to uninstall`. `market uninstall` does **not** expose `--source`, so re-running it to tear down leftover shared sub-charts is not reachable from the CLI — clean those up from the Market SPA.
 
 ### Uninstalling an in-flight app (auto-orchestrated)
 
@@ -157,6 +157,26 @@ olares-cli market cancel firefox --watch               # block until row stops m
 | `resume` | `running` | Already running → returns immediately |
 | `cancel` | Any "stopped moving" state | — |
 
+### Per-op foreground watch windows
+
+`--watch` defaults to a 15m timeout, but progressing states have very long backend TTLs (`downloading` = 30 days; `installing` 30m; `initializing`/`upgrading` 1h — see [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md#backend-fail-ttls-how-long-a-state-can-sit-before-app-service-gives-up)). Don't sit on the default. Use a short foreground window sized to the verb, then switch to polling:
+
+| Verb / phase | Suggested foreground `--watch-timeout` | After timeout |
+|---|---|---|
+| `stop` / `cancel` / `resume` / `uninstall` | `30s` | poll `market status <app> --watch --watch-interval 5s` |
+| `install` deploy phase (post-download) / `upgrade` / `clone` | `1m` | poll `status`, then diagnose if STATE doesn't move |
+| `install` while STATE is `downloading` | judge by pull progress, not a timeout (see below) | keep polling patiently — a 30-day TTL means it won't self-fail |
+
+A timed-out short window is **not** a failure — it just means "not terminal yet". Re-judge by the STATE row, never by the PROGRESS number (unreliable).
+
+### `install` download phase is special
+
+When STATE is `downloading`, the app is pulling images and may legitimately stay there for many minutes (multi-GB images), with a 30-day backend TTL — so it will not self-fail. Poll patiently (`market status <app> --watch --watch-interval 5s`); only once it **leaves** `downloading` (into `installing`/`initializing`) do the 1m deploy-phase window and the "stuck" rules apply. A `downloading` row that never advances AND whose byte-level pull progress is flat is a *stalled* pull, not a slow one — diagnose via [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md) (it shows where real pull progress lives). Judge by STATE, not PROGRESS.
+
+### Verifying an app is actually healthy
+
+`state=running` only proves each entrance is **TCP-reachable**, not that the app serves correctly (backend fact: [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md#what-running-really-means-tcp-reachable-not-healthy)). For a quick post-install confidence check: `state=running` (necessary, not sufficient) -> pod Ready and `RESTARTS` stable (`cluster application status <ns>`) -> entrance returns a real HTTP response -> still stable a few checks later. If any rung fails (running-but-unreachable, crashloop, soft-hang), it's a runtime-health problem — the full ladder + triage is [`../../olares-doctor/references/olares-doctor-running-unhealthy.md`](../../olares-doctor/references/olares-doctor-running-unhealthy.md).
+
 ## Agent best practices
 
 - **For "install X and tell me when it's running"** → `market install X --watch -o json`, then parse `.finalState`.
@@ -165,15 +185,14 @@ olares-cli market cancel firefox --watch               # block until row stops m
 - **For "stop everything for this user"** → `market list --mine -o json | jq -r '.[].name'` + a shell loop calling `market stop`. The cluster doesn't expose a bulk-stop verb.
 - **For "install a custom chart"** → `market upload ./mychart.tgz` (always lands in source `upload`), then `market install <name> -s upload`.
 - **For ambiguous source rows on uninstall/stop/resume**: the verb already resolves automatically. Don't pass `-s` even when the SPA shows it under multiple sources.
+- **Don't block on a long foreground watch.** Use a short `--watch-timeout` per the table above; on timeout switch to `market status <app> --watch --watch-interval 5s`, or fire-and-forget the mutation and poll `market status <app>` periodically. Judge by STATE, not PROGRESS.
+- **For "install X and watch it without hanging"** → `market install X --watch --watch-timeout 1m -o json`; if it returns non-terminal (still `downloading`/`installing`), poll `market status X --watch --watch-interval 5s` and only diagnose once a short window passes with no STATE movement.
 
 ## Stuck in installing / initializing
 
-The `--watch` market row is coarse: a long `installing` / `initializing` is NOT the same as a failure, but app-service can keep polling for a long time before it gives up. So after ~1-2 minutes with no progress, stop watching passively and inspect the app's own pods. Two non-obvious traps:
+A long `installing` / `initializing` is NOT a failure — app-service polls a long TTL before giving up. Discipline: let a **short window** (~1m, post-download) run; if STATE hasn't moved, **stop watching passively and diagnose**. Two non-obvious traps make `--watch` misleading here (full backend detail in the appstate reference): a **soft hang** (pod Running but never serve-ready) is never fast-failed, and a **scheduling failure** (pod `Pending`) ends in `stopped`, NOT `installFailed`.
 
-- A soft hang (pod Running but the app never becomes serve-ready, without crashing) is never fast-failed — only the pod itself reveals it, not the row.
-- A scheduling failure (pod `Pending`) ends in `Stopping` / `stopped`, NOT `installFailed` — watching only for `*Failed` misses it.
-
-Once stalled, resolve the app's namespace (per [`../../olares-shared/references/olares-platform.md`](../../olares-shared/references/olares-platform.md#finding-an-apps-namespace) — shared apps use `<app>-shared` and a v2 app spans several namespaces, so don't assume `<app>-<owner>`) and diagnose its workload; for orchestration issues, also check the app-service pod `os-framework/app-service-0` — pod status, logs, and previous-instance logs are all via [`../../olares-cluster/SKILL.md`](../../olares-cluster/SKILL.md). Note `os-framework` system pods are typically admin-only; if the active profile can't see them, fall back to the app's own pod logs. For the crash triage (exitCode / `CreateContainerConfigError` / permission), see [`../../olares-chart/references/olares-chart-deploy.md`](../../olares-chart/references/olares-chart-deploy.md).
+**Hand stuck/won't-start installs to [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** ([app-stuck](../../olares-doctor/references/olares-doctor-app-stuck.md)) — it owns the symptom→root-cause routing (queue vs stalled download vs scheduling failure vs soft-hang), the namespace resolution, and the exact pod/log/event commands. This reference no longer duplicates that triage.
 
 ## Common errors
 

--- a/cli/skills/olares-publish/SKILL.md
+++ b/cli/skills/olares-publish/SKILL.md
@@ -27,6 +27,10 @@ metadata:
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md).
 
+## Mental model
+
+Publishing is a **one-way diff against `beclab/apps`**, not a CLI lifecycle. There is no `olares-cli publish` verb: the only command you run is `olares-cli chart lint` (flags owned by [`../olares-chart/SKILL.md`](../olares-chart/SKILL.md)); everything else is git/GitHub plus a metadata/image/PR checklist that `lint` does **not** enforce. So the work is: take a chart that already installs and runs locally, layer on market-ready metadata + multi-arch images, then open a PR that GitBot will gate and a human will merge. You own the chart edits and PR authoring; you never run on-chain or wallet writes for the developer.
+
 ## What publishing adds on top of a working local chart
 
 A chart that installs and runs locally is **functionally** done (storage / middleware / entrances / a pullable image are all settled in `olares-chart`). Public distribution adds three layers, none of which `chart lint` enforces:
@@ -61,6 +65,7 @@ flowchart TD
 ## Agent boundaries
 
 - **Do NOT** fork, push, or open PRs on the developer's behalf without explicit consent — these write to their GitHub account.
+- **The fork here is legitimate and required.** Submitting to the public Market is the standard open-source contribution flow: fork [`beclab/apps`](https://github.com/beclab/apps), push a branch, open a PR. This is the *public app catalog*, a different repo from the beclab dev repos the workspace "no-fork, push to `origin`" rule covers — that rule does not apply to `beclab/apps` submissions.
 - **Do NOT** run `did-cli rsa set` (an on-chain, gas-costing write), touch the wallet mnemonic, or handle `rsa-private.pem` for paid apps — guide the user to run those themselves.
 - **Do** verify the chart against the market-ready checklist, author `price.yaml`, wire the manifest, and interpret GitBot labels.
 - Login / token / auth-error recovery: [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md). Upload / install verbs (for the local-validation prerequisite): [`../olares-market/SKILL.md`](../olares-market/SKILL.md).

--- a/cli/skills/olares-publish/references/olares-publish-paid-apps.md
+++ b/cli/skills/olares-publish/references/olares-publish-paid-apps.md
@@ -10,7 +10,7 @@ A paid (pay-to-download) app is **almost identical** to a free market app. Only 
 1. A `price.yaml` at the OAC root.
 2. The `VERIFIABLE_CREDENTIAL` env exposed to the workload so it can read the buyer's purchase credential.
 
-Only pay-to-download is supported today. In-app purchases and subscriptions are not implemented (`products: []`).
+Only pay-to-download is supported. In-app purchases and subscriptions are not implemented (`products: []`).
 
 ## Prerequisites
 

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -30,11 +30,11 @@ metadata:
 
 ## 13 area sub-trees
 
-The umbrella registers the 12 canonical Settings docs sections, plus a 13th non-canonical `me` self-service tree:
+The umbrella registers the 12 canonical Settings docs sections, plus a 13th non-canonical `me` self-service tree. The accelerator section is **version-split**: `gpu` on Olares 1.12.5 (legacy HAMI), `compute` on 1.12.6+ (see the per-area table) — they are the same Settings slot across versions, not two extra areas:
 
 ```
 users         appearance   apps          integration   vpn         network
-gpu           video        search        backup        restore     advanced
+gpu / compute video        search        backup        restore     advanced
 + me (self-service: whoami / version / check-update / sso list)
 ```
 
@@ -53,11 +53,11 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `integration` | [references/olares-settings-integration.md](references/olares-settings-integration.md) (`accounts add awss3|tencent`) |
 | `backup` | [references/olares-settings-backup.md](references/olares-settings-backup.md) (plans / snapshots / password) |
 | `appearance` | `olares-cli settings appearance --help` (`get`, `language set`) |
-| `network` | `olares-cli settings network --help` (read-only reverse-proxy / frp / hosts-file; writes blocked by JWS gap — see below) |
+| `network` | `olares-cli settings network --help` (read-only reverse-proxy / frp / hosts-file; writes blocked by JWS gap — see [Currently-implemented mutating verbs](#currently-implemented-mutating-verbs)) |
 | `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute list`) |
 | `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
-| `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories (filenames are indexed broadly by default; full-text defaults to Drive `/Documents/` only — add more with `dirs add`). `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only today. Index coverage model lives in [`olares-search`](../olares-search/SKILL.md) |
+| `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories (filenames are indexed broadly by default; full-text defaults to Drive `/Documents/` only — add more with `dirs add`). `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only (the CLI's `settings search excludes` is not wired up). Index coverage model lives in [`olares-search`](../olares-search/SKILL.md) |
 | `restore` | `olares-cli settings restore --help` (read-only `plans list`) |
 | `advanced` | `olares-cli settings advanced --help` (read-only `status`, `registries list`, `images list`, `env (system|user) list`) |
 
@@ -136,7 +136,7 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 - Backup plan create / update (needs full `BackupPolicy` + `LocationConfig` vector design)
 - Restore plan update / non-cancel delete — backup-server has no routes
 
-**Don't suggest the deferred verbs today** — they will error with "command not found".
+**Don't suggest the deferred verbs** — they will error with "command not found".
 
 ## Security rules
 
@@ -146,7 +146,7 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 - Read-only verbs do NOT carry "this will change X" prompts. **Don't fabricate one for read verbs.**
 - The `profile whoami --refresh` recovery path is the only authentication-adjacent action this skill recommends. **All** other auth recovery belongs in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md).
 
-## Common errors → fixes
+## Common errors
 
 | Error | Cause | Fix |
 |---|---|---|

--- a/cli/skills/olares-settings/references/olares-settings-backup.md
+++ b/cli/skills/olares-settings/references/olares-settings-backup.md
@@ -51,7 +51,7 @@ echo -n "my-secret-password" | olares-cli settings backup password set my-plan -
 - **Default reads from a TTY without echo.** `--password-stdin` reads once from stdin (newline-terminated; trim newline if your producer adds one).
 - **Losing the password means losing the ability to decrypt existing snapshots.** The upstream cannot recover this password — make sure the user has it stored somewhere safe (password manager) BEFORE the call.
 
-## Plan create / update — out of scope (today)
+## Plan create / update — out of scope
 
 `plans create` and `plans update` are **not implemented yet**. They need either:
 

--- a/cli/skills/olares-settings/references/olares-settings-users.md
+++ b/cli/skills/olares-settings/references/olares-settings-users.md
@@ -76,7 +76,7 @@ Same shape as [`olares-cli market --watch`](../../olares-market/SKILL.md): opt-i
 - **Always run `users get <name>` before `users delete <name>`** in interactive sessions to confirm role and quota — gives the user a chance to back out if they targeted the wrong account.
 - For "create user and tell me when they can log in" → `users create <name> --defaults --watch -o json | jq '.wizard_url'`.
 - **NEVER paste the auto-generated password into chat.** Recommend the user copy it directly from the CLI output.
-- The opt-in `--watch` shape **flipped from a prior default of "wait by default + `--no-wait`"** — existing scripts that relied on blocking semantics must add `--watch` explicitly.
+- `--watch` is **opt-in**: without it, `users create` / `users delete` return as soon as the request is accepted. Scripts that need blocking semantics must pass `--watch` explicitly.
 
 ## Common errors
 

--- a/cli/skills/olares-settings/references/olares-settings-vpn.md
+++ b/cli/skills/olares-settings/references/olares-settings-vpn.md
@@ -70,7 +70,7 @@ Every `--tcp` / `--udp` / `--any-proto` value is a **Headscale destination spec 
 | `'*:8000-8100'` | Port range (Headscale accepts; CLI doesn't validate ranges specifically) |
 | `'*:*'` | Allow everything (Headscale accepts) |
 
-**Bare port numbers are rejected** by the Headscale policy parser with `invalid port format`. The CLI now pre-validates the `<host>:<port>` shape and surfaces a copy-pasteable suggestion rather than letting BFL reject the POST.
+**Bare port numbers are rejected** by the Headscale policy parser with `invalid port format`. The CLI pre-validates the `<host>:<port>` shape and surfaces a copy-pasteable suggestion rather than letting BFL reject the POST.
 
 ### `--any-proto` = SPA "Add ACL" parity
 
@@ -110,7 +110,7 @@ olares-cli settings vpn acl add olares-app --any-proto '*:8080'
 olares-cli settings vpn public-domain-policy get
 ```
 
-Returns the `deny_all` flag (0 or 1). The write side stays in the SPA today.
+Returns the `deny_all` flag (0 or 1). The write side stays in the SPA.
 
 ## Agent best practices
 

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -16,6 +16,8 @@ Foundation for every other `olares-cli` skill. Every business verb under `cluste
 
 > **This skill also hosts the cross-skill platform model** in [references/olares-platform.md](references/olares-platform.md) — the userspace storage model, uid-1000 run identity, system-managed `drive/Home` dirs, app/namespace & networking, system middleware, and version/semver. `files` / `chart` / `cluster` link there (one hop) instead of re-describing it. That reference is pure platform model and needs no login.
 
+> **It also hosts the application state machine** in [references/olares-platform-appstate.md](references/olares-platform-appstate.md) — app-service's lifecycle states/transitions, per-state allowed operations, backend fail TTLs, single-download serialization, what `running` actually proves, and why `progress` is unreliable. `market` / `chart` / `doctor` link there instead of re-stating these backend facts. Also pure platform contract, no login.
+
 > **Source of truth for flags & syntax is always `olares-cli profile --help`.** This file only carries what `--help` cannot give: the profile mental model, agent-driven login flow, token-storage backends, refresh semantics, and the error → fix matrix.
 
 ## When to use
@@ -40,6 +42,9 @@ The olares-cli skills ship and install as one suite; each owns a distinct slice.
 | [`olares-search`](../olares-search/SKILL.md) | Full-content search (Desktop "Text Search") over the per-user index: Drive files + Sync libraries | finding a file by its content / keyword |
 | [`olares-chart`](../olares-chart/SKILL.md) | Local chart authoring + deploy to your Olares: from-compose / lint / package, then upload + install | authoring, validating, or deploying your own chart |
 | [`olares-publish`](../olares-publish/SKILL.md) | Public Market distribution: market-ready metadata / multi-arch, the beclab/apps PR, paid apps | listing / submitting / selling an app on the public Market |
+| [`olares-doctor`](../olares-doctor/SKILL.md) | Runtime diagnosis: symptom -> root cause for an app that won't install, won't start, crashes, is `running` but unreachable, or is slow; orchestrates `cluster` / `dashboard` / `market` to gather evidence | an app or the system is misbehaving and you need to find out why — both catalog (`market`) and dev (`chart`) apps hand runtime failures here |
+
+> **The four-skill develop->deploy->debug combo:** porting and running your own app usually loads [`olares-chart`](../olares-chart/SKILL.md) (package + deploy + chart fixes), [`olares-market`](../olares-market/SKILL.md) (lifecycle), this `olares-shared` (platform facts), and [`olares-doctor`](../olares-doctor/SKILL.md) (runtime diagnosis) together. `chart` owns fixes that mean editing your chart; `doctor` owns figuring out the root cause regardless of who deployed the app.
 
 > Host-side maintenance (cluster install, node join, OS upgrade, GPU drivers) is NOT a skill — it's the kubeconfig-based `olares-cli node` / `os` / `gpu` trees, separate from this profile-based suite.
 

--- a/cli/skills/olares-shared/references/olares-platform-appstate.md
+++ b/cli/skills/olares-shared/references/olares-platform-appstate.md
@@ -1,0 +1,110 @@
+# Olares application state machine (single source of truth)
+
+> Cross-skill platform facts about how app-service drives an app through its lifecycle. `market` (operational gating + `--watch` discipline), `chart` (deploy loop), and `doctor` (diagnosis) all link here (one hop) instead of re-stating the state machine. Pure backend contract — no login/profile content (that is in [`../SKILL.md`](../SKILL.md)).
+>
+> Source of truth in the backend: `framework/app-service/pkg/appstate/state_transition.go` (states, transitions, allowed ops, TTLs), `pending_app.go` (download serialization), `appinstaller/helm_ops_install.go` (`WaitForLaunch` / `WaitForStartUp`), `images/puller.go` (progress).
+
+## Lifecycle state machine
+
+A normal install advances through a fixed pipeline; each arrow is the only legal forward edge:
+
+```
+pending -> downloading -> installing -> initializing -> running
+```
+
+- **`installing` may skip `initializing`** straight to `running` (system-middleware fast-path).
+- **`upgrade` of a stopped app** re-renders the chart at `replicas=0` and lands **back in `stopped`** (nothing to launch), not `running`.
+- The state enum groups into four buckets (the CLI mirrors these):
+
+| Bucket | States | Meaning for an agent |
+|---|---|---|
+| **Progressing** | `pending`, `downloading`, `installing`, `initializing`, `upgrading`, `applyingEnv`, `resuming`, `stopping`, `uninstalling`, every `*Canceling` | Backend is actively working — keep polling, do NOT treat as failure |
+| **Terminal success** | `running`, `stopped`, `uninstalled` | Operation finished cleanly |
+| **Terminal failure** | `downloadFailed`, `installFailed`, `upgradeFailed`, `stopFailed`, `resumeFailed`, `applyEnvFailed`, `uninstallFailed` | Operation finished with a hard error |
+| **Canceled / cancel-failed** | `*Canceled` (the op was canceled before completing — app is NOT really installed), `*CancelFailed` (the cancel itself failed — conservatively treat as "still there") | A `cancel` landed (or itself failed) |
+
+Used by: `market` (bucket classification for watchers), `doctor` (is this state a failure, a queue, or normal progress?).
+
+## Per-state allowed operations (the gate)
+
+app-service rejects any operation not allowed in the current state (`OperationAllowedInState`). This is why "just retry install" often fails — the row must be in an install-accepting state first.
+
+| Current state | Operations app-service accepts |
+|---|---|
+| no row / `uninstalled` / `pendingCanceled` / `downloadingCanceled` / `installingCanceled` | `install` |
+| `pending` / `downloading` / `installing` / `initializing` / `upgrading` / `applyingEnv` | `cancel` only |
+| `resuming` | `cancel`, `stop` |
+| `running` | `uninstall`, `upgrade`, `env`, `stop` |
+| `stopped` | `uninstall`, `upgrade`, `env`, `resume` |
+| `downloadFailed` | `install` |
+| `installFailed` | `install`, `uninstall` |
+| `upgradeFailed` | `upgrade`, `uninstall` |
+| `applyEnvFailed` | `env`, `uninstall` |
+| `stopFailed` | `stop`, `upgrade`, `uninstall` |
+| `resumeFailed` | `resume`, `upgrade`, `env`, `uninstall` |
+| `uninstallFailed` | `uninstall` |
+| `pendingCancelFailed` / `downloadingCancelFailed` | `cancel` |
+| `installingCancelFailed` / `upgradingCancelFailed` / `applyingEnvCancelFailed` | `cancel`, `uninstall` |
+| any `*Canceling` / `uninstalling` | none — only wait for the terminal state |
+
+Key consequences: an **in-flight** app accepts only `cancel` (never a direct `uninstall` — the CLI auto-cancels first); `install` against an already-existing settled app is rejected (use `upgrade`).
+
+Used by: `market` (verb pre-flight gating), `chart` (install-vs-upgrade verb choice), `doctor` ("why was my operation rejected?").
+
+## Backend fail TTLs (how long a state can sit before app-service gives up)
+
+Each progressing state has its own timeout before the backend itself fails the op (`StateToDurationMap`, default fallback 10m):
+
+| State | Backend TTL |
+|---|---|
+| `pending` | 24h |
+| `downloading` | **30 days** |
+| `installing` | 30m |
+| `initializing` | 1h |
+| `upgrading` | 1h |
+| `applyingEnv` | 30m |
+| (any other) | 10m |
+
+The `downloading` 30-day TTL is the headline fact: **a slow/large image pull will never self-fail in any reasonable agent timeframe**, so a foreground `--watch` that sits in `downloading` is not a hang to wait out — judge it by image-pull progress, not by waiting for a terminal state.
+
+Used by: `market` (why `--watch` blocks so long), `doctor` (distinguishing a stalled pull from a slow one).
+
+## Serialized downloads (only one app downloads at a time)
+
+app-service admits **at most one app in `downloading`** cluster-wide (`pending_app.go`: it counts `Downloading` rows and only proceeds when `count < 1`, else the app waits in line in `pending`).
+
+- A batch of installs therefore drains **serially**: one downloads while the rest sit in `pending`. This is normal queuing, NOT a stuck install.
+- An app parked in `pending` while another app is `downloading` needs no intervention — it advances once the in-flight download finishes.
+
+Used by: `market` (a `pending` row is expected during batch installs), `doctor` (rule out the queue before declaring an app stuck — check whether any other app is `downloading`).
+
+## What `running` really means (TCP-reachable, not "healthy")
+
+`running` is set by `WaitForLaunch`, which polls every 1s and only checks that **each entrance's host:port accepts a TCP connection** (`apputils.TryConnect`). It does **not** issue an HTTP request, check readiness, or verify the app actually serves correctly.
+
+- So `state=running` means **L4 reachable**, not "the app works". An app can be `running` yet return 5xx, show a blank page, or still be warming up. Full health needs a layer-by-layer check (pod Ready / RESTARTS stable / entrance HTTP 200 / logs clean) on top of the row.
+- **`StudioSource` (Devbox) apps skip the launch probe entirely** — they reach `running` without any TCP check.
+- **Fast-fail during `installing` / `initializing`:** `WaitForStartUp` / `WaitForLaunch` bail early (instead of polling the full 30m/1h TTL) when `hasUnrecoverablePod` reports a condition that persists past a **5-minute grace** (`unrecoverableGrace`):
+  - hard, never-self-healing pod errors: `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError`, `Unschedulable`;
+  - `CrashLoopBackOff` with `RestartCount >= 5` (`crashLoopRestartThreshold`).
+- A crash that has NOT yet crossed that threshold/grace does not fast-fail — the row legitimately stays `initializing` for several minutes while the container is already crashlooping.
+
+Used by: `market` (the "running ≠ healthy" verification ladder), `doctor` (a `running` app with a broken entrance is a runtime-health case, not an install failure).
+
+## `progress` is not a reliable signal
+
+The `PROGRESS` field on the state row cannot be trusted for fine-grained tracking:
+
+- Image-pull progress is a no-op in app-service (`images/puller.go` `Progress()` returns `""`).
+- The install progress is initialized to a hardcoded `"0.00"`.
+
+**Judge by STATE transitions, not by the progress number.** Byte-level image-pull progress comes from the per-node `image-service` DaemonSet logs / `imagemanagers` CRD, not from this field (see `doctor`).
+
+Used by: `market` (don't poll on progress), `doctor` (where real pull progress actually lives).
+
+## Two non-obvious terminal behaviors
+
+- **A scheduling failure does not become `installFailed`.** When a pod can't be scheduled (stays `Pending`), app-service tears the install down through `Stopping -> stopped`, not `installFailed`. A watcher that only looks for `*Failed` will miss it — a fresh install that ends in `stopped` is a red flag, not a success.
+- **`cancel` is teardown-vs-stop depending on phase.** Canceling `pending` / `downloading` / `installing` **tears the partial install down (namespace deleted)** — functionally equivalent to uninstalled. Canceling `initializing` / `upgrading` / `applyingEnv` / `resuming` only **stops** the app (it lands in `stopped`, still installed). `market uninstall` relies on this split when it auto-orchestrates an in-flight uninstall.
+
+Used by: `market` (uninstall auto-orchestration, cancel outcome), `doctor` (a just-installed app sitting in `stopped` is the scheduling-failure trap).


### PR DESCRIPTION
## Summary

- Add `olares-doctor` as a thin router skill for runtime diagnosis (app stuck, crash, image-pull, running-but-unhealthy, resources), keeping the heavy diagnostic cases out of `market`/`cluster`/`chart` and cross-referenced from one place.
- Add `olares-shared/references/olares-platform-appstate.md` as the single source of truth for the app lifecycle: state machine, fail TTLs, what `running` really means (L4 TCP reachable, not "healthy"), and serialized downloads (one app downloads at a time). `market`/`cluster`/`chart` now link to it instead of restating facts.
- Skill-guideline review pass across `chart`/`cluster`/`files`/`market`/`publish`/`settings`/`shared`: dedupe content, correct CLI flags, fix dead anchor links, and drop time-sensitive wording.

This PR is docs-only (skills). The `olares-cli search` paging fix is intentionally kept out and will land as a separate PR.

## Test plan

- [ ] Skills are markdown docs; no build/runtime change. Verify reference links/anchors resolve and 1-hop reference structure holds.
- [ ] Spot-check that flag/command claims match `olares-cli <area> --help`.
- [ ] Confirm no `cli/cmd/ctl/search/*` or `olares-search/SKILL.md` changes are included here.

Made with [Cursor](https://cursor.com)