### PR TITLE
fix(search): honor --offset/--limit for drive and sync paging

### DIFF
--- a/cli/cmd/ctl/search/common.go
+++ b/cli/cmd/ctl/search/common.go
@@ -23,6 +23,17 @@ const (
 
 	searchTypeAggregate = "aggregate"
 	searchTypeFileName  = "file_name"
+
+	// initPageSize is the fixed number of hits /search/init returns (it
+	// ignores the requested limit). moreMaxLimit is the upper bound the
+	// backend enforces on /search/more's limit.
+	initPageSize = 20
+	moreMaxLimit = 100
+
+	// codeNoMoreResults is the envelope code /search/more returns when the
+	// requested offset is past the end of the cached result set. It carries an
+	// empty data array and should be treated as "no results", not an error.
+	codeNoMoreResults = -3
 )
 
 type Format string
@@ -115,13 +126,25 @@ type bflEnvelope struct {
 // message, data} envelope into out. out may be nil for fire-and-forget
 // calls (e.g. cancel).
 func doEnvelope(ctx context.Context, d *whoami.HTTPClient, method, path string, body, out interface{}) error {
+	return doEnvelopeAllowing(ctx, d, method, path, body, out)
+}
+
+// doEnvelopeAllowing behaves like doEnvelope but additionally treats the given
+// soft codes as success, decoding whatever data they carry. This lets callers
+// tolerate non-fatal upstream codes (e.g. /search/more's "no more results").
+func doEnvelopeAllowing(ctx context.Context, d *whoami.HTTPClient, method, path string, body, out interface{}, softCodes ...int) error {
 	var env bflEnvelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
+	ok := env.Code == 0 || env.Code == 200
+	for _, c := range softCodes {
+		if env.Code == c {
+			ok = true
+			break
+		}
+	}
+	if !ok {
 		msg := strings.TrimSpace(env.Message)
 		if msg == "" {
 			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
@@ -154,6 +177,39 @@ func (it resultItem) location() string {
 		return it.ResourceURI
 	}
 	return it.Path
+}
+
+// paginateRaw applies client-side offset/limit windowing to raw result
+// rows. It exists for endpoints that do not paginate server-side (sync), and
+// for trimming an over-sized server page down to the requested limit (drive
+// init). Callers must pass offset >= 0 and limit > 0 (pagingOptions.validate
+// guarantees this).
+func paginateRaw(rows []json.RawMessage, offset, limit int) []json.RawMessage {
+	if offset >= len(rows) {
+		return nil
+	}
+	end := len(rows)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return rows[offset:end]
+}
+
+// needsMorePage reports whether the requested [offset, offset+limit) window
+// extends beyond what /search/init already returned and therefore requires a
+// /search/more call. A short init page (fewer than initPageSize hits) means
+// the cached result set is exhausted, so the window can always be served from
+// the init rows.
+func needsMorePage(offset, limit, initLen int) bool {
+	return offset+limit > initLen && initLen >= initPageSize
+}
+
+// clampMoreLimit caps a requested limit to the backend's /search/more maximum.
+func clampMoreLimit(limit int) int {
+	if limit > moreMaxLimit {
+		return moreMaxLimit
+	}
+	return limit
 }
 
 func decodeResultRows(rawRows []json.RawMessage) ([]resultItem, error) {

--- a/cli/cmd/ctl/search/common_test.go
+++ b/cli/cmd/ctl/search/common_test.go
@@ -1,0 +1,96 @@
+package search
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPaginateRaw(t *testing.T) {
+	t.Parallel()
+
+	rows := func(n int) []json.RawMessage {
+		out := make([]json.RawMessage, n)
+		for i := range out {
+			out[i] = json.RawMessage(`{}`)
+		}
+		return out
+	}
+
+	cases := []struct {
+		name   string
+		total  int
+		offset int
+		limit  int
+		want   int
+	}{
+		{"limit smaller than total", 20, 0, 10, 10},
+		{"limit larger than total", 5, 0, 50, 5},
+		{"offset past end", 5, 10, 20, 0},
+		{"offset at end", 5, 5, 20, 0},
+		{"offset with remaining window", 30, 20, 20, 10},
+		{"offset plus limit within total", 30, 5, 10, 10},
+		{"empty input", 0, 0, 20, 0},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := paginateRaw(rows(tc.total), tc.offset, tc.limit)
+			if len(got) != tc.want {
+				t.Fatalf("paginateRaw(total=%d, offset=%d, limit=%d) = %d rows, want %d",
+					tc.total, tc.offset, tc.limit, len(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestNeedsMorePage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		offset  int
+		limit   int
+		initLen int
+		want    bool
+	}{
+		{"first page within init", 0, 20, 20, false},
+		{"small first page", 0, 5, 20, false},
+		{"window inside full init page", 5, 10, 20, false},
+		{"window touches init edge", 10, 10, 20, false},
+		{"limit beyond full init page", 0, 50, 20, true},
+		{"offset beyond full init page", 25, 10, 20, true},
+		{"short init page is exhaustive", 0, 50, 8, false},
+		{"offset past short page stays local", 10, 20, 8, false},
+		{"empty results never page", 0, 50, 0, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsMorePage(tc.offset, tc.limit, tc.initLen); got != tc.want {
+				t.Fatalf("needsMorePage(offset=%d, limit=%d, initLen=%d) = %v, want %v",
+					tc.offset, tc.limit, tc.initLen, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClampMoreLimit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want int
+	}{
+		{1, 1},
+		{20, 20},
+		{100, 100},
+		{101, 100},
+		{500, 100},
+	}
+	for _, tc := range cases {
+		if got := clampMoreLimit(tc.in); got != tc.want {
+			t.Fatalf("clampMoreLimit(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli/cmd/ctl/search/common_test.go
+++ b/cli/cmd/ctl/search/common_test.go
@@ -2,43 +2,58 @@ package search
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 )
 
 func TestPaginateRaw(t *testing.T) {
 	t.Parallel()
 
+	// Each row encodes its own index so the test can assert the window is
+	// sliced at the right offset, not merely that the count matches.
 	rows := func(n int) []json.RawMessage {
 		out := make([]json.RawMessage, n)
 		for i := range out {
-			out[i] = json.RawMessage(`{}`)
+			out[i] = json.RawMessage(strconv.Itoa(i))
 		}
 		return out
 	}
 
 	cases := []struct {
-		name   string
-		total  int
-		offset int
-		limit  int
-		want   int
+		name      string
+		total     int
+		offset    int
+		limit     int
+		wantFirst int // index of the first returned row; -1 when empty
+		wantLen   int
 	}{
-		{"limit smaller than total", 20, 0, 10, 10},
-		{"limit larger than total", 5, 0, 50, 5},
-		{"offset past end", 5, 10, 20, 0},
-		{"offset at end", 5, 5, 20, 0},
-		{"offset with remaining window", 30, 20, 20, 10},
-		{"offset plus limit within total", 30, 5, 10, 10},
-		{"empty input", 0, 0, 20, 0},
+		{"limit smaller than total", 20, 0, 10, 0, 10},
+		{"limit larger than total", 5, 0, 50, 0, 5},
+		{"offset past end", 5, 10, 20, -1, 0},
+		{"offset at end", 5, 5, 20, -1, 0},
+		{"offset with remaining window", 30, 20, 20, 20, 10},
+		{"offset plus limit within total", 30, 5, 10, 5, 10},
+		{"empty input", 0, 0, 20, -1, 0},
 	}
 
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := paginateRaw(rows(tc.total), tc.offset, tc.limit)
-			if len(got) != tc.want {
+			if len(got) != tc.wantLen {
 				t.Fatalf("paginateRaw(total=%d, offset=%d, limit=%d) = %d rows, want %d",
-					tc.total, tc.offset, tc.limit, len(got), tc.want)
+					tc.total, tc.offset, tc.limit, len(got), tc.wantLen)
+			}
+			for k, raw := range got {
+				wantIdx := tc.wantFirst + k
+				var gotIdx int
+				if err := json.Unmarshal(raw, &gotIdx); err != nil {
+					t.Fatalf("row %d: decode %s: %v", k, raw, err)
+				}
+				if gotIdx != wantIdx {
+					t.Fatalf("paginateRaw(total=%d, offset=%d, limit=%d): row %d = index %d, want %d",
+						tc.total, tc.offset, tc.limit, k, gotIdx, wantIdx)
+				}
 			}
 		})
 	}

--- a/cli/cmd/ctl/search/drive.go
+++ b/cli/cmd/ctl/search/drive.go
@@ -22,8 +22,9 @@ func newDriveCommand(f *cmdutil.Factory) *cobra.Command {
 		Short: "Full-content search of user Drive files",
 		Long: `Search the per-user search3 index for Drive files.
 
-Drive search is session-based: the CLI bootstraps /api/search/init, then
-pages deeper results via /api/search/more using the same session id.
+Drive search is session-based: the CLI bootstraps /api/search/init and, only
+when the requested window runs past the first page, pages deeper via
+/api/search/more using the same session id.
 
 Note: a single search resolves at most ~50 hits server-side, so --limit is
 effectively capped around 50.

--- a/cli/cmd/ctl/search/drive.go
+++ b/cli/cmd/ctl/search/drive.go
@@ -25,6 +25,9 @@ func newDriveCommand(f *cmdutil.Factory) *cobra.Command {
 Drive search is session-based: the CLI bootstraps /api/search/init, then
 pages deeper results via /api/search/more using the same session id.
 
+Note: a single search resolves at most ~50 hits server-side, so --limit is
+effectively capped around 50.
+
 Examples:
   olares-cli search drive report
   olares-cli search drive invoice --type file_name --limit 50
@@ -70,30 +73,41 @@ func runDriveSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *
 			map[string]interface{}{"reqid": reqid}, nil)
 	}()
 
+	// init runs the search, caches the full (server-capped) result set, and
+	// returns only the first initPageSize hits. It ignores offset/limit, so we
+	// don't send them.
 	initBody := map[string]interface{}{
 		"reqid":   reqid,
 		"keyword": keyword,
 		"type":    searchType,
 		"app":     appFilesV2,
-		"offset":  0,
-		"limit":   o.limit,
 	}
-	var rawRows []json.RawMessage
-	if err := doEnvelope(ctx, doer, "POST", "/api/search/init", initBody, &rawRows); err != nil {
+	var initRows []json.RawMessage
+	if err := doEnvelope(ctx, doer, "POST", "/api/search/init", initBody, &initRows); err != nil {
 		return err
 	}
-	if o.offset > 0 {
+
+	// Honor --offset/--limit client-side. If the requested window already lies
+	// within what init returned -- or init returned a short final page (fewer
+	// than initPageSize hits means the cache holds no more) -- serve it
+	// directly. Otherwise page the exact window via /search/more, whose limit
+	// must stay within the backend's 1-100 range; a past-the-end offset comes
+	// back as codeNoMoreResults, which we treat as an empty result set.
+	var window []json.RawMessage
+	if needsMorePage(o.offset, o.limit, len(initRows)) {
 		moreBody := map[string]interface{}{
 			"reqid":  reqid,
 			"offset": o.offset,
-			"limit":  o.limit,
+			"limit":  clampMoreLimit(o.limit),
 		}
-		if err := doEnvelope(ctx, doer, "POST", "/api/search/more", moreBody, &rawRows); err != nil {
+		if err := doEnvelopeAllowing(ctx, doer, "POST", "/api/search/more", moreBody, &window, codeNoMoreResults); err != nil {
 			return err
 		}
+	} else {
+		window = paginateRaw(initRows, o.offset, o.limit)
 	}
 
-	items, err := decodeResultRows(rawRows)
+	items, err := decodeResultRows(window)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/ctl/search/sync.go
+++ b/cli/cmd/ctl/search/sync.go
@@ -53,15 +53,17 @@ func runSyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *s
 		return err
 	}
 
+	// The sync proxy (user-service -> files /api/search/sync_search/) only
+	// forwards the query and ignores offset/limit, so paginate client-side to
+	// keep --offset/--limit honest.
 	body := map[string]interface{}{
-		"query":  keyword,
-		"offset": o.offset,
-		"limit":  o.limit,
+		"query": keyword,
 	}
 	var rawRows []json.RawMessage
 	if err := doEnvelope(ctx, doer, "POST", "/api/search/sync", body, &rawRows); err != nil {
 		return err
 	}
+	rawRows = paginateRaw(rawRows, o.offset, o.limit)
 
 	items, err := decodeResultRows(rawRows)
 	if err != nil {

--- a/cli/cmd/ctl/search/sync.go
+++ b/cli/cmd/ctl/search/sync.go
@@ -20,6 +20,8 @@ func newSyncCommand(f *cmdutil.Factory) *cobra.Command {
 		Short: "Search Seafile/Sync libraries",
 		Long: `Search the user's Sync (Seafile) libraries via /api/search/sync.
 
+--offset/--limit are applied client-side; the backend returns the full result set.
+
 Examples:
   olares-cli search sync notes
   olares-cli search sync invoice --limit 50

--- a/cli/skills/olares-search/SKILL.md
+++ b/cli/skills/olares-search/SKILL.md
@@ -46,14 +46,14 @@ Multiple words are joined into one keyword (quote multi-word phrases to be expli
 
 ### drive
 
-- Session-based: bootstraps `/api/search/init` (offset always 0), pages deeper with `/api/search/more` (same `reqid`), best-effort cleanup via `/api/search/cancel`.
+- Session-based: bootstraps `/api/search/init`, pages deeper with `/api/search/more` (same `reqid`), best-effort cleanup via `/api/search/cancel`.
 - `--type aggregate` (default) is full-content search; `--type file_name` matches on filename only.
-- `--limit` (default 20) caps results; `--offset` pages. `--offset > 0` triggers the `/more` page after the init bootstrap.
+- `--limit` (default 20) caps results; `--offset` pages. `/init` always returns the first 20 hits and ignores offset/limit, so the CLI honors them itself: when the requested window fits inside those 20 hits (or the search returned fewer), it is sliced client-side with no extra call; only a window past the first 20 triggers `/more` (limit clamped to the backend's 1-100). A single search resolves at most ~50 hits server-side, so `--limit` is effectively capped around 50, and an `--offset` past the end prints "no results" rather than erroring.
 
 ### sync
 
-- Single endpoint: `POST /api/search/sync {query, offset, limit}`.
-- Supports `--limit`, `--offset`, `--output`. **No `--type` flag** (sync does not support search mode selection).
+- Single endpoint: `POST /api/search/sync {query}` (the proxy ignores any paging fields).
+- **No `--type` flag** (sync does not support search mode selection). `--limit` / `--offset` are applied **client-side** by the CLI (the backend returns the full result set and does not paginate), so they still work but every call fetches everything first.
 
 ### app
 
@@ -63,16 +63,16 @@ Multiple words are joined into one keyword (quote multi-word phrases to be expli
 
 ### Indexing (drive / sync only)
 
-Indexing is asynchronous on the server: a just-created/just-uploaded file may not be searchable until the index catches up. A miss is "not indexed yet", not necessarily "absent" — confirm a known path with `files ls`, check progress with `olares-cli settings search status`, and force a full reindex with `olares-cli settings search rebuild` (both in the `olares-settings` skill).
+Indexing is asynchronous on the server: a just-created/just-uploaded file may not be searchable until the index catches up. A miss is "not indexed yet", not necessarily "absent" — confirm a known path with `files ls`, check progress with `olares-cli settings search status`, and force a full reindex with `olares-cli settings search rebuild` (both in the [`olares-settings`](../olares-settings/SKILL.md) skill).
 
 ## Index coverage (drive only)
 
 Two distinct indexes back Drive search — knowing which one a query hits explains most "why didn't it find X" cases.
 
 - **Filenames — indexed broadly by default.** Effectively every Drive file's *name* is indexed, so `--type file_name` hits almost anywhere. The only opt-outs are paths matching an **exclude pattern** (a per-user regex list: built-in non-removable entries plus user-added ones).
-- **Full-text (content) — only `/Documents/` by default.** A `--type aggregate` query matches file *contents* only where content indexing is enabled, which by default is just the Drive `/Documents/` directory. Everywhere else you get filename matches but no in-content hits. Supported full-text formats: pdf, doc/docx, csv, rtf, txt/md/json/xml.
-- **To make another directory full-text searchable**, add it to the full-content index: `olares-cli settings search dirs add <path>` (inspect the current set with `olares-cli settings search dirs list`). This lives in the `olares-settings` skill (`settings search`).
-- **To see what is being blocked**, the exclude patterns are currently viewable/editable only in the Olares Settings SPA → Search → File search (the CLI's `settings search excludes` subcommand is not wired up); built-in patterns cannot be removed.
+- **Full-text (content) — only `/Documents/` by default.** A `--type aggregate` query matches file *contents* only where content indexing is enabled, which by default is just the Drive `/Documents/` directory. Everywhere else you get filename matches but no in-content hits. Supported full-text formats: pdf, Word (doc/docx), Excel (xls/xlsx), csv, rtf, plus a wide range of plain-text and source-code extensions (txt/md/json/xml/yaml and many more).
+- **To make another directory full-text searchable**, add it to the full-content index: `olares-cli settings search dirs add <path>` (inspect the current set with `olares-cli settings search dirs list`). This lives in the [`olares-settings`](../olares-settings/SKILL.md) skill (`settings search`).
+- **To see what is being blocked**, the exclude patterns are viewable/editable only in the Olares Settings SPA → Search → File search (the CLI's `settings search excludes` subcommand is not wired up); built-in patterns cannot be removed.
 - **Full-text extraction can fail per file** (encrypted / corrupt / oversized), so a supported-format file in an indexed directory may still have no in-content hits. `olares-cli settings search status` surfaces a `Failures` count (use `-o json` for the per-file detail) — check it first when content search misses a file you expect.
 
 ## Examples


### PR DESCRIPTION
## Summary

`olares-cli search` exposed `--offset`/`--limit` on `drive` and `sync`, but both were effectively no-ops:

- **sync**: the user-service proxy forwards only the query to files (dropping offset/limit), and the CLI never trimmed the result set.
- **drive**: `/search/init` always returns the first 20 hits and ignores the requested limit, while the CLI only paged via `/search/more` when `offset > 0` -- so `--limit > 20` was unreachable and `--limit < 20` was not honored.

This PR makes the flags behave as documented and removes a sharp edge:

- **sync**: paginate the full result set client-side via a shared `paginateRaw` helper.
- **drive**: serve the requested window straight from the init page when it fits (or when the search returned fewer than a full page), and only call `/search/more` for windows past the first 20 hits, clamping its limit to the backend's `1-100` range. A past-the-end `--offset` (backend `NoMoreResults`) is now treated as an empty result set instead of surfacing an upstream error -- this also fixes a regression where empty/short results with `--limit > 20` could error.
- drop the dead `offset`/`limit` fields from the init request (the backend's `SearchShareRequest` ignores them).
- document the behavior and the ~50-hit server cap in the `olares-search` skill, and broaden the listed extractable full-text formats.

## Test plan

- [x] `go build ./cmd/ctl/search/...`, `go vet ./cmd/ctl/search/...`, `gofmt` clean.
- [x] `go test ./cmd/ctl/search/...` -- unit tests for `paginateRaw`, `needsMorePage`, `clampMoreLimit` pass.
- [ ] Manual against a live Olares: `search drive <kw> --limit 5`, `--limit 50`, `--offset <past-end>`, and `search sync <kw> --offset N --limit M` return the expected windows.

Made with [Cursor](https://cursor.com)