### PR TITLE
docs(skills): consolidate diagnosis to doctor and unify conventions (audit P2)

### DIFF
--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -53,7 +53,7 @@ olares-cli market upload ./<app>-<version>.tgz   # use the new <version> in the 
 
 `chart package` mirrors `helm package` and preserves `OlaresManifest.yaml`, so the archive is accepted as-is by both `chart lint` and `market upload`. Because the filename is `<app>-<version>.tgz`, a bumped version produces a new `.tgz` name — pass that name to `upload` and the new number to `install` / `upgrade --version`.
 
-- `upload` always lands the chart in the `upload` source (see [`../../olares-market/references/olares-market-charts.md`](../../olares-market/references/olares-market-charts.md)). `-s` is intentionally not exposed.
+- `upload` always lands the chart in the `upload` source (see [`../../olares-market/SKILL.md`](../../olares-market/SKILL.md)). `-s` is intentionally not exposed.
 - Upload runs the server-side ingest, so a chart that passed local `lint` can still be rejected here (e.g. cluster-specific checks). Surface that message as a chart problem and go back to refine.
 
 ## 3. Actually run it
@@ -70,7 +70,7 @@ olares-cli market install <app> -s upload --version <version> --watch -o json
   olares-cli market upgrade <app> -s upload --version <NEW version> --watch -o json
   ```
   Bump `metadata.version` (= `Chart.yaml` `version`), re-package, and re-upload, then upgrade to the new number. This is the canonical loop for iterating on an installed app and for recovering one stuck in `upgradeFailed`. **Fallback:** the upload source also permits a **same-version** upgrade (the CLI's strict-newer gate is waived there; app-service gates on `>= deployed`), so re-uploading the same version overwrites the stored chart — use this only when the chart didn't change (a *lower* version is always rejected).
-- Parse `.finalState`: `running` = deployed. `*Failed` / a watcher stuck near `*Failed` = go diagnose. See [`../../olares-market/references/olares-market-lifecycle.md`](../../olares-market/references/olares-market-lifecycle.md) for the state machine and `missing required env var(s)` (re-run with `--env KEY=VALUE`).
+- Parse `.finalState`: `running` = deployed. `*Failed` / a watcher stuck near `*Failed` = go diagnose. The lifecycle state machine (states, transitions, fail TTLs, `running` semantics) is the platform **application state machine** ([`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md)); the verb-level watch behavior and `missing required env var(s)` handling (re-run with `--env KEY=VALUE`) are in [`../../olares-market/references/olares-market-lifecycle.md`](../../olares-market/references/olares-market-lifecycle.md).
 - **Hydration race — `HTTP 404: App not found` right after upload is transient, NOT a chart problem.** `upload` lands the package in the chart repo immediately, but the app only becomes installable after the market backend indexes ("hydrates") it a few seconds later. Installing in that window 404s. This is the one install failure you *should* retry: wait for hydration, then re-run the same `install`. The chart didn't change here, so there's nothing to re-`upload` or bump — the chart is already stored and re-uploading the same bytes wouldn't speed up hydration. Confirm hydration finished via the `appstore-backend` log (`isAppHydrationComplete RETURNING TRUE ... appID=<app>` → `Added new app to latest: <app>` → `new_app_ready`), or poll `olares-cli market get <app> -s upload` until it resolves:
   ```bash
   until olares-cli market get <app> -s upload -o json 2>/dev/null | grep -q '"name"'; do sleep 2; done
@@ -81,13 +81,7 @@ olares-cli market install <app> -s upload --version <version> --watch -o json
 
 The `--watch` market row (`downloading` / `initializing`) is a **coarse** signal, and a crashlooping main container is NOT fast-failed for several minutes (the 5-minute `hasUnrecoverablePod` grace). If you can multitask, kick off `market install ... --watch` AND, in parallel, inspect the app's own workload directly rather than waiting for the row to flip.
 
-**The runtime diagnosis itself now lives in [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** — it owns the symptom→root-cause routing shared by catalog and dev apps:
-
-- A slow vs **stalled** image pull (byte-level progress from the per-node `image-service` DaemonSet / `imagemanagers` CRD; model-weights are a separate phase) → [olares-doctor-app-stuck.md](../../olares-doctor/references/olares-doctor-app-stuck.md).
-- A crashlooping / non-starting container (catch it early via `restartCount` / `state.waiting.reason`, read `--previous` logs) → [olares-doctor-app-crash.md](../../olares-doctor/references/olares-doctor-app-crash.md).
-- `running` but the entrance is unreachable / 504 → [olares-doctor-running-unhealthy.md](../../olares-doctor/references/olares-doctor-running-unhealthy.md).
-
-Doctor diagnoses the root cause; **for a chart you author, it points back here** — the fix is a manifest/template edit (next section), then re-lint + re-deploy.
+**The runtime diagnosis itself lives in [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** — it owns the symptom→root-cause routing (stalled image pull, crashlooping / non-starting container, `running`-but-unreachable) shared by catalog and dev apps. Doctor diagnoses the root cause; **for a chart you author, it points back here** — the fix is a manifest/template edit (§4b below), then re-lint + re-deploy.
 
 ## 4. Diagnose: deploy-pipeline logs (chart-specific), then the app's runtime via doctor
 

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -121,7 +121,7 @@ Every `list` verb under `pod` / `cronjob` / `job` / `namespace` / `node` / `work
 Two image-inventory commands ride on top of this:
 
 - `cluster workload images [IMAGE]` follows the same pagination contract. An IMAGE-argument lookup always full-scans the cluster, but the plain listing is NOT full-cluster unless `--all` is set. See [references/olares-cluster-workload.md](references/olares-cluster-workload.md).
-- For a local-image-vs-workload diagnostic, use the top-level `doctor images` instead — always full-scans (no pagination), annotates each local containerd image with its workload reference count, and takes `--unused` for zero-reference orphans. It is owned by [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md); its completeness/coverage caveats live in [`../olares-doctor/references/olares-doctor-image.md`](../olares-doctor/references/olares-doctor-image.md).
+- For a local-image-vs-workload diagnostic, use the top-level `doctor images` instead — always full-scans (no pagination), annotates each local containerd image with its workload reference count, and takes `--unused` for zero-reference orphans. It is owned by [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md), which routes to its image-diagnosis reference for the completeness/coverage caveats.
 
 ### `--watch` / `--follow` semantics (uniform)
 
@@ -135,7 +135,7 @@ Two image-inventory commands ride on top of this:
 
 ## Common errors
 
-| Error message starts with | Meaning | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | `server rejected the request (HTTP 401: ...); please run: olares-cli profile login --olares-id <id>` | Auto-refresh failed, OR refreshed token still rejected | Run the suggested `profile login` |
 | `server rejected the request (HTTP 403: ...)` | The active profile's role can't perform this | `cluster context --refresh` to confirm the cached role matches the server. If still 403, the user genuinely lacks permission |

--- a/cli/skills/olares-dashboard/SKILL.md
+++ b/cli/skills/olares-dashboard/SKILL.md
@@ -29,7 +29,7 @@ This subtree is an **AI-agent-first JSON mirror of the Olares Dashboard SPA's Ov
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
-> **Mental model:** dashboard answers *"what's the resource usage and health"*. For inventory and lifecycle, route elsewhere.
+> **Mental model:** dashboard answers *"what's the resource usage and health"*. For inventory and lifecycle, route elsewhere. When the metrics reveal a problem (resource pressure, an app that's `running` but slow/unreachable), hand off to [`../olares-doctor/SKILL.md`](../olares-doctor/SKILL.md) for root-cause diagnosis.
 
 ## JSON envelope (two shapes, frozen)
 

--- a/cli/skills/olares-dashboard/references/olares-dashboard-overview.md
+++ b/cli/skills/olares-dashboard/references/olares-dashboard-overview.md
@@ -92,9 +92,4 @@ For `gpu tasks <ref>`, `<ref>` accepts EITHER the TASK column (`name`) OR the PO
 
 ## Common errors
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `not_olares_one` empty envelope on `fan *` | Hard gate | Don't ask for fan data on this device |
-| `(advisory) ...` line on stderr from `gpu *` | Soft gate; data still returned | Surface the note to the user as informational |
-| `--user requires platform-admin role` | Non-admin tried `--user <other>` | Use the active profile only |
-| 404 / 5xx on `overview gpu *` | HAMI absent or unhealthy (`no_vgpu_integration` / `vgpu_unavailable`) | Branch on `meta.empty_reason` |
+The fan / GPU gate, `--user` admin-only, and HAMI-absent errors are in the consolidated [Common errors](../SKILL.md#common-errors) table in the parent skill.

--- a/cli/skills/olares-dashboard/references/olares-dashboard-watch.md
+++ b/cli/skills/olares-dashboard/references/olares-dashboard-watch.md
@@ -132,9 +132,4 @@ olares-cli dashboard overview ranking --watch -o json \
 
 ## Common errors
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `--watch-iterations requires --watch` | Knob without gate | Add `--watch` or drop the knob |
-| `--since and --start/--end are mutually exclusive` | Both window forms set | Pick one |
-| Process exits non-zero immediately on the first iteration | `ErrNotLoggedIn` / `ErrTokenInvalidated` | Run `olares-cli profile login` and retry |
-| Process exits non-zero after a few iterations | 3 consecutive transient errors | Investigate upstream (HAMI / capi); restart the loop |
+The watch-knob, window mutual-exclusion, and iteration-failure exit errors are in the consolidated [Common errors](../SKILL.md#common-errors) table in the parent skill (with the exit-code semantics described above).

--- a/cli/skills/olares-files/SKILL.md
+++ b/cli/skills/olares-files/SKILL.md
@@ -169,7 +169,7 @@ For flags, examples, and wire shapes, **always start with `olares-cli files <ver
 
 ## Common errors
 
-| Error fragment | Meaning | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | `is the volume listing layer (read-only); point at a real volume, e.g. external/<node>/<volume>/<sub>/` | Quirk #3 — bare `external/<node>/` write attempt | Add the `<volume>` segment |
 | `refusing to mkdir external/<node>/<X>/: depth-1 entries under external/<node>/ are mounted volumes` | Quirk #3 depth-1 — would create a phantom volume | Mount the volume via LarePass; target an existing one |

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -175,7 +175,7 @@ When STATE is `downloading`, the app is pulling images and may legitimately stay
 
 ### Verifying an app is actually healthy
 
-`state=running` only proves each entrance is **TCP-reachable**, not that the app serves correctly (backend fact: [`../../olares-shared/references/olares-platform-appstate.md`](../../olares-shared/references/olares-platform-appstate.md#what-running-really-means-tcp-reachable-not-healthy)). For a quick post-install confidence check: `state=running` (necessary, not sufficient) -> pod Ready and `RESTARTS` stable (`cluster application status <ns>`) -> entrance returns a real HTTP response -> still stable a few checks later. If any rung fails (running-but-unreachable, crashloop, soft-hang), it's a runtime-health problem — the full ladder + triage is [`../../olares-doctor/references/olares-doctor-running-unhealthy.md`](../../olares-doctor/references/olares-doctor-running-unhealthy.md).
+`state=running` only proves each entrance is **TCP-reachable**, not that the app serves correctly ([what `running` really means](../../olares-shared/references/olares-platform-appstate.md#what-running-really-means-tcp-reachable-not-healthy)). Treat `running` as necessary-but-not-sufficient. If a freshly-installed app is `running` but anything looks off (running-but-unreachable, crashloop, soft-hang), hand it to [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md), which owns the full health ladder and triage.
 
 ## Agent best practices
 
@@ -190,9 +190,9 @@ When STATE is `downloading`, the app is pulling images and may legitimately stay
 
 ## Stuck in installing / initializing
 
-A long `installing` / `initializing` is NOT a failure — app-service polls a long TTL before giving up. Discipline: let a **short window** (~1m, post-download) run; if STATE hasn't moved, **stop watching passively and diagnose**. Two non-obvious traps make `--watch` misleading here (full backend detail in the appstate reference): a **soft hang** (pod Running but never serve-ready) is never fast-failed, and a **scheduling failure** (pod `Pending`) ends in `stopped`, NOT `installFailed`.
+A long `installing` / `initializing` is NOT a failure — app-service polls a long TTL before giving up, and two non-obvious traps make `--watch` misleading here (a soft-hang is never fast-failed; a scheduling failure ends in `stopped`, not `installFailed` — see [the appstate reference](../../olares-shared/references/olares-platform-appstate.md#two-non-obvious-terminal-behaviors)). Operational discipline: let a **short window** (~1m, post-download) run; if STATE hasn't moved, **stop watching passively and diagnose**.
 
-**Hand stuck/won't-start installs to [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** ([app-stuck](../../olares-doctor/references/olares-doctor-app-stuck.md)) — it owns the symptom→root-cause routing (queue vs stalled download vs scheduling failure vs soft-hang), the namespace resolution, and the exact pod/log/event commands. This reference no longer duplicates that triage.
+**Hand stuck/won't-start installs to [`../../olares-doctor/SKILL.md`](../../olares-doctor/SKILL.md)** — it owns the symptom→root-cause routing (queue vs stalled download vs scheduling failure vs soft-hang), the namespace resolution, and the exact pod/log/event commands. This reference does not duplicate that triage.
 
 ## Common errors
 

--- a/cli/skills/olares-publish/references/olares-publish-paid-apps.md
+++ b/cli/skills/olares-publish/references/olares-publish-paid-apps.md
@@ -72,7 +72,7 @@ The app reads the buyer's purchase credential from an injected env var. Add it t
   value: "{{ .Values.olaresEnv.VERIFIABLE_CREDENTIAL }}"
 ```
 
-Declare it in `OlaresManifest.yaml` (env rules — [`../../olares-chart/references/olares-chart-env.md`](../../olares-chart/references/olares-chart-env.md)):
+Declare it in `OlaresManifest.yaml` (env rules — see the env reference under [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md)):
 
 ```yaml
 envs:

--- a/cli/skills/olares-publish/references/olares-publish-submit.md
+++ b/cli/skills/olares-publish/references/olares-publish-submit.md
@@ -5,7 +5,7 @@
 
 ## Before you start
 
-**The app must already run locally first.** Upload + install on the developer's Olares and confirm `running` — see [`../../olares-chart/references/olares-chart-deploy.md`](../../olares-chart/references/olares-chart-deploy.md). Market submission without a working install wastes GitBot cycles and reviewer time.
+**The app must already run locally first.** Upload + install on the developer's Olares and confirm `running` — see the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow. Market submission without a working install wastes GitBot cycles and reviewer time.
 
 **Market-ready checklist must be complete** — see [olares-publish-targets.md](olares-publish-targets.md#market-ready-checklist). In particular:
 
@@ -126,9 +126,9 @@ Host assets yourself or use the **Olares Market image hosting** service (pick ap
 
 Submit these via an `UPDATE` PR with a version bump.
 
-## Troubleshooting GitBot rejection
+## Common errors (GitBot rejection)
 
-| Symptom | Likely cause | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | Invalid categories | stub `Utilities` only, or wrong enum value | Add both 1.11 + 1.12 category values per [manifest docs](https://docs.olares.com/developer/develop/package/manifest.html#categories) |
 | Name/version mismatch in title | PR title folder or version != chart | Align PR title with folder name and `Chart.yaml` / `metadata.version` |

--- a/cli/skills/olares-publish/references/olares-publish-targets.md
+++ b/cli/skills/olares-publish/references/olares-publish-targets.md
@@ -1,6 +1,6 @@
 # Market-ready requirements: what public distribution demands
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first, and confirm the app already installs and reaches `running` on your Olares via [`../../olares-chart/references/olares-chart-deploy.md`](../../olares-chart/references/olares-chart-deploy.md).
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first, and confirm the app already installs and reaches `running` on your Olares via the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow.
 > This file is the requirements matrix + checklist for a **public Market** listing. It assumes the chart is already functionally complete (storage / middleware / entrances / a pullable image) from `olares-chart`.
 
 ## What local deploy gives you vs. what the Market demands
@@ -57,7 +57,7 @@ Then proceed to [olares-publish-submit.md](olares-publish-submit.md).
 
 Common path: get the app running locally first (in `olares-chart`), then polish for public listing.
 
-1. Confirm local install already reached `running` ([../../olares-chart/references/olares-chart-deploy.md](../../olares-chart/references/olares-chart-deploy.md)).
+1. Confirm local install already reached `running` (via the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow).
 2. Work through the market-ready checklist above.
 3. Rebuild images multi-arch if currently single-arch.
 4. Add `spec.supportArch` matching the image platforms.

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -57,7 +57,7 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute list`) |
 | `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
-| `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories (filenames are indexed broadly by default; full-text defaults to Drive `/Documents/` only — add more with `dirs add`). `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only (the CLI's `settings search excludes` is not wired up). Index coverage model lives in [`olares-search`](../olares-search/SKILL.md) |
+| `search` | `olares-cli settings search --help` (`status`, `rebuild`, `dirs list/add/rm`). `dirs` = the **full-content** index directories; `status` shows the index `Status` plus a full-text-extraction `Failures` count (`-o json` for per-file detail). Exclude-pattern view/edit is SPA-only (the CLI's `settings search excludes` is not wired up). The index coverage model (what's indexed by filename vs full-text, and the defaults) lives once in [`olares-search`](../olares-search/SKILL.md) |
 | `restore` | `olares-cli settings restore --help` (read-only `plans list`) |
 | `advanced` | `olares-cli settings advanced --help` (read-only `status`, `registries list`, `images list`, `env (system|user) list`) |
 
@@ -148,7 +148,7 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 
 ## Common errors
 
-| Error | Cause | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | `this command needs role "<R>" or higher to <verb>, but profile "<id>" is cached as "<r>"` | Cached role below the verb's floor | If your role on the server changed: `olares-cli profile whoami --refresh`. Otherwise ask owner to grant the role |
 | `HTTP 403 while attempting to <verb>` (with refresh hint) | Server rejected even though cache said OK — stale role cache | `olares-cli profile whoami --refresh`, retry the verb |

--- a/cli/skills/olares-shared/SKILL.md
+++ b/cli/skills/olares-shared/SKILL.md
@@ -136,7 +136,7 @@ Across goroutines AND across concurrent `olares-cli` processes, `/api/refresh` i
 
 ## Auth error recovery table
 
-| Error message (excerpt) | Meaning | Fix |
+| Symptom | Cause | Fix |
 |-------------------------|---------|-----|
 | `refresh token for <id> became invalid at <ts>` | `/api/refresh` returned 401/403 — the grant is dead | `olares-cli profile login --olares-id <id>` |
 | `no access token for <id>` | Profile selected but keychain has no entry | `olares-cli profile login` or `profile import` |


### PR DESCRIPTION
## Summary

Second of three PRs from the full skills audit. Architecture dedup + consistency. **Stacked on #3527 (P1)** — review/merge that first; this PR's base will retarget to `main` after P1 merges.

- **Single source of truth / doctor boundary**: slim the residual health-ladder and stuck-install triage in `olares-market-lifecycle.md` to one-line handoffs to `olares-doctor`; point `olares-chart-deploy.md`'s state-machine reference at `olares-platform-appstate.md` (the chart skill previously linked the appstate SSOT nowhere) and drop the duplicated parallel-diagnosis bullets.
- **Flatten two-hop links**: reference files no longer deep-link a *sibling skill's* reference; they link the sibling `SKILL.md` per the README's one-hop contract (cluster → doctor, publish → chart, chart-deploy → market).
- **dashboard**: fold the per-reference `Common errors` subsets into the parent SKILL's superset table; add an explicit dashboard → doctor outbound route.
- **settings ↔ search**: keep the search index-coverage model only in `olares-search` and link it.
- **Consistency**: unify every `## Common errors` table header to `Symptom | Cause | Fix`.

Deliberately deferred to the optional P3 pass (to avoid contradicting the README's intentional per-reference prerequisite design): merging the chart-internal version-bump / `workloadReplicas` restatements and the `files` per-reference preamble blocks.

## Test plan

- [ ] Docs-only under `cli/skills/`; no code touched.
- [ ] Confirm flattened links resolve to existing sibling `SKILL.md` files and the appstate anchors exist.

Made with [Cursor](https://cursor.com)