### PR TITLE
docs(skills): polish chart/market references (audit P3)

### DIFF
--- a/cli/skills/olares-chart/references/olares-chart-archetypes.md
+++ b/cli/skills/olares-chart/references/olares-chart-archetypes.md
@@ -3,6 +3,12 @@
 > **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
 > The rest of the skill assumes the upstream maps onto a web app with an HTTP entrance. Many don't. When the upstream ships no compose/chart and the deployment shape is unclear, **match it to an archetype below, apply the recipe, then continue with Refine -> lint** ([olares-chart-manifest.md](olares-chart-manifest.md)).
 
+## Contents
+
+- [Archetype: Headless CLI / service (no web UI)](#archetype-headless-cli--service-no-web-ui)
+- [Archetype: GUI desktop application (browser-streamed)](#archetype-gui-desktop-application-browser-streamed)
+- [Adding an archetype](#adding-an-archetype)
+
 ## Archetype: Headless CLI / service (no web UI)
 
 A tool you operate from a command line, or a daemon exposing an API, that ships **no GUI**. The Olares challenge: an app must have at least one entrance, but there is no web page to point at.
@@ -70,7 +76,7 @@ metadata:
   labels:
     io.kompose.service: terminal
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.terminal.replicaCount }}
   selector:
     matchLabels:
       io.kompose.service: terminal
@@ -178,7 +184,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: { io.kompose.service: <app> }
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.<app>.replicaCount }}
   strategy: { type: Recreate }
   selector:
     matchLabels: { io.kompose.service: <app> }

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -111,7 +111,7 @@ Once the app's container is the problem (it pulled, scheduled, and started but m
 
 After the chart fix: re-lint, bump the version, re-package, re-upload, and re-apply with the right verb (§3 / §5).
 
-## 4c. Upgrade recovery: `stopped` after upgrade
+### 4c. Upgrade recovery: `stopped` after upgrade
 
 An upgrade can leave the **market row** in `state=stopped` while the **workload** is actually `Running`. Two paths land in `stopped`: upgrading an **already-stopped** app re-renders the chart at `replicas=0` and intentionally returns to `stopped` (by design); and **canceling an in-flight** op (`initializing` / `upgrading` / `applyingEnv` / `resuming`) only *stops* the app — so if a crashing initContainer was fixed and the workload later came up on its own, the row can read `stopped` while the pod is `1/1 Running`:
 

--- a/cli/skills/olares-chart/references/olares-chart-env.md
+++ b/cli/skills/olares-chart/references/olares-chart-env.md
@@ -1,6 +1,6 @@
 # Environment variables — system / user / app level
 
-> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md). Env wiring is the configuration half of refinement §3 in [olares-chart-manifest.md](olares-chart-manifest.md) (middleware values are siblings of this).
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md). Env wiring is the configuration that accompanies the §3 Middleware & dependencies area of [olares-chart-manifest.md](olares-chart-manifest.md) (middleware values are its sibling).
 
 Olares exposes configuration to an app through env vars at **three levels**. The app declares only the app-level ones (in `OlaresManifest.yaml` `envs[]`); the other two are platform-managed and consumed by reference.
 

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -18,6 +18,15 @@ The mutating verb family. Every verb here returns an `OperationResult` JSON shap
 }
 ```
 
+## Contents
+
+- [Source-aware vs source-implicit verbs](#source-aware-vs-source-implicit-verbs)
+- [`install`](#install) · [`upgrade`](#upgrade) · [`uninstall`](#uninstall) · [`clone`](#clone) · [`stop` / `resume`](#stop--resume) · [`cancel`](#cancel)
+- [`--watch` interaction with each verb](#--watch-interaction-with-each-verb)
+- [Agent best practices](#agent-best-practices)
+- [Stuck in installing / initializing](#stuck-in-installing--initializing)
+- [Common errors](#common-errors)
+
 ## Source-aware vs source-implicit verbs
 
 | Verb | `-s / --source` | Why |


### PR DESCRIPTION
## Summary

Third and final PR from the skills audit — low-risk polish. **Stacked on #3528 (P2)**; base retargets after P2 merges.

- **chart archetypes**: wire the templated Deployment examples' `spec.replicas` to `{{ .Values.workloads.<name>.replicaCount }}` instead of a hardcoded `1`, matching the `workloadReplicas` rule the skill itself teaches (the value behind it is still `1` in practice).
- **chart-deploy**: fix the §4c heading level (`###` under `## 4. Diagnose`).
- **chart-env**: stop implying env *is* manifest §3 — §3 is "Middleware & dependencies"; env is the configuration that accompanies it.
- **TOCs**: add a `## Contents` to the two longest references that lacked one (chart archetypes, market lifecycle) so a partial read shows full scope. (`llm-models` already had one.)

## Deferred (open decisions for the maintainer)

These plan items are explicitly "your call" and were left out of this PR:

- **Frontmatter version strategy** — `olares-doctor` is `1.0.0` while market/shared/cluster/dashboard carry their own `4.x`. Whether to bump the suite uniformly (and whether edited skills should bump on publish) is a release-policy decision, not a docs fix.
- **Reference-file merges** — collapsing the archive trio (compress/extract/archive) and extracting a shared smb/nfs mount section are larger restructures worth evaluating on their own; they risk dangling links and contradict the README's intentional per-reference prerequisite design.

## Test plan

- [ ] Docs-only under `cli/skills/`; no code touched.
- [ ] Confirm the new TOC anchors resolve and the templated `replicas` examples still read as valid Helm.

Made with [Cursor](https://cursor.com)