### PR TITLE
fix(security): ensure shared namespace label is set correctly 

### DIFF
--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -277,6 +277,11 @@ func (r *SecurityReconciler) reconcileNamespaceLabels(ctx context.Context, ns *c
 				updated = true
 			}
 		}
+
+		if label, ok := ns.Labels[security.NamespaceSharedLabel]; !ok || label != "true" {
+			ns.Labels[security.NamespaceSharedLabel] = "true"
+			updated = true
+		}
 	} else {
 		owner, internal, system, shared, isMiddleware, err := r.findOwnerOfNamespace(ctx, ns)
 		if err != nil {


### PR DESCRIPTION
Ensure shared namespace label is set correctly during reconciliation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security controller namespace labeling used for network policy and shared-app routing; scope is small but mis-labeling could affect isolation behavior.
> 
> **Overview**
> Shared app namespaces that take the **`app.bytetrade.io/shared=true`** fast path in `reconcileNamespaceLabels` now also get **`bytetrade.io/ns-shared=true`** when that label is missing or not `"true"`.
> 
> That path already backfills **`ns-owner`** and deliberately avoids **`findOwnerOfNamespace`**, so those namespaces never received the shared label the generic branch sets from workload discovery. The change mirrors the existing set-or-correct logic used in the else branch so labeling stays consistent for anything that keys off **`NamespaceSharedLabel`** (including shared network-policy and gateway resolution paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d23b208e1eb0fdf932633e0e36d6935f9afe93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->