### PR TITLE
chartrepo: oac up to 0.0.31

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.46
+        image: beclab/dynamic-chart-repository:v0.3.47
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
oac up to 0.0.31

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/dynamic-chart-repository/pull/54


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no config or env changes; rollout risk is limited to behavior in the new chart-repository image.
> 
> **Overview**
> Bumps the **chartrepo** deployment to **`beclab/dynamic-chart-repository:v0.3.47`** (from `v0.3.46`), aligning the cluster chart-repo with the upstream release that brings **OAC to 0.0.31** (see [dynamic-chart-repository#54](https://github.com/beclab/dynamic-chart-repository/pull/54)).
> 
> No manifest changes beyond the container image tag in `chart_repo_deploy.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3fefbe82abcdd1a1d264dd31bc1431f2c30d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->