### PR TITLE
fix: all system pod set with high priority

### DIFF
--- a/cli/pkg/plugins/network/templates/multus.go
+++ b/cli/pkg/plugins/network/templates/multus.go
@@ -186,6 +186,7 @@ spec:
         app: multus
         name: multus
     spec:
+      priorityClassName: system-cluster-critical
       hostNetwork: true
       tolerations:
       - operator: Exists

--- a/cli/pkg/plugins/storage/templates/openebs.go
+++ b/cli/pkg/plugins/storage/templates/openebs.go
@@ -122,6 +122,7 @@ spec:
         openebs.io/component-name: openebs-localpv-provisioner
         openebs.io/version: 3.3.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner-hostpath

--- a/cli/pkg/terminus/velero.go
+++ b/cli/pkg/terminus/velero.go
@@ -167,6 +167,10 @@ func (v *PatchVelero) Execute(runtime connector.Runtime) error {
 		logger.Errorf("velero plugin patched error %s", stdout)
 	}
 
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s patch deploy velero -n %s --type=merge -p='{\"spec\":{\"template\":{\"spec\":{\"priorityClassName\":\"system-cluster-critical\"}}}}'", kubectl, ns), false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "patch velero priorityClassName failed")
+	}
+
 	return nil
 }
 

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -80,6 +80,12 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},
+		&task.LocalTask{
+			Name:   "PatchWorkloadPriorityClassName",
+			Action: new(patchWorkloadPriorityClassName),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
 	}
 	pre = append(pre, retagLegacyAMDGPUImage()...)
 	// backfill the per-mode (multi-mode) node labels for Intel/AMD GPUs so

--- a/cli/pkg/upgrade/1_12_7_20260629.go
+++ b/cli/pkg/upgrade/1_12_7_20260629.go
@@ -1,0 +1,217 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const systemClusterCriticalPriorityClassName = "system-cluster-critical"
+
+// systemNamespacesForPriorityPatch lists the well-known system namespaces in
+// which Deployments / DaemonSets / StatefulSets without an explicit
+// priorityClassName should be patched to system-cluster-critical.
+var systemNamespacesForPriorityPatch = []string{
+	"kube-system",
+	"kubesphere-monitoring-system",
+	"kubesphere-system",
+	"os-framework",
+	"os-gateway",
+	"os-gpu",
+	"os-network",
+	"os-protected",
+}
+
+type upgrader_1_12_7_20260629 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260629) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260629")
+}
+
+func (u upgrader_1_12_7_20260629) UpgradeSystemComponents() []task.Interface {
+	tasks := append([]task.Interface{
+		&task.LocalTask{
+			Name:   "PatchWorkloadPriorityClassName",
+			Action: new(patchWorkloadPriorityClassName),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	}, u.upgraderBase.UpgradeSystemComponents()...)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260629{})
+}
+
+// patchWorkloadPriorityClassName iterates over a fixed list of system
+// namespaces plus the per-user user-space-<name> / user-system-<name>
+// namespaces and, for every Deployment / DaemonSet / StatefulSet whose pod
+// template does NOT already set a priorityClassName, patches it to
+// system-cluster-critical via a strategic merge patch. Workloads that already
+// have any priorityClassName configured (e.g. system-node-critical) are left
+// untouched.
+type patchWorkloadPriorityClassName struct {
+	common.KubeAction
+}
+
+func (a *patchWorkloadPriorityClassName) Execute(_ connector.Runtime) error {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %v", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	namespaces := append([]string{}, systemNamespacesForPriorityPatch...)
+	userNamespaces, err := listUserScopedNamespacesForPriorityPatch(config)
+	if err != nil {
+		return fmt.Errorf("failed to list user-scoped namespaces: %v", err)
+	}
+	namespaces = append(namespaces, userNamespaces...)
+
+	for _, ns := range namespaces {
+		if err := patchNamespaceWorkloadsMissingPriorityClassName(client, ns); err != nil {
+			return fmt.Errorf("failed to patch workloads in namespace %s: %v", ns, err)
+		}
+	}
+	return nil
+}
+
+func listUserScopedNamespacesForPriorityPatch(config *rest.Config) ([]string, error) {
+	scheme := kruntime.NewScheme()
+	if err := iamv1alpha2.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add iam scheme: %v", err)
+	}
+	userClient, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	var userList iamv1alpha2.UserList
+	if err := userClient.List(ctx, &userList); err != nil {
+		return nil, fmt.Errorf("failed to list users: %v", err)
+	}
+	namespaces := make([]string, 0, len(userList.Items)*2)
+	for _, user := range userList.Items {
+		if user.DeletionTimestamp != nil {
+			continue
+		}
+		namespaces = append(namespaces,
+			fmt.Sprintf("user-space-%s", user.Name),
+			fmt.Sprintf("user-system-%s", user.Name),
+		)
+	}
+	return namespaces, nil
+}
+
+func patchNamespaceWorkloadsMissingPriorityClassName(client *kubernetes.Clientset, namespace string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	if _, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Infof("namespace %s not found, skipping priorityClassName patch", namespace)
+			return nil
+		}
+		return fmt.Errorf("failed to get namespace %s: %v", namespace, err)
+	}
+
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"spec":{"priorityClassName":%q}}}}`,
+		systemClusterCriticalPriorityClassName,
+	))
+
+	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list deployments in %s: %v", namespace, err)
+	}
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
+		if d.Spec.Template.Spec.PriorityClassName != "" {
+			continue
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, patchErr := client.AppsV1().Deployments(namespace).Patch(
+				ctx, d.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
+			)
+			return patchErr
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to patch deployment %s/%s priorityClassName: %v", namespace, d.Name, err)
+		}
+		logger.Infof("patched deployment %s/%s priorityClassName to %s", namespace, d.Name, systemClusterCriticalPriorityClassName)
+	}
+
+	daemonSets, err := client.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list daemonsets in %s: %v", namespace, err)
+	}
+	for i := range daemonSets.Items {
+		ds := &daemonSets.Items[i]
+		if ds.Spec.Template.Spec.PriorityClassName != "" {
+			continue
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, patchErr := client.AppsV1().DaemonSets(namespace).Patch(
+				ctx, ds.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
+			)
+			return patchErr
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to patch daemonset %s/%s priorityClassName: %v", namespace, ds.Name, err)
+		}
+		logger.Infof("patched daemonset %s/%s priorityClassName to %s", namespace, ds.Name, systemClusterCriticalPriorityClassName)
+	}
+
+	statefulSets, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list statefulsets in %s: %v", namespace, err)
+	}
+	for i := range statefulSets.Items {
+		sts := &statefulSets.Items[i]
+		if sts.Spec.Template.Spec.PriorityClassName != "" {
+			continue
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, patchErr := client.AppsV1().StatefulSets(namespace).Patch(
+				ctx, sts.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
+			)
+			return patchErr
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to patch statefulset %s/%s priorityClassName: %v", namespace, sts.Name, err)
+		}
+		logger.Infof("patched statefulset %s/%s priorityClassName to %s", namespace, sts.Name, systemClusterCriticalPriorityClassName)
+	}
+
+	return nil
+}

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.32"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.33"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/app-gateway/.olares/config/cluster/deploy/envoyproxy.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/envoyproxy.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   provider:
     type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        pod:
+          priorityClassName: system-cluster-critical
   telemetry:
     accessLog:
       settings:

--- a/infrastructure/gpu/.olares/config/gpu/hami/templates/webui/deployment.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/templates/webui/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "hami-webui.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "hami-webui"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "hami-webui.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.webui.podSecurityContext | nindent 8 }}

--- a/platform/tapr/pkg/workload/kvrocks/templates.go
+++ b/platform/tapr/pkg/workload/kvrocks/templates.go
@@ -51,6 +51,7 @@ var (
 				},
 
 				Spec: corev1.PodSpec{
+					PriorityClassName: "system-cluster-critical",
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{


### PR DESCRIPTION


* **Background**
set all system pod with high priority
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade patches many Deployments/DaemonSets/StatefulSets cluster-wide (including user namespaces), which can trigger rolling restarts and change scheduling/preemption behavior for workloads that previously had default priority.
> 
> **Overview**
> Sets **`system-cluster-critical`** on platform/system pod templates and backfills existing clusters during upgrade so critical workloads are less likely to be preempted under node pressure.
> 
> **Fresh installs / manifests:** pod specs gain `priorityClassName` for Multus, OpenEBS local PV provisioner, Velero (kubectl merge patch in `PatchVelero`), app-gateway Envoy deployment via `EnvoyProxy`, HAMi web UI, and KVRocks StatefulSet templates.
> 
> **Upgrades:** `PatchWorkloadPriorityClassName` runs on **1.12.6** and the new daily upgrader **1.12.7-20260629**. It lists fixed system namespaces (`kube-system`, `os-*`, KubeSphere, etc.) plus per-user `user-space-*` / `user-system-*`, then strategic-merge-patches Deployments, DaemonSets, and StatefulSets that have **no** existing `priorityClassName` (workloads already using e.g. `system-node-critical` are skipped).
> 
> Also bumps the base **L4BFL proxy** image tag from `v0.3.32` to `v0.3.33`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a620c3bc2124fe2c2ecd530f4aaa4b19c049a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->