### PR TITLE
 fix(tapr): patch kvrock with system-cluster-critical priority

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -57,7 +57,7 @@ spec:
           path: '{{ $dbbackup_rootpath }}/pg_backup'
       containers:
       - name: operator-api
-        image: beclab/middleware-operator:0.2.37
+        image: beclab/middleware-operator:0.2.38
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/platform/tapr/pkg/workload/kvrocks/helper.go
+++ b/platform/tapr/pkg/workload/kvrocks/helper.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -126,6 +127,8 @@ func GetKVRocksDefineByUser(ctx context.Context, client *kubernetes.Clientset,
 		sts.Spec.Template.Spec.Containers[0].Command =
 			append(sts.Spec.Template.Spec.Containers[0].Command, []string{"--requirepass", password}...)
 	}
+
+	sts.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 
 	return sts, nil
 
@@ -274,6 +277,40 @@ func CreateOrUpdateKVRocks(ctx context.Context,
 		return nil, err
 	}
 
+	if retSts != nil {
+		retSts, err = patchKVRocksPriorityClassName(ctx, client, clusterDef.Namespace, clusterDef.Name)
+		if err != nil {
+			klog.Error("patch kvrocks priorityClassName error, ", err)
+			return nil, err
+		}
+	}
+
+	return retSts, nil
+}
+
+func patchKVRocksPriorityClassName(ctx context.Context, client *kubernetes.Clientset, namespace, name string) (*appv1.StatefulSet, error) {
+	const priorityClassName = "system-cluster-critical"
+
+	sts, err := client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if sts.Spec.Template.Spec.PriorityClassName == priorityClassName {
+		return sts, nil
+	}
+
+	patch := []byte(`{"spec":{"template":{"spec":{"priorityClassName":"system-cluster-critical"}}}}`)
+	var retSts *appv1.StatefulSet
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		retSts, err = client.AppsV1().StatefulSets(namespace).Patch(
+			ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	klog.Infof("patched kvrocks statefulset %s/%s priorityClassName to %s", namespace, name, priorityClassName)
 	return retSts, nil
 }
 


### PR DESCRIPTION


* **Background**
patch kvrock with system-cluster-critical priority

* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod scheduling priority for a core datastore workload; misconfiguration could affect preemption or admission on clusters, though scope is limited to priority class patching.
> 
> **Overview**
> KVRocks StatefulSets now run with **`system-cluster-critical`** priority so they are less likely to be preempted during node pressure, aligned with other critical tapr middleware.
> 
> **Operator behavior:** new KVRocks workloads get `priorityClassName` on the pod template in `GetKVRocksDefineByUser`. After create/update in `CreateOrUpdateKVRocks`, a merge patch applies the same class to **existing** StatefulSets when it is missing (with conflict retries).
> 
> **Deploy:** the tapr middleware deployment image is bumped to **`beclab/middleware-operator:0.2.38`** to ship this logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68fe4290497aabdcead0263c6799532a8209756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->