### PR TITLE
fix: move patch workload priority after upgrade system task

### DIFF
--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -80,12 +80,6 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},
-		&task.LocalTask{
-			Name:   "PatchWorkloadPriorityClassName",
-			Action: new(patchWorkloadPriorityClassName),
-			Retry:  3,
-			Delay:  5 * time.Second,
-		},
 	}
 	pre = append(pre, retagLegacyAMDGPUImage()...)
 	// backfill the per-mode (multi-mode) node labels for Intel/AMD GPUs so
@@ -119,6 +113,12 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		&task.LocalTask{
 			Name:   "MigrateLegacyGPUBindings",
 			Action: new(migrateLegacyGPUBindings),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+		&task.LocalTask{
+			Name:   "PatchWorkloadPriorityClassName",
+			Action: new(patchWorkloadPriorityClassName),
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},

--- a/cli/pkg/upgrade/1_12_7_20260629.go
+++ b/cli/pkg/upgrade/1_12_7_20260629.go
@@ -55,7 +55,8 @@ func (u upgrader_1_12_7_20260629) UpgradeSystemComponents() []task.Interface {
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},
-	}, u.upgraderBase.UpgradeSystemComponents()...)
+	})
+	tasks = append(u.upgraderBase.UpgradeSystemComponents(), tasks...)
 	return tasks
 }
 
@@ -69,9 +70,27 @@ func init() {
 // template does NOT already set a priorityClassName, patches it to
 // system-cluster-critical via a strategic merge patch. Workloads that already
 // have any priorityClassName configured (e.g. system-node-critical) are left
-// untouched.
+// untouched, as are Helm-managed workloads (so the patch is not reverted on
+// the next `helm upgrade`).
 type patchWorkloadPriorityClassName struct {
 	common.KubeAction
+}
+
+// isHelmManagedWorkload reports whether the given object is owned by Helm.
+// We treat both the standard managed-by label and the meta.helm.sh release
+// annotations as evidence, because some charts only set one or the other.
+func isHelmManagedWorkload(obj metav1.Object) bool {
+	if v, ok := obj.GetLabels()["app.kubernetes.io/managed-by"]; ok && v == "Helm" {
+		return true
+	}
+	annotations := obj.GetAnnotations()
+	if _, ok := annotations["meta.helm.sh/release-name"]; ok {
+		return true
+	}
+	if _, ok := annotations["meta.helm.sh/release-namespace"]; ok {
+		return true
+	}
+	return false
 }
 
 func (a *patchWorkloadPriorityClassName) Execute(_ connector.Runtime) error {
@@ -153,6 +172,10 @@ func patchNamespaceWorkloadsMissingPriorityClassName(client *kubernetes.Clientse
 		if d.Spec.Template.Spec.PriorityClassName != "" {
 			continue
 		}
+		if isHelmManagedWorkload(&d.ObjectMeta) {
+			logger.Infof("skipping Helm-managed deployment %s/%s priorityClassName patch", namespace, d.Name)
+			continue
+		}
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			_, patchErr := client.AppsV1().Deployments(namespace).Patch(
 				ctx, d.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
@@ -176,6 +199,10 @@ func patchNamespaceWorkloadsMissingPriorityClassName(client *kubernetes.Clientse
 		if ds.Spec.Template.Spec.PriorityClassName != "" {
 			continue
 		}
+		if isHelmManagedWorkload(&ds.ObjectMeta) {
+			logger.Infof("skipping Helm-managed daemonset %s/%s priorityClassName patch", namespace, ds.Name)
+			continue
+		}
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			_, patchErr := client.AppsV1().DaemonSets(namespace).Patch(
 				ctx, ds.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
@@ -197,6 +224,10 @@ func patchNamespaceWorkloadsMissingPriorityClassName(client *kubernetes.Clientse
 	for i := range statefulSets.Items {
 		sts := &statefulSets.Items[i]
 		if sts.Spec.Template.Spec.PriorityClassName != "" {
+			continue
+		}
+		if isHelmManagedWorkload(&sts.ObjectMeta) {
+			logger.Infof("skipping Helm-managed statefulset %s/%s priorityClassName patch", namespace, sts.Name)
 			continue
 		}
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION


* **Background**
move patch workload priority after upgrade system task and skip helm managed workload
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade-time patches to workload pod templates affect scheduling priority across system and user namespaces; ordering and skip logic reduce conflict with Helm but incorrect detection could leave some workloads unprioritized.
> 
> **Overview**
> **`PatchWorkloadPriorityClassName` now runs after system/Helm upgrades** on both the v1.12.6 main upgrader and the v1.12.7 daily upgrader, so Helm chart updates are not immediately undone by a later strategic-merge patch.
> 
> The patch step **skips Helm-managed** Deployments, DaemonSets, and StatefulSets (via `app.kubernetes.io/managed-by=Helm` or `meta.helm.sh/*` release metadata), with info logs when skipping. Non-Helm workloads without an existing `priorityClassName` are still patched to `system-cluster-critical` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffef77f94f672b1a81c1400f41f86f406806f4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->