### PR TITLE
cli/market: prefer installed app row across sources in lookupInstalledApp

### DIFF
--- a/cli/cmd/ctl/market/common_test.go
+++ b/cli/cmd/ctl/market/common_test.go
@@ -39,6 +39,41 @@ func TestResolveInstalledSource(t *testing.T) {
 		}
 	})
 
+	t.Run("same name in two sources resolves to the installed one", func(t *testing.T) {
+		// firefox lingers as `uninstalled` in market.olares but is
+		// `stopped` (installed) in market.test. resolveInstalledSource
+		// must resolve the live instance's source so `resume firefox`
+		// works, instead of failing on the uninstalled row.
+		const multiSource = `{
+            "user_data": {
+                "sources": {
+                    "market.olares": {
+                        "type": "market",
+                        "app_state_latest": [
+                            {"version": "1.0.11", "status": {"name": "firefox", "rawAppName": "firefox", "state": "uninstalled"}}
+                        ]
+                    },
+                    "market.test": {
+                        "type": "market",
+                        "app_state_latest": [
+                            {"version": "1.2.11", "status": {"name": "firefox", "rawAppName": "firefox", "state": "stopped"}}
+                        ]
+                    }
+                }
+            }
+        }`
+		srv := newFakeMarketDataServer(t, stateAndDataResponses{state: multiSource})
+		mc := newTestMarketClient(t, srv.URL)
+
+		got, err := resolveInstalledSource(context.Background(), &MarketOptions{}, mc, "firefox")
+		if err != nil {
+			t.Fatalf("resolveInstalledSource on multi-source app: %v", err)
+		}
+		if got != "market.test" {
+			t.Fatalf("source = %q, want market.test (the installed instance)", got)
+		}
+	})
+
 	t.Run("explicit --source bypasses the state lookup", func(t *testing.T) {
 		// Point at a server that has NO matching row; an explicit source
 		// must still win without consulting /market/state.

--- a/cli/cmd/ctl/market/preflight.go
+++ b/cli/cmd/ctl/market/preflight.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -101,6 +102,20 @@ type installedAppRow struct {
 // up the source app for clones — same trick fetchInstalledApps and
 // preflightUpgrade use for the /apps lookup key. RawName is data on
 // the return path, never a match key on the lookup path.
+//
+// MULTI-SOURCE RESOLUTION — prefer an INSTALLED row, mirroring the SPA's
+// findAppByName (apps/.../stores/market/appStore.ts): when the same name
+// exists in more than one source (e.g. an `uninstalled` row in
+// market.olares AND a `stopped` row in market.test), the SPA skips
+// uninstalled rows (`!uninstalledApp(status)`) and keeps searching, so
+// resume / stop resolve to the live instance. We do the same in two
+// passes (Name pass, then legacy-RawName pass), each preferring an
+// installed row, and we iterate sources in sorted order so the result is
+// deterministic (Go map iteration is randomized). When NO installed row
+// matches we fall back to the first not-installed match (Name beats
+// legacy-RawName) so uninstall / cancel can still clean up a lingering
+// failed row, and resolveInstalledSource still emits its "state %q;
+// nothing to operate on" message for resume / stop.
 func lookupInstalledApp(ctx context.Context, mc *MarketClient, appName string) (*installedAppRow, error) {
 	resp, err := mc.GetMarketState(ctx)
 	if err != nil {
@@ -115,40 +130,80 @@ func lookupInstalledApp(ctx context.Context, mc *MarketClient, appName string) (
 		return nil, nil
 	}
 
-	for sourceName, sourceData := range data.UserData.Sources {
-		sourceName = strings.TrimSpace(sourceName)
-		if sourceName == "" || sourceData == nil {
+	sourceNames := make([]string, 0, len(data.UserData.Sources))
+	for sourceName := range data.UserData.Sources {
+		sourceNames = append(sourceNames, sourceName)
+	}
+	sort.Strings(sourceNames)
+
+	var nameFallback, rawFallback *installedAppRow
+
+	// Pass 1: exact Name match. Return the first installed row; remember
+	// the first not-installed Name match as a fallback.
+	for _, sourceName := range sourceNames {
+		sn := strings.TrimSpace(sourceName)
+		sourceData := data.UserData.Sources[sourceName]
+		if sn == "" || sourceData == nil {
+			continue
+		}
+		for _, appState := range sourceData.AppStateLatest {
+			if strings.TrimSpace(appState.Status.Name) != appName {
+				continue
+			}
+			row := &installedAppRow{
+				Name:    appName,
+				RawName: strings.TrimSpace(appState.Status.RawName),
+				Source:  sn,
+				State:   appState.Status.State,
+				Version: strings.TrimSpace(appState.Version),
+			}
+			if isInstalledState(row.State) {
+				return row, nil
+			}
+			if nameFallback == nil {
+				nameFallback = row
+			}
+		}
+	}
+
+	// Pass 2: legacy / malformed rows that omit Name but carry
+	// RawName == appName. We only accept this when Name is empty — never
+	// when Name is populated with something else (that would be a clone
+	// whose source app happens to match the user's input; see the doc
+	// above). Again prefer an installed row.
+	for _, sourceName := range sourceNames {
+		sn := strings.TrimSpace(sourceName)
+		sourceData := data.UserData.Sources[sourceName]
+		if sn == "" || sourceData == nil {
 			continue
 		}
 		for _, appState := range sourceData.AppStateLatest {
 			rowName := strings.TrimSpace(appState.Status.Name)
 			rawName := strings.TrimSpace(appState.Status.RawName)
-			if rowName != appName {
-				// Defensive: legacy / malformed rows that omit Name
-				// but populate RawName can still be identified IF
-				// no other row in the same source is going to claim
-				// this name first. We only accept that fallback
-				// when Name is empty — never when Name is populated
-				// with something else (which would mean this is a
-				// clone whose source app happens to match the
-				// user's input, the exact ambiguity documented in
-				// the lookupInstalledApp doc above).
-				if rowName != "" || rawName != appName {
-					continue
-				}
+			if rowName != "" || rawName != appName {
+				continue
 			}
-			canonical := rowName
-			if canonical == "" {
-				canonical = rawName
-			}
-			return &installedAppRow{
-				Name:    canonical,
+			row := &installedAppRow{
+				Name:    rawName,
 				RawName: rawName,
-				Source:  sourceName,
+				Source:  sn,
 				State:   appState.Status.State,
 				Version: strings.TrimSpace(appState.Version),
-			}, nil
+			}
+			if isInstalledState(row.State) {
+				return row, nil
+			}
+			if rawFallback == nil {
+				rawFallback = row
+			}
 		}
+	}
+
+	if nameFallback != nil {
+		return nameFallback, nil
+	}
+	if rawFallback != nil {
+		return rawFallback, nil
 	}
 	return nil, nil
 }

--- a/cli/cmd/ctl/market/preflight_test.go
+++ b/cli/cmd/ctl/market/preflight_test.go
@@ -154,10 +154,10 @@ func TestIsAppSuspended(t *testing.T) {
 type fakeMarketBackend struct {
 	t          *testing.T
 	srv        *httptest.Server
-	stateRows  map[string]fakeStateRow         // by sourceName
-	appLabels  map[string][]string             // by appName: returned via /apps
-	appMissing map[string]bool                 // appName -> 404-ish empty apps list
-	appsCalls  []map[string]interface{}        // POST /apps payloads received
+	stateRows  map[string]fakeStateRow  // by sourceName
+	appLabels  map[string][]string      // by appName: returned via /apps
+	appMissing map[string]bool          // appName -> 404-ish empty apps list
+	appsCalls  []map[string]interface{} // POST /apps payloads received
 	stateErr   bool
 	appsHook   func(payload map[string]interface{}) (map[string]interface{}, error)
 }
@@ -612,6 +612,90 @@ func TestLookupInstalledAppDisambiguatesPrimaryFromClones(t *testing.T) {
 			t.Fatalf("legacy fallback row: name=%q version=%q (want vault / 0.9.0)", row.Name, row.Version)
 		}
 	})
+}
+
+// TestLookupInstalledAppPrefersInstalledAcrossSources is the regression
+// test for the multi-source masking bug: the same app name exists in two
+// sources, one in a not-installed terminal state (`uninstalled`) and one
+// live (`stopped`). lookupInstalledApp used to return whichever the
+// randomized Go map iteration surfaced first, so `resume firefox` could
+// fail with "state uninstalled" even though an installed firefox existed
+// in another source. The fix mirrors the SPA findAppByName: skip
+// uninstalled rows and prefer the installed one, deterministically.
+func TestLookupInstalledAppPrefersInstalledAcrossSources(t *testing.T) {
+	// market.olares sorts before market.test, so the uninstalled row is
+	// visited first; the resolver must still skip it and return the
+	// installed market.test row.
+	state := `{
+        "user_data": {
+            "sources": {
+                "market.olares": {
+                    "type": "market",
+                    "app_state_latest": [
+                        {"version": "1.0.11", "status": {"name": "firefox", "rawAppName": "firefox", "state": "uninstalled"}}
+                    ]
+                },
+                "market.test": {
+                    "type": "market",
+                    "app_state_latest": [
+                        {"version": "1.2.11", "status": {"name": "firefox", "rawAppName": "firefox", "state": "stopped"}}
+                    ]
+                }
+            }
+        }
+    }`
+
+	srv := newFakeMarketDataServer(t, stateAndDataResponses{state: state})
+	mc := newTestMarketClient(t, srv.URL)
+
+	// Run several times: with the deterministic sorted-source iteration
+	// the answer must be stable regardless of Go's randomized map order.
+	for i := 0; i < 8; i++ {
+		row, err := lookupInstalledApp(context.Background(), mc, "firefox")
+		if err != nil {
+			t.Fatalf("lookupInstalledApp: %v", err)
+		}
+		if row == nil {
+			t.Fatalf("lookupInstalledApp returned nil while an installed firefox exists")
+		}
+		if row.Source != "market.test" || row.State != "stopped" {
+			t.Fatalf("must prefer the installed row: got source=%q state=%q, want market.test/stopped", row.Source, row.State)
+		}
+	}
+}
+
+// TestLookupInstalledAppFallsBackToNotInstalled confirms that when NO
+// installed row matches, the lenient fallback still returns a
+// not-installed row so uninstall / cancel can clean up a lingering failed
+// row (and resolveInstalledSource can surface its "nothing to operate on"
+// message for resume / stop).
+func TestLookupInstalledAppFallsBackToNotInstalled(t *testing.T) {
+	state := `{
+        "user_data": {
+            "sources": {
+                "market.olares": {
+                    "type": "market",
+                    "app_state_latest": [
+                        {"version": "1.0.0", "status": {"name": "ghost", "rawAppName": "ghost", "state": "installFailed"}}
+                    ]
+                }
+            }
+        }
+    }`
+
+	srv := newFakeMarketDataServer(t, stateAndDataResponses{state: state})
+	mc := newTestMarketClient(t, srv.URL)
+
+	row, err := lookupInstalledApp(context.Background(), mc, "ghost")
+	if err != nil {
+		t.Fatalf("lookupInstalledApp: %v", err)
+	}
+	if row == nil {
+		t.Fatalf("lenient fallback must return the lingering failed row, got nil")
+	}
+	if row.State != "installFailed" || row.Source != "market.olares" {
+		t.Fatalf("fallback row wrong: source=%q state=%q (want market.olares/installFailed)", row.Source, row.State)
+	}
 }
 
 // TestPreflightUpgrade_SourceMismatchWarns confirms that preflight does


### PR DESCRIPTION
* **Background**
`olares-cli market resume <app>` could fail with `"<app>" is not an installed app (state "uninstalled")` even though `market list --mine` showed the app as installed. This happened when the same app name existed in more than one source (e.g. an `uninstalled` row in `market.olares` and a `stopped` row in `market.test`): `lookupInstalledApp` iterated `UserData.Sources`, which is a Go map (randomized order), and returned the first row matching by name regardless of its state. When it hit the not-installed row first, `resolveInstalledSource` rejected the operation, so resume/stop/upgrade failed non-deterministically.

This change aligns `lookupInstalledApp` with the SPA's `findAppByName` (`stores/market/appStore.ts`), which skips uninstalled rows and keeps searching for a live instance:

- Iterate sources in sorted order so resolution is deterministic (no more map-order flakiness).
- Two passes mirroring the SPA: an exact `Name` pass, then a legacy `RawName`-only-when-`Name`-empty pass. Each pass returns the first row whose state passes `isInstalledState`, preferring an installed instance.
- When no installed row matches, fall back to the first not-installed match (Name beats legacy-RawName). This preserves the lenient behavior `uninstall`/`cancel` rely on to clean up a lingering failed row, and keeps `resolveInstalledSource`'s `state %q; nothing to operate on` message for genuinely-uninstalled apps.
- Clone disambiguation (typing the source-app name never matches a clone) is unchanged.

Tests: multi-source prefer-installed (asserted stable across repeated runs), not-installed lenient fallback, `resolveInstalledSource` multi-source resolution, plus the existing clone/legacy regressions.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
None

* **Other information**:
None

Made with [Cursor](https://cursor.com)