### PR TITLE
fix(appservice): handle legacy apps without replica spec when applying env

### DIFF
--- a/framework/app-service/controllers/appenv_controller.go
+++ b/framework/app-service/controllers/appenv_controller.go
@@ -2,10 +2,13 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
@@ -19,7 +22,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type AppEnvController struct {
@@ -33,9 +41,48 @@ type AppEnvController struct {
 //+kubebuilder:rbac:groups=app.bytetrade.io,resources=applicationmanagers/status,verbs=get;update;patch
 
 func (r *AppEnvController) SetupWithManager(mgr ctrl.Manager) error {
+	// When an app becomes Running again, re-enqueue its AppEnv so any change
+	// that was deferred while the app was Stopped (see reconcileAppEnv) gets
+	// applied. Without this the pending change would sit forever, since the
+	// AppEnv itself does not change on resume.
+	appMgrBecameRunning := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldAM, ok1 := e.ObjectOld.(*appv1alpha1.ApplicationManager)
+			newAM, ok2 := e.ObjectNew.(*appv1alpha1.ApplicationManager)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return oldAM.Status.State != appv1alpha1.Running && newAM.Status.State == appv1alpha1.Running
+		},
+		CreateFunc:  func(event.CreateEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sysv1alpha1.AppEnv{}).
+		Watches(
+			&appv1alpha1.ApplicationManager{},
+			handler.EnqueueRequestsFromMapFunc(appEnvRequestForAppMgr),
+			builder.WithPredicates(appMgrBecameRunning),
+		).
 		Complete(r)
+}
+
+// appEnvRequestForAppMgr maps an ApplicationManager to its backing AppEnv so a
+// pending env change can be re-evaluated when the app's state changes.
+func appEnvRequestForAppMgr(_ context.Context, obj client.Object) []reconcile.Request {
+	am, ok := obj.(*appv1alpha1.ApplicationManager)
+	if !ok {
+		return nil
+	}
+	if am.Spec.AppName == "" || am.Spec.AppOwner == "" || am.Spec.AppNamespace == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Namespace: am.Spec.AppNamespace,
+		Name:      apputils.FormatAppEnvName(am.Spec.AppName, am.Spec.AppOwner),
+	}}}
 }
 
 func (r *AppEnvController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -75,6 +122,29 @@ func (r *AppEnvController) reconcileAppEnv(ctx context.Context, appEnv *sysv1alp
 	}
 
 	if appEnv.NeedApply {
+		appMgr, err := r.getAppMgr(ctx, appEnv)
+		if err != nil {
+			klog.Errorf("Failed to get app manager for AppEnv %s/%s: %v", appEnv.Namespace, appEnv.Name, err)
+			return ctrl.Result{}, err
+		}
+
+		// An applyEnv runs a helm upgrade that re-renders the workload. When the
+		// app is stopped, the outcome depends on how its replicas are controlled:
+		//   - No workloadReplicas (replicas hardcoded in the chart): stop only
+		//     patched the live workload to replicas=0, so the upgrade re-renders
+		//     the hardcoded count and resurrects the app. Defer the apply; the
+		//     change stays pending (NeedApply=true) and is applied by the next
+		//     upgrade / when the app runs.
+		//   - workloadReplicas: stop scaled the release to zero (replicaCount=0 is
+		//     pinned in the release values), so the env upgrade reuses that and
+		//     stays at zero. We let it proceed so the new env is baked into the
+		//     release and picked up on the next resume; the applyEnv flow records
+		//     the pre-op state and lands back in Stopped without waiting for pods.
+		if appMgr.Status.State == appv1alpha1.Stopped && !appMgrHasWorkloadReplicas(appMgr) {
+			klog.Infof("app %s owner %s is stopped without workloadReplicas, deferring applyEnv (env change kept pending)", appEnv.AppName, appEnv.AppOwner)
+			return ctrl.Result{}, nil
+		}
+
 		// check for active user batch lease to avoid mid-batch apply
 		userNamespace := utils.UserspaceName(appEnv.AppOwner)
 		lease := &coordinationv1.Lease{}
@@ -180,6 +250,36 @@ func (r *AppEnvController) syncEnvValues(ctx context.Context, appEnv *sysv1alpha
 	return nil
 }
 
+// getAppMgr loads the ApplicationManager backing the given AppEnv.
+func (r *AppEnvController) getAppMgr(ctx context.Context, appEnv *sysv1alpha1.AppEnv) (*appv1alpha1.ApplicationManager, error) {
+	appMgrName, err := apputils.FmtAppMgrName(appEnv.AppName, appEnv.AppOwner, appEnv.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to format app manager name: %v", err)
+	}
+
+	var appMgr appv1alpha1.ApplicationManager
+	if err := r.Get(ctx, types.NamespacedName{Name: appMgrName}, &appMgr); err != nil {
+		return nil, fmt.Errorf("failed to get ApplicationManager %s: %v", appMgrName, err)
+	}
+
+	return &appMgr, nil
+}
+
+// appMgrHasWorkloadReplicas reports whether the app declares per-workload
+// replica counts (and is therefore stopped via a helm scale-to-zero rather than
+// a direct replicas=0 patch).
+func appMgrHasWorkloadReplicas(appMgr *appv1alpha1.ApplicationManager) bool {
+	if appMgr == nil || appMgr.Spec.Config == "" {
+		return false
+	}
+	var cfg appcfg.ApplicationConfig
+	if err := json.Unmarshal([]byte(appMgr.Spec.Config), &cfg); err != nil {
+		klog.Warningf("failed to unmarshal app config for %s when checking workloadReplicas: %v", appMgr.Name, err)
+		return false
+	}
+	return cfg.HasWorkloadReplicas()
+}
+
 func (r *AppEnvController) triggerApplyEnv(ctx context.Context, appEnv *sysv1alpha1.AppEnv) error {
 	klog.Infof("Triggering ApplyEnv for app: %s owner: %s", appEnv.AppName, appEnv.AppOwner)
 
@@ -201,6 +301,13 @@ func (r *AppEnvController) triggerApplyEnv(ctx context.Context, appEnv *sysv1alp
 
 	appMgrCopy := targetAppMgr.DeepCopy()
 	appMgrCopy.Spec.OpType = appv1alpha1.ApplyEnvOp
+	// Record the state right before applyEnv so the applyEnv flow can detect an
+	// app that was Stopped (scaled to zero) and land it back in Stopped without
+	// waiting for pods, instead of forcing it to start up.
+	if appMgrCopy.Annotations == nil {
+		appMgrCopy.Annotations = make(map[string]string)
+	}
+	appMgrCopy.Annotations[api.AppPreUpgradeStateKey] = string(state)
 
 	if err := r.Patch(ctx, appMgrCopy, client.MergeFrom(&targetAppMgr)); err != nil {
 		return fmt.Errorf("failed to update ApplicationManager Spec.OpType: %v", err)

--- a/framework/app-service/pkg/apiserver/api/types.go
+++ b/framework/app-service/pkg/apiserver/api/types.go
@@ -19,9 +19,11 @@ const (
 	AppStopByControllerDuePendingPod = "bytetrade.io/pending-pod"
 	AppImagesKey                     = "bytetrade.io/images"
 	// AppPreUpgradeStateKey records the ApplicationManager state right
-	// before an UpgradeOp begins. upgrading_app reads it to decide
-	// whether to scale the workloads back up after the helm upgrade or
-	// to land in Stopped (when the pre-upgrade state was Stopped).
+	// before an UpgradeOp or ApplyEnvOp begins. upgrading_app/applying_env_app
+	// read it to decide whether to scale the workloads back up after the helm
+	// upgrade or to land in Stopped (when the pre-op state was Stopped). It must
+	// be refreshed on every such operation so a stale Stopped value cannot make
+	// a Running app incorrectly land back in Stopped.
 	AppPreUpgradeStateKey = "bytetrade.io/pre-upgrade-state"
 )
 

--- a/framework/app-service/pkg/apiserver/handler_applyenv.go
+++ b/framework/app-service/pkg/apiserver/handler_applyenv.go
@@ -47,6 +47,11 @@ func (h *Handler) appApplyEnv(req *restful.Request, resp *restful.Response) {
 		return
 	}
 	appCopy.Annotations[api.AppTokenKey] = token
+	// Refresh the pre-op state on every applyEnv so the applyEnv flow
+	// (applying_env_app.go) sees the actual state right before this operation.
+	// Without this, a stale Stopped value left by a previous applyEnv/upgrade
+	// would make a Running app incorrectly land back in Stopped.
+	appCopy.Annotations[api.AppPreUpgradeStateKey] = string(appMgr.Status.State)
 
 	err = h.ctrlClient.Patch(req.Request.Context(), appCopy, client.MergeFrom(&appMgr))
 	if err != nil {

--- a/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
@@ -33,6 +33,12 @@ func (h *HelmOps) ApplyEnv() error {
 	if h.app.Type == appv1alpha1.Middleware.String() {
 		return nil
 	}
+	if h.options.SkipWaitForStartUp {
+		// App was Stopped (release scaled to zero); the env upgrade keeps it at
+		// zero replicas, so there are no pods to wait for.
+		klog.Infof("App %s applyenv with skipWaitForStartUp, not waiting for pods", h.app.AppName)
+		return nil
+	}
 	ok, err := h.WaitForStartUp()
 	if !ok {
 		klog.Errorf("Failed to wait for app %s startup", h.app.AppName)

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_applyenv.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_applyenv.go
@@ -46,6 +46,13 @@ func (h *HelmOpsV2) ApplyEnv() error {
 		return nil
 	}
 
+	if h.Options().SkipWaitForStartUp {
+		// App was Stopped (release scaled to zero); the env upgrade keeps it at
+		// zero replicas, so there are no pods to wait for.
+		klog.Infof("App (V2) %s applyenv with skipWaitForStartUp, not waiting for pods", h.App().AppName)
+		return nil
+	}
+
 	ok, err := h.WaitForStartUp()
 	if err != nil && (errors.Is(err, errcode.ErrPodPending) || errors.Is(err, errcode.ErrServerSidePodPending)) {
 		return err

--- a/framework/app-service/pkg/appstate/applying_env_app.go
+++ b/framework/app-service/pkg/appstate/applying_env_app.go
@@ -20,6 +20,12 @@ var _ OperationApp = &ApplyingEnvApp{}
 
 type ApplyingEnvApp struct {
 	*baseOperationApp
+	// landedState overrides the default success transition (Initializing) when
+	// applyEnv runs against an app that was Stopped. A stopped (workloadReplicas)
+	// app keeps its release scaled to zero through the env upgrade, so there are
+	// no pods to wait for: it lands back in Stopped with the new env baked in.
+	landedState  appsv1.ApplicationManagerState
+	landedReason string
 }
 
 func NewApplyingEnvApp(c client.Client,
@@ -72,6 +78,22 @@ func (a *ApplyingEnvApp) Exec(ctx context.Context) (StatefulInProgressApp, error
 					return
 				}
 
+				if a.landedState != "" {
+					landed := a.landedState
+					reason := a.landedReason
+					if reason == "" {
+						reason = landed.String()
+					}
+					a.finally = func() {
+						klog.Infof("ApplyEnv operation success, app %s landed in state %s (reason=%s)", a.manager.Name, landed, reason)
+						updateErr := a.updateStatus(context.Background(), a.manager, landed, nil, landed.String(), reason)
+						if updateErr != nil {
+							klog.Errorf("update appmgr state to %s state failed %v", landed, updateErr)
+						}
+					}
+					return
+				}
+
 				a.finally = func() {
 					klog.Info("ApplyEnv operation success, update app status to Initializing, ", a.manager.Name)
 					updateErr := a.updateStatus(context.Background(), a.manager, appsv1.Initializing, nil, "Environment variables applied, waiting for application to initialize", "")
@@ -102,7 +124,19 @@ func (a *ApplyingEnvApp) exec(ctx context.Context) error {
 		return err
 	}
 
-	helmOps, err := newHelmOps(ctx, kubeConfig, appCfg, token, appinstaller.Opt{Source: a.manager.Spec.Source, MarketSource: appcfg.GetMarketSource(a.manager)})
+	// When the app was Stopped before applyEnv, its release is scaled to zero
+	// (workloadReplicas apps; non-workloadReplicas stopped apps are deferred by
+	// the AppEnv controller and never reach here). The env upgrade reuses the
+	// zeroed replica values, so there are no pods to wait for: skip WaitForStartUp
+	// and land back in Stopped with the new env baked into the release.
+	preState := a.manager.Annotations[api.AppPreUpgradeStateKey]
+	skipWaitForStartUp := preState == appsv1.Stopped.String()
+
+	helmOps, err := newHelmOps(ctx, kubeConfig, appCfg, token, appinstaller.Opt{
+		Source:             a.manager.Spec.Source,
+		MarketSource:       appcfg.GetMarketSource(a.manager),
+		SkipWaitForStartUp: skipWaitForStartUp,
+	})
 	if err != nil {
 		klog.Errorf("Failed to create HelmOps: %v", err)
 		return err
@@ -111,6 +145,12 @@ func (a *ApplyingEnvApp) exec(ctx context.Context) error {
 	if err := helmOps.ApplyEnv(); err != nil {
 		klog.Errorf("Failed to upgrade chart with environment variables: %v", err)
 		return err
+	}
+
+	if skipWaitForStartUp {
+		klog.Infof("app %s applyEnv from Stopped state, landing back in Stopped", a.manager.Spec.AppName)
+		a.landedState = appsv1.Stopped
+		a.landedReason = constants.AppStopByUser
 	}
 
 	klog.Infof("ApplyEnv operation completed successfully for app: %s", a.manager.Name)

--- a/framework/app-service/pkg/appstate/state_transition.go
+++ b/framework/app-service/pkg/appstate/state_transition.go
@@ -113,6 +113,14 @@ var StateTransitions = map[appv1alpha1.ApplicationManagerState][]appv1alpha1.App
 		appv1alpha1.Initializing,
 		appv1alpha1.ApplyEnvFailed,
 		appv1alpha1.ApplyingEnvCanceling,
+		// OperationAllowedInState[ApplyingEnv][StopOp]=true, so
+		// pod_abnormal_suspend_app_controller can flip ApplyingEnv -> Stopping
+		// as a fallback when a pod goes abnormal mid-applyEnv.
+		appv1alpha1.Stopping,
+		// applying_env_app.go: applyEnv-from-Stopped (workloadReplicas app whose
+		// release stays scaled to zero) lands back in Stopped via landedState,
+		// mirroring the upgrade-from-Stopped path on Upgrading.
+		appv1alpha1.Stopped,
 	},
 	appv1alpha1.Uninstalling: {
 		appv1alpha1.Uninstalled,
@@ -269,6 +277,7 @@ var OperationAllowedInState = map[appv1alpha1.ApplicationManagerState]map[appv1a
 	},
 	appv1alpha1.ApplyingEnv: {
 		appv1alpha1.CancelOp: true,
+		appv1alpha1.StopOp:   true,
 	},
 	appv1alpha1.Resuming: {
 		appv1alpha1.CancelOp: true,
@@ -343,6 +352,7 @@ var OperationAllowedInState = map[appv1alpha1.ApplicationManagerState]map[appv1a
 	appv1alpha1.ApplyEnvFailed: {
 		appv1alpha1.UninstallOp: true,
 		appv1alpha1.ApplyEnvOp:  true,
+		appv1alpha1.StopOp:      true,
 	},
 	appv1alpha1.PendingCancelFailed: {
 		appv1alpha1.CancelOp: true,


### PR DESCRIPTION
## Summary

Fixes `applyenv` resurrecting **stopped** apps and getting stuck mid-transition.

- **`appenv_controller`**: defer `applyenv` for `Stopped` apps **without** `workloadReplicas` (legacy apps with hardcoded YAML replicas), so a `helm upgrade`-based env apply no longer brings their pods back. Added an `ApplicationManager` watch that re-enqueues the `AppEnv` when the app transitions back to `Running`, so deferred env changes are applied on resume.
- **`applying_env_app` / helm ops (v1 + v2)**: for `Stopped` apps **with** `workloadReplicas`, allow `applyenv` to proceed but skip `WaitForStartUp` and land back in `Stopped` (release stays scaled to zero), reusing the `AppPreUpgradeStateKey` annotation pattern from the upgrade-from-stopped path.
- **`state_transition`**:
  - add `ApplyingEnv -> Stopping` so `pod_abnormal_suspend_app_controller` can fall back to `Stopped` mid-applyEnv.
  - add `ApplyingEnv -> Stopped` so the applyEnv-from-Stopped landing state is accepted by the `updateStatus` transition guard (without this the workloadReplicas-stopped path got stuck in `ApplyingEnv`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/appstate/...`
- [x] Manual: stop a legacy (no `workloadReplicas`) app, edit env -> stays `Stopped`; resume -> env applied.
- [x] Manual: stop a `workloadReplicas` app, edit env -> applies and lands back in `Stopped` (no pods).
- [x] Manual: edit env on a `Running` app -> applies normally.


Made with [Cursor](https://cursor.com)