### PR TITLE
fix(l4): readiness probe checks 443/444 via envoy admin /listeners

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.33"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.34"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.33
+          value: v0.3.34
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.33
+      name: beclab/l4-bfl-proxy:v0.3.34
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/xds/server/health.go
+++ b/framework/l4-bfl-proxy/internal/xds/server/health.go
@@ -1,24 +1,37 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"k8s.io/klog/v2"
 )
 
-// healthTracker records Envoy's ACK/NACK of the xDS config that this control
-// plane pushes. When Envoy rejects a listener update (for example a bad 443/444
-// listener config), it replies with a discovery request whose ErrorDetail is
-// set — a NACK. In that case the rejected listener is never installed, so the
-// port simply does not listen even though both the control plane and Envoy
-// processes are healthy. Tracking NACKs lets us surface that condition through
-// the Kubernetes readiness probe.
+// envoyAdminAddr is the host:port of the Envoy admin interface queried by the
+// readiness check. It is a var (not const) so tests can point it at a stub.
+var envoyAdminAddr = "127.0.0.1:19000"
+
+// adminClient is the HTTP client used to talk to the Envoy admin interface.
+var adminClient = &http.Client{Timeout: 2 * time.Second}
+
+// criticalListenerNames are the core ingress listeners whose absence means the
+// proxy cannot serve user HTTPS traffic. Readiness only cares about these; a
+// per-app TCP/UDP stream listener (e.g. a DNS app on host port 53 that fails to
+// bind) must not mark the whole proxy NotReady.
+var criticalListenerNames = []string{"https_443", "https_pp_444"}
+
+// healthTracker records Envoy's ACK/NACK of the xDS config purely for
+// diagnostics. The readiness decision is made by querying the Envoy admin
+// /listeners endpoint (see XdsServer.ReadyCheck); this just surfaces *why* a
+// listener failed (e.g. "cannot bind '0.0.0.0:53'") in the logs.
 type healthTracker struct {
 	mu    sync.RWMutex
 	nacks map[string]string // typeURL -> last error message reported by Envoy
@@ -28,10 +41,10 @@ func newHealthTracker() *healthTracker {
 	return &healthTracker{nacks: make(map[string]string)}
 }
 
-// callbacks returns go-control-plane callbacks that update the tracker on every
-// (delta and state-of-the-world) discovery request. Envoy sends a request with
-// ErrorDetail set when it NACKs a config, and an empty-error request carrying a
-// non-empty response nonce when it ACKs one.
+// callbacks returns go-control-plane callbacks that log Envoy's ACK/NACK on
+// every (delta and state-of-the-world) discovery request. Envoy sets
+// ErrorDetail on a NACK and sends an empty-error request with a non-empty nonce
+// on an ACK.
 func (h *healthTracker) callbacks() serverv3.CallbackFuncs {
 	return serverv3.CallbackFuncs{
 		StreamDeltaRequestFunc: func(_ int64, req *discoverygrpc.DeltaDiscoveryRequest) error {
@@ -58,7 +71,6 @@ func (h *healthTracker) observe(typeURL, nonce, errMsg string) {
 		}
 		h.nacks[typeURL] = errMsg
 	case nonce != "":
-		// A request with a nonce and no error is an ACK; clear any prior NACK.
 		if _, ok := h.nacks[typeURL]; ok {
 			klog.Infof("xds-server: Envoy ACK recovered for %s", shortType(typeURL))
 			delete(h.nacks, typeURL)
@@ -66,26 +78,73 @@ func (h *healthTracker) observe(typeURL, nonce, errMsg string) {
 	}
 }
 
-// err returns a non-nil error if Envoy is currently rejecting any xDS config.
-func (h *healthTracker) err() error {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	if len(h.nacks) == 0 {
-		return nil
+// ReadyCheck is a controller-runtime readiness checker. It asks the Envoy admin
+// interface which listeners are actually active and fails while any core ingress
+// listener (443/444) is not listening — e.g. when a bad/duplicate listener
+// config was rejected. App stream listeners are ignored.
+func (s *XdsServer) ReadyCheck(req *http.Request) error {
+	ctx := context.Background()
+	if req != nil {
+		ctx = req.Context()
 	}
-	parts := make([]string, 0, len(h.nacks))
-	for t, m := range h.nacks {
-		parts = append(parts, fmt.Sprintf("%s (%s)", shortType(t), m))
+	active, err := fetchActiveListeners(ctx, envoyAdminAddr)
+	if err != nil {
+		return fmt.Errorf("query envoy admin /listeners: %w", err)
 	}
-	sort.Strings(parts)
-	return fmt.Errorf("envoy rejected xDS config: %s", strings.Join(parts, "; "))
+	return evaluateReadiness(criticalListenerNames, active)
 }
 
-// ReadyCheck is a controller-runtime readiness checker. It fails while Envoy is
-// rejecting the pushed xDS config, e.g. when a duplicate/invalid listener leaves
-// ports 443/444 not listening. Register it with mgr.AddReadyzCheck.
-func (s *XdsServer) ReadyCheck(_ *http.Request) error {
-	return s.health.err()
+// evaluateReadiness returns an error naming any expected listener that Envoy is
+// not currently reporting as active.
+func evaluateReadiness(expected []string, active map[string]bool) error {
+	var missing []string
+	for _, name := range expected {
+		if !active[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("envoy ingress listener(s) not active: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// fetchActiveListeners returns the set of listener names Envoy reports as active
+// via GET /listeners. The default text format is one "<name>::<address>" per
+// line.
+func fetchActiveListeners(ctx context.Context, adminAddr string) (map[string]bool, error) {
+	url := fmt.Sprintf("http://%s/listeners", adminAddr)
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := adminClient.Do(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	active := make(map[string]bool)
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name := line
+		if i := strings.Index(line, "::"); i >= 0 {
+			name = line[:i]
+		}
+		active[name] = true
+	}
+	return active, nil
 }
 
 func shortType(typeURL string) string {

--- a/framework/l4-bfl-proxy/internal/xds/server/health_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/server/health_test.go
@@ -1,61 +1,125 @@
 package server
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
-
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
-func TestHealthTracker_NackThenAckRecovers(t *testing.T) {
-	h := newHealthTracker()
+func newListenersServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/listeners" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
 
-	if err := h.err(); err != nil {
-		t.Fatalf("fresh tracker should be healthy, got %v", err)
-	}
+// useAdminAddr points the readiness check at addr for the duration of the test.
+func useAdminAddr(t *testing.T, addr string) {
+	t.Helper()
+	old := envoyAdminAddr
+	envoyAdminAddr = addr
+	t.Cleanup(func() { envoyAdminAddr = old })
+}
 
-	// Envoy NACKs the listener config.
-	h.observe(resourcev3.ListenerType, "nonce-1", "duplicate matcher")
-	if err := h.err(); err == nil {
-		t.Fatal("expected unhealthy after NACK")
-	}
+func adminHostPort(ts *httptest.Server) string {
+	return strings.TrimPrefix(ts.URL, "http://")
+}
 
-	// A subsequent ACK (nonce set, no error) clears it.
-	h.observe(resourcev3.ListenerType, "nonce-2", "")
-	if err := h.err(); err != nil {
-		t.Fatalf("expected healthy after ACK, got %v", err)
+const sampleListeners = `http_redirect_81::0.0.0.0:81
+https_443::0.0.0.0:443
+https_pp_444::0.0.0.0:444
+stream_udp_olarestest004_53::0.0.0.0:53
+`
+
+// All core ingress listeners are active → ready.
+func TestReadyCheck_AllActive_Ready(t *testing.T) {
+	ts := newListenersServer(t, http.StatusOK, sampleListeners)
+	defer ts.Close()
+	useAdminAddr(t, adminHostPort(ts))
+
+	s := &XdsServer{}
+	if err := s.ReadyCheck(nil); err != nil {
+		t.Fatalf("expected ready, got %v", err)
 	}
 }
 
-func TestHealthTracker_InitialRequestIgnored(t *testing.T) {
-	h := newHealthTracker()
-	// Envoy's first request for a type has no nonce and no error; it must not
-	// be treated as an ACK or NACK.
-	h.observe(resourcev3.ClusterType, "", "")
-	if err := h.err(); err != nil {
-		t.Fatalf("initial request should keep tracker healthy, got %v", err)
+// A core ingress listener missing from Envoy → not ready, and the error names
+// the missing listener.
+func TestReadyCheck_MissingCritical_NotReady(t *testing.T) {
+	body := "http_redirect_81::0.0.0.0:81\nhttps_443::0.0.0.0:443\n" // no 444
+	ts := newListenersServer(t, http.StatusOK, body)
+	defer ts.Close()
+	useAdminAddr(t, adminHostPort(ts))
+
+	s := &XdsServer{}
+	err := s.ReadyCheck(nil)
+	if err == nil {
+		t.Fatal("expected not ready when https_pp_444 is missing")
+	}
+	if !strings.Contains(err.Error(), "https_pp_444") {
+		t.Fatalf("error should name the missing listener, got %v", err)
 	}
 }
 
-func TestHealthTracker_CallbacksWireUp(t *testing.T) {
-	h := newHealthTracker()
-	cb := h.callbacks()
+// A per-app stream listener failing to bind (absent from /listeners) does not
+// affect readiness, since it is not a critical listener.
+func TestReadyCheck_AppStreamListenerIrrelevant(t *testing.T) {
+	body := "https_443::0.0.0.0:443\nhttps_pp_444::0.0.0.0:444\n" // 53 never bound
+	ts := newListenersServer(t, http.StatusOK, body)
+	defer ts.Close()
+	useAdminAddr(t, adminHostPort(ts))
 
-	_ = cb.StreamDeltaRequestFunc(1, &discoverygrpc.DeltaDiscoveryRequest{
-		TypeUrl:       resourcev3.ListenerType,
-		ResponseNonce: "n1",
-		ErrorDetail:   &status.Status{Message: "boom"},
-	})
-	if err := h.err(); err == nil {
-		t.Fatal("expected unhealthy after delta NACK callback")
+	s := &XdsServer{}
+	if err := s.ReadyCheck(nil); err != nil {
+		t.Fatalf("app stream listener absence must not affect readiness, got %v", err)
 	}
+}
 
-	_ = cb.StreamDeltaRequestFunc(1, &discoverygrpc.DeltaDiscoveryRequest{
-		TypeUrl:       resourcev3.ListenerType,
-		ResponseNonce: "n2",
-	})
-	if err := h.err(); err != nil {
-		t.Fatalf("expected healthy after delta ACK callback, got %v", err)
+// Envoy admin unreachable → not ready.
+func TestReadyCheck_AdminUnreachable_NotReady(t *testing.T) {
+	ts := newListenersServer(t, http.StatusOK, sampleListeners)
+	addr := adminHostPort(ts)
+	ts.Close() // now unreachable
+	useAdminAddr(t, addr)
+
+	s := &XdsServer{}
+	if err := s.ReadyCheck(nil); err == nil {
+		t.Fatal("expected not ready when admin is unreachable")
+	}
+}
+
+func TestEvaluateReadiness(t *testing.T) {
+	active := map[string]bool{"https_443": true, "https_pp_444": true}
+	if err := evaluateReadiness([]string{"https_443", "https_pp_444"}, active); err != nil {
+		t.Fatalf("expected ready, got %v", err)
+	}
+	err := evaluateReadiness([]string{"https_443", "https_pp_444"}, map[string]bool{"https_443": true})
+	if err == nil || !strings.Contains(err.Error(), "https_pp_444") {
+		t.Fatalf("expected error naming https_pp_444, got %v", err)
+	}
+}
+
+func TestFetchActiveListeners_Parsing(t *testing.T) {
+	ts := newListenersServer(t, http.StatusOK, sampleListeners)
+	defer ts.Close()
+
+	active, err := fetchActiveListeners(context.Background(), adminHostPort(ts))
+	if err != nil {
+		t.Fatalf("fetchActiveListeners: %v", err)
+	}
+	for _, name := range []string{"http_redirect_81", "https_443", "https_pp_444", "stream_udp_olarestest004_53"} {
+		if !active[name] {
+			t.Errorf("expected listener %q to be parsed as active", name)
+		}
+	}
+	if len(active) != 4 {
+		t.Errorf("expected 4 active listeners, got %d", len(active))
 	}
 }


### PR DESCRIPTION
* **Background**

The xDS NACK-based readiness check marked the whole proxy NotReady on any rejected listener, including per-app stream listeners (e.g. a DNS app that fails to bind 0.0.0.0:53 with "Address already in use"). That is unrelated to ingress and should not gate readiness.

Replace the NACK-driven ReadyCheck with a direct query to the Envoy admin interface (GET http://127.0.0.1:19000/listeners): readiness fails only while a core ingress listener (https_443 / https_pp_444) is not actually active, so a duplicate/invalid listener that leaves 443/444 down is caught while app stream listeners are ignored.

The healthTracker is kept for diagnostics only — it logs Envoy ACK/NACK (surfacing *why* a listener failed) but no longer drives the probe.

Tests cover all-active, missing critical listener, irrelevant app stream listener, admin unreachable, /listeners parsing, and the readiness eval.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes readiness for the ingress proxy (443/444 gating); misconfiguration could mark pods ready when ingress is down or vice versa, though behavior is more targeted than the prior NACK-based check.
> 
> **Overview**
> **L4 BFL proxy readiness** no longer fails on any xDS NACK. `ReadyCheck` now queries Envoy admin (`GET /listeners` on `127.0.0.1:19000`) and reports **NotReady** only when core ingress listeners `https_443` or `https_pp_444` are not active—so a per-app stream listener that fails to bind (e.g. port 53) does not block the whole pod. The xDS **healthTracker** remains for ACK/NACK logging only.
> 
> **Release alignment:** `beclab/l4-bfl-proxy` is bumped **v0.3.33 → v0.3.34** in the CLI upgrade task, BFL launcher env `L4_PROXY_IMAGE_VERSION`, and `Olares.yaml`. Tests cover admin parsing, missing critical listeners, irrelevant app listeners, and unreachable admin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb825a59556294c823c5e6bc360e852b0474072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->