### PR TITLE
fix: files cache share upload

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.188
+          image: beclab/files-server:v0.2.189
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: stage cache share chunk uploads under the sharer's cache PVC

Target Version for Merge
- 1.12.6

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/355

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest or config changes beyond version; risk is limited to normal files upload/cache-share behavior in the new release.
> 
> **Overview**
> Rolls out **files-server v0.2.189** on the `files` DaemonSet by updating the container image tag in `files_deploy.yaml` (from `v0.2.188`).
> 
> This deploy change picks up the upstream fix that **stages cache-share chunk uploads under the sharer’s cache PVC** instead of the wrong location. Manifest mounts for `upload-appdata` (`/data/appcache/`, `/appcache/`) are unchanged; behavior changes live in the new image (see beclab/files#355).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fe84e6bbe981f5be8d2dcae6f7010d320368e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->