### PR TITLE
backup: fix Common path backup failed

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.66" }}
+{{ $backupVersion := "0.3.67" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/pkg/constant/constant.go
+++ b/framework/backup-server/pkg/constant/constant.go
@@ -70,6 +70,7 @@ const (
 
 	CachePath    string = "/appcache"
 	ExternalPath string = "/shares"
+	CommonPath   string = "/rootfs/Common"
 
 	DefaultStoragePrefix = "olares-backups/"
 

--- a/framework/backup-server/pkg/handlers/helper.go
+++ b/framework/backup-server/pkg/handlers/helper.go
@@ -764,20 +764,23 @@ func GetUserspacePvc(owner string) (string, string, string, string, error) {
 	return p, userspacePvc, cachePath, appcachePvc, nil
 }
 
-func TrimPathPrefix(p string) (bool, bool, string) {
+func TrimPathPrefix(p string) (bool, bool, bool,string) {
 	if !strings.HasSuffix(p, "/") {
 		p = p + "/"
 	}
 	var external = fmt.Sprintf("/Files/External/%s/", constant.NodeName)
 	var cache = fmt.Sprintf("/Cache/%s/", constant.NodeName)
+	var common = "/Common/"
 	if strings.HasPrefix(p, external) {
-		return true, false, strings.TrimPrefix(p, external)
+		return true, false,false, strings.TrimPrefix(p, external)
 	} else if strings.HasPrefix(p, cache) {
-		return false, true, strings.TrimPrefix(p, cache)
-	} else if strings.HasPrefix(p, "/Files/") {
-		return false, false, strings.TrimPrefix(p, "/Files/")
+		return false, true,false, strings.TrimPrefix(p, cache)
+	} else if strings.HasPrefix(p,common) {
+		return false,false,true,strings.TrimPrefix(p, common)
+	}else if strings.HasPrefix(p, "/Files/") {
+		return false, false,false, strings.TrimPrefix(p, "/Files/")
 	} else {
-		return false, false, p
+		return false, false,false, p
 	}
 }
 
@@ -799,13 +802,15 @@ func FormatEndpoint(location, schema, host, urlPath, pvc, cachepvc string) (*rep
 		result.Endpoint = strings.TrimPrefix(result.Endpoint, "s3:")
 		return result, nil
 	case constant.BackupLocationFileSystem.String():
-		external, cache, relativePath := TrimPathPrefix(p)
+		external, cache,common, relativePath := TrimPathPrefix(p)
 		var endpoint string
 		if external {
 			endpoint = path.Join(constant.ExternalPath, relativePath)
 		} else if cache {
 			endpoint = path.Join(cachepvc, relativePath)
-		} else {
+		} else if common{
+			endpoint = path.Join(constant.CommonPath,relativePath)
+		}else {
 			endpoint = path.Join(pvc, relativePath)
 		}
 		return &repo.RepositoryInfo{

--- a/framework/backup-server/pkg/storage/storage_backup.go
+++ b/framework/backup-server/pkg/storage/storage_backup.go
@@ -212,7 +212,7 @@ func (s *StorageBackup) checkSnapshotType() error {
 }
 
 func (s *StorageBackup) prepareBackupParams() error {
-	var external, cache bool
+	var external, cache, common bool
 	var backupSourcePath string
 	var backupSourceRealPath string
 	var locationInFileSystem string
@@ -233,12 +233,14 @@ func (s *StorageBackup) prepareBackupParams() error {
 
 	if s.BackupType == constant.BackupTypeFile {
 		backupSourcePath = handlers.ParseBackupTypePath(s.Backup.Spec.BackupType)
-		external, cache, backupSourceRealPath = handlers.TrimPathPrefix(backupSourcePath)
+		external, cache, common, backupSourceRealPath = handlers.TrimPathPrefix(backupSourcePath)
 		var filesPrefix []string
 		if external {
 			filesPrefix = append(filesPrefix, filepath.Join(constant.ExternalPath, backupSourceRealPath))
 		} else if cache {
 			filesPrefix = append(filesPrefix, filepath.Join(s.AppcachePvcPath, backupSourceRealPath))
+		} else if common {
+			filesPrefix = append(filesPrefix, filepath.Join(constant.CommonPath, backupSourceRealPath))
 		} else {
 			filesPrefix = append(filesPrefix, filepath.Join(s.UserspacePvcPath, backupSourceRealPath))
 		}
@@ -263,11 +265,13 @@ func (s *StorageBackup) prepareBackupParams() error {
 		locPath := location["path"]
 		locationInFileSystem = locPath
 
-		external, cache, locPath = handlers.TrimPathPrefix(locPath)
+		external, cache, common, locPath = handlers.TrimPathPrefix(locPath)
 		if external {
 			location["path"] = path.Join(constant.ExternalPath, locPath)
 		} else if cache {
 			location["path"] = path.Join(s.AppcachePvcPath, locPath)
+		} else if common {
+			location["path"] = path.Join(constant.CommonPath, locPath)
 		} else {
 			location["path"] = path.Join(s.UserspacePvcPath, locPath)
 		}
@@ -275,11 +279,13 @@ func (s *StorageBackup) prepareBackupParams() error {
 
 	var backupPath string
 	if s.BackupType == constant.BackupTypeFile {
-		var tmpBackupExternal, tmpCache, tmpBackupPath = handlers.TrimPathPrefix(handlers.GetBackupPath(s.Backup))
+		var tmpBackupExternal, tmpCache, tmpCommon, tmpBackupPath = handlers.TrimPathPrefix(handlers.GetBackupPath(s.Backup))
 		if tmpBackupExternal {
 			backupPath = path.Join(constant.ExternalPath, tmpBackupPath)
 		} else if tmpCache {
 			backupPath = path.Join(s.AppcachePvcPath, tmpBackupPath)
+		} else if tmpCommon {
+			backupPath = path.Join(constant.CommonPath, tmpBackupPath)
 		} else {
 			backupPath = path.Join(s.UserspacePvcPath, tmpBackupPath)
 		}

--- a/framework/backup-server/pkg/storage/storage_restore.go
+++ b/framework/backup-server/pkg/storage/storage_restore.go
@@ -184,7 +184,7 @@ func (s *StorageRestore) prepareRestoreParams() error {
 	var locationConfig = make(map[string]string)
 	var err error
 	var token string
-	var external, cache bool
+	var external, cache, common bool
 
 	if s.RestoreType.Type == constant.RestoreTypeSnapshot {
 		token, err = integration.IntegrationService.GetAuthToken(s.Backup.Spec.Owner, fmt.Sprintf("user-system-%s", s.Backup.Spec.Owner), constant.DefaultServiceAccountSettings)
@@ -210,11 +210,13 @@ func (s *StorageRestore) prepareRestoreParams() error {
 		location := locationConfig["location"]
 		if location == constant.BackupLocationFileSystem.String() {
 			locPath := locationConfig["path"]
-			external, cache, locPath = handlers.TrimPathPrefix(locPath)
+			external, cache, common, locPath = handlers.TrimPathPrefix(locPath)
 			if external {
 				locationConfig["path"] = path.Join(constant.ExternalPath, locPath)
 			} else if cache {
 				locationConfig["path"] = path.Join(s.AppcachePvcPath, locPath)
+			} else if common {
+				locationConfig["path"] = path.Join(constant.CommonPath, locPath)
 			} else {
 				locationConfig["path"] = path.Join(s.UserspacePvcPath, locPath)
 			}
@@ -254,16 +256,19 @@ func (s *StorageRestore) prepareRestoreParams() error {
 	if s.BackupType == constant.BackupTypeFile {
 		var dotRestorePath = path.Join(s.RestoreType.Path, fmt.Sprintf("%s.restore-%d", s.RestoreType.SubPath, s.RestoreType.SubPathTimestamp)) + "/"
 		var dotRestoreRootPath = path.Join(s.RestoreType.Path)
-		var tmpRestoreExternal, tmpRestoreCache, tmpRestorePath = handlers.TrimPathPrefix(dotRestorePath)
+		var tmpRestoreExternal, tmpRestoreCache, tmpRestoreCommon, tmpRestorePath = handlers.TrimPathPrefix(dotRestorePath)
 		log.Infof("Restore %s, dotRPath: %s, dotRRootPath: %s, tmpRestorePath: %s", s.RestoreId, dotRestorePath, dotRestoreRootPath, tmpRestorePath)
 		log.Infof("Restore %s, cachePvcPath: %s, userPvcPath: %s,", s.RestoreId, s.AppcachePvcPath, s.UserspacePvcPath)
-		var _, _, tmpRootRestorePath = handlers.TrimPathPrefix(dotRestoreRootPath)
+		var _, _, _, tmpRootRestorePath = handlers.TrimPathPrefix(dotRestoreRootPath)
 		if tmpRestoreExternal {
 			restorePath = path.Join(constant.ExternalPath, tmpRestorePath)
 			rootRestorePath = path.Join(constant.ExternalPath, tmpRootRestorePath)
 		} else if tmpRestoreCache {
 			restorePath = path.Join(s.AppcachePvcPath, tmpRestorePath)
 			rootRestorePath = path.Join(s.AppcachePvcPath, tmpRootRestorePath)
+		} else if tmpRestoreCommon {
+			restorePath = path.Join(constant.CommonPath, tmpRestorePath)
+			rootRestorePath = path.Join(constant.CommonPath, tmpRootRestorePath)
 		} else {
 			restorePath = path.Join(s.UserspacePvcPath, tmpRestorePath)
 			rootRestorePath = path.Join(s.UserspacePvcPath, tmpRootRestorePath)


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix Common path backup failed

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/pull/3546


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path resolution for filesystem backup/restore; wrong mapping could read or write the wrong directories, but scope is limited to the new Common prefix handling.
> 
> **Overview**
> Fixes **filesystem backups and restores** when the user selects paths under **`/Common/`** by treating them like External and Cache instead of misrouting them through userspace or `/Files/`.
> 
> Adds **`constant.CommonPath`** (`/rootfs/Common`) and extends **`TrimPathPrefix`** with a **common** flag for the `/Common/` prefix. **`FormatEndpoint`**, **`prepareBackupParams`**, and **`prepareRestoreParams`** now join that prefix to the correct on-disk location for source, repo, backup target, and restore targets.
> 
> Deploy image tag is bumped to **backup-server v0.3.67**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1630abfd13c5581db8adcc1ed21a797555f648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->