### PR TITLE
fix: search3 appcommon error

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.3
+        image: beclab/search3:v0.3.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -306,7 +306,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.3
+        image: beclab/search3monitor:v0.3.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.3
+        image: beclab/search3validation:v0.3.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: appcommon search error
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
Fix **appcommon (`drive/Common/`) search** for local `files_v2` search when the frontend bundles cluster-wide paths with a per-user owner in `can_watch_file_param`.

- **Search scope normalization**: rename `extract_external_paths` → `extract_cluster_wide_paths` and treat `drive/Common/` like `external/` — split into `owner=""` groups before SQL is built, so queries use `owner_userid=''` and `files_v2::drive/Common/` URIs that match indexed documents.
- **Server-side fallback**: even if the frontend passes `drive/Common/` under the wrong owner, `POST /search/init` normalizes scope on the server (same pattern as existing `external/` handling).
- **Task cleanup**: add a 4th cleanup pass `(owner="", node="")` on Owner + master for appcommon documents (`fnd.node=''`).
- **Tests**: Rust regression tests for preprocessing and `build_owner_condition`; HTTP integration test for folder `appcommonhaobao` under `drive/Common/` (when present in env).

**Also included in this branch (code merge only — not shipping to users yet):**

- Google Drive / Dropbox federated search (`clouddrive` module + controller dispatch).
- NATS federated search scaffold (`natssearch` module).

Cloud Drive and NATS paths have **not** been fully validated in production-like environments. They are merged for continued development but **will not be enabled / released** as part of this PR’s user-facing rollout.



* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.6
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only image tag updates in Kubernetes deploy YAML; risk depends on v0.3.4 image contents but this diff itself is a routine rollout bump.
> 
> **Overview**
> Bumps the **search3** cluster rollout from **v0.3.3** to **v0.3.4** by updating container image tags only—no manifest structure or env changes.
> 
> **`search3_server_deploy.yaml`**: `beclab/search3` and `beclab/search3monitor` images move to **v0.3.4**. **`search3_validation.yaml`**: `beclab/search3validation` moves to **v0.3.4**.
> 
> This aligns the framework deploy with the **v0.3.4** search3 build (e.g. appcommon / `drive/Common/` search fixes described in the PR narrative); behavior changes live in those images, not in these YAML edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831625ac9b88193948c1876c765de1f7521c44ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->