### PR TITLE
market: push upgrade target version regardless of app runtime state

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.69
+        image: beclab/market-backend:v0.6.70
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
market: push upgrade target version regardless of app runtime state

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/322


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on the market deployment; application logic changes are confined to the new backend release with no cluster config edits here.
> 
> **Overview**
> Bumps the **market** `appstore-backend` container image from `beclab/market-backend:v0.6.69` to **`v0.6.70`** in `market_deploy.yaml`, rolling out the backend build that implements pushing upgrade target versions without waiting on app runtime state (see beclab/market#322).
> 
> No other manifest, env, or RBAC changes in this diff—only the image tag on the market deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f91a66971edd079a33e6e148f69e763558838283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->