### PR TITLE
olares: bump system-frontend image to v1.10.67

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.65
+          image: beclab/system-frontend:v1.10.67
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
Title: olares: bump system-frontend image to v1.10.67

* **Background**
Roll out **system-frontend v1.10.67** on the Olares system app by updating the `olares-app-init` container image tag in `olares-app.yaml` (v1.10.65 → v1.10.67). This picks up the latest TermiPass system frontend changes shipped in the companion sub-system PR.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1239

* **Other information**:
None

## Test plan
- [ ] Verify `olares-app-init` pulls and starts with `beclab/system-frontend:v1.10.67`
- [ ] Confirm system frontend UI loads correctly after Olares system app upgrade

Made with [Cursor](https://cursor.com)