### PR TITLE
docs: allow table cells to wrap text without manual line breaks

### DIFF
--- a/docs/.vitepress/theme/styles/custom.css
+++ b/docs/.vitepress/theme/styles/custom.css
@@ -1,8 +1,6 @@
-/* 只影响文档正文里的表格 */
-.vp-doc table td:nth-child(2),
-.vp-doc table th:nth-child(2) {
-  white-space: nowrap;      /* 第二列不换行 */
+/* Allow table cells in doc content to wrap text at word boundaries */
+.vp-doc table td,
+.vp-doc table th {
+  white-space: normal;
+  overflow-wrap: break-word;
 }
-
-/* 若想让整张表放宽布局，顺便改一下 ↓ */
-/* .vp-doc table { table-layout: auto; } */


### PR DESCRIPTION
Enables text wrapping in documentation tables by default, so authors do not need to insert manual `<br> `line breaks.

Changes:
- Updated docs/.vitepress/theme/styles/custom.css to set white-space: normal and overflow-wrap: break-word on table cells.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only theme CSS with no runtime, auth, or data impact; layout in tables may look slightly different on narrow viewports.
> 
> **Overview**
> Documentation table styling no longer forces the **second column** to stay on one line (`white-space: nowrap` on `nth-child(2)` only). **All** `.vp-doc` table `td`/`th` cells now use `white-space: normal` and `overflow-wrap: break-word`, so long cell text wraps at word boundaries without authors adding manual `<br>` breaks.
> 
> Removed the old commented note about optional `table-layout: auto`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2039fe925395629006371d786c239b7c60a160e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->