### PR TITLE
fix: ignore im not found error while cancel operation 

### DIFF
--- a/framework/app-service/pkg/appstate/download_canceling_app.go
+++ b/framework/app-service/pkg/appstate/download_canceling_app.go
@@ -48,8 +48,16 @@ func NewDownloadingCancelingApp(c client.Client,
 func (p *DownloadingCancelingApp) exec(ctx context.Context) error {
 	err := p.imageClient.UpdateStatus(ctx, p.manager.Name, appsv1.DownloadingCanceled.String(), appsv1.DownloadingCanceled.String())
 	if err != nil {
-		klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
-		return err
+		// Im may has already been cleaned up. In either case there is nothing to mark as canceled on the IM
+		// side and the cancel must still continue with namespace cleanup and
+		// the transition to DownloadingCanceled; otherwise the AM gets pinned
+		// in DownloadingCancelFailed (which only re-enters DownloadingCanceling
+		// and would hit the same NotFound again).
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
+			return err
+		}
+		klog.Infof("im name=%s not found while canceling download, treating as already canceled", p.manager.Name)
 	}
 	if ok := appFactory.cancelOperation(p.manager.Name); !ok {
 		klog.Errorf("app %s operation is not ", p.manager.Name)

--- a/framework/app-service/pkg/appstate/downloading_canceling_failed_app.go
+++ b/framework/app-service/pkg/appstate/downloading_canceling_failed_app.go
@@ -62,6 +62,9 @@ func (p *DownloadingCancelFailedApp) Exec(ctx context.Context) (StatefulInProgre
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
 	if im.Status.State != appsv1.DownloadingCanceled.String() {
 		err = p.imageClient.UpdateStatus(ctx, p.manager.Name, appsv1.DownloadingCanceled.String(), appsv1.DownloadingCanceled.String())
 		if err != nil {

--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -330,8 +331,15 @@ func (p *UpgradingApp) Cancel(ctx context.Context) error {
 	klog.Infof("execute upgrading cancel operation appName=%s", p.manager.Spec.AppName)
 	err = p.imageClient.UpdateStatus(ctx, p.manager.Name, appsv1.DownloadingCanceled.String(), appsv1.DownloadingCanceled.String())
 	if err != nil {
-		klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
-		return err
+		// IM may  has already been cleaned up.
+		// Either way, there is no IM status to mark canceled; the in-process
+		// cancel below is still required so the running upgrade goroutine
+		// observes context.Canceled and unwinds.
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
+			return err
+		}
+		klog.Infof("im name=%s not found while canceling upgrade (timeout), treating as already canceled", p.manager.Name)
 	}
 
 	if ok := appFactory.cancelOperation(p.manager.Name); !ok {

--- a/framework/app-service/pkg/appstate/upgrading_canceling_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_canceling_app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/images"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -45,8 +46,14 @@ func (p *UpgradingCancelingApp) Exec(ctx context.Context) (StatefulInProgressApp
 	klog.Infof("execute upgrading cancel operation appName=%s", p.manager.Spec.AppName)
 	err = p.imageClient.UpdateStatus(ctx, p.manager.Name, appsv1.DownloadingCanceled.String(), appsv1.DownloadingCanceled.String())
 	if err != nil {
-		klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
-		return nil, err
+		// IM may has been cleaned up.
+		// Treat as already canceled and continue so the AM proceeds to
+		// Stopping instead of getting pinned in UpgradingCancelFailed.
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("update im name=%s to downloadingCanceled state failed %v", p.manager.Name, err)
+			return nil, err
+		}
+		klog.Infof("im name=%s not found while canceling upgrade, treating as already canceled", p.manager.Name)
 	}
 
 	if ok := appFactory.cancelOperation(p.manager.Name); !ok {


### PR DESCRIPTION


* **Background**
ignore im not found error while cancel operation, in that situation image-service already canceled download
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes application lifecycle state machine behavior during cancel; wrong error handling could mask real failures, but scope is limited to NotFound on IM updates/gets.
> 
> **Overview**
> When canceling a **download** or **upgrade**, marking the `ImageManager` as `DownloadingCanceled` no longer fails if that CR is already gone (e.g. image-service already tore it down). **`apierrors.IsNotFound`** is ignored so cancel still runs namespace cleanup, in-process operation cancel, and the normal state transitions instead of leaving the `ApplicationManager` stuck in **`DownloadingCancelFailed`** / **`UpgradingCancelFailed`**.
> 
> **`DownloadingCancelFailedApp`** recovery now exits successfully when the `ImageManager` get returns **NotFound**, instead of attempting a status update on a missing resource.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87fc16d9121b466491beb75dea5084399bdb4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->