### PR TITLE
fix(cli): drop pagination from search app subcommand

### DIFF
--- a/cli/cmd/ctl/search/app.go
+++ b/cli/cmd/ctl/search/app.go
@@ -25,7 +25,7 @@ var uninstalledAppStates = map[string]struct{}{
 }
 
 type appOptions struct {
-	pagingOptions
+	output string
 }
 
 type appEntrance struct {
@@ -71,8 +71,7 @@ entrance title (case-insensitive substring match).
 
 Examples:
   olares-cli search app wise
-  olares-cli search app drive --limit 10
-  olares-cli search app notes -o json
+  olares-cli search app firefox -o json
 `,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -84,7 +83,7 @@ Examples:
 		},
 	}
 	cmd.SilenceUsage = true
-	registerPagingFlags(cmd, &o.pagingOptions)
+	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "output format: table, json")
 	return cmd
 }
 
@@ -92,7 +91,7 @@ func runAppSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *ap
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	format, err := o.validate()
+	format, err := parseFormat(o.output)
 	if err != nil {
 		return err
 	}
@@ -107,8 +106,7 @@ func runAppSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *ap
 		return err
 	}
 
-	matched := filterAppsByKeyword(apps, keyword)
-	items := paginateAppItems(matched, o.offset, o.limit)
+	items := filterAppsByKeyword(apps, keyword)
 
 	switch format {
 	case FormatJSON:
@@ -213,17 +211,6 @@ func filterAppsByKeyword(apps []appRaw, keyword string) []appItem {
 		}
 	}
 	return items
-}
-
-func paginateAppItems(items []appItem, offset, limit int) []appItem {
-	if offset >= len(items) {
-		return nil
-	}
-	end := offset + limit
-	if end > len(items) {
-		end = len(items)
-	}
-	return items[offset:end]
 }
 
 func printAppResultsJSON(w io.Writer, items []appItem) error {

--- a/cli/skills/olares-search/SKILL.md
+++ b/cli/skills/olares-search/SKILL.md
@@ -58,7 +58,7 @@ Multiple words are joined into one keyword (quote multi-word phrases to be expli
 ### app
 
 - Fetches installed apps from `/server/myApps`, expands visible entrances, filters by case-insensitive substring match on the entrance title (falling back to the app title when an entrance declares none).
-- Client-side pagination via `--limit` / `--offset` after filtering.
+- Returns all matches in one response (**no `--limit` / `--offset`**).
 - Skips uninstalled/failed apps and invisible entrances (same rules as the Desktop SPA). For a `running` app the row shows the per-entrance state.
 
 ### Indexing (drive / sync only)


### PR DESCRIPTION
## Summary

- Remove `--limit` and `--offset` from `olares-cli search app`; the subcommand now returns all matching installed applications in one response.
- Drop client-side `paginateAppItems` slicing and keep only `-o/--output` for formatting.
- Refresh help examples (remove misleading `search app drive` sample) and update `olares-search` skill docs.

## Rationale

`search app` mirrors the Desktop global search "Application" category, which does not paginate results. Exposing paging flags suggested backend support that does not exist.

## Test plan

- [ ] `go test ./cmd/ctl/search/...` passes
- [ ] `olares-cli search app --help` shows only `--output`, not `--limit`/`--offset`
- [ ] `olares-cli search app <keyword>` prints all matches
- [ ] `olares-cli search drive` / `search sync` paging flags are unchanged

Made with [Cursor](https://cursor.com)