### PR TITLE
docs: update zh translation for manifest appid

### DIFF
--- a/docs/zh/developer/develop/package/manifest.md
+++ b/docs/zh/developer/develop/package/manifest.md
@@ -55,6 +55,7 @@ olaresManifest.version: '0.10.0'
 olaresManifest.type: app
 metadata:
   name: helloworld
+  appid: helloworld
   title: Hello World
   description: app helloworld
   icon: https://app.cdn.olares.com/appstore/default/defaulticon.webp
@@ -154,6 +155,7 @@ olaresManifest.version: "3.0.122"
 ```yaml
 metadata:
   name: nextcloud
+  appid: nextcloud
   title: Nextcloud
   description: The productivity platform that keeps you in control
   icon: https://app.cdn.olares.com/appstore/nextcloud/icon.png
@@ -170,6 +172,14 @@ metadata:
 - 有效值：`^[a-z][a-z0-9]{0,29}$`
 
 Olares 中的应用的命名空间，仅限小写字母数字字符。最多 30 个字符，需要与 `Chart.yaml` 中的 `FolderName` 和 `name` 字段保持一致。
+
+### appid
+
+- 类型： `string`
+- 可选
+- 有效值：使用由小写字母和数字组成的应用标识符，例如 `metadata.name`。不得使用系统保留的应用 ID，例如 `market`、`auth`、`desktop`、`files` 或 `settings`。
+
+Olares 系统服务使用的应用 ID。加载器在返回 manifest 前，会将 `metadata.appid` 规范化为 `md5(metadata.name)[:8]`，因此，此处填写的原始值不会在加载时保留。若应用 ID 与系统保留 ID 发生冲突，验证器将拒绝该 manifest。
 
 ### title
 


### PR DESCRIPTION
* **Background**

* **Target Version for Merge**
1.12.5

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅更新中文开发者文档，不涉及运行时或配置实现。
> 
> **Overview**
> **中文 OlaresManifest 文档**补充了 `metadata.appid` 字段说明，与英文版对齐。
> 
> 示例 YAML（`helloworld`、`nextcloud`）中增加了 `appid` 行。新增 **appid** 小节：可选字符串、小写字母数字标识符、禁止系统保留 ID；说明加载器会将 `metadata.appid` 规范化为 `md5(metadata.name)[:8]`，且与保留 ID 冲突时验证器会拒绝 manifest。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e55cc7eea1847e4059e2c17e2b6aee160527290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->