### PR TITLE
olares: bump system-frontend image to v1.10.68

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.67
+          image: beclab/system-frontend:v1.10.68
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
Title: olares: bump system-frontend image to v1.10.68

* **Background**
Roll out **system-frontend v1.10.68** on the Olares system app by updating the `olares-app-init` container image tag in `olares-app.yaml` (v1.10.67 → v1.10.68). This picks up the latest TermiPass system frontend changes shipped in the companion sub-system PRs.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1241
https://github.com/beclab/TermiPass/pull/1243

* **Other information**:
None

## Test plan
- [ ] Verify `olares-app-init` pulls and starts with `beclab/system-frontend:v1.10.68`
- [ ] Confirm system frontend UI loads correctly after Olares system app upgrade

Made with [Cursor](https://cursor.com)