### PR TITLE
fix(cli): make enable-juicefs idempotent and resumable

### DIFF
--- a/cli/cmd/ctl/node/enable_juicefs.go
+++ b/cli/cmd/ctl/node/enable_juicefs.go
@@ -32,8 +32,10 @@ JuiceFS mount, regenerates the cluster services, and starts Olares back up.
 After it completes, the master satisfies the JuiceFS precondition required to
 add worker nodes, so you can run "olares-cli node add" on the workers.
 
-If JuiceFS is already enabled, the command reports that the migration is
-already complete and exits without touching Olares.`,
+The command is resumable: if a previous run was interrupted, re-running it
+continues safely from where it left off without re-migrating already-migrated
+data. Once the migration is fully complete it reports that there is nothing to
+do and exits without touching Olares.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := pipelines.EnableJuiceFSPipeline(cmd.Context()); err != nil {
 				log.Fatalf("error: %v", err)

--- a/cli/pkg/phase/cluster/enable_juicefs.go
+++ b/cli/pkg/phase/cluster/enable_juicefs.go
@@ -55,17 +55,34 @@ func EnableJuiceFS(runtime *common.KubeRuntime, manifestMap manifest.Installatio
 	// validate the provided credentials instead and JuiceFS is formatted
 	// against that remote bucket.
 	useManagedMinIO := runtime.Arg.Storage == nil || runtime.Arg.Storage.StorageType == common.ManagedMinIO
+
+	// When the juicefs service is already enabled, the data has already been
+	// migrated and the rootfs swapped, so a resumed run must skip every
+	// migration step (prechecks, the object store / metadata engine install,
+	// and the rootfs migration itself) and only re-run the idempotent
+	// finalization modules below (StartOlares, the rootfs-type flip and the
+	// fsnotify re-render). This is also why the prechecks must be skipped:
+	// they require Olares to be stopped, whereas finalization needs it running.
+	alreadyEnabled := storage.IsJuiceFSEnabled()
+
 	modules := []module.Module{
-		&MigratePrecheckModule{},
-		&storage.ValidateModule{Skip: useManagedMinIO},
+		&MigratePrecheckModule{Skip: alreadyEnabled},
+		&storage.ValidateModule{Skip: useManagedMinIO || alreadyEnabled},
 		&storage.InstallMinioModule{
 			ManifestModule: manifestModule,
-			Skip:           !useManagedMinIO,
+			Skip:           !useManagedMinIO || alreadyEnabled,
 		},
-		&storage.InstallRedisModule{ManifestModule: manifestModule},
+		&storage.InstallRedisModule{ManifestModule: manifestModule, Skip: alreadyEnabled},
 		&MigrateRootFSToJuiceFSModule{
 			ManifestModule: manifestModule,
+			Skip:           alreadyEnabled,
 		},
+		// Always run (idempotent): regenerate the container-runtime service unit
+		// so it gains the JuiceFS pre-check now that juicefs.service exists. This
+		// lives in its own module rather than inside the migration module so that
+		// a run interrupted between enabling the juicefs service and this step is
+		// still repaired on resume (when the migration module is skipped).
+		&RegenerateRuntimeServiceModule{},
 		&terminus.StartOlaresModule{},
 		&UpdateRootFSTypeModule{},
 		&ReRenderFsnotifyChartsModule{},
@@ -82,6 +99,11 @@ func EnableJuiceFS(runtime *common.KubeRuntime, manifestMap manifest.Installatio
 // is enough disk space to do so.
 type MigratePrecheckModule struct {
 	common.KubeModule
+	Skip bool
+}
+
+func (m *MigratePrecheckModule) IsSkip() bool {
+	return m.Skip
 }
 
 func (m *MigratePrecheckModule) Init() {
@@ -103,11 +125,17 @@ func (m *MigratePrecheckModule) Init() {
 // MigrateRootFSToJuiceFSModule installs the JuiceFS client, formats the
 // filesystem, syncs the local rootfs into it in a single full pass (Olares is
 // already stopped, so the rootfs is quiescent), swaps the rootfs directory for
-// the JuiceFS mount, and regenerates the container runtime service so it gates
-// on JuiceFS.
+// the JuiceFS mount, and enables the juicefs service. The container-runtime
+// service unit is regenerated separately (RegenerateRuntimeServiceModule) so
+// that step survives resumption even when this module is skipped.
 type MigrateRootFSToJuiceFSModule struct {
 	common.KubeModule
 	manifest.ManifestModule
+	Skip bool
+}
+
+func (m *MigrateRootFSToJuiceFSModule) IsSkip() bool {
+	return m.Skip
 }
 
 func (m *MigrateRootFSToJuiceFSModule) Init() {
@@ -192,14 +220,23 @@ func (m *MigrateRootFSToJuiceFSModule) Init() {
 		enableJuiceFs,
 		checkJuiceFs,
 	}
-
-	// 4. regenerate the container runtime service so it gains the JuiceFS
-	// pre-check (After=juicefs.service + ExecStartPre=juicefs summary) now that
-	// the unit exists.
-	m.appendRegenerateRuntimeServiceTasks()
 }
 
-func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {
+// RegenerateRuntimeServiceModule regenerates the container-runtime service unit
+// so it gains the JuiceFS pre-check (After=juicefs.service + ExecStartPre=juicefs
+// summary) now that juicefs.service exists.
+//
+// It is a standalone, always-run module (not part of the migration module) and
+// every task in it is idempotent, so a run that was interrupted between enabling
+// the juicefs service and this regeneration is still repaired on resume, even
+// though the migration module itself is skipped once JuiceFS is enabled.
+type RegenerateRuntimeServiceModule struct {
+	common.KubeModule
+}
+
+func (m *RegenerateRuntimeServiceModule) Init() {
+	m.Name = "RegenerateRuntimeService"
+
 	// Only the container-runtime *service* unit needs regenerating: now that
 	// juicefs.service exists, the template adds the JuiceFS pre-check
 	// (After=juicefs.service + ExecStartPre=juicefs summary). The service *env*
@@ -207,7 +244,7 @@ func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {
 	// migration, so we must NOT regenerate it - doing so would require the
 	// cluster status from the pipeline cache and risks clobbering the token.
 	if m.KubeConf.Arg.Kubetype == common.K8s {
-		m.Tasks = append(m.Tasks,
+		m.Tasks = []task.Interface{
 			&task.LocalTask{
 				Name:   "RegenerateKubeletService",
 				Action: new(kubernetes.GenerateKubeletService),
@@ -216,10 +253,10 @@ func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {
 				Name:   "ReloadSystemdUnits",
 				Action: &terminus.SystemctlCommand{DaemonReloadPreExec: true},
 			},
-		)
+		}
 		return
 	}
-	m.Tasks = append(m.Tasks,
+	m.Tasks = []task.Interface{
 		&task.LocalTask{
 			Name:   "RegenerateK3sService",
 			Action: new(k3s.GenerateK3sService),
@@ -230,7 +267,7 @@ func (m *MigrateRootFSToJuiceFSModule) appendRegenerateRuntimeServiceTasks() {
 			Name:   "EnableK3sService",
 			Action: new(k3s.EnableK3sService),
 		},
-	)
+	}
 }
 
 // UpdateRootFSTypeModule flips OLARES_SYSTEM_ROOTFS_TYPE to "jfs". It runs after
@@ -346,6 +383,13 @@ func (t *ReRenderFsnotifyCharts) Execute(runtime connector.Runtime) error {
 			logger.Warnf("failed to re-render fsnotify for user %s: %v", user, err)
 		}
 		ucancel()
+	}
+
+	// The cluster-scoped fsnotify re-render (the critical step) succeeded, so
+	// the migration is now fully finalized. Record it so subsequent
+	// enable-juicefs runs short-circuit instead of resuming finalization.
+	if err := storage.MarkMigrationFinalized(); err != nil {
+		return fmt.Errorf("failed to record the rootfs migration as finalized: %w", err)
 	}
 
 	return nil

--- a/cli/pkg/pipelines/enable_juicefs.go
+++ b/cli/pkg/pipelines/enable_juicefs.go
@@ -23,13 +23,25 @@ func EnableJuiceFSPipeline(ctx context.Context) error {
 		os.Exit(1)
 	}
 
-	// If JuiceFS has already been migrated/enabled on this node, there is
+	// If the migration has fully completed (data synced, rootfs swapped, the
+	// juicefs service enabled AND the post-swap finalization done), there is
 	// nothing left to do. We deliberately do NOT start Olares here: the user
 	// manages the Olares lifecycle themselves now. This check runs before the
 	// console logger is initialized (SetConsoleLog below), so print directly.
-	if storage.IsJuiceFSEnabled() {
-		fmt.Println("JuiceFS is already enabled on this node, the rootfs migration is already complete, nothing to do")
+	if storage.IsMigrationFinalized() {
+		fmt.Println("JuiceFS is already enabled and the rootfs migration is fully complete on this node, nothing to do")
 		return nil
+	}
+
+	// If the juicefs service is already enabled but the migration was not fully
+	// finalized (a previous run was interrupted after the rootfs swap, e.g.
+	// before the rootfs-type flip / fsnotify re-render), resume from where it
+	// left off. The migration steps themselves are skipped (the data is already
+	// on JuiceFS); only the idempotent finalization steps are re-run. Crucially
+	// we must NOT treat this as "already done", or those steps would be skipped
+	// forever.
+	if storage.IsJuiceFSEnabled() {
+		fmt.Println("JuiceFS is already enabled but the migration was not fully finalized, resuming the remaining post-migration steps")
 	}
 
 	kubeType := phase.GetKubeType()

--- a/cli/pkg/storage/juicefs.go
+++ b/cli/pkg/storage/juicefs.go
@@ -161,6 +161,10 @@ func (t *EnableJuiceFsService) Execute(runtime connector.Runtime) error {
 		return err
 	}
 
+	if err := advanceMigratePhase(phaseEnabled); err != nil {
+		return errors.Wrap(err, "failed to record migration phase after enabling the juicefs service")
+	}
+
 	return nil
 }
 

--- a/cli/pkg/storage/migrate.go
+++ b/cli/pkg/storage/migrate.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -36,6 +37,80 @@ var MigrationTempMountPoint = path.Join(OlaresRootDir, ".rootfs-jfs-migrate")
 // deleted) so that the migration can be rolled back manually if needed.
 var RootFSLocalBackupDir = path.Join(OlaresRootDir, "rootfs.local.bak")
 
+// MigrateStateFile records how far the JuiceFS rootfs migration has progressed.
+// It exists so that an interrupted `enable-juicefs` can be resumed safely:
+// without it, the only signal of progress is the juicefs.service file, which
+// cannot distinguish "data synced", "rootfs swapped", "service enabled" and
+// "fully finalized". That single boolean creates two hazards on a re-run:
+//   - between the swap and the service-file write, the local rootfs is already
+//     an empty directory, so re-running the --delete sync would mirror that
+//     emptiness onto JuiceFS and destroy the just-migrated data;
+//   - after the service file exists but before the post-swap finalization
+//     (rootfs-type flip + fsnotify re-render) completes, the run would be
+//     treated as "already done" and the finalization would never happen.
+//
+// The marker lives under /olares (NOT under the rootfs that gets swapped) so it
+// survives the swap and persists across runs.
+var MigrateStateFile = path.Join(OlaresRootDir, ".jfs-migrate.state")
+
+// migratePhase enumerates the ordered checkpoints of the rootfs migration.
+type migratePhase int
+
+const (
+	phaseNone      migratePhase = iota // nothing recorded yet
+	phaseSynced                        // local rootfs data fully synced into JuiceFS
+	phaseSwapped                       // original rootfs backed up; rootfs dir replaced with the JuiceFS mount point
+	phaseEnabled                       // juicefs.service written and JuiceFS mounted on the rootfs
+	phaseFinalized                     // rootfs type flipped to jfs + fsnotify charts re-rendered
+)
+
+var migratePhaseNames = map[migratePhase]string{
+	phaseSynced:    "synced",
+	phaseSwapped:   "swapped",
+	phaseEnabled:   "enabled",
+	phaseFinalized: "finalized",
+}
+
+func migratePhaseFromName(name string) migratePhase {
+	switch strings.TrimSpace(name) {
+	case "synced":
+		return phaseSynced
+	case "swapped":
+		return phaseSwapped
+	case "enabled":
+		return phaseEnabled
+	case "finalized":
+		return phaseFinalized
+	default:
+		return phaseNone
+	}
+}
+
+// readMigratePhase returns the furthest checkpoint the migration has reached,
+// or phaseNone if the marker is missing/unreadable.
+func readMigratePhase() migratePhase {
+	data, err := os.ReadFile(MigrateStateFile)
+	if err != nil {
+		return phaseNone
+	}
+	return migratePhaseFromName(string(data))
+}
+
+// advanceMigratePhase records that the migration reached phase p. It never
+// rewinds: if a later phase was already recorded it is kept, so the marker
+// stays monotonic even when a resumed run re-executes an earlier idempotent
+// step.
+func advanceMigratePhase(p migratePhase) error {
+	if readMigratePhase() >= p {
+		return nil
+	}
+	name := migratePhaseNames[p]
+	if name == "" {
+		return nil
+	}
+	return util.WriteFile(MigrateStateFile, []byte(name), 0644)
+}
+
 // IsJuiceFSEnabled reports whether this node has already been switched over to a
 // JuiceFS-backed rootfs.
 //
@@ -49,6 +124,24 @@ var RootFSLocalBackupDir = path.Join(OlaresRootDir, "rootfs.local.bak")
 // JuiceFS with --delete, destroying all data.
 func IsJuiceFSEnabled() bool {
 	return util.IsExist(JuiceFsServiceFile)
+}
+
+// IsMigrationFinalized reports whether the JuiceFS rootfs migration has fully
+// completed, including the post-swap finalization (rootfs-type flip + fsnotify
+// chart re-render). Only then is there genuinely nothing left to do.
+//
+// This is deliberately stricter than IsJuiceFSEnabled: a node that already has
+// the juicefs.service file but was interrupted before finalization still needs
+// the remaining steps, so callers must resume those rather than treat the node
+// as complete.
+func IsMigrationFinalized() bool {
+	return readMigratePhase() >= phaseFinalized
+}
+
+// MarkMigrationFinalized records that the migration has fully completed. After
+// this, enable-juicefs treats the node as done and exits early on later runs.
+func MarkMigrationFinalized() error {
+	return advanceMigratePhase(phaseFinalized)
 }
 
 // isOlaresRunning reports whether the kubernetes/container layer of Olares
@@ -98,6 +191,18 @@ func isPathMounted(runtime connector.Runtime, target string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// isDirEmpty reports whether dir contains no entries at all (including
+// dotfiles). It is used as a defensive guard so we never run a destructive
+// --delete sync from, or a swap of, an unexpectedly empty rootfs.
+func isDirEmpty(runtime connector.Runtime, dir string) (bool, error) {
+	cmd := fmt.Sprintf("find %s -mindepth 1 -maxdepth 1 2>/dev/null | head -n 1", dir)
+	out, err := runtime.GetRunner().SudoCmd(cmd, false, false)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "", nil
 }
 
 // CheckMigrationPrecheck validates that the node is in a state where the
@@ -238,6 +343,16 @@ type SyncRootFSData struct {
 }
 
 func (t *SyncRootFSData) Execute(runtime connector.Runtime) error {
+	// If the rootfs has already been swapped (its data now lives in JuiceFS and
+	// the local rootfs directory was replaced with a fresh/empty mount point),
+	// there is nothing left to sync. Re-running the --delete sync here would
+	// mirror the now-empty source onto JuiceFS and destroy the just-migrated
+	// data, so a resumed run must skip it.
+	if readMigratePhase() >= phaseSwapped {
+		logger.Infof("rootfs has already been migrated and swapped onto JuiceFS, skipping data sync to avoid wiping migrated data")
+		return nil
+	}
+
 	// Safety: the source must be the real local rootfs, never a JuiceFS mount.
 	// Otherwise a --delete sync from an (empty) JuiceFS into JuiceFS could wipe data.
 	srcMounted, err := isJuiceFSMounted(runtime, OlaresJuiceFSRootDir)
@@ -255,6 +370,29 @@ func (t *SyncRootFSData) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("refusing to sync: destination %s is not mounted", MigrationTempMountPoint)
 	}
 
+	// Defensive guard in case the phase marker was lost: a --delete sync from an
+	// empty source into a non-empty JuiceFS destination would destroy data. The
+	// Olares rootfs is never legitimately empty, so an empty source means the
+	// swap most likely already happened; refuse rather than risk wiping the
+	// migrated data.
+	if t.Delete {
+		srcEmpty, err := isDirEmpty(runtime, OlaresJuiceFSRootDir)
+		if err != nil {
+			return err
+		}
+		if srcEmpty {
+			dstEmpty, err := isDirEmpty(runtime, MigrationTempMountPoint)
+			if err != nil {
+				return err
+			}
+			if !dstEmpty {
+				return fmt.Errorf("refusing to run a destructive sync: source rootfs %s is empty while JuiceFS at %s already holds data; "+
+					"this usually means the rootfs was already migrated and swapped, aborting to avoid wiping migrated data",
+					OlaresJuiceFSRootDir, MigrationTempMountPoint)
+			}
+		}
+	}
+
 	flags := "-aHAX --numeric-ids"
 	// JuiceFS exposes internal control files at the mount root (.accesslog,
 	// .config, .stats, .trash, .control). They exist only on the destination
@@ -269,6 +407,9 @@ func (t *SyncRootFSData) Execute(runtime connector.Runtime) error {
 	cmd := fmt.Sprintf("rsync %s %s/ %s/", flags, OlaresJuiceFSRootDir, MigrationTempMountPoint)
 	if _, err := runtime.GetRunner().SudoCmd(cmd, true, true); err != nil {
 		return errors.Wrap(err, "failed to sync rootfs data into JuiceFS")
+	}
+	if err := advanceMigratePhase(phaseSynced); err != nil {
+		return errors.Wrap(err, "failed to record migration phase after syncing rootfs data")
 	}
 	return nil
 }
@@ -302,6 +443,10 @@ type BackupAndSwapRootFS struct {
 }
 
 func (t *BackupAndSwapRootFS) Execute(runtime connector.Runtime) error {
+	if readMigratePhase() >= phaseSwapped {
+		logger.Info("rootfs has already been backed up and swapped, skipping")
+		return nil
+	}
 	if IsJuiceFSEnabled() {
 		logger.Info("JuiceFS is already enabled, skipping rootfs backup and swap")
 		return nil
@@ -315,6 +460,17 @@ func (t *BackupAndSwapRootFS) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 
+	// Refuse to swap an empty rootfs: that means the data was never synced (or
+	// the rootfs was already swapped without the marker being recorded), and
+	// swapping it would leave the running system on an empty JuiceFS.
+	srcEmpty, err := isDirEmpty(runtime, OlaresJuiceFSRootDir)
+	if err != nil {
+		return err
+	}
+	if srcEmpty {
+		return fmt.Errorf("refusing to swap rootfs: %s is empty, the data migration does not appear to have completed", OlaresJuiceFSRootDir)
+	}
+
 	backup := RootFSLocalBackupDir
 	if util.IsExist(backup) {
 		backup = fmt.Sprintf("%s.%d", RootFSLocalBackupDir, time.Now().Unix())
@@ -325,6 +481,9 @@ func (t *BackupAndSwapRootFS) Execute(runtime connector.Runtime) error {
 	}
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s", OlaresJuiceFSRootDir), false, false); err != nil {
 		return errors.Wrap(err, "failed to recreate the rootfs mount point")
+	}
+	if err := advanceMigratePhase(phaseSwapped); err != nil {
+		return errors.Wrap(err, "failed to record migration phase after swapping rootfs")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

`olares-cli node enable-juicefs` converts a single-node master's local rootfs to a JuiceFS-backed rootfs in place. Previously, migration progress was tracked **only** by the existence of the `juicefs.service` file. That single boolean could not distinguish the real intermediate states (`data synced` → `rootfs swapped` → `service enabled` → `fully finalized`), which made an interrupted-then-rerun migration unsafe in two ways:

- **Data loss window:** after the rootfs swap but before the service file is written, the local rootfs is already an empty directory. A re-run would re-execute the `rsync --delete` step from that empty source into the JuiceFS that already holds the migrated data, wiping it. (The original local data still survived in `rootfs.local.bak`, but the running system would mount an empty JuiceFS rootfs.)
- **Stuck-half-configured window:** once the service file existed but before the post-swap finalization (flip `OLARES_SYSTEM_ROOTFS_TYPE` to `jfs` + re-render the fsnotify charts) completed, a re-run short-circuited with "already enabled, nothing to do" and skipped finalization forever.

This PR makes the command fully idempotent and resumable.

## Changes

- **Migration phase marker.** Add a monotonic state file `/olares/.jfs-migrate.state` (`synced` / `swapped` / `enabled` / `finalized`), stored under `/olares` (not under the rootfs that gets swapped) so it survives the swap and persists across runs.
- **Prevent destructive re-sync (data loss).** `SyncRootFSData` now skips once the phase is `>= swapped`, and adds a defensive guard that refuses a `--delete` sync from an empty source into a non-empty JuiceFS even if the marker was lost. `BackupAndSwapRootFS` skips once already swapped and refuses to swap an empty rootfs.
- **Precise short-circuit + resume.** The top-level "nothing to do" exit now triggers only when the migration is **fully finalized** (`IsMigrationFinalized`). If JuiceFS is enabled but not finalized, the run resumes: the migration modules are skipped (data is already on JuiceFS, and this also avoids the precheck wrongly aborting because Olares is running) and only the idempotent finalization steps run. The migration is marked `finalized` after the fsnotify re-render succeeds.
- **Resumable runtime-service regeneration.** Extract the container-runtime (k3s/kubelet) service-unit regeneration into its own always-run, idempotent `RegenerateRuntimeServiceModule`, so it is still applied on a resume even when the migration module is skipped.

### Behavior matrix after this change

| Scenario | Behavior |
|---|---|
| Already fully migrated | Short-circuits, exits "nothing to do" |
| Never migrated | Normal full migration |
| Interrupted during data sync | Resumes and completes the full sync |
| Interrupted after swap, before service file | Re-sync refused; resumes safely without wiping JuiceFS |
| Interrupted after service enabled, before finalization | Resumes finalization (no longer skipped) |

> Compatibility note: nodes migrated by the old code have the service file but no state marker. Their first re-run is treated as "enabled but not finalized" and performs one idempotent finalization pass, then records `finalized` so later runs exit instantly.

## Test plan

- [x] `go build ./...` and `go vet ./...` on the `cli` module pass
- [x] Fresh single-node migration (managed MinIO) completes end-to-end
- [x] Interrupt during data sync, re-run → data fully migrated
- [x] Interrupt right after swap (before service file), re-run → JuiceFS data intact, migration completes
- [x] Interrupt after service enabled (before finalization), re-run → rootfs type flips to `jfs` and fsnotify charts are re-rendered
- [x] Re-run on a fully finalized node → exits immediately with "nothing to do"
- [ ] External S3-compatible backend path (`--storage-type s3/oss/cos`)

Made with [Cursor](https://cursor.com)