### PR TITLE
docs(vitepress): fix logo link 404 by forcing full navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -70,7 +70,7 @@ export default defineVersionedConfig2(withMermaid({
     },
   },
   themeConfig: {
-    logoLink: "https://www.olares.com/",
+    logoLink: { link: "https://www.olares.com/", target: "_self" },
     editLink: {
       pattern: "https://github.com/beclab/Olares/edit/main/docs/:path",
       text: "Edit this page on GitHub",


### PR DESCRIPTION
## Problem

Clicking the nav logo on the production docs site lands on a 404 page.

The logo points at the absolute, same-origin URL `https://www.olares.com/`. In production the docs are served from that same host, so VitePress's SPA router treats the click as an in-app navigation instead of a real external link. The in-app navigation to `/` hits the `'/' -> '/manual/overview'` client redirect and ends up at a non-docs path that 404s.

It works locally and in Vercel preview only because those origins differ from the link's host, so the same click is treated as a genuine external navigation.

The router interception condition (`node_modules/vitepress/dist/client/app/router.js`) skips a link only when it has a `target`/`download` attribute or a different origin. The logo had none, so on the production host it was always intercepted.

## Fix

Give `logoLink` a `target` attribute so VitePress skips interception and performs a real full-page navigation to the marketing homepage in every environment. `_self` keeps it in the same tab, matching normal logo-to-home behavior.

```ts
logoLink: { link: "https://www.olares.com/", target: "_self" },
```

## Testing

- Verify on the production docs host that clicking the logo navigates to the marketing homepage instead of 404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single VitePress theme config change for docs navigation only; no auth, data, or runtime application logic.
> 
> **Overview**
> **Fixes production docs nav logo 404** by changing `themeConfig.logoLink` from a plain URL string to an object with `target: "_self"`.
> 
> On production, docs and the logo URL share `https://www.olares.com/`, so VitePress treated the logo click as in-app routing and landed on a broken path. Adding `target` makes the client skip SPA interception and perform a full navigation to the marketing homepage, matching behavior already seen on other origins (local/preview).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a690c2016e0fe65cef5720743d02cdd1a7963310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->