### PR TITLE
docs(vitepress): fix logo link 404 by forcing full navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,7 +60,7 @@ export default defineVersionedConfig2(withMermaid({
     },
   },
   themeConfig: {
-    logoLink: "https://www.olares.com/",
+    logoLink: { link: "https://www.olares.com/", target: "_self" },
     editLink: {
       pattern: "https://github.com/beclab/Olares/edit/main/docs/:path",
       text: "Edit this page on GitHub",


### PR DESCRIPTION
Backport of the logo-link 404 fix to the `docs-1.12.5` branch.

## Problem

Clicking the nav logo on the production docs site lands on a 404 page.

The logo points at the absolute, same-origin URL `https://www.olares.com/`. In production the docs are served from that same host, so VitePress's SPA router treats the click as an in-app navigation instead of a real external link. The in-app navigation to `/` hits the `'/' -> '/manual/overview'` client redirect and ends up at a non-docs path that 404s.

It works locally and in Vercel preview only because those origins differ from the link's host, so the same click is treated as a genuine external navigation.

## Fix

Give `logoLink` a `target` attribute so VitePress skips interception and performs a real full-page navigation to the marketing homepage in every environment. `_self` keeps it in the same tab, matching normal logo-to-home behavior.

```ts
logoLink: { link: "https://www.olares.com/", target: "_self" },
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single VitePress theme config change with no auth, data, or runtime logic impact.
> 
> **Overview**
> Fixes the production docs nav logo landing on a **404** when docs and the marketing site share `https://www.olares.com/`.
> 
> `themeConfig.logoLink` is changed from a plain URL string to `{ link: "https://www.olares.com/", target: "_self" }` so VitePress does not treat the click as in-app SPA routing (which was resolving to `/` and the client redirect chain). **`target: "_self"`** keeps a full-page navigation to the homepage in the same tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c9fea70ac596f156c1b73d2757634d153c21b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->