### PR TITLE
fix(l4): remove listening port 443/444 ready check

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -147,7 +147,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.34"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.35"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.34
+          value: v0.3.35
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.34
+      name: beclab/l4-bfl-proxy:v0.3.35
 # must have blank new line            

--- a/framework/l4-bfl-proxy/cmd/main.go
+++ b/framework/l4-bfl-proxy/cmd/main.go
@@ -123,9 +123,9 @@ func main() {
 	}
 	// Fail readiness when Envoy rejects the pushed xDS config (e.g. a bad
 	// listener that leaves ports 443/444 not listening).
-	if err := mgr.AddReadyzCheck("envoy-config", xdsSrv.ReadyCheck); err != nil {
-		klog.Fatalf("set up envoy-config ready check failed: %v", err)
-	}
+	//if err := mgr.AddReadyzCheck("envoy-config", xdsSrv.ReadyCheck); err != nil {
+	//	klog.Fatalf("set up envoy-config ready check failed: %v", err)
+	//}
 
 	runners := []runner.Runner{
 		prov,


### PR DESCRIPTION


* **Background**
fix(l4): remove listening port 443/444 ready check
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches L4 ingress readiness semantics for user HTTPS (443/444); pods may report Ready without verifying Envoy listeners, which can affect rollout detection during bad xDS config.
> 
> **Overview**
> Ships **l4-bfl-proxy v0.3.35** by updating the image tag in the CLI upgrade task (`UpgradeL4BFLProxy`), BFL launcher env `L4_PROXY_IMAGE_VERSION`, and Olares prebuilt output.
> 
> The functional change in **v0.3.35** disables the **`envoy-config` Kubernetes readiness probe** that called `xdsSrv.ReadyCheck` and could mark the pod NotReady when Envoy rejected xDS or critical listeners on **443/444** were not bound. Readiness now relies on **`cache-synced`** only; the Envoy config check is left commented in `main.go` with the original rationale noted in code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5503aa1b855e9b2c6699dd0796cb0f8cfda8f799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->