### PR TITLE
Revert "fix(daemon): reduce NetworkManager CPU from frequent nmcli polling"

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -131,13 +131,13 @@ func CheckCurrentStatus(ctx context.Context) error {
 		return err
 	}
 
-	// Use a single lightweight enumeration that also switches unmanaged
-	// devices to managed. CheckCurrentStatus only reads Name/Type/Connection
-	// below, so the expensive per-device detail queries are intentionally
-	// skipped here to avoid hammering NetworkManager on this 5s poll.
-	devices, err := utils.ManagedDeviceStatus(ctx)
+	if _, err := utils.ManagedAllDevices(ctx); err != nil {
+		klog.Error("managed all devices error, ", err)
+	}
+
+	devices, err := utils.GetAllDevice(ctx)
 	if err != nil {
-		klog.Error("managed device status error, ", err)
+		klog.Error(err)
 	}
 
 	// clear value

--- a/daemon/pkg/utils/network.go
+++ b/daemon/pkg/utils/network.go
@@ -35,11 +35,6 @@ func ManagedAllDevices(ctx context.Context) (map[string]Device, error) {
 	return nil, nil
 }
 
-func ManagedDeviceStatus(ctx context.Context) (map[string]Device, error) {
-	klog.Warning("not implement")
-	return nil, nil
-}
-
 func UpdateNetworkTraffic(ctx context.Context) {
 	klog.Warning("not implement")
 }

--- a/daemon/pkg/utils/network_linux.go
+++ b/daemon/pkg/utils/network_linux.go
@@ -79,87 +79,55 @@ func EnableWifi(ctx context.Context) error {
 }
 
 func GetWifiDevice(ctx context.Context) (map[string]Device, error) {
-	return deviceStatus(ctx, func(d *Device) bool { return d.Type == "wifi" }, true)
-}
-
-// managedByOthers reports whether the device is managed by another component
-// (CNI, tunnels, tailscale, ...) and should be skipped by NetworkManager logic.
-func managedByOthers(name string) bool {
-	for _, devPrefix := range []string{"cali", "kube", "tun", "tailscale"} {
-		if strings.HasPrefix(name, devPrefix) {
-			return true
-		}
-	}
-	return false
+	return deviceStatus(ctx, func(d *Device) bool { return d.Type == "wifi" })
 }
 
 func GetAllDevice(ctx context.Context) (map[string]Device, error) {
 	return deviceStatus(ctx, func(d *Device) bool {
-		return !managedByOthers(d.Name)
-	}, true)
-}
+		managedByOthers := []string{"cali", "kube", "tun", "tailscale"}
+		for _, devPrefix := range managedByOthers {
+			if strings.HasPrefix(d.Name, devPrefix) {
+				return false
+			}
+		}
 
-// setDeviceManaged switches a single device to managed via nmcli.
-func setDeviceManaged(ctx context.Context, name string) error {
-	nmcli, err := findCommand(ctx, "nmcli")
-	if err != nil {
-		klog.Error("find nmcli error, ", err)
-		return err
-	}
-
-	cmd := exec.CommandContext(ctx, nmcli, "device", "set", name, "managed", "yes")
-	cmd.Env = os.Environ()
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		klog.Error("exec cmd error, ", err, ", nmcli device set ", name, " managed yes")
-		return err
-	}
-	if strings.Contains(string(output), "Error") {
-		err = errors.New(string(output))
-		klog.Error("exec cmd error, ", err, ", nmcli device set ", name, " managed yes")
-		return err
-	}
-	return nil
+		return true
+	})
 }
 
 func ManagedAllDevices(ctx context.Context) (map[string]Device, error) {
 	return deviceStatus(ctx, func(d *Device) bool {
-		if managedByOthers(d.Name) {
-			return false
+		managedByOthers := []string{"cali", "kube", "tun", "tailscale"}
+		for _, devPrefix := range managedByOthers {
+			if strings.HasPrefix(d.Name, devPrefix) {
+				return false
+			}
 		}
 		if d.State == "unmanaged" {
-			if err := setDeviceManaged(ctx, d.Name); err != nil {
+			nmcli, err := findCommand(ctx, "nmcli")
+			if err != nil {
+				klog.Error("find nmcli error, ", err)
+				return false
+			}
+
+			cmd := exec.CommandContext(ctx, nmcli, "device", "set", d.Name, "managed", "yes")
+			cmd.Env = os.Environ()
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				klog.Error("exec cmd error, ", err, ", nmcli device set ", d.Name, " managed yes")
+				return false
+			}
+			if strings.Contains(string(output), "Error") {
+				err = errors.New(string(output))
+				klog.Error("exec cmd error, ", err, ", nmcli device set ", d.Name, " managed yes")
 				return false
 			}
 		}
 		return true
-	}, true)
+	})
 }
 
-// ManagedDeviceStatus enumerates network devices with a single
-// `nmcli device status` call and, in the same pass, switches any unmanaged
-// device to managed. It deliberately skips the per-device `nmcli device show`
-// / `nmcli connection show` fan-out (i.e. it does not populate IP/gateway/DNS/
-// method fields), because the frequent state-polling path only needs
-// Name/Type/State/Connection. This replaces the previous back-to-back
-// ManagedAllDevices + GetAllDevice calls, which together spawned ~(4 + 8M)
-// bash/nmcli processes per poll (M = device count) and kept NetworkManager
-// busy.
-func ManagedDeviceStatus(ctx context.Context) (map[string]Device, error) {
-	return deviceStatus(ctx, func(d *Device) bool {
-		if managedByOthers(d.Name) {
-			return false
-		}
-		if d.State == "unmanaged" {
-			if err := setDeviceManaged(ctx, d.Name); err != nil {
-				return false
-			}
-		}
-		return true
-	}, false)
-}
-
-func deviceStatus(ctx context.Context, filter func(d *Device) bool, details bool) (map[string]Device, error) {
+func deviceStatus(ctx context.Context, filter func(d *Device) bool) (map[string]Device, error) {
 	nmcli, err := findCommand(ctx, "nmcli")
 	if err != nil {
 		return nil, err
@@ -193,12 +161,10 @@ func deviceStatus(ctx context.Context, filter func(d *Device) bool, details bool
 		}
 
 		if filter == nil || filter(&d) {
-			if details {
-				err = showDeviceByNM(ctx, d.Name, &d)
-				if err != nil {
-					klog.Error("failed to get device details for ", d.Name, ": ", err)
-					continue
-				}
+			err = showDeviceByNM(ctx, d.Name, &d)
+			if err != nil {
+				klog.Error("failed to get device details for ", d.Name, ": ", err)
+				continue
 			}
 
 			statuss[d.Name] = d

--- a/daemon/pkg/utils/network_types.go
+++ b/daemon/pkg/utils/network_types.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"k8s.io/klog/v2"
 )
@@ -33,39 +32,16 @@ type BridgeConnection struct {
 	Ipv4Address string
 }
 
-var (
-	cmdPathCache   = make(map[string]string)
-	cmdPathCacheMu sync.RWMutex
-)
-
-// findCommand resolves the absolute path of cmdName. The result is cached
-// because callers (nmcli wrappers) invoke it on every command, and the
-// previous implementation forked a `bash -c "command -v ..."` subprocess
-// each time. On the 5s state-polling path this doubled the process churn
-// against NetworkManager. The executable path is effectively immutable for
-// the lifetime of the daemon, so a process-wide cache is safe.
-func findCommand(ctx context.Context, cmdName string) (string, error) {
-	cmdPathCacheMu.RLock()
-	cached, ok := cmdPathCache[cmdName]
-	cmdPathCacheMu.RUnlock()
-	if ok {
-		return cached, nil
-	}
-
+func findCommand(ctx context.Context, cmdName string) (cmdPath string, err error) {
 	cmd := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("command -v %s", cmdName))
 	cmd.Env = os.Environ()
 	output, err := cmd.Output()
 	if err != nil {
-		klog.Error("find command error, ", cmdName, ", ", err)
-		return "", err
+		klog.Error("find nmcli error, ", err)
+		return
 	}
 
-	cmdPath := strings.TrimSpace(string(output))
-	if cmdPath != "" {
-		cmdPathCacheMu.Lock()
-		cmdPathCache[cmdName] = cmdPath
-		cmdPathCacheMu.Unlock()
-	}
+	cmdPath = strings.TrimSpace(string(output))
 
-	return cmdPath, nil
+	return
 }


### PR DESCRIPTION
Reverts beclab/Olares#3545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores heavier NetworkManager/nmcli load on a hot 5s daemon loop; functional networking behavior should match pre-fix code but host CPU/stability may regress.
> 
> **Overview**
> **Reverts** the NetworkManager CPU reduction from Olares#3545. The daemon’s ~5s `CheckCurrentStatus` path no longer uses a single lightweight `ManagedDeviceStatus` pass; it again calls **`ManagedAllDevices`** (to flip unmanaged devices to managed) and then **`GetAllDevice`**, which means two full device enumerations per poll instead of one.
> 
> On Linux, **`ManagedDeviceStatus`** and the **`details`** flag on `deviceStatus` are removed, so every enumeration again runs per-device **`nmcli device show`** / connection lookups. **`setDeviceManaged`** and **`managedByOthers`** are inlined into the filters rather than shared helpers. **`findCommand`** no longer caches resolved binary paths and again shells out via `bash -c command -v` on each lookup.
> 
> **Expected effect:** more `nmcli`/bash subprocess churn and higher NetworkManager load on the status poll, in exchange for the pre-optimization behavior and richer device detail on each call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ccac6a7f4f98193ab12da1aef6501f5f3b4e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->