### PR TITLE
Revert "perf(daemon): cache k8s clients and rest.Config"

### DIFF
--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -9,10 +9,7 @@ import (
 	"k8s.io/klog"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
 	bflconst "bytetrade.io/web3os/bfl/pkg/constants"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -26,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,116 +41,10 @@ const (
 	RoleOwner = "owner"
 )
 
-// K8s clients and the rest.Config are safe for concurrent use and do not need
-// to be rebuilt on every call. olaresd's status loop reconstructs them many
-// times per 5s tick; caching them removes the repeated ctrl.GetConfig +
-// NewForConfig (REST/HTTP/TLS transport) churn. Each value is memoized only on
-// success, so a failure before the cluster is reachable is retried on the next
-// call instead of being cached permanently.
-var (
-	clientCacheMu           sync.Mutex
-	cachedConfig            *rest.Config
-	cachedKubeClient        kubernetes.Interface
-	cachedDynamicClient     dynamic.Interface
-	cachedAppClientSet      *versioned.Clientset
-	cachedApixClient        apixclientset.Interface
-	cachedKubeconfigPath    string
-	cachedKubeconfigModTime time.Time
-)
-
-// kubeconfigPaths resolves the kubeconfig files backing ctrl.GetConfig,
-// mirroring the env/default lookup. ctrl.GetConfig merges every file listed in
-// KUBECONFIG, so all of them are tracked for freshness. It returns nil when no
-// file applies (e.g. in-cluster), in which case the freshness check is skipped.
-func kubeconfigPaths() []string {
-	if v := os.Getenv("KUBECONFIG"); v != "" {
-		if parts := filepath.SplitList(v); len(parts) > 0 {
-			return parts
-		}
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil
-	}
-	return []string{filepath.Join(home, ".kube", "config")}
-}
-
-// ensureFreshLocked invalidates the cached config and clients when any tracked
-// kubeconfig file changes (e.g. IP change or k3s cert rotation), so olaresd
-// recovers without a restart instead of pinning a stale config forever.
-// Callers must hold clientCacheMu.
-func ensureFreshLocked() {
-	paths := kubeconfigPaths()
-	if len(paths) == 0 {
-		return
-	}
-	key := strings.Join(paths, string(os.PathListSeparator))
-	var modTime time.Time
-	for _, p := range paths {
-		info, err := os.Stat(p)
-		if err != nil {
-			continue
-		}
-		if mt := info.ModTime(); mt.After(modTime) {
-			modTime = mt
-		}
-	}
-	if modTime.IsZero() {
-		// None of the tracked files are readable right now; keep any cached
-		// clients. A momentarily-missing file (e.g. during an atomic rewrite)
-		// should not tear down a working in-memory client.
-		return
-	}
-	if cachedConfig == nil {
-		cachedKubeconfigPath = key
-		cachedKubeconfigModTime = modTime
-		return
-	}
-	if key == cachedKubeconfigPath && modTime.Equal(cachedKubeconfigModTime) {
-		return
-	}
-	klog.Info("kubeconfig changed, rebuilding k8s clients")
-	cachedConfig = nil
-	cachedKubeClient = nil
-	cachedDynamicClient = nil
-	cachedAppClientSet = nil
-	cachedApixClient = nil
-	cachedKubeconfigPath = key
-	cachedKubeconfigModTime = modTime
-}
-
-// configLocked returns the cached rest.Config, loading it once on first
-// success. Callers must hold clientCacheMu.
-func configLocked() (*rest.Config, error) {
-	if cachedConfig != nil {
-		return cachedConfig, nil
-	}
+func GetKubeClient() (kubernetes.Interface, error) {
 	config, err := ctrl.GetConfig()
 	if err != nil {
-		return nil, err
-	}
-	cachedConfig = config
-	return config, nil
-}
-
-// GetConfig returns the cached rest.Config, loading it once on first success.
-func GetConfig() (*rest.Config, error) {
-	clientCacheMu.Lock()
-	defer clientCacheMu.Unlock()
-	ensureFreshLocked()
-	return configLocked()
-}
-
-func GetKubeClient() (kubernetes.Interface, error) {
-	clientCacheMu.Lock()
-	defer clientCacheMu.Unlock()
-	ensureFreshLocked()
-	if cachedKubeClient != nil {
-		return cachedKubeClient, nil
-	}
-
-	config, err := configLocked()
-	if err != nil {
+		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -164,20 +54,13 @@ func GetKubeClient() (kubernetes.Interface, error) {
 		return nil, err
 	}
 
-	cachedKubeClient = client
 	return client, nil
 }
 
 func GetDynamicClient() (dynamic.Interface, error) {
-	clientCacheMu.Lock()
-	defer clientCacheMu.Unlock()
-	ensureFreshLocked()
-	if cachedDynamicClient != nil {
-		return cachedDynamicClient, nil
-	}
-
-	config, err := configLocked()
+	config, err := ctrl.GetConfig()
 	if err != nil {
+		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -187,20 +70,13 @@ func GetDynamicClient() (dynamic.Interface, error) {
 		return nil, err
 	}
 
-	cachedDynamicClient = client
 	return client, nil
 }
 
 func GetAppClientSet() (versioned.Clientset, error) {
-	clientCacheMu.Lock()
-	defer clientCacheMu.Unlock()
-	ensureFreshLocked()
-	if cachedAppClientSet != nil {
-		return *cachedAppClientSet, nil
-	}
-
-	config, err := configLocked()
+	config, err := ctrl.GetConfig()
 	if err != nil {
+		klog.Error("get k8s config error, ", err)
 		return versioned.Clientset{}, err
 	}
 
@@ -210,7 +86,6 @@ func GetAppClientSet() (versioned.Clientset, error) {
 		return versioned.Clientset{}, err
 	}
 
-	cachedAppClientSet = client
 	return *client, nil
 }
 
@@ -701,7 +576,7 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 		klog.Error("list applications error, ", err)
 		return nil, err
 	}
-	config, err := GetConfig()
+	config, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -751,15 +626,9 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 }
 
 func GetApixClient() (apixclientset.Interface, error) {
-	clientCacheMu.Lock()
-	defer clientCacheMu.Unlock()
-	ensureFreshLocked()
-	if cachedApixClient != nil {
-		return cachedApixClient, nil
-	}
-
-	config, err := configLocked()
+	config, err := ctrl.GetConfig()
 	if err != nil {
+		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -769,7 +638,6 @@ func GetApixClient() (apixclientset.Interface, error) {
 		return nil, err
 	}
 
-	cachedApixClient = client
 	return client, nil
 }
 


### PR DESCRIPTION
Reverts beclab/Olares#3516

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases load and latency on hot paths (e.g. status loops) and removes automatic recovery when kubeconfig changes without restart; behavior is a known pre-optimization baseline rather than new logic.
> 
> **Overview**
> Reverts the daemon k8s client caching from #3516 in `daemon/pkg/utils/k8s.go`.
> 
> **Removed** the shared mutex-backed cache for `rest.Config`, kube/dynamic/app/apix clients, and kubeconfig mtime-based invalidation (`ensureFreshLocked`, `kubeconfigPaths`, and the exported `GetConfig` helper).
> 
> **Restored** the prior behavior: `GetKubeClient`, `GetDynamicClient`, `GetAppClientSet`, and `GetApixClient` each call `ctrl.GetConfig()` and build a new clientset on every invocation; `GetApplicationUrlAll` again loads config via `ctrl.GetConfig()` instead of `GetConfig()`. Several getters now log config load failures with `klog.Error`.
> 
> This trades repeated REST/transport setup (notably under olaresd’s frequent status polling) for always-fresh kubeconfig without explicit cache invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d8e43c98bd3e782b71e776de486d48f212f8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->