### PR TITLE
Revert "perf(daemon): cache static machine info, GPU and CPU name"

### DIFF
--- a/daemon/pkg/cluster/state/utils.go
+++ b/daemon/pkg/cluster/state/utils.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -140,27 +139,7 @@ func IsIpChangeRunning() (bool, error) {
 	return running, err
 }
 
-var (
-	machineInfoMu     sync.Mutex
-	machineInfoCached bool
-	machineInfoCache  struct {
-		osType, osInfo, osArch, osVersion, osKernel string
-	}
-)
-
-// GetMachineInfo returns OS type/info/arch/version/kernel. These are static for
-// the lifetime of the process, but the underlying `olares-cli osinfo show` is a
-// subprocess fork that the status loop ran on every 5s tick. The result is
-// cached after the first successful read; if the CLI is not yet available the
-// call returns empty values and is retried on the next tick.
 func GetMachineInfo(ctx context.Context) (osType, osInfo, osArch, osVersion, osKernel string, err error) {
-	machineInfoMu.Lock()
-	defer machineInfoMu.Unlock()
-	if machineInfoCached {
-		c := machineInfoCache
-		return c.osType, c.osInfo, c.osArch, c.osVersion, c.osKernel, nil
-	}
-
 	cmd := exec.CommandContext(ctx, cli.TERMINUS_CLI, "osinfo", "show")
 
 	if output, err := cmd.Output(); err == nil {
@@ -183,17 +162,6 @@ func GetMachineInfo(ctx context.Context) (osType, osInfo, osArch, osVersion, osK
 				osKernel = kv[1]
 			}
 		}
-	}
-
-	// Cache only once we actually parsed something, so an early-boot read before
-	// olares-cli is ready does not get memoized as permanently empty.
-	if osType != "" || osInfo != "" || osArch != "" || osVersion != "" || osKernel != "" {
-		machineInfoCache.osType = osType
-		machineInfoCache.osInfo = osInfo
-		machineInfoCache.osArch = osArch
-		machineInfoCache.osVersion = osVersion
-		machineInfoCache.osKernel = osKernel
-		machineInfoCached = true
 	}
 
 	return

--- a/daemon/pkg/utils/gpu_linux.go
+++ b/daemon/pkg/utils/gpu_linux.go
@@ -8,58 +8,27 @@ import (
 	"io"
 	"log"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/jaypipes/ghw"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
-// gpuEmptyRescanInterval bounds how often an empty GPU scan is retried, so a
-// node without a GPU does not re-scan the PCI bus on every status tick while a
-// GPU that only appears after boot is still eventually detected.
-const gpuEmptyRescanInterval = 5 * time.Minute
-
-var (
-	gpuInfoMu     sync.Mutex
-	gpuInfoCached bool
-	gpuInfoValue  *string
-	gpuLastScan   time.Time
-)
-
-// GetGpuInfo returns the primary GPU description. GPUs are not hot-plugged at
-// runtime, but scanning the PCI bus via ghw on every status tick is expensive.
-// A found GPU is cached for the process lifetime; an empty scan is retried at
-// most once per gpuEmptyRescanInterval, and a failed scan is retried on the
-// next call.
 func GetGpuInfo() (*string, error) {
-	gpuInfoMu.Lock()
-	defer gpuInfoMu.Unlock()
-	if gpuInfoCached {
-		return gpuInfoValue, nil
-	}
-	if !gpuLastScan.IsZero() && time.Since(gpuLastScan) < gpuEmptyRescanInterval {
-		return gpuInfoValue, nil
-	}
-
 	gpu, err := ghw.GPU(ghw.WithAlerter(log.New(io.Discard, "", 0))) // discard warnings
 	if err != nil {
 		klog.Errorf("Error getting GPU info: %v", err)
 		return nil, err
 	}
-	gpuLastScan = time.Now()
 
 	var first string
-	var result *string
 	for _, card := range gpu.GraphicsCards {
 		if card.DeviceInfo == nil || card.DeviceInfo.Vendor == nil || card.DeviceInfo.Product == nil {
 			continue
 		}
 		info := fmt.Sprintf("%s %s", card.DeviceInfo.Vendor.Name, card.DeviceInfo.Product.Name)
 		if strings.Contains(strings.ToLower(info), "nvidia") {
-			first = info
-			break
+			return ptr.To(info), nil
 		}
 
 		if first == "" {
@@ -67,13 +36,9 @@ func GetGpuInfo() (*string, error) {
 		}
 	}
 
-	if first != "" {
-		result = ptr.To(first)
+	if first == "" {
+		return nil, nil
 	}
 
-	gpuInfoValue = result
-	if result != nil {
-		gpuInfoCached = true
-	}
-	return result, nil
+	return ptr.To(first), nil
 }

--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -290,26 +289,7 @@ func GetBaseDirFromReleaseFile() (string, error) {
 	return baseDir, nil
 }
 
-var (
-	cpuNameMu    sync.Mutex
-	cpuNameValue string
-)
-
-// GetCPUName returns the CPU brand name. The result is static for the lifetime
-// of the process, so it is cached to avoid the lscpu/dmidecode fallbacks below
-// running on every status tick. An empty result (e.g. a transient boot-time
-// failure) is not cached, so a later tick can still populate it.
 func GetCPUName() string {
-	cpuNameMu.Lock()
-	defer cpuNameMu.Unlock()
-	if cpuNameValue != "" {
-		return cpuNameValue
-	}
-	cpuNameValue = computeCPUName()
-	return cpuNameValue
-}
-
-func computeCPUName() string {
 	brandName := cpu.CPU.BrandName
 	if brandName == "" {
 		// cannot read info from /proc/cpuinfo, try to get from lscpu command

--- a/daemon/pkg/utils/utils_test.go
+++ b/daemon/pkg/utils/utils_test.go
@@ -72,11 +72,6 @@ func TestGetGpu(t *testing.T) {
 		return
 	}
 
-	if s == nil {
-		t.Log("no gpu info")
-		return
-	}
-
 	t.Log(*s)
 }
 


### PR DESCRIPTION
Reverts beclab/Olares#3517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases daemon CPU and I/O on the periodic status loop (~5s) without changing correctness of auth or data handling; possible regressions if the reverted caching fixed boot-time or empty-result edge cases.
> 
> **Overview**
> Reverts the **perf(daemon)** caching from #3517 so machine OS info, GPU detection, and CPU name are computed on **every call** again instead of being memoized for the process lifetime.
> 
> **`GetMachineInfo`** drops mutex-backed cache and always runs `olares-cli osinfo show`. **`GetGpuInfo`** (Linux) drops scan throttling/caching and always walks PCI via `ghw`, while keeping the early return when an NVIDIA card is found. **`GetCPUName`** inlines the former `computeCPUName` path with no one-shot cache. **`TestGetGpu`** no longer skips when GPU info is nil.
> 
> Cluster status refresh in `current.go` still invokes these helpers on its ~5s poll, so this change restores the heavier per-tick work that caching had removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8273b74841a42aacad87b312d69f930fc0bec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->