### PR TITLE
Revert "perf(daemon): make BLE WiFi scan cadence adaptive"

### DIFF
--- a/daemon/internel/ble/ble_common.go
+++ b/daemon/internel/ble/ble_common.go
@@ -12,56 +12,24 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const (
-	// bleScanIntervalActive is used during onboarding (the node is not online
-	// yet), when the LarePass app needs a fresh WiFi AP list to connect.
-	bleScanIntervalActive = 2 * time.Second
-	// bleScanIntervalIdle is used once the node is online, when the AP list
-	// rarely matters. Backing off here removes the bulk of the periodic D-Bus
-	// WiFi scan CPU cost.
-	bleScanIntervalIdle = 30 * time.Second
-)
-
-// scanInterval picks the WiFi scan cadence based on network connectivity:
-// frequent while onboarding (no network), relaxed once the node is online.
-func (s *service) scanInterval() time.Duration {
-	if state.CurrentState.WiredConnected || state.CurrentState.WifiConnected {
-		return bleScanIntervalIdle
-	}
-	return bleScanIntervalActive
-}
-
 func (s *service) Start() {
+	ticker := time.NewTicker(2 * time.Second)
 	go func() {
-		defer s.cancel()
-		s.scanOnce()
-		lastScan := time.Now()
-		// Poll at the active cadence so a connectivity drop is noticed within a
-		// couple of seconds, but only run the expensive D-Bus scan when due:
-		// every tick while offline, every bleScanIntervalIdle once online.
 		for {
-			timer := time.NewTimer(bleScanIntervalActive)
 			select {
 			case <-s.ctx.Done():
-				timer.Stop()
-				return
+				s.cancel()
+				ticker.Stop()
 
-			case <-timer.C:
-				if time.Since(lastScan) >= s.scanInterval() {
-					s.scanOnce()
-					lastScan = time.Now()
+			case <-ticker.C:
+				s.getAPList()
+				s.getTerminusInfo()
+				if s.update != nil {
+					s.update()
 				}
 			}
 		}
 	}()
-}
-
-func (s *service) scanOnce() {
-	s.getAPList()
-	s.getTerminusInfo()
-	if s.update != nil {
-		s.update()
-	}
 }
 
 func (s *service) Stop() {


### PR DESCRIPTION
Reverts beclab/Olares#3519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores higher D-Bus WiFi scan frequency on online nodes, which was the original CPU motivation for the reverted perf change; behavior is otherwise a return to the prior onboarding path.
> 
> **Overview**
> Reverts the adaptive BLE WiFi scan cadence from #3519 and restores a **fixed 2-second** polling loop in `ble_common.go`.
> 
> The revert removes `bleScanIntervalActive` / `bleScanIntervalIdle`, `scanInterval()` (which slowed scans to 30s when wired or WiFi was connected), and the `scanOnce` helper. The background goroutine again uses `time.NewTicker(2 * time.Second)` and runs `getAPList()`, `getTerminusInfo()`, and the optional `update` callback on every tick. Shutdown handling on `ctx.Done()` is simplified compared to the adaptive version (cancel + stop ticker in the done branch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a978a8d926a03327e9fcb2ca97c63eac145150d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->