### PR TITLE
fix(oac): strip UTF-8 BOM before regex-based chart scans

### DIFF
--- a/framework/oac/appdata.go
+++ b/framework/oac/appdata.go
@@ -2,6 +2,7 @@ package oac
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -20,6 +21,9 @@ var (
 
 // findFirstTemplateRef scans templates/*.yaml under oacPath and returns the
 // basename of the first file whose content matches re, or "" when none match.
+//
+// File bytes are passed through stripUTF8BOM before scanning; see the
+// helper's doc for the BOM-induced false-negative this guards against.
 func findFirstTemplateRef(oacPath string, re *regexp.Regexp) (string, error) {
 	if !strings.HasSuffix(oacPath, string(filepath.Separator)) {
 		oacPath += string(filepath.Separator)
@@ -33,12 +37,11 @@ func findFirstTemplateRef(oacPath string, re *regexp.Regexp) (string, error) {
 		if !strings.HasSuffix(path, ".yaml") {
 			return nil
 		}
-		f, e := os.Open(path)
-		if e != nil {
-			return e
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
 		}
-		defer f.Close()
-		scanner := bufio.NewScanner(f)
+		scanner := bufio.NewScanner(bytes.NewReader(stripUTF8BOM(data)))
 		for scanner.Scan() {
 			if re.MatchString(scanner.Text()) {
 				if firstHit == "" {

--- a/framework/oac/chartscan.go
+++ b/framework/oac/chartscan.go
@@ -2,6 +2,7 @@ package oac
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,28 @@ import (
 	"regexp"
 	"strings"
 )
+
+// utf8BOM is the canonical UTF-8 byte-order mark sequence (U+FEFF encoded
+// as three bytes). Editors on Windows and pre-7 PowerShell pipelines often
+// emit it at the head of newly-saved YAML files.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripUTF8BOM trims a leading UTF-8 BOM from data, returning data
+// otherwise unchanged.
+//
+// The chart-scan rules in this package match ^-anchored regexes against
+// chart files line by line. Go's regexp \s class does not include U+FEFF,
+// so an unstripped BOM at column 0 of the first line silently breaks the
+// kind: / replicas: anchors and turns the affected rule into a no-op for
+// the entire first YAML document. YAML/Helm parsers tolerate the BOM
+// transparently, so the same file renders fine and the regression goes
+// unnoticed (see the codeserver fleet-report case where chartmuseum.yaml's
+// hardcoded `replicas: 1` slipped past checkWorkloadReplicaTemplates).
+// Callers should run file bytes through this helper before handing them
+// off to the line-oriented scanners below.
+func stripUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
 
 // olaresUserChartRef matches user-level environment variable names embedded in
 // chart files. v3 apps must reference app envs via .Values.olaresEnv.<envName>
@@ -62,6 +85,10 @@ func shouldScanChartFile(oacPath, path string) bool {
 // findFirstInChartFiles scans chart templates and values.yaml files under
 // oacPath (including subcharts) and returns the relative path of the first
 // file whose content matches re.
+//
+// File bytes are passed through stripUTF8BOM before scanning so a leading
+// UTF-8 BOM on Windows-authored files doesn't desynchronise ^-anchored
+// patterns from the first line.
 func findFirstInChartFiles(oacPath string, re *regexp.Regexp) (string, error) {
 	if !strings.HasSuffix(oacPath, string(filepath.Separator)) {
 		oacPath += string(filepath.Separator)
@@ -77,12 +104,11 @@ func findFirstInChartFiles(oacPath string, re *regexp.Regexp) (string, error) {
 		if !shouldScanChartFile(oacPath, path) {
 			return nil
 		}
-		f, e := os.Open(path)
-		if e != nil {
-			return e
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("read %s: %w", path, readErr)
 		}
-		defer f.Close()
-		scanner := bufio.NewScanner(f)
+		scanner := bufio.NewScanner(bytes.NewReader(stripUTF8BOM(data)))
 		for scanner.Scan() {
 			if re.MatchString(scanner.Text()) {
 				if firstHit == "" {
@@ -168,7 +194,7 @@ func checkWorkloadReplicaTemplates(oacPath string, replicas map[string]int32) er
 		if relErr != nil {
 			rel = filepath.Base(path)
 		}
-		errs = append(errs, scanWorkloadReplicaDoc(rel, string(data), replicas)...)
+		errs = append(errs, scanWorkloadReplicaDoc(rel, string(stripUTF8BOM(data)), replicas)...)
 		return nil
 	})
 	if walkErr != nil {

--- a/framework/oac/internal/manifest/envs_test.go
+++ b/framework/oac/internal/manifest/envs_test.go
@@ -5,9 +5,20 @@ import (
 	"testing"
 )
 
+// v3EnvManifest returns a modern (>= 0.12.0) v3 manifest pre-populated
+// with the trigger-side prerequisites — workloadReplicas and the Olares
+// system dependency locked to the post-v3 window — so the assertion in
+// each test focuses on v3 env semantics rather than the manifest-version
+// gate (apiVersion=v3 is itself a 1.12.6-only trigger, so the legacy
+// fixture would otherwise trip validateModernFieldRequiresManifestVersion
+// before envs are even inspected).
 func v3EnvManifest(envs []AppEnvVar) *AppConfiguration {
 	c := newValidConfig()
+	c.ConfigVersion = "0.13.0"
 	c.APIVersion = APIVersionV3
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	c.Envs = envs
 	return c
 }

--- a/framework/oac/internal/manifest/probe.go
+++ b/framework/oac/internal/manifest/probe.go
@@ -18,11 +18,21 @@ var (
 	apiVersionRE    = regexp.MustCompile(`^apiVersion\s*:\s*(.*)$`)
 )
 
+// utf8BOM is the canonical UTF-8 byte-order mark sequence (U+FEFF encoded
+// as three bytes). YAML files saved by Windows editors and pre-7
+// PowerShell pipelines often start with one; the regexes below are
+// ^-anchored, and Go's \s class does not include U+FEFF, so an unstripped
+// BOM at column 0 would desynchronise the very first line from
+// olaresVersionRE / apiVersionRE and send the dispatch through the wrong
+// (legacy vs modern) pipeline. We strip it once at the top of Peek so the
+// downstream scanner sees the same first line a BOM-less file would.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
 // Peek extracts OlaresVersion and APIVersion from content using a
 // line-oriented regex scan instead of a full YAML decode.
 func Peek(content []byte) (Header, error) {
 	var h Header
-	scanner := bufio.NewScanner(bytes.NewReader(content))
+	scanner := bufio.NewScanner(bytes.NewReader(bytes.TrimPrefix(content, utf8BOM)))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/framework/oac/internal/manifest/probe_test.go
+++ b/framework/oac/internal/manifest/probe_test.go
@@ -182,3 +182,21 @@ func TestPeek_HandlesCRLF(t *testing.T) {
 		t.Fatalf("unexpected header: %+v", h)
 	}
 }
+
+// TestPeek_HandlesUTF8BOM exercises the same Windows-editor scenario the
+// chart-scan rules guard against: manifests written with a leading UTF-8
+// BOM (EF BB BF). The header probe uses ^-anchored regexes whose \s does
+// NOT match U+FEFF, so without an explicit strip the BOM sticks to
+// "olaresManifest.version" and the header silently comes back empty,
+// which would send the manifest down the wrong dispatch pipeline
+// (legacy vs modern) downstream.
+func TestPeek_HandlesUTF8BOM(t *testing.T) {
+	content := []byte("\ufeff" + "olaresManifest.version: 0.12.0\napiVersion: v3\n")
+	h, err := Peek(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.OlaresVersion != "0.12.0" || h.APIVersion != "v3" {
+		t.Fatalf("unexpected header: %+v", h)
+	}
+}

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -113,6 +113,7 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 		validatePermission(c.ConfigVersion, c.Permission),
 		validateRootProvider(c.ConfigVersion, c.Provider),
 		validateWorkloadReplicas(c.ConfigVersion, c.APIVersion, c.WorkloadReplicas),
+		validateModernFieldRequiresManifestVersion(c),
 		validateOlaresDependency(c),
 		validateSharedAppRequirements(c),
 		validateV3Configuration(c),
@@ -468,8 +469,11 @@ func validateFlatResourceQuantities(spec *AppSpec, templateOnly bool) error {
 //     modern manifest must leave it empty so the platform can finish
 //     migrating callers away from it.
 //
-// permission.appCommon (access to the Common directory) is accepted at
-// every version and needs no extra validation here.
+// permission.appCommon (access to the cross-app Common directory) is a
+// >= 1.12.6 field and is gated by validateModernFieldRequiresManifestVersion
+// (requires olaresManifest.version >= 0.12.0 + Olares dep locked to
+// >=1.12.6-0), so this function deliberately leaves it alone — adding a
+// check here would emit a duplicate error.
 func validatePermission(configVersion string, p Permission) error {
 	var errs []error
 	if p.ExternalData && !resourcesCheckApplies(configVersion) {
@@ -581,6 +585,48 @@ func pickOlaresDepRule(c *AppConfiguration) (rule olaresDepConstraintRule, featu
 		return olaresDepRulePostV3, triggers
 	}
 	return olaresDepRulePreV3, nil
+}
+
+// validateModernFieldRequiresManifestVersion is the inverse gate of
+// validateOlaresDependency: it fires only on LEGACY manifests
+// (olaresManifest.version < 0.12.0) and rejects any manifest that
+// declares a field whose semantics only exist on Olares 1.12.6+.
+//
+// Two trigger sources are checked:
+//
+//   - apiVersion=v3 — the v3 runtime itself ships with Olares 1.12.6+.
+//   - any field returned by detectOlares1126OnlyFields (spec.accelerator,
+//     workloadReplicas, overlayGateway, options.LLMGatewaySupported,
+//     options.templateOnly, options.shared, permission.appCommon).
+//
+// When any trigger is declared the manifest must bump
+// olaresManifest.version to at least 0.12.0 AND lock
+// options.dependencies[name=olares].version to ">=1.12.6-0". The
+// dependency-side check itself is owned by validateOlaresDependency
+// (which only runs on modern manifests), so this function deliberately
+// stays out of the legacy-but-no-triggers branch: pre-existing legacy
+// manifests with no modern fields keep their historical freedom to
+// declare any (or no) Olares dependency. The error message names the
+// triggers so a manifest that backslid on multiple fields surfaces them
+// all in one Lint run, and explicitly states the >=1.12.6-0 requirement
+// to spare the user a second round trip once they bump the version.
+func validateModernFieldRequiresManifestVersion(c *AppConfiguration) error {
+	if resourcesCheckApplies(c.ConfigVersion) {
+		return nil
+	}
+	var triggers []string
+	if normalizeAPIVersion(c.APIVersion) == APIVersionV3 {
+		triggers = append(triggers, "apiVersion=v3")
+	}
+	triggers = append(triggers, detectOlares1126OnlyFields(c)...)
+	if len(triggers) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"olaresManifest.version must be >= %s when the manifest declares %s; bump olaresManifest.version to >= %s and lock options.dependencies[name=%s].version to \">=1.12.6-0\"",
+		minResourcesManifestVersion, strings.Join(triggers, " / "),
+		minResourcesManifestVersion, olaresSystemDepName,
+	)
 }
 
 // validateOlaresDependency enforces the rules on the Olares system

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -74,8 +74,17 @@ func TestAppConfiguration_APIVersionEnum(t *testing.T) {
 		t.Fatalf("empty apiVersion should be accepted: %v", err)
 	}
 
+	// apiVersion=v3 is a 1.12.6-only trigger, so the legacy baseline
+	// trips validateModernFieldRequiresManifestVersion. Pair v3 with a
+	// modern manifest version + locked Olares dep so the assertion
+	// really tracks the apiVersion enum rule rather than the
+	// manifest-version gate.
 	c = newValidConfig()
+	c.ConfigVersion = "0.13.0"
 	c.APIVersion = APIVersionV3
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("apiVersion=v3 should be accepted: %v", err)
 	}
@@ -1045,9 +1054,17 @@ func TestPolicy_DurationPattern(t *testing.T) {
 	}
 }
 
-// TestPermission_ExternalDataVersionGate documents that permission.externalData
-// is only accepted on modern manifests (olaresManifest.version >= 0.12.0).
-// permission.appCommon carries no such gate and must validate at any version.
+// TestPermission_ExternalDataVersionGate documents that
+// permission.externalData and permission.appCommon are both gated by
+// olaresManifest.version >= 0.12.0:
+//
+//   - permission.externalData was introduced at 0.12.0; the gate is
+//     enforced directly by validatePermission and emits a message naming
+//     the field.
+//   - permission.appCommon is one of the 1.12.6-only trigger fields, so
+//     the gate fires from validateModernFieldRequiresManifestVersion and
+//     additionally requires options.dependencies[name=olares].version to
+//     be locked to ">=1.12.6-0".
 func TestPermission_ExternalDataVersionGate(t *testing.T) {
 	// externalData on a legacy (< 0.12.0) manifest is rejected.
 	c := newValidConfig() // ConfigVersion "0.11.0"
@@ -1074,11 +1091,30 @@ func TestPermission_ExternalDataVersionGate(t *testing.T) {
 		t.Fatalf("permission.externalData should be accepted at >= 0.12.0: %v", err)
 	}
 
-	// appCommon is unconstrained: it must validate on a legacy manifest.
+	// appCommon on a legacy (< 0.12.0) manifest is rejected by
+	// validateModernFieldRequiresManifestVersion: appCommon is one of
+	// the 1.12.6-only trigger fields and demands both
+	// olaresManifest.version >= 0.12.0 and a locked Olares dep.
 	c = newValidConfig()
 	c.Permission.AppCommon = true
+	err = ValidateAppConfiguration(c)
+	if err == nil {
+		t.Fatal("expected error for permission.appCommon on olaresManifest.version < 0.12.0")
+	}
+	if !strings.Contains(err.Error(), "permission.appCommon") {
+		t.Fatalf("error should mention permission.appCommon, got: %v", err)
+	}
+
+	// appCommon on a modern manifest validates once the prerequisites
+	// (workloadReplicas + locked Olares dep) are in place.
+	c = newValidConfig()
+	c.ConfigVersion = "0.13.0"
+	c.Permission.AppCommon = true
+	wr = WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
-		t.Fatalf("permission.appCommon should be accepted at any version: %v", err)
+		t.Fatalf("permission.appCommon should validate on modern manifest with locked dep: %v", err)
 	}
 }
 
@@ -1092,8 +1128,33 @@ func newValidOverlayEntrance() OverlayEntrance {
 	}
 }
 
-func TestOverlayGateway_ValidEntrance(t *testing.T) {
+// newOverlayGatewayBaseline returns a modern (>= 0.12.0) baseline that
+// declares the prerequisites overlayGateway requires:
+//
+//   - olaresManifest.version=0.13.0 — overlayGateway is a 1.12.6-only
+//     feature field, so the legacy fixture would trip
+//     validateModernFieldRequiresManifestVersion before the overlay
+//     entrance is even inspected.
+//   - workloadReplicas with one entry — required on every non-v2 modern
+//     manifest, and the test wouldn't be exercising overlay-specific
+//     behaviour if it failed for missing replicas instead.
+//   - the olares system dependency locked to the post-v3 window —
+//     overlayGateway promotes the dep window to >=1.12.6-0 via
+//     pickOlaresDepRule, so the helper picks that automatically.
+//
+// Each test then layers exactly one overlay entrance on top so the
+// assertion focuses on overlay rules alone.
+func newOverlayGatewayBaseline() *AppConfiguration {
 	c := newValidConfig()
+	c.ConfigVersion = "0.13.0"
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
+	return c
+}
+
+func TestOverlayGateway_ValidEntrance(t *testing.T) {
+	c := newOverlayGatewayBaseline()
 	c.OverlayGateway = OverlayGateway{
 		Enable:    true,
 		Entrances: []OverlayEntrance{newValidOverlayEntrance()},
@@ -1117,7 +1178,7 @@ func TestOverlayGateway_ProtocolEnum(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
-			c := newValidConfig()
+			c := newOverlayGatewayBaseline()
 			e := newValidOverlayEntrance()
 			e.Protocol = tc.value
 			c.OverlayGateway = OverlayGateway{Enable: true, Entrances: []OverlayEntrance{e}}
@@ -1185,9 +1246,18 @@ func TestOptions_TemplateOnlyRequiresAllowMultipleInstall(t *testing.T) {
 		t.Fatal("expected error: explicit allowMultipleInstall=false still violates the rule")
 	}
 
+	// templateOnly is a 1.12.6-only trigger, so the happy-path case
+	// requires a modern manifest with the prerequisites
+	// (workloadReplicas + locked Olares dep). Without them the new
+	// validateModernFieldRequiresManifestVersion gate would mask the
+	// templateOnly+allowMultipleInstall pairing under test here.
 	c = newValidConfig()
+	c.ConfigVersion = "0.13.0"
 	c.Options.TemplateOnly = true
 	c.Options.AllowMultipleInstall = true
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("templateOnly=true + allowMultipleInstall=true must pass: %v", err)
 	}
@@ -1202,14 +1272,26 @@ func TestOptions_TemplateOnlyRequiresAllowMultipleInstall(t *testing.T) {
 	}
 }
 
+// TestAppSpec_TemplateOnlyAllowsAutoOnNonDiskLegacy verifies that a
+// template-only manifest may use AutoResourceValue ("-1") on the legacy
+// flat cpu/memory fields. "Legacy" in the name refers to the legacy
+// resource ENVELOPE (flat spec.required*/limited* fields) rather than
+// the manifest version itself: templateOnly is a 1.12.6-only trigger,
+// so the manifest must still declare olaresManifest.version >= 0.12.0
+// and lock the Olares dep. The legacy flat envelope remains a supported
+// shape at modern versions when spec.resources[] is not used.
 func TestAppSpec_TemplateOnlyAllowsAutoOnNonDiskLegacy(t *testing.T) {
 	c := newValidConfig()
+	c.ConfigVersion = "0.13.0"
 	c.Options.TemplateOnly = true
 	c.Options.AllowMultipleInstall = true
 	c.Spec.RequiredCPU = AutoResourceValue
 	c.Spec.LimitedCPU = AutoResourceValue
 	c.Spec.RequiredMemory = AutoResourceValue
 	c.Spec.LimitedMemory = AutoResourceValue
+	wr := WorkloadReplicas{c.Metadata.Name: 1}
+	c.WorkloadReplicas = &wr
+	c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("template-only legacy envelope with -1 on cpu/memory must pass: %v", err)
 	}
@@ -1958,6 +2040,182 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 	})
 }
 
+// TestModernFieldRequiresManifestVersion is the inverse of
+// TestOlaresDependency_FeatureTriggersPromoteRange: on a LEGACY manifest
+// (olaresManifest.version < 0.12.0), declaring any 1.12.6-only feature
+// field — or apiVersion=v3 — must be rejected with guidance to bump the
+// manifest version AND lock the Olares dep to >=1.12.6-0.
+//
+// Each subtest starts from the legacy baseline (newValidConfig pins
+// ConfigVersion=0.11.0), flips exactly one trigger, and asserts:
+//
+//  1. validation fails;
+//  2. the error names the field that triggered the gate;
+//  3. the error spells out the >=1.12.6-0 dep requirement so the user
+//     doesn't have to discover it on a second Lint pass after bumping
+//     olaresManifest.version.
+//
+// The "no triggers stay legacy" control case anchors the gate so future
+// edits don't accidentally fire it on plain legacy manifests.
+func TestModernFieldRequiresManifestVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		flip       func(c *AppConfiguration)
+		wantLabel  string
+		extraSetup func(c *AppConfiguration)
+	}{
+		{
+			name: "apiVersion=v3",
+			flip: func(c *AppConfiguration) {
+				c.APIVersion = APIVersionV3
+			},
+			wantLabel: "apiVersion=v3",
+		},
+		{
+			name: "spec.accelerator",
+			flip: func(c *AppConfiguration) {
+				c.Spec.Accelerator = []ResourceMode{{
+					Mode: ResourceModeCPU,
+					ResourceRequirement: ResourceRequirement{
+						RequiredCPU:    "100m",
+						LimitedCPU:     "200m",
+						RequiredMemory: "128Mi",
+						LimitedMemory:  "256Mi",
+						RequiredDisk:   "10Mi",
+						LimitedDisk:    "20Mi",
+					},
+				}}
+			},
+			wantLabel: "spec.accelerator",
+		},
+		{
+			name: "workloadReplicas",
+			flip: func(c *AppConfiguration) {
+				wr := WorkloadReplicas{c.Metadata.Name: 1}
+				c.WorkloadReplicas = &wr
+			},
+			wantLabel: "workloadReplicas",
+		},
+		{
+			name: "overlayGateway",
+			flip: func(c *AppConfiguration) {
+				c.OverlayGateway = OverlayGateway{
+					Enable:    true,
+					Entrances: []OverlayEntrance{newValidOverlayEntrance()},
+				}
+			},
+			wantLabel: "overlayGateway",
+		},
+		{
+			name: "options.LLMGatewaySupported",
+			flip: func(c *AppConfiguration) {
+				c.Options.LLMGatewaySupported = true
+			},
+			wantLabel: "options.LLMGatewaySupported",
+		},
+		{
+			name: "options.templateOnly",
+			flip: func(c *AppConfiguration) {
+				// templateOnly cross-field rule also requires
+				// allowMultipleInstall=true; set it so this assertion
+				// stays focused on the manifest-version gate.
+				c.Options.AllowMultipleInstall = true
+				c.Options.TemplateOnly = true
+			},
+			wantLabel: "options.templateOnly",
+		},
+		{
+			name: "options.shared",
+			flip: func(c *AppConfiguration) {
+				// shared has additional cross-field rules; the
+				// manifest-version gate must fire regardless of those.
+				c.Options.Shared = true
+			},
+			wantLabel: "options.shared",
+		},
+		{
+			name: "permission.appCommon",
+			flip: func(c *AppConfiguration) {
+				c.Permission.AppCommon = true
+			},
+			wantLabel: "permission.appCommon",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"_rejected_on_legacy_manifest", func(t *testing.T) {
+			c := newValidConfig() // ConfigVersion=0.11.0
+			if tc.extraSetup != nil {
+				tc.extraSetup(c)
+			}
+			tc.flip(c)
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("expected error: declaring %s on olaresManifest.version=0.11.0 must be rejected", tc.wantLabel)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tc.wantLabel) {
+				t.Fatalf("error should name the trigger %s, got: %v", tc.wantLabel, err)
+			}
+			if !strings.Contains(msg, "olaresManifest.version must be >= 0.12.0") {
+				t.Fatalf("error should require bumping olaresManifest.version, got: %v", err)
+			}
+			if !strings.Contains(msg, `">=1.12.6-0"`) {
+				t.Fatalf("error should mention the Olares dep lock, got: %v", err)
+			}
+		})
+	}
+
+	t.Run("legacy_without_triggers_accepted", func(t *testing.T) {
+		// Anchor case: a plain legacy manifest must keep validating.
+		// Catches regressions where the new gate accidentally fires on
+		// every legacy manifest.
+		c := newValidConfig()
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("legacy manifest without triggers must validate: %v", err)
+		}
+	})
+
+	t.Run("modern_with_triggers_does_not_double_fire", func(t *testing.T) {
+		// At olaresManifest.version>=0.12.0 the legacy gate must stay
+		// silent — the dep window is owned by validateOlaresDependency.
+		// permission.appCommon would trigger the legacy gate at 0.11.0
+		// but here we expect the error (if any) to come from the dep
+		// check, not from the legacy gate.
+		c := newValidConfig()
+		c.ConfigVersion = "0.13.0"
+		c.Permission.AppCommon = true
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("modern manifest with permission.appCommon and locked dep must validate: %v", err)
+		}
+	})
+
+	t.Run("multiple_triggers_listed_together", func(t *testing.T) {
+		// When several triggers fire on one legacy manifest the gate
+		// should list every offender in a single message so the author
+		// fixes the version once instead of chasing them piecemeal.
+		c := newValidConfig()
+		c.APIVersion = APIVersionV3
+		c.Permission.AppCommon = true
+		wr := WorkloadReplicas{c.Metadata.Name: 1}
+		c.WorkloadReplicas = &wr
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: legacy manifest with multiple triggers")
+		}
+		msg := err.Error()
+		for _, want := range []string{"apiVersion=v3", "workloadReplicas", "permission.appCommon"} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error should list trigger %q, got: %v", want, err)
+			}
+		}
+	})
+}
+
 // TestOptions_SharedRequiresAPIVersionV3 pins down the shared => v3
 // cross-field rule on Options: shared installs only make sense on the v3
 // schema (a single install services multiple users). v1/v2/empty must
@@ -1992,8 +2250,19 @@ func TestOptions_SharedRequiresAPIVersionV3(t *testing.T) {
 			// would mask the apiVersion gate for the v3 happy path. Set
 			// the minimum extra fields it demands so the assertion stays
 			// focused on the shared+v3 rule.
+			//
+			// apiVersion=v3 (and options.shared=true) are 1.12.6-only
+			// triggers, so the legacy fixture would also trip
+			// validateModernFieldRequiresManifestVersion before the v3
+			// happy path is reached. Bump the manifest to a modern
+			// version and pin the Olares dep so the assertion really
+			// tracks the shared/v3 rule and nothing else.
 			if tc.apiVersion == APIVersionV3 && tc.shared {
 				c.Spec.OnlyAdmin = true
+				c.ConfigVersion = "0.13.0"
+				wr := WorkloadReplicas{c.Metadata.Name: 1}
+				c.WorkloadReplicas = &wr
+				c.Options.Dependencies = []Dependency{newOlaresSystemDep(c)}
 			}
 			err := ValidateAppConfiguration(c)
 			if tc.wantErr {

--- a/framework/oac/testdata/wlrbad/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlrbad/OlaresManifest.yaml
@@ -1,4 +1,10 @@
-olaresManifest.version: "0.11.0"
+# Modern manifest version is required: both workloadReplicas and
+# overlayGateway are 1.12.6-only feature fields, which means the
+# validateModernFieldRequiresManifestVersion gate would otherwise
+# short-circuit the test before the chart-render-time overlay workload
+# check (the actual subject of TestLint_OverlayGatewayWorkloadMissing)
+# ever runs.
+olaresManifest.version: "0.13.0"
 olaresManifest.type: app
 apiVersion: v1
 metadata:
@@ -38,3 +44,9 @@ overlayGateway:
 options:
   policies: []
   resetCookie: { enabled: false }
+  # workloadReplicas + overlayGateway are 1.12.6-only triggers, so the
+  # Olares system dep must lock to the post-v3 window.
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.6-0"

--- a/framework/oac/workloadrefs_internal_test.go
+++ b/framework/oac/workloadrefs_internal_test.go
@@ -138,6 +138,30 @@ spec:
 	}
 }
 
+// TestCheckWorkloadReplicaTemplates_HardcodedWithBOM guards against the
+// codeserver regression: chart files saved by Windows editors / older
+// PowerShell pipelines carry a UTF-8 BOM (EF BB BF). Go's regexp \s class
+// does not include U+FEFF, so the kind: / replicas: ^-anchored regexes used
+// to silently skip the first YAML document, turning the rule into a no-op
+// for the entire file. The scan must strip the BOM before matching.
+func TestCheckWorkloadReplicaTemplates_HardcodedWithBOM(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "deployment.yaml", "\ufeff"+`kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: web
+spec:
+  replicas: 1
+`)
+	err := checkWorkloadReplicaTemplates(dir, map[string]int32{"web": 1})
+	if err == nil {
+		t.Fatal("expected error for hardcoded spec.replicas in a BOM-prefixed file")
+	}
+	if !strings.Contains(err.Error(), "must reference .Values.workloads") {
+		t.Fatalf("error should explain the values requirement, got: %v", err)
+	}
+}
+
 func TestCheckWorkloadReplicaValues_AllPresent(t *testing.T) {
 	dir := writeValues(t, `
 workloads:


### PR DESCRIPTION

* **Background**
   Several lint paths read chart files and match line-oriented ^-anchored
    regexes against them: chartscan.go's checkWorkloadReplicaTemplates and
    findFirstInChartFiles, appdata.go's findFirstTemplateRef (the appdata /
    appCommon / sharedlib permission cross-checks), and
    internal/manifest.Peek (the apiVersion / olaresManifest.version dispatch
    probe). Go's regexp \s class does not include U+FEFF, so a UTF-8 BOM
    (EF BB BF) at column 0 of the first line silently breaks every one of
    those anchors and turns the affected rule into a no-op for the rest of
    the first YAML document. YAML/Helm parsers tolerate the BOM
    transparently, so the same file still renders and the regression goes
    unnoticed.
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAC lint and manifest validation behavior (stricter legacy manifests, BOM-sensitive scans); misconfiguration could block previously accepted manifests until authors bump versions/deps.
> 
> **Overview**
> Fixes **silent lint false negatives** when chart or manifest YAML starts with a **UTF-8 BOM**: line scanners now strip the BOM before `^-anchored` regexes run in chart template/values scans (`stripUTF8BOM` in `chartscan.go`, `appdata.go` template refs, workload replica template checks) and in manifest **`Peek`** (`probe.go`), so rules like hardcoded `replicas:` and version dispatch still match the first line.
> 
> Adds **`validateModernFieldRequiresManifestVersion`**: on **`olaresManifest.version` &lt; 0.12.0**, declaring **`apiVersion=v3`** or any **1.12.6-only** field (e.g. `workloadReplicas`, `overlayGateway`, `permission.appCommon`, `options.shared`) fails with guidance to bump the manifest version and lock **`options.dependencies[name=olares].version`** to **`>=1.12.6-0`**. Tests and the **`wlrbad`** fixture are updated so modern-field cases don’t hit this gate before the behavior under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35609def9eb16ee8624ead1299e5c0a0ea94921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->