### PR TITLE
fix: add wsl master-node hosts config

### DIFF
--- a/cli/pkg/windows/tasks.go
+++ b/cli/pkg/windows/tasks.go
@@ -410,7 +410,7 @@ func (c *ConfigWSLHostsAndDns) Execute(runtime connector.Runtime) error {
 	_, _ = cmd.RunCmd("wsl", utils.DEFAULT)
 
 	cmd = &utils.DefaultCommandExecutor{
-		Commands: []string{"-d", distro, "-u", "root", "bash", "-c", "echo -e '127.0.0.1 localhost\\n$(ip -4 addr show eth0 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}') $(hostname)' > /etc/hosts && echo -e 'nameserver 1.1.1.1\\nnameserver 1.0.0.1' > /etc/resolv.conf"},
+		Commands: []string{"-d", distro, "-u", "root", "bash", "-c", "echo -e '127.0.0.1 localhost\\n$(ip -4 addr show eth0 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}') $(hostname)\\n$(ip -4 addr show eth0 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}') master-node' > /etc/hosts && echo -e 'nameserver 1.1.1.1\\nnameserver 1.0.0.1' > /etc/resolv.conf"},
 	}
 
 	if _, err := cmd.RunCmd("wsl", utils.DEFAULT); err != nil {


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
add wsl master-node hosts config

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to WSL host file generation during install; no auth, data, or core cluster logic changes.
> 
> **Overview**
> **WSL `/etc/hosts` setup now includes a `master-node` alias** so Windows installs match the hostname used elsewhere in the Olares bootstrap flow (e.g. Linux init scripts that map the master IP to `master-node`).
> 
> `ConfigWSLHostsAndDns` still writes `localhost`, the eth0 IP with `$(hostname)`, and Cloudflare DNS in `resolv.conf`; it adds one more line mapping the same eth0 IP to `master-node`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37891a9ffb22ac8e6f2a43b9bf5e3035c9a0e09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->