### PR TITLE
chart-repo: oac up to 0.0.32

### DIFF
--- a/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
+++ b/framework/chart-repo/.olares/config/cluster/deploy/chart_repo_deploy.yaml
@@ -121,7 +121,7 @@ spec:
           name: check-appservice
       containers:
       - name: chartrepo
-        image: beclab/dynamic-chart-repository:v0.3.47
+        image: beclab/dynamic-chart-repository:v0.3.48
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
oac up to 0.0.32

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/dynamic-chart-repository/pull/55


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no configuration changes; rollout risk is limited to behavior in the new container image version.
> 
> **Overview**
> Bumps the **chartrepo** deployment container image from `beclab/dynamic-chart-repository:v0.3.47` to **v0.3.48** in `chart_repo_deploy.yaml`. No other manifest changes (env, init containers, volumes, or middleware) are modified.
> 
> This aligns cluster deploy with the updated chart-repo / OAC stack (related upstream changes in [dynamic-chart-repository#55](https://github.com/beclab/dynamic-chart-repository/pull/55)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4cad5111737f0995792a533d35be3ad7079540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->