### PR TITLE
feat(systemApps): update system-frontend image to v1.10.70

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.68
+          image: beclab/system-frontend:v1.10.70
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
On macOS, Olares runs in Docker without the native olaresd daemon. The client still tries local *.olares.local endpoints for Dashboard and Settings, which fail when olaresd is missing, leaving those pages without data. This PR adds a fallback to remote URLs when local routing is unavailable.


* **Target Version for Merge**
v1.12.6

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1247


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on an init container; behavior change is confined to bundled frontend assets with no auth or data-plane template edits in this PR.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image from `beclab/system-frontend:v1.10.68` to **`v1.10.70`** in the olares-app Helm deployment. That init container still copies bundled system UI assets into the shared `www` volume before nginx serves Dashboard, Settings, and related entrances.
> 
> The new image tag carries the **macOS Docker** fix described in the PR: when **olaresd** is absent, the client can fall back from failing local `*.olares.local` routes to remote URLs so Dashboard and Settings can load data. No other manifest fields change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a8034bacc3f51b1ee98c74e75e7e77797039e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->