### PR TITLE
ci(cli): decouple npm publish from latest and split binary/npm versions

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -40,6 +40,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   resolve-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -55,17 +55,41 @@ jobs:
           BINARY_VERSION: ${{ inputs.binary-version }}
           REF: ${{ inputs.ref }}
           BRANCH: ${{ inputs.branch }}
+          PUBLISH_NPM: ${{ inputs.publish-npm }}
         run: |
           set -euo pipefail
           npm_ver="${VERSION}"
           bin_ver="${BINARY_VERSION}"
-          if [ -z "$bin_ver" ]; then
+
+          # An explicit binary-version must be a clean OS-line semver so the
+          # upgrade framework can parse it (cli/pkg/upgrade/version.go).
+          if [ -n "$bin_ver" ] && ! echo "$bin_ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::binary-version '$bin_ver' must match X.Y.Z (OS line)"
+            exit 1
+          fi
+
+          if [ "$PUBLISH_NPM" = "true" ]; then
+            # The publish path is the iterating CLI line; enforce the canonical
+            # npm version so package.json/CDN names and the derived binary
+            # version stay well-formed.
+            if ! echo "$npm_ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-cli\.[0-9]+$'; then
+              echo "::error::version '$npm_ver' must match X.Y.Z-cli.N when publishing to npm"
+              exit 1
+            fi
+            if [ -z "$bin_ver" ]; then
+              bin_ver=$(echo "$npm_ver" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-cli\.[0-9]+$/\1/')
+            fi
+          elif [ -z "$bin_ver" ]; then
+            # Non-publish callers (daily/check/release) build from their own
+            # version forms (1.12.7-<date>, 1.12.7-<random>, a release tag);
+            # keep the previous behavior and reuse the npm version as-is.
             if echo "$npm_ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-cli\.[0-9]+$'; then
-              bin_ver=$(echo "$npm_ver" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-cli\.[0-9]+/\1/')
+              bin_ver=$(echo "$npm_ver" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-cli\.[0-9]+$/\1/')
             else
               bin_ver="$npm_ver"
             fi
           fi
+
           checkout_ref="${REF:-${BRANCH:-main}}"
           echo "npm_version=$npm_ver" >> "$GITHUB_OUTPUT"
           echo "binary_version=$bin_ver" >> "$GITHUB_OUTPUT"
@@ -229,8 +253,10 @@ jobs:
 
       - name: Sync npm package.json version
         working-directory: cli/npm
+        env:
+          NPM_VERSION: ${{ needs.resolve-versions.outputs.npm_version }}
         run: |
-          npm version "${{ needs.resolve-versions.outputs.npm_version }}" \
+          npm version "$NPM_VERSION" \
             --no-git-tag-version \
             --allow-same-version
 

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -12,14 +12,24 @@ on:
         type: string
       release-id:
         type: string
+      binary-version:
+        type: string
       publish-npm:
         type: boolean
         default: false
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Git branch to build from'
+        type: string
+        default: main
       version:
+        description: 'npm version and CDN tar name (e.g. 1.12.6-cli.5)'
         type: string
         required: true
+      binary-version:
+        description: 'Go binary VERSION (OS line, e.g. 1.12.6). Defaults from version.'
+        type: string
       ref:
         type: string
       repository:
@@ -29,26 +39,75 @@ on:
       publish-npm:
         type: boolean
         default: true
+
 jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      npm_version: ${{ steps.resolve.outputs.npm_version }}
+      binary_version: ${{ steps.resolve.outputs.binary_version }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+    steps:
+      - name: Resolve npm and binary versions
+        id: resolve
+        env:
+          VERSION: ${{ inputs.version }}
+          BINARY_VERSION: ${{ inputs.binary-version }}
+          REF: ${{ inputs.ref }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          npm_ver="${VERSION}"
+          bin_ver="${BINARY_VERSION}"
+          if [ -z "$bin_ver" ]; then
+            if echo "$npm_ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-cli\.[0-9]+$'; then
+              bin_ver=$(echo "$npm_ver" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-cli\.[0-9]+/\1/')
+            else
+              bin_ver="$npm_ver"
+            fi
+          fi
+          checkout_ref="${REF:-${BRANCH:-main}}"
+          echo "npm_version=$npm_ver" >> "$GITHUB_OUTPUT"
+          echo "binary_version=$bin_ver" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
+          echo "npm_version=$npm_ver binary_version=$bin_ver checkout_ref=$checkout_ref"
+
   goreleaser:
+    needs: [resolve-versions]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-versions.outputs.checkout_ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Add Local Git Tag For GoReleaser
-        run: git tag ${{ inputs.version }}
-        continue-on-error: true
+      - name: Preflight npm version (publish only)
+        if: ${{ inputs.publish-npm }}
+        env:
+          NPM_VERSION: ${{ needs.resolve-versions.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+          if npm view "@olares/cli@${NPM_VERSION}" version 2>/dev/null; then
+            echo "::error::@olares/cli@${NPM_VERSION} already exists on npm"
+            exit 1
+          fi
+
+      # GoReleaser derives .Version from the current git tag. This workflow
+      # never pushes tags; the tag is local only. When building from an
+      # already-tagged ref (e.g. release.yaml builds from an existing tag),
+      # the tag is already present, so tolerate the failure.
+      - name: Add local git tag for GoReleaser
+        env:
+          NPM_VERSION: ${{ needs.resolve-versions.outputs.npm_version }}
+        run: git tag "${NPM_VERSION}" || true
 
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.24.11
-          
+
       - name: Install x86_64 cross-compiler
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
@@ -64,10 +123,13 @@ jobs:
           args: release --clean
         env:
           OLARES_RELEASE_ID: ${{ inputs.release-id }}
+          BINARY_VERSION: ${{ needs.resolve-versions.outputs.binary_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Assert binary version was injected
         working-directory: cli
+        env:
+          EXPECTED_BINARY_VERSION: ${{ needs.resolve-versions.outputs.binary_version }}
         run: |
           set -euo pipefail
           binary=$(find ./output -type f -name 'olares-cli' -path '*linux_amd64*' | head -n1)
@@ -77,20 +139,17 @@ jobs:
             exit 1
           fi
           actual=$("$binary" --version 2>&1)
-          expected="${{ inputs.version }}"
-          expected_stripped="${expected#v}"
+          expected="${EXPECTED_BINARY_VERSION#v}"
           if echo "$actual" | grep -qE '0\.0\.0-development'; then
             echo "::error::binary still reports placeholder version; ldflags did not take effect"
             echo "binary: $binary"
             echo "output: $actual"
             exit 1
           fi
-          if ! echo "$actual" | grep -qF "$expected_stripped"; then
-            echo "::error::binary version output '$actual' does not contain expected '$expected_stripped'"
+          if ! echo "$actual" | grep -qF "$expected"; then
+            echo "::error::binary version output '$actual' does not contain expected '$expected'"
             exit 1
           fi
-          # Assert build metadata (git commit / build time) was injected and is
-          # not the unknown/placeholder default baked into version.go.
           if ! echo "$actual" | grep -qE '^Git commit: '; then
             echo "::error::binary version output is missing the 'Git commit:' line"
             echo "output: $actual"
@@ -110,7 +169,7 @@ jobs:
           echo "$actual"
 
       - name: Install coscmd
-        run: pip install coscmd        
+        run: pip install coscmd
 
       - name: Configure coscmd
         env:
@@ -123,7 +182,7 @@ jobs:
           coscmd config -a $TENCENT_SECRET_ID \
                         -s $TENCENT_SECRET_KEY \
                         -b $COS_BUCKET \
-                        -r $COS_REGION 
+                        -r $COS_REGION
 
       - name: Upload to CDN
         run: |
@@ -131,8 +190,27 @@ jobs:
             coscmd upload "$file" ${{ secrets.REPO_PATH }}${file}
           done
 
+      # Verify the exact URL @olares/cli postinstall fetches (see
+      # cli/npm/scripts/install.js: `${CDN_BASE}/${name}`, no REPO_PATH prefix).
+      - name: Verify CDN tar for npm postinstall (publish only)
+        if: ${{ inputs.publish-npm }}
+        env:
+          NPM_VERSION: ${{ needs.resolve-versions.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+          for arch in linux_amd64 darwin_arm64; do
+            file="olares-cli-v${NPM_VERSION}_${arch}.tar.gz"
+            url="https://cdn.olares.com/${file}"
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -I "$url" || true)
+            if [ "$code" != "200" ]; then
+              echo "::error::CDN asset not reachable: ${url} (HTTP ${code})"
+              exit 1
+            fi
+            echo "CDN OK: ${url}"
+          done
+
   publish-npm:
-    needs: [goreleaser]
+    needs: [resolve-versions, goreleaser]
     if: ${{ inputs.publish-npm }}
     runs-on: ubuntu-22.04
     steps:
@@ -140,7 +218,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-versions.outputs.checkout_ref }}
           repository: ${{ inputs.repository }}
 
       - name: Set up Node.js
@@ -149,15 +227,15 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Sync npm package.json version to release input
+      - name: Sync npm package.json version
         working-directory: cli/npm
         run: |
-          npm version "${{ inputs.version }}" \
+          npm version "${{ needs.resolve-versions.outputs.npm_version }}" \
             --no-git-tag-version \
             --allow-same-version
 
-      - name: Publish @olares/cli (dist-tag latest)
+      - name: Publish @olares/cli (dist-tag next)
         working-directory: cli/npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_OLARES_PUBLISH_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --tag next

--- a/.github/workflows/tag-npm-cli.yaml
+++ b/.github/workflows/tag-npm-cli.yaml
@@ -1,0 +1,38 @@
+name: Tag npm CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published npm version (e.g. 1.12.6-cli.5)'
+        type: string
+        required: true
+      tag:
+        description: 'npm dist-tag to point at this version'
+        type: string
+        default: latest
+
+jobs:
+  tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify version exists on npm and apply dist-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_OLARES_PUBLISH_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! npm view "@olares/cli@${VERSION}" version; then
+            echo "::error::@olares/cli@${VERSION} is not published on npm"
+            exit 1
+          fi
+          npm dist-tag add "@olares/cli@${VERSION}" "${TAG}"
+          echo "dist-tag ${TAG} -> @olares/cli@${VERSION}"
+          npm dist-tag ls @olares/cli

--- a/.github/workflows/tag-npm-cli.yaml
+++ b/.github/workflows/tag-npm-cli.yaml
@@ -9,8 +9,15 @@ on:
         required: true
       tag:
         description: 'npm dist-tag to point at this version'
-        type: string
+        type: choice
         default: latest
+        options:
+          - latest
+          - next
+          - daily
+
+permissions:
+  contents: read
 
 jobs:
   tag:

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -22,7 +22,12 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X github.com/beclab/Olares/cli/version.VERSION={{ .Version }}
+      - >-
+        {{- if index .Env "BINARY_VERSION" }}
+        -X github.com/beclab/Olares/cli/version.VERSION={{ .Env.BINARY_VERSION }}
+        {{- else }}
+        -X github.com/beclab/Olares/cli/version.VERSION={{ .Version }}
+        {{- end }}
       - -X github.com/beclab/Olares/cli/version.GitCommit={{ .FullCommit }}
       - -X github.com/beclab/Olares/cli/version.BuildTime={{ .Date }}
       - >-

--- a/cli/npm/README.md
+++ b/cli/npm/README.md
@@ -76,6 +76,31 @@ Before running `npm install -g`, the wizard reads `--version` on the existing `/
 - `OLARES_CLI_DOWNLOAD_MIRROR` — base URL for downloading the prebuilt binary if `https://github.com/beclab/Olares/releases/download/...` is unreachable (defaults to `https://cdn.olares.com`).
 - `OLARES_CLI_SKIP_DOWNLOAD=1` — install the JS shim only, no binary fetch.
 
+## Versioning and release (maintainers)
+
+Two version numbers are tracked:
+
+| Field | Example | Used for |
+| --- | --- | --- |
+| **npm version** | `1.12.6-cli.5` | `package.json`, npm registry, CDN/GitHub tar names |
+| **binary version** (`version.VERSION`) | `1.12.6` | Olares OS upgrade line; shown by `olares-cli --version` |
+
+`postinstall` downloads `olares-cli-v{npm_version}_{platform}.tar.gz` using the npm package version, so each `-cli.N` bump is a distinct artifact and does not overwrite prior builds.
+
+**npm dist-tags**
+
+| Tag | Meaning |
+| --- | --- |
+| `latest` | Production default (`npx @olares/cli@latest`, install wizard). Set manually via **Tag npm CLI** workflow. |
+| `next` | Fresh CI publish from **Release CLI** (`npx @olares/cli@next`). Does not move `latest`. |
+| `daily` | Optional tag for daily builds (manual promote). |
+
+**Release CLI** (`release-cli.yaml`, manual dispatch): builds with GoReleaser, uploads tars to CDN, publishes `@olares/cli` with `--tag next`. Inputs: `branch` (default `main`), `version` (npm), optional `binary-version` (defaults from `version` — strips `-cli.N` suffix).
+
+**Tag npm CLI** (`tag-npm-cli.yaml`): promotes an already-published version to a dist-tag (default `latest`). Fails if the version is not on npm.
+
+Daily / OS release pipelines call **Release CLI** with `publish-npm: false` — they only upload binaries; npm publish stays a separate manual step.
+
 ## Links
 
 - GitHub: <https://github.com/beclab/Olares>


### PR DESCRIPTION
## Summary

Rework the `@olares/cli` npm release so publishing no longer auto-moves the `latest` dist-tag, and so the OS-line binary version is tracked separately from the npm/CDN version.

- **Dual versioning**: npm/CDN version (e.g. `1.12.6-cli.5`) vs Go binary `version.VERSION` (the OS line, e.g. `1.12.6`). The npm version names the `package.json` and CDN tarball (so each `-cli.N` bump is a distinct artifact and never overwrites a prior build); the binary `VERSION` stays a clean semver the upgrade framework can parse.
- **`cli/.goreleaser.yaml`**: inject `version.VERSION` from a new `BINARY_VERSION` env when set; archive name still uses the npm `.Version`.
- **`release-cli.yaml`**:
  - new `resolve-versions` job derives the binary version from the npm version (strips `-cli.N`);
  - `workflow_dispatch` gains `branch` (default `main`) and optional `binary-version` inputs;
  - preflight npm version conflicts before building;
  - verify the **exact** CDN URL the postinstall fetches (`https://cdn.olares.com/<file>`, no `REPO_PATH` prefix) for `linux_amd64` + `darwin_arm64`;
  - publish with `--tag next` instead of `latest` so a publish never moves `latest`;
  - the local git tag for GoReleaser is tolerant (`|| true`) since `release.yaml` builds from an already-tagged ref.
- **`tag-npm-cli.yaml`** (new): manual workflow to promote an already-published version to a dist-tag (default `latest`).
- **`cli/npm/README.md`**: document the dual versioning and dist-tag policy.

Callers (`release.yaml`, `release-daily.yaml`, `check.yaml`) still pass `publish-npm: false`; only the manual `Release CLI` dispatch and the new `Tag npm CLI` workflow touch npm.

## Test plan

- [ ] Manually dispatch `Release CLI` (publish-npm default true) from `main` with `version: 1.12.x-cli.N`; confirm it builds, uploads to CDN, and publishes `@olares/cli@next` without moving `latest`.
- [ ] `npx @olares/cli@next install` pulls the new tarball via postinstall.
- [ ] Run `Tag npm CLI` with the published version to promote it to `latest`; confirm `npm dist-tag ls @olares/cli`.
- [ ] Re-run the official `release.yaml` (builds from an existing tag) and confirm the CLI build no longer fails on the git-tag step.

Made with [Cursor](https://cursor.com)