### PR TITLE
fix(cli): update local installed & prepared marker after upgrade

### DIFF
--- a/cli/pkg/storage/tasks.go
+++ b/cli/pkg/storage/tasks.go
@@ -281,6 +281,7 @@ func (t *RemoveJuiceFSFiles) Execute(runtime connector.Runtime) error {
 		"/usr/local/bin/juicefs",
 		"/etc/systemd/system/redis-server.service",
 		"/etc/systemd/system/juicefs.service",
+		MigrateStateFile,
 	}
 
 	for _, f := range files {

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -109,6 +109,14 @@ func (u upgraderBase) UpdateReleaseFile() []task.Interface {
 			Name:   "UpdateReleaseFile",
 			Action: new(terminus.WriteReleaseFile),
 		},
+		&task.LocalTask{
+			Name:   "UpdatePreparedMarker",
+			Action: new(terminus.PrepareFinished),
+		},
+		&task.LocalTask{
+			Name:   "UpdateInstalledMarker",
+			Action: new(terminus.InstallFinished),
+		},
 	}
 }
 


### PR DESCRIPTION
* **Background**
Currently, the upgrade process only updates the olares version in K8s cluster and the global `/etc/olares/release` file, however the `.installed` and `.prepared` state file are not updated.
Also, the juicefs migration state file should be cleaned upon uninstallation.

* **Target Version for Merge**
1.12.6, 1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only touch local marker files and uninstall cleanup paths; no cluster auth, data migration logic, or upgrade orchestration behavior beyond writing existing install-state tasks.
> 
> **Overview**
> After an Olares upgrade, the CLI now refreshes the local **`.prepared`** and **`.installed`** state files (via `PrepareFinished` and `InstallFinished`) in the same `UpdateReleaseFile` step that already writes `/etc/olares/release`, so on-disk install phase markers match the new version instead of staying stale.
> 
> JuiceFS uninstall cleanup in `RemoveJuiceFSFiles` also removes **`MigrateStateFile`** (`.jfs-migrate.state`), so interrupted migration checkpoints are not left behind when JuiceFS components are torn down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b58dcc0015471f7b24e0cac649807d924a842db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->