### PR TITLE
ci(cli): cache go build and drop unused cross-compilers

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -131,15 +131,10 @@ jobs:
         run: git tag "${NPM_VERSION}" || true
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.11
-
-      - name: Install x86_64 cross-compiler
-        run: sudo apt-get update && sudo apt-get install -y build-essential
-
-      - name: Install ARM cross-compiler
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+          cache-dependency-path: cli/go.sum
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0


### PR DESCRIPTION
## Summary

Speed up the `olares-cli` release build in `release-cli.yaml` by applying the parts of the `market` build approach that actually help here (persistent build cache + dropping wasted work), without a risky restructure.

The CLI release uses GoReleaser with `CGO_ENABLED=0` for every target, so arm/arm64 are produced by pure Go cross-compilation with no C toolchain and no QEMU emulation. That means market's native-arm-runner trick gives no compile speedup here, while two real inefficiencies remain:

- **No Go cache**: `actions/setup-go@v3` re-downloads modules and recompiles stdlib/deps from scratch on every run. Bumped to `@v5` with the built-in module/build cache (`cache-dependency-path: cli/go.sum`), mirroring the existing precedent in `module_appservice_test_main.yaml`.
- **Unused cross-compilers**: removed the `build-essential` and `gcc/g++-arm` apt installs (and their `apt-get update`); they are pointless when CGO is disabled.

## Test plan

- [ ] Dispatch / re-run `Release CLI`; confirm `Set up Go` reports a cache hit on the second run.
- [ ] Confirm GoReleaser still produces all platform tarballs (linux/darwin/windows x amd64/arm/arm64 per the matrix) despite the cross-compiler steps being gone.
- [ ] Confirm overall `goreleaser` job wall-clock drops on a warm-cache run.

Made with [Cursor](https://cursor.com)