### PR TITLE
ci(cli): drop go build cache, keep cross-compiler removal

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -131,10 +131,9 @@ jobs:
         run: git tag "${NPM_VERSION}" || true
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v3
         with:
           go-version: 1.24.11
-          cache-dependency-path: cli/go.sum
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0


### PR DESCRIPTION
## Summary

Follow-up to the build-speedup change (#3577). Measured runs showed the `setup-go` cache made the release build net slower, so revert the cache and keep only the safe win.

Evidence (manual `Release CLI` runs):

| | with cache (#11) | without cache (#10) |
| --- | --- | --- |
| Run GoReleaser (actual compile) | 397s | 391s |
| cross-compiler installs | removed (-16s) | 16s |
| Post Set up Go (cache save) | +24s | 0s |
| goreleaser job total | 7m56s | 7m25s |

- The build step did not get faster: run #11 was a cold cache **miss** (saved, never restored), so it paid the save cost with no restore benefit.
- The cli cross-compiles 7 OS/arch targets, so the build cache was **2.8GB** — ~28% of the repo's 10GB Actions cache quota, which evicts other workflows' caches and slows their CI.

Changes:
- Revert `actions/setup-go` to `@v3` without `cache-dependency-path` (no module/build cache).
- Keep the removal of the unused `build-essential` / `gcc/g++-arm` cross-compilers (`CGO_ENABLED=0` needs no C toolchain) — a safe ~16s win, leaving the build slightly faster than the original.

## Test plan

- [ ] Dispatch `Release CLI`; confirm no cross-compiler install steps and no `Post Set up Go` cache save.
- [ ] Confirm GoReleaser still produces all platform tarballs and the job total is back around / below the pre-cache baseline.

Made with [Cursor](https://cursor.com)