### PR TITLE
fix(app-service): scope gpu-limit cleanup-on-zero to nvidia so GB10 pods get GPU injected

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -369,7 +369,14 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		return cleanupAndReturn()
 	}
 	GPUType := computeReq.Mode
-	if computeReq.RequiredGPU == 0 {
+	// A zero RequiredGPU means "app dropped its GPU need" ONLY for nvidia
+	// discrete/HAMi mode (installed with requiredGpu>0, then upgraded to 0),
+	// so we clean up the previously-injected GPU keys. The unified-memory
+	// modes (nvidia-gb10/amd/intel/apple-m/moore-soc) legitimately carry
+	// RequiredGPU==0 by design (their manifests must not declare requiredGpu),
+	// and must still fall through to be injected (gb10 -> nvidia.com/gpu) or
+	// get their nodeSelector, so they must NOT be cleaned up here.
+	if computeReq.RequiredGPU == 0 && GPUType == utils.NvidiaCardType {
 		return cleanupAndReturn()
 	}
 


### PR DESCRIPTION
## Summary

On Spark / NVIDIA GB10 (`nvidia-gb10`) machines, the app-service gpu-limit mutating webhook stopped injecting `nvidia.com/gpu` (and `runtimeClassName: nvidia`) into app pods, so GB10 apps ran without GPU access.

### What #3471 was trying to solve

[#3471](https://github.com/beclab/Olares/pull/3471) ("fix(app-service): remove patched gpu limits if an app removed gpu required") addressed a real cleanup problem: when an app that was installed with a GPU requirement later drops it on upgrade (e.g. its manifest no longer needs GPU), the previously-injected GPU keys (`nvidia.com/gpu`, `nvidia.com/gpumem`, `runtimeClassName: nvidia`) survived on the live workload as "live-only" fields under Helm 3-way strategic merge, because the chart template never declared them. To fix that, it added `cleanupAndReturn()` on the "no GPU" branches of `gpuLimitMutate`, including a new early return:

```go
if computeReq.RequiredGPU == 0 {
    return cleanupAndReturn()
}
```

### What it broke

`RequiredGPU == 0` is not a reliable "app has no GPU" signal. `nvidia-gb10` is a unified-memory architecture and its manifests are **forbidden** from declaring `requiredGpu` / `limitedGpu` (only the discrete/HAMi-memory modes `nvidia` / `amd-gpu` / `intel-gpu` are in `gpuMemoryModes`; see `ensureNoGPUSection`). As a result GB10 apps **always** have `RequiredGPU == 0`, so this early return short-circuited them before the injection logic — it even emitted a cleanup patch removing `nvidia.com/gpu`. The same over-broad gate would also affect the other unified-memory modes (`amd` / `intel` / `apple-m` / `moore-soc`), which likewise carry `RequiredGPU == 0` and need to fall through to get their `nodeSelector`.

This was a regression: before #3471 there was no `RequiredGPU == 0` gate, and `getGPUResourceTypeKey(nvidia-gb10)` correctly maps to `nvidia.com/gpu`, so GB10 pods were injected fine.

### The fix

Scope the cleanup-on-zero to `nvidia` discrete/HAMi mode — the only mode where a zero `RequiredGPU` genuinely means "the GPU requirement was dropped on upgrade":

```go
if computeReq.RequiredGPU == 0 && GPUType == utils.NvidiaCardType {
    return cleanupAndReturn()
}
```

- `nvidia` with `RequiredGPU == 0` -> still cleaned up (original #3471 intent preserved).
- `nvidia-gb10` -> falls through and gets `nvidia.com/gpu` injected (no `gpumem`, since it is unified memory).
- `amd` / `intel` / `apple-m` / `moore-soc` -> fall through and still get their `nodeSelector`.
- `cpu` / no-mode -> still cleaned up via the existing `GPUType == "" || GPUType == utils.CPUType` and `!ok` branches.

Also added a comment explaining the nvidia scoping to prevent the gate from being widened again.

## Test plan

- [ ] Install a GPU app in `nvidia-gb10` mode on a Spark/GB10 node; verify the app pod is mutated with `nvidia.com/gpu: 1` and `runtimeClassName: nvidia`, and that no `nvidia.com/gpumem` is added.
- [ ] Regression: an `nvidia` app that drops its GPU requirement on upgrade still gets its stale GPU keys removed.
- [ ] Regression: unified-memory modes (`amd` / `intel` / `apple-m` / `moore-soc`) still receive their `nodeSelector`.
- [ ] Regression: `cpu` / no-mode apps still get GPU keys cleaned up.

Made with [Cursor](https://cursor.com)