### PR TITLE
fix(oac): enforce olares dependency on all manifests and pin v1/v2 to pre-v3 window

### DIFF
--- a/framework/oac/internal/manifest/resources_test.go
+++ b/framework/oac/internal/manifest/resources_test.go
@@ -36,13 +36,10 @@ func newResourcesConfig(modes ...ResourceMode) *AppConfiguration {
 }
 
 // newOlaresSystemDep returns the canonical options.dependencies entry
-// that satisfies validateOlaresDependency for c. It mirrors the validator
-// rules: apiVersion=v3 OR any 1.12.6-only feature field on the config
-// selects the post-v3 (>=1.12.6-0) constraint, otherwise the legacy
-// pre-v3 (>=1.12.3-0,<1.12.6) constraint is used. Callers should set
-// every relevant config field (workloadReplicas, overlayGateway, etc.)
-// before invoking this helper so the picked constraint stays in sync
-// with the validator's view of the same config.
+// that satisfies validateOlaresDependency for c. apiVersion=v3 selects
+// the post-v3 (>=1.12.6-0) constraint; apiVersion in {empty, v1, v2}
+// always selects the pre-v3 (>=1.12.3-0,<1.12.6) constraint regardless
+// of 1.12.6-only feature fields.
 func newOlaresSystemDep(c *AppConfiguration) Dependency {
 	rule, _ := pickOlaresDepRule(c)
 	return Dependency{

--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -580,6 +580,9 @@ func pickOlaresDepRule(c *AppConfiguration) (rule olaresDepConstraintRule, featu
 	if api == APIVersionV3 {
 		return olaresDepRulePostV3, nil
 	}
+	if api == APIVersionV1 || api == APIVersionV2 || len(api) == 0 {
+		return olaresDepRulePreV3, nil
+	}
 	triggers := detectOlares1126OnlyFields(c)
 	if len(triggers) > 0 {
 		return olaresDepRulePostV3, triggers
@@ -656,9 +659,9 @@ func validateModernFieldRequiresManifestVersion(c *AppConfiguration) error {
 // manifests — the platform always pins the host Olares version, so
 // omitting it makes the manifest non-portable.
 func validateOlaresDependency(c *AppConfiguration) error {
-	if !resourcesCheckApplies(c.ConfigVersion) {
-		return nil
-	}
+	//if !resourcesCheckApplies(c.ConfigVersion) {
+	//	return nil
+	//}
 	var olaresDep *Dependency
 	for i := range c.Options.Dependencies {
 		d := &c.Options.Dependencies[i]

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -36,6 +36,13 @@ func newValidConfig() *AppConfiguration {
 			LimitedMemory:  "256Mi",
 			RequiredDisk:   "1Gi",
 		},
+		Options: Options{
+			Dependencies: []Dependency{{
+				Name:    olaresSystemDepName,
+				Version: olaresDepRulePreV3.requirement,
+				Type:    "system",
+			}},
+		},
 	}
 }
 
@@ -1020,18 +1027,23 @@ func TestSpec_SupportArch_RejectsDuplicates(t *testing.T) {
 }
 
 func TestDependency_TypeEnum(t *testing.T) {
+	olaresDep := Dependency{
+		Name:    olaresSystemDepName,
+		Version: olaresDepRulePreV3.requirement,
+		Type:    "system",
+	}
 	c := newValidConfig()
-	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "bogus"}}
+	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "bogus"}, olaresDep}
 	if err := ValidateAppConfiguration(c); err == nil {
 		t.Fatal("expected error for bad dependency type")
 	}
 
-	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "system"}}
+	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "system"}, olaresDep}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("system is a valid dep type: %v", err)
 	}
 
-	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "application"}}
+	c.Options.Dependencies = []Dependency{{Name: "foo", Version: "1.0.0", Type: "application"}, olaresDep}
 	if err := ValidateAppConfiguration(c); err != nil {
 		t.Fatalf("application is a valid dep type: %v", err)
 	}
@@ -1138,9 +1150,10 @@ func newValidOverlayEntrance() OverlayEntrance {
 //   - workloadReplicas with one entry — required on every non-v2 modern
 //     manifest, and the test wouldn't be exercising overlay-specific
 //     behaviour if it failed for missing replicas instead.
-//   - the olares system dependency locked to the post-v3 window —
-//     overlayGateway promotes the dep window to >=1.12.6-0 via
-//     pickOlaresDepRule, so the helper picks that automatically.
+//   - the olares system dependency locked to the pre-v3 window — v1
+//     manifests always sit in the >=1.12.3-0,<1.12.6 window regardless
+//     of 1.12.6-only feature fields; newOlaresSystemDep picks that
+//     automatically.
 //
 // Each test then layers exactly one overlay entrance on top so the
 // assertion focuses on overlay rules alone.
@@ -1611,27 +1624,19 @@ func TestWorkloadReplicas_RequiredAtOrAbove012(t *testing.T) {
 // system dependency (options.dependencies entry with name="olares" and
 // type="system"):
 //
-//   - On olaresManifest.version >= 0.12.0, the entry must exist.
-//   - apiVersion=v3 OR any 1.12.6-only feature field (workloadReplicas,
-//     spec.accelerator, overlayGateway, options.LLMGatewaySupported,
-//     options.templateOnly, options.shared, permission.appCommon) forces
-//     the constraint to restrict Olares to >=1.12.6-0.
-//   - apiVersion in {empty, v1, v2} AND none of those feature fields
-//     declared: the constraint must restrict Olares to
-//     >=1.12.3-0,<1.12.6 (no leakage into 1.12.6+, no permission below
-//     the 1.12.3-0 floor).
-//   - Below the modern gate (< 0.12.0), the entry is unconstrained.
+//   - The entry must exist on every manifest.
+//   - apiVersion=v3 forces the constraint to restrict Olares to
+//     >=1.12.6-0.
+//   - apiVersion in {empty, v1, v2}: the constraint must restrict Olares
+//     to >=1.12.3-0,<1.12.6 regardless of 1.12.6-only feature fields
+//     (no leakage into 1.12.6+, no permission below the 1.12.3-0 floor).
 //
 // Each subtest builds a config that already satisfies every other modern
 // gate so the assertion truly tracks validateOlaresDependency alone.
-// Note: modern non-v2 manifests must declare workloadReplicas, so they
-// always sit in the post-v3 window — the pre-v3 window is exercised
-// through the apiVersion=v2 path.
 func TestOlaresDependency_ConstraintGate(t *testing.T) {
 	// modernV1 builds a non-v2 modern manifest. workloadReplicas is
-	// required for non-v2 modern manifests, so the helper sets it; that
-	// also trips rule 4 and pulls the required constraint window up to
-	// >=1.12.6-0.
+	// required for non-v2 modern manifests; apiVersion=v1 still selects
+	// the pre-v3 (>=1.12.3-0,<1.12.6) window.
 	modernV1 := func() *AppConfiguration {
 		c := newValidConfig()
 		c.ConfigVersion = "0.13.0"
@@ -1666,6 +1671,7 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 
 	t.Run("modern_without_olares_dep_rejected", func(t *testing.T) {
 		c := modernV1()
+		c.Options.Dependencies = nil
 		err := ValidateAppConfiguration(c)
 		if err == nil {
 			t.Fatal("expected error: modern manifest must declare the Olares system dependency")
@@ -1675,10 +1681,15 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy_without_olares_dep_accepted", func(t *testing.T) {
-		c := newValidConfig() // ConfigVersion 0.11.0; no dep set
-		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("legacy manifest without Olares dep must validate: %v", err)
+	t.Run("legacy_without_olares_dep_rejected", func(t *testing.T) {
+		c := newValidConfig()
+		c.Options.Dependencies = nil
+		err := ValidateAppConfiguration(c)
+		if err == nil {
+			t.Fatal("expected error: legacy manifest must declare the Olares system dependency")
+		}
+		if !strings.Contains(err.Error(), `options.dependencies must declare an entry with name="olares" and type="system"`) {
+			t.Fatalf("error should mention the missing Olares dep, got: %v", err)
 		}
 	})
 
@@ -1730,39 +1741,32 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 		}
 	})
 
-	t.Run("v1_with_workload_replicas_demands_post_v3_range", func(t *testing.T) {
+	t.Run("v1_with_workload_replicas_accepts_pre_v3_range", func(t *testing.T) {
 		c := modernV1()
-		// The pre-v3 window would have satisfied apiVersion alone, but
-		// workloadReplicas (required on non-v2 modern manifests) trips
-		// rule 4 and forces >=1.12.6-0.
 		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v1 with workloadReplicas must accept the pre-v3 dep window: %v", err)
+		}
+	})
+
+	t.Run("v1_with_workload_replicas_rejects_post_v3_range", func(t *testing.T) {
+		c := modernV1()
+		setOlaresDep(c, ">=1.12.6-0")
 		err := ValidateAppConfiguration(c)
 		if err == nil {
-			t.Fatal("expected error: workloadReplicas must promote v1 into the post-v3 dep window")
+			t.Fatal("expected error: v1 dep constraint must stay in the pre-v3 window")
 		}
-		msg := err.Error()
-		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0" for apiVersion=v1`) {
-			t.Fatalf("error should mention the post-v3 requirement on v1, got: %v", err)
-		}
-		if !strings.Contains(msg, "workloadReplicas") {
-			t.Fatalf("error should attribute the promotion to workloadReplicas, got: %v", err)
+		if !strings.Contains(err.Error(), `must restrict the Olares system version to ">=1.12.3-0,<1.12.6" for apiVersion=v1`) {
+			t.Fatalf("error should mention the pre-v3 requirement on v1, got: %v", err)
 		}
 	})
 
-	t.Run("v1_with_workload_replicas_accepts_post_v3_range", func(t *testing.T) {
-		c := modernV1()
-		setOlaresDep(c, ">=1.12.6-0")
-		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("v1 with workloadReplicas and >=1.12.6-0 must validate: %v", err)
-		}
-	})
-
-	t.Run("empty_apiversion_treated_as_v1_post_v3_range", func(t *testing.T) {
+	t.Run("empty_apiversion_treated_as_v1_pre_v3_range", func(t *testing.T) {
 		c := modernV1()
 		c.APIVersion = ""
-		setOlaresDep(c, ">=1.12.6-0")
+		setOlaresDep(c, ">=1.12.3-0,<1.12.6")
 		if err := ValidateAppConfiguration(c); err != nil {
-			t.Fatalf("empty apiVersion with workloadReplicas must accept >=1.12.6-0: %v", err)
+			t.Fatalf("empty apiVersion with workloadReplicas must accept the pre-v3 window: %v", err)
 		}
 	})
 
@@ -1833,18 +1837,10 @@ func TestOlaresDependency_ConstraintGate(t *testing.T) {
 	})
 }
 
-// TestOlaresDependency_FeatureTriggersPromoteRange exercises rule 4:
-// when a v1/v2 manifest declares any of the 1.12.6-only feature fields,
-// the Olares dep constraint must restrict to >=1.12.6-0 and the error
-// must attribute the promotion to that field. Each subtest starts from
-// modernV2NoTriggers (which would otherwise sit in the pre-v3 window),
-// flips exactly one trigger, and verifies both the promotion and the
-// attribution.
-func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
-	// preV3Constraint is the constraint that satisfies the validator
-	// for a manifest with NO triggers. By keeping it constant across
-	// subtests we make the assertion "trigger X promoted the required
-	// range to >=1.12.6-0" unambiguous: nothing else in the config moved.
+// TestOlaresDependency_FeatureTriggersDoNotPromoteV1V2Range verifies that
+// 1.12.6-only feature fields on v1/v2 manifests do NOT promote the Olares
+// dep constraint window — apiVersion alone selects pre-v3 vs post-v3.
+func TestOlaresDependency_FeatureTriggersDoNotPromoteV1V2Range(t *testing.T) {
 	const preV3Constraint = ">=1.12.3-0,<1.12.6"
 
 	base := func() *AppConfiguration {
@@ -1860,14 +1856,10 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 		return c
 	}
 
-	// flipTrigger mutates c to declare exactly one 1.12.6-only feature.
-	// Each function returns the user-facing label the error message
-	// is expected to include.
 	cases := []struct {
-		name       string
-		flip       func(c *AppConfiguration)
-		wantLabel  string
-		extraSetup func(c *AppConfiguration) // pre-flip prerequisites, if any
+		name      string
+		flip      func(c *AppConfiguration)
+		extraSetup func(c *AppConfiguration)
 	}{
 		{
 			name: "workloadReplicas",
@@ -1875,7 +1867,6 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 				wr := WorkloadReplicas{c.Metadata.Name: 1}
 				c.WorkloadReplicas = &wr
 			},
-			wantLabel: "workloadReplicas",
 		},
 		{
 			name: "overlayGateway",
@@ -1885,49 +1876,35 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 					Entrances: []OverlayEntrance{newValidOverlayEntrance()},
 				}
 			},
-			wantLabel: "overlayGateway",
 		},
 		{
 			name: "options.LLMGatewaySupported",
 			flip: func(c *AppConfiguration) {
 				c.Options.LLMGatewaySupported = true
 			},
-			wantLabel: "options.LLMGatewaySupported",
 		},
 		{
 			name: "permission.appCommon",
 			flip: func(c *AppConfiguration) {
 				c.Permission.AppCommon = true
 			},
-			wantLabel: "permission.appCommon",
 		},
 	}
 
 	for _, tc := range cases {
 		tc := tc
-		t.Run(tc.name+"_promotes_to_post_v3_range", func(t *testing.T) {
+		t.Run(tc.name+"_accepts_pre_v3_with_feature", func(t *testing.T) {
 			c := base()
 			if tc.extraSetup != nil {
 				tc.extraSetup(c)
 			}
 			tc.flip(c)
-			err := ValidateAppConfiguration(c)
-			if err == nil {
-				t.Fatalf("expected error: declaring %s must promote the dep window to >=1.12.6-0", tc.wantLabel)
-			}
-			msg := err.Error()
-			if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
-				t.Fatalf("error should require the post-v3 range, got: %v", err)
-			}
-			if !strings.Contains(msg, tc.wantLabel) {
-				t.Fatalf("error should attribute the promotion to %s, got: %v", tc.wantLabel, err)
-			}
-			if !strings.Contains(msg, "because the manifest declares") {
-				t.Fatalf("error should explain the rule-4 promotion with a 'because' clause, got: %v", err)
+			if err := ValidateAppConfiguration(c); err != nil {
+				t.Fatalf("declaring %s on v2 with pre-v3 dep must validate: %v", tc.name, err)
 			}
 		})
 
-		t.Run(tc.name+"_accepts_post_v3_range", func(t *testing.T) {
+		t.Run(tc.name+"_rejects_post_v3_on_v2", func(t *testing.T) {
 			c := base()
 			if tc.extraSetup != nil {
 				tc.extraSetup(c)
@@ -1938,19 +1915,21 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 				Version: ">=1.12.6-0",
 				Type:    "system",
 			}}
-			if err := ValidateAppConfiguration(c); err != nil {
-				t.Fatalf("declaring %s with >=1.12.6-0 dep must validate: %v", tc.wantLabel, err)
+			err := ValidateAppConfiguration(c)
+			if err == nil {
+				t.Fatalf("expected error: v2 dep constraint must stay in the pre-v3 window even with %s", tc.name)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.3-0,<1.12.6" for apiVersion=v2`) {
+				t.Fatalf("error should require the pre-v3 range, got: %v", err)
+			}
+			if strings.Contains(msg, "because the manifest declares") {
+				t.Fatalf("v2 error must not attribute the requirement to feature triggers, got: %v", err)
 			}
 		})
 	}
 
-	// Two extra rule-4 triggers (spec.accelerator, options.shared,
-	// options.templateOnly) have additional cross-field constraints that
-	// don't fit the v2 baseline above, so cover them on shapes that do.
-	t.Run("spec.accelerator_promotes_to_post_v3_range", func(t *testing.T) {
-		// spec.accelerator lives on v1 (v2 forbids it; v3 always sits in
-		// the post-v3 window). Pair it with workloadReplicas (required on
-		// v1) but assert the trigger list includes spec.accelerator.
+	t.Run("spec.accelerator_accepts_pre_v3_on_v1", func(t *testing.T) {
 		c := newValidConfig()
 		c.ConfigVersion = "0.13.0"
 		c.APIVersion = APIVersionV1
@@ -1977,28 +1956,15 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 		c.WorkloadReplicas = &wr
 		c.Options.Dependencies = []Dependency{{
 			Name:    olaresSystemDepName,
-			Version: ">=1.12.3-0,<1.12.6",
+			Version: preV3Constraint,
 			Type:    "system",
 		}}
-		err := ValidateAppConfiguration(c)
-		if err == nil {
-			t.Fatal("expected error: spec.accelerator must promote dep window to >=1.12.6-0")
-		}
-		msg := err.Error()
-		if !strings.Contains(msg, "spec.accelerator") {
-			t.Fatalf("error should attribute the promotion to spec.accelerator, got: %v", err)
-		}
-		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
-			t.Fatalf("error should require the post-v3 range, got: %v", err)
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v1 with spec.accelerator and pre-v3 dep must validate: %v", err)
 		}
 	})
 
 	t.Run("options.shared_is_v3_only_post_v3_range", func(t *testing.T) {
-		// options.shared=true requires apiVersion=v3 (a separate rule),
-		// so promotion is observable through the v3 branch. The trigger
-		// list intentionally omits "options.shared" here because v3
-		// already routes through the apiVersion path; the assertion
-		// focuses on the post-v3 requirement.
 		c := newValidConfig()
 		c.ConfigVersion = "0.13.0"
 		c.APIVersion = APIVersionV3
@@ -2007,7 +1973,7 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 		c.WorkloadReplicas = &wr
 		c.Options.Dependencies = []Dependency{{
 			Name:    olaresSystemDepName,
-			Version: ">=1.12.3-0,<1.12.6",
+			Version: preV3Constraint,
 			Type:    "system",
 		}}
 		err := ValidateAppConfiguration(c)
@@ -2019,29 +1985,18 @@ func TestOlaresDependency_FeatureTriggersPromoteRange(t *testing.T) {
 		}
 	})
 
-	t.Run("options.templateOnly_promotes_to_post_v3_range", func(t *testing.T) {
-		// templateOnly=true additionally needs allowMultipleInstall=true
-		// (a separate cross-field rule). Anchor it on a v2 baseline so
-		// the post-v3 promotion comes purely from rule 4.
+	t.Run("options.templateOnly_accepts_pre_v3_on_v2", func(t *testing.T) {
 		c := base()
 		c.Options.AllowMultipleInstall = true
 		c.Options.TemplateOnly = true
-		err := ValidateAppConfiguration(c)
-		if err == nil {
-			t.Fatal("expected error: options.templateOnly must promote dep window to >=1.12.6-0")
-		}
-		msg := err.Error()
-		if !strings.Contains(msg, "options.templateOnly") {
-			t.Fatalf("error should attribute the promotion to options.templateOnly, got: %v", err)
-		}
-		if !strings.Contains(msg, `must restrict the Olares system version to ">=1.12.6-0"`) {
-			t.Fatalf("error should require the post-v3 range, got: %v", err)
+		if err := ValidateAppConfiguration(c); err != nil {
+			t.Fatalf("v2 with options.templateOnly and pre-v3 dep must validate: %v", err)
 		}
 	})
 }
 
 // TestModernFieldRequiresManifestVersion is the inverse of
-// TestOlaresDependency_FeatureTriggersPromoteRange: on a LEGACY manifest
+// TestOlaresDependency_FeatureTriggersDoNotPromoteV1V2Range: on a LEGACY manifest
 // (olaresManifest.version < 0.12.0), declaring any 1.12.6-only feature
 // field — or apiVersion=v3 — must be rejected with guidance to bump the
 // manifest version AND lock the Olares dep to >=1.12.6-0.

--- a/framework/oac/testdata/firefox/OlaresManifest.yaml
+++ b/framework/oac/testdata/firefox/OlaresManifest.yaml
@@ -40,7 +40,7 @@ options:
     version: ">=0.1.0"
   - name: olares
     type: system
-    version: '>=1.10.1-0'
+    version: '>=1.12.3-0,<1.12.6'
 entrances:
 {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
 - name: firefox

--- a/framework/oac/testdata/multiclusterbad/OlaresManifest.yaml
+++ b/framework/oac/testdata/multiclusterbad/OlaresManifest.yaml
@@ -29,3 +29,7 @@ options:
   policies: []
   resetCookie: { enabled: false }
   allowMultipleInstall: true
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/multiclusterbadworkload/OlaresManifest.yaml
+++ b/framework/oac/testdata/multiclusterbadworkload/OlaresManifest.yaml
@@ -29,3 +29,7 @@ options:
   policies: []
   resetCookie: { enabled: false }
   allowMultipleInstall: true
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/multiclusterok/OlaresManifest.yaml
+++ b/framework/oac/testdata/multiclusterok/OlaresManifest.yaml
@@ -29,3 +29,7 @@ options:
   policies: []
   resetCookie: { enabled: false }
   allowMultipleInstall: true
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/multiclusterusername/OlaresManifest.yaml
+++ b/framework/oac/testdata/multiclusterusername/OlaresManifest.yaml
@@ -29,3 +29,7 @@ options:
   policies: []
   resetCookie: { enabled: false }
   allowMultipleInstall: false
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/wlrbad/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlrbad/OlaresManifest.yaml
@@ -44,9 +44,7 @@ overlayGateway:
 options:
   policies: []
   resetCookie: { enabled: false }
-  # workloadReplicas + overlayGateway are 1.12.6-only triggers, so the
-  # Olares system dep must lock to the post-v3 window.
   dependencies:
     - name: olares
       type: system
-      version: ">=1.12.6-0"
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlreplicas/OlaresManifest.yaml
@@ -43,4 +43,4 @@ options:
   dependencies:
     - name: olares
       type: system
-      version: ">=1.12.6-0"
+      version: ">=1.12.3-0,<1.12.6"


### PR DESCRIPTION


* **Background**
enforce olares dependency on all manifests and pin v1/v2 to pre-v3 window
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter validation will reject legacy manifests missing an Olares dep or using `>=1.12.6-0` on v1/v2, which can break existing app store charts until they are updated.
> 
> **Overview**
> **Tightens Olares manifest validation** so every app must declare `options.dependencies` with `name=olares` and `type=system`, including legacy manifests below `olaresManifest.version` 0.12.0 (the modern-only gate on that check is removed).
> 
> **Olares version window selection** is now driven only by `apiVersion`: **v3** requires `>=1.12.6-0`; **empty, v1, and v2** always require `>=1.12.3-0,<1.12.6`, even when the manifest uses 1.12.6-only fields such as `workloadReplicas`, `overlayGateway`, or `spec.accelerator`. Feature fields no longer bump v1/v2 into the post-v3 constraint or add “because the manifest declares …” promotion errors.
> 
> Tests and OAC testdata fixtures are updated to include the Olares system dependency and the pre-v3 range where appropriate (e.g. v1 manifests with overlay/workload replicas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7339b44e3498847a5c17db978809aeb91fc3f424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->