### PR TITLE
app-service: honor limitedGpu as the HAMi nvidia.com/gpumem cap

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -410,10 +410,8 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 	}
 
 	var hamiGpuMemory *string
-	if compute.IsHAMIMode(GPUType) && computeReq.RequiredGPU > 0 {
-		gpuRequiredValue := computeReq.RequiredGPU / 1024 / 1024 // HAMi gpu memory format
-		hamiFormatGpuRequired := resource.NewQuantity(gpuRequiredValue, resource.DecimalSI)
-		hamiGpuMemory = ptr.To(hamiFormatGpuRequired.String())
+	if compute.IsHAMIMode(GPUType) {
+		hamiGpuMemory = hamiGPUMemoryLimit(computeReq)
 	}
 	patchBytes, err := webhook.CreatePatchForDeployment(
 		tpl,
@@ -451,6 +449,26 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		h.sidecarWebhook.PatchAdmissionResponse(resp, patchBytes)
 	}
 	return resp
+}
+
+// hamiGPUMemoryLimit derives the HAMi nvidia.com/gpumem value (in MiB) for a
+// compute requirement. It prefers LimitedGPU (the runtime cap the app may use)
+// when set, falling back to RequiredGPU (the scheduling floor). This mirrors
+// the FitLevelLimit convention in pkg/compute/scheduler.go so requiredGpu stays
+// the scheduling floor while limitedGpu becomes the runtime memory cap. In HAMI
+// mode this injected gpumem is what the scheduler/device-plugin places the pod
+// against, so pods with limitedGpu are intentionally scheduled against that cap.
+// It returns nil when neither value is positive (no gpumem injection).
+func hamiGPUMemoryLimit(req compute.Requirement) *string {
+	gpuMemBytes := req.RequiredGPU
+	if req.LimitedGPU > 0 {
+		gpuMemBytes = req.LimitedGPU
+	}
+	if gpuMemBytes <= 0 {
+		return nil
+	}
+	gpuMemValue := gpuMemBytes / 1024 / 1024 // HAMi gpu memory format (MiB)
+	return ptr.To(resource.NewQuantity(gpuMemValue, resource.DecimalSI).String())
 }
 
 // FIXME: should not hardcode

--- a/framework/app-service/pkg/apiserver/handler_webhook_test.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook_test.go
@@ -1,0 +1,67 @@
+package apiserver
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+)
+
+func TestHamiGPUMemoryLimit(t *testing.T) {
+	const gi int64 = 1024 * 1024 * 1024
+
+	tests := []struct {
+		name      string
+		req       compute.Requirement
+		wantBytes int64
+		wantNil   bool
+	}{
+		{
+			name: "limitedGpu set and greater than requiredGpu",
+			req: compute.Requirement{
+				RequiredGPU: 1 * gi,
+				LimitedGPU:  24 * gi,
+			},
+			wantBytes: 24 * gi,
+		},
+		{
+			name: "limitedGpu unset falls back to requiredGpu",
+			req: compute.Requirement{
+				RequiredGPU: 8 * gi,
+			},
+			wantBytes: 8 * gi,
+		},
+		{
+			name:    "requiredGpu zero and limitedGpu zero returns nil",
+			req:     compute.Requirement{},
+			wantNil: true,
+		},
+		{
+			name: "limitedGpu equal to requiredGpu",
+			req: compute.Requirement{
+				RequiredGPU: 12 * gi,
+				LimitedGPU:  12 * gi,
+			},
+			wantBytes: 12 * gi,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hamiGPUMemoryLimit(tt.req)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("hamiGPUMemoryLimit() = %q, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("hamiGPUMemoryLimit() = nil, want non-nil")
+			}
+			want := strconv.FormatInt(tt.wantBytes/1024/1024, 10)
+			if *got != want {
+				t.Fatalf("hamiGPUMemoryLimit() = %q, want %q", *got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Derive the HAMi `nvidia.com/gpumem` value the app-service admission webhook injects from the manifest's `limitedGpu` (the runtime cap the app may use) instead of `requiredGpu` (the scheduling floor), falling back to `requiredGpu` when `limitedGpu` is unset. Charts that do not set `limitedGpu` keep their current behavior exactly.

## Background

When `applications.app.bytetrade.io/gpu-inject` is set, the webhook injects `nvidia.com/gpumem` for HAMi-managed workloads. The value was computed from `requiredGpu`, so a chart that sets a conservative floor such as `requiredGpu: 1Gi` hard-caps the container at 1 GB of VRAM and silently ignores `limitedGpu: 24Gi`; a larger model then fails to load with no clear signal.

`requiredGpu` is meant to be the scheduling minimum and `limitedGpu` the maximum the app is allowed to consume, so the runtime memory cap should come from `limitedGpu` when it is set. This mirrors the existing `FitLevelLimit` convention in `pkg/compute/scheduler.go`, where `targetGPU`/`levelMemory` already prefer `LimitedGPU` over `RequiredGPU` at the limit level and the scheduler tries that level first.

## Changes

- Prefer `limitedGpu` (when greater than zero) over `requiredGpu` for the injected `nvidia.com/gpumem` cap, still injecting nothing when neither is positive.
- Extract the byte-to-quantity derivation into a small pure helper (`hamiGPUMemoryLimit`) so it is unit-testable without a live admission request.
- Add table-driven tests covering the four cases: `limitedGpu > requiredGpu`, `limitedGpu` unset (falls back to `requiredGpu`), both zero (returns nil), and `limitedGpu == requiredGpu`.

Scope is limited to `framework/app-service/pkg/apiserver/handler_webhook.go` and a new `handler_webhook_test.go`.

## Testing

`gofmt`, `go vet`, `go build`, and `go test` all pass for `pkg/apiserver`.

## Related issues

Refs #3213

Note: issue #3213 also describes a second, separate problem (a hardcoded `release_early_check_interval` inside the proprietary `libvgpu.so`). That value lives only in a compiled shared object with no source in this repository, so it is out of scope here; this PR addresses only the webhook memory-cap derivation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission-time GPU memory limits for HAMi workloads, which affects scheduling and runtime VRAM caps; behavior is unchanged when limitedGpu is unset.
> 
> **Overview**
> For HAMi GPU injection, the gpu-limit admission webhook now sets **`nvidia.com/gpumem`** from **`limitedGpu`** when it is positive, otherwise **`requiredGpu`**, instead of always using **`requiredGpu`**. That aligns the runtime VRAM cap with the scheduler’s **`FitLevelLimit`** behavior so a low scheduling floor no longer silently caps workloads that declare a higher limit.
> 
> The byte-to-MiB conversion moves into **`hamiGPUMemoryLimit`**, which returns **nil** when neither GPU field is positive (no gpumem patch). HAMi mode no longer skips that helper when only the limit path would apply—the outer check is **`IsHAMIMode`** only. Table-driven tests cover limit &gt; required, fallback, both zero, and equal values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016c96f75c4d6edfdafd41bc0d186effe58bcaa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->