### PR TITLE
cli/market, cli/settings: add market restart and settings network overlay commands

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,3 @@
+# Trellis task-management scaffolding (local workflow state; not product code).
+# Hidden from Cursor AI/features so it does not surface in context or search.
+.trellis/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ cli/cmd/ctl/settings/scripts/*
 cli/cmd/ctl/settings/KNOWN_ISSUES.md
 cli/cmd/ctl/settings/NOTES.md
 cli/cmd/ctl/files/scripts/*
+
+# Trellis task-management scaffolding (local workflow state; not product code).
+.trellis/

--- a/cli/cmd/ctl/market/common.go
+++ b/cli/cmd/ctl/market/common.go
@@ -55,17 +55,31 @@ func resolveInstalledSource(ctx context.Context, opts *MarketOptions, mc *Market
 	if s := strings.TrimSpace(opts.Source); s != "" {
 		return s, nil
 	}
-	row, err := lookupInstalledApp(ctx, mc, appName)
+	row, err := resolveInstalledRow(ctx, mc, appName)
 	if err != nil {
 		return "", err
 	}
+	return row.Source, nil
+}
+
+// resolveInstalledRow returns the full per-user state row for an installed
+// app, applying the same "must be installed" guards as resolveInstalledSource
+// (no --source override path — callers that need the whole row, like restart's
+// --watch baseline capture, always resolve the row from /market/state). It is
+// the single source of truth for the not-installed / wrong-state error
+// messages so resolveInstalledSource and restart stay in lockstep.
+func resolveInstalledRow(ctx context.Context, mc *MarketClient, appName string) (*installedAppRow, error) {
+	row, err := lookupInstalledApp(ctx, mc, appName)
+	if err != nil {
+		return nil, err
+	}
 	if row == nil || strings.TrimSpace(row.Source) == "" {
-		return "", fmt.Errorf("%q is not installed for this user (run `olares-cli market list --mine` to see installed apps)", appName)
+		return nil, fmt.Errorf("%q is not installed for this user (run `olares-cli market list --mine` to see installed apps)", appName)
 	}
 	if !isInstalledState(row.State) {
-		return "", fmt.Errorf("%q is not an installed app (state %q); nothing to operate on (run `olares-cli market list --mine` to see installed apps)", appName, row.State)
+		return nil, fmt.Errorf("%q is not an installed app (state %q); nothing to operate on (run `olares-cli market list --mine` to see installed apps)", appName, row.State)
 	}
-	return row.Source, nil
+	return row, nil
 }
 
 func validateVersion(version string) error {

--- a/cli/cmd/ctl/market/preflight.go
+++ b/cli/cmd/ctl/market/preflight.go
@@ -66,6 +66,10 @@ type installedAppRow struct {
 	Source  string
 	State   string
 	Version string
+	// StatusTime is the backend-generated statusTime on the matched row
+	// (RFC3339, verbatim). restart captures it before POST /apps/restart as
+	// the --watch baseline; empty when the backend omits it.
+	StatusTime string
 }
 
 // lookupInstalledApp finds the active profile's per-user state row
@@ -151,11 +155,12 @@ func lookupInstalledApp(ctx context.Context, mc *MarketClient, appName string) (
 				continue
 			}
 			row := &installedAppRow{
-				Name:    appName,
-				RawName: strings.TrimSpace(appState.Status.RawName),
-				Source:  sn,
-				State:   appState.Status.State,
-				Version: strings.TrimSpace(appState.Version),
+				Name:       appName,
+				RawName:    strings.TrimSpace(appState.Status.RawName),
+				Source:     sn,
+				State:      appState.Status.State,
+				Version:    strings.TrimSpace(appState.Version),
+				StatusTime: strings.TrimSpace(appState.Status.StatusTime),
 			}
 			if isInstalledState(row.State) {
 				return row, nil
@@ -184,11 +189,12 @@ func lookupInstalledApp(ctx context.Context, mc *MarketClient, appName string) (
 				continue
 			}
 			row := &installedAppRow{
-				Name:    rawName,
-				RawName: rawName,
-				Source:  sn,
-				State:   appState.Status.State,
-				Version: strings.TrimSpace(appState.Version),
+				Name:       rawName,
+				RawName:    rawName,
+				Source:     sn,
+				State:      appState.Status.State,
+				Version:    strings.TrimSpace(appState.Version),
+				StatusTime: strings.TrimSpace(appState.Status.StatusTime),
 			}
 			if isInstalledState(row.State) {
 				return row, nil

--- a/cli/cmd/ctl/market/restart.go
+++ b/cli/cmd/ctl/market/restart.go
@@ -1,0 +1,161 @@
+package market
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/market/restart"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// appStateStopped is the per-user state-row value for a suspended app
+// (APP_STATUS.STOP.COMPLETED in the SPA). RestartApp uses it to leave stopped
+// apps stopped, mirroring OverlayGatewayPage's `!isStopped` guard.
+const appStateStopped = "stopped"
+
+func NewCmdMarketRestart(f *cmdutil.Factory) *cobra.Command {
+	opts := newMarketOptions(f)
+	cmd := &cobra.Command{
+		Use:   "restart {app-name}",
+		Short: "Restart a running app (sends POST /apps/restart)",
+		Long: `Restart an installed application.
+
+Source is implicit: restart acts on whichever per-user state row matches
+the app name, regardless of source (no -s flag exposed).
+
+The restart endpoint is version-agnostic (the SPA shares one body between
+resume and restart): POST /apps/restart with {app_name, source}. On
+Olares 1.12.6+ an app that uses a GPU/accelerator may need a device
+selected; use --compute-binding <node>:<device>[:<mem>] (repeatable) to
+pin it, or answer the interactive prompt. On 1.12.5 --compute-binding is
+rejected.
+
+--watch blocks until the row settles back at 'running' (or one of the
+resumeFailed / resumingCanceled / resumingCancelFailed failure states).
+
+Examples:
+  olares-cli market restart firefox                    # fire-and-forget; returns once backend accepts
+  olares-cli market restart firefox --watch            # block until row reports running
+  olares-cli market restart comfyui --compute-binding node-1:gpu-0 --watch   # pin a device (1.12.6+)`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRestart(opts, args[0])
+		},
+	}
+	opts.addOutputFlags(cmd)
+	opts.addComputeBindingFlag(cmd)
+	opts.addWatchFlags(cmd)
+	return cmd
+}
+
+func runRestart(opts *MarketOptions, appName string) error {
+	mc, err := opts.prepare()
+	if err != nil {
+		return opts.failOp("restart", appName, err)
+	}
+
+	opts.info("Restarting '%s' for user '%s'...", appName, mc.olaresID)
+
+	ctx := context.Background()
+
+	// Resolve the installed app's source: enforces the "only operate on an
+	// installed app" guard and yields the source the restart body needs
+	// (restart exposes no -s). The resolved source also sharpens --watch.
+	source, err := resolveInstalledSource(ctx, opts, mc, appName)
+	if err != nil {
+		return opts.failOp("restart", appName, err)
+	}
+
+	atLeast126, err := opts.factory.OlaresBackendAtLeast(ctx, "1.12.6")
+	if err != nil {
+		return opts.failOp("restart", appName, err)
+	}
+
+	// --compute-binding is a 1.12.6+ concept; reject it on 1.12.5.
+	bindings, err := parseComputeBindingFlags(opts.ComputeBinding)
+	if err != nil {
+		return opts.failOp("restart", appName, err)
+	}
+	if len(bindings) > 0 && !atLeast126 {
+		return opts.failOp("restart", appName, fmt.Errorf("--compute-binding requires Olares 1.12.6+; re-run without --compute-binding"))
+	}
+
+	resp, err := sendRestart(ctx, mc, appName, source, bindings)
+	// 1.12.6+: recover once from a computeBindingRequired / Unavailable 422,
+	// exactly as `market resume` does.
+	if err != nil && atLeast126 {
+		if checkType, raw := parseFailedCheck(resp); isComputeBindingPrompt(checkType) {
+			if len(bindings) > 0 {
+				return opts.failOp("restart", appName, computeBindingRejected(raw, appName, bindings))
+			}
+			sel, berr := resolveComputeBinding(raw, checkType, appName, opts.isInteractive())
+			if berr != nil {
+				return opts.failOp("restart", appName, berr)
+			}
+			resp, err = sendRestart(ctx, mc, appName, source, sel)
+		}
+	}
+	if err != nil {
+		return opts.failOp("restart", appName, err)
+	}
+
+	result := newOperationResult(mc, "restart", appName, "", "", "restart requested", resp)
+	return runWithWatch(opts, mc, result, newWatchTarget(watchResume, appName, source))
+}
+
+// sendRestart posts the restart body ({app_name, source, computeBinding?}) to
+// /apps/restart. computeBinding is only populated on 1.12.6+.
+func sendRestart(ctx context.Context, mc *MarketClient, appName, source string, bindings []BindingSelection) (*APIResponse, error) {
+	var cb any
+	if len(bindings) > 0 {
+		cb = bindings
+	}
+	method, path, body := restart.Build(appName, source, cb)
+	return mc.doRequest(ctx, method, path, body)
+}
+
+// RestartApp restarts an installed app when it is currently running, mirroring
+// the SPA's OverlayGatewayPage flow: after toggling an app's overlay the store
+// restarts the app (via AppService.restartApp) so the change takes effect, but
+// only when the app is not stopped — stopped apps keep the persisted setting and
+// pick it up on their next start.
+//
+// It is a best-effort, fire-and-forget submit (no --watch, no compute-binding
+// recovery). The return value reports whether a restart was actually issued:
+//   - (false, nil): app is not installed, not in an installed state, or stopped
+//     -> nothing to restart.
+//   - (true, nil):  a restart request was accepted by the backend.
+//   - (_, err):     the lookup or restart POST failed. Callers such as
+//     `settings network overlay app enable/disable` treat this as a soft
+//     warning because the primary operation (the overlay toggle) already
+//     succeeded.
+//
+// Exported so the settings network overlay commands can reuse the market
+// transport/auth path instead of re-implementing the app-store v2 client.
+func RestartApp(ctx context.Context, f *cmdutil.Factory, appName string) (restarted bool, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts := newMarketOptions(f)
+	opts.Quiet = true
+	mc, err := opts.prepare()
+	if err != nil {
+		return false, err
+	}
+	row, err := lookupInstalledApp(ctx, mc, appName)
+	if err != nil {
+		return false, err
+	}
+	if row == nil || !isInstalledState(row.State) {
+		return false, nil
+	}
+	if row.State == appStateStopped {
+		return false, nil
+	}
+	if _, err := sendRestart(ctx, mc, appName, row.Source, nil); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/cli/cmd/ctl/market/restart.go
+++ b/cli/cmd/ctl/market/restart.go
@@ -15,6 +15,11 @@ import (
 // apps stopped, mirroring OverlayGatewayPage's `!isStopped` guard.
 const appStateStopped = "stopped"
 
+// restartMinOlaresVersion is the first Olares line that exposes POST
+// /apps/restart. Restart shipped as part of the overlay feature set in 1.12.6;
+// on 1.12.5 the endpoint doesn't exist.
+const restartMinOlaresVersion = "1.12.6"
+
 func NewCmdMarketRestart(f *cmdutil.Factory) *cobra.Command {
 	opts := newMarketOptions(f)
 	cmd := &cobra.Command{
@@ -25,15 +30,20 @@ func NewCmdMarketRestart(f *cmdutil.Factory) *cobra.Command {
 Source is implicit: restart acts on whichever per-user state row matches
 the app name, regardless of source (no -s flag exposed).
 
-The restart endpoint is version-agnostic (the SPA shares one body between
-resume and restart): POST /apps/restart with {app_name, source}. On
-Olares 1.12.6+ an app that uses a GPU/accelerator may need a device
+Requires Olares >= 1.12.6: POST /apps/restart is part of the overlay
+feature set introduced in 1.12.6 (the SPA shares one wire body between
+resume and restart: {app_name, source}). On 1.12.5 the command fails fast
+with a version error. An app that uses a GPU/accelerator may need a device
 selected; use --compute-binding <node>:<device>[:<mem>] (repeatable) to
-pin it, or answer the interactive prompt. On 1.12.5 --compute-binding is
-rejected.
+pin it, or answer the interactive prompt.
 
---watch blocks until the row settles back at 'running' (or one of the
-resumeFailed / resumingCanceled / resumingCancelFailed failure states).
+--watch blocks until the restart's stop-then-resume cycle actually
+completes. Because a finished restart looks identical to the app's
+pre-restart resting row ('running' with opType 'resume'), --watch
+captures the row's statusTime before the request and only reports success
+once the row is 'running' with a strictly newer statusTime. Failure is
+reported for either phase (stopFailed in the stop phase; resumeFailed /
+resumingCanceled / resumingCancelFailed in the resume phase).
 
 Examples:
   olares-cli market restart firefox                    # fire-and-forget; returns once backend accepts
@@ -60,32 +70,40 @@ func runRestart(opts *MarketOptions, appName string) error {
 
 	ctx := context.Background()
 
-	// Resolve the installed app's source: enforces the "only operate on an
-	// installed app" guard and yields the source the restart body needs
-	// (restart exposes no -s). The resolved source also sharpens --watch.
-	source, err := resolveInstalledSource(ctx, opts, mc, appName)
-	if err != nil {
+	// `market restart` posts to /apps/restart, which is part of the overlay
+	// feature set introduced in Olares 1.12.6 (the SPA shares one wire body
+	// between resume and restart). Older backends don't expose the endpoint,
+	// so fail fast with an actionable message instead of surfacing a confusing
+	// 404 from the POST below.
+	if err := requireRestartBackendVersion(ctx, opts); err != nil {
 		return opts.failOp("restart", appName, err)
 	}
 
-	atLeast126, err := opts.factory.OlaresBackendAtLeast(ctx, "1.12.6")
+	// Resolve the installed app's row: enforces the "only operate on an
+	// installed app" guard and yields both the source the restart body needs
+	// (restart exposes no -s) and the row's current statusTime, which we
+	// capture as the --watch baseline BEFORE issuing the restart. A completed
+	// restart rests at `running, OpType=resume` — identical to this
+	// pre-restart row — so the watcher can only tell them apart by requiring
+	// a strictly-newer statusTime (see watchRestart / requireNewerThanBaseline).
+	row, err := resolveInstalledRow(ctx, mc, appName)
 	if err != nil {
 		return opts.failOp("restart", appName, err)
 	}
+	source := row.Source
+	baselineStatusTime := parseStatusTime(row.StatusTime)
 
-	// --compute-binding is a 1.12.6+ concept; reject it on 1.12.5.
+	// --compute-binding is a 1.12.6+ concept; the command is already gated to
+	// >= 1.12.6 above, so no separate 1.12.5 rejection is needed here.
 	bindings, err := parseComputeBindingFlags(opts.ComputeBinding)
 	if err != nil {
 		return opts.failOp("restart", appName, err)
 	}
-	if len(bindings) > 0 && !atLeast126 {
-		return opts.failOp("restart", appName, fmt.Errorf("--compute-binding requires Olares 1.12.6+; re-run without --compute-binding"))
-	}
 
 	resp, err := sendRestart(ctx, mc, appName, source, bindings)
-	// 1.12.6+: recover once from a computeBindingRequired / Unavailable 422,
-	// exactly as `market resume` does.
-	if err != nil && atLeast126 {
+	// Recover once from a computeBindingRequired / Unavailable 422, exactly as
+	// `market resume` does (restart is 1.12.6+, so this path always applies).
+	if err != nil {
 		if checkType, raw := parseFailedCheck(resp); isComputeBindingPrompt(checkType) {
 			if len(bindings) > 0 {
 				return opts.failOp("restart", appName, computeBindingRejected(raw, appName, bindings))
@@ -102,7 +120,35 @@ func runRestart(opts *MarketOptions, appName string) error {
 	}
 
 	result := newOperationResult(mc, "restart", appName, "", "", "restart requested", resp)
-	return runWithWatch(opts, mc, result, newWatchTarget(watchResume, appName, source))
+	target := newWatchTarget(watchRestart, appName, source)
+	target.baselineStatusTime = baselineStatusTime
+	return runWithWatch(opts, mc, result, target)
+}
+
+// requireRestartBackendVersion gates `market restart` on Olares >=
+// restartMinOlaresVersion. POST /apps/restart is part of the overlay feature
+// set that landed in 1.12.6; on 1.12.5 the endpoint doesn't exist and the call
+// would 404. Fail-closed (mirrors settings' RequireMinVersion / files'
+// requireArchiveBackendVersion): an undetectable version is rejected because
+// the feature provably doesn't exist on anything older, with --olares-version
+// as the escape hatch.
+func requireRestartBackendVersion(ctx context.Context, opts *MarketOptions) error {
+	ok, err := opts.factory.OlaresBackendAtLeast(ctx, restartMinOlaresVersion)
+	if err != nil {
+		return fmt.Errorf(
+			"market restart requires Olares >= %s (the overlay feature set), but the backend version could not be determined: %w; pass --%s <version> to set it manually (e.g. --%s %s)",
+			restartMinOlaresVersion, err, cmdutil.FlagOlaresVersion, cmdutil.FlagOlaresVersion, restartMinOlaresVersion)
+	}
+	if !ok {
+		got := "unknown"
+		if v, verr := opts.factory.OlaresBackendVersion(ctx); verr == nil && v != nil {
+			got = v.Original()
+		}
+		return fmt.Errorf(
+			"market restart requires Olares >= %s (the overlay feature set, incl. POST /apps/restart), but this backend is %s",
+			restartMinOlaresVersion, got)
+	}
+	return nil
 }
 
 // sendRestart posts the restart body ({app_name, source, computeBinding?}) to

--- a/cli/cmd/ctl/market/restart/restart.go
+++ b/cli/cmd/ctl/market/restart/restart.go
@@ -1,0 +1,26 @@
+// Package restart builds the `market restart` request. Unlike
+// stop/resume/uninstall (whose wire format diverges across Olares versions and
+// therefore lives in per-version builder sub-packages), the restart endpoint is
+// version-agnostic in the SPA: apps/packages/app/src/api/market/private/operations.ts
+// declares Resume2RestartRequest with the note "no version, shared by resume and
+// restart" and POSTs {app_name, source, computeBinding?} to /apps/restart. We
+// mirror that single body here. computeBinding is a 1.12.6+ concept and is only
+// written when non-nil (identical to resume's 1.12.6 body), so a restart without
+// a GPU binding keeps the minimal {app_name, source} payload.
+package restart
+
+import "net/http"
+
+// Build returns the restart request. computeBinding is passed as `any` so this
+// package stays free of a dependency on the parent market package (no import
+// cycle); pass nil when there is no binding to send.
+func Build(appName, source string, computeBinding any) (method, path string, body any) {
+	b := map[string]any{
+		"app_name": appName,
+		"source":   source,
+	}
+	if computeBinding != nil {
+		b["computeBinding"] = computeBinding
+	}
+	return http.MethodPost, "/apps/restart", b
+}

--- a/cli/cmd/ctl/market/root.go
+++ b/cli/cmd/ctl/market/root.go
@@ -37,7 +37,8 @@ Verb families:
   catalog (read-only)   list, categories, get         browse /market/data
   runtime (read-only)   status                        read /market/state
   lifecycle (mutating)  install, upgrade, uninstall,  POST/PUT/DELETE on
-                        clone, stop, resume, cancel    /apps/{name}/*
+                        clone, stop, resume, restart,  /apps/{name}/*
+                        cancel
   charts (mutating)     upload, delete                 SPA Local Sources
 
 Universal flags:
@@ -82,6 +83,7 @@ cli/skills/olares-market/SKILL.md.`,
 	cmd.AddCommand(NewCmdMarketCancel(f))
 	cmd.AddCommand(NewCmdMarketStop(f))
 	cmd.AddCommand(NewCmdMarketResume(f))
+	cmd.AddCommand(NewCmdMarketRestart(f))
 	cmd.AddCommand(NewCmdMarketUpload(f))
 	cmd.AddCommand(NewCmdMarketDelete(f))
 	cmd.AddCommand(NewCmdMarketStatus(f))

--- a/cli/cmd/ctl/market/status.go
+++ b/cli/cmd/ctl/market/status.go
@@ -84,6 +84,10 @@ type statusRow struct {
 	CfgType  string `json:"cfgType,omitempty"`
 	Message  string `json:"message,omitempty"`
 	Source   string `json:"source"`
+	// StatusTime carries the backend-generated statusTime verbatim (RFC3339).
+	// The restart watcher parses it (see effectiveTime) to compare against a
+	// pre-restart baseline; empty/unparseable means "no reliable timestamp".
+	StatusTime string `json:"statusTime,omitempty"`
 }
 
 func parseStatusRows(resp *APIResponse, source string, showAll bool) ([]statusRow, error) {
@@ -121,13 +125,14 @@ func parseStatusRows(resp *APIResponse, source string, showAll bool) ([]statusRo
 				progress = "-"
 			}
 			rows = append(rows, statusRow{
-				Name:     name,
-				State:    appState.Status.State,
-				OpType:   appState.Status.OpType,
-				Progress: progress,
-				CfgType:  appState.Status.CfgType,
-				Message:  appState.Status.Message,
-				Source:   sourceName,
+				Name:       name,
+				State:      appState.Status.State,
+				OpType:     appState.Status.OpType,
+				Progress:   progress,
+				CfgType:    appState.Status.CfgType,
+				Message:    appState.Status.Message,
+				Source:     sourceName,
+				StatusTime: strings.TrimSpace(appState.Status.StatusTime),
 			})
 		}
 	}

--- a/cli/cmd/ctl/market/types.go
+++ b/cli/cmd/ctl/market/types.go
@@ -221,6 +221,13 @@ type AppStatus struct {
 	Progress string `json:"progress,omitempty"`
 	Message  string `json:"message,omitempty"`
 	Reason   string `json:"reason,omitempty"`
+	// StatusTime is the backend-generated timestamp the SPA uses as the
+	// canonical ordering key for a status row (getEffectiveTime in
+	// apps/.../constant/constants.ts prefers statusTime; updateTime is
+	// commented out and lastTransitionTime is not used for ordering). The
+	// restart watcher uses it as a baseline to tell a freshly-completed
+	// restart apart from the identical-looking pre-restart resting row.
+	StatusTime string `json:"statusTime,omitempty"`
 }
 
 type SourceInfoData struct {

--- a/cli/cmd/ctl/market/watch.go
+++ b/cli/cmd/ctl/market/watch.go
@@ -23,6 +23,7 @@ const (
 	watchUninstall watchOp = "uninstall"
 	watchStop      watchOp = "stop"
 	watchResume    watchOp = "resume"
+	watchRestart   watchOp = "restart"
 	watchCancel    watchOp = "cancel"
 	// watchStatus is the op-agnostic variant used by the `status --watch`
 	// command: the user didn't kick off any lifecycle in this CLI
@@ -135,6 +136,28 @@ type watchTarget struct {
 	// distinguish "no-op success" from "pre-tick-zero" from the row
 	// alone, so we keep the strict gate for those.
 	idempotentSuccess bool
+
+	// requireNewerThanBaseline gates BOTH success and failure on the row's
+	// statusTime being strictly newer than baselineStatusTime. This is the
+	// crux of the restart watcher: a completed restart rests at
+	// `state=running, OpType=resume` — byte-for-byte identical to the row's
+	// pre-restart resting state (OpType is never cleared). The ONLY way to
+	// tell "restart just finished" from "restart hasn't started yet" is
+	// temporal, and we align with the SPA which orders status rows by
+	// statusTime (getEffectiveTime in apps/.../constant/constants.ts).
+	//
+	// We use STRICT `>` (not `>=`) on purpose: the baseline IS the stale
+	// row's statusTime, so `>=` would let the tick-zero stale row satisfy
+	// `T0 >= T0` and short-circuit to success — exactly the false positive
+	// this whole mechanism exists to prevent.
+	//
+	// When the row's statusTime is missing/unparseable (effectiveTime == 0)
+	// we mirror the SPA (newTime===0 → invalid, skip): the row is NOT
+	// treated as terminal and we keep polling until --watch-timeout. Only
+	// restart sets this; every other op leaves it false (passesBaseline is
+	// then a no-op).
+	requireNewerThanBaseline bool
+	baselineStatusTime       int64
 }
 
 func newWatchTarget(op watchOp, appName, source string) watchTarget {
@@ -185,6 +208,32 @@ func newWatchTarget(op watchOp, appName, source string) watchTarget {
 		// Symmetric to stop: `resume` on an already-running row is a
 		// backend no-op and would otherwise hang the watcher.
 		t.idempotentSuccess = true
+	case watchRestart:
+		// restart = backend stop THEN resume once stop succeeds. The row
+		// therefore passes through `OpType=stop` (stop phase) and
+		// `OpType=resume` (resume phase, via `initializing`) before
+		// resting at `state=running`. We must NOT reuse watchResume:
+		//   - idempotentSuccess would fire on the tick-zero stale
+		//     `running, OpType=resume` row (the restart target is by
+		//     definition a running app), returning before the cycle even
+		//     starts.
+		//   - matchOpType=true / OpType=resume can't catch a `stopFailed`
+		//     in the stop phase (it carries OpType=stop), so a failed stop
+		//     would hang until timeout.
+		//
+		// Instead: op-agnostic success on `running`, a failure set that
+		// spans BOTH phases, and a statusTime baseline gate that alone
+		// distinguishes the freshly-completed row from the pre-restart
+		// resting row (see requireNewerThanBaseline). No idempotentSuccess.
+		t.successSet = map[string]bool{"running": true}
+		t.failureSet = map[string]bool{
+			"stopFailed":           true,
+			"resumeFailed":         true,
+			"resumingCanceled":     true,
+			"resumingCancelFailed": true,
+		}
+		t.matchOpType = false
+		t.requireNewerThanBaseline = true
 	case watchCancel:
 		// `cancel` is op-agnostic on settling: once the row leaves its
 		// in-flight phase the cancel has done all it can, regardless of
@@ -397,7 +446,7 @@ func waitForTerminal(parentCtx context.Context, mc *MarketClient, opts *MarketOp
 			rowCopy := row
 			last = &rowCopy
 
-			if t.successSet[row.State] {
+			if t.successSet[row.State] && t.passesBaseline(row) {
 				switch {
 				case t.matchesOpType(row):
 					return row, nil
@@ -410,7 +459,7 @@ func waitForTerminal(parentCtx context.Context, mc *MarketClient, opts *MarketOp
 					return row, nil
 				}
 			}
-			if t.matchesOpType(row) && t.failureSet[row.State] {
+			if t.matchesOpType(row) && t.failureSet[row.State] && t.passesBaseline(row) {
 				return row, &watchFailureError{target: t, row: row}
 			}
 		}
@@ -427,6 +476,46 @@ func (t watchTarget) matchesOpType(row statusRow) bool {
 		return true
 	}
 	return row.OpType == string(t.op)
+}
+
+// passesBaseline enforces the statusTime baseline gate (restart only). For
+// targets that don't set requireNewerThanBaseline it's a no-op. When set, the
+// row's statusTime must parse AND be strictly newer than the captured
+// baseline; a missing/unparseable statusTime (effectiveTime == 0) is treated
+// as "no reliable signal yet" and keeps the watcher polling (mirrors the SPA's
+// `newTime === 0 → invalid, skip` in appStore.setAppStatus).
+func (t watchTarget) passesBaseline(row statusRow) bool {
+	if !t.requireNewerThanBaseline {
+		return true
+	}
+	et := effectiveTime(row)
+	if et == 0 {
+		return false
+	}
+	return et > t.baselineStatusTime
+}
+
+// effectiveTime mirrors the SPA's getEffectiveTime
+// (apps/.../constant/constants.ts): the canonical ordering key for a status
+// row is statusTime. Returns unix-millis, or 0 when statusTime is
+// absent/unparseable (the SPA's "invalid" sentinel).
+func effectiveTime(row statusRow) int64 {
+	return parseStatusTime(row.StatusTime)
+}
+
+// parseStatusTime parses a backend statusTime (RFC3339, e.g.
+// "2026-07-01T08:29:03Z"; fractional seconds accepted) into unix-millis.
+// Returns 0 for empty or unparseable input.
+func parseStatusTime(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0
+	}
+	return tm.UnixMilli()
 }
 
 func unionStateSets(sets ...map[string]bool) map[string]bool {

--- a/cli/cmd/ctl/market/watch_test.go
+++ b/cli/cmd/ctl/market/watch_test.go
@@ -19,13 +19,14 @@ import (
 // classifyForTest mirrors the classification waitForTerminal performs on each
 // poll: it returns "success" / "failure" / "progressing" for a hypothetical
 // row, without invoking the actual poll loop. Kept in lockstep with the
-// classifier branches in waitForTerminal (state ∈ successSet ∧ matchesOpType
-// → success; idempotentSuccess shortcut for `state ∈ successSet ∧ OpType ==
-// ""`; matchesOpType ∧ state ∈ failureSet → failure; everything else still
-// in motion). Keeping the helper local avoids growing the package's exported
-// surface just for unit coverage.
+// classifier branches in waitForTerminal (state ∈ successSet ∧ passesBaseline
+// ∧ matchesOpType → success; idempotentSuccess shortcut for `state ∈
+// successSet ∧ OpType == ""`; matchesOpType ∧ state ∈ failureSet ∧
+// passesBaseline → failure; everything else still in motion). Keeping the
+// helper local avoids growing the package's exported surface just for unit
+// coverage.
 func classifyForTest(t watchTarget, row statusRow) string {
-	if t.successSet[row.State] {
+	if t.successSet[row.State] && t.passesBaseline(row) {
 		if t.matchesOpType(row) {
 			return "success"
 		}
@@ -33,7 +34,7 @@ func classifyForTest(t watchTarget, row statusRow) string {
 			return "success"
 		}
 	}
-	if t.matchesOpType(row) && t.failureSet[row.State] {
+	if t.matchesOpType(row) && t.failureSet[row.State] && t.passesBaseline(row) {
 		return "failure"
 	}
 	return "progressing"
@@ -397,6 +398,219 @@ func TestClassifierInstallNoIdempotentShortcut(t *testing.T) {
 	}
 }
 
+// restartTarget builds a watchRestart target with the given baseline
+// statusTime (RFC3339). Mirrors what runRestart does: create the target then
+// stamp the pre-restart baseline onto it.
+func restartTarget(baseline string) watchTarget {
+	tgt := newWatchTarget(watchRestart, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+	return tgt
+}
+
+func TestClassifierRestartBaselineGate(t *testing.T) {
+	const baseline = "2026-07-01T08:28:00Z" // pre-restart resting statusTime
+	tgt := restartTarget(baseline)
+
+	// tick-zero stale resting row: state=running, op=resume, SAME statusTime
+	// as the baseline. This is the exact false-positive the old watchResume
+	// reuse produced — must NOT be success (strict `>` baseline).
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "resume", StatusTime: baseline}); got != "progressing" {
+		t.Fatalf("stale running row at baseline statusTime must be progressing, got %s", got)
+	}
+	// An OLDER statusTime than baseline is likewise not terminal.
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "resume", StatusTime: "2026-07-01T08:27:00Z"}); got != "progressing" {
+		t.Fatalf("running row older than baseline must be progressing, got %s", got)
+	}
+	// A strictly-newer running row = the restart actually completed.
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "resume", StatusTime: "2026-07-01T08:29:03Z"}); got != "success" {
+		t.Fatalf("running row newer than baseline must be success, got %s", got)
+	}
+	// Success is op-agnostic: even if the backend leaves op empty, a
+	// strictly-newer running row is terminal success.
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "", StatusTime: "2026-07-01T08:29:03Z"}); got != "success" {
+		t.Fatalf("newer running row with empty op must still be success (op-agnostic), got %s", got)
+	}
+}
+
+func TestClassifierRestartMissingStatusTime(t *testing.T) {
+	// D2: when statusTime is missing/unparseable (effectiveTime == 0) we
+	// mirror the SPA (newTime===0 → invalid) and keep polling rather than
+	// declaring terminal. A missing statusTime on a running row must NOT be
+	// success, and a missing statusTime on a failure state must NOT be
+	// failure.
+	tgt := restartTarget("2026-07-01T08:28:00Z")
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "resume", StatusTime: ""}); got != "progressing" {
+		t.Fatalf("running row with missing statusTime must be progressing, got %s", got)
+	}
+	if got := classifyForTest(tgt, statusRow{State: "stopFailed", OpType: "stop", StatusTime: "not-a-timestamp"}); got != "progressing" {
+		t.Fatalf("failure row with unparseable statusTime must be progressing, got %s", got)
+	}
+}
+
+func TestClassifierRestartFailureSpansBothPhases(t *testing.T) {
+	// restart = stop THEN resume; a failure in EITHER phase is terminal.
+	// The stop phase carries OpType=stop, the resume phase OpType=resume —
+	// success/failure detection is op-agnostic (matchOpType=false) so both
+	// are caught. Each must also clear the baseline gate.
+	newer := "2026-07-01T08:29:00Z"
+	tgt := restartTarget("2026-07-01T08:28:00Z")
+
+	for _, c := range []struct {
+		state, op string
+	}{
+		{"stopFailed", "stop"},     // stop phase died
+		{"resumeFailed", "resume"}, // resume phase died
+		{"resumingCanceled", "resume"},
+		{"resumingCancelFailed", "resume"},
+	} {
+		if got := classifyForTest(tgt, statusRow{State: c.state, OpType: c.op, StatusTime: newer}); got != "failure" {
+			t.Fatalf("%s (op=%s) newer than baseline must be failure, got %s", c.state, c.op, got)
+		}
+	}
+
+	// Intermediate progressing states never terminate.
+	for _, c := range []struct {
+		state, op string
+	}{
+		{"stopping", "stop"},
+		{"stopped", "stop"},
+		{"initializing", "resume"},
+		{"resuming", "resume"},
+	} {
+		if got := classifyForTest(tgt, statusRow{State: c.state, OpType: c.op, StatusTime: newer}); got != "progressing" {
+			t.Fatalf("%s (op=%s) must be progressing, got %s", c.state, c.op, got)
+		}
+	}
+}
+
+func TestClassifierRestartNoIdempotentShortcut(t *testing.T) {
+	// Regression guard for the original bug: restart must NOT inherit the
+	// idempotentSuccess shortcut resume/stop use. Even with an empty op, a
+	// running row at (or before) the baseline statusTime is NOT success.
+	tgt := restartTarget("2026-07-01T08:28:00Z")
+	if tgt.idempotentSuccess {
+		t.Fatalf("watchRestart must not enable idempotentSuccess")
+	}
+	if !tgt.requireNewerThanBaseline {
+		t.Fatalf("watchRestart must enable requireNewerThanBaseline")
+	}
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "", StatusTime: "2026-07-01T08:28:00Z"}); got != "progressing" {
+		t.Fatalf("running/empty-op at baseline must be progressing, got %s", got)
+	}
+}
+
+func TestWaitForTerminalRestartSuccess(t *testing.T) {
+	// Full stop→resume cycle: baseline captured before POST, then the row
+	// walks op=stop → op=resume/initializing → op=resume/running with
+	// strictly-increasing statusTime. Only the final running row (newer than
+	// baseline) resolves to success.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		// Tick-zero could still show the stale resting row (same statusTime
+		// as baseline) before the backend picks up the restart — must be
+		// skipped, not treated as success.
+		{State: "running", OpType: "resume", StatusTime: baseline},
+		{State: "stopping", OpType: "stop", StatusTime: "2026-07-01T08:28:30Z"},
+		{State: "stopped", OpType: "stop", StatusTime: "2026-07-01T08:28:39Z"},
+		{State: "initializing", OpType: "resume", StatusTime: "2026-07-01T08:29:02Z"},
+		{State: "running", OpType: "resume", StatusTime: "2026-07-01T08:29:03Z"},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(5*time.Second, 5*time.Millisecond)
+
+	tgt := newWatchTarget(watchRestart, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	row, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err != nil {
+		t.Fatalf("expected restart success, got error: %v", err)
+	}
+	if row.State != "running" || row.StatusTime != "2026-07-01T08:29:03Z" {
+		t.Fatalf("expected terminal running row at 08:29:03, got state=%s statusTime=%s", row.State, row.StatusTime)
+	}
+}
+
+func TestWaitForTerminalRestartFastComplete(t *testing.T) {
+	// The scenario the "observe a transition" approach could NOT handle: the
+	// whole cycle finishes before/at our first poll, so we only ever see the
+	// final running row — never an intermediate state. The statusTime
+	// baseline lets us accept it immediately (newer than baseline) instead of
+	// hanging until --watch-timeout.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "running", OpType: "resume", StatusTime: "2026-07-01T08:29:03Z"},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(200*time.Millisecond, 5*time.Millisecond)
+
+	tgt := newWatchTarget(watchRestart, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	row, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err != nil {
+		t.Fatalf("expected immediate restart success, got error: %v", err)
+	}
+	if row.State != "running" {
+		t.Fatalf("expected running, got %s", row.State)
+	}
+}
+
+func TestWaitForTerminalRestartStopPhaseFailure(t *testing.T) {
+	// stop phase dies with stopFailed (OpType=stop). The old watchResume
+	// reuse would never catch this (its OpType gate required "resume") and
+	// hang until timeout. watchRestart's op-agnostic failure set catches it.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "stopping", OpType: "stop", StatusTime: "2026-07-01T08:28:30Z"},
+		{State: "stopFailed", OpType: "stop", StatusTime: "2026-07-01T08:28:40Z", Message: "failed to stop"},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(5*time.Second, 5*time.Millisecond)
+
+	tgt := newWatchTarget(watchRestart, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	_, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err == nil {
+		t.Fatalf("expected stop-phase failure, got nil")
+	}
+	var fail *watchFailureError
+	if !errors.As(err, &fail) {
+		t.Fatalf("expected watchFailureError, got %T: %v", err, err)
+	}
+	if fail.row.State != "stopFailed" {
+		t.Fatalf("expected stopFailed in error row, got %s", fail.row.State)
+	}
+}
+
+func TestWaitForTerminalRestartStaleRowTimesOut(t *testing.T) {
+	// If the backend NEVER advances past the stale resting row (statusTime
+	// stuck at the baseline — e.g. the restart POST silently no-op'd), the
+	// watcher must NOT report a false success; it should time out instead.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "running", OpType: "resume", StatusTime: baseline},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(120*time.Millisecond, 10*time.Millisecond)
+
+	tgt := newWatchTarget(watchRestart, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	_, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err == nil {
+		t.Fatalf("expected timeout on stale row, got nil (false success)")
+	}
+	var to *watchTimeoutError
+	if !errors.As(err, &to) {
+		t.Fatalf("expected watchTimeoutError, got %T: %v", err, err)
+	}
+}
+
 // fakeStateServer serves /app-store/api/v2/market/state with a configurable
 // queue of states so we can drive waitForTerminal end-to-end without a real
 // cluster. It models exactly the response shape parseStatusRows expects.
@@ -452,11 +666,12 @@ func (f *fakeStateServer) envelope(row statusRow) []byte {
 	if !missing {
 		apps = append(apps, map[string]interface{}{
 			"status": map[string]interface{}{
-				"name":     f.app,
-				"state":    row.State,
-				"opType":   row.OpType,
-				"progress": row.Progress,
-				"message":  row.Message,
+				"name":       f.app,
+				"state":      row.State,
+				"opType":     row.OpType,
+				"progress":   row.Progress,
+				"message":    row.Message,
+				"statusTime": row.StatusTime,
 			},
 		})
 	}

--- a/cli/cmd/ctl/settings/network/overlay.go
+++ b/cli/cmd/ctl/settings/network/overlay.go
@@ -1,0 +1,577 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	marketcmd "github.com/beclab/Olares/cli/cmd/ctl/market"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// `olares-cli settings network overlay ...`
+//
+// 1:1 mirror of the SPA's Settings -> Network -> Overlay Gateway page
+// (apps/packages/app/src/pages/settings/Network/OverlayGatewayPage.vue,
+// stores/settings/overlayGateway.ts, api/settings/overlayGateway.ts). The
+// Overlay Gateway gives supported apps a dedicated LAN IP (via a virtual
+// bridge/macvlan gateway) for screen mirroring, DLNA, and device discovery.
+//
+// Backed by user-service's overlay-gateway.controller.ts, which forwards to the
+// olaresd daemon:
+//
+//	GET  /api/system/overlay-gateway-status/{user}   -> OverlayGatewayStatus
+//	POST /api/command/enable-overlay-gateway         (owner-only)
+//	POST /api/command/disable-overlay-gateway        (owner-only)
+//	POST /api/command/enable-app-overlay-gateway     {app_id, user}
+//	POST /api/command/disable-app-overlay-gateway    {app_id, user}
+//
+// All responses are the uniform BFL {code, message, data} envelope, so the
+// same doGetEnvelope / doMutateEnvelope helpers this package already uses for
+// reverse-proxy / frp / hosts-file apply here. Unlike hosts-file / frp / ssl
+// writes (JWS-gated), these overlay endpoints only require Authorization (plus
+// RequireOwner on the gateway master switch), so the CLI can implement them in
+// full — exactly like `reverse-proxy set`.
+func NewOverlayCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "overlay",
+		Short: "Overlay gateway (Settings -> Network)",
+		Long: `Inspect and control the Overlay Gateway, which gives supported apps a
+dedicated LAN IP for screen mirroring, DLNA, and device discovery.
+
+Subcommands:
+  status              show gateway state + per-app overlay + LAN endpoints
+  enable              turn the overlay gateway on   (owner-only)
+  disable             turn the overlay gateway off  (owner-only)
+  app enable  <app>   turn an app's overlay on
+  app disable <app>   turn an app's overlay off
+
+Toggling an app's overlay restarts the app when it is running (so the
+change takes effect), mirroring the Settings page; stopped apps keep the
+persisted setting and pick it up on their next start.
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newOverlayStatusCommand(f))
+	cmd.AddCommand(newOverlayEnableCommand(f))
+	cmd.AddCommand(newOverlayDisableCommand(f))
+	cmd.AddCommand(newOverlayAppCommand(f))
+	return cmd
+}
+
+// overlayStatus mirrors olaresd's OverlayGatewayStatus
+// (daemon handler_overlay_gateway_status.go) and the SPA's
+// OverlayGatewayStatus (api/settings/overlayGateway.ts).
+type overlayStatus struct {
+	Status        string                `json:"status"` // on|off|activating|deactivating
+	Disable       bool                  `json:"disable"`
+	DisableReason string                `json:"disable_reason"`
+	SupportedApps []overlaySupportedApp `json:"supported_apps"`
+	ErrorMessage  string                `json:"error_message"`
+}
+
+type overlaySupportedApp struct {
+	AppName          string            `json:"app_name"`
+	AppID            string            `json:"app_id"`
+	Enabled          bool              `json:"enabled"`
+	SharedApp        bool              `json:"shared_app"`
+	UnderlayNetworks []underlayNetwork `json:"underlay_networks"`
+}
+
+type underlayNetwork struct {
+	IP    string         `json:"ip"`
+	Ports []underlayPort `json:"ports"`
+}
+
+type underlayPort struct {
+	Title       string `json:"title"`
+	Port        int    `json:"port"`
+	Workload    string `json:"workload"`
+	Description string `json:"description,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+}
+
+// appOverlayCommand is the {app_id, user} body of the per-app enable/disable
+// commands (api/settings/overlayGateway.ts AppOverlayGatewayCommand).
+type appOverlayCommand struct {
+	AppID string `json:"app_id"`
+	User  string `json:"user"`
+}
+
+const overlayStatusPath = "/api/system/overlay-gateway-status/"
+
+// currentUser resolves the active profile's Olares user name — the value the
+// daemon's `itsMe` check requires in the status path's {user} segment, and the
+// `user` field the per-app commands send for non-shared apps. It reuses the
+// whoami round-trip (BFL /api/backend/v1/user-info) but does NOT persist to the
+// role cache (cfg=nil): we only need the name, in-memory.
+func currentUser(ctx context.Context, pc *preparedClient) (string, error) {
+	res, err := whoami.FetchAndCache(ctx, pc.doer, nil, pc.profile.OlaresID, time.Now)
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(res.Info.Name)
+	if name == "" {
+		return "", fmt.Errorf("could not resolve current user name from %s", whoami.Endpoint)
+	}
+	return name, nil
+}
+
+func fetchOverlayStatus(ctx context.Context, pc *preparedClient, user string) (overlayStatus, error) {
+	var st overlayStatus
+	err := doGetEnvelope(ctx, pc.doer, overlayStatusPath+url.PathEscape(user), &st)
+	return st, err
+}
+
+// -------- status --------
+
+func newOverlayStatusCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "show overlay gateway status and per-app overlay",
+		Long: `Show the overlay gateway status as a key/value summary plus, when the
+gateway is on, a table of overlay-capable apps and their LAN endpoints:
+
+  Status:       on / off / activating / deactivating
+  Available:    yes / no
+  Reason:       why it's unavailable (WSL / macOS / no ethernet), if any
+  Error:        last gateway operation error, if any
+
+  NAME  OVERLAY  SHARED  APP-ID  LAN ENDPOINTS
+
+Use --output json for the raw daemon status (includes per-port workload,
+protocol, and description).
+`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			return preflight.Wrap(ctx, f, runOverlayStatus(ctx, f, output), "show overlay gateway status")
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runOverlayStatus(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	user, err := currentUser(ctx, pc)
+	if err != nil {
+		return err
+	}
+	st, err := fetchOverlayStatus(ctx, pc, user)
+	if err != nil {
+		return err
+	}
+	switch format {
+	case FormatJSON:
+		return printJSON(os.Stdout, st)
+	default:
+		return renderOverlayStatus(os.Stdout, st)
+	}
+}
+
+func renderOverlayStatus(w io.Writer, st overlayStatus) error {
+	rows := [][2]string{
+		{"Status", nonEmpty(st.Status)},
+		{"Available", boolStr(!st.Disable)},
+	}
+	if st.Disable && strings.TrimSpace(st.DisableReason) != "" {
+		rows = append(rows, [2]string{"Reason", st.DisableReason})
+	}
+	if strings.TrimSpace(st.ErrorMessage) != "" {
+		rows = append(rows, [2]string{"Error", st.ErrorMessage})
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(w, "%-11s %s\n", r[0]+":", r[1]); err != nil {
+			return err
+		}
+	}
+
+	// The daemon only populates supported_apps when the gateway is on
+	// (mirrored by the SPA store's `apps` getter, which returns [] otherwise).
+	if st.Status != "on" {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, "\nApps:"); err != nil {
+		return err
+	}
+	return renderOverlayApps(w, st.SupportedApps)
+}
+
+func renderOverlayApps(w io.Writer, apps []overlaySupportedApp) error {
+	if len(apps) == 0 {
+		_, err := fmt.Fprintln(w, "no overlay-capable apps")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tOVERLAY\tSHARED\tAPP-ID\tLAN ENDPOINTS"); err != nil {
+		return err
+	}
+	for _, a := range apps {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			nonEmpty(a.AppName),
+			overlayOnOff(a.Enabled),
+			boolStr(a.SharedApp),
+			nonEmpty(a.AppID),
+			nonEmpty(overlayEndpoints(a)),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func overlayOnOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
+}
+
+// overlayEndpoints flattens underlay_networks into a comma-separated list of
+// ip:port, matching OverlayAppItem.vue's networkPortRows. Only enabled apps
+// carry LAN endpoints.
+func overlayEndpoints(a overlaySupportedApp) string {
+	if !a.Enabled {
+		return ""
+	}
+	var eps []string
+	for _, net := range a.UnderlayNetworks {
+		if strings.TrimSpace(net.IP) == "" {
+			continue
+		}
+		for _, p := range net.Ports {
+			eps = append(eps, fmt.Sprintf("%s:%d", net.IP, p.Port))
+		}
+	}
+	return strings.Join(eps, ", ")
+}
+
+// overlayHasIP reports whether an app has at least one underlay network with an
+// assigned IP. Mirrors the store's hasUnderlayIp: enabling is only "done" once
+// an IP shows up (the app finished restarting).
+func overlayHasIP(a *overlaySupportedApp) bool {
+	for _, net := range a.UnderlayNetworks {
+		if strings.TrimSpace(net.IP) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// -------- --watch (poll until the change converges) --------
+
+// overlayGatewayPollInterval mirrors the SPA's OVERLAY_GATEWAY_POLL_MS (8s):
+// how often OverlayGatewayPage re-fetches status while a gateway/app change is
+// syncing.
+const overlayGatewayPollInterval = 8 * time.Second
+
+type overlayWatchFlags struct {
+	watch    bool
+	interval time.Duration
+	timeout  time.Duration
+}
+
+func addOverlayWatchFlags(cmd *cobra.Command, wf *overlayWatchFlags) {
+	cmd.Flags().BoolVarP(&wf.watch, "watch", "w", false,
+		"poll status until the change converges (gateway settles on/off; app reports enabled + an assigned LAN IP)")
+	cmd.Flags().DurationVar(&wf.interval, "watch-interval", overlayGatewayPollInterval,
+		"polling interval when --watch is set (default matches the SPA's 8s cadence); no-op without --watch")
+	cmd.Flags().DurationVar(&wf.timeout, "watch-timeout", 5*time.Minute,
+		"max wall-clock to wait when --watch is set; no-op without --watch")
+}
+
+// pollOverlay re-fetches overlay status until done(status) is true, the timeout
+// elapses, or ctx is canceled (e.g. Ctrl-C via main.go's signal context). The
+// first check happens immediately so an already-converged state returns without
+// a wasted sleep.
+func pollOverlay(ctx context.Context, pc *preparedClient, user string, wf overlayWatchFlags, done func(overlayStatus) bool) (overlayStatus, error) {
+	interval := wf.interval
+	if interval <= 0 {
+		interval = overlayGatewayPollInterval
+	}
+	timeout := wf.timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	deadline := time.Now().Add(timeout)
+
+	for {
+		st, err := fetchOverlayStatus(ctx, pc, user)
+		if err != nil {
+			return st, err
+		}
+		if done(st) {
+			return st, nil
+		}
+		if time.Now().After(deadline) {
+			return st, fmt.Errorf("timed out after %s waiting for the overlay change to converge (current status: %s)", timeout, nonEmpty(st.Status))
+		}
+		select {
+		case <-ctx.Done():
+			return st, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// -------- enable / disable (gateway master switch, owner-only) --------
+
+func newOverlayEnableCommand(f *cmdutil.Factory) *cobra.Command {
+	var wf overlayWatchFlags
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "turn the overlay gateway on (owner-only)",
+		Long: `Turn the overlay gateway on. Owner-only: non-owner callers hit a 403.
+
+The gateway comes up asynchronously; it may report 'activating' for a
+while. Re-run 'status' (or the SPA polls every 8s) to see it settle at
+'on', or pass --watch to block until it does.
+`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleOwner, "enable overlay gateway"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runOverlayGatewayToggle(ctx, f, true, wf), "enable overlay gateway")
+		},
+	}
+	addOverlayWatchFlags(cmd, &wf)
+	return cmd
+}
+
+func newOverlayDisableCommand(f *cmdutil.Factory) *cobra.Command {
+	var wf overlayWatchFlags
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "turn the overlay gateway off (owner-only)",
+		Long: `Turn the overlay gateway off. Owner-only: non-owner callers hit a 403.
+
+The gateway goes down asynchronously; it may report 'deactivating' for a
+while. Re-run 'status' to see it settle at 'off', or pass --watch to block
+until it does.
+`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+			if err := preflight.Gate(ctx, f, whoami.RoleOwner, "disable overlay gateway"); err != nil {
+				return err
+			}
+			return preflight.Wrap(ctx, f, runOverlayGatewayToggle(ctx, f, false, wf), "disable overlay gateway")
+		},
+	}
+	addOverlayWatchFlags(cmd, &wf)
+	return cmd
+}
+
+func runOverlayGatewayToggle(ctx context.Context, f *cmdutil.Factory, enable bool, wf overlayWatchFlags) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	path := "/api/command/disable-overlay-gateway"
+	if enable {
+		path = "/api/command/enable-overlay-gateway"
+	}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", path, nil, nil); err != nil {
+		return err
+	}
+
+	target := "off"
+	transient := "deactivating"
+	if enable {
+		target = "on"
+		transient = "activating"
+	}
+
+	if !wf.watch {
+		fmt.Fprintf(os.Stdout, "overlay gateway %s requested (%s); run 'settings network overlay status' to check\n",
+			map[bool]string{true: "enable", false: "disable"}[enable], transient)
+		return nil
+	}
+
+	// --watch: poll status until the gateway settles at the target
+	// (activating/deactivating are the transient states we wait through),
+	// mirroring OverlayGatewayPage's 8s polling.
+	user, err := currentUser(ctx, pc)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "overlay gateway %s requested (%s); waiting until it settles at %q (timeout: %s)...\n",
+		map[bool]string{true: "enable", false: "disable"}[enable], transient, target, wf.timeout)
+	if _, err := pollOverlay(ctx, pc, user, wf, func(s overlayStatus) bool {
+		return s.Status == target
+	}); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "overlay gateway is now %s\n", target)
+	return nil
+}
+
+// -------- app enable / disable --------
+
+func newOverlayAppCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app",
+		Short: "per-app overlay (enable / disable)",
+		Long: `Turn a single app's overlay on or off. The app must be overlay-capable
+(declared in its manifest and visible under 'status' while the gateway is
+on).
+
+When the app is running it is restarted so the change takes effect
+(mirrors the Settings page); stopped apps keep the persisted setting and
+pick it up on their next start.
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newOverlayAppToggleCommand(f, true))
+	cmd.AddCommand(newOverlayAppToggleCommand(f, false))
+	return cmd
+}
+
+func newOverlayAppToggleCommand(f *cmdutil.Factory, enable bool) *cobra.Command {
+	use := "disable {app-name}"
+	short := "turn an app's overlay off"
+	verb := "disable app overlay"
+	if enable {
+		use = "enable {app-name}"
+		short = "turn an app's overlay on"
+		verb = "enable app overlay"
+	}
+	var wf overlayWatchFlags
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			return preflight.Wrap(ctx, f, runOverlayAppToggle(ctx, f, args[0], enable, wf), verb)
+		},
+	}
+	addOverlayWatchFlags(cmd, &wf)
+	return cmd
+}
+
+func runOverlayAppToggle(ctx context.Context, f *cmdutil.Factory, appName string, enable bool, wf overlayWatchFlags) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	user, err := currentUser(ctx, pc)
+	if err != nil {
+		return err
+	}
+
+	// Look up the supported app so we send the right app_id and the correct
+	// `user` (empty for shared apps), exactly as the store's toggleAppOverlay
+	// does. The daemon only reports supported_apps while the gateway is on.
+	st, err := fetchOverlayStatus(ctx, pc, user)
+	if err != nil {
+		return err
+	}
+	if st.Status != "on" {
+		return fmt.Errorf("overlay gateway is not on (status: %s); enable it first with 'settings network overlay enable'", nonEmpty(st.Status))
+	}
+	var found *overlaySupportedApp
+	for i := range st.SupportedApps {
+		if st.SupportedApps[i].AppName == appName || st.SupportedApps[i].AppID == appName {
+			found = &st.SupportedApps[i]
+			break
+		}
+	}
+	if found == nil {
+		return fmt.Errorf("%q is not an overlay-capable app (run 'settings network overlay status' to list them)", appName)
+	}
+
+	appID := found.AppID
+	if appID == "" {
+		appID = appName
+	}
+	body := appOverlayCommand{AppID: appID, User: user}
+	if found.SharedApp {
+		body.User = ""
+	}
+
+	path := "/api/command/disable-app-overlay-gateway"
+	if enable {
+		path = "/api/command/enable-app-overlay-gateway"
+	}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", path, body, nil); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "overlay %s for app %q\n", overlayOnOff(enable), found.AppName)
+
+	// Mirror OverlayGatewayPage: restart running apps so the change takes
+	// effect. Best-effort — the overlay setting is already persisted, so a
+	// restart hiccup is a warning, not a failure of this command.
+	restarted, rerr := marketcmd.RestartApp(ctx, f, found.AppName)
+	switch {
+	case rerr != nil:
+		fmt.Fprintf(os.Stderr, "warning: overlay %s but restarting %q failed: %v\n  the setting is persisted; restart the app manually with 'olares-cli market restart %s'\n",
+			overlayOnOff(enable), found.AppName, rerr, found.AppName)
+	case restarted:
+		fmt.Fprintf(os.Stdout, "restarting %q to apply the change\n", found.AppName)
+	default:
+		fmt.Fprintf(os.Stdout, "%q is not running; the change is persisted and applies on next start\n", found.AppName)
+	}
+
+	if !wf.watch {
+		return nil
+	}
+
+	// --watch: poll status until the app converges, mirroring the store's
+	// evaluateStatusSyncTargets — enabling is "done" once the app reports
+	// enabled AND an underlay IP is assigned (i.e. the restart finished);
+	// disabling is done as soon as it is no longer enabled (or drops off the
+	// supported list).
+	appName = found.AppName
+	fmt.Fprintf(os.Stdout, "waiting for %q overlay to converge (timeout: %s)...\n", appName, wf.timeout)
+	if _, err := pollOverlay(ctx, pc, user, wf, func(s overlayStatus) bool {
+		var sup *overlaySupportedApp
+		for i := range s.SupportedApps {
+			if s.SupportedApps[i].AppName == appName || (appID != "" && s.SupportedApps[i].AppID == appID) {
+				sup = &s.SupportedApps[i]
+				break
+			}
+		}
+		if enable {
+			return sup != nil && sup.Enabled && overlayHasIP(sup)
+		}
+		return sup == nil || !sup.Enabled
+	}); err != nil {
+		return err
+	}
+	if enable {
+		fmt.Fprintf(os.Stdout, "%q overlay is active (LAN IP assigned)\n", appName)
+	} else {
+		fmt.Fprintf(os.Stdout, "%q overlay is now off\n", appName)
+	}
+	return nil
+}

--- a/cli/cmd/ctl/settings/network/root.go
+++ b/cli/cmd/ctl/settings/network/root.go
@@ -25,20 +25,21 @@ import (
 func NewNetworkCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "network",
-		Short: "Network settings (reverse-proxy, FRP, SSL, hosts-file)",
+		Short: "Network settings (reverse-proxy, FRP, SSL, hosts-file, overlay)",
 		Long: `Read and configure network plumbing: reverse-proxy mode, FRP server,
-SSL toggles, and the system hosts-file.
+SSL toggles, the system hosts-file, and the overlay gateway.
 
 Subcommands:
-  reverse-proxy get
+  reverse-proxy get / set
   frp list
   hosts-file get
+  overlay status / enable / disable / app enable / app disable
 
 Out of scope until a JWS key sourcing path exists:
   frp set, ssl enable / disable / update, hosts-file set
 
-Note: reverse-proxy set is owner-only; non-owner callers will hit a
-403 from BFL.
+Note: reverse-proxy set and overlay enable / disable are owner-only;
+non-owner callers will hit a 403 from BFL.
 `,
 	}
 	cmd.SilenceUsage = true
@@ -46,5 +47,6 @@ Note: reverse-proxy set is owner-only; non-owner callers will hit a
 	cmd.AddCommand(NewFRPCommand(f))
 	cmd.AddCommand(NewSSLCommand(f))
 	cmd.AddCommand(NewHostsFileCommand(f))
+	cmd.AddCommand(NewOverlayCommand(f))
 	return cmd
 }

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-market
-version: 4.4.0
-description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, upload chart."
+version: 4.5.0
+description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume, restart apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, restart app, upload chart."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
   openclaw:
@@ -20,7 +20,7 @@ metadata:
 
 ## When to use
 
-- Olares Market, olares-cli market, Olares app store, install / upgrade / uninstall / clone / stop / resume / cancel an app
+- Olares Market, olares-cli market, Olares app store, install / upgrade / uninstall / clone / stop / resume / restart / cancel an app
 - `my Olares apps`, `我的应用`, `market list --mine`, `is <app> installed yet`, chart upload / delete, `--watch` until terminal state
 - Catalog: `list`, `get`, `categories`; runtime: `status`
 
@@ -34,7 +34,7 @@ metadata:
 |---|---|---|
 | **catalog** | `list`, `get`, `categories` | no |
 | **runtime** | `status` | no |
-| **lifecycle** | `install`, `upgrade`, `uninstall`, `clone`, `stop`, `resume`, `cancel` | yes |
+| **lifecycle** | `install`, `upgrade`, `uninstall`, `clone`, `stop`, `resume`, `restart`, `cancel` | yes |
 | **charts** | `upload`, `delete` | yes |
 
 For verb-specific behavior, **always start with `olares-cli market <verb> --help`**. Then drill into a reference if listed:
@@ -42,7 +42,7 @@ For verb-specific behavior, **always start with `olares-cli market <verb> --help
 | Family | Reference |
 |---|---|
 | catalog + runtime | [references/olares-market-list.md](references/olares-market-list.md) (`list` / `--mine` / `categories` / `get` / `status`) |
-| lifecycle | [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md) (`install` / `upgrade` / `uninstall` / `clone` / `stop` / `resume` / `cancel`) |
+| lifecycle | [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md) (`install` / `upgrade` / `uninstall` / `clone` / `stop` / `resume` / `cancel`). `restart` (POST `/apps/restart`, version-agnostic body `{app_name, source}`) shares the `resume` watch bucket (`running`) and, like `stop`/`resume`, exposes no `-s`; it also backs the auto-restart in `settings network overlay app enable/disable` |
 | `--watch` / stuck / errors | [references/olares-market-watch.md](references/olares-market-watch.md) (per-verb watch buckets, foreground windows, stuck-state handling, common errors) |
 | charts | [references/olares-market-charts.md](references/olares-market-charts.md) (`upload` / `delete`) |
 
@@ -68,7 +68,7 @@ The market backend serves multiple "sources" of charts. The CLI resolves which o
 | `-s / --source` | `list`, `categories`, `status`, `get` | `install`, `upgrade`, `clone` | — (hard-coded `upload`) |
 | `-a / --all-sources` | `list`, `categories`, `status` | — | — |
 
-> **`-s` is NOT on `uninstall` / `stop` / `resume`:** they act on whichever per-user state row matches the app name, regardless of source.
+> **`-s` is NOT on `uninstall` / `stop` / `resume` / `restart`:** they act on whichever per-user state row matches the app name, regardless of source.
 > **`cancel` now exposes `--source`** — but only as a fallback for the Olares 1.12.6+ edge case where the per-user state row is gone (or `/market/state` is unreadable) and the 1.12.6 cancel body still needs a source. In the normal case the source is read from the state row; do not pass it.
 
 ## App lifecycle / state machine
@@ -103,7 +103,7 @@ The same `State` can mean different things depending on which mutation is in fli
 - `--watch-timeout D` caps total wall-clock time.
 - One-shot (no `--watch`) returns as soon as the backend ACKs the mutation request — the row may still be `progressing` for minutes.
 - With `--watch`, the CLI blocks until the row reaches a terminal bucket (success OR failure) matching the OpType safety rules above.
-- **Idempotent no-ops — `stop` / `resume` only**: `stop` on an already-`stopped` row and `resume` on an already-`running` row return immediately with success (the watcher recognizes the backend's no-op `opType=""` instead of hanging). `install` / `upgrade` / `clone` have **no** such shortcut — they require the matching `OpType` before declaring success.
+- **Idempotent no-ops — `stop` / `resume` only**: `stop` on an already-`stopped` row and `resume` on an already-`running` row return immediately with success (the watcher recognizes the backend's no-op `opType=""` instead of hanging). `install` / `upgrade` / `clone` have **no** such shortcut — they require the matching `OpType` before declaring success. `restart` reuses the `resume` watch bucket (terminal `running`), so its `--watch` inherits the same idempotent-`running` shortcut.
 - `--watch-timeout` / `--watch-interval` are **no-ops without `--watch`** (silently ignored, not rejected). There is no `--watch-iterations` flag on market verbs.
 
 ### Agent watch discipline (don't block on a long watch)

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-settings
-version: 4.2.2
-description: "Olares Settings via olares-cli settings — mirror of Settings SPA: users, apps, VPN, backup, integration, GPU, search, me/whoami. Use for Olares Settings, role, VPN ACL, backup, integration accounts, language."
+version: 4.4.0
+description: "Olares Settings via olares-cli settings — mirror of Settings SPA: users, apps, VPN, network (reverse-proxy / overlay gateway), backup, integration, GPU, search, me/whoami. Use for Olares Settings, role, VPN ACL, overlay gateway, backup, integration accounts, language."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
   openclaw:
@@ -53,7 +53,7 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `integration` | [references/olares-settings-integration.md](references/olares-settings-integration.md) (`accounts add awss3|tencent`) |
 | `backup` | [references/olares-settings-backup.md](references/olares-settings-backup.md) (plans / snapshots / password) |
 | `appearance` | `olares-cli settings appearance --help` (`get`, `language set`) |
-| `network` | `olares-cli settings network --help` (read-only reverse-proxy / frp / hosts-file; writes blocked by JWS gap — see [Currently-implemented mutating verbs](#currently-implemented-mutating-verbs)) |
+| `network` | `olares-cli settings network --help` (read-only frp / hosts-file; `reverse-proxy get/set` (owner set); `overlay` gateway `status` / `enable` / `disable` (owner) / `app enable`|`app disable` — NOT JWS-gated, see [Currently-implemented mutating verbs](#currently-implemented-mutating-verbs). `frp set` / `ssl` / `hosts-file set` still blocked by the JWS gap.) |
 | `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute list`) |
 | `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
@@ -80,7 +80,8 @@ All three delegate to the same driver — same output, same caching, same `--ref
 | Floor | Verbs |
 |---|---|
 | **Admin (owner / admin)** | `users list / get / create / delete`; `network reverse-proxy get`, `network frp list`, `network hosts-file get`; `gpu list`; `compute list`, `compute unbind`, `compute set-type`; `advanced status / registries list / images list`; `vpn ssh status/enable/disable`, `vpn subroutes status`, `vpn acl all/get/add/remove`, `vpn public-domain-policy get` |
-| **Normal (any authenticated user)** | `me whoami / version / check-update / sso list`; `apps list/get`, `apps entrances list`, `apps env get`, `apps domain get`, `apps policy get`; `vpn devices list / routes <id>`; `appearance get`, `appearance language set`; `integration accounts list / list-by-type / get / add / delete`; `video config get`; `search status / dirs list / dirs add / dirs rm / rebuild`; `backup plans list`, `backup snapshots list`; `restore plans list`; `advanced env (system|user) list` |
+| **Owner only** | `network reverse-proxy set` (BFL owner-gated), `network overlay enable`, `network overlay disable` |
+| **Normal (any authenticated user)** | `me whoami / version / check-update / sso list`; `apps list/get`, `apps entrances list`, `apps env get`, `apps domain get`, `apps policy get`; `network overlay status`, `network overlay app enable`, `network overlay app disable`; `vpn devices list / routes <id>`; `appearance get`, `appearance language set`; `integration accounts list / list-by-type / get / add / delete`; `video config get`; `search status / dirs list / dirs add / dirs rm / rebuild`; `backup plans list`, `backup snapshots list`; `restore plans list`; `advanced env (system|user) list` |
 
 ### Soft preflight behavior
 
@@ -104,6 +105,7 @@ Different upstream services return JSON in different envelopes. The CLI normaliz
 | Area | Endpoint family | Wire envelope |
 |---|---|---|
 | `me`, `apps`, `network`, `appearance`, `integration`, `gpu`, `video`, `search`, `advanced` | `/api/*` (user-service / BFL / terminusd) | Unwrapped BFL `{data: ...}` envelope |
+| `network overlay` | `GET /api/system/overlay-gateway-status/{user}`, `POST /api/command/{enable,disable}-overlay-gateway`, `POST /api/command/{enable,disable}-app-overlay-gateway` (user-service → olaresd) | BFL `{code,message,data}` envelope. Status `data`: `{status, disable, disable_reason, supported_apps[], error_message}`; each app: `{app_name, app_id, enabled, shared_app, underlay_networks[]}`. `status` path `{user}` must be the current user (daemon `itsMe`); `-o json` for per-port workload/protocol/description |
 | `users` | `/api/users/v2`, `/api/users/:name`, `POST/DELETE /api/users/...` | List-result decoder; mutating returns axios-inner `{name}` |
 | `vpn` devices / ACL | `<SettingsURL>/headscale/machine`, `/headscale/machine/:id/routes` | Raw Headscale JSON (NO envelope), `route.id` is a string |
 | `vpn` public-domain-policy | `/api/launcher-public-domain-access-policy` | Already-unwrapped `{deny_all: 0|1}` |
@@ -116,6 +118,8 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 
 | Area | Verb | Status |
 |---|---|---|
+| `network overlay` | `enable` / `disable` (owner; gateway master switch, async — status settles at on/off; `--watch` polls until it settles) | UNVERIFIED |
+| `network overlay` | `app enable <app>` / `app disable <app>` (any user; auto-restarts the app when running, via `market restart`; `--watch` polls until enabled+IP assigned / disabled) | UNVERIFIED |
 | `appearance` | `language set <code>` | VERIFIED |
 | `users` | `create` / `delete` (with `--watch`) | VERIFIED |
 | `search` | `rebuild`, `dirs add / rm` | VERIFIED (rebuild + dirs writes) |
@@ -130,7 +134,7 @@ Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Ve
 
 - App lifecycle (`install` / `uninstall` / `upgrade` / `stop` / `resume` / `cancel` / `clone`) → use [`olares-market`](../olares-market/SKILL.md) instead
 - Per-app secrets / permissions / providers (Infisical-backed) → admin / chart-side tooling
-- Network writes requiring a JWS-signed device-id header (`hosts-file set`, `frp set`, `ssl enable/disable/update`)
+- Network writes requiring a JWS-signed device-id header (`hosts-file set`, `frp set`, `ssl enable/disable/update`) — note the overlay-gateway writes are NOT in this bucket: they only need Authorization (plus RequireOwner on the gateway master switch), so `network overlay enable/disable` and `overlay app enable/disable` ARE implemented
 - Containerd registry mutations (`registries mirrors put/delete`, `images delete/prune`) — JWS-gated
 - Hardware / restart-class (reboot, shutdown, ssh-password, OS upgrade) — JWS-gated via TermiPass QR callback
 - Backup plan create / update (needs full `BackupPolicy` + `LocationConfig` vector design)


### PR DESCRIPTION
* **Background**

Adds two related olares-cli capabilities, mirroring the Settings SPA 1:1.

- **`olares-cli market restart <app>`**: restart an installed app in place (`POST /apps/restart`, version-agnostic). Supports `--watch` (polls until the app is running again) and `--compute-binding`. Also exports a reusable `RestartApp` helper so other commands can trigger a restart of a running app.
- **`olares-cli settings network overlay`** command group, mirroring the overlay gateway page:
  - `status` — list overlay-capable apps and their LAN endpoints.
  - `enable` / `disable` — gateway master switch (owner-only; async, status settles at `on`/`off`).
  - `app enable <app>` / `app disable <app>` — per-app overlay toggle (any authenticated user); running apps are auto-restarted via `market restart` so the change takes effect, matching the SPA.
  - All four write commands accept `--watch` to block until the change converges — the gateway settles at `on`/`off`, or the app reports `enabled` + an assigned LAN IP (enable) / no longer enabled (disable) — using the same 8s polling cadence as the SPA (`--watch-interval` / `--watch-timeout` tunable).

These overlay endpoints only require an `Authorization` header (the gateway master switch additionally requires Owner); no JWS device-id signing is needed, so they are fully implementable from the CLI.

Docs: updates `cli/skills/olares-market/SKILL.md` and `cli/skills/olares-settings/SKILL.md` (verb tables, floor/role tables, wire-format cheat sheet).

* **Target Version for Merge**

1.12.6  1.12.7

* **Related Issues**

None

* **PRs Involving Sub-Systems**

None

* **Other information**:

None

Made with [Cursor](https://cursor.com)