### PR TITLE
docs: fix empty-sitemap crash on archived version builds

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,7 +179,12 @@ export default defineVersionedConfig2(withMermaid({
     ]);
   },
 
-  sitemap: {
+  // Archived versioned builds noindex every page, so their sitemap would be
+  // empty. The `sitemap` package throws `EmptySitemap` when the stream ends
+  // with zero URLs, which crashes the whole build (exit != 0) and makes the
+  // release-docs pipeline silently skip that version. Since we explicitly do
+  // not want archived versions in the sitemap anyway, disable it for them.
+  sitemap: isArchivedVersionBuild ? undefined : {
     hostname: "https://www.olares.com/docs/",
     transformItems: (items) =>
       // Drop noindex pages from sitemap.xml so crawlers don't even discover


### PR DESCRIPTION
## Problem
Versioned (archived) doc builds (`BASE_URL=/docs/<version>/`, e.g. /docs/1.12.6/)
crash at the end of `vitepress build`:

    build complete in 92.29s.
    EmptySitemap: You ended the stream without writing anything.

`isArchivedVersionBuild` marks every page `noindex`, and `sitemap.transformItems`
then filters out all noindex pages, leaving zero sitemap entries. The `sitemap`
package throws `EmptySitemap` on an empty stream, so the process exits non-zero.
In the release-docs pipeline this build is `|| continue`'d, so the version is
silently dropped from the image (missing dir + 404 + absent from the version
switcher).

## Fix
Archived versions are intentionally excluded from the sitemap anyway, so disable
the sitemap entirely for archived builds instead of producing an empty one.

## Test
BASE_URL=/docs/1.12.6/ SITE_PATH_PREFIX=/docs CURRENT_VERSION=1.12.6 \
VERSIONS=1.12.6,1.12.5,1.12.4,1.12.2 LATEST_VERSION=1.12.5 LANGUAGES=zh \
npm run build
# before: EmptySitemap crash, exit != 0
# after:  build complete, exit 0, full dist output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in docs build config; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Archived doc builds (`BASE_URL` with a version segment) already mark every page **noindex**, and the sitemap filter drops those URLs, so the build used to finish with an **empty sitemap** and the `sitemap` package threw **`EmptySitemap`**, failing `vitepress build` and causing release-docs to skip that version.
> 
> The VitePress config now sets **`sitemap` to `undefined`** when `isArchivedVersionBuild` is true, skipping sitemap generation entirely for those builds—matching the intent that archived versions should not appear in the sitemap anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d495d194da50ba183d5ff473b97ce6a9c74c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->