### PR TITLE
fix(app-service): release a stopped shared server's compute allocation from live workload state

### DIFF
--- a/framework/app-service/pkg/appstate/stopped_app.go
+++ b/framework/app-service/pkg/appstate/stopped_app.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -62,9 +61,21 @@ func (p *StoppedApp) cleanupComputeAllocation(ctx context.Context) error {
 		klog.Errorf("unmarshal app config for compute cleanup of stopped app %s failed %v", p.manager.Spec.AppName, err)
 		return err
 	}
-	// Mirror SuspendingApp / SuspendFailedApp: stop-all also frees the shared
-	// server's allocation, a client-only stop must not.
-	stopServer := p.manager.Annotations[api.AppStopAllKey] == "true"
+	// Whether to also release the shared server's allocation. SuspendingApp /
+	// SuspendFailedApp read this from the AppStopAllKey annotation because they
+	// run while the original stop request is still in flight. StoppedApp is the
+	// steady-state handler and runs long after that annotation has been
+	// consumed and deleted (see suspendOrResumeApp in utils.go), so keying off
+	// it would always evaluate false and leak a stopped shared server's
+	// allocation. Instead decide from the live workload state: only reclaim the
+	// shared server's allocation once its workloads are actually scaled to zero
+	// — the stop-side mirror of ShouldIncludeSharedServerForResume. For
+	// non-shared apps this is false and EnsureAllocationsDeletedForComputeTarget
+	// still releases the app's own allocation.
+	stopServer, err := compute.SharedServerSuspended(ctx, p.client, &appCfg)
+	if err != nil {
+		return err
+	}
 	cleaned, err := compute.EnsureAllocationsDeletedForComputeTarget(ctx, p.client, &appCfg, stopServer)
 	if err != nil {
 		return err

--- a/framework/app-service/pkg/compute/target.go
+++ b/framework/app-service/pkg/compute/target.go
@@ -123,6 +123,28 @@ func ShouldIncludeSharedServerForResume(ctx context.Context, c client.Client, ap
 	return false, nil
 }
 
+// SharedServerSuspended reports whether appConfig's v2 cluster-shared server
+// side is currently scaled to zero (all its shared-chart workloads suspended).
+// It returns false for apps that are not v2 cluster-shared, and false when the
+// shared namespace / workloads can't be found (nothing to reclaim).
+//
+// Unlike the AppStopAllKey annotation — which is consumed and deleted as soon
+// as the suspend op finishes — this reflects the live workload state, so
+// steady-state reconcilers (e.g. StoppedApp) can decide whether a shared
+// server's compute allocation is still in use or safe to release long after
+// the original stop request's annotation is gone. It is the stop-side mirror
+// of the check ShouldIncludeSharedServerForResume performs on resume.
+func SharedServerSuspended(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, error) {
+	if appConfig == nil || !appConfig.IsV2() || !appConfig.HasClusterSharedCharts() {
+		return false, nil
+	}
+	suspended, found, err := sharedServerSuspended(ctx, c, appConfig)
+	if err != nil {
+		return false, err
+	}
+	return found && suspended, nil
+}
+
 func sharedServerSuspended(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (bool, bool, error) {
 	for _, chart := range appConfig.SubCharts {
 		if !chart.Shared {


### PR DESCRIPTION
## Summary
- `StoppedApp` decided whether to also free a v2 cluster-shared **server's** compute allocation by reading the `AppStopAllKey` annotation. That annotation is consumed and deleted as soon as the suspend op finishes (`suspendOrResumeApp`), so the steady-state `StoppedApp` handler always evaluated it as `false` and never reclaimed the shared server's GPU/compute allocation after its workloads were scaled to zero — a leaked reservation.
- Add `compute.SharedServerSuspended` (the stop-side mirror of `ShouldIncludeSharedServerForResume`) and have `StoppedApp` decide from the **live workload state** instead: only release the shared server's allocation once its workloads are actually scaled to zero.
- Non-shared apps are unaffected — they still release their own allocation via `EnsureAllocationsDeletedForComputeTarget`.

## Test plan
- [ ] v2 cluster-shared app: admin stop-all → server scaled to 0 → StoppedApp releases the shared server allocation.
- [ ] v2 cluster-shared app: client-only stop while server keeps running for other users → StoppedApp does NOT release the shared server allocation.
- [ ] Non-shared v1/v3 app: stop → own allocation released as before.

Made with [Cursor](https://cursor.com)