### PR TITLE
fix(app-service): restrict remote-options proxy to a domain whitelist

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_appenv.go
+++ b/framework/app-service/pkg/apiserver/handler_appenv.go
@@ -178,6 +178,10 @@ func (h *Handler) proxyRemoteOptions(req *restful.Request, resp *restful.Respons
 		api.HandleBadRequest(resp, req, fmt.Errorf("unsupported scheme: %s", u.Scheme))
 		return
 	}
+	if !constants.IsRemoteOptionsHostAllowed(u.Hostname()) {
+		api.HandleForbidden(resp, req, fmt.Errorf("endpoint host %q is not allowed", u.Hostname()))
+		return
+	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	httpReq, err := http.NewRequestWithContext(req.Request.Context(), http.MethodGet, body.Endpoint, nil)

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -3,6 +3,7 @@ package constants
 import (
 	"flag"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -185,7 +186,39 @@ var (
 	CHART_REPO_URL string = "http://chart-repo-service.os-framework:82/"
 
 	OLARES_APP_NAME = "olares-app"
+
+	// RemoteOptionsDomainWhitelist restricts which domains the remote-options
+	// proxy (proxyRemoteOptions) may fetch from. The proxy lets any normal user
+	// have app-service issue an outbound GET, so without a whitelist it becomes
+	// an open proxy / SSRF vector to arbitrary URLs. Validating only against the
+	// remoteOptions URL declared in the app manifest is insufficient, because a
+	// user can bypass that by uploading a custom chart, so we gate on an
+	// explicit domain whitelist instead. Currently only the Olares app CDN is
+	// used, but it is kept as a list for future entries. Override at runtime
+	// with the comma-separated REMOTE_OPTIONS_DOMAIN_WHITELIST env var.
+	RemoteOptionsDomainWhitelist = []string{"app.cdn.olares.com"}
 )
+
+// IsRemoteOptionsHostAllowed reports whether host is permitted by the
+// remote-options domain whitelist. A whitelist entry matches the exact host or
+// any of its subdomains (both compared case-insensitively). An empty whitelist
+// denies everything.
+func IsRemoteOptionsHostAllowed(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if host == "" {
+		return false
+	}
+	for _, d := range RemoteOptionsDomainWhitelist {
+		d = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(d), "."))
+		if d == "" {
+			continue
+		}
+		if host == d || strings.HasSuffix(host, "."+d) {
+			return true
+		}
+	}
+	return false
+}
 
 // AppMgrTerminalRetention bounds how long an ApplicationManager is allowed to
 // linger in a safely-deletable terminal state (Uninstalled / InstallingCanceled
@@ -288,5 +321,17 @@ func init() {
 	url := os.Getenv("CHART_REPO_URL")
 	if url != "" {
 		CHART_REPO_URL = url
+	}
+
+	if wl := os.Getenv("REMOTE_OPTIONS_DOMAIN_WHITELIST"); wl != "" {
+		domains := make([]string, 0)
+		for _, d := range strings.Split(wl, ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				domains = append(domains, d)
+			}
+		}
+		if len(domains) > 0 {
+			RemoteOptionsDomainWhitelist = domains
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The remote-options proxy endpoint `POST /app-service/v1/appenv/remote-options-proxy` (`proxyRemoteOptions`) currently accepts a fully user-controlled `endpoint` and has app-service perform an outbound `GET` to it, returning the response to the caller. Any authenticated (normal) user can therefore make app-service fetch **any** URL.

This is effectively an open proxy / SSRF vector: a user can point the endpoint at arbitrary external hosts, or at in-cluster / link-local / metadata addresses that are only reachable from inside the cluster, and read the response.

This PR gates the proxy on an explicit server-side **domain whitelist**. Requests whose host is not on the whitelist are rejected with `403`.

## Why validating against the app manifest URL is not enough

The only legitimate use of this proxy today is fetching the `remoteOptions` URL declared in an app's `OlaresManifest.yaml` (currently only `https://app.cdn.olares.com/...`). A natural idea is to validate the requested endpoint against the `remoteOptions` value in the app's manifest instead of maintaining a whitelist.

That does **not** close the hole, because a user is not restricted to market apps: they can install from a **custom uploaded chart** and declare whatever `remoteOptions` URL they like in its manifest. Since the manifest itself is attacker-controlled in that flow, "endpoint must match the manifest's remoteOptions" reduces to "endpoint can be anything the user wants" — the same SSRF. So the trust anchor cannot be the manifest/chart; it has to be a fixed server-side allowlist.

## Changes

- Add `RemoteOptionsDomainWhitelist` and `IsRemoteOptionsHostAllowed(host)` in `pkg/constants`.
  - Defaults to `app.cdn.olares.com` (the only domain in use), kept as a list for future entries.
  - Overridable at runtime via the comma-separated `REMOTE_OPTIONS_DOMAIN_WHITELIST` env var.
  - An entry matches the exact host or any of its subdomains (case-insensitive); an empty whitelist denies everything.
- Enforce the whitelist in `proxyRemoteOptions` right after the scheme check; disallowed hosts return `403`.

## Test plan

Built a `linux/amd64` image and deployed it to a live Olares node, then exercised the endpoint:

- [x] Whitelisted host `https://app.cdn.olares.com/appstore/macos/version_options.json` → `200`, returns the options JSON.
- [x] Non-whitelisted host `https://example.com/foo.json` → `403` `endpoint host "example.com" is not allowed`.
- [x] Lookalike suffix `https://app.cdn.olares.com.evil.com/x` → `403` (subdomain matching does not false-positive).
- [x] Missing auth header → `401` (unchanged auth behavior).

Made with [Cursor](https://cursor.com)