### PR TITLE
cli: implement PatchNfsScript to resolve GPU driver issues during NFS mounting

### DIFF
--- a/cli/pkg/bootstrap/patch/module.go
+++ b/cli/pkg/bootstrap/patch/module.go
@@ -98,3 +98,20 @@ func (m *CorrectHostnameModule) Init() {
 		correctHostname,
 	}
 }
+
+type PatchNfsScriptModule struct {
+	common.KubeModule
+}
+
+func (m *PatchNfsScriptModule) Init() {
+	m.Name = "PatchNfsScript"
+
+	patchNfsScript := &task.LocalTask{
+		Name:   "PatchNfsScript",
+		Action: new(PatchNfsScriptTask),
+	}
+
+	m.Tasks = []task.Interface{
+		patchNfsScript,
+	}
+}

--- a/cli/pkg/bootstrap/patch/tasks.go
+++ b/cli/pkg/bootstrap/patch/tasks.go
@@ -312,3 +312,28 @@ func (t *DisableLocalDNSTask) configResolvConf(runtime connector.Runtime) error 
 	}
 	return nil
 }
+
+// patch nfs script to fix the issue that when nfs mounting systemd reloading will cause the GPU driver to fail in the running containers
+type PatchNfsScriptTask struct {
+	common.KubeAction
+}
+
+func (t *PatchNfsScriptTask) Execute(runtime connector.Runtime) error {
+	if utils.IsExist("/lib/systemd/system/rpc-statd.service") ||
+		utils.IsExist("/etc/systemd/system/rpc-statd.service") {
+		if _, err := runtime.GetRunner().SudoCmd("systemctl add-wants --runtime remote-fs.target rpc-statd.service", false, true); err != nil {
+			logger.Errorf("exec systemctl add-wants error %v", err)
+			return err
+		}
+
+	}
+
+	if utils.IsExist("/usr/sbin/start-statd") {
+		if _, err := runtime.GetRunner().SudoCmd("sed -i 's/systemctl add-wants/#systemctl add-wants/' /usr/sbin/start-statd", false, true); err != nil {
+			logger.Errorf("exec sed error %v", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -111,6 +111,7 @@ func (l *linuxInstallPhaseBuilder) build() []module.Module {
 			return l.storage()
 		}).withJuiceFS(l.runtime)...).
 		addModule(&patch.CorrectHostnameModule{}).
+		addModule(&patch.PatchNfsScriptModule{}).
 		addModule(l.installCluster()...).
 		addModule(gpuModuleBuilder(func() []module.Module {
 			return l.installGpuPlugin()

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/bootstrap/patch"
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/version"
 )
@@ -119,6 +120,12 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		&task.LocalTask{
 			Name:   "PatchWorkloadPriorityClassName",
 			Action: new(patchWorkloadPriorityClassName),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+		&task.LocalTask{
+			Name:   "PatchNfsScript",
+			Action: new(patch.PatchNfsScriptTask),
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},

--- a/cli/pkg/upgrade/1_12_7_20260701.go
+++ b/cli/pkg/upgrade/1_12_7_20260701.go
@@ -1,0 +1,35 @@
+package upgrade
+
+import (
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/bootstrap/patch"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260701 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260701) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260701")
+}
+
+func (u upgrader_1_12_7_20260701) UpgradeSystemComponents() []task.Interface {
+	tasks := append([]task.Interface{
+		&task.LocalTask{
+			Name:   "PatchNfsScript",
+			Action: new(patch.PatchNfsScriptTask),
+			Retry:  3,
+			Delay:  5 * time.Second,
+		},
+	})
+	tasks = append(u.upgraderBase.UpgradeSystemComponents(), tasks...)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260701{})
+}


### PR DESCRIPTION
* **Background**
During the NFS mounting, it executes a `systemctl` command that triggers a `systemd reload`, causing the GPU driver within the container to fail.

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
The GPU driver failed when the system rebooted

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change runs privileged `systemctl`/`sed` edits on host NFS/systemd files, which can affect NFS mount behavior and GPU workloads if the patch is wrong or paths differ across distros.
> 
> **Overview**
> Adds a **host bootstrap/upgrade patch** so NFS mounts no longer trigger a `systemd` reload that breaks GPU drivers in running containers.
> 
> `PatchNfsScriptTask` pre-links `rpc-statd.service` to `remote-fs.target` at runtime (when the unit files exist) and comments out the `systemctl add-wants` line in `/usr/sbin/start-statd`, avoiding the reload path during NFS mounting. A new `PatchNfsScriptModule` runs this on **fresh Linux cluster installs** (before cluster/GPU setup), and the same task is included in the **v1.12.6** upgrader plus a new **daily upgrader** `1.12.7-20260701`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74803f8a13754e4e30215fc09f85bf69cc797d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->