### PR TITLE
market: read OLARES_VERSION once at startup

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,11 +148,13 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.70
+        image: beclab/market-backend:v0.6.71
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81
         env:
+          - name: OLARES_VERSION
+            value: "1.12.6"
           - name: APP_SOTRE_SERVICE_SERVICE_PORT
             value: "443"
           - name: APP_SERVICE_SERVICE_HOST


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
read OLARES_VERSION once at startup, drop app-service version query

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/323


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-only image bump and a static env var; no auth or data-path changes in this diff.
> 
> **Overview**
> Updates the market **appstore-backend** deployment to ship **`beclab/market-backend:v0.6.71`** (from v0.6.70) and inject **`OLARES_VERSION=1.12.6`** into the container environment so the backend can read the cluster Olares version at startup instead of querying app-service for it (behavior lives in [beclab/market#323](https://github.com/beclab/market/pull/323)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10042c5c49e9fea11c5e3734bd76b1e5e69afbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->