### PR TITLE
daemon: add 'master-node' to internal hosts list

### DIFF
--- a/daemon/pkg/nets/net_types.go
+++ b/daemon/pkg/nets/net_types.go
@@ -11,5 +11,6 @@ var (
 		"dockerhub.kubekey.local",
 		"lb.kubesphere.local",
 		"localhost",
+		"master-node",
 	}
 )


### PR DESCRIPTION
* **Background**
Add 'master-node' to the internal hosts list to reserve it when the hosts file is updated

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
Updating the hosts file in `settings` causes `master-node` host info losing

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string addition to an existing preserve list; no auth or broad behavioral refactor.
> 
> **Overview**
> Adds **`master-node`** to the daemon’s `internalHostsItem` list so it is treated like other reserved hostnames (e.g. `localhost`, cluster-local names).
> 
> When settings trigger a hosts file rewrite, `filterBlacklist` skips deleting entries whose hostname matches this list. Without this entry, **`master-node` mappings were dropped** on update; they are now preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ada2f48acca47d48080a35360bf8aea2ae63852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->