### PR TITLE
fix(daemon): reconcile master-node hosts entry with cluster master IP

### DIFF
--- a/daemon/internel/watcher/system/watchers.go
+++ b/daemon/internel/watcher/system/watchers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	changeip "github.com/beclab/Olares/daemon/pkg/commands/change_ip"
 	"github.com/beclab/Olares/daemon/pkg/commands/uninstall"
+	"github.com/beclab/Olares/daemon/pkg/nets"
 	"github.com/beclab/Olares/daemon/pkg/utils"
 	"k8s.io/klog/v2"
 )
@@ -31,6 +32,40 @@ func (w *systemWatcher) Watch(ctx context.Context) {
 		_, err := cmd.Execute(ctx, nil)
 		if err != nil {
 			klog.Error("change ip error, ", err)
+		}
+	case state.IPChanging, state.Installing, state.Uninstalling,
+		state.Upgrading, state.Restarting, state.NetworkNotReady:
+		// do nothing, wait for the operation to finish
+	default:
+		client, err := utils.GetKubeClient()
+		if err != nil {
+			klog.V(8).ErrorS(err, "failed to get kube client")
+			// k8s client is not ready, skip the check
+			return
+		}
+
+		masterIp, err := utils.GetMasterNodeIpInCluster(ctx, client)
+		if err != nil {
+			klog.V(8).ErrorS(err, "failed to get master node IP")
+			// master node IP is not available, skip the check
+			return
+		}
+
+		masterIpInHosts, err := nets.GetHostIpFromHostsFile(nets.MASTER_NODE_HOSTNAME)
+		if err != nil {
+			klog.ErrorS(err, "failed to get master node IP from hosts file")
+			// master node IP is not available in hosts file, skip the check
+			return
+		}
+
+		if masterIp != masterIpInHosts {
+			klog.Info("master node IP is invalid, updating hosts file")
+			err := nets.WriteIpToHostsFile(masterIp, nets.MASTER_NODE_HOSTNAME)
+			if err != nil {
+				klog.ErrorS(err, "failed to update hosts file with new master node IP")
+				return
+			}
+			klog.Info("hosts file updated with new master node IP")
 		}
 	}
 }

--- a/daemon/pkg/cluster/fanout/fanout.go
+++ b/daemon/pkg/cluster/fanout/fanout.go
@@ -99,7 +99,7 @@ func ListReadyNodes(ctx context.Context) ([]NodeTarget, error) {
 	var targets []NodeTarget
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
-		if !isNodeReady(n) {
+		if !utils.IsNodeReady(n) {
 			continue
 		}
 		ip := internalIP(n)
@@ -111,7 +111,7 @@ func ListReadyNodes(ctx context.Context) ([]NodeTarget, error) {
 			Name:     n.Name,
 			IP:       ip,
 			IsSelf:   self,
-			IsMaster: isMaster(n),
+			IsMaster: utils.IsMasterNode(n),
 		})
 	}
 	return targets, nil
@@ -198,15 +198,6 @@ func (d *Dispatcher) call(ctx context.Context, t NodeTarget, payload any, timeou
 	return res
 }
 
-func isNodeReady(n *corev1.Node) bool {
-	for _, c := range n.Status.Conditions {
-		if c.Type == corev1.NodeReady {
-			return c.Status == corev1.ConditionTrue
-		}
-	}
-	return false
-}
-
 func internalIP(n *corev1.Node) string {
 	for _, addr := range n.Status.Addresses {
 		if addr.Type == corev1.NodeInternalIP {
@@ -214,14 +205,4 @@ func internalIP(n *corev1.Node) string {
 		}
 	}
 	return ""
-}
-
-func isMaster(n *corev1.Node) bool {
-	if cp, ok := n.Labels["node-role.kubernetes.io/control-plane"]; ok && cp != "false" {
-		return true
-	}
-	if m, ok := n.Labels["node-role.kubernetes.io/master"]; ok && m != "false" {
-		return true
-	}
-	return false
 }

--- a/daemon/pkg/nets/net_types.go
+++ b/daemon/pkg/nets/net_types.go
@@ -5,12 +5,14 @@ type HostsItem struct {
 	Host string `json:"host"`
 }
 
+const MASTER_NODE_HOSTNAME = "master-node"
+
 var (
 	internalHostsItem []string = []string{
 		".cluster.local",
 		"dockerhub.kubekey.local",
 		"lb.kubesphere.local",
 		"localhost",
-		"master-node",
+		MASTER_NODE_HOSTNAME,
 	}
 )

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/klog"
 	"net/url"
 	"os"
 	"strings"
+
+	"k8s.io/klog"
 
 	bflconst "bytetrade.io/web3os/bfl/pkg/constants"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -909,4 +910,45 @@ func isPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return true
+}
+
+func IsMasterNode(n *corev1.Node) bool {
+	if cp, ok := n.Labels["node-role.kubernetes.io/control-plane"]; ok && cp != "false" {
+		return true
+	}
+	if m, ok := n.Labels["node-role.kubernetes.io/master"]; ok && m != "false" {
+		return true
+	}
+	return false
+}
+
+func IsNodeReady(n *corev1.Node) bool {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func GetMasterNodeIpInCluster(ctx context.Context, client kubernetes.Interface) (string, error) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error listing nodes: %s", err)
+	}
+	for _, node := range nodes.Items {
+		if !IsMasterNode(&node) {
+			continue
+		}
+		if !IsNodeReady(&node) {
+			continue
+		}
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				return address.Address, nil
+			}
+		}
+	}
+
+	return "", errors.New("no master node found")
 }


### PR DESCRIPTION
## Summary
- Add a `systemWatcher` reconciliation loop that compares the ready control-plane node's InternalIP from the Kubernetes API with the `master-node` entry in `/etc/hosts`, and updates hosts when they diverge.
- Extract shared `IsMasterNode`, `IsNodeReady`, and `GetMasterNodeIpInCluster` helpers into `pkg/utils`, and reuse them in `fanout`.
- Introduce `MASTER_NODE_HOSTNAME` constant and skip reconciliation during transitional cluster states (`IPChanging`, `Installing`, `Uninstalling`, `Upgrading`, `Restarting`, `NetworkNotReady`) to avoid racing with `change-ip` and other operations.

## Test plan
- [ ] On a running cluster, verify `/etc/hosts` contains a correct `master-node` entry matching the control-plane InternalIP
- [ ] Manually change the `master-node` IP in `/etc/hosts` to a stale value; confirm olaresd restores the correct IP within one watcher cycle (~5s)
- [ ] During `change-ip`, confirm the watcher does not overwrite hosts while state is `IPChanging`
- [ ] On a worker node, confirm `master-node` resolves to the cluster master IP after join
- [ ] Verify fanout node listing still correctly identifies master and ready nodes


Made with [Cursor](https://cursor.com)