### PR TITLE
download: refactor download task lifecycle and reliability across manager, HuggingFace, aria2, and ytdlp

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v0.1.23"
+        image: "beclab/download-server:v1.0.2"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -171,7 +171,7 @@ spec:
         - name: DEBUG
           value: "false"
         - name: YTDLP_SERVER_URL
-          value: http://ytdlp-svc.ytserver-shared:3082
+          value: http://ytdlp-svc.ytdlp-shared:3082
         - name: ARIA2_RPC_URL
           value: http://download-svc:6800/jsonrpc
         - name: PG_USERNAME
@@ -197,6 +197,24 @@ spec:
               name: download-secrets
         - name: NATS_PROGRESS_PUBLISH_SUB
           value: os.download_status
+        - name: LLDAP_READONLY_URL
+          value: http://lldap-service.os-platform:17171
+        - name: LLDAP_NATS_URL
+          value: nats://nats.os-platform:4222
+        - name: LLDAP_NATS_USERNAME
+          value: os-framework-download
+        - name: LLDAP_NATS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: download-secrets
+              key: password
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: LLDAP_RESYNC_SECONDS
+          value: '30'
         volumeMounts:
         - name: download-dir
           mountPath: /app/downloads


### PR DESCRIPTION
Background
download-server has been refactored around task lifecycle management, error classification, and download reliability. The changes unify failure handling, improve HuggingFace download progress and stall recovery, support mirrors and token passthrough, fix aria2 and ytdlp edge cases, and enhance frontend visibility into task status and errors. Together, these updates make downloads more resilient, observable, and consistent for users.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image bump plus new external dependencies (LLDAP, renamed ytdlp service) can break downloads if endpoints or secrets are wrong in the cluster.
> 
> **Overview**
> Updates the **download** DaemonSet to ship **`beclab/download-server:v1.0.2`** (from `v0.1.23`) and points **`YTDLP_SERVER_URL`** at **`ytdlp-svc.ytdlp-shared`** instead of **`ytserver-shared`**.
> 
> Adds runtime configuration for directory sync and node identity: **`LLDAP_READONLY_URL`**, NATS credentials for LLDAP (`**LLDAP_NATS_*`**, reusing **`download-secrets`**), **`NODE_NAME`** from the pod’s node, and **`LLDAP_RESYNC_SECONDS`** set to **30**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb06bfc12fcad8056c192fe2dc0317602005f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->