### PR TITLE
market: increase definition render failure retry cap from 5 to 20

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.71
+        image: beclab/market-backend:v0.6.72
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
increase definition render failure retry cap from 5 to 20

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/324


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-image version bump with no manifest or env changes; behavior change is limited to more retries on definition render failures in market-backend.
> 
> **Overview**
> Bumps the **appstore-backend** container image from `beclab/market-backend:v0.6.71` to **`v0.6.72`** in the market cluster deployment manifest.
> 
> That image tag carries the market change that **raises the definition render failure retry cap from 5 to 20** (see beclab/market#324); this repo diff only updates the pinned version for rollout on Olares **v1.12.6** / **v1.12.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e7be2689303d4254689866b20f33197922e29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->