### PR TITLE
fix(daemon): handle older CIFS versions by retrying mount without unsupported options

### DIFF
--- a/daemon/pkg/utils/drivers_linux.go
+++ b/daemon/pkg/utils/drivers_linux.go
@@ -518,17 +518,24 @@ func MountSambaDriver(ctx context.Context, mountBaseDir string, smbPath string, 
 		}
 	}
 
-	opts = append(opts, "uid=1000", "gid=1000", "cache=none", "fsc", "noserverino")
-	err = mounter.Mount(smbPath, mntPath, "cifs", opts)
+	tryOpts := append(opts, "uid=1000", "gid=1000", "cache=none", "fsc", "noserverino")
+	err = mounter.Mount(smbPath, mntPath, "cifs", tryOpts)
 	if err != nil {
-		klog.Error("mount path as rw error, ", err)
-
-		// retry to mount as read-only
-		opts = append(opts, "ro")
-		err = mounter.Mount(smbPath, mntPath, "cifs", opts)
+		// maybe it's an older version cifs, option "fsc" is not supported, retry without it
+		klog.Warning("mount path as rw error, ", err, ", retry without fsc option")
+		tryOpts := append(opts, "uid=1000", "gid=1000", "cache=none", "noserverino")
+		err = mounter.Mount(smbPath, mntPath, "cifs", tryOpts)
 		if err != nil {
-			if e := os.Remove(mntPath); e != nil {
-				klog.Error("remove dir error, ", e, ", ", mntPath)
+
+			klog.Error("mount path as rw error, ", err)
+
+			// retry to mount as read-only
+			tryOpts = append(tryOpts, "ro")
+			err = mounter.Mount(smbPath, mntPath, "cifs", tryOpts)
+			if err != nil {
+				if e := os.Remove(mntPath); e != nil {
+					klog.Error("remove dir error, ", e, ", ", mntPath)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* **Background**
In older CIFS versions, less than v7.0, the option `fsc` is unsupported

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
Failed to mount smb shared directories on some devices

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to SMB mount retry logic on Linux; behavior improves compatibility without touching auth or data paths.
> 
> **Overview**
> **SMB/CIFS mounts** on the Linux daemon now **retry without the `fsc` mount option** when the first read-write mount fails, targeting hosts with CIFS **older than v7.0** where `fsc` is unsupported.
> 
> Mount attempts use separate **`tryOpts` slices** instead of growing a shared `opts` list, so the existing **read-only fallback** still runs on the reduced option set (without `fsc`) rather than inheriting a bad option mix from the first failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddeea17a3610ad5b209429d89570fa74c08149f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->