### PR TITLE
fix: skip call system/status if run on minikube

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -177,17 +177,6 @@ spec:
           name: api
         - containerPort: 8433
           name: webhook
-        startupProbe:
-          failureThreshold: 30
-          periodSeconds: 1
-          tcpSocket:
-            port: 8433
-        readinessProbe:
-          failureThreshold: 30
-          initialDelaySeconds: 1
-          periodSeconds: 1
-          tcpSocket:
-            port: 6755
         securityContext:
           runAsUser: 0
         env:

--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -72,16 +72,25 @@ func BuildBaseHelmValues(ctx context.Context, kubeConfig *rest.Config, appConfig
 	}
 	values["nodes"] = nodeInfo
 
-	deviceName, err := utils.GetDeviceName()
-	if err != nil {
-		return values, err
-	}
-	values["deviceName"] = deviceName
-
 	kClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return values, err
 	}
+
+	isOnMinikube, err := utils.IsRunningOnMinikube(ctx, kClient)
+	if err != nil {
+		return values, err
+	}
+	if isOnMinikube {
+		values["deviceName"] = "selfhosted"
+	} else {
+		deviceName, err := utils.GetDeviceName()
+		if err != nil {
+			return values, err
+		}
+		values["deviceName"] = deviceName
+	}
+
 	nodes, err := kClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return values, err

--- a/framework/app-service/pkg/utils/k8sutil.go
+++ b/framework/app-service/pkg/utils/k8sutil.go
@@ -40,9 +40,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// CalicoTunnelAddrAnnotation annotation key for calico tunnel address.
-const CalicoTunnelAddrAnnotation = "projectcalico.org/IPv4IPIPTunnelAddr"
-const DefaultRegistry = "https://registry-1.docker.io"
+const (
+	// CalicoTunnelAddrAnnotation annotation key for calico tunnel address.
+	CalicoTunnelAddrAnnotation = "projectcalico.org/IPv4IPIPTunnelAddr"
+	DefaultRegistry            = "https://registry-1.docker.io"
+
+	minikubeLabelPrefix = "minikube.k8s.io/"
+	// docker or  podman driver's providerID prefix
+	minikubeKICProvider = "kic://"
+)
 
 // GetAllNodesPodCIDRs returns all node pod's cidr.
 func GetAllNodesPodCIDRs() (cidrs []string) {
@@ -516,4 +522,42 @@ func GetPendingKind(ctrlClient client.Client, pod *corev1.Pod) (string, error) {
 		}
 	}
 	return pendingKind, nil
+}
+
+func IsMinikubeNode(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	for k := range node.Labels {
+		if strings.HasPrefix(k, minikubeLabelPrefix) {
+			return true
+		}
+	}
+	if strings.HasPrefix(node.Spec.ProviderID, minikubeKICProvider) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(node.Name), "minikube") {
+		return true
+	}
+	return false
+}
+
+func IsRunningOnMinikube(ctx context.Context, client kubernetes.Interface) (bool, error) {
+	if nodeName := os.Getenv("NODE_NAME"); nodeName != "" {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return IsMinikubeNode(node), nil
+	}
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for i := range nodes.Items {
+		if IsMinikubeNode(&nodes.Items[i]) {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION


* **Background**
fix: skip call system/status if run on minikube
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Helm install values and app-service health probing; minikube mis-detection could set wrong deviceName, and removing probes may affect rollout/readiness behavior on real clusters.
> 
> **Overview**
> Helm base values for app installs no longer always call **olaresd** `system/status` to resolve `deviceName`. When the cluster is detected as **minikube**, `deviceName` is set to **`selfhosted`** instead of using `GetDeviceName()`.
> 
> Minikube detection is added in **`IsMinikubeNode`** / **`IsRunningOnMinikube`** (minikube labels, `kic://` provider ID, or node name), wired from **`BuildBaseHelmValues`** after the Kubernetes client is created. Non-minikube clusters still use the existing olaresd path.
> 
> The **app-service** StatefulSet manifest drops **TCP startup and readiness probes** on ports 8433 and 6755.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed77e1ff7121f8e9f973ac6443dd7dd00e72fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->