### PR TITLE
chore: remove unused images

### DIFF
--- a/framework/upgrade/.olares/Olares.yaml
+++ b/framework/upgrade/.olares/Olares.yaml
@@ -1,9 +1,5 @@
 apiVersion: v1
 target: prebuilt
-output:
-  containers:
-    - 
-      name: beclab/upgrade-job:0.1.7
 
 
       


### PR DESCRIPTION
* **Background**
Remove unused images

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only change with no runtime logic; cluster job image may still be set elsewhere (e.g. app-service deploy env).
> 
> **Overview**
> Removes the **`output.containers`** entry for **`beclab/upgrade-job:0.1.7`** from **`framework/upgrade/.olares/Olares.yaml`**, leaving only **`target: prebuilt`** with no declared container outputs for this package.
> 
> This aligns the upgrade framework’s Olares manifest with the “unused images” cleanup so **`build/deps-manifest.sh`** no longer pulls that image from this path when processing **`Olares.yaml`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824d3a7cef1913bb4235a79203736be06f60642c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->