### PR TITLE
cli/market: add compute-mode selection to clone (Olares 1.12.6+)

### DIFF
--- a/cli/cmd/ctl/market/client.go
+++ b/cli/cmd/ctl/market/client.go
@@ -270,18 +270,24 @@ func (c *MarketClient) InstallApp(ctx context.Context, appName, version, source,
 	})
 }
 
-func (c *MarketClient) CloneApp(ctx context.Context, appName, source, title string, envs []AppEnvVar, entrances []AppEntrance, templateClone bool) (*APIResponse, error) {
+// CloneApp issues POST /apps/{name}/clone. selectedGpuType pins the compute
+// mode on Olares 1.12.6+ (CloneRequest.SelectedGpuType, omitempty), mirroring
+// InstallApp: callers pass "" on 1.12.5 so the wire stays byte-identical, and
+// the 1.12.6 path passes either the --compute-mode value or the mode resolved
+// from a computeModeSelect 422 retry.
+func (c *MarketClient) CloneApp(ctx context.Context, appName, source, title, selectedGpuType string, envs []AppEnvVar, entrances []AppEntrance, templateClone bool) (*APIResponse, error) {
 	if source == "" {
 		source = c.source
 	}
 	return c.doRequest(ctx, http.MethodPost, "/apps/"+appName+"/clone", CloneRequest{
-		Source:        source,
-		AppName:       appName,
-		Title:         title,
-		Sync:          true,
-		Envs:          envs,
-		Entrances:     entrances,
-		TemplateClone: templateClone,
+		Source:          source,
+		AppName:         appName,
+		Title:           title,
+		Sync:            true,
+		Envs:            envs,
+		Entrances:       entrances,
+		SelectedGpuType: selectedGpuType,
+		TemplateClone:   templateClone,
 	})
 }
 

--- a/cli/cmd/ctl/market/clone.go
+++ b/cli/cmd/ctl/market/clone.go
@@ -38,12 +38,21 @@ Cloned rows look up their catalog metadata via RawName (the source
 app's name), so a clone like 'windowsefe992' renders the source app
 'windows' title / categories in 'list --mine'.
 
+Compute mode (Olares 1.12.6+ only): apps that can run on more than one
+accelerator (e.g. cpu vs nvidia) need a mode picked at clone time. Use
+--compute-mode <type> to pin it; if omitted, an interactive terminal
+prompts you to choose from the installable modes, while a non-interactive
+session (-q, -o json, or a pipe) fails with the list so you can re-run
+with the flag. On Olares 1.12.5 the clone path is unchanged and
+--compute-mode is rejected.
+
 Examples:
   olares-cli market clone firefox --title "Firefox Dev"
   olares-cli market clone firefox --title "Firefox Dev" --watch                   # block until clone reaches running
   olares-cli market clone firefox --title "Firefox Dev" --watch -o json | jq '.cloneTarget'   # capture new app name
   olares-cli market clone myapp --title "MyApp Dev" --env API_URL=http://dev.example.com
   olares-cli market clone myapp --title "MyApp Dev" --entrance-title ui="New UI" --entrance-title api="New API"
+  olares-cli market clone comfyui --title "ComfyUI Dev" --compute-mode nvidia     # pin GPU mode (1.12.6+)
   olares-cli market clone myapp --title "MyApp Dev" --watch --watch-timeout 20m   # heavyweight clones`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,6 +64,7 @@ Examples:
 	opts.addTitleFlag(cmd)
 	opts.addEnvFlag(cmd)
 	opts.addEntranceTitleFlag(cmd)
+	opts.addComputeModeFlag(cmd)
 	opts.addWatchFlags(cmd)
 	return cmd
 }
@@ -97,20 +107,52 @@ func runClone(opts *MarketOptions, appName string) error {
 		return opts.failOp("clone", appName, err)
 	}
 
+	// Compute-mode selection and template bodies are both 1.12.6+ concepts,
+	// so detect the backend version once. Version handling mirrors `market
+	// install`: on 1.12.5 (or an undetectable version, unless --compute-mode
+	// is explicitly set) we send no selectedGpuType and never interpret a
+	// computeModeSelect 422, keeping the clone byte-identical to before.
+	computeMode := strings.TrimSpace(opts.ComputeMode)
+	atLeast126, verr := opts.factory.OlaresBackendAtLeast(ctx, "1.12.6")
+	if verr != nil {
+		if computeMode != "" {
+			return opts.failOp("clone", appName, fmt.Errorf("cannot determine Olares backend version to honor --compute-mode: %w", verr))
+		}
+		atLeast126 = false
+	}
+	if computeMode != "" && !atLeast126 {
+		return opts.failOp("clone", appName, fmt.Errorf("--compute-mode requires Olares 1.12.6+; this backend uses a different (unchanged) clone path — re-run without --compute-mode"))
+	}
+	selected := ""
+	if atLeast126 {
+		selected = computeMode
+	}
+
 	// Template bodies (templateOnly) are cloned to create instances even
 	// though the body itself is never installed; the SPA's onClone() sets
 	// templateClone:true for them so the backend / dialog can branch. Only
 	// emit the flag on 1.12.6+ (the field is omitempty, so 1.12.5 stays
 	// byte-identical).
-	atLeast126, err := opts.factory.OlaresBackendAtLeast(ctx, "1.12.6")
-	if err != nil {
-		return opts.failOp("clone", appName, err)
-	}
 	templateClone := atLeast126 && appIsTemplateOnly(appInfo)
 
 	opts.info("Cloning '%s' as '%s' from '%s' for user '%s'...", appName, title, source, mc.olaresID)
 
-	resp, err := mc.CloneApp(ctx, appName, source, title, envs, entrances, templateClone)
+	resp, err := mc.CloneApp(ctx, appName, source, title, selected, envs, entrances, templateClone)
+	// Recover once from a computeModeSelect 422 by resolving the mode (from
+	// --compute-mode, an interactive prompt, or a clear error) and retrying.
+	// Keyed off the response check type, NOT the version probe: computeModeSelect
+	// is a 1.12.6+ signal that 1.12.5 never emits, so 1.12.5 can't enter this
+	// branch even when the probe was skipped or failed (atLeast126 false).
+	if err != nil {
+		if checkType, raw := parseFailedCheck(resp); isComputeModeSelect(checkType) {
+			mode, merr := resolveComputeMode(raw, appName, computeMode, opts.isInteractive())
+			if merr != nil {
+				return opts.failOp("clone", appName, merr)
+			}
+			opts.info("Selected compute mode: %s", mode)
+			resp, err = mc.CloneApp(ctx, appName, source, title, mode, envs, entrances, templateClone)
+		}
+	}
 	if err != nil {
 		if envErr := parseServerEnvError(resp, appName); envErr != nil {
 			return opts.failOp("clone", appName, envErr)

--- a/cli/cmd/ctl/market/compute_test.go
+++ b/cli/cmd/ctl/market/compute_test.go
@@ -31,6 +31,37 @@ func TestInstallRequestWireFormat(t *testing.T) {
 	}
 }
 
+func TestCloneRequestWireFormat(t *testing.T) {
+	// Without a compute mode the field is omitted entirely (1.12.5 clone wire
+	// stays byte-identical to before SelectedGpuType existed).
+	b, _ := json.Marshal(CloneRequest{Source: "market.olares", AppName: "firefox", Title: "Firefox Dev", Sync: true})
+	if strings.Contains(string(b), "selectedGpuType") {
+		t.Fatalf("clone body must omit selectedGpuType when empty: %s", b)
+	}
+	// With a mode the field is present.
+	b, _ = json.Marshal(CloneRequest{Source: "market.olares", AppName: "comfyui", Title: "ComfyUI Dev", Sync: true, SelectedGpuType: "nvidia"})
+	if !strings.Contains(string(b), `"selectedGpuType":"nvidia"`) {
+		t.Fatalf("clone body must carry selectedGpuType when set: %s", b)
+	}
+}
+
+// TestCloneComputeModeRecoveryChain documents that `market clone` reuses the
+// same computeModeSelect 422 recovery chain as `market install`: a clone-shaped
+// failed-check response is classified by parseFailedCheck + isComputeModeSelect
+// and resolved by resolveComputeMode.
+func TestCloneComputeModeRecoveryChain(t *testing.T) {
+	resp := failedCheckResp(checkTypeComputeModeSelect,
+		`[{"computeType":"cpu","status":"installable"},{"computeType":"nvidia","status":"installable"}]`)
+	checkType, raw := parseFailedCheck(resp)
+	if !isComputeModeSelect(checkType) {
+		t.Fatalf("clone 422 should classify as computeModeSelect, got %q", checkType)
+	}
+	// preset that is installable -> returned verbatim (the --compute-mode path).
+	if mode, err := resolveComputeMode(raw, "comfyui", "nvidia", false); err != nil || mode != "nvidia" {
+		t.Fatalf("clone preset nvidia: got (%q, %v), want (nvidia, nil)", mode, err)
+	}
+}
+
 func TestParseFailedCheck(t *testing.T) {
 	checkType, raw := parseFailedCheck(failedCheckResp(checkTypeComputeModeSelect,
 		`[{"computeType":"cpu","status":"installable"}]`))

--- a/cli/cmd/ctl/market/types.go
+++ b/cli/cmd/ctl/market/types.go
@@ -143,6 +143,12 @@ type CloneRequest struct {
 	Sync      bool          `json:"sync"`
 	Envs      []AppEnvVar   `json:"envs,omitempty"`
 	Entrances []AppEntrance `json:"entrances,omitempty"`
+	// SelectedGpuType pins the compute mode (cpu / nvidia / ...) the clone
+	// should schedule against, mirroring InstallRequest.SelectedGpuType and
+	// the Market SPA's clone payload field of the same name. Only honored by
+	// Olares 1.12.6+ (the auto-select / computeModeSelect surface); omitempty
+	// keeps a 1.12.5 clone — where the CLI never sets it — byte-identical.
+	SelectedGpuType string `json:"selectedGpuType,omitempty"`
 	// TemplateClone marks an instance created from a template app (no
 	// installable body), mirroring the SPA's onClone() which sets
 	// templateClone:true for templateOnly apps (1.12.6+). omitempty keeps

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-market
-version: 4.5.0
+version: 4.5.1
 description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume, restart apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, restart app, upload chart."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -95,12 +95,14 @@ app-service only accepts `uninstall` from a settled state (`running` / `stopped`
 ```bash
 olares-cli market clone firefox --title "Work Browser"
 olares-cli market clone firefox --title "Work Browser" --entrance-title web=WorkWeb
+olares-cli market clone comfyui --title "ComfyUI Dev" --compute-mode nvidia  # pin GPU mode (1.12.6+)
 olares-cli market clone firefox --title "Work Browser" --watch
 ```
 
 - **Clonable apps** are either multi-instance apps (`allowMultipleInstall: true`) **or** template apps (`templateOnly: true`). A template app has no installable body — instances are created from it via clone — and on 1.12.6+ the CLI sends `templateClone:true` for it automatically. Pre-flight check the source app's `market get <app> -o json` if unsure.
 - `--title` is REQUIRED — feeds the cloned app's desktop shortcut title.
 - For apps with multiple entrances: `--entrance-title NAME=TITLE` (repeatable) overrides per-entrance titles. For single-entrance apps, the entrance title defaults to `--title`.
+- `--compute-mode <type>` (**Olares 1.12.6+ only**) works exactly like on `install`: apps runnable on more than one accelerator (`cpu`, `nvidia`, ...) require a choice, so when it is omitted the backend returns HTTP 422 / `type=computeModeSelect` and the CLI either **prompts interactively** (TTY) or **fails listing the installable modes** (non-interactive: `-q`, `-o json`, or a pipe) so you re-run with the flag. On **1.12.5 the clone path is unchanged** and `--compute-mode` is rejected.
 - **The backend mints a per-instance app name** (e.g. `firefoxe992`). The CLI surfaces it as `targetApp` in the JSON output so scripted callers can chain follow-ups (`jq -r '.targetApp'`). **`--watch` tracks the new clone name, not the source app.**
 
 ## `stop` / `resume`

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-settings
-version: 4.4.0
+version: 4.4.2
 description: "Olares Settings via olares-cli settings — mirror of Settings SPA: users, apps, VPN, network (reverse-proxy / overlay gateway), backup, integration, GPU, search, me/whoami. Use for Olares Settings, role, VPN ACL, overlay gateway, backup, integration accounts, language."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -53,7 +53,7 @@ For every area, **start with `olares-cli settings <area> --help`**. References b
 | `integration` | [references/olares-settings-integration.md](references/olares-settings-integration.md) (`accounts add awss3|tencent`) |
 | `backup` | [references/olares-settings-backup.md](references/olares-settings-backup.md) (plans / snapshots / password) |
 | `appearance` | `olares-cli settings appearance --help` (`get`, `language set`) |
-| `network` | `olares-cli settings network --help` (read-only frp / hosts-file; `reverse-proxy get/set` (owner set); `overlay` gateway `status` / `enable` / `disable` (owner) / `app enable`|`app disable` — NOT JWS-gated, see [Currently-implemented mutating verbs](#currently-implemented-mutating-verbs). `frp set` / `ssl` / `hosts-file set` still blocked by the JWS gap.) |
+| `network` | `olares-cli settings network --help` (read-only frp / hosts-file; `reverse-proxy get/set` (owner set); `overlay` gateway `status` / `enable` / `disable` (owner) / `app enable`|`app disable` — **all `overlay` verbs are Olares 1.12.6+ only** (the overlay gateway wire surface landed in 1.12.6; on 1.12.5 the CLI fails fast with `requires Olares >= 1.12.6` instead of a raw 404), NOT JWS-gated, see [Currently-implemented mutating verbs](#currently-implemented-mutating-verbs). `frp set` / `ssl` / `hosts-file set` still blocked by the JWS gap.) |
 | `gpu` | `olares-cli settings gpu --help` (read-only `list`; **legacy, 1.12.5 only** HAMI `/api/gpu/list` — **removed in 1.12.6**: the CLI fails fast there and points at `compute list`) |
 | `compute` | `olares-cli settings compute --help` (**1.12.6+ new "Accelerator"**: `list`, `unbind <app>`, `set-type <node> <device>`; version-gated, replaces `gpu list`. `<node>`/`<device>` come from `list`'s node header + DEVICE-ID column) |
 | `video` | `olares-cli settings video --help` (read-only `config get`) |
@@ -105,7 +105,7 @@ Different upstream services return JSON in different envelopes. The CLI normaliz
 | Area | Endpoint family | Wire envelope |
 |---|---|---|
 | `me`, `apps`, `network`, `appearance`, `integration`, `gpu`, `video`, `search`, `advanced` | `/api/*` (user-service / BFL / terminusd) | Unwrapped BFL `{data: ...}` envelope |
-| `network overlay` | `GET /api/system/overlay-gateway-status/{user}`, `POST /api/command/{enable,disable}-overlay-gateway`, `POST /api/command/{enable,disable}-app-overlay-gateway` (user-service → olaresd) | BFL `{code,message,data}` envelope. Status `data`: `{status, disable, disable_reason, supported_apps[], error_message}`; each app: `{app_name, app_id, enabled, shared_app, underlay_networks[]}`. `status` path `{user}` must be the current user (daemon `itsMe`); `-o json` for per-port workload/protocol/description |
+| `network overlay` | `GET /api/system/overlay-gateway-status/{user}`, `POST /api/command/{enable,disable}-overlay-gateway`, `POST /api/command/{enable,disable}-app-overlay-gateway` (user-service → olaresd) — **1.12.6+ only** (client-side version-gated; on 1.12.5 these routes 404, so the CLI rejects up front) | BFL `{code,message,data}` envelope. Status `data`: `{status, disable, disable_reason, supported_apps[], error_message}`; each app: `{app_name, app_id, enabled, shared_app, underlay_networks[]}`. `status` path `{user}` must be the current user (daemon `itsMe`); `-o json` for per-port workload/protocol/description |
 | `users` | `/api/users/v2`, `/api/users/:name`, `POST/DELETE /api/users/...` | List-result decoder; mutating returns axios-inner `{name}` |
 | `vpn` devices / ACL | `<SettingsURL>/headscale/machine`, `/headscale/machine/:id/routes` | Raw Headscale JSON (NO envelope), `route.id` is a string |
 | `vpn` public-domain-policy | `/api/launcher-public-domain-access-policy` | Already-unwrapped `{deny_all: 0|1}` |
@@ -114,20 +114,21 @@ Different upstream services return JSON in different envelopes. The CLI normaliz
 
 ## Currently-implemented mutating verbs
 
-Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Verbs flagged **UNVERIFIED** ship in the binary but are tracked as experimental; the CLI emits a one-line "experimental" stderr hint when they run.
+Verbs marked **VERIFIED** have been confirmed against a live Olares instance. Verbs flagged **UNVERIFIED** ship in the binary and work the same way, but have not yet been smoke-tested against a live instance — treat their result as provisional and confirm the outcome after running.
 
 | Area | Verb | Status |
 |---|---|---|
-| `network overlay` | `enable` / `disable` (owner; gateway master switch, async — status settles at on/off; `--watch` polls until it settles) | UNVERIFIED |
-| `network overlay` | `app enable <app>` / `app disable <app>` (any user; auto-restarts the app when running, via `market restart`; `--watch` polls until enabled+IP assigned / disabled) | UNVERIFIED |
+| `network overlay` | `enable` / `disable` (owner; gateway master switch, async — status settles at on/off; `--watch` polls until it settles) | VERIFIED |
+| `network overlay` | `app enable <app>` / `app disable <app>` (any user; auto-restarts the app when running, via `market restart`; `--watch` polls until enabled+IP assigned / disabled) | VERIFIED |
 | `appearance` | `language set <code>` | VERIFIED |
 | `users` | `create` / `delete` (with `--watch`) | VERIFIED |
 | `search` | `rebuild`, `dirs add / rm` | VERIFIED (rebuild + dirs writes) |
 | `vpn ssh` | `enable` / `disable` | VERIFIED |
 | `vpn acl` | `add` / `remove` | VERIFIED |
 | `integration accounts` | `add awss3` / `add tencent` / `delete` | VERIFIED |
-| `apps` | `suspend [--cascade]` / `resume` (thin aliases over `market stop` / `market resume`), `env set`, `domain set/finish`, `policy set`, `auth-level set` | UNVERIFIED |
-| `compute` | `unbind <app>` (unbind + stop app), `set-type <node> <device> --type X` (may stop bound apps; handles `bound-apps-stop-blocked`) — **1.12.6+** | UNVERIFIED |
+| `apps` | `suspend [--cascade]` / `resume` (thin aliases over `market stop` / `market resume`) | VERIFIED |
+| `apps` | `env set`, `domain set/finish`, `policy set`, `auth-level set` | UNVERIFIED |
+| `compute` | `unbind <app>` (unbind + stop app), `set-type <node> <device> --type X` (may stop bound apps; handles `bound-apps-stop-blocked`) — **1.12.6+** | VERIFIED |
 | `backup` | `password set` | UNVERIFIED |
 
 **Not yet implemented** (and the CLI deliberately does NOT register them):

--- a/cli/skills/olares-settings/references/olares-settings-apps.md
+++ b/cli/skills/olares-settings/references/olares-settings-apps.md
@@ -133,7 +133,7 @@ olares-cli settings apps list --all            # also include uninstalled / pend
 - **Always run `entrances list <app>` before any per-entrance edit.** Don't assume entrance names; the user-facing names (e.g. `www`) often differ from the chart-defined service names.
 - **For `policy set`**, surface `policy get` output to the user BEFORE applying — the sub-policy replacement semantics are easy to misuse.
 - **For `domain set --third-party`**, remind the user to set up the CNAME at their DNS provider AND run `domain finish` once it propagates.
-- **For UNVERIFIED verbs**, the CLI emits a one-line "experimental" hint on stderr — don't suppress it.
+- **For UNVERIFIED verbs** (`env set`, `domain set/finish`, `policy set`, `auth-level set`), the result is provisional (not yet smoke-tested against a live instance) — confirm the outcome after running.
 
 ## Common errors
 
@@ -143,4 +143,3 @@ olares-cli settings apps list --all            # also include uninstalled / pend
 | `--cert-file and --key-file are required when --third-party is set` | Third-party domain without cert | Provide both, or use `--clear-third-party` |
 | `--default-policy: invalid value 'X' (allowed: system, one_factor, two_factor, public)` | Typo | Use one of the four valid values |
 | `auth-level get is not supported (no upstream endpoint); use 'apps entrances list <app>' to read the AUTH LEVEL column` | Tried to GET auth-level | Read from `entrances list` |
-| `experimental: this verb is not yet smoke-verified` (stderr) | UNVERIFIED verb | Informational; proceed with caution |

--- a/cli/skills/olares-settings/references/olares-settings-backup.md
+++ b/cli/skills/olares-settings/references/olares-settings-backup.md
@@ -69,5 +69,4 @@ The CLI does **not** create or update backup plans — the only backup verbs are
 | `plan '<name>' not found` | Wrong backup-id or name | `plans list` to enumerate |
 | `snapshots list: backup-id required` | Missing positional | Provide the backup-id from `plans list` |
 | `failed to read password from stdin: EOF` | `--password-stdin` invoked without piped input | Pipe from `echo -n` / a file / a secret manager |
-| `experimental: this verb is not yet smoke-verified` (stderr) | UNVERIFIED (`password set`) | Proceed with caution; verify result manually |
 | `GET /apis/backup/v1/plans/backup: upstream returned code N` | Backup-server unreachable / 5xx | Check `settings advanced status` for backup-server health |


### PR DESCRIPTION
* **Background**

`olares-cli market clone` lacked the compute-mode (accelerator) selection that `market install` and the Market SPA (both install and clone) already have. Apps runnable on more than one accelerator (e.g. comfyui: cpu vs nvidia) need a mode chosen at clone time; without it the backend's `computeModeSelect` 422 surfaced as a raw, unhandled error on the CLI while the web UI popped a picker.

This PR brings `clone` to parity with `install`, mirroring its behavior exactly:

- New `CloneRequest.SelectedGpuType` (omitempty) and `CloneApp` passes it through, matching `InstallRequest` / `InstallApp`.
- New `--compute-mode` flag on `clone`, reusing the shared `addComputeModeFlag`.
- Version handling copied line-for-line from `install`: it is an **Olares 1.12.6+** feature only. On 1.12.5 the flag is rejected and no `selectedGpuType` is sent, so the clone wire stays byte-identical to before. An undetectable version is handled leniently (only errors when `--compute-mode` is explicitly set, otherwise treated as old backend), identical to install.
- Single `computeModeSelect` 422 recovery: when the flag is omitted and the app supports multiple modes, an interactive terminal prompts for a choice while a non-interactive session (`-q`, `-o json`, or a pipe) fails listing the installable modes. `templateClone` continues to reuse the same version probe.

Also refreshes the CLI skill docs to match:

- Documents `clone --compute-mode` in the market lifecycle reference.
- Notes that all `settings network overlay` commands are 1.12.6+ gated (fail fast with `requires Olares >= 1.12.6` instead of a raw 404).
- Corrects the settings skill's VERIFIED/UNVERIFIED markers: removes an outdated "experimental stderr hint" claim that is not implemented in the binary, and marks the overlay verbs, `compute unbind/set-type`, and `apps suspend/resume` as VERIFIED.

Adds unit tests for the `CloneRequest` wire format (1.12.5 stays byte-identical; carries the field when set) and the clone `computeModeSelect` recovery chain.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
None

* **Other information**:
None

Made with [Cursor](https://cursor.com)