### PR TITLE
chore(ci): add linkerd-pki-guardian publish workflow

### DIFF
--- a/.github/workflows/module_appgateway_publish_pki_guardian.yaml
+++ b/.github/workflows/module_appgateway_publish_pki_guardian.yaml
@@ -1,0 +1,35 @@
+name: Publish app-gateway linkerd-pki-guardian to Dockerhub
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Release Tags'
+
+jobs:
+  publish_pki_guardian:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Build and push multi-arch linkerd-pki-guardian image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: beclab/linkerd-pki-guardian:${{ github.event.inputs.tags }}
+          file: framework/app-gateway/cmd/linkerd-pki-guardian/Dockerfile
+          context: framework/app-gateway
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Manual workflow_dispatch to build and push multi-arch beclab/linkerd-pki-guardian.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime application logic; uses existing Docker Hub secrets for publish.
> 
> **Overview**
> Adds a **manual** GitHub Actions workflow (`workflow_dispatch`) to build and push the **linkerd-pki-guardian** image to Docker Hub as `beclab/linkerd-pki-guardian:<tag>`, where the tag is supplied at run time.
> 
> The job uses **Buildx** with **QEMU** for **linux/amd64** and **linux/arm64**, builds from `framework/app-gateway/cmd/linkerd-pki-guardian/Dockerfile` with context `framework/app-gateway`, and authenticates via existing `DOCKERHUB_USERNAME` / `DOCKERHUB_PASS` secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4384e72978124e0e8845c27c3be36595c99b45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->