### PR TITLE
fix: remove IsClusterScoped check from IsGatewaySharedApp function

### DIFF
--- a/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
+++ b/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
@@ -15,7 +15,7 @@ func IsGatewaySharedApp(app *appv1alpha1.Application) bool {
 	if app == nil {
 		return false
 	}
-	return IsShared(app) || IsClusterScoped(app)
+	return IsShared(app) // || IsClusterScoped(app)
 }
 
 // LogicalHostPattern returns the canonical shared gateway host pattern:


### PR DESCRIPTION
Exclude cluster-scoped apps from shared-apps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows gateway routing eligibility for cluster-scoped apps and may change SRR/HTTPRoute behavior; the file comment and a test still expect cluster-scoped apps to qualify.
> 
> **Overview**
> **`IsGatewaySharedApp`** no longer treats cluster-scoped applications as participants in the shared Envoy Gateway path (SRR + HTTPRoute). Qualification is limited to apps that pass **`IsShared`** (`options.shared` / shared label); the **`IsClusterScoped`** branch is commented out rather than removed.
> 
> Cluster-scoped installs that are not also marked shared will stop being classified as gateway-shared, which affects downstream logic (e.g. route mode / shared gateway reconciliation) that keys off this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b10d12780a742fec2c3cdfb6c54b670938627e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->