### PR TITLE
fix(headscale): Recreate deploy and write keys to .new files

### DIFF
--- a/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
+++ b/framework/headscale/.olares/config/user/helm-charts/headscale/templates/headscale_deploy.yaml
@@ -136,6 +136,8 @@ spec:
   selector:
     matchLabels:
       app: headscale
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -251,14 +253,14 @@ spec:
                           fi
                       done
                       sleep 2
-                      headscale apikeys create -e 3650d > /etc/headscale/apikey
+                      headscale apikeys create -e 3650d > /etc/headscale/apikey.new
                       headscale users create default
                       USER_ID=$(headscale users list | awk '/default/ {print $1; exit}')
                       [ -n "$USER_ID" ] || { echo "user default not found"; exit 1; }
                       headscale preauthkeys create -e 3650d --reusable -u "$USER_ID" \
-                          > /etc/headscale/preauthkey
-                      if ! test -s /etc/headscale/apikey; then echo apikey-empty; exit 1; fi
-                      if ! test -s /etc/headscale/preauthkey; then echo preauthkey-empty; exit 1; fi
+                          > /etc/headscale/preauthkey.new
+                      if ! test -s /etc/headscale/apikey.new; then echo apikey.new-empty; exit 1; fi
+                      if ! test -s /etc/headscale/preauthkey.new; then echo preauthkey.new-empty; exit 1; fi
                   ) > /etc/headscale/.headscale.log 2>&1
         volumeMounts:
         - name: config
@@ -288,7 +290,7 @@ spec:
           name: headscale-nginx-config
           readOnly: true
       - args:
-        - APIKEY=$(cat /etc/headscale/apikey) exec /headscale-api-wrapper
+        - APIKEY=$(cat /etc/headscale/apikey.new) exec /headscale-api-wrapper
         command:
         - /bin/sh
         - -c
@@ -381,7 +383,7 @@ spec:
           - >-
             cp /certs/ca.crt /usr/local/share/ca-certificates/headscale-ca.crt &&
             update-ca-certificates &&
-            TS_AUTHKEY=$(cat /etc/headscale/preauthkey)
+            TS_AUTHKEY=$(cat /etc/headscale/preauthkey.new)
             exec /usr/local/bin/containerboot
         securityContext:
           capabilities:


### PR DESCRIPTION
* **Background**
Prevents concurrent headscale pod conflicts during upgrades via Recreate and .new key files.

* **Target Version for Merge**
1.12.6 1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VPN/auth credential bootstrap and deployment rollout for a critical networking stack; mis-timed key reads could break tailscale login until keys are regenerated.
> 
> **Overview**
> Reduces upgrade races on the **headscale** Deployment by setting **`strategy.type: Recreate`** so only one pod uses the shared hostPath config at a time.
> 
> The **postStart** bootstrap now writes **`apikey.new`** and **`preauthkey.new`** instead of overwriting the legacy paths, with emptiness checks updated accordingly. **`headscale-api-wrapper`** and the **tailscale** sidecar read credentials from those **`.new`** files so startup aligns with freshly generated keys after a replace rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0587cc6c69132ca407a5b549acda153a15e737e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->