### PR TITLE
olares: bump system-frontend image to v1.10.72

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.70
+          image: beclab/system-frontend:v1.10.72
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  Upgrade the `system-frontend` image used by `olares-app-init` from `v1.10.70` to `v1.10.72` to ship the latest desktop/UI fixes and UX improvements from the TermiPass `release-1.12.6` branch:

  - **Faster WebSocket leader election** (beclab/TermiPass#1270): on insecure-context http origins (e.g. `*.olares.local`) where the Web Locks API is unavailable, leader election falls back to the shared worker. Previously dead tabs lingered in the worker's connection set (election could pick a dead port, resulting in no leader) and re-election could take ~20s. Now every tab reports liveness, the worker prunes dead ports and elects only live ones, and a crashed leader is detected in ~1.5–2s. Secure-context (https) origins keep using Web Locks and are unaffected.
  - **SHARE download handling & preview cleanup** (beclab/TermiPass#1270): apply FILES-style folder-download handling to the SHARE app (warn on folder selections, skip folder entries) and remove the archive "extract to" action from the file preview dialog.
  - **i18n / UX copy sync** (beclab/TermiPass#1248): polish market app conflict error copy, deduplicate settings i18n keys, and update GPU/accelerator wording and compute-resource formatting (e.g. "assigned" phrasing, lowercase core/cores, GiB units, zh-CN GPU mode labels).

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1270
  https://github.com/beclab/TermiPass/pull/1248

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.72
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.70...v1.10.72