### PR TITLE
olares: bump system-frontend image to v1.10.73

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.10.72
+          image: beclab/system-frontend:v1.10.73
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  Bump the `olares-app-init` (system-frontend) image from `v1.10.72` to `v1.10.73`.

  This release ships the nginx CORS fix from beclab/TermiPass#1272: the shared `ws-proxy-common` snippet is renamed from `*.conf` to `*.inc` so the stock nginx image's `include /etc/nginx/conf.d/*.conf;` no longer loads it globally at the `http{}` level. Previously it leaked `add_header Access-Control-Allow-Origin $http_origin always;` into every location, which combined with an upstream that already emits `Access-Control-Allow-Origin: *` produced a duplicated header (e.g. `*, capacitor://localhost`) and broke CORS on WebView clients such as LarePass. The snippet is now applied only where explicitly included (the `/ws` proxy locations).

* **Target Version for Merge**
  v1.12.6, v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  beclab/TermiPass#1272

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.10.73
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.10.72...v1.10.73

Made with [Cursor](https://cursor.com)