### PR TITLE
fix(l4-bfl-proxy): scope Envoy CORS injection to fileserver vhosts

### DIFF
--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -632,29 +632,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -725,29 +702,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -822,29 +776,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -915,29 +846,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1117,29 +1025,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1210,29 +1095,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1307,29 +1169,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1400,29 +1239,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -659,29 +659,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -722,29 +699,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -789,29 +743,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -854,29 +785,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -917,29 +825,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1089,29 +974,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1152,29 +1014,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1219,29 +1058,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1284,29 +1100,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1347,29 +1140,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -1250,29 +1250,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1313,29 +1290,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1380,29 +1334,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1443,29 +1374,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1615,29 +1523,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1708,29 +1593,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1805,29 +1667,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1898,29 +1737,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1995,29 +1811,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2088,29 +1881,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2290,29 +2060,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2353,29 +2100,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2420,29 +2144,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2483,29 +2184,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2655,29 +2333,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2748,29 +2403,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2845,29 +2477,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2938,29 +2547,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3035,29 +2621,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3128,29 +2691,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -1711,29 +1711,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1782,29 +1759,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1845,29 +1799,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1912,29 +1843,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1975,29 +1883,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2147,29 +2032,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2218,29 +2080,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2281,29 +2120,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2348,29 +2164,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2411,29 +2204,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2583,29 +2353,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2654,29 +2401,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2717,29 +2441,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -2784,29 +2485,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -2847,29 +2525,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3019,29 +2674,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3090,29 +2722,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3153,29 +2762,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3220,29 +2806,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3283,29 +2846,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3455,29 +2995,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3526,29 +3043,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3589,29 +3083,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3656,29 +3127,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3719,29 +3167,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -3891,29 +3316,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -3962,29 +3364,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -4025,29 +3404,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -4092,29 +3448,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -4155,29 +3488,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -724,29 +724,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -787,29 +764,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -854,29 +808,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -919,29 +850,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -982,29 +890,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1154,29 +1039,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1217,29 +1079,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1284,29 +1123,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1349,29 +1165,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1412,29 +1205,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -707,29 +707,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -770,29 +747,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -837,29 +791,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -902,29 +833,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -965,29 +873,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1137,29 +1022,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1200,29 +1062,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {
@@ -1267,29 +1106,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1332,29 +1148,6 @@
               ]
             }
           ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            }
-          ],
           "typedPerFilterConfig": {
             "envoy.filters.http.ext_authz": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
@@ -1395,29 +1188,6 @@
                   "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
                 }
               ]
-            }
-          ],
-          "responseHeadersToAdd": [
-            {
-              "header": {
-                "key": "access-control-allow-headers",
-                "value": "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-methods",
-                "value": "PUT, GET, DELETE, POST, OPTIONS"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-            },
-            {
-              "header": {
-                "key": "access-control-allow-origin",
-                "value": "*"
-              },
-              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/ir/xds.go
+++ b/framework/l4-bfl-proxy/internal/ir/xds.go
@@ -45,6 +45,11 @@ type VirtualHostIR struct {
 	UserZone              string
 	UserName              string
 	SourceCIDRs           []string // When non-empty, only these source IPs may reach this VH (RBAC).
+	// IsFileserver is true for vhosts that host fileserver routes (files/settings apps).
+	// Used by the xds layer to attach CORS response headers
+	// that the upstream fileserver / nginx do not emit, so Capacitor / browser
+	// cross-origin requests to /api/preview/*, /api/raw/*, etc. succeed.
+	IsFileserver bool
 }
 
 type HTTPRouteIR struct {

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -544,6 +544,8 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			Language:              user.Language,
 			UserZone:              zone,
 			UserName:              user.Name,
+			// Only the (files,settings apps) vhost needs Envoy-level CORS
+			IsFileserver: fileserverPatchApps[prefix],
 		}
 
 		var routes []*ir.HTTPRouteIR

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -706,27 +706,28 @@ func translateVirtualHost(vhIR *ir.VirtualHostIR) *routev3.VirtualHost {
 		})
 	}
 
-	// CORS response headers are normalized at the vhost level using
-	// OVERWRITE_IF_EXISTS_OR_ADD so that any duplicates emitted by upstream
-	// services (e.g. BFL's filter that calls AddHeader instead of Set, or an
-	// intermediate Node.js proxy that reflects the request Origin) collapse
-	// into a single deterministic value. Without this, the browser would
-	// receive headers like "Access-Control-Allow-Origin: *,http://localhost"
-	// which is invalid per the Fetch spec.
-	vh.ResponseHeadersToAdd = append(vh.ResponseHeadersToAdd,
-		&corev3.HeaderValueOption{
-			Header:       &corev3.HeaderValue{Key: "access-control-allow-headers", Value: "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"},
-			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-		},
-		&corev3.HeaderValueOption{
-			Header:       &corev3.HeaderValue{Key: "access-control-allow-methods", Value: "PUT, GET, DELETE, POST, OPTIONS"},
-			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-		},
-		&corev3.HeaderValueOption{
-			Header:       &corev3.HeaderValue{Key: "access-control-allow-origin", Value: "*"},
-			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-		},
-	)
+	// Fileserver vhosts (files apps) need Envoy-level CORS because
+	// the upstream files nginx + backend do not emit any Access-Control-* on
+	// the /api/preview/*, /api/raw/*, /videos/* and similar routes that
+	// Capacitor / browser clients hit cross-origin.
+	if vhIR.IsFileserver {
+		vh.ResponseHeadersToAdd = append(vh.ResponseHeadersToAdd,
+			&corev3.HeaderValueOption{
+				Header: &corev3.HeaderValue{
+					Key:   "access-control-allow-headers",
+					Value: "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization,x-archive-password"},
+				AppendAction: corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+			},
+			&corev3.HeaderValueOption{
+				Header:       &corev3.HeaderValue{Key: "access-control-allow-methods", Value: "PUT, GET, DELETE, POST, OPTIONS"},
+				AppendAction: corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+			},
+			&corev3.HeaderValueOption{
+				Header:       &corev3.HeaderValue{Key: "access-control-allow-origin", Value: "*"},
+				AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+			},
+		)
+	}
 
 	vh.TypedPerFilterConfig = map[string]*anypb.Any{
 		"envoy.filters.http.ext_authz": mustAny(&extauthzv3.ExtAuthzPerRoute{

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
@@ -779,6 +779,34 @@ func TestTranslate_EmptyIR(t *testing.T) {
 	assert.Empty(t, snap.Clusters)
 }
 
+// TestTranslateVirtualHost_CORSFileserverOnly pins the invariant that only
+// vhosts flagged as IsFileserver receive Envoy-level CORS response headers.
+// Regular vhosts (profile, generic apps) must be left alone so upstream CORS
+// is passed through untouched.
+func TestTranslateVirtualHost_CORSFileserverOnly(t *testing.T) {
+	hasCORSOrigin := func(vh *routev3.VirtualHost) bool {
+		for _, h := range vh.GetResponseHeadersToAdd() {
+			if h.GetHeader().GetKey() == "access-control-allow-origin" {
+				return true
+			}
+		}
+		return false
+	}
+
+	fs := translateVirtualHost(&ir.VirtualHostIR{
+		Name:         "app_alice_files_files",
+		Domains:      []string{"files.alice.example.com"},
+		IsFileserver: true,
+	})
+	assert.True(t, hasCORSOrigin(fs), "fileserver vhost must carry allow-origin")
+
+	other := translateVirtualHost(&ir.VirtualHostIR{
+		Name:    "app_alice_vault_vault-frontend",
+		Domains: []string{"vault.alice.example.com"},
+	})
+	assert.False(t, hasCORSOrigin(other), "non-fileserver vhost must not carry allow-origin")
+}
+
 // ---------------------------------------------------------------------------
 // suppress unused imports
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

* **Background**
fix(l4-bfl-proxy): scope Envoy CORS injection to fileserver vhosts
* **Target Version for Merge**
v1.12.6,v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edge proxy CORS behavior for all non-fileserver apps (headers no longer forced), which can fix invalid duplicate CORS but may break clients that depended on proxy-injected CORS outside fileserver routes.
> 
> **Overview**
> Envoy no longer adds **Access-Control-*** response headers on every app virtual host. CORS is injected only when the vhost is flagged as a **fileserver** (`files` / `settings` apps), where upstream nginx does not emit headers needed for Capacitor and browser calls to `/api/preview/*`, `/api/raw/*`, and similar paths.
> 
> The IR gains **`IsFileserver`** on `VirtualHostIR`, set in the app translator from `fileserverPatchApps`. The xDS translator gates the three CORS headers on that flag and uses **`APPEND_IF_EXISTS_OR_ADD`** for allow-headers and allow-methods (allow-origin still **`OVERWRITE_IF_EXISTS_OR_ADD`**). E2E golden configs drop per-vhost CORS blocks for non-fileserver routes; **`TestTranslateVirtualHost_CORSFileserverOnly`** locks in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67a197a292ddfe73e8310c432204e291932e67b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->