### PR TITLE
feat(download-server): expand download-server provider

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_provider.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_provider.yaml
@@ -25,7 +25,11 @@ metadata:
     provider-registry-ref: {{ .Release.Namespace }}/download-provider-svc
     provider-service-ref: download-provider-svc.{{ .Release.Namespace }}:28080
 rules:
-  - nonResourceURLs: ["/api/download*"]
+  - nonResourceURLs:
+      - "/api/download*"
+      - "/api/user/*"
+      - "/api/system/*"
+      - "/api/url/*"
     verbs: ["*"]
 
 ---


### PR DESCRIPTION
Background
extend provider to /api/user, /api/system, /api/url paths

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens provider RBAC to user, system, and URL API paths with full verbs, increasing exposed surface through the provider registry.
> 
> **Overview**
> Expands the **`backend:download-provider`** ClusterRole so the download provider can register and authorize additional non-resource API paths beyond **`/api/download*`**.
> 
> The role’s **`nonResourceURLs`** list now also includes **`/api/user/*`**, **`/api/system/*`**, and **`/api/url/*`**, still with **`verbs: ["*"]`**. The YAML is reformatted to a multi-line list; Service and nginx ConfigMap behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcae6d4359590daa308e8db585e76f423ecda41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->