### PR TITLE
market: fail fast when NATS connection fails at startup

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-chart-repo
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.72
+        image: beclab/market-backend:v0.6.73
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fail fast when NATS connection fails at startup

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.6, v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/356

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest logic changes; main effect is faster pod failure/restart when NATS is unavailable at startup.
> 
> **Overview**
> Rolls out **market-backend** `v0.6.73` (from `v0.6.72`) on the `appstore-backend` container in `market_deploy.yaml`.
> 
> That image carries the startup behavior from [beclab/market#356](https://github.com/beclab/market/pull/356): the backend **exits immediately** if NATS cannot be connected at boot, instead of running in a broken state. No Helm env, secrets, or NATS wiring changes in this diff—only the image tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45634eea9377232f210a6acc4030863b43a2480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->