### PR TITLE
docs: add BIOS and EC reference for automatic startup

### DIFF
--- a/docs/manual/olares/settings/my-olares.md
+++ b/docs/manual/olares/settings/my-olares.md
@@ -54,7 +54,10 @@ Available actions are:
   Turn on this switch to start the device automatically when power is connected or restored after a power outage.
 
   :::info
-  Requires Olares OS 1.12.6 or later and EC firmware 1.03 or later. If either prerequisite is not met, the toggle is visible but disabled.
+
+  Requires Olares OS 1.12.6 or later and EC firmware 1.03 or later. If either prerequisite is not met, the toggle is visible but disabled. 
+  
+  To check your current EC firmware version or update EC firmware, see [Manage BIOS and EC](/one/update-firmware.md).
   :::
   
 

--- a/docs/zh/manual/olares/settings/my-olares.md
+++ b/docs/zh/manual/olares/settings/my-olares.md
@@ -41,6 +41,8 @@ description: 了解如何利用“我的 Olares”页面管理账户、设备、
 
   :::info
   需要 Olares OS 1.12.6 或更高版本，以及 EC 固件 1.03 或更高版本。如果任一条件未满足，开关会显示但无法操作。
+  
+  如需查看当前 EC 固件版本或升级 EC 固件，可参考[管理 BIOS 和 EC](/zh/one/update-firmware.md)。
   :::
   
 


### PR DESCRIPTION
* **Background**

* **Target Version for Merge**
1.12.6

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product or runtime behavior changes.
> 
> **Overview**
> Adds a cross-link from the **Automatic startup** / **自动开机** prerequisite note on **My Olares** to the **Manage BIOS and EC** guide so readers can check or update EC firmware when the toggle is disabled.
> 
> English and Chinese `my-olares.md` both get the new sentence inside the existing `:::info` block; the English page also moves the OS/EC version requirement into that block with minor formatting cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba92fa0d8fb9b2ae4683f977e385a34d5812c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->