### PR TITLE
fix(download-server): fall back to %(title)s for URL-derived placeholder names + forward real title

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -170,6 +170,10 @@ spec:
         env:
         - name: DEBUG
           value: "false"
+        - name: SA_TOKEN_NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: SA_TOKEN_NAME
+          value: download-cluster-view
         - name: YTDLP_SERVER_URL
           value: http://ytdlp-svc.ytdlp-shared:3082
         - name: ARIA2_RPC_URL
@@ -218,6 +222,8 @@ spec:
         volumeMounts:
         - name: download-dir
           mountPath: /app/downloads
+        - name: config-dir
+          mountPath: /app/ytdlp/downloads
         ports:
         - containerPort: 8080
         resources:

--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.2"
+        image: "beclab/download-server:v1.0.3"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
A watch URL whose collect-time metadata probe failed arrived as a placeholder file_name (watch.download), which yt-dlp materialised into watch.download.webm and which then became the entry title downstream.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image bump plus new SA-token env and hostPath mount affect how downloads run in production; misconfiguration could break cluster API access or yt-dlp paths.
> 
> **Overview**
> Rolls out **`beclab/download-server:v1.0.3`** (from v1.0.2), which carries the title/`%(title)s` fallback behavior described in the PR; this diff only updates the cluster DaemonSet manifest.
> 
> The **`download-server`** container now gets **`SA_TOKEN_NAMESPACE`** and **`SA_TOKEN_NAME`** (`download-cluster-view`) so the app can mint/use the existing cluster-view ServiceAccount token, and mounts the shared **`config-dir`** host volume at **`/app/ytdlp/downloads`** for yt-dlp output/config alongside `/app/downloads`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f819655652f9352ad54f9f8cc5a1fc456ccf7a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->