### PR TITLE
feat(cli): shard each AMD GPU into multiple virtual devices

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/nvidia/amdgpu-device-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/nvidia/amdgpu-device-plugin.yaml
@@ -20,7 +20,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       containers:
-        - image: rocm/k8s-device-plugin:1.31.0.10
+        - image: beclab/amd-device-plugin:1.1
           name: amdgpu-dp-cntr
           securityContext:
             privileged: true


### PR DESCRIPTION

* **Background**
shard each AMD GPU into multiple virtual devices
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/amd-k8s-device-plugin/pull/1

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster-wide GPU scheduling and device advertisement on AMD nodes; misbehavior could break GPU workloads or over-commit hardware, though the change is limited to a single DaemonSet image swap.
> 
> **Overview**
> **Switches the AMD GPU Kubernetes device plugin** on amd64 nodes from the upstream `rocm/k8s-device-plugin:1.31.0.10` image to **`beclab/amd-device-plugin:1.1`** in the `amdgpu-device-plugin` DaemonSet (`amdgpu-device-plugin.yaml`). The DaemonSet wiring (privileged container, device-plugin and `/sys` mounts, node selector, tolerations) is unchanged.
> 
> This deploys the Beclab fork that **shards each physical AMD GPU into multiple schedulable virtual devices**, so workloads can request fractional GPU capacity instead of a full card per pod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71fc77348e48b77995ea4addf78172b8000a0ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->