### PR TITLE
feat(appservice): inject amd.com/gpu for AMD compute modes

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -434,7 +434,7 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		klog.Errorf("create patch error %v", err)
 		return h.sidecarWebhook.AdmissionError(req.UID, err)
 	}
-	if !compute.IsHAMIMode(GPUType) && GPUType != utils.CPUType {
+	if !compute.UsesGPUExtendedResource(GPUType) && GPUType != utils.CPUType {
 		allocations, err := compute.FindAllocationsForApp(ctx, h.ctrlClient, appName, appcfg.OwnerName)
 		if err != nil {
 			klog.Errorf("find compute allocation for app %s failed %v", appName, err)
@@ -467,6 +467,8 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 		return constants.NvidiaGPU
 	case utils.GB10ChipType:
 		return constants.NvidiaGPU
+	case utils.AMDType, utils.AMDGPUType:
+		return constants.AMDGPU
 	case utils.CPUType:
 		klog.Info("CPU type is selected, no GPU resource will be injected")
 		return ""

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -269,3 +269,20 @@ func IsHAMIMode(mode string) bool {
 		return false
 	}
 }
+
+// UsesGPUExtendedResource reports whether pods in this GPU mode are scheduled
+// onto GPU nodes via a Kubernetes extended resource (nvidia.com/gpu or
+// amd.com/gpu). For these modes the kube-scheduler already picks a matching
+// node from resources.limits, so the gpu-limit webhook must NOT additionally
+// pin the pod with a nodeSelector — doing so can create an unschedulable
+// combination when the allocation's node no longer advertises the resource.
+// All other GPU modes (intel/apple-m/moore-soc/…) have no extended resource
+// and rely on nodeSelector to reach the correct node.
+func UsesGPUExtendedResource(mode string) bool {
+	switch mode {
+	case utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.AMDGPUType:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
* **Background**
The gpu-limit mutating webhook previously only injected extended-resource limits for nvidia/nvidia-gb10, leaving AMD (integrated Ryzen AI Max) and amd-gpu (discrete) apps without any resources.limits key. Kube-scheduler then had no signal to route those pods onto AMD nodes, so they had to rely on the nodeSelector fallback, which conflicts once ROCm exposes amd.com/gpu as an extended resource.

- getGPUResourceTypeKey: return constants.AMDGPU ("amd.com/gpu") for AMDType and AMDGPUType, matching how NvidiaCardType/GB10ChipType map to nvidia.com/gpu. CreatePatchForDeployment already writes "1" under the returned key, so both AMD modes now get amd.com/gpu: "1".
- Skip the nodeSelector pin for AMD modes: they are scheduled by the extended resource, and additionally pinning them can produce an unschedulable pod when the previously-allocated node no longer advertises the resource.
- Extract the "does this mode schedule via a k8s extended resource" predicate into compute.UsesGPUExtendedResource, so the webhook no longer open-codes the (HAMi || AMD || AMDGPU) union. Future extended-resource-backed modes only need to be added in one place alongside getGPUResourceTypeKey.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission-time pod patches that affect GPU scheduling and node placement; wrong mode classification could leave AMD pods without limits or with conflicting nodeSelectors.
> 
> **Overview**
> The **gpu-limit** mutating webhook now treats AMD integrated (`AMDType`) and discrete (`AMDGPUType`) compute modes like NVIDIA HAMi modes for scheduling: pods get **`amd.com/gpu`** limits via `getGPUResourceTypeKey`, and the webhook **no longer adds a hostname `nodeSelector`** from compute allocations for those modes.
> 
> The nodeSelector skip is driven by a new **`compute.UsesGPUExtendedResource`** helper (replacing the previous `!IsHAMIMode` check). Modes that schedule via Kubernetes extended resources (`nvidia.com/gpu` or `amd.com/gpu`) rely on the scheduler only; pinning an allocation node on top can make pods unschedulable when that node stops advertising the resource. Non-extended-resource modes still use the allocation-based nodeSelector path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4704717518c1609f7329aa6ee4bfcc6018175a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->