### PR TITLE
daemon: improve handling of invalid mounted paths and clean up uninstall script

### DIFF
--- a/cli/pkg/k3s/templates/uninstall_script.go
+++ b/cli/pkg/k3s/templates/uninstall_script.go
@@ -66,6 +66,7 @@ rm -rf /var/lib/rancher/k3s
 rm -rf /var/lib/kubelet
 rm -f /usr/local/bin/k3s
 rm -f /usr/local/bin/k3s-killall.sh
+rm -f /etc/mounttab
 
 if type yum >/dev/null 2>&1; then
     yum remove -y k3s-selinux

--- a/daemon/pkg/utils/notify.go
+++ b/daemon/pkg/utils/notify.go
@@ -114,12 +114,15 @@ func GetMountedPathDetail(ctx context.Context, mutate func(*disk.UsageStat) *dis
 	var mountedMountPoints []string
 	for _, p := range paths {
 		mountedMountPoints = append(mountedMountPoints, p.Path)
-		u, err := disk.UsageWithContext(ctx, p.Path)
-		if err != nil {
-			klog.Error("get path usage error, ", err, ", ", p)
+		u := &disk.UsageStat{Path: p.Path}
+		if !p.Invalid {
+			u, err = disk.UsageWithContext(ctx, p.Path)
+			if err != nil {
+				klog.Error("get path usage error, ", err, ", ", p)
 
-			u = &disk.UsageStat{Path: p.Path}
-			p.Invalid = true
+				u = &disk.UsageStat{Path: p.Path}
+				p.Invalid = true
+			}
 		}
 
 		if mutate != nil {


### PR DESCRIPTION
* **Background**
1. Ignore checking the disk status of an invalid mounted path 
2. Remove SMB and NFS mount point records in Olares uninstallation 

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized daemon mount-notification behavior and uninstall cleanup; no auth, data, or core cluster path changes.
> 
> **Overview**
> **Mounted path reporting** now skips `disk.UsageWithContext` when a path is already marked **invalid**, so broken SMB/NFS mounts no longer trigger repeated usage checks and error logs while still reporting path metadata to the files pod.
> 
> **K3s uninstall** removes **`/etc/mounttab`** so Olares uninstall clears SMB/NFS mount point records left on the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b44c33c1bf980be8464e662a1d2450b5e5d383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->