### PR TITLE
feat(app): bump system-frontend and wizard to v1.11.3 and add more UI languages

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.2
+          image: beclab/system-frontend:v1.11.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
+++ b/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
@@ -29,7 +29,7 @@ spec:
 
       containers:
       - name: wizard
-        image: beclab/wizard:v1.10.44
+        image: beclab/wizard:v1.11.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/build/user-env.yaml
+++ b/build/user-env.yaml
@@ -30,6 +30,16 @@ userEnvs:
       value: "en-US"
     - title: "简体中文"
       value: "zh-CN"
+    - title: "Deutsch"
+      value: "de-DE"
+    - title: "Español"
+      value: "es-ES"
+    - title: "Italiano"
+      value: "it-IT"
+    - title: "Français"
+      value: "fr-FR"
+    - title: "日本語"
+      value: "ja-JP"
   - envName: OLARES_USER_THEME
     type: string
     editable: true


### PR DESCRIPTION
* **Background**

  The Olares app frontend now ships additional UI localizations (German,
  Spanish, Italian, French and Japanese) on top of English and Simplified
  Chinese. This PR wires those into Olares by:
  - Bumping the `system-frontend` image from `v1.11.2` to `v1.11.3`.
  - Bumping the `wizard` image from `v1.10.44` to `v1.11.3`.
  - Expanding the selectable `OLARES_USER_LANGUAGE` options in `build/user-env.yaml`
    with `de-DE`, `es-ES`, `it-IT`, `fr-FR` and `ja-JP`.

* **Target Version for Merge**
  v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1276

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.11.3
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.11.2...v1.11.3

Made with [Cursor](https://cursor.com)