### PR TITLE
docs: remove BIOS 105 from 1.12.6

### DIFF
--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -34,11 +34,11 @@ Review the following changelogs for features or fixes included in each update.
 If your current versions are older than the ones listed below, download the corresponding update packages to proceed.
 
 ### BIOS versions
+<!--| [1.05 (Download)](https://cdn.olares.com/common/OlaresOne_BIOS_1.05.zip) | 2026-07-06 | <ul><li>Fix the Thunderbolt port issue by disabling the D3 (D3Cold) low-power state only for the GPU. Previously, D3 was disabled for all devices to address the abnormal power consumption issue.</li></ul> |-->
 
 | Version | Release date | Changelog |
 |:--------|:-------------|:----------|
-| [1.05 (Download)](https://cdn.olares.com/common/OlaresOne_BIOS_1.05.zip) | 2026-07-06 | <ul><li>Fix the Thunderbolt port issue by disabling the D3 (D3Cold) low-power state only for the GPU. Previously, D3 was disabled for all devices to address the abnormal power consumption issue.</li></ul> |
-| 1.04 | 2026-05-09 | <ul><li>Add a warning prompt when changing the **Primary Display** setting to **HG**.</li><li>Fix the issue where the GPU unexpectedly disconnects by locking the GPU PCIe speed to Gen4.</li><li>Fix the issue where performance degrades and power consumption is abnormally limited after prolonged use by disabling the function that puts the GPU into sleep mode when the product is idle.</li></ul> |
+| [1.04 (Download)](https://cdn.olares.com/common/OlaresOne_BIOS_1.04.zip) | 2026-05-09 | <ul><li>Add a warning prompt when changing the **Primary Display** setting to **HG**.</li><li>Fix the issue where the GPU unexpectedly disconnects by locking the GPU PCIe speed to Gen4.</li><li>Fix the issue where performance degrades and power consumption is abnormally limited after prolonged use by disabling the function that puts the GPU into sleep mode when the product is idle.</li></ul> |
 | 1.03  | 2026-03-19 | <ul><li>Fix the ACPI error that occurs during Ubuntu system boot.</li><li>Update the Intel CPU microcode to version 0x121.</li></ul> |
 | 1.01  | 2025-12-04 | <ul><li>Fix the issue where SSDs unexpectedly disconnect by disabling ASPM and L-state power management for SSD1 and SSD2.</li></ul> |
 | 1.00 | 2025-11-28 | <ul><li>Update version naming convention.</li></ul> |

--- a/docs/zh/one/update-firmware.md
+++ b/docs/zh/one/update-firmware.md
@@ -39,10 +39,11 @@ head:
 
 ### BIOS 版本
 
+<!--| [1.05 (下载)](https://cdn.olares.com/common/OlaresOne_BIOS_1.05.zip) | 2026-07-06 | <ul><li>修复雷电口功能异常的问题。此前为改善功耗异常，禁用了所有设备的 D3 (D3Cold) 低功耗状态；现在仅禁用 GPU 的 D3 状态。</li></ul> |-->
+
 | 版本 | 发布日期 | 更新日志 |
 |:--------|:-------------|:----------|
-| [1.05 (下载)](https://cdn.olares.com/common/OlaresOne_BIOS_1.05.zip) | 2026-07-06 | <ul><li>修复雷电口功能异常的问题。此前为改善功耗异常，禁用了所有设备的 D3 (D3Cold) 低功耗状态；现在仅禁用 GPU 的 D3 状态。</li></ul> |
-| 1.04 | 2026-05-09 | <ul><li>在将 **Primary Display** 设置更改为 **HG** 时添加警告提示。</li><li>通过锁定 GPU PCIe 速度为 Gen4 修复 GPU 意外断开连接的问题。</li><li>通过禁用产品空闲时将 GPU 置于睡眠模式的功能，修复长时间使用后性能下降且功耗异常受限的问题。</li></ul> |
+| [1.04 (下载)](https://cdn.olares.com/common/OlaresOne_BIOS_1.04.zip)| 2026-05-09 | <ul><li>在将 **Primary Display** 设置更改为 **HG** 时添加警告提示。</li><li>通过锁定 GPU PCIe 速度为 Gen4 修复 GPU 意外断开连接的问题。</li><li>通过禁用产品空闲时将 GPU 置于睡眠模式的功能，修复长时间使用后性能下降且功耗异常受限的问题。</li></ul> |
 | 1.03  | 2026-03-19 | <ul><li>修复 Ubuntu 系统启动时出现的 ACPI 错误。</li><li>将 Intel CPU 微码更新至版本 0x121。</li></ul> |
 | 1.01  | 2025-12-04 | <ul><li>通过禁用 SSD1 和 SSD2 的 ASPM 和 L-state 电源管理，修复 SSD 意外断开连接的问题。</li></ul> |
 | 1.00 | 2025-11-28 | <ul><li>更新版本命名规范。</li></ul> |


### PR DESCRIPTION
Title: Remove BIOS 105 from 1.12.6

* **Background**
See title.

* **Target Version for Merge**
None.
* **Related Issues**
None.

* **PRs Involving Sub-Systems** 
None.


* **Other information**:
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to firmware version tables; no application or firmware logic is modified.
> 
> **Overview**
> Updates the Olares One firmware docs (English and Chinese) so **BIOS 1.05** is no longer offered as the current release for the 1.12.6 line: the 1.05 table row is moved into an HTML comment (hidden from readers) instead of appearing as the top downloadable version.
> 
> **BIOS 1.04** becomes the latest visible entry and gains an explicit **Download** link to `OlaresOne_BIOS_1.04.zip`, replacing the previous plain version row without a link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595df4d62aa7c6f962990a18477cbd03fe4ea9fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->