### PR TITLE
feat: add device plugin for intel

### DIFF
--- a/cli/pkg/gpu/intelgpu/module.go
+++ b/cli/pkg/gpu/intelgpu/module.go
@@ -1,6 +1,8 @@
 package intelgpu
 
 import (
+	"time"
+
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/task"
 )
@@ -28,7 +30,42 @@ func (m *InstallIntelPluginModule) Init() {
 		Retry:  1,
 	}
 
+	// nfd.yaml installs CRDs; keep it in its own task and retry so the CRDs are
+	// established before the dependent CR / plugin manifests are applied.
+	applyNFD := &task.LocalTask{
+		Name:   "ApplyIntelNFD",
+		Action: new(ApplyIntelNFD),
+		Retry:  5,
+		Delay:  5 * time.Second,
+	}
+
+	// depends on the NodeFeatureRule CRD created by applyNFD, retry until ready
+	applyNodeFeatureRules := &task.LocalTask{
+		Name:   "ApplyIntelNodeFeatureRules",
+		Action: new(ApplyIntelNodeFeatureRules),
+		Retry:  10,
+		Delay:  6 * time.Second,
+	}
+
+	applyGPUPlugin := &task.LocalTask{
+		Name:   "ApplyIntelGPUPlugin",
+		Action: new(ApplyIntelGPUPlugin),
+		Retry:  3,
+		Delay:  5 * time.Second,
+	}
+
+	checkGPUPlugin := &task.LocalTask{
+		Name:   "CheckIntelGpu",
+		Action: new(CheckIntelGpu),
+		Retry:  50,
+		Delay:  10 * time.Second,
+	}
+
 	m.Tasks = []task.Interface{
 		updateNode,
+		applyNFD,
+		applyNodeFeatureRules,
+		applyGPUPlugin,
+		checkGPUPlugin,
 	}
 }

--- a/cli/pkg/gpu/intelgpu/tasks.go
+++ b/cli/pkg/gpu/intelgpu/tasks.go
@@ -2,15 +2,24 @@ package intelgpu
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
 
 	"github.com/beclab/Olares/cli/pkg/clientset"
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/util"
 	"github.com/beclab/Olares/cli/pkg/gpu"
 
 	"github.com/pkg/errors"
 )
+
+// intelConfigDir is the installer-relative directory that holds the Intel GPU
+// manifests (mirrors infrastructure/gpu/.olares/config/gpu/intel).
+const intelConfigDir = "wizard/config/gpu/intel"
 
 // UpdateNodeIntelGPUInfo labels the node as supporting the "intel" mode (Intel
 // integrated GPU)
@@ -30,4 +39,105 @@ func (u *UpdateNodeIntelGPUInfo) Execute(runtime connector.Runtime) error {
 	}
 
 	return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelType, nil, nil, nil)
+}
+
+// applyIntelManifest kubectl-applies a single manifest under intelConfigDir.
+func applyIntelManifest(runtime connector.Runtime, fileName, desc string) error {
+	manifestPath := path.Join(runtime.GetInstallerDir(), intelConfigDir, fileName)
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("kubectl apply -f %s", manifestPath), false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("failed to apply Intel %s (%s)", desc, fileName))
+	}
+	logger.Infof("Intel %s applied successfully", desc)
+	return nil
+}
+
+// ApplyIntelNFD applies the node-feature-discovery manifests (nfd.yaml). This is
+// kept in its own task because nfd.yaml installs CRDs (NodeFeature,
+// NodeFeatureRule, NodeFeatureGroup): kubectl apply returns before the CRDs are
+// fully established on the API server, so any manifest applied immediately after
+// (e.g. the NodeFeatureRule CRs in node-feature-rules.yaml) may fail. Running it
+// separately with a retry lets the CRDs settle before dependent applies.
+type ApplyIntelNFD struct {
+	common.KubeAction
+}
+
+func (t *ApplyIntelNFD) Execute(runtime connector.Runtime) error {
+	return applyIntelManifest(runtime, "nfd.yaml", "node-feature-discovery")
+}
+
+// ApplyIntelNodeFeatureRules applies the NodeFeatureRule CRs
+// (node-feature-rules.yaml). It depends on the CRDs created by ApplyIntelNFD, so
+// it is retried until the CRDs are established.
+type ApplyIntelNodeFeatureRules struct {
+	common.KubeAction
+}
+
+func (t *ApplyIntelNodeFeatureRules) Execute(runtime connector.Runtime) error {
+	return applyIntelManifest(runtime, "node-feature-rules.yaml", "node feature rules")
+}
+
+// ApplyIntelGPUPlugin applies the Intel GPU device plugin DaemonSet
+// (gpu-plugin.yaml).
+type ApplyIntelGPUPlugin struct {
+	common.KubeAction
+}
+
+func (t *ApplyIntelGPUPlugin) Execute(runtime connector.Runtime) error {
+	return applyIntelManifest(runtime, "gpu-plugin.yaml", "GPU device plugin")
+}
+
+// CheckIntelGpu waits until the whole Intel GPU stack is Running: the NFD pods
+// (nfd-master, nfd-gc, nfd-worker) and the intel-gpu-plugin DaemonSet. Without
+// this gate the install can finish while pods are still Pending (e.g. before NFD
+// applies the intel.feature.node.kubernetes.io/gpu label that the plugin's
+// nodeSelector requires), making the device-plugin setup look successful when it
+// is not yet working.
+type CheckIntelGpu struct {
+	common.KubeAction
+}
+
+func (t *CheckIntelGpu) Execute(runtime connector.Runtime) error {
+	kubectlpath, err := util.GetCommand(common.CommandKubectl)
+	if err != nil {
+		return fmt.Errorf("kubectl not found")
+	}
+
+	nodeName, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "get hostname error")
+	}
+	nodeName = strings.ToLower(nodeName)
+
+	checks := []struct {
+		selector string
+		withNode bool
+	}{
+		{selector: "app=nfd-master", withNode: false},
+		{selector: "app=nfd-gc", withNode: false},
+		{selector: "app=nfd-worker", withNode: true},
+		{selector: "app=intel-gpu-plugin", withNode: true},
+	}
+
+	for _, c := range checks {
+		cmd := fmt.Sprintf("%s get pod -n kube-system -l '%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, c.selector)
+		if c.withNode {
+			cmd = fmt.Sprintf("%s get pod -n kube-system -l '%s' --field-selector 'spec.nodeName=%s' -o jsonpath='{.items[*].status.phase}'", kubectlpath, c.selector, nodeName)
+		}
+
+		rphase, _ := runtime.GetRunner().SudoCmd(cmd, false, false)
+		if !hasRunningPod(rphase) {
+			return fmt.Errorf("pod for selector %q is not Running", c.selector)
+		}
+	}
+
+	return nil
+}
+
+func hasRunningPod(phases string) bool {
+	for _, phase := range strings.Fields(phases) {
+		if phase == "Running" {
+			return true
+		}
+	}
+	return false
 }

--- a/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: intel-gpu-plugin
+  name: intel-gpu-plugin
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: intel-gpu-plugin
+  template:
+    metadata:
+      labels:
+        app: intel-gpu-plugin
+    spec:
+      containers:
+      - args:
+        - -enable-monitoring
+        - -shared-dev-num=50
+        - -v=4
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: beclab/intel-device-plugin:1.1
+        imagePullPolicy: IfNotPresent
+        name: intel-gpu-plugin
+        resources:
+          limits:
+            cpu: 100m
+            memory: 90Mi
+          requests:
+            cpu: 40m
+            memory: 45Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seLinuxOptions:
+            type: container_device_plugin_t
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /dev/dri
+          name: dev-dri-fs
+          readOnly: true
+        - mountPath: /sys/class/drm
+          name: sysfsdrm
+          readOnly: true
+        - mountPath: /var/lib/kubelet/device-plugins
+          name: kubeletsockets
+        - mountPath: /var/run/cdi
+          name: cdipath
+        - mountPath: /dev/accel
+          name: dev-accel-fs
+          readOnly: true
+        - mountPath: /sys/class/accel
+          name: sysfsaccel
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+        kubernetes.io/arch: amd64
+      volumes:
+      - hostPath:
+          path: /dev/dri
+        name: dev-dri-fs
+      - hostPath:
+          path: /sys/class/drm
+        name: sysfsdrm
+      - hostPath:
+          path: /var/lib/kubelet/device-plugins
+        name: kubeletsockets
+      - hostPath:
+          path: /var/run/cdi
+          type: DirectoryOrCreate
+        name: cdipath
+      - hostPath:
+          path: /dev/accel
+        name: dev-accel-fs
+      - hostPath:
+          path: /sys/class/accel
+        name: sysfsaccel
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/infrastructure/gpu/.olares/config/gpu/intel/nfd.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/nfd.yaml
@@ -1,0 +1,1214 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodefeaturegroups.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeatureGroup
+    listKind: NodeFeatureGroupList
+    plural: nodefeaturegroups
+    shortNames:
+    - nfg
+    singular: nodefeaturegroup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeFeatureGroup resource holds Node pools by featureGroup
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the rules to be evaluated.
+            properties:
+              featureGroupRules:
+                description: List of rules to evaluate to determine nodes that belong
+                  in this group.
+                items:
+                  description: GroupRule defines a rule for nodegroup filtering.
+                  properties:
+                    matchAny:
+                      description: MatchAny specifies a list of matchers one of which
+                        must match.
+                      items:
+                        description: MatchAnyElem specifies one sub-matcher of MatchAny.
+                        properties:
+                          matchFeatures:
+                            description: MatchFeatures specifies a set of matcher
+                              terms all of which must match.
+                            items:
+                              description: |-
+                                FeatureMatcherTerm defines requirements against one feature set. All
+                                requirements (specified as MatchExpressions) are evaluated against each
+                                element in the feature set.
+                              properties:
+                                feature:
+                                  description: Feature is the name of the feature
+                                    set to match against.
+                                  type: string
+                                matchExpressions:
+                                  additionalProperties:
+                                    description: |-
+                                      MatchExpression specifies an expression to evaluate against a set of input
+                                      values. It contains an operator that is applied when matching the input and
+                                      an array of values that the operator evaluates the input against.
+                                    properties:
+                                      op:
+                                        description: Op is the operator to be applied.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - InRegexp
+                                        - Exists
+                                        - DoesNotExist
+                                        - Gt
+                                        - Lt
+                                        - GtLt
+                                        - IsTrue
+                                        - IsFalse
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Value is the list of values that the operand evaluates the input
+                                          against. Value should be empty if the operator is Exists, DoesNotExist,
+                                          IsTrue or IsFalse. Value should contain exactly one element if the
+                                          operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                          In other cases Value should contain at least one element.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - op
+                                    type: object
+                                  description: |-
+                                    MatchExpressions is the set of per-element expressions evaluated. These
+                                    match against the value of the specified elements.
+                                  type: object
+                                matchName:
+                                  description: |-
+                                    MatchName in an expression that is matched against the name of each
+                                    element in the feature set.
+                                  properties:
+                                    op:
+                                      description: Op is the operator to be applied.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - InRegexp
+                                      - Exists
+                                      - DoesNotExist
+                                      - Gt
+                                      - Lt
+                                      - GtLt
+                                      - IsTrue
+                                      - IsFalse
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value is the list of values that the operand evaluates the input
+                                        against. Value should be empty if the operator is Exists, DoesNotExist,
+                                        IsTrue or IsFalse. Value should contain exactly one element if the
+                                        operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                        In other cases Value should contain at least one element.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - op
+                                  type: object
+                              required:
+                              - feature
+                              type: object
+                            type: array
+                        required:
+                        - matchFeatures
+                        type: object
+                      type: array
+                    matchFeatures:
+                      description: MatchFeatures specifies a set of matcher terms
+                        all of which must match.
+                      items:
+                        description: |-
+                          FeatureMatcherTerm defines requirements against one feature set. All
+                          requirements (specified as MatchExpressions) are evaluated against each
+                          element in the feature set.
+                        properties:
+                          feature:
+                            description: Feature is the name of the feature set to
+                              match against.
+                            type: string
+                          matchExpressions:
+                            additionalProperties:
+                              description: |-
+                                MatchExpression specifies an expression to evaluate against a set of input
+                                values. It contains an operator that is applied when matching the input and
+                                an array of values that the operator evaluates the input against.
+                              properties:
+                                op:
+                                  description: Op is the operator to be applied.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - InRegexp
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                                  - GtLt
+                                  - IsTrue
+                                  - IsFalse
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value is the list of values that the operand evaluates the input
+                                    against. Value should be empty if the operator is Exists, DoesNotExist,
+                                    IsTrue or IsFalse. Value should contain exactly one element if the
+                                    operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                    In other cases Value should contain at least one element.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - op
+                              type: object
+                            description: |-
+                              MatchExpressions is the set of per-element expressions evaluated. These
+                              match against the value of the specified elements.
+                            type: object
+                          matchName:
+                            description: |-
+                              MatchName in an expression that is matched against the name of each
+                              element in the feature set.
+                            properties:
+                              op:
+                                description: Op is the operator to be applied.
+                                enum:
+                                - In
+                                - NotIn
+                                - InRegexp
+                                - Exists
+                                - DoesNotExist
+                                - Gt
+                                - Lt
+                                - GtLt
+                                - IsTrue
+                                - IsFalse
+                                type: string
+                              value:
+                                description: |-
+                                  Value is the list of values that the operand evaluates the input
+                                  against. Value should be empty if the operator is Exists, DoesNotExist,
+                                  IsTrue or IsFalse. Value should contain exactly one element if the
+                                  operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                  In other cases Value should contain at least one element.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - op
+                            type: object
+                        required:
+                        - feature
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the rule.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - featureGroupRules
+            type: object
+          status:
+            description: |-
+              Status of the NodeFeatureGroup after the most recent evaluation of the
+              specification.
+            properties:
+              nodes:
+                description: Nodes is a list of FeatureGroupNode in the cluster that
+                  match the featureGroupRules
+                items:
+                  properties:
+                    name:
+                      description: Name of the node.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodefeaturerules.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeatureRule
+    listKind: NodeFeatureRuleList
+    plural: nodefeaturerules
+    shortNames:
+    - nfr
+    singular: nodefeaturerule
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NodeFeatureRule resource specifies a configuration for feature-based
+          customization of node objects, such as node labeling.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the rules to be evaluated.
+            properties:
+              rules:
+                description: Rules is a list of node customization rules.
+                items:
+                  description: Rule defines a rule for node customization such as
+                    labeling.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to create if the rule matches.
+                      type: object
+                    extendedResources:
+                      additionalProperties:
+                        type: string
+                      description: ExtendedResources to create if the rule matches.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to create if the rule matches.
+                      type: object
+                    labelsTemplate:
+                      description: |-
+                        LabelsTemplate specifies a template to expand for dynamically generating
+                        multiple labels. Data (after template expansion) must be keys with an
+                        optional value (<key>[=<value>]) separated by newlines.
+                      type: string
+                    matchAny:
+                      description: MatchAny specifies a list of matchers one of which
+                        must match.
+                      items:
+                        description: MatchAnyElem specifies one sub-matcher of MatchAny.
+                        properties:
+                          matchFeatures:
+                            description: MatchFeatures specifies a set of matcher
+                              terms all of which must match.
+                            items:
+                              description: |-
+                                FeatureMatcherTerm defines requirements against one feature set. All
+                                requirements (specified as MatchExpressions) are evaluated against each
+                                element in the feature set.
+                              properties:
+                                feature:
+                                  description: Feature is the name of the feature
+                                    set to match against.
+                                  type: string
+                                matchExpressions:
+                                  additionalProperties:
+                                    description: |-
+                                      MatchExpression specifies an expression to evaluate against a set of input
+                                      values. It contains an operator that is applied when matching the input and
+                                      an array of values that the operator evaluates the input against.
+                                    properties:
+                                      op:
+                                        description: Op is the operator to be applied.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - InRegexp
+                                        - Exists
+                                        - DoesNotExist
+                                        - Gt
+                                        - Lt
+                                        - GtLt
+                                        - IsTrue
+                                        - IsFalse
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Value is the list of values that the operand evaluates the input
+                                          against. Value should be empty if the operator is Exists, DoesNotExist,
+                                          IsTrue or IsFalse. Value should contain exactly one element if the
+                                          operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                          In other cases Value should contain at least one element.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - op
+                                    type: object
+                                  description: |-
+                                    MatchExpressions is the set of per-element expressions evaluated. These
+                                    match against the value of the specified elements.
+                                  type: object
+                                matchName:
+                                  description: |-
+                                    MatchName in an expression that is matched against the name of each
+                                    element in the feature set.
+                                  properties:
+                                    op:
+                                      description: Op is the operator to be applied.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - InRegexp
+                                      - Exists
+                                      - DoesNotExist
+                                      - Gt
+                                      - Lt
+                                      - GtLt
+                                      - IsTrue
+                                      - IsFalse
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value is the list of values that the operand evaluates the input
+                                        against. Value should be empty if the operator is Exists, DoesNotExist,
+                                        IsTrue or IsFalse. Value should contain exactly one element if the
+                                        operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                        In other cases Value should contain at least one element.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - op
+                                  type: object
+                              required:
+                              - feature
+                              type: object
+                            type: array
+                        required:
+                        - matchFeatures
+                        type: object
+                      type: array
+                    matchFeatures:
+                      description: MatchFeatures specifies a set of matcher terms
+                        all of which must match.
+                      items:
+                        description: |-
+                          FeatureMatcherTerm defines requirements against one feature set. All
+                          requirements (specified as MatchExpressions) are evaluated against each
+                          element in the feature set.
+                        properties:
+                          feature:
+                            description: Feature is the name of the feature set to
+                              match against.
+                            type: string
+                          matchExpressions:
+                            additionalProperties:
+                              description: |-
+                                MatchExpression specifies an expression to evaluate against a set of input
+                                values. It contains an operator that is applied when matching the input and
+                                an array of values that the operator evaluates the input against.
+                              properties:
+                                op:
+                                  description: Op is the operator to be applied.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - InRegexp
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                                  - GtLt
+                                  - IsTrue
+                                  - IsFalse
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value is the list of values that the operand evaluates the input
+                                    against. Value should be empty if the operator is Exists, DoesNotExist,
+                                    IsTrue or IsFalse. Value should contain exactly one element if the
+                                    operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                    In other cases Value should contain at least one element.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - op
+                              type: object
+                            description: |-
+                              MatchExpressions is the set of per-element expressions evaluated. These
+                              match against the value of the specified elements.
+                            type: object
+                          matchName:
+                            description: |-
+                              MatchName in an expression that is matched against the name of each
+                              element in the feature set.
+                            properties:
+                              op:
+                                description: Op is the operator to be applied.
+                                enum:
+                                - In
+                                - NotIn
+                                - InRegexp
+                                - Exists
+                                - DoesNotExist
+                                - Gt
+                                - Lt
+                                - GtLt
+                                - IsTrue
+                                - IsFalse
+                                type: string
+                              value:
+                                description: |-
+                                  Value is the list of values that the operand evaluates the input
+                                  against. Value should be empty if the operator is Exists, DoesNotExist,
+                                  IsTrue or IsFalse. Value should contain exactly one element if the
+                                  operator is Gt or Lt and exactly two elements if the operator is GtLt.
+                                  In other cases Value should contain at least one element.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - op
+                            type: object
+                        required:
+                        - feature
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the rule.
+                      type: string
+                    taints:
+                      description: Taints to create if the rule matches.
+                      items:
+                        description: |-
+                          The node this Taint is attached to has the "effect" on
+                          any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: |-
+                              Required. The effect of the taint on pods
+                              that do not tolerate the taint.
+                              Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: |-
+                              TimeAdded represents the time at which the taint was added.
+                              It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
+                    vars:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Vars is the variables to store if the rule matches. Variables do not
+                        directly inflict any changes in the node object. However, they can be
+                        referenced from other rules enabling more complex rule hierarchies,
+                        without exposing intermediary output values as labels.
+                      type: object
+                    varsTemplate:
+                      description: |-
+                        VarsTemplate specifies a template to expand for dynamically generating
+                        multiple variables. Data (after template expansion) must be keys with an
+                        optional value (<key>[=<value>]) separated by newlines.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - rules
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodefeatures.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeature
+    listKind: NodeFeatureList
+    plural: nodefeatures
+    singular: nodefeature
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NodeFeature resource holds the features discovered for one node in the
+          cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the NodeFeature, containing features discovered
+              for a node.
+            properties:
+              features:
+                description: Features is the full "raw" features data that has been
+                  discovered.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      description: AttributeFeatureSet is a set of features having
+                        string value.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            type: string
+                          description: Individual features of the feature set.
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Attributes contains all the attribute-type features
+                      of the node.
+                    type: object
+                  flags:
+                    additionalProperties:
+                      description: FlagFeatureSet is a set of simple features only
+                        containing names without values.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            description: |-
+                              Nil is a dummy empty struct for protobuf compatibility.
+                              NOTE: protobuf definitions have been removed but this is kept for API compatibility.
+                            type: object
+                          description: Individual features of the feature set.
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Flags contains all the flag-type features of the
+                      node.
+                    type: object
+                  instances:
+                    additionalProperties:
+                      description: InstanceFeatureSet is a set of features each of
+                        which is an instance having multiple attributes.
+                      properties:
+                        elements:
+                          description: Individual features of the feature set.
+                          items:
+                            description: InstanceFeature represents one instance of
+                              a complex features, e.g. a device.
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  type: string
+                                description: Attributes of the instance feature.
+                                type: object
+                            required:
+                            - attributes
+                            type: object
+                          type: array
+                      required:
+                      - elements
+                      type: object
+                    description: Instances contains all the instance-type features
+                      of the node.
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels is the set of node labels that are requested to
+                  be created.
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-gc
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-master
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-worker
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nfd-worker
+  namespace: kube-system
+rules:
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - create
+  - get
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-gc
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - delete
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-master
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturerules
+  - nodefeaturegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeaturegroup/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - nfd-master.nfd.kubernetes.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfd-worker
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nfd-worker
+subjects:
+- kind: ServiceAccount
+  name: nfd-worker
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-gc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-gc
+subjects:
+- kind: ServiceAccount
+  name: nfd-gc
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-master
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-master
+subjects:
+- kind: ServiceAccount
+  name: nfd-master
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  nfd-master.conf: |
+    # noPublish: false
+    # autoDefaultNs: true
+    # extraLabelNs: ["added.ns.io","added.kubernets.io"]
+    # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
+    # enableTaints: false
+    # labelWhiteList: "foo"
+    # resyncPeriod: "2h"
+    # restrictions:
+    #   disableLabels: true
+    #   disableTaints: true
+    #   disableExtendedResources: true
+    #   disableAnnotations: true
+    #   allowOverwrite: false
+    #   denyNodeFeatureLabels: true
+    #   nodeFeatureNamespaceSelector:
+    #    matchLabels:
+    #      kubernetes.io/metadata.name: "node-feature-discovery"
+    #    matchExpressions:
+    #      - key: "kubernetes.io/metadata.name"
+    #        operator: "In"
+    #        values:
+    #           - "node-feature-discovery"
+    # klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-master restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
+    # leaderElection:
+    #   leaseDuration: 15s
+    #   # this value has to be lower than leaseDuration and greater than retryPeriod*1.2
+    #   renewDeadline: 10s
+    #   # this value has to be greater than 0
+    #   retryPeriod: 2s
+    # nfdApiParallelism: 10
+kind: ConfigMap
+metadata:
+  name: nfd-master-conf-9mfc26f2tc
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  nfd-worker.conf: |
+    core:
+      labelSources:
+       - "local"
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf-82th75ht67
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nfd
+  name: nfd-gc
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nfd-gc
+  template:
+    metadata:
+      labels:
+        app: nfd-gc
+    spec:
+      containers:
+      - command:
+        - nfd-gc
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.17.1
+        imagePullPolicy: IfNotPresent
+        name: nfd-gc
+        ports:
+        - containerPort: 8081
+          name: metrics
+        resources:
+          limits:
+            cpu: 20m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: nfd-gc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nfd
+  name: nfd-master
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfd-master
+  template:
+    metadata:
+      labels:
+        app: nfd-master
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
+            weight: 1
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - ""
+            weight: 1
+      containers:
+      - command:
+        - nfd-master
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.17.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          grpc:
+            port: 8082
+        name: nfd-master
+        ports:
+        - containerPort: 8081
+          name: metrics
+        readinessProbe:
+          failureThreshold: 10
+          grpc:
+            port: 8082
+        resources:
+          limits:
+            cpu: 300m
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          grpc:
+            port: 8082
+        volumeMounts:
+        - mountPath: /etc/kubernetes/node-feature-discovery
+          name: nfd-master-conf
+          readOnly: true
+      enableServiceLinks: false
+      serviceAccount: nfd-master
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+      volumes:
+      - configMap:
+          name: nfd-master-conf-9mfc26f2tc
+        name: nfd-master-conf
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nfd
+  name: nfd-worker
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nfd-worker
+  template:
+    metadata:
+      labels:
+        app: nfd-worker
+    spec:
+      containers:
+      - command:
+        - nfd-worker
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.17.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          grpc:
+            port: 8082
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        name: nfd-worker
+        ports:
+        - containerPort: 8081
+          name: metrics
+        readinessProbe:
+          failureThreshold: 10
+          grpc:
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /host-boot
+          name: host-boot
+          readOnly: true
+        - mountPath: /host-etc/os-release
+          name: host-os-release
+          readOnly: true
+        - mountPath: /host-sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /host-proc/swaps
+          name: host-proc-swaps
+          readOnly: true
+        - mountPath: /host-usr/lib
+          name: host-usr-lib
+          readOnly: true
+        - mountPath: /host-lib
+          name: host-lib
+          readOnly: true
+        - mountPath: /etc/kubernetes/node-feature-discovery/features.d/
+          name: features-d
+          readOnly: true
+        - mountPath: /etc/kubernetes/node-feature-discovery
+          name: nfd-worker-conf
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: nfd-worker
+      volumes:
+      - hostPath:
+          path: /boot
+        name: host-boot
+      - hostPath:
+          path: /proc/swaps
+        name: host-proc-swaps
+      - hostPath:
+          path: /etc/os-release
+        name: host-os-release
+      - hostPath:
+          path: /sys
+        name: host-sys
+      - hostPath:
+          path: /usr/lib
+        name: host-usr-lib
+      - hostPath:
+          path: /lib
+        name: host-lib
+      - hostPath:
+          path: /etc/kubernetes/node-feature-discovery/features.d/
+        name: features-d
+      - configMap:
+          name: nfd-worker-conf-82th75ht67
+        name: nfd-worker-conf

--- a/infrastructure/gpu/.olares/config/gpu/intel/node-feature-rules.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/node-feature-rules.yaml
@@ -1,0 +1,426 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-dp-devices
+spec:
+  rules:
+  - labels:
+      intel.feature.node.kubernetes.io/dlb: "true"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - 0b40
+        device:
+          op: In
+          value:
+          - "2710"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    - feature: kernel.loadedmodule
+      matchExpressions:
+        dlb2:
+          op: Exists
+    name: intel.dlb
+  - labels:
+      intel.feature.node.kubernetes.io/dsa: "true"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0880"
+        device:
+          op: In
+          value:
+          - 0b25
+          - 11fb
+          - "1212"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    - feature: kernel.loadedmodule
+      matchExpressions:
+        idxd:
+          op: Exists
+    name: intel.dsa
+  - labels:
+      intel.feature.node.kubernetes.io/fpga-arria10: "true"
+    matchAny:
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          dfl_pci:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          intel_fpga_pci:
+            op: Exists
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "1200"
+        device:
+          op: In
+          value:
+          - 09c4
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.fpga-arria10
+  - labels:
+      intel.feature.node.kubernetes.io/gpu: "true"
+    matchAny:
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          i915:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.enabledmodule
+        matchExpressions:
+          i915:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          xe:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.enabledmodule
+        matchExpressions:
+          xe:
+            op: Exists
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0300"
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu
+  - labels:
+      intel.feature.node.kubernetes.io/iaa: "true"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0880"
+        device:
+          op: In
+          value:
+          - 0cfe
+          - "1216"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    - feature: kernel.loadedmodule
+      matchExpressions:
+        idxd:
+          op: Exists
+    name: intel.iaa
+  - labels:
+      intel.feature.node.kubernetes.io/qat: "true"
+    matchAny:
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          vfio_pci:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.enabledmodule
+        matchExpressions:
+          vfio-pci:
+            op: Exists
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - 0b40
+        device:
+          op: In
+          value:
+          - 37c8
+          - "4940"
+          - "4942"
+          - "4944"
+          - "4946"
+          - "4948"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    - feature: kernel.loadedmodule
+      matchExpressions:
+        intel_qat:
+          op: Exists
+    name: intel.qat
+  - extendedResources:
+      sgx.intel.com/epc: '@cpu.security.sgx.epc'
+    labels:
+      intel.feature.node.kubernetes.io/sgx: "true"
+    matchFeatures:
+    - feature: cpu.cpuid
+      matchExpressions:
+        SGX:
+          op: Exists
+        SGXLC:
+          op: Exists
+    - feature: cpu.security
+      matchExpressions:
+        sgx.enabled:
+          op: IsTrue
+    - feature: kernel.config
+      matchExpressions:
+        X86_SGX:
+          op: Exists
+    name: intel.sgx
+  - labels:
+      intel.feature.node.kubernetes.io/npu: "true"
+    matchAny:
+    - matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          intel_vpu:
+            op: Exists
+    - matchFeatures:
+      - feature: kernel.enabledmodule
+        matchExpressions:
+          intel_vpu:
+            op: Exists
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "1200"
+        device:
+          op: In
+          value:
+          - 7e4c
+          - 643e
+          - ad1d
+          - 7d1d
+          - b03e
+          - fd3e
+          - d71d
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.npu
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-gpu-platform-labeling
+spec:
+  rules:
+  - labelsTemplate: |
+      {{ range .pci.device }}gpu.intel.com/device-id.{{ .class }}-{{ .device }}.present=true
+      {{ end }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0300"
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.generic.deviceid
+  - labelsTemplate: gpu.intel.com/device-id.0300-{{ (index .pci.device 0).device }}.count={{
+      len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0300"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.generic.count.300
+  - labelsTemplate: gpu.intel.com/device-id.0380-{{ (index .pci.device 0).device }}.count={{
+      len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.generic.count.380
+  - labels:
+      gpu.intel.com/product: Max_1100
+    labelsTemplate: gpu.intel.com/device.count={{ len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        device:
+          op: In
+          value:
+          - 0bda
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.max.1100
+  - labels:
+      gpu.intel.com/product: Max_1550
+    labelsTemplate: gpu.intel.com/device.count={{ len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        device:
+          op: In
+          value:
+          - 0bd5
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.max.1550
+  - labels:
+      gpu.intel.com/family: Max_Series
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        device:
+          op: In
+          value:
+          - 0bda
+          - 0bd5
+          - 0bd9
+          - 0bdb
+          - 0bd7
+          - 0bd6
+          - 0bd0
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.max.series
+  - labels:
+      gpu.intel.com/family: Flex_Series
+      gpu.intel.com/product: Flex_170
+    labelsTemplate: gpu.intel.com/device.count={{ len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        device:
+          op: In
+          value:
+          - 56c0
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.flex.170
+  - labels:
+      gpu.intel.com/family: Flex_Series
+      gpu.intel.com/product: Flex_140
+    labelsTemplate: gpu.intel.com/device.count={{ len .pci.device }}
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        device:
+          op: In
+          value:
+          - 56c1
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.flex.140
+  - labels:
+      gpu.intel.com/family: A_Series
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0300"
+        device:
+          op: In
+          value:
+          - 56a6
+          - 56a5
+          - 56a1
+          - 56a0
+          - "5694"
+          - "5693"
+          - "5692"
+          - "5691"
+          - "5690"
+          - 56b3
+          - 56b2
+          - 56a4
+          - 56a3
+          - "5697"
+          - "5696"
+          - "5695"
+          - 56b1
+          - 56b0
+          - 56a2
+          - 56ba
+          - 56bc
+          - 56bd
+          - 56bb
+        vendor:
+          op: In
+          value:
+          - "8086"
+    name: intel.gpu.a.series


### PR DESCRIPTION


* **Background**
feat: add device plugin for intel

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/intel-device-plugins-for-kubernetes/pull/1

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster install by applying NFD CRDs and privileged-adjacent hostPath workloads in kube-system; mis-ordering or partial failure could leave nodes unlabeled or plugins pending, though retries and CheckIntelGpu mitigate false success.
> 
> **Overview**
> **Intel GPU setup is no longer label-only:** the installer now deploys Node Feature Discovery, Intel `NodeFeatureRule` CRs, and the `intel-gpu-plugin` DaemonSet, then blocks until the stack is healthy.
> 
> The `InstallIntelPlugin` module gains a sequenced pipeline after node labeling—**ApplyIntelNFD** (with retries for CRD establishment), **ApplyIntelNodeFeatureRules**, **ApplyIntelGPUPlugin**, and **CheckIntelGpu** (polls NFD master/gc/worker and the plugin on the local node until `Running`). Manifests are applied via a shared `applyIntelManifest` helper from `wizard/config/gpu/intel`.
> 
> New bundled YAML under `infrastructure/gpu/.olares/config/gpu/intel/` includes full NFD v0.17.1 (CRDs, RBAC, master/gc/worker), Intel device-plugin rules (including `intel.feature.node.kubernetes.io/gpu` and GPU product labels), and a `kube-system` DaemonSet using `beclab/intel-device-plugin:1.1` with `nodeSelector` on the NFD GPU label and host mounts for DRI/accel/device-plugin sockets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c8b5545822f72decd25f3f92f4ae589a5154de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->