### PR TITLE
feat: inject gpu.intel.com/i915 for intel compute mode

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -469,6 +469,8 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 		return constants.NvidiaGPU
 	case utils.AMDType, utils.AMDGPUType:
 		return constants.AMDGPU
+	case utils.IntelType, utils.IntelGPUType:
+		return constants.IntelGPU
 	case utils.CPUType:
 		klog.Info("CPU type is selected, no GPU resource will be injected")
 		return ""

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -280,7 +280,7 @@ func IsHAMIMode(mode string) bool {
 // and rely on nodeSelector to reach the correct node.
 func UsesGPUExtendedResource(mode string) bool {
 	switch mode {
-	case utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.AMDGPUType:
+	case utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.AMDGPUType, utils.IntelType, utils.IntelGPUType:
 		return true
 	default:
 		return false

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -91,8 +91,9 @@ const (
 	NvidiaGPU    = "nvidia.com/gpu"
 	NvidiaGPUMem = "nvidia.com/gpumem"
 	//	NvidiaGB10GPU = "nvidia.com/gb10"
-	AMDAPU = "amd.com/apu"
-	AMDGPU = "amd.com/gpu"
+	AMDAPU   = "amd.com/apu"
+	AMDGPU   = "amd.com/gpu"
+	IntelGPU = "gpu.intel.com/i915"
 
 	AuthorizationLevelOfPublic   = "public"
 	AuthorizationLevelOfPrivate  = "private"


### PR DESCRIPTION


* **Background**
inject gpu.intel.com/i915 for intel compute mode
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod scheduling and resource injection for Intel GPU workloads; misconfiguration could cause unschedulable pods, but scope is limited to Intel mode branches parallel to existing NVIDIA/AMD logic.
> 
> **Overview**
> Intel compute modes now get the same **gpu-limit webhook** treatment as NVIDIA and AMD extended-resource GPUs.
> 
> The webhook maps `intel` / `intel-gpu` modes to **`gpu.intel.com/i915`** when patching workload limits, and **`UsesGPUExtendedResource`** treats those modes as scheduler-driven (extended resource only, **no extra nodeSelector** from allocation pinning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4259a0bb9408aa0afd7a6dd01bcfc8a26b09842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->