### PR TITLE
docs: hide version switcher when a single version is published

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,6 +34,13 @@ function defineVersionedConfig2(
   const latestVersion = process.env.LATEST_VERSION || versions![versions!.length - 1];
   console.log(versions, latestVersion);
 
+  // With a single published version, every non-latest copy 301s to /docs/, so
+  // the switcher would render an empty dropdown (its only entry equals the
+  // current version and is filtered out). Skip injecting it entirely.
+  if( !versions || versions.length <= 1 ) {
+    return config;
+  }
+
   for( const locale of Object.keys(config.locales) ) {
     let themeConfig = config.locales[locale]!.themeConfig!;
 


### PR DESCRIPTION
## Background

Part of a cross-repo SEO change to eliminate duplicate documentation pages. The  webmaster console flagged large numbers of duplicate pages caused by multiple doc versions being online at once. We are consolidating to a single published version (`/docs/`) and 301-redirecting every versioned path to it (see the companion `beclab/release-docs` PR).

## Change

In `docs/.vitepress/config.mts`, skip injecting the `VersionSwitcher` into the nav when `VERSIONS` carries a single entry. With only the latest version published, the switcher's only option equals the current version and gets filtered out, leaving an empty dropdown. Hiding it removes that dead UI.

No effect when 2+ versions are configured — the switcher returns automatically.

## Test plan

- [ ] Build with `VERSIONS=1.12.6 LATEST_VERSION=1.12.6` → nav has no version dropdown
- [ ] Build with `VERSIONS=1.12.6,1.12.5` → switcher still renders

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress config guard with no runtime product impact; multi-version behavior is preserved.
> 
> **Overview**
> When **`VERSIONS`** resolves to **one entry** (or is missing after split), **`defineVersionedConfig2`** in `docs/.vitepress/config.mts` now **returns before** pushing **`VersionSwitcher`** into each locale’s nav. That avoids an empty version dropdown when only the latest docs are published and versioned paths redirect to `/docs/`.
> 
> **Multi-version builds are unchanged:** if `VERSIONS` has two or more comma-separated values, the switcher is still injected as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe8a7a6f1ecd0478e3b6a342b63e6f6080c652f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->