### PR TITLE
Reopn "fix(daemon): reduce NetworkManager CPU from frequent nmcli polling"

### DIFF
--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -131,13 +131,13 @@ func CheckCurrentStatus(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := utils.ManagedAllDevices(ctx); err != nil {
-		klog.Error("managed all devices error, ", err)
-	}
-
-	devices, err := utils.GetAllDevice(ctx)
+	// Use a single lightweight enumeration that also switches unmanaged
+	// devices to managed. CheckCurrentStatus only reads Name/Type/Connection
+	// below, so the expensive per-device detail queries are intentionally
+	// skipped here to avoid hammering NetworkManager on this 5s poll.
+	devices, err := utils.ManagedDeviceStatus(ctx)
 	if err != nil {
-		klog.Error(err)
+		klog.Error("managed device status error, ", err)
 	}
 
 	// clear value

--- a/daemon/pkg/utils/network.go
+++ b/daemon/pkg/utils/network.go
@@ -35,6 +35,11 @@ func ManagedAllDevices(ctx context.Context) (map[string]Device, error) {
 	return nil, nil
 }
 
+func ManagedDeviceStatus(ctx context.Context) (map[string]Device, error) {
+	klog.Warning("not implement")
+	return nil, nil
+}
+
 func UpdateNetworkTraffic(ctx context.Context) {
 	klog.Warning("not implement")
 }

--- a/daemon/pkg/utils/network_linux.go
+++ b/daemon/pkg/utils/network_linux.go
@@ -79,55 +79,87 @@ func EnableWifi(ctx context.Context) error {
 }
 
 func GetWifiDevice(ctx context.Context) (map[string]Device, error) {
-	return deviceStatus(ctx, func(d *Device) bool { return d.Type == "wifi" })
+	return deviceStatus(ctx, func(d *Device) bool { return d.Type == "wifi" }, true)
+}
+
+// managedByOthers reports whether the device is managed by another component
+// (CNI, tunnels, tailscale, ...) and should be skipped by NetworkManager logic.
+func managedByOthers(name string) bool {
+	for _, devPrefix := range []string{"cali", "kube", "tun", "tailscale"} {
+		if strings.HasPrefix(name, devPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func GetAllDevice(ctx context.Context) (map[string]Device, error) {
 	return deviceStatus(ctx, func(d *Device) bool {
-		managedByOthers := []string{"cali", "kube", "tun", "tailscale"}
-		for _, devPrefix := range managedByOthers {
-			if strings.HasPrefix(d.Name, devPrefix) {
-				return false
-			}
-		}
+		return !managedByOthers(d.Name)
+	}, true)
+}
 
-		return true
-	})
+// setDeviceManaged switches a single device to managed via nmcli.
+func setDeviceManaged(ctx context.Context, name string) error {
+	nmcli, err := findCommand(ctx, "nmcli")
+	if err != nil {
+		klog.Error("find nmcli error, ", err)
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, nmcli, "device", "set", name, "managed", "yes")
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Error("exec cmd error, ", err, ", nmcli device set ", name, " managed yes")
+		return err
+	}
+	if strings.Contains(string(output), "Error") {
+		err = errors.New(string(output))
+		klog.Error("exec cmd error, ", err, ", nmcli device set ", name, " managed yes")
+		return err
+	}
+	return nil
 }
 
 func ManagedAllDevices(ctx context.Context) (map[string]Device, error) {
 	return deviceStatus(ctx, func(d *Device) bool {
-		managedByOthers := []string{"cali", "kube", "tun", "tailscale"}
-		for _, devPrefix := range managedByOthers {
-			if strings.HasPrefix(d.Name, devPrefix) {
-				return false
-			}
+		if managedByOthers(d.Name) {
+			return false
 		}
 		if d.State == "unmanaged" {
-			nmcli, err := findCommand(ctx, "nmcli")
-			if err != nil {
-				klog.Error("find nmcli error, ", err)
-				return false
-			}
-
-			cmd := exec.CommandContext(ctx, nmcli, "device", "set", d.Name, "managed", "yes")
-			cmd.Env = os.Environ()
-			output, err := cmd.CombinedOutput()
-			if err != nil {
-				klog.Error("exec cmd error, ", err, ", nmcli device set ", d.Name, " managed yes")
-				return false
-			}
-			if strings.Contains(string(output), "Error") {
-				err = errors.New(string(output))
-				klog.Error("exec cmd error, ", err, ", nmcli device set ", d.Name, " managed yes")
+			if err := setDeviceManaged(ctx, d.Name); err != nil {
 				return false
 			}
 		}
 		return true
-	})
+	}, true)
 }
 
-func deviceStatus(ctx context.Context, filter func(d *Device) bool) (map[string]Device, error) {
+// ManagedDeviceStatus enumerates network devices with a single
+// `nmcli device status` call and, in the same pass, switches any unmanaged
+// device to managed. It deliberately skips the per-device `nmcli device show`
+// / `nmcli connection show` fan-out (i.e. it does not populate IP/gateway/DNS/
+// method fields), because the frequent state-polling path only needs
+// Name/Type/State/Connection. This replaces the previous back-to-back
+// ManagedAllDevices + GetAllDevice calls, which together spawned ~(4 + 8M)
+// bash/nmcli processes per poll (M = device count) and kept NetworkManager
+// busy.
+func ManagedDeviceStatus(ctx context.Context) (map[string]Device, error) {
+	return deviceStatus(ctx, func(d *Device) bool {
+		if managedByOthers(d.Name) {
+			return false
+		}
+		if d.State == "unmanaged" {
+			if err := setDeviceManaged(ctx, d.Name); err != nil {
+				return false
+			}
+		}
+		return true
+	}, false)
+}
+
+func deviceStatus(ctx context.Context, filter func(d *Device) bool, details bool) (map[string]Device, error) {
 	nmcli, err := findCommand(ctx, "nmcli")
 	if err != nil {
 		return nil, err
@@ -161,10 +193,12 @@ func deviceStatus(ctx context.Context, filter func(d *Device) bool) (map[string]
 		}
 
 		if filter == nil || filter(&d) {
-			err = showDeviceByNM(ctx, d.Name, &d)
-			if err != nil {
-				klog.Error("failed to get device details for ", d.Name, ": ", err)
-				continue
+			if details {
+				err = showDeviceByNM(ctx, d.Name, &d)
+				if err != nil {
+					klog.Error("failed to get device details for ", d.Name, ": ", err)
+					continue
+				}
 			}
 
 			statuss[d.Name] = d

--- a/daemon/pkg/utils/network_types.go
+++ b/daemon/pkg/utils/network_types.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"k8s.io/klog/v2"
 )
@@ -32,16 +33,39 @@ type BridgeConnection struct {
 	Ipv4Address string
 }
 
-func findCommand(ctx context.Context, cmdName string) (cmdPath string, err error) {
+var (
+	cmdPathCache   = make(map[string]string)
+	cmdPathCacheMu sync.RWMutex
+)
+
+// findCommand resolves the absolute path of cmdName. The result is cached
+// because callers (nmcli wrappers) invoke it on every command, and the
+// previous implementation forked a `bash -c "command -v ..."` subprocess
+// each time. On the 5s state-polling path this doubled the process churn
+// against NetworkManager. The executable path is effectively immutable for
+// the lifetime of the daemon, so a process-wide cache is safe.
+func findCommand(ctx context.Context, cmdName string) (string, error) {
+	cmdPathCacheMu.RLock()
+	cached, ok := cmdPathCache[cmdName]
+	cmdPathCacheMu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
 	cmd := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("command -v %s", cmdName))
 	cmd.Env = os.Environ()
 	output, err := cmd.Output()
 	if err != nil {
-		klog.Error("find nmcli error, ", err)
-		return
+		klog.Error("find command error, ", cmdName, ", ", err)
+		return "", err
 	}
 
-	cmdPath = strings.TrimSpace(string(output))
+	cmdPath := strings.TrimSpace(string(output))
+	if cmdPath != "" {
+		cmdPathCacheMu.Lock()
+		cmdPathCache[cmdName] = cmdPath
+		cmdPathCacheMu.Unlock()
+	}
 
-	return
+	return cmdPath, nil
 }


### PR DESCRIPTION
Reverts beclab/Olares#3565

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how often and how deeply NetworkManager is queried on the status poll path; Wi‑Fi/wired reporting should stay the same but relies on lighter device fields only.
> 
> **Overview**
> Cuts **nmcli** churn on the daemon’s **5s** `CheckCurrentStatus` poll by replacing back-to-back `ManagedAllDevices` + `GetAllDevice` with a single **`ManagedDeviceStatus`** call that still marks unmanaged devices as managed but skips per-device `device show` / connection detail fan-out (only **Name/Type/Connection** are needed for Wi‑Fi/wired flags).
> 
> On Linux, **`deviceStatus`** gains a **`details`** flag so the hot poll path avoids expensive enrichment while **`GetAllDevice`**, **`ManagedAllDevices`**, and **`GetWifiDevice`** keep full details. **`setDeviceManaged`** and **`managedByOthers`** are factored out to dedupe logic. **`findCommand`** now caches resolved binary paths so repeated nmcli wrappers no longer spawn **`bash -c "command -v …"`** on every invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3016e595b36b29ccdacae93a274c84862978de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->