### PR TITLE
Reopen "perf(daemon): cache k8s clients and rest.Config"

### DIFF
--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"k8s.io/klog"
 
@@ -24,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,10 +46,116 @@ const (
 	RoleOwner = "owner"
 )
 
-func GetKubeClient() (kubernetes.Interface, error) {
+// K8s clients and the rest.Config are safe for concurrent use and do not need
+// to be rebuilt on every call. olaresd's status loop reconstructs them many
+// times per 5s tick; caching them removes the repeated ctrl.GetConfig +
+// NewForConfig (REST/HTTP/TLS transport) churn. Each value is memoized only on
+// success, so a failure before the cluster is reachable is retried on the next
+// call instead of being cached permanently.
+var (
+	clientCacheMu           sync.Mutex
+	cachedConfig            *rest.Config
+	cachedKubeClient        kubernetes.Interface
+	cachedDynamicClient     dynamic.Interface
+	cachedAppClientSet      *versioned.Clientset
+	cachedApixClient        apixclientset.Interface
+	cachedKubeconfigPath    string
+	cachedKubeconfigModTime time.Time
+)
+
+// kubeconfigPaths resolves the kubeconfig files backing ctrl.GetConfig,
+// mirroring the env/default lookup. ctrl.GetConfig merges every file listed in
+// KUBECONFIG, so all of them are tracked for freshness. It returns nil when no
+// file applies (e.g. in-cluster), in which case the freshness check is skipped.
+func kubeconfigPaths() []string {
+	if v := os.Getenv("KUBECONFIG"); v != "" {
+		if parts := filepath.SplitList(v); len(parts) > 0 {
+			return parts
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, ".kube", "config")}
+}
+
+// ensureFreshLocked invalidates the cached config and clients when any tracked
+// kubeconfig file changes (e.g. IP change or k3s cert rotation), so olaresd
+// recovers without a restart instead of pinning a stale config forever.
+// Callers must hold clientCacheMu.
+func ensureFreshLocked() {
+	paths := kubeconfigPaths()
+	if len(paths) == 0 {
+		return
+	}
+	key := strings.Join(paths, string(os.PathListSeparator))
+	var modTime time.Time
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if mt := info.ModTime(); mt.After(modTime) {
+			modTime = mt
+		}
+	}
+	if modTime.IsZero() {
+		// None of the tracked files are readable right now; keep any cached
+		// clients. A momentarily-missing file (e.g. during an atomic rewrite)
+		// should not tear down a working in-memory client.
+		return
+	}
+	if cachedConfig == nil {
+		cachedKubeconfigPath = key
+		cachedKubeconfigModTime = modTime
+		return
+	}
+	if key == cachedKubeconfigPath && modTime.Equal(cachedKubeconfigModTime) {
+		return
+	}
+	klog.Info("kubeconfig changed, rebuilding k8s clients")
+	cachedConfig = nil
+	cachedKubeClient = nil
+	cachedDynamicClient = nil
+	cachedAppClientSet = nil
+	cachedApixClient = nil
+	cachedKubeconfigPath = key
+	cachedKubeconfigModTime = modTime
+}
+
+// configLocked returns the cached rest.Config, loading it once on first
+// success. Callers must hold clientCacheMu.
+func configLocked() (*rest.Config, error) {
+	if cachedConfig != nil {
+		return cachedConfig, nil
+	}
 	config, err := ctrl.GetConfig()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
+		return nil, err
+	}
+	cachedConfig = config
+	return config, nil
+}
+
+// GetConfig returns the cached rest.Config, loading it once on first success.
+func GetConfig() (*rest.Config, error) {
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
+	return configLocked()
+}
+
+func GetKubeClient() (kubernetes.Interface, error) {
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
+	if cachedKubeClient != nil {
+		return cachedKubeClient, nil
+	}
+
+	config, err := configLocked()
+	if err != nil {
 		return nil, err
 	}
 
@@ -55,13 +165,20 @@ func GetKubeClient() (kubernetes.Interface, error) {
 		return nil, err
 	}
 
+	cachedKubeClient = client
 	return client, nil
 }
 
 func GetDynamicClient() (dynamic.Interface, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
+	if cachedDynamicClient != nil {
+		return cachedDynamicClient, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -71,13 +188,20 @@ func GetDynamicClient() (dynamic.Interface, error) {
 		return nil, err
 	}
 
+	cachedDynamicClient = client
 	return client, nil
 }
 
 func GetAppClientSet() (versioned.Clientset, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
+	if cachedAppClientSet != nil {
+		return *cachedAppClientSet, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return versioned.Clientset{}, err
 	}
 
@@ -87,6 +211,7 @@ func GetAppClientSet() (versioned.Clientset, error) {
 		return versioned.Clientset{}, err
 	}
 
+	cachedAppClientSet = client
 	return *client, nil
 }
 
@@ -577,7 +702,7 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 		klog.Error("list applications error, ", err)
 		return nil, err
 	}
-	config, err := ctrl.GetConfig()
+	config, err := GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -627,9 +752,15 @@ func GetApplicationUrlAll(ctx context.Context) ([]string, error) {
 }
 
 func GetApixClient() (apixclientset.Interface, error) {
-	config, err := ctrl.GetConfig()
+	clientCacheMu.Lock()
+	defer clientCacheMu.Unlock()
+	ensureFreshLocked()
+	if cachedApixClient != nil {
+		return cachedApixClient, nil
+	}
+
+	config, err := configLocked()
 	if err != nil {
-		klog.Error("get k8s config error, ", err)
 		return nil, err
 	}
 
@@ -639,6 +770,7 @@ func GetApixClient() (apixclientset.Interface, error) {
 		return nil, err
 	}
 
+	cachedApixClient = client
 	return client, nil
 }
 


### PR DESCRIPTION
Reverts beclab/Olares#3566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching cluster credentials and long-lived clients affects every daemon path that talks to the API; incorrect invalidation could leave stale endpoints until kubeconfig changes, though mtime-based refresh and no cache-on-failure mitigate that.
> 
> **Overview**
> **Reintroduces memoized Kubernetes access in `daemon/pkg/utils/k8s.go`** so olaresd’s frequent status/watch paths stop rebuilding `ctrl.GetConfig` and `NewForConfig` on every call.
> 
> `GetKubeClient`, `GetDynamicClient`, `GetAppClientSet`, and `GetApixClient` now share a mutex-guarded cache of `rest.Config` and the derived clients; only successful builds are stored so transient “cluster not ready” errors are retried on the next call. A new **`GetConfig()`** exposes the same cached config, and **`GetApplicationUrlAll`** uses it instead of calling `ctrl.GetConfig` directly.
> 
> **Kubeconfig freshness:** before returning cached values, the code tracks `KUBECONFIG` (or `~/.kube/config`) paths and their latest mod time. When those files change (e.g. API endpoint or cert rotation), the cache is cleared and clients are rebuilt on the next access—without requiring a daemon restart. Brief unreadable kubeconfig during atomic rewrites does not invalidate a working in-memory client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fae1ee55e54a59121448583395144138db44ffbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->