### PR TITLE
Reopen "perf(daemon): make BLE WiFi scan cadence adaptive"

### DIFF
--- a/daemon/internel/ble/ble_common.go
+++ b/daemon/internel/ble/ble_common.go
@@ -12,24 +12,56 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const (
+	// bleScanIntervalActive is used during onboarding (the node is not online
+	// yet), when the LarePass app needs a fresh WiFi AP list to connect.
+	bleScanIntervalActive = 2 * time.Second
+	// bleScanIntervalIdle is used once the node is online, when the AP list
+	// rarely matters. Backing off here removes the bulk of the periodic D-Bus
+	// WiFi scan CPU cost.
+	bleScanIntervalIdle = 30 * time.Second
+)
+
+// scanInterval picks the WiFi scan cadence based on network connectivity:
+// frequent while onboarding (no network), relaxed once the node is online.
+func (s *service) scanInterval() time.Duration {
+	if state.CurrentState.WiredConnected || state.CurrentState.WifiConnected {
+		return bleScanIntervalIdle
+	}
+	return bleScanIntervalActive
+}
+
 func (s *service) Start() {
-	ticker := time.NewTicker(2 * time.Second)
 	go func() {
+		defer s.cancel()
+		s.scanOnce()
+		lastScan := time.Now()
+		// Poll at the active cadence so a connectivity drop is noticed within a
+		// couple of seconds, but only run the expensive D-Bus scan when due:
+		// every tick while offline, every bleScanIntervalIdle once online.
 		for {
+			timer := time.NewTimer(bleScanIntervalActive)
 			select {
 			case <-s.ctx.Done():
-				s.cancel()
-				ticker.Stop()
+				timer.Stop()
+				return
 
-			case <-ticker.C:
-				s.getAPList()
-				s.getTerminusInfo()
-				if s.update != nil {
-					s.update()
+			case <-timer.C:
+				if time.Since(lastScan) >= s.scanInterval() {
+					s.scanOnce()
+					lastScan = time.Now()
 				}
 			}
 		}
 	}()
+}
+
+func (s *service) scanOnce() {
+	s.getAPList()
+	s.getTerminusInfo()
+	if s.update != nil {
+		s.update()
+	}
 }
 
 func (s *service) Stop() {


### PR DESCRIPTION
Reverts beclab/Olares#3568

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to BLE onboarding WiFi scan timing and CPU load; no auth, data, or security paths touched.
> 
> **Overview**
> Re-applies **adaptive BLE WiFi scanning** in the daemon BLE service (reopening the reverted change).
> 
> Instead of a fixed **2s** ticker that always runs D-Bus WiFi scans and terminus updates, the loop polls every **2s** but only runs the expensive work when due: **2s** while the node has no wired/WiFi connectivity (onboarding), **30s** once online. Scan/AP list, terminus info, and optional `update` are grouped in **`scanOnce()`**, with an immediate run on start. Shutdown handling moves **`cancel`** to a **`defer`** on goroutine exit instead of calling it from the select branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6cb9285465a36d6dde6260635d2a4ac89628e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->