### PR TITLE
docs: update olares-cli output examples for consistency

### DIFF
--- a/docs/one/olares-onboarding.md
+++ b/docs/one/olares-onboarding.md
@@ -121,6 +121,8 @@ Before OpenCode can run Olares CLI Agent Skills on your behalf, authenticate the
 
    ```bash
    olares-cli version 1.12.6
+   Git commit: d30eca705df2fb614bf2bbea95daa2e6998adeeb
+   Build time: 2026-07-06T06:33:00Z
    ```
 
 3. Run the following command to log in to your Olares account. Replace `<your-olares-id>` with your actual Olares ID.

--- a/docs/one/olares-onboarding.md
+++ b/docs/one/olares-onboarding.md
@@ -120,7 +120,7 @@ Before OpenCode can run Olares CLI Agent Skills on your behalf, authenticate the
    Example output:
 
    ```bash
-   olares-cli version >=1.12.6
+   olares-cli version 1.12.6
    ```
 
 3. Run the following command to log in to your Olares account. Replace `<your-olares-id>` with your actual Olares ID.
@@ -146,8 +146,8 @@ Before OpenCode can run Olares CLI Agent Skills on your behalf, authenticate the
    Example output:
 
    ```text
-      NAME                   OLARES-ID              STATUS
-   *  laresprime@olares.com  laresprime@olares.com  logged-in
+     NAME                   OLARES-ID              STATUS     VERSION
+   * laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15  
    ```
 
 ## Step 5: Manage Olares through natural language

--- a/docs/one/olares-onboarding.md
+++ b/docs/one/olares-onboarding.md
@@ -143,10 +143,11 @@ Before OpenCode can run Olares CLI Agent Skills on your behalf, authenticate the
    olares-cli profile list
    ```
 
-   Example output:
+   Example output (`*` marks the current profile):
 
    ```text
      NAME                   OLARES-ID              STATUS     VERSION
+     laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15
    * laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15  
    ```
 

--- a/docs/zh/one/olares-onboarding.md
+++ b/docs/zh/one/olares-onboarding.md
@@ -124,7 +124,7 @@ Olares 上的智能体应用已内置这些技能。本指南以 OpenCode 为例
    示例输出：
 
    ```bash
-   olares-cli version >=1.12.6
+   olares-cli version 1.12.6
    ```
 
 3. 运行以下命令登录你的 Olares 账号。将 `<你的-olares-id>` 替换为你的真实 Olares ID。
@@ -150,8 +150,8 @@ Olares 上的智能体应用已内置这些技能。本指南以 OpenCode 为例
    示例输出：
 
    ```text
-      NAME                   OLARES-ID              STATUS
-   *  laresprime@olares.com  laresprime@olares.com  logged-in
+     NAME                   OLARES-ID              STATUS     VERSION
+   * laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15  
    ```
 
 ## 步骤 5：通过自然语言管理 Olares

--- a/docs/zh/one/olares-onboarding.md
+++ b/docs/zh/one/olares-onboarding.md
@@ -147,10 +147,11 @@ Olares 上的智能体应用已内置这些技能。本指南以 OpenCode 为例
    olares-cli profile list
    ```
 
-   示例输出：
+   示例输出（开头的 `*` 标记着当前 profile）：
 
    ```text
      NAME                   OLARES-ID              STATUS     VERSION
+     laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15
    * laresprime@olares.com  laresprime@olares.com  logged-in  1.12.6-alpha.15  
    ```
 

--- a/docs/zh/one/olares-onboarding.md
+++ b/docs/zh/one/olares-onboarding.md
@@ -125,6 +125,8 @@ Olares 上的智能体应用已内置这些技能。本指南以 OpenCode 为例
 
    ```bash
    olares-cli version 1.12.6
+   Git commit: d30eca705df2fb614bf2bbea95daa2e6998adeeb
+   Build time: 2026-07-06T06:33:00Z
    ```
 
 3. 运行以下命令登录你的 Olares 账号。将 `<你的-olares-id>` 替换为你的真实 Olares ID。


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example CLI output; no runtime or security impact.
> 
> **Overview**
> Updates the English and Chinese **Olares onboarding** docs so sample **`olares-cli`** output matches the current CLI format.
> 
> **`olares-cli -v`** examples now show an exact version plus **Git commit** and **Build time**, instead of `>=1.12.6`. **`olares-cli profile list`** examples add a **VERSION** column, refresh row values (e.g. `1.12.6-alpha.15`), and note that **`*`** marks the active profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536cbbdcb0946414e720580f390ad6891245096d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->