### PR TITLE
fix(download-server):  land shared-cache downloads at Common/huggingface

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.3"
+        image: "beclab/download-server:v1.0.4"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -224,6 +224,8 @@ spec:
           mountPath: /app/downloads
         - name: config-dir
           mountPath: /app/ytdlp/downloads
+        - name: common-data
+          mountPath: /appcommon
         ports:
         - containerPort: 8080
         resources:
@@ -243,6 +245,10 @@ spec:
         hostPath:
           type: DirectoryOrCreate
           path: '{{ .Values.rootPath }}/rootfs/userspace'
+      - name: common-data
+        hostPath:
+          type: DirectoryOrCreate
+          path: '{{ .Values.rootPath }}/rootfs/Common'
           
 ---
 


### PR DESCRIPTION
Background
Cache-mode ("Shared cache / Common") HuggingFace downloads now land directly at <CommonDir>/huggingface/models--<owner>--<repo>/ instead of <CommonDir>/.cache/huggingface/hub/models--<...>

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download DaemonSet storage mounts and image version, which affects where shared HuggingFace artifacts are written on disk across nodes.
> 
> **Overview**
> **Deploys download-server v1.0.4** and gives the pod access to the host **Common** shared storage so cache-mode HuggingFace downloads can be written to the new layout (`Common/huggingface/models--…` instead of under `.cache/huggingface/hub`).
> 
> The DaemonSet adds a **`common-data` hostPath volume** (`{{ .Values.rootPath }}/rootfs/Common`) mounted at **`/appcommon`** on the `download-server` container, alongside the existing userspace and ytdlp cache mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1aabb7bd1d560b4868d148e6879588891e48d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->