### PR TITLE
cli: add task to upgrade CNI plugins in upgrade process

### DIFF
--- a/cli/pkg/plugins/network/modules.go
+++ b/cli/pkg/plugins/network/modules.go
@@ -386,7 +386,7 @@ type EnableCniDhcpService struct {
 }
 
 func (e *EnableCniDhcpService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp && systemctl restart cni-dhcp",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")
 	}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -968,6 +968,9 @@ type upgradeCniPluginsBinaryOnly struct {
 
 func (u *upgradeCniPluginsBinaryOnly) Execute(runtime connector.Runtime) error {
 	m, err := manifest.ReadAll(u.KubeConf.Arg.Manifest)
+	if err != nil {
+		return fmt.Errorf("read manifest failed: %w", err)
+	}
 
 	binary, err := m.Get("cni-plugins")
 	if err != nil {

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -757,6 +757,12 @@ func upgradeMultus() []task.Interface {
 			},
 		},
 		&task.LocalTask{
+			Name:   "UpgradeCNIPlugins",
+			Desc:   "Upgrade CNI plugins",
+			Action: new(upgradeCniPluginsBinaryOnly),
+			Retry:  5,
+		},
+		&task.LocalTask{
 			Name:   "DeployMultus",
 			Desc:   "Deploy multus",
 			Action: new(network.DeployNetworkMultusPlugin),
@@ -954,4 +960,31 @@ func upgradeUserReverseProxy() []task.Interface {
 			Delay:  5 * time.Second,
 		},
 	}
+}
+
+type upgradeCniPluginsBinaryOnly struct {
+	common.KubeAction
+}
+
+func (u *upgradeCniPluginsBinaryOnly) Execute(runtime connector.Runtime) error {
+	m, err := manifest.ReadAll(u.KubeConf.Arg.Manifest)
+
+	binary, err := m.Get("cni-plugins")
+	if err != nil {
+		return fmt.Errorf("get cni-plugins binary info failed: %w", err)
+	}
+
+	path := binary.FilePath(runtime.GetBaseDir())
+
+	fileName := binary.Filename
+	dst := filepath.Join(common.TmpDir, fileName)
+	logger.Debugf("SyncKubeBinary cp cni-plugins from %s to %s", path, dst)
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
+	}
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
* **Background**
Upgrade CNI plugin to the new version for overlay-gateway

* **Target Version for Merge**
v1.12.6

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade overwrites `/opt/cni/bin` and restarts `cni-dhcp` on masters during the Multus path, which can briefly affect overlay networking if the rollout fails mid-task.
> 
> **Overview**
> The **Multus upgrade** sequence now refreshes host **CNI plugin binaries** from the manifest before deploying Multus, so clusters pick up the newer plugins needed for **overlay-gateway**.
> 
> A new local task **`UpgradeCNIPlugins`** runs after Multus config generation and before deploy: it copies the `cni-plugins` artifact from the manifest into `/opt/cni/bin` (same extract pattern as install-time kube binary sync), with retries.
> 
> **`EnableCniDhcpService`** also **`systemctl restart cni-dhcp`** after enable, so the DHCP daemon reloads after plugin updates instead of staying on the old binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae23ccac8c578ae186598d55baa84bf067a22c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->