### PR TITLE
docs: fix table formatting

### DIFF
--- a/docs/manual/olares/market/shared-apps.md
+++ b/docs/manual/olares/market/shared-apps.md
@@ -36,7 +36,7 @@ The new architecture replaces the client/server split with a single, unified sha
 | v2 architecture | New architecture |
 |:----------------|:----------------|
 | Server + client-side access point | Single unified shared server |
-| Uninstalling an access point might break the server | Server lifecycle is independent of any access point |
+| Uninstalling an access point might<br>break the server | Server lifecycle is independent<br>of any access point |
 | Multiple access addresses and formats | Unified address format for all users |
 | Client and server managed separately | Administrators manage one shared service |
 

--- a/docs/manual/olares/market/shared-apps.md
+++ b/docs/manual/olares/market/shared-apps.md
@@ -22,7 +22,7 @@ Key characteristics of shared applications include:
 
     - **Headless backend service**: Provides API services for compatible clients, with no end-user graphical interface. For example, model instances created on Engine Base apps expose a **Base URL** in their model console. Members paste this address into clients such as Open WebUI or LobeChat.
     
-    - **Applications with built-in UI**: Includes both a backend service and a web UI. Members open it directly from the Launchpad. Examples include **Dify** and **ComfyUI Shared**.
+    - **Applications with built-in UI**: Includes both a backend service and a web UI. Members open it directly from the Launchpad. Examples include **Dify** and **ComfyUI**.
     
 - **Unified HTTPS address**: All shared applications use the same URL pattern, that is `https://<app-id>.<username>.<platform-domain>`. Each member accesses the same shared application through their own username.
 <!-- #endregion shared-apps-what-are -->


### PR DESCRIPTION
Title: 
* **Background**
See title.

* **Target Version for Merge**
1.12.6

* **Related Issues**
None.

* **PRs Involving Sub-Systems** 
None.

* **Other information**:
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting and wording; no runtime or security impact.
> 
> **Overview**
> Updates **`shared-apps.md`** for readability in the architecture comparison table and a small example correction.
> 
> The v2 vs new architecture table now uses **`<br>` breaks** in two cells so long phrases (*"Uninstalling an access point might break the server"* and *"Server lifecycle is independent of any access point"*) wrap instead of stretching column width.
> 
> The built-in UI example is renamed from **ComfyUI Shared** to **ComfyUI** to match current product naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05e412233c19522e6f4027827f50137c5542741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->