### PR TITLE
fix(daemon): ensure proper shutdown of existing mDNS server on host reset

### DIFF
--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -98,7 +98,10 @@ func (s *mDNSServer) SetHosts(hosts []DNSConfig, reset bool) {
 		} else {
 
 			if reset {
-				server.queryServer.Shutdown()
+				// reset existing host, shutdown the server and remove it from the map
+				if server != nil && server.queryServer != nil {
+					server.queryServer.Shutdown()
+				}
 				s.servers[host.Domain] = nil
 			}
 		}


### PR DESCRIPTION

* **Background**
Ensure proper shutdown of existing mDNS server on host reset

* **Target Version for Merge**
v1.12.6 v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive nil check in intranet mDNS host reset; reduces panic risk during daemon start/reload with no behavior change when servers are running.
> 
> **Overview**
> When **`SetHosts`** runs with **`reset: true`** for a domain that already exists in the mDNS map, shutdown is now skipped unless both the **`instanceServer`** and its **`queryServer`** are non-nil.
> 
> Previously **`queryServer.Shutdown()`** was called unconditionally on reset, which could panic if the entry was only a **`nil`** placeholder (domain registered but not yet started via **`StartAll`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af546606b38f8775e1a86e677812cb7e926eceda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->