### PR TITLE
docs: add noindex to redirecting URLs in English and Chinese documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
+# /docs/ 301-redirects to /manual/overview (see theme/redirects.ts), so keep this
+# redirecting URL out of the sitemap and search index.
+noindex: true
 
 hero:
   name: "Olares"

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,6 +1,9 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
+# /docs/zh/ 301-redirects to /zh/manual/overview (see theme/redirects.ts), so keep
+# this redirecting URL out of the sitemap and search index.
+noindex: true
 
 hero:
   name: "Olares"


### PR DESCRIPTION
* **Background**
Added 'noindex: true' to /docs/ and /docs/zh/ to prevent search indexing of redirecting URLs, ensuring better SEO management.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation frontmatter-only SEO change; no runtime, auth, or application logic affected.
> 
> **Overview**
> Adds **`noindex: true`** to the English (`docs/index.md`) and Chinese (`docs/zh/index.md`) VitePress home pages, with comments noting that **`/docs/`** and **`/docs/zh/`** **301-redirect** to the manual overview routes (see `theme/redirects.ts`).
> 
> That keeps these redirecting entry URLs out of **search indexing** and the **sitemap**, so crawlers focus on the canonical overview pages instead of duplicate redirect sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fed96a8ef1c1a4bc00ad94cc63fb6a46cb763f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->