### PR TITLE
docs: add migration notes for Xinference

### DIFF
--- a/docs/.vitepress/data/useCases.ts
+++ b/docs/.vitepress/data/useCases.ts
@@ -68,7 +68,7 @@ export const useCases: UseCase[] = [
   { title: "TensorZero", link: "/use-cases/tensorzero", category: "Model services", description: "AI model gateway and observability platform", descriptionZh: "AI 模型网关与可观测性平台" },
   { title: "LLMFit", link: "/use-cases/llmfit", category: "Model services", description: "Benchmark your hardware to find the best models", descriptionZh: "对硬件进行基准测试以找到最合适的模型" },
   { title: "Engine Base apps", link: "/use-cases/llm-base-apps", category: "Model services", description: "Self-host local LLMs by cloning base apps for different inference engines", descriptionZh: "通过克隆不同推理引擎的基座应用来自托管本地大语言模型" },
-  // { title: "Xinference", link: "/use-cases/xinference", category: "Model services", description: "Deploy and serve models on Olares", descriptionZh: "在 Olares 上部署和提供模型服务" },
+  { title: "Xinference", link: "/use-cases/xinference", category: "Model services", description: "Deploy and serve models on Olares", descriptionZh: "在 Olares 上部署和提供模型服务" },
   { title: "Isaac Lab", link: "/use-cases/isaac-lab", category: "Embodied AI", description: "GPU-accelerated robot simulation training", descriptionZh: "GPU 加速的机器人仿真训练" },
   { title: "macOS", link: "/use-cases/macos", category: "Virtual machine", description: "Run a macOS VM with browser-based VNC", descriptionZh: "通过浏览器 VNC 运行 macOS 虚拟机" },
   { title: "Windows", link: "/use-cases/windows", category: "Virtual machine", description: "Run a Windows VM with VNC or Remote Desktop", descriptionZh: "通过 VNC 或远程桌面运行 Windows 虚拟机" },

--- a/docs/.vitepress/usecase.en.ts
+++ b/docs/.vitepress/usecase.en.ts
@@ -268,10 +268,10 @@ export const useCaseSidebar: DefaultTheme.Sidebar = {
                   text: "LLMFit",
                   link: "/use-cases/llmfit",
                 },
-                // {
-                //   text: "Xinference",
-                //   link: "/use-cases/xinference",
-                // },
+                {
+                  text: "Xinference",
+                  link: "/use-cases/xinference",
+                },
                 // {
                 //   text: "Dify",
                 //   link: "/use-cases/dify",

--- a/docs/.vitepress/usecase.zh.ts
+++ b/docs/.vitepress/usecase.zh.ts
@@ -268,10 +268,10 @@ export const useCaseSidebar: DefaultTheme.Sidebar = {
                   text: "LLMFit",
                   link: "/zh/use-cases/llmfit",
                 },
-                // {
-                //   text: "Xinference",
-                //   link: "/zh/use-cases/xinference",
-                // },
+                {
+                  text: "Xinference",
+                  link: "/zh/use-cases/xinference",
+                },
                 // {
                 //   text: "Dify",
                 //   link: "/zh/use-cases/dify",

--- a/docs/manual/olares/market/shared-apps.md
+++ b/docs/manual/olares/market/shared-apps.md
@@ -105,8 +105,8 @@ Use this option when the shared app has no user-created data to migrate.
 
 Use this option when the shared app stores user-created data or settings that must be moved manually.
 
-- **Apps in this category**: Dify, OnlyOffice, and SearXNG
-- **Steps**: Follow the migration guide for the shared app you are migrating: [Dify](/use-cases/dify-upgrade.md), [OnlyOffice](/use-cases/onlyoffice.md), and [SearXNG](/use-cases/searxng.md).
+- **Apps in this category**: Dify, OnlyOffice, SearXNG, and Xinference
+- **Steps**: Follow the migration guide for the shared app you are migrating: [Dify](/use-cases/dify-upgrade.md), [OnlyOffice](/use-cases/onlyoffice.md), [SearXNG](/use-cases/searxng.md), and [Xinference](/use-cases/xinference.md).
 
 ### Option 4: Upgrade the Ollama app to Engine Base
 

--- a/docs/use-cases/searxng.md
+++ b/docs/use-cases/searxng.md
@@ -34,7 +34,7 @@ The preferences hash is an encoded string that contains all your SearXNG setting
    
    ![Copy SearXNG preferences hash](/images/manual/use-cases/searxng-copy-preferences-hash.png#bordered)
 
-2. Uninstall the previously installed SearXNG app.
+2. Uninstall the previously installed SearXNG app. When prompted, do not select **Also remove all local data**.
 3. Install the new SearXNG app.
 
    a. Open Market and search for "SearXNG".

--- a/docs/use-cases/xinference.md
+++ b/docs/use-cases/xinference.md
@@ -1,23 +1,45 @@
 ---
 outline: [2, 3]
-description: Learn how to use and migrate Xinference on Olares.
+description: Learn how to migrate Xinference from the v2 architecture to the new shared app architecture in Olares 1.12.6.
 head:
   - - meta
     - name: keywords
-      content: Olares, Xinference, migration, shared app
+      content: Olares, Xinference, migration, shared app, Olares 1.12.6
+app_version: "1.0.0"
+doc_version: "1.0"
+doc_updated: "2026-07-13"
 ---
 
-# Xinference
+# Migrate Xinference to the new architecture
 
-Xinference is a shared application on Olares for deploying and serving models.
+Xinference is a shared application on Olares for deploying and serving models. Olares 1.12.6 updates the shared app architecture, so you cannot update Xinference in place. This guide shows how to reinstall Xinference and re-download your models after upgrading to Olares 1.12.6.
 
-## Migrate from v2 to the new architecture
+## Before you migrate
 
-Olares 1.12.6 introduces a new shared app architecture. To migrate Xinference:
+Previously, Xinference stored all models as local files in its own Cache directory.
 
-1. Back up your v2 app data.
-2. Uninstall the v2 Xinference app.
-3. Install the new Xinference app.
-4. Restore your deployed models and service settings.
+Olares 1.12.6 introduces the [Common directory](/manual/olares/files/files-common.md) for managing shared AI models across applications. In the new architecture, Xinference stores models differently based on their source:
 
-For the generic migration workflow, see [Migrate from v2 to the new architecture](../manual/olares/market/shared-apps.md#option-3-back-up-uninstall-v2-install-the-new-app-then-restore-data).
+- **Models downloaded from Hugging Face** are stored in **Application** > **Common** > **huggingface**, following the official Hugging Face cache structure.
+- **Models downloaded from other sources** are stored in **Application** > **Data** > **xinferencesv3**.
+
+Therefore, your existing models cannot be migrated automatically. You must reinstall the app and re-download your models.
+
+## Reinstall Xinference and re-download models
+
+1. Uninstall the previously installed Xinference app. When prompted, do not select **Also remove all local data**.
+2. Install the new Xinference app.
+
+   a. Open Market and search for "Xinference".
+
+   b. Click the app card to open the app details page.
+
+   c. Check the **Information** panel. The **Compatibility** field shows `Olares >=1.12.6-0` for the new version.
+
+   d. Click **Get**, then **Install**, and wait for the installation to finish.
+
+3. Open the new Xinference app, and then re-download all models you need. The system will store them to the correct locations automatically.
+
+## Learn more
+
+- [Shared applications](../manual/olares/market/shared-apps.md): Understand the new shared app architecture.

--- a/docs/use-cases/xinference.md
+++ b/docs/use-cases/xinference.md
@@ -14,7 +14,7 @@ doc_updated: "2026-07-13"
 
 Xinference is a shared application on Olares for deploying and serving models. Olares 1.12.6 updates the shared app architecture, so you cannot update Xinference in place. This guide shows how to reinstall Xinference and re-download your models after upgrading to Olares 1.12.6.
 
-## Before you migrate
+## Before you begin
 
 Previously, Xinference stored all models as local files in its own Cache directory.
 

--- a/docs/zh/manual/olares/market/shared-apps.md
+++ b/docs/zh/manual/olares/market/shared-apps.md
@@ -110,8 +110,8 @@ head:
 
 以下情况使用该方法：应用存储了用户创建的数据或设置，必须手动迁移。
 
-- **属于该方法的应用**：Dify、OnlyOffice 和 SearXNG
-- **步骤**：按应用查看对应的迁移指南：[Dify](/zh/use-cases/dify-upgrade.md)、[OnlyOffice](/zh/use-cases/onlyoffice.md) 和 [SearXNG](/zh/use-cases/searxng.md)。
+- **属于该方法的应用**：Dify、OnlyOffice、SearXNG 和 Xinference
+- **步骤**：按应用查看对应的迁移指南：[Dify](/zh/use-cases/dify-upgrade.md)、[OnlyOffice](/zh/use-cases/onlyoffice.md)、[SearXNG](/zh/use-cases/searxng.md) 和 [Xinference](/zh/use-cases/xinference.md)。
 
 ### 选项四：将 Ollama 应用升级到引擎基座
 

--- a/docs/zh/use-cases/searxng.md
+++ b/docs/zh/use-cases/searxng.md
@@ -38,7 +38,7 @@ Preferences hash 是一串包含你所有 SearXNG 设置的编码字符串。复
    
    ![复制 SearXNG preferences hash](/images/manual/use-cases/searxng-copy-preferences-hash.png#bordered)
 
-2. 卸载之前安装的 SearXNG。
+2. 卸载之前安装的 SearXNG。在提示时，不要勾选**同时删除所有本地数据**。
 3. 安装新版 SearXNG。
 
    a. 打开 Market，搜索 "SearXNG"。

--- a/docs/zh/use-cases/xinference.md
+++ b/docs/zh/use-cases/xinference.md
@@ -1,23 +1,45 @@
 ---
 outline: [2, 3]
-description: 了解如何在 Olares 上使用并迁移 Xinference。
+description: 了解如何将 Xinference 从 v2 架构迁移到 Olares 1.12.6 的新共享应用架构。
 head:
   - - meta
     - name: keywords
-      content: Olares, Xinference, 迁移, 共享应用
+      content: Olares, Xinference, 迁移, 共享应用, Olares 1.12.6
+app_version: "1.0.0"
+doc_version: "1.0"
+doc_updated: "2026-07-13"
 ---
 
-# Xinference
+# 将 Xinference 迁移到新架构
 
-Xinference 是 Olares 上用于部署和提供模型服务的共享应用。
+Xinference 是 Olares 上用于部署和提供模型服务的共享应用。Olares 1.12.6 更新了共享应用架构，因此无法直接原地升级 Xinference。本文介绍如何在升级到 Olares 1.12.6 后重新安装 Xinference 并重新下载模型。
 
-## 从 v2 迁移到新架构
+## 迁移前须知
 
-Olares 1.12.6 引入了新的共享应用架构。迁移 Xinference 的步骤如下：
+在 v2 应用中，Xinference 将所有模型以 local files 的形式存放在自己的 Cache 目录中。
 
-1. 备份 v2 应用数据。
-2. 卸载 v2 版 Xinference。
-3. 安装新版 Xinference。
-4. 恢复你的已部署模型和服务设置。
+Olares 1.12.6 引入了[公共目录](/zh/manual/olares/files/files-common.md)，用于跨应用管理共享的 AI 模型。在新架构中，Xinference 会根据模型的来源将其存放到不同位置：
 
-通用迁移流程请参阅[从 v2 迁移到新架构](../manual/olares/market/shared-apps.md#option-3-back-up-uninstall-v2-install-the-new-app-then-restore-data)。
+- **从 Hugging Face 下载的模型**存放在 **应用** > **公共** > **huggingface** 中，遵循 Hugging Face 官方缓存结构。
+- **从其他渠道下载的模型**存放在 **应用** > **数据** > **xinferencesv3** 中。
+
+因此，已有模型无法自动迁移。你必须重新安装应用并重新下载模型。
+
+## 重新安装 Xinference 并重新下载模型
+
+1. 卸载之前安装的 Xinference 应用。提示时，请勿勾选**同时删除所有本地数据**。
+2. 安装新版 Xinference 应用。
+
+   a. 打开应用市场，搜索 "Xinference"。
+
+   b. 点击应用卡片进入详情页。
+
+   c. 查看**信息**面板中的**兼容性**字段，新版应用显示为 `Olares >=1.12.6-0`。
+
+   d. 点击**获取**，然后点击**安装**，等待安装完成。
+
+3. 打开新版 Xinference 应用，然后重新下载你需要的所有模型。系统会自动将它们存放到正确的位置。
+
+## 了解更多
+
+- [共享应用](../manual/olares/market/shared-apps.md)：了解新的共享应用架构。

--- a/docs/zh/use-cases/xinference.md
+++ b/docs/zh/use-cases/xinference.md
@@ -10,11 +10,15 @@ doc_version: "1.0"
 doc_updated: "2026-07-13"
 ---
 
+:::warning WARNING
+本页面内容由 AI 翻译生成，仅供参考。如有疑问，请以[英文原文](../../use-cases/xinference.md)为准。
+:::
+
 # 将 Xinference 迁移到新架构
 
 Xinference 是 Olares 上用于部署和提供模型服务的共享应用。Olares 1.12.6 更新了共享应用架构，因此无法直接原地升级 Xinference。本文介绍如何在升级到 Olares 1.12.6 后重新安装 Xinference 并重新下载模型。
 
-## 迁移前须知
+## 开始之前
 
 在 v2 应用中，Xinference 将所有模型以 local files 的形式存放在自己的 Cache 目录中。
 


### PR DESCRIPTION
Title: Add migration notes for the shared app Xinference
* **Background**
See title.
* **Target Version for Merge**
1.12.6

* **Related Issues**
None.

* **PRs Involving Sub-Systems** 
None.

* **Other information**:
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents **Olares 1.12.6** shared-app migration for **Xinference** and wires it into site navigation and the shared-apps index.
> 
> The **Xinference** use-case pages (EN/ZH) are expanded from a short stub into a full guide: models cannot be carried over automatically because v2 cache layout differs from the new **Common** / **Data** paths (Hugging Face vs other sources), so users uninstall without deleting local data, install the `>=1.12.6-0` build from Market, and re-download models. **Option 3** in the shared-apps manual now lists Xinference alongside Dify, OnlyOffice, and SearXNG with links to that guide. Xinference is re-enabled in the use-cases gallery and EN/ZH sidebars.
> 
> **SearXNG** migration steps gain the same uninstall warning—do not choose **Also remove all local data**—so behavior matches the other manual-migration apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6317d1c7fd03926c3b8a306c69a23760debf5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->