### PR TITLE
fix(xds): de-duplicate route-config domains to prevent full 404 outage

### DIFF
--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -190,33 +190,6 @@
       }
     },
     {
-      "name": "app_bob_desktop_desktop-frontend",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "app_bob_desktop_desktop-frontend",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "desktop-svc.desktop-bob.svc.cluster.local",
-                      "portValue": 80
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
       "name": "nonapp_auth_bob",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -1633,78 +1606,6 @@
           }
         },
         {
-          "name": "app_bob_desktop_desktop-frontend",
-          "domains": [
-            "desktop.bob.snowinning.com",
-            "desktop.bob.olares.local"
-          ],
-          "routes": [
-            {
-              "name": "default_bob_desktop_desktop-frontend",
-              "match": {
-                "prefix": "/"
-              },
-              "route": {
-                "cluster": "app_bob_desktop_desktop-frontend",
-                "timeout": "300s",
-                "upgradeConfigs": [
-                  {
-                    "upgradeType": "websocket"
-                  },
-                  {
-                    "upgradeType": "tailscale-control-protocol"
-                  }
-                ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
-            }
-          ],
-          "typedPerFilterConfig": {
-            "envoy.filters.http.ext_authz": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-              "disabled": true
-            },
-            "envoy.filters.http.rbac": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute",
-              "rbac": {
-                "rules": {
-                  "policies": {
-                    "allow_cidrs": {
-                      "permissions": [
-                        {
-                          "any": true
-                        }
-                      ],
-                      "principals": [
-                        {
-                          "remoteIp": {
-                            "addressPrefix": "100.64.0.0",
-                            "prefixLen": 16
-                          }
-                        },
-                        {
-                          "remoteIp": {
-                            "addressPrefix": "10.0.0.5",
-                            "prefixLen": 32
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "name": "nonapp_auth_bob",
           "domains": [
             "auth.bob.snowinning.com",
@@ -2384,78 +2285,6 @@
               },
               "route": {
                 "cluster": "app_bob_vault_vault-frontend",
-                "timeout": "300s",
-                "upgradeConfigs": [
-                  {
-                    "upgradeType": "websocket"
-                  },
-                  {
-                    "upgradeType": "tailscale-control-protocol"
-                  }
-                ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
-            }
-          ],
-          "typedPerFilterConfig": {
-            "envoy.filters.http.ext_authz": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-              "disabled": true
-            },
-            "envoy.filters.http.rbac": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute",
-              "rbac": {
-                "rules": {
-                  "policies": {
-                    "allow_cidrs": {
-                      "permissions": [
-                        {
-                          "any": true
-                        }
-                      ],
-                      "principals": [
-                        {
-                          "remoteIp": {
-                            "addressPrefix": "100.64.0.0",
-                            "prefixLen": 16
-                          }
-                        },
-                        {
-                          "remoteIp": {
-                            "addressPrefix": "10.0.0.5",
-                            "prefixLen": 32
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "name": "app_bob_desktop_desktop-frontend",
-          "domains": [
-            "desktop.bob.snowinning.com",
-            "desktop.bob.olares.local"
-          ],
-          "routes": [
-            {
-              "name": "default_bob_desktop_desktop-frontend",
-              "match": {
-                "prefix": "/"
-              },
-              "route": {
-                "cluster": "app_bob_desktop_desktop-frontend",
                 "timeout": "300s",
                 "upgradeConfigs": [
                   {

--- a/framework/l4-bfl-proxy/internal/ir/xds.go
+++ b/framework/l4-bfl-proxy/internal/ir/xds.go
@@ -50,6 +50,12 @@ type VirtualHostIR struct {
 	// that the upstream fileserver / nginx do not emit, so Capacitor / browser
 	// cross-origin requests to /api/preview/*, /api/raw/*, etc. succeed.
 	IsFileserver bool
+	// Priority controls who keeps a domain when two virtual hosts in the same
+	// route config declare it. Domains are claimed in descending Priority order
+	// (higher wins); within the same priority the earlier-declared vhost wins.
+	// System services (auth/desktop/wizard) use a high priority so a
+	// misconfigured app can never hijack their domains. Default 0.
+	Priority int
 }
 
 type HTTPRouteIR struct {

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -24,6 +24,11 @@ const (
 	settingsCustomDomain                 = "customDomain"
 	settingsCustomDomainThirdLevelDomain = "third_level_domain"
 	settingsCustomDomainThirdPartyDomain = "third_party_domain"
+
+	// systemServicePriority makes system-service virtual hosts (auth/desktop/
+	// wizard) outrank apps and custom domains when a domain is claimed by more
+	// than one virtual host in the same route config.
+	systemServicePriority = 100
 )
 
 var nodeLocationPrefixes = []string{
@@ -462,6 +467,7 @@ func (t *Translator) buildUserVirtualHosts(user *message.UserInfo, zone string, 
 				"X-BFL-USER": user.Name,
 			},
 		}},
+		Priority: systemServicePriority,
 	}
 	vhosts = append(vhosts, profileVHost)
 
@@ -546,6 +552,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			UserName:              user.Name,
 			// Only the (files,settings apps) vhost needs Envoy-level CORS
 			IsFileserver: fileserverPatchApps[prefix],
+			Priority:     systemAppPriority(app.Name),
 		}
 
 		var routes []*ir.HTTPRouteIR
@@ -696,6 +703,9 @@ func (t *Translator) buildSystemVirtualHost(user *message.UserInfo, def systemSe
 		Language: user.Language,
 		UserZone: zone,
 		UserName: user.Name,
+		// System services (auth/desktop/wizard) outrank apps and custom domains
+		// when claiming a domain, so a misconfigured app cannot hijack them.
+		Priority: systemServicePriority,
 		Routes: []*ir.HTTPRouteIR{{
 			Name:       fmt.Sprintf("nonapp_%s_root_%s", def.Name, user.Name),
 			PathPrefix: "/",
@@ -871,4 +881,11 @@ func sanitizeName(s string) string {
 		s = s[:40]
 	}
 	return s
+}
+
+func systemAppPriority(appName string) int {
+	if appName == "olares-app" {
+		return systemServicePriority
+	}
+	return 0
 }

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -401,10 +401,53 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 
 		routeConfigName := httpIR.Name + "_routes"
 
-		// Build virtual hosts
+		// Build virtual hosts.
+		//
+		// Envoy rejects the ENTIRE RouteConfiguration ("Only unique values for
+		// domains are permitted") if a domain appears on more than one virtual
+		// host. A single misconfigured app — e.g. two apps sharing the same
+		// custom third_level_domain or third_party_domain, or an app whose
+		// third_level_domain collides with a system service — would otherwise
+		// take the whole route table down and 404 every request for that user.
+		//
+		// Defensively de-duplicate domains within each route config. Domains are
+		// claimed in descending Priority order (system services outrank apps and
+		// custom domains, so a misconfigured app can never hijack auth/desktop/
+		// wizard); within the same priority the earlier-declared virtual host
+		// wins. Virtual hosts are still EMITTED in their original declaration
+		// order; a virtual host left with no domains is skipped entirely.
+		claimOrder := make([]int, len(httpIR.VirtualHosts))
+		for i := range claimOrder {
+			claimOrder[i] = i
+		}
+		sort.SliceStable(claimOrder, func(a, b int) bool {
+			return httpIR.VirtualHosts[claimOrder[a]].Priority > httpIR.VirtualHosts[claimOrder[b]].Priority
+		})
+		keptDomains := make([][]string, len(httpIR.VirtualHosts))
+		seenDomains := make(map[string]struct{}, len(httpIR.VirtualHosts))
+		for _, idx := range claimOrder {
+			vhIR := httpIR.VirtualHosts[idx]
+			uniqueDomains := make([]string, 0, len(vhIR.Domains))
+			for _, d := range vhIR.Domains {
+				if _, dup := seenDomains[d]; dup {
+					klog.Warningf("xds-translator: route %s: dropping duplicate domain %q from virtual host %q (already claimed by a higher-priority or earlier virtual host)", routeConfigName, d, vhIR.Name)
+					continue
+				}
+				seenDomains[d] = struct{}{}
+				uniqueDomains = append(uniqueDomains, d)
+			}
+			keptDomains[idx] = uniqueDomains
+		}
+
 		var virtualHosts []*routev3.VirtualHost
-		for _, vhIR := range httpIR.VirtualHosts {
+		for i, vhIR := range httpIR.VirtualHosts {
+			if len(keptDomains[i]) == 0 {
+				klog.Warningf("xds-translator: route %s: skipping virtual host %q with no unique domains", routeConfigName, vhIR.Name)
+				continue
+			}
+
 			vh := translateVirtualHost(vhIR)
+			vh.Domains = keptDomains[i]
 			virtualHosts = append(virtualHosts, vh)
 
 			for _, route := range vhIR.Routes {

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
@@ -576,6 +576,142 @@ func TestBuildMultiUserHTTPSListener_DistinctSNIKept(t *testing.T) {
 	require.Len(t, listener.FilterChains, 2)
 }
 
+// Two virtual hosts inside the same route config sharing a domain (e.g. two
+// apps configured with the same custom third_level_domain) must not make Envoy
+// reject the whole RouteConfiguration. The first virtual host keeps the shared
+// domain; the second keeps only its own unique domains.
+func TestBuildMultiUserHTTPSListener_DuplicateDomainDeduped(t *testing.T) {
+	httpIR := &ir.HTTPListenerIR{
+		Name:       "https_443_onetest06_zone",
+		Address:    "0.0.0.0",
+		Port:       443,
+		TLS:        true,
+		SNIMatches: []string{"*.onetest06.olares.com", "onetest06.olares.com"},
+		TLSCert:    &ir.SecretIR{Name: "tls", CertData: "cert", KeyData: "key"},
+		UserName:   "onetest06",
+		VirtualHosts: []*ir.VirtualHostIR{
+			{
+				Name:    "app_onetest06_radarr",
+				Domains: []string{"radarr.onetest06.olares.com", "test.onetest06.olares.com"},
+				Routes:  []*ir.HTTPRouteIR{{Name: "r1", PathPrefix: "/", Cluster: ""}},
+			},
+			{
+				Name:    "app_onetest06_sonarr",
+				Domains: []string{"sonarr.onetest06.olares.com", "test.onetest06.olares.com"},
+				Routes:  []*ir.HTTPRouteIR{{Name: "r2", PathPrefix: "/", Cluster: ""}},
+			},
+		},
+	}
+
+	clusterSet := make(map[string]bool)
+	_, routeConfigs, _ := buildMultiUserHTTPSListener(443, false, []*ir.HTTPListenerIR{httpIR}, map[string]*ir.ClusterIR{}, clusterSet)
+
+	require.Len(t, routeConfigs, 1)
+	rc := asRouteConfig(t, routeConfigs[0])
+
+	domainsByVH := map[string][]string{}
+	seen := map[string]int{}
+	for _, vh := range rc.VirtualHosts {
+		domainsByVH[vh.Name] = vh.Domains
+		for _, d := range vh.Domains {
+			seen[d]++
+		}
+	}
+
+	// No domain appears twice across the whole route config (Envoy's rule).
+	for d, n := range seen {
+		assert.Equalf(t, 1, n, "domain %q must appear exactly once across the route config", d)
+	}
+	// First virtual host keeps the shared domain.
+	assert.Contains(t, domainsByVH["app_onetest06_radarr"], "test.onetest06.olares.com")
+	// Second keeps its own unique domain but loses the duplicate.
+	assert.Contains(t, domainsByVH["app_onetest06_sonarr"], "sonarr.onetest06.olares.com")
+	assert.NotContains(t, domainsByVH["app_onetest06_sonarr"], "test.onetest06.olares.com")
+}
+
+// A virtual host whose every domain is already claimed (e.g. a second app with
+// an identical third_party_domain and no other domain) is dropped entirely
+// instead of poisoning the route config.
+func TestBuildMultiUserHTTPSListener_VirtualHostFullyDuplicateDropped(t *testing.T) {
+	httpIR := &ir.HTTPListenerIR{
+		Name:       "https_443_onetest06_zone",
+		Port:       443,
+		TLS:        true,
+		SNIMatches: []string{"onetest06.olares.com"},
+		TLSCert:    &ir.SecretIR{Name: "tls", CertData: "cert", KeyData: "key"},
+		UserName:   "onetest06",
+		VirtualHosts: []*ir.VirtualHostIR{
+			{
+				Name:    "custom_onetest06_appA",
+				Domains: []string{"foo.example.com"},
+				Routes:  []*ir.HTTPRouteIR{{Name: "r1", PathPrefix: "/"}},
+			},
+			{
+				Name:    "custom_onetest06_appB",
+				Domains: []string{"foo.example.com"},
+				Routes:  []*ir.HTTPRouteIR{{Name: "r2", PathPrefix: "/"}},
+			},
+		},
+	}
+
+	clusterSet := make(map[string]bool)
+	_, routeConfigs, _ := buildMultiUserHTTPSListener(443, false, []*ir.HTTPListenerIR{httpIR}, map[string]*ir.ClusterIR{}, clusterSet)
+
+	require.Len(t, routeConfigs, 1)
+	rc := asRouteConfig(t, routeConfigs[0])
+
+	var names []string
+	for _, vh := range rc.VirtualHosts {
+		names = append(names, vh.Name)
+	}
+	assert.Contains(t, names, "custom_onetest06_appA")
+	assert.NotContains(t, names, "custom_onetest06_appB")
+}
+
+// A higher-Priority virtual host (e.g. a system service) must keep a contested
+// domain even when a lower-Priority virtual host (an app) is declared earlier,
+// so a misconfigured app cannot hijack auth/desktop/wizard.
+func TestBuildMultiUserHTTPSListener_HigherPriorityWinsDomain(t *testing.T) {
+	httpIR := &ir.HTTPListenerIR{
+		Name:       "https_443_bob_zone",
+		Port:       443,
+		TLS:        true,
+		SNIMatches: []string{"bob.snowinning.com"},
+		TLSCert:    &ir.SecretIR{Name: "tls", CertData: "cert", KeyData: "key"},
+		UserName:   "bob",
+		VirtualHosts: []*ir.VirtualHostIR{
+			{
+				// App declared first but lower priority.
+				Name:     "app_bob_desktop",
+				Priority: 0,
+				Domains:  []string{"desktop.bob.snowinning.com"},
+				Routes:   []*ir.HTTPRouteIR{{Name: "r1", PathPrefix: "/"}},
+			},
+			{
+				// System service declared later but higher priority.
+				Name:     "nonapp_desktop_bob",
+				Priority: 100,
+				Domains:  []string{"desktop.bob.snowinning.com"},
+				Routes:   []*ir.HTTPRouteIR{{Name: "r2", PathPrefix: "/"}},
+			},
+		},
+	}
+
+	clusterSet := make(map[string]bool)
+	_, routeConfigs, _ := buildMultiUserHTTPSListener(443, false, []*ir.HTTPListenerIR{httpIR}, map[string]*ir.ClusterIR{}, clusterSet)
+
+	require.Len(t, routeConfigs, 1)
+	rc := asRouteConfig(t, routeConfigs[0])
+
+	domainsByVH := map[string][]string{}
+	for _, vh := range rc.VirtualHosts {
+		domainsByVH[vh.Name] = vh.Domains
+	}
+	// System service keeps the domain; the app is dropped (no domains left).
+	assert.Equal(t, []string{"desktop.bob.snowinning.com"}, domainsByVH["nonapp_desktop_bob"])
+	assert.NotContains(t, domainsByVH, "app_bob_desktop")
+}
+
 // ---------------------------------------------------------------------------
 // parseCIDR
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
* **Background**
Envoy NACKs the ENTIRE RouteConfiguration ("Only unique values for domains are permitted") when a domain appears on more than one virtual host. A single misconfigured app — two apps sharing the same custom third_level_domain / third_party_domain, or an app whose domain collides with a system service — took the whole route table down and 404'd every request for the user (flags=NR, route_not_found).

De-duplicate domains within each route config at the single choke point in buildMultiUserHTTPSListener. Domains are claimed in descending Priority order (system services outrank apps and custom domains, so a misconfigured app can never hijack auth/desktop/wizard); within the same priority the earlier-declared virtual host wins. Virtual hosts are still emitted in their original declaration order; a vhost left with no domains is skipped entirely.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Envoy route generation for every HTTPS user; wrong priority or dedup logic could drop app routes or mis-route traffic, but behavior is defensive and covered by new tests.
> 
> **Overview**
> Prevents Envoy from rejecting an entire per-user **RouteConfiguration** when two virtual hosts declare the same domain—a misconfiguration that previously NACK’d the route table and caused broad **404**s for that user.
> 
> **`buildMultiUserHTTPSListener`** now de-duplicates domains before emitting virtual hosts: each domain is claimed once, with **higher `Priority` winning** (ties go to the earlier-declared vhost). Virtual hosts that lose all domains are omitted; duplicates are logged. Vhosts are still listed in their original order.
> 
> The IR layer adds **`VirtualHostIR.Priority`**. Profile, auth/desktop/wizard, and **`olares-app`** get priority **100** so system routes keep contested names (e.g. desktop) instead of a colliding app vhost. E2E golden output drops the redundant **`app_bob_desktop_*`** cluster/routes when they collide with **`nonapp_desktop_bob`**.
> 
> Unit tests cover shared custom domains, fully duplicate vhosts, and priority-based wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7dc23a82072c7da6c2915ae18b1740c6ef711c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->