### PR TITLE
fix(download-server): update ytdlp url

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -175,7 +175,7 @@ spec:
         - name: SA_TOKEN_NAME
           value: download-cluster-view
         - name: YTDLP_SERVER_URL
-          value: http://ytdlp-svc.ytdlp-shared:3082
+          value: http://ytdlp-svc.ytdlpv3-shared:3082
         - name: ARIA2_RPC_URL
           value: http://download-svc:6800/jsonrpc
         - name: PG_USERNAME


### PR DESCRIPTION
Background
Rename ytdlp to ytdlpv3 and update the URL.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single deployment env URL change with no auth or data logic; risk is mainly misrouting if the ytdlpv3 service is unavailable in the target cluster.
> 
> **Overview**
> Updates the **download-server** container env **`YTDLP_SERVER_URL`** in the cluster deploy manifest so it targets **`ytdlp-svc.ytdlpv3-shared:3082`** instead of **`ytdlp-svc.ytdlp-shared:3082`**, matching the ytdlp → ytdlpv3 rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6a7d8098dd0cc092b9dcd203954a2809114f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->