### PR TITLE
download-server: add ClusterRoleBinding for download provider and update service reference

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/downloadserver-provider.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/downloadserver-provider.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: user:{{ .Values.bfl.username }}:download-provider-svc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backend:download-provider
+subjects:
+- kind: User
+  name: '{{ .Values.bfl.username }}'    
+

--- a/framework/download-server/.olares/config/cluster/deploy/download_provider.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_provider.yaml
@@ -23,7 +23,7 @@ metadata:
   name: backend:download-provider
   annotations:
     provider-registry-ref: {{ .Release.Namespace }}/download-provider-svc
-    provider-service-ref: download-provider-svc.{{ .Release.Namespace }}:28080
+    provider-service-ref: download-svc.{{ .Release.Namespace }}:8080
 rules:
   - nonResourceURLs:
       - "/api/download*"


### PR DESCRIPTION

* **Background**
1. Update the download-server service reference of the provider
2. Add ClusterRoleBinding for the backend forwarding to download-server

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster RBAC bindings and API gateway provider routing for download paths; misconfiguration could break download API access or route traffic to the wrong service.
> 
> **Overview**
> **Download API routing** is retargeted so the `backend:download-provider` ClusterRole’s `provider-service-ref` now points at **`download-svc:8080`** instead of **`download-provider-svc:28080`**, so backend forwarding matches the download-server endpoint.
> 
> **Per-user RBAC** adds a **ClusterRoleBinding** in user system-apps that binds each Olares user (`{{ .Values.bfl.username }}`) to **`backend:download-provider`**, enabling backend forwarding to download-server for that user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec7b298242cee468be1b5174b420ffd30f8afd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->