### PR TITLE
fix(app-gateway): support multi-arch ARM for linkerd-pki-guardian

### DIFF
--- a/framework/app-gateway/.olares/Olares.yaml
+++ b/framework/app-gateway/.olares/Olares.yaml
@@ -11,4 +11,4 @@ output:
     - 
       name: cr.l5d.io/linkerd/controller:edge-26.5.1
     - 
-      name: beclab/linkerd-pki-guardian@sha256:74e57f82cc741452ba32888a7e67f6c2196949e4f09b6d8e8f6a21806df1d58c
+      name: beclab/linkerd-pki-guardian@sha256:3dbde1a3829034216e72b7ef332c09f62a96b22ef408ab4aae1a63fd2162f72e

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: guardian
-          image: beclab/linkerd-pki-guardian@sha256:74e57f82cc741452ba32888a7e67f6c2196949e4f09b6d8e8f6a21806df1d58c
+          image: beclab/linkerd-pki-guardian@sha256:3dbde1a3829034216e72b7ef332c09f62a96b22ef408ab4aae1a63fd2162f72e
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-init.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-init.yaml
@@ -81,7 +81,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: linkerd-pki-init
-          image: beclab/linkerd-pki-guardian@sha256:74e57f82cc741452ba32888a7e67f6c2196949e4f09b6d8e8f6a21806df1d58c
+          image: beclab/linkerd-pki-guardian@sha256:3dbde1a3829034216e72b7ef332c09f62a96b22ef408ab4aae1a63fd2162f72e
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/linkerd-pki-guardian

--- a/framework/app-gateway/cmd/linkerd-pki-guardian/Dockerfile
+++ b/framework/app-gateway/cmd/linkerd-pki-guardian/Dockerfile
@@ -1,8 +1,15 @@
 # syntax=docker/dockerfile:1
 # Multi-stage build for the always-on Linkerd PKI guardian.
 # Build context is the app-gateway module root (framework/app-gateway):
-#   docker build -f cmd/linkerd-pki-guardian/Dockerfile -t linkerd-pki-guardian:<tag> .
-FROM golang:1.24.11 AS builder
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -f cmd/linkerd-pki-guardian/Dockerfile -t linkerd-pki-guardian:<tag> .
+#
+# Cross-compile from the builder native arch (BUILDPLATFORM) into TARGETARCH.
+# Do not default TARGETARCH to amd64 — that labeled arm64 images with x86-64 binaries.
+FROM --platform=$BUILDPLATFORM golang:1.24.11 AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH
 
 WORKDIR /workspace
 
@@ -13,13 +20,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
 # CGO disabled for a fully static binary; -trimpath/-s -w keep it small and
 # reproducible. UPX is intentionally not used (avoids AV false positives and
 # keeps the build reproducible).
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /out && \
+    test -n "${TARGETARCH}" && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w" \
     -o /out/linkerd-pki-guardian ./cmd/linkerd-pki-guardian


### PR DESCRIPTION
Fix the Dockerfile cross-build and pin the verified 0.1.2 multi-arch digest so ARM nodes pull a real AArch64 binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Linkerd PKI bootstrap/init and the always-on guardian in os-mesh; a bad image would break mesh cert lifecycle on affected nodes, but the change is a targeted build fix plus digest bump.
> 
> **Overview**
> Fixes **ARM64** deployments of `linkerd-pki-guardian` by correcting the Docker cross-compile setup and rolling cluster manifests to a new multi-arch image digest.
> 
> The **Dockerfile** now uses `BUILDPLATFORM` for the Go builder, requires `TARGETARCH` (no default to `amd64`), and documents `docker buildx` for `linux/amd64` and `linux/arm64` so arm64-tagged images ship real AArch64 binaries instead of x86-64.
> 
> **Olares** prebuilt output and the **linkerd-pki-guardian** Deployment plus **linkerd-pki-init** Job are repinned from the old `beclab/linkerd-pki-guardian` digest to `sha256:3dbde1a3…` (verified 0.1.2 multi-arch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a82a349ef44016cea52116a8d921e86da05ca53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->