### PR TITLE
docs: enhance sitemap handling by adding noindex for specific routes and redirect sources

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,11 +3,31 @@ import { withMermaid } from "vitepress-plugin-mermaid";
 import { en } from "./en";
 import { zh } from "./zh";
 import _ from "lodash";
+import { redirects, temporaryRedirects } from "./theme/redirects";
 //import defaultConfig from 'vitepress-versioning-plugin';
 
 // Paths collected during transformPageData so sitemap.transformItems can
 // filter them out without re-reading frontmatter from disk.
 const noindexPaths = new Set<string>();
+
+// Normalize a route/path to the extensionless, slash-trimmed form used for
+// sitemap comparisons (works regardless of cleanUrls or trailing slashes).
+const normalizeRoute = (p: string) =>
+  p.replace(/^\/+/, "").replace(/\.html$/, "").replace(/\/$/, "");
+
+// Every path that 301/302-redirects at the edge (see theme/redirects.ts) must
+// be kept out of sitemap.xml: a sitemap URL that redirects is flagged by Google
+// as "Page with redirect" and wastes crawl budget.
+const redirectSources = new Set<string>(
+  [...Object.keys(redirects), ...Object.keys(temporaryRedirects)].map(normalizeRoute)
+);
+
+// Deep, low-value reference pages that inflate "Discovered – currently not
+// indexed" without real search demand. noindex them in both locales so crawl
+// budget concentrates on the pages users actually search for. Matched against
+// the locale-stripped route (so it covers /docs/... and /docs/zh/... alike).
+const noindexRoutePattern =
+  /^developer\/contribute\/olares-id\/(contract|verifiable-credential)\//;
 
 // Archived (non-latest) versioned doc builds deploy under /docs/<version>/
 // (e.g. /docs/1.12.4/...) and duplicate the latest docs almost verbatim,
@@ -145,7 +165,9 @@ export default defineVersionedConfig2(withMermaid({
     // we don't shift source line numbers, which would break `@include` ranges
     // in files that embed this one as a snippet.
     // Archived versioned builds noindex every page (see isArchivedVersionBuild).
-    if (isArchivedVersionBuild || pageData.frontmatter?.noindex) {
+    const localeStrippedRoute = pageData.relativePath.replace(/^zh\//, "");
+    const noindexByPath = noindexRoutePattern.test(localeStrippedRoute);
+    if (isArchivedVersionBuild || pageData.frontmatter?.noindex || noindexByPath) {
       pageData.frontmatter.head ??= [];
       pageData.frontmatter.head.push([
         'meta',
@@ -204,6 +226,9 @@ export default defineVersionedConfig2(withMermaid({
         // Repo READMEs are srcExclude'd above, but guard the sitemap too so a
         // stray /docs/README (or nested README) can never leak back in.
         if (p === 'README' || p.endsWith('/README')) return false;
+        // Drop URLs that 301/302-redirect at the edge — a sitemap entry that
+        // redirects is what Google reports as "Page with redirect".
+        if (redirectSources.has(p.replace(/\/$/, ''))) return false;
         return !noindexPaths.has(p);
       }),
   },


### PR DESCRIPTION
* **Background**
- Implemented normalization for routes to improve sitemap comparisons.
- Added logic to exclude URLs that redirect from the sitemap to optimize crawl budget.
- Introduced a pattern to noindex low-value reference pages in both English and Chinese locales.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress config for sitemap and robots meta; no runtime product or auth behavior changes.
> 
> **Overview**
> Tightens **VitePress SEO** in `config.mts` so crawlers spend budget on real doc pages instead of redirects and deep reference stubs.
> 
> **Sitemap:** Imports `redirects` / `temporaryRedirects`, normalizes their source paths, and **drops those URLs from `sitemap.xml`** so Google does not see “Page with redirect” entries.
> 
> **Robots:** Adds a **locale-agnostic path pattern** for `developer/contribute/olares-id/(contract|verifiable-credential)/…` so matching pages get **`noindex, nofollow`** (and stay out of the sitemap via the existing `noindexPaths` flow), in both English and Chinese builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6192de77a351bddfaf70b13f58702fa6b0ba43d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->