### PR TITLE
fix(appservice): third-level, third-party conflict check

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -170,7 +170,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.2
+        image: beclab/app-service:0.6.7
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -21,6 +21,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/tapr"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"github.com/beclab/api/pkg/generated/clientset/versioned"
 
 	"github.com/emicklei/go-restful/v3"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -177,6 +178,22 @@ func (h *Handler) setupAppEntranceDomain(req *restful.Request, resp *restful.Res
 	merge := make(map[string]interface{})
 
 	keys := []string{"third_level_domain", "third_party_domain"}
+
+	// Reject the request if the caller is trying to set a domain that is
+	// already taken. third_party_domain (a full custom domain) must be
+	// globally unique across every user and app; third_level_domain only
+	// needs to be unique within the caller's own apps because it resolves
+	// to "<prefix>.<caller-zone>" and the zone is bound to the user. Only
+	// the values the caller explicitly provided are checked so a re-save
+	// of the untouched sibling field is not flagged against itself.
+	if ok {
+		reqThirdLevel, _ := customDomain["third_level_domain"].(string)
+		reqThirdParty, _ := customDomain["third_party_domain"].(string)
+		if err = checkEntranceDomainDuplicate(req.Request.Context(), kclient.AppClient, caller, appCopy.Spec.Name, entranceName, reqThirdLevel, reqThirdParty); err != nil {
+			api.HandleBadRequest(resp, req, err)
+			return
+		}
+	}
 
 	if len(existing) > 0 {
 		var origins map[string]interface{}
@@ -342,6 +359,267 @@ func (h *Handler) setupAppEntranceDomain(req *restful.Request, resp *restful.Res
 	// Respond with the caller's effective view so the UI sees their own
 	// customDomain entries (the global Spec.Settings is admin-only for v3).
 	resp.WriteAsJson(appUpdated.EffectiveSettings(caller))
+}
+
+// reservedThirdLevelDomains are subdomain prefixes owned by system apps
+// (auth.<zone>, desktop.<zone>, wizard-<user>.<zone>, ...) that a caller
+// must never be able to claim as a custom third_level_domain. Keys are
+// lower-cased for case-insensitive matching.
+var reservedThirdLevelDomains = map[string]struct{}{
+	"auth":    {},
+	"desktop": {},
+	"wizard":  {},
+}
+
+// entranceCustomDomain is the per-entrance shape stored under the
+// "customDomain" settings key: {"third_level_domain": "", "third_party_domain": ""}.
+type entranceCustomDomain struct {
+	thirdLevel string
+	thirdParty string
+}
+
+// parseCustomDomain decodes a "customDomain" settings blob
+// ({"<entrance>": {"third_level_domain": "", "third_party_domain": ""}})
+// into a per-entrance map. A malformed or empty blob yields an empty map.
+func parseCustomDomain(blob string) map[string]entranceCustomDomain {
+	out := make(map[string]entranceCustomDomain)
+	if blob == "" {
+		return out
+	}
+	var raw map[string]map[string]interface{}
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		klog.Warningf("failed to parse customDomain blob for duplicate check: %v", err)
+		return out
+	}
+	for entrance, cfg := range raw {
+		tl, _ := cfg["third_level_domain"].(string)
+		tp, _ := cfg["third_party_domain"].(string)
+		out[entrance] = entranceCustomDomain{thirdLevel: tl, thirdParty: tp}
+	}
+	return out
+}
+
+// ownedCustomDomainBlob is a customDomain blob tagged with the user it belongs
+// to: the install owner for the global Spec.Settings entry, or the map key for
+// a per-user Spec.UserSettings overlay.
+type ownedCustomDomainBlob struct {
+	owner string
+	blob  string
+}
+
+// allCustomDomainBlobs returns every customDomain blob stored on the app —
+// the global Spec.Settings entry (owner = install owner) plus every per-user
+// overlay in Spec.UserSettings (owner = the user key) — each tagged with its
+// owner. Used for the global third_party_domain uniqueness scan, where the
+// owner is needed to skip only the caller's own entry: a shared app lets each
+// user set their own third_party per entrance, so other users' overlays on the
+// same entrance must still be enforced.
+func allCustomDomainBlobs(app *v1alpha1.Application) []ownedCustomDomainBlob {
+	blobs := make([]ownedCustomDomainBlob, 0)
+	if b := app.Spec.Settings["customDomain"]; b != "" {
+		blobs = append(blobs, ownedCustomDomainBlob{owner: app.Spec.Owner, blob: b})
+	}
+	for user, us := range app.Spec.UserSettings {
+		if b := us["customDomain"]; b != "" {
+			blobs = append(blobs, ownedCustomDomainBlob{owner: user, blob: b})
+		}
+	}
+	return blobs
+}
+
+// callerCustomDomainBlob returns the customDomain blob that resolves under the
+// caller's zone for the given app. It must match the effective view the domain
+// handler itself uses (EffectiveSettings(caller)):
+//   - shared app: the caller's Spec.UserSettings[caller] overlay when present,
+//     otherwise the global Spec.Settings default — both are effective in the
+//     caller's zone, so a prefix present only in the global blob still counts;
+//   - per-user app the caller owns: the global Spec.Settings entry.
+//
+// Other users' entries live under their own zones and are irrelevant to the
+// caller's third_level_domain scope, so per-user apps not owned by the caller
+// contribute nothing.
+func callerCustomDomainBlob(app *v1alpha1.Application, caller string) string {
+	if appcfg.IsShared(app) {
+		// EffectiveSettings overlays UserSettings[caller] onto Spec.Settings,
+		// falling back to the global customDomain when the caller has no
+		// per-user override — exactly what resolves in the caller's zone.
+		return app.EffectiveSettings(caller)["customDomain"]
+	}
+	if app.Spec.Owner == caller {
+		return app.Spec.Settings["customDomain"]
+	}
+	return ""
+}
+
+// defaultThirdLevelPrefixes returns the live default third-level subdomain
+// prefix of every entrance of the app, mirroring the URL generation in
+// GenEntranceURL / EntrancesWithZone (and the gateway's resolveEntrancePrefix):
+//   - a single-entrance app always uses the bare "<appid>" and ignores any
+//     defaultThirdLevelDomainConfig override;
+//   - a multi-entrance app uses the configured thirdLevelDomain for an entrance
+//     when present, otherwise the positional "<appid><i>".
+//
+// These are the domains a caller-supplied third_level_domain must not collide
+// with. Resolving per entrance (rather than pre-filling then overriding) keeps
+// the result limited to entrances that actually exist on the app.
+func defaultThirdLevelPrefixes(app *v1alpha1.Application) map[string]string {
+	out := make(map[string]string)
+	appid := strings.ToLower(strings.TrimSpace(app.Spec.Appid))
+	if appid == "" {
+		return out
+	}
+
+	var cfgs []appcfg.DefaultThirdLevelDomainConfig
+	if raw := app.Spec.Settings["defaultThirdLevelDomainConfig"]; raw != "" {
+		if err := json.Unmarshal([]byte(raw), &cfgs); err != nil {
+			klog.Warningf("failed to parse defaultThirdLevelDomainConfig for duplicate check: %v", err)
+		}
+	}
+
+	for i := range app.Spec.Entrances {
+		out[app.Spec.Entrances[i].Name] = resolveDefaultThirdLevelPrefix(app.Spec.Entrances, i, appid, app.Spec.Name, cfgs)
+	}
+	return out
+}
+
+func resolveDefaultThirdLevelPrefix(entrances []v1alpha1.Entrance, index int, appid, appName string, cfgs []appcfg.DefaultThirdLevelDomainConfig) string {
+	for _, cfg := range cfgs {
+		if cfg.AppName == appName && cfg.EntranceName == entrances[index].Name && cfg.ThirdLevelDomain != "" {
+			return cfg.ThirdLevelDomain
+		}
+	}
+	if len(entrances) == 1 {
+		return appid
+	}
+	return fmt.Sprintf("%s%d", appid, index)
+}
+
+// checkEntranceDomainDuplicate reports an error when the requested
+// third_level_domain / third_party_domain for (currentApp, currentEntrance)
+// is already taken. thirdLevel/thirdParty are the raw requested values; an
+// empty value is skipped. The (currentApp, currentEntrance) entrance itself
+// is excluded so re-saving an unchanged value is never a conflict.
+func checkEntranceDomainDuplicate(ctx context.Context, appClient versioned.Interface, caller, currentApp, currentEntrance, thirdLevel, thirdParty string) error {
+	thirdLevel = strings.TrimSpace(thirdLevel)
+	thirdParty = strings.TrimSpace(thirdParty)
+	if thirdLevel == "" && thirdParty == "" {
+		return nil
+	}
+
+	applist, err := appClient.AppV1alpha1().Applications().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	return findEntranceDomainConflict(applist.Items, caller, currentApp, currentEntrance, thirdLevel, thirdParty)
+}
+
+// domainRecord is one already-claimed entrance domain, flattened out of the
+// whole cluster so the conflict check is a single linear scan.
+//   - thirdParty is compared globally (across every user and app);
+//   - thirdLevel is only compared when inCallerZone, i.e. the value resolves
+//     under the caller's own zone, because third_level_domain expands to
+//     "<prefix>.<caller-zone>" and the zone is bound to the user;
+//   - isSelf marks the exact entry the caller is editing (same app + entrance,
+//     owned by the caller) so re-saving an unchanged value never conflicts;
+//   - isDefault marks a synthesized default subdomain (appid / appid<i>) rather
+//     than a user-set value, so the error can say so.
+type domainRecord struct {
+	app          string
+	entrance     string
+	thirdLevel   string
+	thirdParty   string
+	inCallerZone bool
+	isSelf       bool
+	isDefault    bool
+}
+
+// collectDomainRecords flattens every claimed entrance domain in the cluster
+// into a single slice, tagging each record with the scope flags the conflict
+// scan needs (see domainRecord). currentApp/currentEntrance identify the entry
+// being edited so it can be excluded.
+func collectDomainRecords(apps []v1alpha1.Application, caller, currentApp, currentEntrance string) []domainRecord {
+	records := make([]domainRecord, 0)
+	for i := range apps {
+		app := &apps[i]
+
+		// Global third_party scope: every stored blob, tagged with the user
+		// that actually set it so only the caller's own target entry is
+		// treated as self (a same-named install owned by another user, or
+		// another user's overlay on a shared app, still counts).
+		for _, ob := range allCustomDomainBlobs(app) {
+			for entrance, cfg := range parseCustomDomain(ob.blob) {
+				records = append(records, domainRecord{
+					app:        app.Spec.Name,
+					entrance:   entrance,
+					thirdParty: cfg.thirdParty,
+					isSelf:     app.Spec.Name == currentApp && entrance == currentEntrance && ob.owner == caller,
+				})
+			}
+		}
+
+		// Caller-zone third_level scope: the blob effective in the caller's
+		// zone (their overlay, or the shared/global default they inherit).
+		for entrance, cfg := range parseCustomDomain(callerCustomDomainBlob(app, caller)) {
+			records = append(records, domainRecord{
+				app:          app.Spec.Name,
+				entrance:     entrance,
+				thirdLevel:   cfg.thirdLevel,
+				inCallerZone: true,
+				isSelf:       app.Spec.Name == currentApp && entrance == currentEntrance,
+			})
+		}
+
+		// Default subdomains (appid / appid<i>) resolve in the caller's zone
+		// for shared apps and for per-user apps the caller owns; other users'
+		// per-user apps render under their own zones and cannot collide.
+		if appcfg.IsShared(app) || app.Spec.Owner == caller {
+			for entrance, prefix := range defaultThirdLevelPrefixes(app) {
+				records = append(records, domainRecord{
+					app:          app.Spec.Name,
+					entrance:     entrance,
+					thirdLevel:   prefix,
+					inCallerZone: true,
+					isDefault:    true,
+					isSelf:       app.Spec.Name == currentApp && entrance == currentEntrance,
+				})
+			}
+		}
+	}
+	return records
+}
+
+// findEntranceDomainConflict is the pure comparison core of
+// checkEntranceDomainDuplicate: given the full set of applications it reports
+// the first conflict for the requested third_level_domain / third_party_domain
+// of (currentApp, currentEntrance). thirdLevel/thirdParty are already trimmed
+// and at least one is non-empty. The (currentApp, currentEntrance) entrance is
+// excluded so re-saving an unchanged value is never a conflict.
+func findEntranceDomainConflict(apps []v1alpha1.Application, caller, currentApp, currentEntrance, thirdLevel, thirdParty string) error {
+	// Reserved system subdomains (auth.<zone>, desktop.<zone>,
+	// wizard-<user>.<zone>, ...) can never be claimed as a custom
+	// third-level domain regardless of which apps exist.
+	if thirdLevel != "" {
+		if _, ok := reservedThirdLevelDomains[strings.ToLower(thirdLevel)]; ok {
+			return fmt.Errorf("third_level_domain %q is reserved and cannot be used", thirdLevel)
+		}
+	}
+
+	for _, r := range collectDomainRecords(apps, caller, currentApp, currentEntrance) {
+		if r.isSelf {
+			continue
+		}
+		if thirdParty != "" && r.thirdParty != "" && strings.EqualFold(r.thirdParty, thirdParty) {
+			return fmt.Errorf("third_party_domain %q is already used by entrance %q of app %q", thirdParty, r.entrance, r.app)
+		}
+		if thirdLevel != "" && r.inCallerZone && r.thirdLevel != "" && strings.EqualFold(r.thirdLevel, thirdLevel) {
+			if r.isDefault {
+				return fmt.Errorf("third_level_domain %q conflicts with the default domain of entrance %q of app %q", thirdLevel, r.entrance, r.app)
+			}
+			return fmt.Errorf("third_level_domain %q is already used by entrance %q of app %q", thirdLevel, r.entrance, r.app)
+		}
+	}
+	return nil
 }
 
 func (h *Handler) getAppEntrances(req *restful.Request, resp *restful.Response) {

--- a/framework/app-service/pkg/apiserver/handler_settings_domain_test.go
+++ b/framework/app-service/pkg/apiserver/handler_settings_domain_test.go
@@ -1,0 +1,398 @@
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"github.com/beclab/api/pkg/generated/clientset/versioned"
+	appfake "github.com/beclab/api/pkg/generated/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// dcApp builds an Application fixture for the domain-duplicate tests. The CR
+// metadata.Name is derived as "<specName>-<owner>" so per-user installs of the
+// same app name can coexist in the fake client, while the conflict logic
+// matches on Spec.Name. Shared apps also carry the v3 api-version label so the
+// EffectiveSettings overlay (used by callerCustomDomainBlob for shared apps)
+// actually applies the per-user Spec.UserSettings.
+func dcApp(specName, owner, appid string, shared bool, entrances ...string) *v1alpha1.Application {
+	labels := map[string]string{}
+	if shared {
+		labels[constants.AppSharedLabel] = constants.AppSharedTrue
+		labels[constants.AppApiVersionLabel] = constants.AppVersionV3
+	}
+	ents := make([]v1alpha1.Entrance, 0, len(entrances))
+	for _, e := range entrances {
+		ents = append(ents, v1alpha1.Entrance{Name: e})
+	}
+	return &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   specName + "-" + owner,
+			Labels: labels,
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Name:      specName,
+			Owner:     owner,
+			Appid:     appid,
+			Entrances: ents,
+		},
+	}
+}
+
+func customDomainJSON(t *testing.T, entries map[string]map[string]string) string {
+	t.Helper()
+	b, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal customDomain blob: %v", err)
+	}
+	return string(b)
+}
+
+// setCustomDomain writes the global Spec.Settings customDomain entry for an
+// entrance. This is the real store only for a per-user (non-shared) app owned
+// by the caller; shared apps keep each user's customDomain in a per-user
+// Spec.UserSettings overlay instead (see setUserCustomDomain).
+func setCustomDomain(t *testing.T, a *v1alpha1.Application, entrance, thirdLevel, thirdParty string) *v1alpha1.Application {
+	t.Helper()
+	if a.Spec.Settings == nil {
+		a.Spec.Settings = map[string]string{}
+	}
+	a.Spec.Settings["customDomain"] = customDomainJSON(t, map[string]map[string]string{
+		entrance: {"third_level_domain": thirdLevel, "third_party_domain": thirdParty},
+	})
+	return a
+}
+
+// setUserCustomDomain writes a per-user Spec.UserSettings overlay customDomain
+// entry (the value effective in that specific user's zone for a shared app).
+func setUserCustomDomain(t *testing.T, a *v1alpha1.Application, user, entrance, thirdLevel, thirdParty string) *v1alpha1.Application {
+	t.Helper()
+	if a.Spec.UserSettings == nil {
+		a.Spec.UserSettings = map[string]map[string]string{}
+	}
+	if a.Spec.UserSettings[user] == nil {
+		a.Spec.UserSettings[user] = map[string]string{}
+	}
+	a.Spec.UserSettings[user]["customDomain"] = customDomainJSON(t, map[string]map[string]string{
+		entrance: {"third_level_domain": thirdLevel, "third_party_domain": thirdParty},
+	})
+	return a
+}
+
+// setDefaultThirdLevelConfig sets the defaultThirdLevelDomainConfig blob that
+// overrides the positional "<appid><i>" default for a specific entrance of a
+// multi-entrance app.
+func setDefaultThirdLevelConfig(t *testing.T, a *v1alpha1.Application, appName, entrance, thirdLevel string) *v1alpha1.Application {
+	t.Helper()
+	if a.Spec.Settings == nil {
+		a.Spec.Settings = map[string]string{}
+	}
+	cfg := []map[string]string{{
+		"appName":          appName,
+		"entranceName":     entrance,
+		"thirdLevelDomain": thirdLevel,
+	}}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal defaultThirdLevelDomainConfig: %v", err)
+	}
+	a.Spec.Settings["defaultThirdLevelDomainConfig"] = string(b)
+	return a
+}
+
+func newDomainClient(objs ...*v1alpha1.Application) versioned.Interface {
+	ro := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		ro = append(ro, o)
+	}
+	return appfake.NewSimpleClientset(ro...)
+}
+
+// Both requested values empty (or whitespace-only) short-circuit before any
+// listing: the check returns nil without touching the API server. The list
+// reactor is wired to fail so the test also proves listing never happens.
+func TestCheckEntranceDomainDuplicate_EmptyInputsSkipListing(t *testing.T) {
+	client := appfake.NewSimpleClientset()
+	client.PrependReactor("list", "applications", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("list must not be called for empty inputs")
+	})
+
+	cases := []struct{ tl, tp string }{
+		{"", ""},
+		{"   ", "\t"},
+		{" ", ""},
+	}
+	for _, c := range cases {
+		if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", c.tl, c.tp); err != nil {
+			t.Fatalf("empty/whitespace inputs must skip listing and return nil, got %v", err)
+		}
+	}
+}
+
+// A failure listing applications is surfaced verbatim to the caller.
+func TestCheckEntranceDomainDuplicate_ListError(t *testing.T) {
+	client := appfake.NewSimpleClientset()
+	client.PrependReactor("list", "applications", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("list boom")
+	})
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "wanted", "")
+	if err == nil || !strings.Contains(err.Error(), "list boom") {
+		t.Fatalf("expected list error to propagate, got %v", err)
+	}
+}
+
+// Reserved system subdomains can never be claimed as a third_level_domain,
+// regardless of which apps exist, and the match is case-insensitive.
+func TestCheckEntranceDomainDuplicate_ReservedThirdLevel(t *testing.T) {
+	client := newDomainClient()
+	for _, name := range []string{"auth", "desktop", "wizard", "AUTH", "Desktop", "WIZARD"} {
+		err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", name, "")
+		if err == nil || !strings.Contains(err.Error(), "reserved") {
+			t.Fatalf("third_level_domain %q must be rejected as reserved, got %v", name, err)
+		}
+	}
+}
+
+// The reserved-subdomain guard only applies to third_level_domain; the same
+// string is a perfectly valid third_party_domain when nothing else claims it.
+func TestCheckEntranceDomainDuplicate_ReservedDoesNotBlockThirdParty(t *testing.T) {
+	client := newDomainClient()
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "", "auth"); err != nil {
+		t.Fatalf("reserved names must not block a third_party_domain, got %v", err)
+	}
+}
+
+// third_party_domain uniqueness is global (across every user and zone): a value
+// already claimed by a different app anywhere blocks the request.
+func TestCheckEntranceDomainDuplicate_ThirdPartyConflictOtherApp(t *testing.T) {
+	other := setCustomDomain(t, dcApp("other", "bob", "otherid", false, "web"), "web", "", "example.com")
+	client := newDomainClient(other)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "", "example.com")
+	if err == nil || !strings.Contains(err.Error(), "third_party_domain") {
+		t.Fatalf("expected third_party_domain conflict, got %v", err)
+	}
+}
+
+// third_party match is case-insensitive.
+func TestCheckEntranceDomainDuplicate_ThirdPartyConflictCaseInsensitive(t *testing.T) {
+	other := setCustomDomain(t, dcApp("other", "bob", "otherid", false, "web"), "web", "", "Example.COM")
+	client := newDomainClient(other)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "", "example.com")
+	if err == nil || !strings.Contains(err.Error(), "third_party_domain") {
+		t.Fatalf("expected case-insensitive third_party_domain conflict, got %v", err)
+	}
+}
+
+// On a shared app each user sets their own third_party overlay per entrance.
+// Another user's overlay on the same app+entrance still counts as a conflict
+// for the caller, because third_party is compared globally and only the
+// caller's OWN overlay is treated as self.
+func TestCheckEntranceDomainDuplicate_ThirdPartyConflictOtherUsersOverlay(t *testing.T) {
+	app := dcApp("cloud", "alice", "cloudid", true, "web")
+	setUserCustomDomain(t, app, "bob", "web", "", "bob.example.com")
+	client := newDomainClient(app)
+
+	// alice edits the very same shared entrance and asks for the value bob
+	// already claimed in his zone -> conflict.
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "cloud", "web", "", "bob.example.com")
+	if err == nil || !strings.Contains(err.Error(), "third_party_domain") {
+		t.Fatalf("expected conflict against another user's overlay, got %v", err)
+	}
+}
+
+// Re-saving the caller's own existing third_party value on the entry being
+// edited is never a conflict (isSelf excludes it via owner==caller).
+func TestCheckEntranceDomainDuplicate_ThirdPartySelfIsNotConflict(t *testing.T) {
+	app := dcApp("cloud", "alice", "cloudid", true, "web")
+	setUserCustomDomain(t, app, "bob", "web", "", "bob.example.com")
+	client := newDomainClient(app)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "bob", "cloud", "web", "", "bob.example.com")
+	if err != nil {
+		t.Fatalf("re-saving own third_party value must not conflict, got %v", err)
+	}
+}
+
+// third_level_domain uniqueness is scoped to the caller's zone. A value already
+// used by another entrance's custom domain that resolves in the caller's zone
+// is a conflict, reported as "already used by entrance" (non-default).
+func TestCheckEntranceDomainDuplicate_ThirdLevelConflictCustomDomain(t *testing.T) {
+	// per-user app owned by the caller: its Spec.Settings customDomain
+	// resolves in the caller's own zone.
+	a := setCustomDomain(t, dcApp("one", "alice", "oneid", false, "web"), "web", "taken", "")
+	client := newDomainClient(a)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "two", "x", "taken", "")
+	if err == nil {
+		t.Fatalf("expected third_level conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "already used by entrance") {
+		t.Fatalf("custom-domain collision should report 'already used by entrance', got %q", err.Error())
+	}
+}
+
+// Leading/trailing whitespace on the requested value is trimmed before the
+// comparison, so a padded request still collides.
+func TestCheckEntranceDomainDuplicate_ThirdLevelTrimmedBeforeCompare(t *testing.T) {
+	a := setCustomDomain(t, dcApp("one", "alice", "oneid", false, "web"), "web", "taken", "")
+	client := newDomainClient(a)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "two", "x", "   taken  ", "")
+	if err == nil || !strings.Contains(err.Error(), "already used by entrance") {
+		t.Fatalf("whitespace-padded third_level must still collide, got %v", err)
+	}
+}
+
+// A third_level_domain colliding with the DEFAULT subdomain of a shared app
+// (which renders in every user's zone) is a conflict reported as "conflicts
+// with the default domain". A single-entrance app uses the bare "<appid>".
+func TestCheckEntranceDomainDuplicate_ThirdLevelConflictSharedDefault(t *testing.T) {
+	shared := dcApp("cloud", "admin", "cloudid", true, "web")
+	client := newDomainClient(shared)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "cloudid", "")
+	if err == nil {
+		t.Fatalf("expected default-domain conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "default domain") {
+		t.Fatalf("shared default collision should mention the default domain, got %q", err.Error())
+	}
+}
+
+// The default subdomain of a per-user app the caller OWNS also resolves in the
+// caller's zone and therefore collides.
+func TestCheckEntranceDomainDuplicate_ThirdLevelConflictOwnDefault(t *testing.T) {
+	mine := dcApp("mine", "alice", "myid", false, "web")
+	client := newDomainClient(mine)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "myid", "")
+	if err == nil || !strings.Contains(err.Error(), "default domain") {
+		t.Fatalf("expected own default-domain conflict, got %v", err)
+	}
+}
+
+// Another user's per-user app renders under THEIR zone, so neither its default
+// subdomain nor its custom domain can collide with the caller's request.
+func TestCheckEntranceDomainDuplicate_ThirdLevelOtherUsersPerUserAppNoConflict(t *testing.T) {
+	hers := setCustomDomain(t, dcApp("hers", "bob", "herid", false, "web"), "web", "taken", "")
+	client := newDomainClient(hers)
+
+	// Neither the default "herid" nor the custom "taken" is in alice's zone.
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "herid", ""); err != nil {
+		t.Fatalf("other user's per-user default must not collide, got %v", err)
+	}
+
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "taken", ""); err != nil {
+		t.Fatalf("other user's per-user custom domain must not collide, got %v", err)
+	}
+}
+
+// Editing an entrance never conflicts with that same entrance's own default
+// subdomain (isSelf excludes the entry being edited).
+func TestCheckEntranceDomainDuplicate_ThirdLevelSelfDefaultSkipped(t *testing.T) {
+	shared := dcApp("cloud", "admin", "cloudid", true, "web")
+	client := newDomainClient(shared)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "cloud", "web", "cloudid", "")
+	if err != nil {
+		t.Fatalf("an entrance's own default domain must not conflict with itself, got %v", err)
+	}
+}
+
+// On a shared app each user's customDomain lives in their own per-user overlay
+// (Spec.UserSettings[user]) and resolves in that user's zone. A third_level the
+// caller already claimed on the shared app therefore collides in the caller's
+// own zone.
+func TestCheckEntranceDomainDuplicate_ThirdLevelSharedOwnOverlayConflict(t *testing.T) {
+	shared := dcApp("svc", "admin", "svcid", true, "web")
+	setUserCustomDomain(t, shared, "bob", "web", "bobdom", "")
+	client := newDomainClient(shared)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "bob", "bar", "x", "bobdom", "")
+	if err == nil || !strings.Contains(err.Error(), "already used by entrance") {
+		t.Fatalf("caller's own shared-app overlay domain must collide in their zone, got %v", err)
+	}
+}
+
+// A third_level_domain set only in ANOTHER user's per-user overlay of a shared
+// app is invisible to the caller: it resolves in that other user's zone, not
+// the caller's, so it must not collide. This is the counterpart to
+// TestCheckEntranceDomainDuplicate_ThirdLevelSharedOwnOverlayConflict — a
+// per-user overlay is scoped to that one user's zone.
+func TestCheckEntranceDomainDuplicate_ThirdLevelOtherUsersOverlayNoConflict(t *testing.T) {
+	shared := dcApp("svc", "admin", "svcid", true, "web")
+	setUserCustomDomain(t, shared, "admin", "web", "adminonly", "")
+	client := newDomainClient(shared)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "bob", "bar", "x", "adminonly", "")
+	if err != nil {
+		t.Fatalf("another user's third_level overlay must not collide in the caller's zone, got %v", err)
+	}
+}
+
+// A multi-entrance app derives positional defaults "<appid><index>"; requesting
+// any of them collides as a default-domain conflict.
+func TestCheckEntranceDomainDuplicate_ThirdLevelMultiEntranceDefault(t *testing.T) {
+	shared := dcApp("multi", "admin", "mid", true, "web", "admin")
+	client := newDomainClient(shared)
+
+	for _, want := range []string{"mid0", "mid1"} {
+		err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", want, "")
+		if err == nil || !strings.Contains(err.Error(), "default domain") {
+			t.Fatalf("positional default %q must collide, got %v", want, err)
+		}
+	}
+}
+
+// defaultThirdLevelDomainConfig overrides the positional default for a specific
+// entrance of a multi-entrance app; the overridden value is what collides.
+func TestCheckEntranceDomainDuplicate_ThirdLevelDefaultConfigOverride(t *testing.T) {
+	shared := dcApp("multi", "admin", "mid", true, "web", "admin")
+	setDefaultThirdLevelConfig(t, shared, "multi", "web", "webcustom")
+	client := newDomainClient(shared)
+
+	// The configured override collides...
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "webcustom", ""); err == nil ||
+		!strings.Contains(err.Error(), "default domain") {
+		t.Fatalf("configured default override must collide, got %v", err)
+	}
+	// ...and the positional value it replaced no longer does.
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "mid0", ""); err != nil {
+		t.Fatalf("replaced positional default must not collide, got %v", err)
+	}
+}
+
+// A value used by another entrance of the SAME app the caller is editing still
+// conflicts (only the exact edited entrance is excluded).
+func TestCheckEntranceDomainDuplicate_ThirdLevelSiblingEntranceConflict(t *testing.T) {
+	// alice claimed "webdom" on the shared app's "web" entrance (her own
+	// per-user overlay); reusing it on the sibling "admin" entrance collides.
+	shared := dcApp("cloud", "admin", "cloudid", true, "web", "admin")
+	setUserCustomDomain(t, shared, "alice", "web", "webdom", "")
+	client := newDomainClient(shared)
+
+	err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "cloud", "admin", "webdom", "")
+	if err == nil || !strings.Contains(err.Error(), "already used by entrance") {
+		t.Fatalf("sibling entrance's domain must collide, got %v", err)
+	}
+}
+
+// A fresh, unused third_level and third_party value on a clean cluster is
+// accepted.
+func TestCheckEntranceDomainDuplicate_NoConflict(t *testing.T) {
+	client := newDomainClient(dcApp("cloud", "admin", "cloudid", true, "web"))
+	if err := checkEntranceDomainDuplicate(context.Background(), client, "alice", "bar", "x", "freshdom", "fresh.example.com"); err != nil {
+		t.Fatalf("unused values must be accepted, got %v", err)
+	}
+}


### PR DESCRIPTION
* **Background**
third-level, third-party conflict check
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior of a user-facing settings API and scans all Applications on each domain update; incorrect scoping could block valid domains or allow collisions that affect routing.
> 
> **Overview**
> **Entrance custom-domain saves are validated before persistence.** `setupAppEntranceDomain` now rejects conflicting `third_level_domain` and `third_party_domain` values with HTTP 400 instead of merging and patching blindly.
> 
> **`third_party_domain`** must be unique cluster-wide across apps, users, and per-user overlays (case-insensitive). **`third_level_domain`** is checked only within the caller’s zone: shared apps, owned per-user apps, default `appid` / `appid<i>` prefixes, and `defaultThirdLevelDomainConfig` overrides. Reserved prefixes `auth`, `desktop`, and `wizard` cannot be used as third-level custom names. Re-saving the same entrance’s unchanged values is allowed.
> 
> The deploy manifest bumps **`beclab/app-service`** from **0.6.2** to **0.6.7**. Unit tests cover reserved names, global third-party conflicts, zone-scoped third-level rules, defaults, and shared vs per-user overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e7a15b6821832690ed878dc7815d45064b846e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->