### PR TITLE
docs: fix meta title and description length

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -84,6 +84,7 @@ function defineVersionedConfig2(
 // https://vitepress.dev/reference/site-config
 export default defineVersionedConfig2(withMermaid({
   title: "Olares",
+  titleTemplate: ":title | Olares Docs",
   description: "Let people own their data again",
   lang: "en",
   locales: {

--- a/docs/developer/cli-agent-skills.md
+++ b/docs/developer/cli-agent-skills.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Install and use the Olares CLI Agent Skill bundles from AI runtimes such as Cursor and Claude Code, or from Olares apps such as Hermes Agent and OpenClaw. Covers the bundles, the shared-first install order, and end-to-end usage.
+description: Install Olares CLI Agent Skills for Cursor, Claude Code, Hermes Agent, and OpenClaw. Learn bundle contents, install order, and end-to-end usage.
 ---
 
 # Install and use Agent Skills

--- a/docs/developer/cli-install.md
+++ b/docs/developer/cli-install.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Install and update olares-cli with npm or npx. Covers the first-run wizard, a persistent install, one-off runs, and the special case of a machine that already runs Olares OS.
+description: Install or update olares-cli with npm or npx. Follow the first-run wizard, choose persistent or one-off use, and handle hosts already running Olares OS.
 ---
 
 # Install olares-cli

--- a/docs/developer/cli-log-in.md
+++ b/docs/developer/cli-log-in.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Log in to Olares from olares-cli and manage profiles. Covers the interactive login, listing and switching profiles, removing a profile, and where tokens are stored.
+description: Log in to Olares with olares-cli and manage profiles. Learn interactive login, profile switching and removal, and where authentication tokens are stored.
 ---
 
 # Log in to Olares

--- a/docs/developer/concepts/account.md
+++ b/docs/developer/concepts/account.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Core principles of Olares account system, including synchronization mechanisms, account stages and unified authentication. Covers multi-factor authentication and multi-device sync fundamentals.
+description: Understand the Olares account system, from account stages and synchronization to unified authentication, multi-factor security, and multi-device sync.
 ---
 
 # Olares account system

--- a/docs/developer/concepts/application.md
+++ b/docs/developer/concepts/application.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Fundamental concepts of Olares application system, explaining application identifiers and characteristics of four application types such as cluster-scoped applications. Includes service provider mechanisms and application dependencies.
+description: Understand Olares applications, including app identifiers, four application types, cluster scope, service providers, and application dependencies.
 ---
 
 # Applications

--- a/docs/developer/concepts/architecture.md
+++ b/docs/developer/concepts/architecture.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: Overview of Olares BEC architecture, explaining distributed node implementation for data storage and security. Details three core components Olares ID, Olares OS and LarePass.
+description: "Explore Olares BEC architecture and its distributed approach to data storage and security across three components: Olares ID, Olares OS, and LarePass."
 ---
 # Olares BEC architecture
 

--- a/docs/developer/concepts/data.md
+++ b/docs/developer/concepts/data.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Olares data management architecture, explaining file system types, application storage paths and database support. Covers technical specifications of JuiceFS, PostgreSQL, MongoDB and Redis.
+description: Explore Olares data architecture, including file system types, app storage paths, databases, and support for JuiceFS, PostgreSQL, MongoDB, and Redis.
 ---
 
 # Data

--- a/docs/developer/concepts/faq.md
+++ b/docs/developer/concepts/faq.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: Answers to common questions about Olares ID, including its relationship to World ID and the differences between DID metadata, verifiable credentials, and reputation.
+description: Find answers to common Olares ID questions, including how it relates to World ID and how DID metadata, verifiable credentials, and reputation differ.
 outline: [2, 3]
 ---
 

--- a/docs/developer/concepts/index.md
+++ b/docs/developer/concepts/index.md
@@ -1,5 +1,5 @@
 ---
-description: Core concepts documentation of Olares system, covering architecture design, identity authentication, application management, network configuration and data security fundamentals for developers.
+description: Explore core Olares concepts for developers, including system architecture, identity, application management, networking, and data security.
 ---
 # Overview
 
@@ -19,5 +19,4 @@ Understand Olares with the following concepts:
 - [Network](network.md)
 - [Data](data.md)
 - [Secrets](secrets.md)
-
 

--- a/docs/developer/concepts/network.md
+++ b/docs/developer/concepts/network.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Olares network architecture principles, covering application entrance types, local access mechanisms, endpoint configurations and internal network security policies.
+description: Understand Olares network architecture, including application entrances, local access, endpoint configuration, and internal network security policies.
 ---
 # Network
 

--- a/docs/developer/concepts/olares-id.md
+++ b/docs/developer/concepts/olares-id.md
@@ -1,5 +1,5 @@
 ---
-description: Definition, structure and purpose of Olares ID system. Covers personal ID types, domain categories and relationship principles with decentralized identifiers (DID).
+description: Understand Olares ID, including its structure, personal ID types, domain categories, and relationship to decentralized identifiers (DIDs).
 ---
 # Olares ID
 

--- a/docs/developer/concepts/secrets.md
+++ b/docs/developer/concepts/secrets.md
@@ -1,5 +1,5 @@
 ---
-description: Olares secrets management system principles, detailing vault items, credentials, secrets and integration credentials classification. Explains sensitive data storage strategies.
+description: Understand Olares secret management, including vault items, credentials, integration credentials, classifications, and secure storage strategies.
 ---
 # Secret management
 

--- a/docs/developer/concepts/system-architecture.md
+++ b/docs/developer/concepts/system-architecture.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Comprehensive guide to Olares architecture covering infrastructure, platform services, and application framework. Learn about container orchestration, storage, networking, and system components.
+description: Explore Olares system architecture across infrastructure, platform services, and the app framework, including orchestration, storage, and networking.
 ---
 
 # Olares system architecture

--- a/docs/developer/concepts/wallet.md
+++ b/docs/developer/concepts/wallet.md
@@ -1,5 +1,5 @@
 ---
-description: A Digital Identity Wallet is an essential tool in the self-sovereign identity ecosystem, allowing users to manage their decentralized identifiers (DIDs), credentials, and interactions with digital ser…
+description: Understand the Olares Identity Wallet and how it manages decentralized identifiers (DIDs), verifiable credentials, and digital identity interactions.
 ---
 # Identity Wallet App
 

--- a/docs/developer/develop/advanced/account.md
+++ b/docs/developer/develop/advanced/account.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: If an app in Olares wants to use the system user as the app's user, it can obtain the user information by defining a SysEventRegistry in application chart to receive system user event callbacks.
+description: Subscribe apps to Olares user events with SysEventRegistry. Learn how application charts receive system user callbacks and use Olares accounts.
 ---
 # Subscribe to Olares user events
 

--- a/docs/developer/develop/advanced/cli/olares-install.md
+++ b/docs/developer/develop/advanced/cli/olares-install.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: The olares install command installs Olares on your system. It supports various options to customize the installation process, such as specifying directories, Kubernetes types, or Minikube profiles.
+description: Use the olares install command with custom directories, Kubernetes distributions, Minikube profiles, and other Olares deployment options.
 ---
 # `olares install`
 
@@ -20,4 +20,3 @@ olares-cli olares install [option]
 | `--kube`     |           | Specifies the Kubernetes type. <br>Supported types are `k3s` (default) and `k8s`.                                                                                                                                                                     |
 | `--profile`  | `-p`      | Sets the Minikube profile name. Only applicable on macOS. <br> Defaults to `olares-0`.                                                                                                                                                                |
 | `--version`  | `-v`      | Specifies the Olares version. <br>Version values follow the format `x.y.z` (e.g., `1.10.0`) or include a build date (e.g., `1.10.0-20241109`).<br> Refer to the [GitHub Releases page](https://github.com/beclab/Olares/releases) for available versions. |
-

--- a/docs/developer/develop/advanced/market.md
+++ b/docs/developer/develop/advanced/market.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: To install or uninstall apps in developing applications (for example, third-party Market extensions), developers can use the install and uninstall API provided by the Market.
+description: Use the Olares Market API to install or uninstall apps during development, including apps that extend Market with third-party packages.
 ---
 # Market
 

--- a/docs/developer/develop/app-env-index.md
+++ b/docs/developer/develop/app-env-index.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how variables are injected during Olares app deployment, including declarative environment variables (.Values.olaresEnv) and system-injected runtime Helm values (.Values.*).
+description: Learn how Olares injects app environment variables through declarative .Values.olaresEnv settings and system-provided .Values runtime values.
 ---
 
 # Environment variables overview

--- a/docs/developer/develop/package/recommend.md
+++ b/docs/developer/develop/package/recommend.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: "When creating an application chart for recommend, you'll primarily need to configure the four files located in the templates/ folder: embedding.yaml, prerank.yaml, rank.yaml, train.yaml."
+description: Configure an Olares Recommend application chart with embedding, prerank, rank, and train templates for recommendation workflows.
 ---
 # Configuration Guideline for Recommend
 

--- a/docs/developer/install/cli/gpu.md
+++ b/docs/developer/install/cli/gpu.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: The gpu command manages GPU-related operations, including installing, enabling, disabling, and uninstalling GPU drivers and related components, as well as checking the GPU status.
+description: Use the olares-cli gpu command to install, enable, disable, or remove GPU drivers and components, and check GPU status in Olares.
 ---
 # `gpu`
 
@@ -54,5 +54,4 @@ olares-cli gpu disable
 # Uninstall GPU drivers and components
 olares-cli gpu uninstall
 ```
-
 

--- a/docs/developer/install/cli/install.md
+++ b/docs/developer/install/cli/install.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: The install command installs Olares on your system. It supports various options to customize the installation process, such as specifying directories, Kubernetes types, or Minikube profiles.
+description: Use the olares-cli install command to deploy Olares with custom directories, Kubernetes distributions, Minikube profiles, and other options.
 ---
 # `install`
 

--- a/docs/developer/install/environment-variables.md
+++ b/docs/developer/install/environment-variables.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Environment variables available in Olares for customizing networking, authentication, GPU support and other features. Includes configuration examples and specifications.
+description: Configure Olares with environment variables for networking, authentication, GPU support, and other installation features, with examples.
 ---
 # Olares environment variables
 

--- a/docs/developer/install/index.md
+++ b/docs/developer/install/index.md
@@ -1,5 +1,5 @@
 ---
-description: Cluster management with olares-cli. How Olares is installed, where its files are stored, which environment variables tune the install, how Olares is versioned, and the alphabetical command reference.
+description: Manage Olares clusters with olares-cli. Learn installation paths, environment variables, versioning, and available cluster commands.
 ---
 # Cluster management
 

--- a/docs/developer/install/installation-overview.md
+++ b/docs/developer/install/installation-overview.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Core architecture of Olares deployment across native system layer, Kubernetes orchestration and containerized services. Technical insights into how Olares layers interact.
+description: Understand Olares installation architecture across the native system layer, Kubernetes orchestration, and containerized services.
 ---
 # Olares installation architecture 
 

--- a/docs/developer/install/installation-process.md
+++ b/docs/developer/install/installation-process.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Technical breakdown of Olares deployment phases covering system validation, component downloads, environment preparation and service deployment. In-depth look at each installation stage.
+description: Follow each phase of Olares deployment, including system validation, downloads, environment preparation, and service installation.
 ---
 # Olares installation breakdown
 This document explains the Olares installation process from the perspective of its four main phases. It is aimed at developers and system administrators who want to understand the installation in detail, including the underlying commands, configurations, and logic behind each phase.

--- a/docs/developer/install/olares-home.md
+++ b/docs/developer/install/olares-home.md
@@ -1,5 +1,5 @@
 ---
-description: Internal structure of Olares Home directory organizing images, logs, dependencies and version management. Details about the default installation directory architecture.
+description: Explore the Olares Home directory structure for images, logs, dependencies, versions, and the default installation path.
 ---
 # Olares Home
 

--- a/docs/developer/install/versioning.md
+++ b/docs/developer/install/versioning.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Version management system in Olares covering release types, branch strategies and upgrade specifications. Details about semantic versioning implementation and compatibility.
+description: Understand Olares versioning, including release types, branch strategy, semantic versioning, upgrade rules, and compatibility.
 ---
 # Olares versioning
 

--- a/docs/manual/best-practices/expand-storage-in-olares.md
+++ b/docs/manual/best-practices/expand-storage-in-olares.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Complete guide to expanding storage in Olares. Learn how to connect to SMB servers, use USB auto-mount, use CLI commands, and manually mount HDDs or SSDs to increase local storage capacity and manage large AI model files efficiently.
+description: Expand Olares storage with SMB servers, USB auto-mount, CLI commands, and manually mounted HDDs or SSDs for files and large AI models.
 ---
 # Expand storage in Olares
 

--- a/docs/manual/best-practices/install-olares-gpu-passthrough.md
+++ b/docs/manual/best-practices/install-olares-gpu-passthrough.md
@@ -1,9 +1,10 @@
 ---
 outline: [2, 3]
+title: Install Olares on PVE with GPU passthrough
 description: Step-by-step tutorial on how to set up GPU passthrough in Proxmox VE (PVE) and install Olares in a virtual machine with GPU acceleration enabled.
 ---
 
-# Install Olares on PVE via ISO with GPU Passthrough
+# Install Olares on PVE via ISO with GPU passthrough
 
 GPU passthrough in **Proxmox Virtual Environment (PVE)** allows virtual machines (VMs) to directly access the physical GPU, enabling hardware-accelerated computing for workloads like AI model inference and graphics processing.
 

--- a/docs/manual/best-practices/install-olares-multi-node.md
+++ b/docs/manual/best-practices/install-olares-multi-node.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Technical guide for installing and configuring a multi-node Olares cluster. Learn how to set up master nodes with JuiceFS support, add worker nodes, and handle network changes in your cluster environment.
+description: Install a multi-node Olares cluster with master and worker nodes. Configure JuiceFS, add workers, and handle network changes.
 ---
 
 # Install a multi-node Olares cluster <Badge type="warning" text="Alpha" />

--- a/docs/manual/best-practices/organize-content.md
+++ b/docs/manual/best-practices/organize-content.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Complete guide to building your knowledge hub with Wise in Olares. Learn how to collect web content, manage PDFs and e-books, subscribe to RSS feeds, and organize your digital content library effectively.
+description: Build a knowledge hub with Wise on Olares. Collect web pages, manage PDFs and e-books, subscribe to RSS feeds, and organize your content library.
 ---
 # Build your knowledge hub with Wise
 
@@ -201,4 +201,3 @@ In addition to regular RSS subscriptions, Wise offers a fully local, privacy-pro
 - [Wise basics](../olares/wise/basics.md)
 - [Discover themed content](../olares/wise/recommend.md)
 - [Subscribe and manage feeds](../olares/wise/subscribe.md)
-

--- a/docs/manual/best-practices/set-custom-domain.md
+++ b/docs/manual/best-practices/set-custom-domain.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Step-by-step guide to setting up a custom domain for your Olares environment. Learn how to add and verify domains, create organizations, configure member access, and create Olares IDs under your domain.
+description: Set up a custom domain for Olares. Add and verify domains, create an organization, manage member access, and issue Olares IDs under your domain.
 ---
 
 # Set up a custom domain for your Olares

--- a/docs/manual/get-started/install-linux-docker.md
+++ b/docs/manual/get-started/install-linux-docker.md
@@ -1,8 +1,9 @@
 ---
 outline: [2, 3]
-description: Learn how to deploy Olares on a Linux server using Docker Compose. This step-by-step guide covers system requirements, configuration, installation, activation, and container management.
+title: Install Olares on Linux with Docker Compose
+description: Install Olares on a Linux server with Docker Compose. Check requirements, configure and activate Olares, and manage its containers.
 ---
-# Install Olares on Linux using Docker Compose
+# Install Olares on Linux with Docker Compose
 You can use Docker to install and run Olares in a containerized environment. This guide walks you through setting up Olares with Docker, preparing the installation environment, completing the activation process, and managing the container lifecycle.
 
 <!--@include: ./reusables.md#installation-troubleshooting-tip-->

--- a/docs/manual/get-started/install-linux-script.md
+++ b/docs/manual/get-started/install-linux-script.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Detailed instructions for installing Olares on Linux systems including Ubuntu and Debian. Covers system requirements, installation steps, and activation process.
+description: Install Olares on Ubuntu or Debian with the Linux installation script. Review requirements, run the setup, and activate your system.
 ---
 # Install Olares on Linux via the script
 This guide explains how to install Olares on Linux using the provided installation script.

--- a/docs/manual/get-started/install-mac-docker.md
+++ b/docs/manual/get-started/install-mac-docker.md
@@ -1,8 +1,9 @@
 ---
 outline: [2, 3]
+title: Install Olares on Mac with Docker
 description: Learn how to run Olares as a containerized application on Mac with Docker, covering image setup and container configuration.
 ---
-# Install Olares on Mac with Docker image
+# Install Olares on Mac with Docker
 You can use Docker to install and run Olares in a containerized environment. This guide walks you through setting up Olares with Docker, preparing the installation environment, completing the activation process, and managing the container lifecycle.
 
 :::warning Not for production use

--- a/docs/manual/get-started/install-olares.md
+++ b/docs/manual/get-started/install-olares.md
@@ -1,5 +1,5 @@
 ---
-description: Overview of supported Olares installation methods. Recommended for Linux environments via ISO image or installation script. Other platforms like macOS, Windows, PVE, and Raspberry Pi are supported for testing and development.
+description: Compare Olares installation methods for Linux, macOS, Windows, PVE, and Raspberry Pi, including recommended production and testing options.
 outline: [2,4]
 ---
 

--- a/docs/manual/get-started/install-pve-iso.md
+++ b/docs/manual/get-started/install-pve-iso.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Guide to installing Olares on Proxmox VE (PVE) using ISO image with system requirements, VM configuration, installation, and step-by-step activation instructions.
+description: Install Olares on Proxmox VE (PVE) from an ISO image. Check requirements, configure the virtual machine, install, and activate Olares.
 ---
 # Install Olares on PVE with ISO image
 You can install Olares directly on Proxmox Virtual Environment (PVE) using an ISO image. This guide walks you through downloading the Olares ISO, configuring PVE environment, completing the installation, and getting your Olares up and running.

--- a/docs/manual/get-started/install-windows-docker.md
+++ b/docs/manual/get-started/install-windows-docker.md
@@ -1,9 +1,10 @@
 ---
 noindex: true
 outline: [2, 3]
+title: Install Olares on Windows with Docker (WSL 2)
 description: Learn how to run Olares on Windows using WSL 2 and Docker, including system preparation, configuration, and container management.
 ---
-# Install Olares on Windows (WSL 2) with Docker image
+# Install Olares on Windows (WSL 2) with Docker
 You can use Docker to install and run Olares in a containerized environment. This guide walks you through setting up Olares with Docker and WSL 2, preparing the installation environment, completing the activation process, and managing the container lifecycle.
 
 :::warning Not for production use

--- a/docs/manual/glossary.md
+++ b/docs/manual/glossary.md
@@ -1,5 +1,5 @@
 ---
-description: Technical glossary of Olares, providing standard definitions and explanations for common technical concepts. Alphabetically organized for easy reference of professional terminology.
+description: Find clear definitions of common Olares and personal cloud terms in this alphabetized technical glossary.
 ---
 # Glossary
 <div style="text-align: center; font-size: 18px; margin-bottom: 20px;">

--- a/docs/manual/help/ts-cs-app-reappears.md
+++ b/docs/manual/help/ts-cs-app-reappears.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Cannot remove app in App exclusive mode
 description: Troubleshoot when a stopped app cannot be removed in App exclusive mode in Olares 1.12.5.
 ---
 

--- a/docs/manual/help/ts-free-memory.md
+++ b/docs/manual/help/ts-free-memory.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Memory not freed after stopping an app
 description: Troubleshoot memory not freeing after stopping apps.
 ---
 

--- a/docs/manual/help/ts-inconsistent-app-status.md
+++ b/docs/manual/help/ts-inconsistent-app-status.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: App status differs across interfaces
 description: Troubleshoot inconsistent app status between Control Hub and Desktop, Settings, or Market.
 ---
 # App status differs after starting or stopping an app in Control Hub

--- a/docs/manual/help/ts-vram-shortage.md
+++ b/docs/manual/help/ts-vram-shortage.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: GPU app stays stopped after install or resume
 description: Troubleshoot GPU-dependent apps that remain stopped after installation or resume in Memory slicing mode.
 ---
 

--- a/docs/manual/larepass/index.md
+++ b/docs/manual/larepass/index.md
@@ -1,5 +1,5 @@
 ---
-description: User documentation for LarePass. Learn how to access and manage Olares through the LarePass client, including account management, file synchronization, device management, system upgrade, password management, and content collection.
+description: Use LarePass to access and manage Olares accounts, files, devices, system updates, passwords, integrations, and saved content.
 outline: [2, 3]
 ---
 

--- a/docs/manual/larepass/integrations.md
+++ b/docs/manual/larepass/integrations.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Connect Olares with third-party services to enhance functionality. Learn how to integrate, authorize, and manage connected services for seamless data synchronization.
+description: Connect and manage third-party integrations in LarePass, including authorization and data synchronization with Olares.
 ---
 
 # Manage integrations in LarePass

--- a/docs/manual/larepass/private-network.md
+++ b/docs/manual/larepass/private-network.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Learn how to securely access your Olares from anywhere.
+title: Use LarePass VPN for remote Olares access
+description: Use LarePass VPN to access Olares remotely, understand connection status, and troubleshoot common VPN issues.
 ---
 # Access Olares services remotely via LarePass VPN
 Your Olares device hosts critical applications intended for personal or internal use, such as Vault and Ollama. To ensure security, these applications are accessed via [private or internal entrances](../../developer/concepts/network.md#private-entrance).

--- a/docs/manual/olares-vs-nas.md
+++ b/docs/manual/olares-vs-nas.md
@@ -1,7 +1,7 @@
 ---
 noindex: true
 outline: [2, 3]
-description: Compares Olares and general NAS, highlighting key differences in storage solutions, application ecosystem, virtual machine support, network configuration, and AI capabilities.
+description: Compare Olares with traditional NAS platforms across storage, apps, virtual machines, networking, and local AI capabilities.
 ---
 
 

--- a/docs/manual/olares/collaborate.md
+++ b/docs/manual/olares/collaborate.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: Collaborate effectively in Olares using shared file storage, secure vault sharing, customized application access, and VPN capabilities for seamless remote team workflows.
+description: Collaborate in Olares with shared files, Vault items, custom app access, and VPN connectivity for secure remote teamwork.
 ---
 # Collaborate in Olares
 Olares helps teams work together efficiently while maintaining data privacy. Set up your collaborative workspace with some essential features.
@@ -39,7 +39,6 @@ When your team works remotely, accessing Olares usually requires going through p
 * Instead of going through public networks, connections stay within internal network, making it faster and reducing your public network usage costs.
 
 For details, see [Access Olares applications on other devices via VPN](/manual/larepass/private-network.md).
-
 
 
 

--- a/docs/manual/olares/controlhub/manage-container.md
+++ b/docs/manual/olares/controlhub/manage-container.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to manage containers and troubleshoot application issues in Olares' Control Hub. This guide covers how to view pod details, check container status, and export container logs for diagnostics. 
+description: Manage Olares containers in Control Hub. Inspect pods and container status, troubleshoot app issues, and export logs for diagnostics.
 ---
 
 # Manage containers

--- a/docs/manual/olares/controlhub/manage-resource.md
+++ b/docs/manual/olares/controlhub/manage-resource.md
@@ -1,6 +1,6 @@
 ---
 outline: [2,3]
-description: Learn how to view and manage resource configurations in Control Hub, including namespaces, secrets, configmaps, services, storage, network policies, jobs, and CRDs.
+description: Manage Olares resources in Control Hub, including namespaces, secrets, ConfigMaps, services, storage, network policies, jobs, and CRDs.
 ---
 
 # Manage resource configurations

--- a/docs/manual/olares/controlhub/manage-workload.md
+++ b/docs/manual/olares/controlhub/manage-workload.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to use Control Hub to manage Olares workloads and configurations. This doc covers project and namespace concepts, managing different workload types, and monitoring resource usage through detailed dashboards.
+description: Manage Olares workloads in Control Hub. Understand projects and namespaces, configure workload types, and monitor resource usage.
 ---
 
 # Manage workloads 

--- a/docs/manual/olares/files/compress-extract-files.md
+++ b/docs/manual/olares/files/compress-extract-files.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Compress and extract files in the Olares Files app. Supports ZIP, 7z, TAR, and more formats, with additional options for compression level, password protection, and split archives.
+description: Compress and extract files in Olares Files with ZIP, 7z, TAR, and other formats. Set compression level, passwords, and split archives.
 ---
 
 # Compress and extract files

--- a/docs/manual/olares/files/files-common.md
+++ b/docs/manual/olares/files/files-common.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Manage shared AI models in Common
 description: Use the Common directory in Olares to manage AI models shared across applications and users.
 ---
 

--- a/docs/manual/olares/files/share-files.md
+++ b/docs/manual/olares/files/share-files.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: A comprehensive guide to sharing files in Olares using Internal, Public, and SMB methods. Learn how to configure access permissions, manage shared content, and facilitate secure collaboration within your team or via LAN.
+description: Share files in Olares through internal, public, or SMB sharing. Configure access permissions and collaborate securely with teams or over a LAN.
 ---
 
 # Share files

--- a/docs/manual/olares/files/sync-files.md
+++ b/docs/manual/olares/files/sync-files.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Guide to synchronizing files between your local devices and Olares. Learn how to set up two-way sync tasks, manage sync status, and ensure seamless data access across all your platforms.
+description: Sync files between Olares and your computer. Set up two-way sync, monitor task status, and keep files available across devices.
 ---
 
 # Sync files to local computer

--- a/docs/manual/olares/index.md
+++ b/docs/manual/olares/index.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use Olares system applications with step-by-step guides covering personalization, application management, file handling, security setup, and team collaboration features. Updated regularly with the latest Olares functionality.
+description: Explore Olares system apps with guides to Desktop, Market, Files, Vault, Settings, Wise, Profile, Control Hub, and team collaboration.
 aside: false
 ---
 

--- a/docs/manual/olares/market/market.md
+++ b/docs/manual/olares/market/market.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Complete guide to managing Olares applications - install from Market, update system and community apps, handle custom installations, and properly uninstall applications.
+description: Manage Olares apps in Market. Install and update system or community apps, add custom apps, and safely uninstall software.
 ---
 
 # Manage applications in Market

--- a/docs/manual/olares/market/shared-apps.md
+++ b/docs/manual/olares/market/shared-apps.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Understand Olares shared applications, why the new shared architecture replaces v2, how the Engine Base architecture replaced the standalone Ollama app, and how to migrate from legacy v2 shared apps.
+description: Understand shared apps in Olares, the Engine Base architecture, differences from v2, and how to migrate legacy shared applications.
 ---
 
 # Shared applications

--- a/docs/manual/olares/profile.md
+++ b/docs/manual/olares/profile.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Create and customize your Olares personal homepage with a unique cover design, social media links, custom layouts, and monitor its performance with powerful analytics tracking capabilities.
+description: Create an Olares personal homepage with a custom cover, social links, flexible layouts, and analytics to track profile performance.
 ---
 
 # Design Your Olares profile

--- a/docs/manual/olares/settings/index.md
+++ b/docs/manual/olares/settings/index.md
@@ -1,5 +1,5 @@
 ---
-description: Configure and manage Olares with Settings, your central hub for personalizing your experience, securing your environment, integrating essential services, and more. 
+description: Configure Olares in Settings. Personalize your system, secure access, manage users, and connect storage or third-party services.
 ---
 
 # Configure and manage Olares with Settings

--- a/docs/manual/olares/settings/integrations.md
+++ b/docs/manual/olares/settings/integrations.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Centralize third-party service connections, SMB network storage credentials, and website cookies in Olares. Extend file storage capabilities and ensure smooth access to subscriptions and automated tasks.
+description: Manage third-party services, SMB storage credentials, and website cookies in Olares Settings for connected storage, subscriptions, and automations.
 ---
 
 # Manage integrations in Settings

--- a/docs/manual/olares/settings/language-appearance.md
+++ b/docs/manual/olares/settings/language-appearance.md
@@ -1,5 +1,5 @@
 ---
-description: Personalize your Olares experience by setting system language preferences, switching themes, managing Desktop widgets, customizing wallpapers, and resetting the Desktop layout.
+description: Set the Olares system language, theme, Desktop widgets, wallpaper, and layout to personalize your workspace.
 ---
 # Set language and appearance
 

--- a/docs/manual/olares/settings/manage-team.md
+++ b/docs/manual/olares/settings/manage-team.md
@@ -1,5 +1,5 @@
 ---
-description: Comprehensive guide to managing teams in Olares, including creating accounts, assigning roles, setting permissions, and maintaining efficient team collaboration within your Olares cluster.
+description: Manage an Olares team by creating accounts, assigning roles and resource limits, setting permissions, and maintaining member access.
 ---
 # Manage your team
 As an administrator, you can create and manage users in your team while ensuring system security and resource efficiency.
@@ -74,4 +74,3 @@ You can adjust the allocated resources for users in your Olares cluster.
 * Ensure the new user has obtained their Olares ID. See [Create an Olares ID](../../get-started/create-olares-id).
 * The name you entered is correctly spelled.
 * There are sufficient system resources to allocate.
-

--- a/docs/manual/olares/settings/team.md
+++ b/docs/manual/olares/settings/team.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: Create collaborative environments in Olares for teams, families, or organizations. Share resources, manage multi-user access, and build customized workspaces efficiently.
+description: Create an Olares team for family, colleagues, or an organization. Share resources, manage multi-user access, and customize each workspace.
 ---
 # Start a team
 Do you want to share Olares with your family, friends, or coworkers? Here's everything you need to know about creating a collaborative Olares environment.
@@ -42,5 +42,4 @@ Set up accounts for your team members.
 <h4><a href="./collaborate">Collaborate in Olares</a></h4>
 Learn how to invite and interact with team members.
 </div>
-
 

--- a/docs/manual/olares/vault/index.md
+++ b/docs/manual/olares/vault/index.md
@@ -1,5 +1,5 @@
 ---
-description: Secure your sensitive data with Vault - a comprehensive password manager featuring end-to-end encryption, shared vaults, cross-device sync, autofill, and two-factor authentication support.
+description: Use Olares Vault to manage passwords and sensitive data with end-to-end encryption, shared vaults, sync, autofill, and two-factor authentication.
 ---
 # Secure sensitive data with Vault
 
@@ -39,4 +39,3 @@ Learn how to generate and store 2FA codes for enhanced security.
 <h4><a href="./autofill">Use autofill with LarePass</a></h4>
 Learn how to set up and use autofill for logins with different LarePass clients.
 </div>
-

--- a/docs/manual/olares/vault/share-vault-items.md
+++ b/docs/manual/olares/vault/share-vault-items.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3] 
-description: Learn how to securely share Vault items in Olares. Understand team roles and permissions, manage shared Vault access, and enable secure collaboration among team members.
+description: Share Olares Vault items securely. Configure team roles and permissions, manage shared access, and collaborate without exposing sensitive data.
 ---
 
 # Manage shared Vaults

--- a/docs/manual/olares/vault/vault-items.md
+++ b/docs/manual/olares/vault/vault-items.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Understand Vault basics in Olares. Learn to set up vaults, manage vault items, organize sensitive data with tags, and protect your information with local passwords and encryption.
+description: Learn Olares Vault basics. Create vaults, manage and tag sensitive items, and protect data with local passwords and encryption.
 ---
 
 # Vault basics

--- a/docs/manual/olares/wise/filter-examples.md
+++ b/docs/manual/olares/wise/filter-examples.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use advanced filters in Wise to organize, prioritize, and rediscover your saved content. These examples cover practical use cases like focusing on unread entries and revisiting old content.
+description: Use Wise advanced filters to organize and rediscover saved content, with examples for unread items, older entries, tags, and custom views.
 ---
 
 # Filtered view examples

--- a/docs/manual/olares/wise/filter.md
+++ b/docs/manual/olares/wise/filter.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to use Wise powerful filtering system to organize your library. Create tag-based views, add custom filtered views, and utilize advanced query parameters to manage your content effectively.
+description: Organize your Wise library with filtered views. Create tag-based views and use advanced query parameters to find and manage saved content.
 ---
 # Organize your knowledge with filtered views
 

--- a/docs/manual/olares/wise/manage-cookies.md
+++ b/docs/manual/olares/wise/manage-cookies.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Manage cookies for Wise so it can access protected websites and feeds. Learn why cookies matter, supported formats, how to obtain them, and ways to upload and maintain cookies.
+description: Manage cookies in Wise to access protected sites and feeds. Learn supported formats, how to obtain cookies, and how to upload and maintain them.
 ---
 
 # Manage cookies for Wise

--- a/docs/manual/olares/wise/recommend.md
+++ b/docs/manual/olares/wise/recommend.md
@@ -1,5 +1,5 @@
 ---
-description: Discover how you can use Wise to implement self-hosted recommendation algorithms, deliver personalized content, and maintain both your privacy and control over content discovery in Olares.
+description: Build private, self-hosted content recommendations with Wise to discover personalized topics while keeping control of your data.
 ---
 # Discover themed content
 Most digital platforms control what content you see through centralized recommendation systems that collect and analyze your data. Wise offers a different approach - you choose and run recommendation algorithms directly on your device, keeping your reading preferences and interactions completely private while still enjoying personalized content discovery.

--- a/docs/manual/olares/wise/subscribe.md
+++ b/docs/manual/olares/wise/subscribe.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to manage content subscriptions in Olares, including adding RSS feeds, importing OPML files, managing subscriptions with LarePass, and organizing your content sources efficiently.
+description: Manage content subscriptions in Wise. Add RSS feeds, import OPML, use LarePass, and organize your sources in one library.
 ---
 
 # Subscribe and manage feeds

--- a/docs/manual/overview.md
+++ b/docs/manual/overview.md
@@ -1,5 +1,5 @@
 ---
-description: Learn about Olares, an open-source sovereign cloud OS for local AI. Discover how to self-host services, run AI applications, manage files, and collaborate securely with enterprise-grade features.
+description: Explore Olares, an open-source personal cloud OS for local AI. Self-host services, run AI apps, manage files, and collaborate securely.
 aside: false
 ---
 # Olares documentation

--- a/docs/manual/space/billing.md
+++ b/docs/manual/space/billing.md
@@ -1,5 +1,5 @@
 ---
-description: Understand Olares Space billing system with service charges and payment workflows. Learn about cloud hosting fees, usage based pricing, and promotional credit applications.
+description: Understand Olares Space billing, including service charges, usage-based pricing, payment workflows, and promotional credits.
 ---
 :::warning Documentation does not match current experience
 We are currently updating this documentation to match the latest experience on the Olares Space platform. If there are differences, follow the actual platform.

--- a/docs/manual/space/create-olares.md
+++ b/docs/manual/space/create-olares.md
@@ -1,7 +1,7 @@
 ---
 noindex: true
 outline: [2, 3]
-description: Set up your cloud based Olares instance in Olares Space. Configure system resources, monitor installation progress, and activate your instance with proper credentials.
+description: Create a cloud-based Olares instance in Olares Space. Choose resources, monitor installation, and activate the system.
 ---
 :::warning Documentation does not match current experience
 We are currently updating this documentation to match the latest experience on the Olares Space platform. If there are differences, follow the actual platform.
@@ -87,4 +87,4 @@ When the installation enters the **Pending Activation** state, activate Olares:
 
 2. Access the wizard URL in your browser, and use the one-time password to log into Olares for the first time. 
 3. Change the Olares password via LarePass when prompted. 
-4. Follow the on-screen instructions to finish the rest of activation process. 
+4. Follow the on-screen instructions to finish the rest of activation process.

--- a/docs/manual/space/index.md
+++ b/docs/manual/space/index.md
@@ -1,5 +1,5 @@
 ---
-description: Olares Space provides infrastructure services for your Olares environment, including account management, custom domain configuration, data backup, and shared GPU resources.
+description: Explore Olares Space services for cloud hosting, account management, custom domains, data backup, traffic, and shared GPU resources.
 ---
 # Olares Space overview
 

--- a/docs/manual/space/manage-olares.md
+++ b/docs/manual/space/manage-olares.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Control your Olares instances through system monitoring, worker node management, and shared GPU solutions. Track storage usage, traffic consumption and maintain instance health.
+description: Manage Olares instances in Olares Space. Monitor system health, storage and traffic, manage worker nodes, and use shared GPUs.
 ---
 :::warning Documentation does not match current experience
 We are currently updating this documentation to match the latest experience on the Olares Space platform. If there are differences, follow the actual platform.

--- a/docs/manual/why-olares.md
+++ b/docs/manual/why-olares.md
@@ -1,6 +1,6 @@
 ---
 noindex: true
-description: Explore key use cases for Olares including edge AI, personal data management, self-hosted workspace, private media server, smart home control, and decentralized social media deployment.
+description: Explore Olares use cases for local AI, personal data, self-hosted workspaces, private media, smart homes, and decentralized social apps.
 ---
 # Why Olares
 Here are some typical use scenarios for Olares.

--- a/docs/one/access-olares-via-vpn.md
+++ b/docs/one/access-olares-via-vpn.md
@@ -1,13 +1,14 @@
 ---
 outline: [2,3]
-description: Learn how to access your Olares services securely using the LarePass VPN.
+title: Access Olares One with LarePass VPN
+description: Access Olares One securely with LarePass VPN and verify the connection type on local or remote networks.
 head:
   - - meta
     - name: keywords
       content: Olares, LarePass VPN, local access
 ---
 
-# Access Olares services securely using LarePass VPN
+# Access Olares One services securely using LarePass VPN
 
 Typically, you access Olares services through a browser using a URL like `https://desktop.<username>.olares.com`. This way, you can reach your services from any device at any time.
 

--- a/docs/one/ace-step.md
+++ b/docs/one/ace-step.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Step-by-step guide to installing ACE-Step AI on Olares, generating songs with lyrics or instrumentals, optimizing audio with retake and repainting, and using Audio2Audio to transform reference audio into new music.
+description: Install ACE-Step on Olares to create songs from lyrics or prompts, refine audio with Retake and Repainting, and transform reference tracks with Audio2Audio.
 head:
   - - meta
     - name: keywords

--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: A technical guide for deploying a scalable Olares cluster. Learn how to configure a master node, resolve hostname conflicts, and join worker nodes to the cluster.
+description: Build a multi-node Olares cluster with Olares One. Configure the master node, resolve hostname conflicts, and join worker nodes.
 head:
   - - meta
     - name: keywords

--- a/docs/one/files.md
+++ b/docs/one/files.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Get started with the Files app on your Olares One. Learn the interface layout, how to upload your first files, preview and edit content, search your drive, and connect external cloud storage like Google Drive.
+description: Use Files on Olares One to upload, preview, edit, and search files, then connect external cloud storage such as Google Drive.
 head:
   - - meta
     - name: keywords

--- a/docs/one/first-boot.md
+++ b/docs/one/first-boot.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to set up your Olares One for the first time, including setting up hardware, installing the client app, creating your Olares account, connecting to your device, installing & activating the system, and logging into your Olares.
+description: Set up Olares One for the first time. Connect the hardware, install LarePass, create an account, activate the system, and log in.
 head:
   - - meta
     - name: keywords

--- a/docs/one/known-issues.md
+++ b/docs/one/known-issues.md
@@ -1,5 +1,5 @@
 ---
-description: This page documents the known issues and unexpected behaviors you might encounter when using Olares One, along with their corresponding solutions or workarounds.
+description: Review known Olares One issues affecting initial setup and Thunderbolt 5 detection in Windows, with symptoms and workarounds.
 ---
 
 # Olares One known issues

--- a/docs/one/steam-stream.md
+++ b/docs/one/steam-stream.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Comprehensive tutorial on streaming Steam games with Olares. Learn to install Steam Headless, configure the streaming service, and stream games on Moonlight from both local and remote networks.
+description: Stream Steam games from Olares with Steam Headless and Moonlight. Configure local and remote game streaming to phones, computers, and other devices.
 head:
   - - meta
     - name: keywords

--- a/docs/one/update-firmware.md
+++ b/docs/one/update-firmware.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to manage the BIOS and EC firmware on your Olares One, including checking firmware versions, downloading firmware update packages, executing updates, unlocking advanced mode, and troubleshooting issues such as black screen.
+description: Manage Olares One BIOS and EC firmware. Check versions, download and install updates, unlock advanced mode, and troubleshoot black screens.
 head:
   - - meta
     - name: keywords

--- a/docs/one/windows.md
+++ b/docs/one/windows.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 4]
-description: A comprehensive guide to installing and running a Windows virtual machine on Olares. Learn how to configure initial credentials, connect via browser-based VNC or Microsoft Remote Desktop (RDP), and transfer files between your computer and the VM.
+description: Install and run a Windows VM on Olares. Set credentials, connect with browser VNC or Remote Desktop (RDP), and transfer files between systems.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/ace-step-1.5.md
+++ b/docs/use-cases/ace-step-1.5.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to install ACE-Step 1.5 on Olares, generate music from prompts or lyrics, and refine your ideas with reference audio, Cover, Repaint, and LoRA-based workflows.
+description: Install ACE-Step 1.5 on Olares to generate music from prompts or lyrics and refine tracks with reference audio, Cover, Repaint, and LoRA workflows.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/ace-step.md
+++ b/docs/use-cases/ace-step.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Step-by-step guide to installing ACE-Step AI on Olares, generating songs with lyrics or instrumentals, optimizing audio with retake and repainting, and using Audio2Audio to transform reference audio into new music.
+title: Create AI music with ACE-Step
+description: Install ACE-Step on Olares to create songs from lyrics or prompts, refine audio with Retake and Repainting, and transform reference tracks with Audio2Audio.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/anythingllm.md
+++ b/docs/use-cases/anythingllm.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Set up AnythingLLM on Olares to build a private, self-hosted knowledge base with RAG. Upload documents, embed them with a local model, and query them in natural language.
+description: Build a private knowledge base with AnythingLLM on Olares. Add documents, create embeddings with a local model, and query them with RAG.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/arrs.md
+++ b/docs/use-cases/arrs.md
@@ -1,6 +1,7 @@
 ---
 outline: deep
-description: Learn how to connect and configure the *Arrs family of applications (Sonarr, Radarr, Prowlarr, Bazarr, and qBittorrent) on Olares for automated media management.
+title: Automate media management with the *Arrs
+description: Configure Sonarr, Radarr, Prowlarr, Bazarr, and qBittorrent on Olares to automate media downloads and library management.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/comfyui-common-issues.md
+++ b/docs/use-cases/comfyui-common-issues.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Common issues and solutions for ComfyUI on Olares, including startup problems, launcher log messages, model download limitations, workflow errors, and high CPU temperature on Olares One.
+description: Troubleshoot ComfyUI on Olares, including startup, launcher logs, model downloads, workflow errors, and high CPU temperature on Olares One.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/comfyui-launcher.md
+++ b/docs/use-cases/comfyui-launcher.md
@@ -1,6 +1,6 @@
 ---
 outline: deep
-description: Administrators' guide for managing ComfyUI on Olares, covering service control, network configuration, model and plugin management, Python dependencies, and troubleshooting.
+description: Manage ComfyUI on Olares. Control services, configure networking, install models and plugins, manage Python dependencies, and troubleshoot issues.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/comfyui.md
+++ b/docs/use-cases/comfyui.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: "Run ComfyUI locally on Olares: install ComfyUI and its models in one click, generate AI images with the default workflow, and keep every output on your own device."
+description: Run ComfyUI locally on Olares. Install models in one click, generate AI images with the default workflow, and keep outputs on your device.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/context7.md
+++ b/docs/use-cases/context7.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Set up Context7 on Olares to provide AI coding assistants with up-to-date library documentation via MCP. Connect it to Olares-hosted agents or external tools like Cursor.
+title: Connect AI coding tools to docs with Context7
+description: Run Context7 on Olares to give AI coding assistants current library documentation through MCP, including Olares-hosted agents and Cursor.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/deerflow.md
+++ b/docs/use-cases/deerflow.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Build a local research agent with DeerFlow
 description: Learn how to set up DeerFlow on your Olares device, complete with Ollama integration and Tavily for web research.
 head:
   - - meta

--- a/docs/use-cases/deerflow2.md
+++ b/docs/use-cases/deerflow2.md
@@ -1,5 +1,6 @@
 ---
 outline: deep
+title: Set up DeerFlow 2.0 for AI research
 description: Set up DeerFlow 2.0 on your Olares device and configure it with a local model app for deep research.
 head:
   - - meta
@@ -128,4 +129,3 @@ To enable it:
    ![Enable follow-up suggestions](/images/manual/use-cases/deerflow2-enable-followup-suggestions.png#bordered)
 
 5. Click **Confirm** to apply the changes.
-

--- a/docs/use-cases/flaresolverr.md
+++ b/docs/use-cases/flaresolverr.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Use FlareSolverr for Cloudflare in Prowlarr
 description: Set up FlareSolverr on Olares to bypass Cloudflare protection and access blocked indexer sites in Prowlarr.
 head:
   - - meta

--- a/docs/use-cases/home-assistant.md
+++ b/docs/use-cases/home-assistant.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Install Home Assistant on Olares to run your smart home hub without a separate Raspberry Pi or Docker setup. Connect your local network and add devices in a few clicks.
+description: Run Home Assistant on Olares as a self-hosted smart home hub. Discover devices on your local network and build automations without a separate server.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/immich.md
+++ b/docs/use-cases/immich.md
@@ -1,6 +1,6 @@
 ---
 outline: deep
-description: Self-host Immich on Olares as an open-source Google Photos alternative. Back up, organize, and search photos and videos with AI while keeping your data on your device.
+description: Self-host Immich on Olares as a Google Photos alternative. Back up, organize, and search photos and videos with AI while keeping data private.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -1,5 +1,5 @@
 ---
-description: Explore practical use cases of Olares, showcasing how to leverage its features for AI workflows, creative tools, and self-hosted applications. Unlock the full potential of Olares in your environment.
+description: Explore Olares use cases for AI agents, local models, creative tools, productivity, media, virtual machines, and self-hosted apps.
 aside: false
 ---
 

--- a/docs/use-cases/indextts2.md
+++ b/docs/use-cases/indextts2.md
@@ -1,6 +1,6 @@
 ---
 outline: deep
-description: Use IndexTTS2 on Olares to generate natural-sounding speech from text with zero-shot voice cloning. Provide a short audio sample, type your text, and get speech that matches the reference voice.
+description: Run IndexTTS2 on Olares for zero-shot voice cloning. Provide a short audio sample and generate natural speech that matches the reference voice.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/jellyfin.md
+++ b/docs/use-cases/jellyfin.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Build a private media server with Jellyfin on Olares, a self-hosted Plex alternative. Add libraries, enable hardware transcoding, and stream to your devices and TV.
+description: Build a private Jellyfin media server on Olares. Add libraries, enable hardware transcoding, and stream to phones, computers, and TVs.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/jupyterhub.md
+++ b/docs/use-cases/jupyterhub.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Set up multi-user notebooks with JupyterHub
 description: Set up JupyterHub on Olares to provide a multi-user Jupyter notebook environment for data science, research, and collaborative coding.
 head:
   - - meta

--- a/docs/use-cases/karakeep.md
+++ b/docs/use-cases/karakeep.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Run Karakeep on Olares to save links, notes, images, and PDFs in one self-hosted workspace. Access your collection from a phone and add AI auto-tagging with a local model.
+description: Self-host Karakeep on Olares to save links, notes, images, and PDFs. Access your library on mobile and add AI auto-tagging with a local model.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/llm-base-apps.md
+++ b/docs/use-cases/llm-base-apps.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Host local LLMs with Engine Base apps
 description: Learn how to use the Engine Base applications on Olares to self-host large language models and run different inference engines by cloning the base apps.
 head:
   - - meta

--- a/docs/use-cases/llmfit.md
+++ b/docs/use-cases/llmfit.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Use LLMFit on Olares to find the best LLM models for your hardware. It benchmarks your system and scores models on quality, speed, compatibility, and context length.
+title: Match LLMs to your hardware with LLMFit
+description: Run LLMFit on Olares to benchmark your hardware and find compatible LLMs, scored by model quality, speed, fit, and context length.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/lobechat.md
+++ b/docs/use-cases/lobechat.md
@@ -1,13 +1,14 @@
 ---
 outline: [2, 4] 
-description: Install LobeHub (LobeChat) on Olares and connect it to Ollama to build self-hosted, local AI assistants with knowledge bases and multimodal input.
+title: Build a local AI agent with LobeHub
+description: Install LobeHub on Olares and connect it to Ollama to build self-hosted local AI assistants with knowledge bases and multimodal input.
 head:
   - - meta
     - name: keywords
       content: Olares, LobeHub, LobeChat, self-hosted lobechat, AI agent, lobechat on olares
 ---
 
-# Build your local AI agent with LobeHub (LobeChat)
+# Build your local AI agent with LobeHub
 
 LobeHub (previously LobeChat) is an open‑source framework for building secure, local AI chat experiences. It supports file handling, knowledge bases, and multimodal inputs, and it supports Ollama to run and switch local LLMs.
 

--- a/docs/use-cases/macos.md
+++ b/docs/use-cases/macos.md
@@ -1,6 +1,6 @@
 ---
 outline: deep
-description: Run macOS as a virtual machine on Olares. Learn how to install macOS from the Market, configure initial settings, and connect via browser-based VNC or VNC client.
+description: Run a macOS VM on Olares. Install it from Market, complete the initial setup, and connect through browser-based VNC or a VNC client.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/navidrome.md
+++ b/docs/use-cases/navidrome.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Set up Navidrome on Olares as a self-hosted Spotify alternative and home music server. Organize your library and stream it from any Subsonic-compatible mobile client.
+description: Self-host Navidrome on Olares as a Spotify alternative. Organize your music library and stream it with Subsonic-compatible mobile apps.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/nofx.md
+++ b/docs/use-cases/nofx.md
@@ -1,5 +1,6 @@
 ---
 outline: deep
+title: Set up an autonomous trading agent with NOFX
 description: Run NOFX, an open-source autonomous AI trading agent, on Olares. Fund an AI wallet, connect an exchange, configure a strategy, and let the agent trade.
 head:
   - - meta

--- a/docs/use-cases/open-notebook.md
+++ b/docs/use-cases/open-notebook.md
@@ -1,6 +1,6 @@
 ---
 outline: deep
-description: Install and use Open Notebook on Olares to collect sources, generate AI insights, chat with your knowledge base, create notes, and generate podcasts from your research materials.
+description: Run Open Notebook on Olares to collect research sources, generate AI insights, chat with your knowledge base, take notes, and create podcasts.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/openclaw.md
+++ b/docs/use-cases/openclaw.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Run OpenClaw as a self-hosted personal AI agent on Olares. Install, configure, and connect it to Discord and Slack while keeping your assistant and data on your device.
+title: Run a self-hosted OpenClaw AI agent
+description: Run OpenClaw on Olares as a self-hosted personal AI agent. Connect Discord or Slack while keeping the assistant and its data on your device.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/opencode-extensions.md
+++ b/docs/use-cases/opencode-extensions.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Extend OpenCode on Olares with skills and plugins. Use pre-installed skills for package management and web preview, or add community plugins for extra functionality.
+description: Extend OpenCode on Olares with built-in skills for package management and web preview, plus community plugins for additional workflows.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/opencode-omo.md
+++ b/docs/use-cases/opencode-omo.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 3]
-description: Enable oh-my-openagent (OMO) in OpenCode on Olares to orchestrate multiple AI agents. Trigger multi-agent collaboration with ultrawork, configure local or external models, and use built-in MCP servers.
+title: Run multi-agent workflows with oh-my-openagent
+description: Run oh-my-openagent with OpenCode on Olares to orchestrate multiple AI agents, choose local or external models, and use built-in MCP servers.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/openwebui-knowledge.md
+++ b/docs/use-cases/openwebui-knowledge.md
@@ -1,5 +1,6 @@
 ---
 outline: deep
+title: Chat with documents in Open WebUI
 description: Upload documents and create a knowledge base in Open WebUI on Olares for retrieval-augmented generation (RAG).
 head:
   - - meta

--- a/docs/use-cases/openwebui.md
+++ b/docs/use-cases/openwebui.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 4]
-description: Set up Open WebUI on Olares as a self-hosted ChatGPT alternative. Connect a local Ollama backend to chat with private LLMs while keeping conversations on your device.
+description: Self-host Open WebUI on Olares as a private ChatGPT alternative. Connect Ollama to chat with local LLMs while keeping conversations on your device.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/paperclip.md
+++ b/docs/use-cases/paperclip.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Run Paperclip on Olares to coordinate multiple AI agents on the same set of tasks. Add agents backed by Claude Code, Codex, OpenCode, Cursor, or other providers, and file issues for them to work on.
+description: Run Paperclip on Olares to coordinate AI agents backed by Claude Code, Codex, OpenCode, Cursor, and other providers through shared issues.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/pdfmathtranslate.md
+++ b/docs/use-cases/pdfmathtranslate.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 4]
-description: Learn how to install and configure PDFMathTranslate on Olares. This tutorial guides you through using the local AI model Ollama to translate scientific PDFs, preserving original layouts and mathematical formulas.
+title: Translate scientific PDFs in PDFMathTranslate
+description: Run PDFMathTranslate on Olares with Ollama to translate scientific PDFs while preserving page layouts, formulas, and other technical content.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/penpot.md
+++ b/docs/use-cases/penpot.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Edit Penpot files with Cursor via MCP
 description: Use Penpot on Olares as a self-hosted design workspace, then connect Cursor through MCP to inspect and modify an active Penpot design file.
 head:
   - - meta

--- a/docs/use-cases/plane.md
+++ b/docs/use-cases/plane.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Self-host Plane on Olares as an open-source Jira and Asana alternative. Organize work with modules, cycles, and multiple views for private team project management.
+description: Self-host Plane on Olares as a private Jira and Asana alternative. Manage projects with modules, cycles, and multiple work views.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/steam-stream.md
+++ b/docs/use-cases/steam-stream.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Comprehensive tutorial on streaming Steam games with Olares. Learn to install Steam Headless, configure the streaming service, and stream games on Moonlight from both local and remote networks.
+description: Stream Steam games from Olares with Steam Headless and Moonlight. Configure local and remote game streaming to phones, computers, and other devices.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/stirling-pdf.md
+++ b/docs/use-cases/stirling-pdf.md
@@ -1,7 +1,7 @@
 ---
 noindex: true
 outline: [2, 5]
-description: A step-by-step guide to installing and using Stirling PDF on Olares. Learn how to securely manage PDF documents, covering essential tasks such as merging, editing, format conversion, and creating automated workflow pipelines.
+description: Install Stirling PDF on Olares to merge, edit, convert, and manage PDF files privately, or build automated document workflows.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/tensorzero.md
+++ b/docs/use-cases/tensorzero.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: Use TensorZero as an AI model gateway
 description: Set up TensorZero on Olares to connect your apps to your AI models, monitor their performance, and manage your setup in one place.
 head:
   - - meta

--- a/docs/use-cases/tradingagents.md
+++ b/docs/use-cases/tradingagents.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Run TradingAgents on Olares to simulate a professional financial trading firm with multiple AI agents. Configure local models, run market analysis, and generate trading strategies.
+description: Run TradingAgents on Olares to simulate a multi-agent trading firm. Configure local models, analyze financial markets, and generate strategies.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/whisper-webui.md
+++ b/docs/use-cases/whisper-webui.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 3]
-description: Learn how to use Whisper-WebUI on Olares for speech-to-text transcription, subtitle generation, real-time recording, subtitle translation, and vocal separation across 96 languages.
+description: Run Whisper-WebUI on Olares for speech-to-text, recording, subtitles, translation, and vocal separation across 96 languages.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/windows-intel-gpu-passthrough.md
+++ b/docs/use-cases/windows-intel-gpu-passthrough.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 4]
-description: Learn how to enable Intel integrated GPU passthrough for a Windows virtual machine on Olares, including supported devices, host configuration, Windows app settings, driver installation, and verification.
+title: Enable Intel GPU passthrough for Windows VM
+description: Enable Intel integrated GPU passthrough for a Windows VM on Olares. Check support, configure the host and app, install drivers, and verify acceleration.
 head:
   - - meta
     - name: keywords
@@ -201,4 +202,3 @@ For self-hosted devices, add the GPU-related environment variables to the Window
 4. Confirm that the Intel graphics device appears and is running without errors.
 
    ![Intel integrated GPU](/images/manual/use-cases/windows-intel-gpu.png#bordered)
-

--- a/docs/use-cases/windows-issues.md
+++ b/docs/use-cases/windows-issues.md
@@ -1,6 +1,6 @@
 ---
 outline: [2,3]
-description: This page documents the known issues and unexpected behaviors you might encounter when using Windows on Olares, along with their corresponding solutions or workarounds.
+description: Troubleshoot known Windows VM issues on Olares, including Remote Desktop connection failures after an upgrade, with causes and workarounds.
 head:
   - - meta
     - name: keywords

--- a/docs/use-cases/windows.md
+++ b/docs/use-cases/windows.md
@@ -1,6 +1,6 @@
 ---
 outline: [2, 4]
-description: A comprehensive guide to installing and running a Windows virtual machine on Olares. Learn how to configure initial credentials, connect via browser-based VNC or Microsoft Remote Desktop (RDP), and transfer files between your computer and the VM.
+description: Install and run a Windows VM on Olares. Set credentials, connect with browser VNC or Remote Desktop (RDP), and transfer files between systems.
 head:
   - - meta
     - name: keywords

--- a/docs/zh/use-cases/flaresolverr.md
+++ b/docs/zh/use-cases/flaresolverr.md
@@ -1,5 +1,6 @@
 ---
 outline: [2, 3]
+title: 使用 FlareSolverr 访问 Cloudflare 站点
 description: 在 Olares 上设置 FlareSolverr，绕过 Cloudflare 保护，在 Prowlarr 中访问被阻止的索引器站点。
 head:
   - - meta

--- a/docs/zh/use-cases/lobechat.md
+++ b/docs/zh/use-cases/lobechat.md
@@ -1,6 +1,7 @@
 ---
 outline: [2, 4]
-description: 在 Olares 上安装 LobeHub (LobeChat) 并接入 Ollama，构建自托管的本地 AI 助手，支持知识库和多模态输入。
+title: 使用 LobeHub 构建本地 AI 智能体
+description: 在 Olares 上安装 LobeHub 并接入 Ollama，构建支持知识库和多模态输入的自托管本地 AI 助手。
 head:
   - - meta
     - name: keywords
@@ -11,7 +12,7 @@ head:
 本文档由 AI 自动翻译，可能存在表述差异。如需核对，请参考[英文原文](../../use-cases/lobechat.md)。
 :::
 
-# 使用 LobeHub (LobeChat) 构建你的本地 AI 智能体
+# 使用 LobeHub 构建你的本地 AI 智能体
 
 LobeHub（前身为 LobeChat）是一个开源框架，用于构建安全、本地化的 AI 聊天体验。它支持文件处理、知识库和多模态输入，并支持 Ollama 来运行和切换本地 LLM。
 


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress frontmatter only; no runtime, auth, or application code changes.
> 
> **Overview**
> This PR tightens **SEO metadata** across the Olares VitePress docs without changing product behavior.
> 
> **Site-wide titles:** `docs/.vitepress/config.mts` adds `titleTemplate: ":title | Olares Docs"` so page titles render as `{page title} | Olares Docs` in the browser and in search snippets.
> 
> **Meta descriptions:** Frontmatter `description` values are rewritten on a large set of manual, developer, use-case, and Olares One pages so they stay within typical length limits (shorter, action-oriented copy instead of long run-on summaries).
> 
> **Page-level titles:** Several guides now set explicit `title` in frontmatter (and matching H1 tweaks where needed)—for example Docker install paths, GPU passthrough, LarePass VPN, troubleshooting help articles, and selected use-case pages—so meta titles are clearer and length-appropriate.
> 
> **Minor cleanup:** Trailing newlines and small list/markdown formatting fixes appear alongside the metadata edits; a few Chinese use-case pages get aligned titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562c486e7e083ef71eb6852dc7527fe1505a3ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->