### PR TITLE
chore(user-service): bump image to v0.1.3

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.2
+          image: beclab/user-service:v0.1.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

  Bump the `user-service` image from `v0.1.2` to `v0.1.3` in the system-apps helm chart.

  The v0.1.3 release refactors the abilities service to drive hook apps from a single `HOOK_APPS` config source: it consolidates the duplicated per-app wiring (`key` / `appName` / `isServer`) into one array, removes the string list and if/else chain in `hookAppStatus`, the separate init list in `onModuleInit`, and the five near-identical `updateXxxStatus` methods, and simplifies `updateHookAppStatus` into a single code path that only mutates and emits a websocket event when the state actually changes. The public `Abilities` shape, the `hookAppStatus` signature, the `/abilities` endpoint, and the NATS caller behavior are all unchanged, so this is a behavior-equivalent internal refactor.

* **Target Version for Merge**

  v1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/user-service/pull/87

* **Other information**

  https://github.com/beclab/user-service/releases/tag/v0.1.3

  Full Changelog: https://github.com/beclab/user-service/compare/v0.1.2...v0.1.3

Made with [Cursor](https://cursor.com)