### PR TITLE
market: fix treat cancel with no active install task as success

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -91,15 +91,6 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: market-secrets
-  namespace: {{ .Release.Namespace }}
-type: Opaque
-data:
-  redis-passwords: {{ $redis_password }}
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: market-pg-secrets
   namespace: {{ .Release.Namespace }}
 type: Opaque
@@ -151,7 +142,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.75
+        image: beclab/market-backend:v0.6.76
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81
@@ -162,6 +153,8 @@ spec:
             value: "443"
           - name: APP_SERVICE_SERVICE_HOST
             value: app-service
+          - name: IMAGE_INFOS
+            value: /opt/app/data/v3/images-info
           - name: MODULE_ENABLE_STATUS_CORRECTION_CHECKER
             value: 'true'
           - name: APP_SERVICE_SERVICE_PORT
@@ -218,6 +211,14 @@ spec:
             value: localhost:82
           - name: IS_ACCOUNT_FROM_HEADER
             value: 'true'
+        volumeMounts:
+          - name: opt-data
+            mountPath: /opt/app/data
+      volumes:
+      - name: opt-data
+        hostPath:
+          path: '{{ .Values.rootPath }}/userdata/Cache/chartrepo'
+          type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service
@@ -237,23 +238,6 @@ spec:
       port: 82
       protocol: TCP
       targetPort: 82
----
-apiVersion: apr.bytetrade.io/v1alpha1
-kind: MiddlewareRequest
-metadata:
-  name: market-redis
-  namespace: {{ .Release.Namespace }}
-spec:
-  app: market
-  appNamespace: {{ .Release.Namespace }}
-  middleware: redis
-  redis:
-    password:
-      valueFrom:
-        secretKeyRef:
-          key: redis-passwords
-          name: market-secrets
-    namespace: market
 ---
 apiVersion: apr.bytetrade.io/v1alpha1
 kind: MiddlewareRequest


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix treat cancel with no active install task as success

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/375


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping Redis middleware and changing data paths affects market persistence/caching behavior on upgrade; hostPath chartrepo coupling can break if node paths differ.
> 
> **Overview**
> Updates the cluster **market** deployment manifest to ship **market-backend v0.6.76** and align runtime with local chart/cache data instead of provisioned Redis.
> 
> **Redis** provisioning is removed from the manifest: the `market-secrets` Secret object and the `market-redis` **MiddlewareRequest** are deleted, so installs no longer request a Redis middleware instance for market.
> 
> The appstore backend pod now mounts a **hostPath** volume at `{{ .Values.rootPath }}/userdata/Cache/chartrepo` into `/opt/app/data`, and sets **`IMAGE_INFOS`** to `/opt/app/data/v3/images-info`, so image metadata is read from the on-disk chart repo cache alongside existing `CHART_ROOT` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0e2c4240946de99c3e5177eb8c415869300bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->