### PR TITLE
cli: add Olares version check to conditionally patch NFS script and enable CNI DHCP service

### DIFF
--- a/cli/pkg/bootstrap/patch/tasks.go
+++ b/cli/pkg/bootstrap/patch/tasks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/utils"
 	"github.com/pkg/errors"
 
@@ -319,6 +320,16 @@ type PatchNfsScriptTask struct {
 }
 
 func (t *PatchNfsScriptTask) Execute(runtime connector.Runtime) error {
+	greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
+	if err != nil {
+		return errors.Wrap(err, "failed to get current Olares version")
+	}
+
+	if greaterThan1125 {
+		logger.Infof("Olares version is greater than 1.12.5, no need to patch nfs script")
+		return nil
+	}
+
 	if utils.IsExist("/lib/systemd/system/rpc-statd.service") ||
 		utils.IsExist("/etc/systemd/system/rpc-statd.service") {
 		if _, err := runtime.GetRunner().SudoCmd("systemctl add-wants --runtime remote-fs.target rpc-statd.service", false, true); err != nil {

--- a/cli/pkg/bootstrap/patch/tasks.go
+++ b/cli/pkg/bootstrap/patch/tasks.go
@@ -317,17 +317,20 @@ func (t *DisableLocalDNSTask) configResolvConf(runtime connector.Runtime) error 
 // patch nfs script to fix the issue that when nfs mounting systemd reloading will cause the GPU driver to fail in the running containers
 type PatchNfsScriptTask struct {
 	common.KubeAction
+	CheckVersion bool
 }
 
 func (t *PatchNfsScriptTask) Execute(runtime connector.Runtime) error {
-	greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
-	if err != nil {
-		return errors.Wrap(err, "failed to get current Olares version")
-	}
+	if t.CheckVersion {
+		greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
+		if err != nil {
+			return errors.Wrap(err, "failed to get current Olares version")
+		}
 
-	if greaterThan1125 {
-		logger.Infof("Olares version is greater than 1.12.5, no need to patch nfs script")
-		return nil
+		if greaterThan1125 {
+			logger.Infof("Olares version is greater than 1.12.5, no need to patch nfs script")
+			return nil
+		}
 	}
 
 	if utils.IsExist("/lib/systemd/system/rpc-statd.service") ||

--- a/cli/pkg/phase/root.go
+++ b/cli/pkg/phase/root.go
@@ -1,6 +1,10 @@
 package phase
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/kubernetes"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 )
@@ -18,4 +22,21 @@ func GetKubeType() string {
 func GetKubeVersion() (string, string, error) {
 	var kubeTask = &kubernetes.GetKubeVersion{}
 	return kubeTask.Execute()
+}
+
+func OlaresVersionGreaterThan(version string) (bool, error) {
+	currentVersionString, err := GetOlaresVersion()
+	if err != nil {
+		return false, err
+	}
+
+	t, err := semver.StrictNewVersion(strings.TrimPrefix(version, "v"))
+	if err != nil {
+		return false, fmt.Errorf("invalid version '%s'", version)
+	}
+	c, err := semver.StrictNewVersion(strings.TrimPrefix(currentVersionString, "v"))
+	if err != nil {
+		return false, fmt.Errorf("invalid current version '%s'", currentVersionString)
+	}
+	return c.Compare(t) > 0, nil
 }

--- a/cli/pkg/plugins/network/modules.go
+++ b/cli/pkg/plugins/network/modules.go
@@ -384,15 +384,21 @@ func K8sVersionAtLeast(version string, compare string) bool {
 
 type EnableCniDhcpService struct {
 	common.KubeAction
+	CheckVersion bool
 }
 
 func (e *EnableCniDhcpService) Execute(runtime connector.Runtime) error {
-	greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
-	if err != nil {
-		return errors.Wrap(err, "failed to get current Olares version")
+	needReload := true
+	if e.CheckVersion {
+		greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
+		if err != nil {
+			return errors.Wrap(err, "failed to get current Olares version")
+		}
+
+		needReload = !greaterThan1125
 	}
 
-	if !greaterThan1125 {
+	if needReload {
 		if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp",
 			false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")

--- a/cli/pkg/plugins/network/modules.go
+++ b/cli/pkg/plugins/network/modules.go
@@ -398,6 +398,8 @@ func (e *EnableCniDhcpService) Execute(runtime connector.Runtime) error {
 			false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")
 		}
+	} else {
+		logger.Infof("cni-dhcp service is already active or Olares version is greater than 1.12.5, skipping enable cni-dhcp")
 	}
 
 	if _, err := runtime.GetRunner().SudoCmd("systemctl restart cni-dhcp",

--- a/cli/pkg/plugins/network/modules.go
+++ b/cli/pkg/plugins/network/modules.go
@@ -392,8 +392,7 @@ func (e *EnableCniDhcpService) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(err, "failed to get current Olares version")
 	}
 
-	stdout, _ := runtime.GetRunner().SudoCmd("systemctl is-active cni-dhcp", false, false)
-	if stdout != "active" && !greaterThan1125 {
+	if !greaterThan1125 {
 		if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp",
 			false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")

--- a/cli/pkg/plugins/network/modules.go
+++ b/cli/pkg/plugins/network/modules.go
@@ -27,6 +27,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/core/util"
 	"github.com/beclab/Olares/cli/pkg/images"
+	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/plugins/network/templates"
 	"github.com/pkg/errors"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
@@ -386,10 +387,24 @@ type EnableCniDhcpService struct {
 }
 
 func (e *EnableCniDhcpService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp && systemctl restart cni-dhcp",
-		false, false); err != nil {
-		return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")
+	greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
+	if err != nil {
+		return errors.Wrap(err, "failed to get current Olares version")
 	}
+
+	stdout, _ := runtime.GetRunner().SudoCmd("systemctl is-active cni-dhcp", false, false)
+	if stdout != "active" && !greaterThan1125 {
+		if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now cni-dhcp",
+			false, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "enable cni-dhcp failed")
+		}
+	}
+
+	if _, err := runtime.GetRunner().SudoCmd("systemctl restart cni-dhcp",
+		false, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "restart cni-dhcp failed")
+	}
+
 	return nil
 }
 

--- a/cli/pkg/upgrade/1_12_6.go
+++ b/cli/pkg/upgrade/1_12_6.go
@@ -129,7 +129,7 @@ func (u upgrader_1_12_6) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "PatchNfsScript",
-			Action: new(patch.PatchNfsScriptTask),
+			Action: &patch.PatchNfsScriptTask{CheckVersion: true},
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -783,7 +783,7 @@ func upgradeMultus() []task.Interface {
 		&task.LocalTask{
 			Name:   "EnableCniDhcpService",
 			Desc:   "Enable multus CNI DHCP service",
-			Action: new(network.EnableCniDhcpService),
+			Action: &network.EnableCniDhcpService{CheckVersion: true},
 			Retry:  5,
 		},
 		&task.LocalTask{

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -771,10 +771,12 @@ func upgradeMultus() []task.Interface {
 		&task.LocalTask{
 			Name: "GenerateMultusDhcpService",
 			Desc: "Generate multus DHCP service",
-			Action: &action.Template{
-				Name:     "GenerateMultusDhcpService",
-				Template: templates.CniDhcpService,
-				Dst:      path.Join("/etc/systemd/system", templates.CniDhcpService.Name()),
+			Action: &generateMultusDhcpService{
+				action.Template{
+					Name:     "GenerateMultusDhcpService",
+					Template: templates.CniDhcpService,
+					Dst:      path.Join("/etc/systemd/system", templates.CniDhcpService.Name()),
+				},
 			},
 			Retry: 5,
 		},
@@ -990,4 +992,22 @@ func (u *upgradeCniPluginsBinaryOnly) Execute(runtime connector.Runtime) error {
 	}
 
 	return nil
+}
+
+type generateMultusDhcpService struct {
+	action.Template
+}
+
+func (a *generateMultusDhcpService) Execute(runtime connector.Runtime) error {
+	greaterThan1125, err := phase.OlaresVersionGreaterThan("1.12.5")
+	if err != nil {
+		return errors.Wrap(err, "failed to get current Olares version")
+	}
+
+	if greaterThan1125 {
+		logger.Infof("Olares version is greater than 1.12.5, skipping generateMultusDhcpService")
+		return nil
+	}
+
+	return a.Template.Execute(runtime)
 }


### PR DESCRIPTION
* **Background**
Add Olares version check to conditionally patch NFS script and enable CNI DHCP service

* **Target Version for Merge**
v1.12.6

* **Related Issues**
Reloading systemd causes the mounted GPU to become invalid in the container

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade flows still run host `systemctl` commands and depend on accurate Olares version detection; mis-gating could skip needed patches or leave DHCP misconfigured on edge version reads.
> 
> **Overview**
> Adds **`phase.OlaresVersionGreaterThan`** (semver compare against the live Olares version) and uses it to **skip host-level fixes on clusters already past 1.12.5**, where those changes are assumed to be in place. The goal is to avoid extra **`systemd daemon-reload`** during upgrades, which was breaking GPU mounts in running containers when NFS-related services were touched.
> 
> **`PatchNfsScriptTask`** gains optional **`CheckVersion`**: when set (1.12.6 upgrade), it no-ops the NFS/`rpc-statd` patch if current version is &gt; 1.12.5. Fresh install/bootstrap still uses the task without the flag.
> 
> **Multus / cni-dhcp upgrade path** (`upgradeMultus` in `task_set.go`): **`generateMultusDhcpService`** skips writing the DHCP unit file when &gt; 1.12.5; **`EnableCniDhcpService`** with **`CheckVersion: true`** skips **`daemon-reload` + enable** on newer versions but still runs **`systemctl restart cni-dhcp`**, with errors split between enable vs restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdc1c1ab3556d260a13fdef38586b755ce12ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->