### PR TITLE
helm-charts: register download provider service and RBAC, bump system-frontend & user-service images

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/download-permission.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/download-permission.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend:{{ .Values.bfl.username }}:system-frontend:download-provider-svc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.bfl.username }}:download-provider-svc
+subjects:
+  - kind: ServiceAccount
+    name: system-frontend
+    namespace: user-space-{{ .Values.bfl.username }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: download
+  namespace: user-system-{{ .Values.bfl.username }}
+spec:
+  type: ClusterIP
+  selector:
+    app: systemserver
+  ports:
+    - protocol: TCP
+      port: 28080
+      targetPort: 28080

--- a/apps/.olares/config/user/helm-charts/system-apps/templates/download-provider.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/download-provider.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.bfl.username }}:download-provider-svc
+  annotations:
+    provider-registry-ref: user-system-{{ .Values.bfl.username }}/download
+    provider-service-ref: download-svc.os-framework:8080
+rules:
+  - nonResourceURLs:
+      - "/api/download*"
+      - "/api/user/*"
+      - "/api/system/*"
+      - "/api/url/*"
+    verbs: ["*"]

--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.3
+          image: beclab/system-frontend:v1.11.9
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.3
+          image: beclab/user-service:v0.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

To support the new download capability, the user's system-frontend needs to reach the download service running in `os-framework` through Olares' provider/permission mechanism. This PR wires up that plumbing on the helm-charts side:

- Add `download-provider.yaml`: a `ClusterRole` (`<user>:download-provider-svc`) that declares the download provider via `provider-registry-ref`/`provider-service-ref` annotations and allows the `/api/download*`, `/api/user/*`, `/api/system/*`, and `/api/url/*` non-resource URLs.
- Add `download-permission.yaml`: a `ClusterRoleBinding` granting the `system-frontend` service account the download provider role, plus a `download` `ClusterIP` Service in `user-system-<user>` that exposes the systemserver on port `28080`.
- Bump `system-frontend` image from `v1.11.3` to `v1.11.9` and `user-service` image from `v0.1.3` to `v0.1.4` in `olares-app.yaml` to ship the corresponding frontend/backend changes.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1291
https://github.com/beclab/user-service/pull/88

* **Other information**:
None

Made with [Cursor](https://cursor.com)