### PR TITLE
feat(cli): migrate node identity on hostname change during change-ip

### DIFF
--- a/cli/pkg/common/common.go
+++ b/cli/pkg/common/common.go
@@ -208,6 +208,14 @@ const (
 
 	CacheCountPodsWaitForRecreation = "count_pods_wait_for_recreation"
 
+	// CacheHostnameChanged is set to true by the change-ip flow when it detects
+	// that the current machine is already registered in Kubernetes under a
+	// different (old) node name, i.e. the hostname was changed before running
+	// change-ip. The old node name and UID identify the exact stale resource.
+	CacheHostnameChanged = "hostname_changed"
+	CacheOldNodeName     = "old_node_name"
+	CacheOldNodeUID      = "old_node_uid"
+
 	CacheUpgradeUsers     = "upgrade_users"
 	CacheUpgradeAdminUser = "upgrade_admin_user"
 

--- a/cli/pkg/core/util/machineid.go
+++ b/cli/pkg/core/util/machineid.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+// machineIDFiles and systemUUIDFiles mirror the sources that the kubelet
+// (through cAdvisor) uses to populate node.status.nodeInfo.machineID and
+// node.status.nodeInfo.systemUUID respectively, so that values read here can be
+// compared against the ones reported on a Kubernetes Node object.
+//
+// machineID:  /etc/machine-id, falling back to /var/lib/dbus/machine-id
+// systemUUID: DMI product_uuid, PowerPC device-tree UUIDs, then the s390
+// /etc/machine-id fallback
+var (
+	machineIDFiles  = []string{"/etc/machine-id", "/var/lib/dbus/machine-id"}
+	systemUUIDFiles = []string{
+		"/sys/class/dmi/id/product_uuid",
+		"/proc/device-tree/system-id",
+		"/proc/device-tree/vm,uuid",
+		"/etc/machine-id",
+	}
+)
+
+// GetMachineID returns the host machine-id, or an empty string if none of the
+// known files exist or are readable. It does not error out: an empty result is
+// a valid "unknown" answer, matching cAdvisor's behavior.
+func GetMachineID() string {
+	return firstNonEmptyFileContent(machineIDFiles)
+}
+
+// GetSystemUUID follows cAdvisor's Linux lookup order and returns an empty
+// string when none of the platform-specific identifiers can be read.
+func GetSystemUUID() string {
+	return firstNonEmptyFileContent(systemUUIDFiles)
+}
+
+func firstNonEmptyFileContent(paths []string) string {
+	for _, p := range paths {
+		content, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		id := strings.TrimSpace(string(content))
+		id = strings.TrimSpace(strings.TrimRight(id, "\x00"))
+		if id != "" {
+			return id
+		}
+	}
+	return ""
+}

--- a/cli/pkg/core/util/machineid_test.go
+++ b/cli/pkg/core/util/machineid_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstNonEmptyFileContent(t *testing.T) {
+	tempDir := t.TempDir()
+	empty := filepath.Join(tempDir, "empty")
+	identifier := filepath.Join(tempDir, "identifier")
+	require.NoError(t, os.WriteFile(empty, nil, 0o600))
+	require.NoError(t, os.WriteFile(identifier, []byte("  ABCD-1234\x00\n"), 0o600))
+
+	require.Equal(t, "ABCD-1234", firstNonEmptyFileContent([]string{
+		filepath.Join(tempDir, "missing"),
+		empty,
+		identifier,
+	}))
+}
+
+func TestFirstNonEmptyFileContentReturnsEmpty(t *testing.T) {
+	require.Empty(t, firstNonEmptyFileContent([]string{
+		filepath.Join(t.TempDir(), "missing"),
+	}))
+}

--- a/cli/pkg/phase/cluster/changeip.go
+++ b/cli/pkg/phase/cluster/changeip.go
@@ -19,6 +19,7 @@ func ChangeIP(runtime *common.KubeRuntime) *pipeline.Pipeline {
 		modules = []module.Module{
 			&terminus.CheckPreparedModule{},
 			&terminus.CheckInstalledModule{},
+			&terminus.DetectHostnameChangeModule{},
 			&terminus.ChangeIPModule{},
 		}
 	}

--- a/cli/pkg/pipelines/changeip.go
+++ b/cli/pkg/pipelines/changeip.go
@@ -3,23 +3,32 @@ package pipelines
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/phase/cluster"
+	"github.com/beclab/Olares/cli/pkg/utils"
 	"github.com/beclab/Olares/cli/version"
 	"github.com/spf13/viper"
 )
 
 func ChangeIPPipeline() error {
+	var arg = common.NewArgument()
+	// Normalize before querying Kubernetes or constructing any runtime state so
+	// every subsequent step observes the canonical node name.
+	if err := normalizeHostnameToLower(arg); err != nil {
+		return err
+	}
+
 	kubeType := phase.GetKubeType()
 	sysversion, _ := phase.GetOlaresVersion()
 	if sysversion == "" {
 		sysversion = version.VERSION
 	}
 
-	var arg = common.NewArgument()
 	arg.SetOlaresVersion(sysversion)
 	arg.SetConsoleLog("changeip.log", true)
 	arg.SetKubeVersion(kubeType)
@@ -45,5 +54,32 @@ func ChangeIPPipeline() error {
 		return err
 	}
 
+	return nil
+}
+
+// normalizeHostnameToLower lowercases the OS hostname (and the in-memory
+// SystemInfo used to build the runtime) when it contains uppercase characters.
+// It is a no-op on macOS/Windows and when the hostname is already lowercase.
+func normalizeHostnameToLower(arg *common.Argument) error {
+	si := arg.SystemInfo
+	if si.IsDarwin() || si.IsWindows() {
+		return nil
+	}
+	hostname := si.GetHostname()
+	if !utils.ContainsUppercase(hostname) {
+		return nil
+	}
+	lower := strings.ToLower(hostname)
+	// NOTE: this runs before the runtime is created, and the zap logger is only
+	// initialized as part of that. So avoid both the logger package and
+	// util.Exec (which logs) here; use fmt and exec directly.
+	fmt.Printf("normalizing hostname %q to %q before change-ip\n", hostname, lower)
+	// change-ip is expected to run as root (sudo), so hostnamectl works without
+	// an explicit sudo prefix.
+	cmd := exec.CommandContext(context.Background(), "hostnamectl", "set-hostname", lower)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to normalize hostname to %q: %w (output: %s)", lower, err, strings.TrimSpace(string(out)))
+	}
+	si.SetHostname(lower)
 	return nil
 }

--- a/cli/pkg/terminus/hostname.go
+++ b/cli/pkg/terminus/hostname.go
@@ -490,25 +490,7 @@ func (a *MigrateRenamedNodeGPUAllocations) Execute(_ connector.Runtime) error {
 		return errors.Wrapf(err, "failed to parse %s", gpuAllocationsConfigMapKey)
 	}
 
-	changed := false
-	for i := range allocations {
-		row := allocations[i]
-		if newName, ok := rewriteStringField(row, "nodeName", func(v string) string {
-			if v == a.OldNode {
-				return a.NewNode
-			}
-			return v
-		}); ok {
-			logger.Infof("migrating GPU allocation nodeName -> %q", newName)
-			changed = true
-		}
-		if newID, ok := rewriteStringField(row, "deviceId", func(v string) string {
-			return rewriteNodeScopedID(v, a.OldNode, a.NewNode)
-		}); ok {
-			logger.Infof("migrating GPU allocation deviceId -> %q", newID)
-			changed = true
-		}
-	}
+	changed := migrateGPUAllocationRows(allocations, a.OldNode, a.NewNode)
 	if !changed {
 		logger.Infof("no GPU allocations reference old node %q; nothing to migrate", a.OldNode)
 		return nil
@@ -527,6 +509,44 @@ func (a *MigrateRenamedNodeGPUAllocations) Execute(_ connector.Runtime) error {
 	}
 	logger.Warnf("migrated GPU allocations from old node %q to new node %q", a.OldNode, a.NewNode)
 	return nil
+}
+
+// migrateGPUAllocationRows rewrites, in place, the allocation rows that belong
+// to oldNode: their nodeName becomes newNode and their node-scoped (non-HAMI)
+// deviceId is rewritten. Rows for other nodes are left untouched, so a node
+// whose name merely shares the "<oldNode>-" prefix used by node-scoped device
+// ids is never corrupted. Returns whether anything changed.
+func migrateGPUAllocationRows(allocations []map[string]json.RawMessage, oldNode, newNode string) bool {
+	changed := false
+	for i := range allocations {
+		row := allocations[i]
+		if name, ok := stringField(row, "nodeName"); !ok || name != oldNode {
+			continue
+		}
+		if _, ok := rewriteStringField(row, "nodeName", func(string) string { return newNode }); ok {
+			changed = true
+		}
+		if _, ok := rewriteStringField(row, "deviceId", func(v string) string {
+			return rewriteNodeScopedID(v, oldNode, newNode)
+		}); ok {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// stringField returns the string value of a generic JSON object field, or
+// ("", false) when the field is missing or not a JSON string.
+func stringField(row map[string]json.RawMessage, field string) (string, bool) {
+	raw, ok := row[field]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
 }
 
 // rewriteStringField applies fn to a string field of a generic JSON object and

--- a/cli/pkg/terminus/hostname.go
+++ b/cli/pkg/terminus/hostname.go
@@ -1,0 +1,881 @@
+package terminus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/core/util"
+
+	"github.com/pkg/errors"
+)
+
+// renamedNodeLabelAllowlistPrefixes / renamedNodeLabelAllowlistKeys control
+// which labels are carried over from the old (pre-rename) node object to the
+// freshly registered node when the hostname changed.
+//
+// We intentionally use an allowlist rather than copying everything: labels like
+// kubernetes.io/hostname or the k3s-managed role labels must NOT be copied (they
+// either belong to the new name or are re-applied automatically by k3s). Only
+// labels that Olares applies itself and that are not self-healing need to be
+// restored here.
+//
+// The categories that need explicit restoration on a k3s Olares node are:
+//   - GPU labels written directly onto the node by olares-cli (gpu.bytetrade.io/*)
+//   - the kube-ovn master role label (a no-op on Calico clusters, which use no
+//     node label)
+var (
+	// Labels olares-cli writes directly onto the node and that are NOT
+	// re-applied automatically after the node is re-registered under a new name:
+	//   - gpu.bytetrade.io/{driver,cuda,cuda-supported,<mode>} (SetNodeGpuModeLabel)
+	//   - node-role.kubernetes.io/worker (AddWorkerLabel; k3s only re-applies the
+	//     master/control-plane roles automatically, not worker)
+	// Deliberately excluded (they self-heal or belong to the new node):
+	//   - kubernetes.io/*, beta.kubernetes.io/* (kubelet built-ins)
+	//   - node-role.kubernetes.io/{master,control-plane} (re-applied by k3s)
+	//   - gpu.intel.com/*, intel.feature.node.kubernetes.io/* (re-applied by NFD)
+	renamedNodeLabelAllowlistPrefixes = []string{
+		"gpu.bytetrade.io/",
+	}
+	renamedNodeLabelAllowlistKeys = []string{
+		"node-role.kubernetes.io/worker",
+		"kube-ovn/role",
+	}
+	// Annotations olares/app-service persist as user configuration and that are
+	// NOT recreated by any controller:
+	//   - sharemode.gpu.bytetrade.io/<gpu-uuid> (per-device GPU share mode set via
+	//     app-service; keyed by the stable GPU UUID, so it maps cleanly to the
+	//     same hardware on the renamed node)
+	// Deliberately excluded (self-heal, or would be stale/wrong after an IP change):
+	//   - hami.io/* (re-registered by the HAMi device plugin daemonset)
+	//   - projectcalico.org/* (re-populated by calico-node; carry the OLD IP)
+	//   - k3s.io/*, nfd.node.kubernetes.io/*, node.alpha.kubernetes.io/ttl,
+	//     volumes.kubernetes.io/* (managed by k3s/NFD/kubelet)
+	renamedNodeAnnotationAllowlistPrefixes = []string{
+		gpuShareModeAnnotationPrefix,
+	}
+)
+
+func newChangeIPKubeClient() (*kubernetes.Clientset, error) {
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load kubeconfig")
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kube client")
+	}
+	return kubeClient, nil
+}
+
+func nodeIsReady(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func configuredNodeName() string {
+	for _, filePath := range []string{
+		"/etc/systemd/system/k3s.service",
+		"/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+	} {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+		for _, flag := range []string{"--node-name=", "--hostname-override="} {
+			if value := commandFlagValue(string(content), flag); value != "" {
+				return strings.ToLower(value)
+			}
+		}
+	}
+	return ""
+}
+
+func commandFlagValue(content, flag string) string {
+	index := strings.Index(content, flag)
+	if index < 0 {
+		return ""
+	}
+	value := content[index+len(flag):]
+	if end := strings.IndexAny(value, " \t\r\n\"'"); end >= 0 {
+		value = value[:end]
+	}
+	return strings.TrimSpace(value)
+}
+
+// pvPinnedToNode reports whether a PersistentVolume's node affinity restricts it
+// to the given node name via the standard kubernetes.io/hostname key, which is
+// how node-local provisioners (local-path, openebs-hostpath, ...) pin volumes.
+func pvPinnedToNode(pv *corev1.PersistentVolume, nodeName string) bool {
+	if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+		return false
+	}
+	for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Operator != corev1.NodeSelectorOpIn ||
+				(expr.Key != corev1.LabelHostname && expr.Key != "beta.kubernetes.io/hostname") {
+				continue
+			}
+			for _, v := range expr.Values {
+				if strings.EqualFold(v, nodeName) {
+					return true
+				}
+			}
+		}
+		for _, field := range term.MatchFields {
+			if field.Key != "metadata.name" || field.Operator != corev1.NodeSelectorOpIn {
+				continue
+			}
+			for _, value := range field.Values {
+				if strings.EqualFold(value, nodeName) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func disposableRenamePV(pv *corev1.PersistentVolume) bool {
+	if pv == nil || pv.Spec.ClaimRef == nil {
+		return false
+	}
+	return pv.Spec.ClaimRef.Namespace == "kubesphere-monitoring-system" &&
+		strings.HasPrefix(pv.Spec.ClaimRef.Name, "prometheus-k8s-db-prometheus-k8s-")
+}
+
+func labelIsAllowlistedForRestore(key string) bool {
+	for _, k := range renamedNodeLabelAllowlistKeys {
+		if key == k {
+			return true
+		}
+	}
+	for _, p := range renamedNodeLabelAllowlistPrefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func annotationIsAllowlistedForRestore(key string) bool {
+	for _, p := range renamedNodeAnnotationAllowlistPrefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	// gpuShareModeAnnotationPrefix is the node-annotation prefix app-service uses
+	// to persist a per-device GPU share mode: sharemode.gpu.bytetrade.io/<deviceID>.
+	gpuShareModeAnnotationPrefix = "sharemode.gpu.bytetrade.io/"
+
+	// GPU allocation store written by app-service: a ConfigMap holding a JSON
+	// array of allocation rows ({nodeName, deviceId, ...}).
+	gpuAllocationsConfigMapNamespace = "os-framework"
+	gpuAllocationsConfigMapName      = "app-gpu-allocations"
+	gpuAllocationsConfigMapKey       = "allocations.json"
+)
+
+// rewriteNodeScopedID rewrites an identifier that embeds the node name as a
+// leading "<node>-" segment from the old node name to the new one. app-service
+// builds non-HAMI GPU device ids as "<node>-<mode>-0" (compute.nonHAMIDevice),
+// so those must follow a hostname change. Identifiers that do not start with
+// "<oldNode>-" (e.g. a HAMI GPU UUID like "GPU-....") are returned unchanged.
+func rewriteNodeScopedID(id, oldNode, newNode string) string {
+	if oldNode == "" || newNode == "" {
+		return id
+	}
+	if !strings.HasPrefix(id, oldNode+"-") {
+		return id
+	}
+	return newNode + strings.TrimPrefix(id, oldNode)
+}
+
+// DetectHostnameChangeModule runs before ChangeIPModule and records, in the
+// pipeline cache, whether this machine is already registered in Kubernetes under
+// a different node name than the current (lowercased) hostname. If so, the
+// hostname was changed prior to running change-ip and ChangeIPModule will take
+// the extra steps needed to migrate to the new node identity.
+type DetectHostnameChangeModule struct {
+	common.KubeModule
+}
+
+func (m *DetectHostnameChangeModule) Init() {
+	m.Name = "DetectHostnameChange"
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "DetectHostnameChange",
+			Action: new(DetectHostnameChange),
+		},
+	}
+}
+
+type DetectHostnameChange struct {
+	common.KubeAction
+}
+
+func (t *DetectHostnameChange) Execute(runtime connector.Runtime) error {
+	// default to "not changed" so downstream logic always has a value to read
+	t.PipelineCache.Set(common.CacheHostnameChanged, false)
+
+	installed, _ := t.PipelineCache.GetMustBool(common.CacheInstalledState)
+	if !installed {
+		logger.Info("Olares is not installed, skipping hostname change detection")
+		return nil
+	}
+
+	currentName := strings.ToLower(runtime.GetSystemInfo().GetHostname())
+	previouslyConfiguredName := configuredNodeName()
+	machineID := util.GetMachineID()
+	systemUUID := util.GetSystemUUID()
+	logger.Infof("detecting hostname change for current node name=%q", currentName)
+	if machineID == "" && systemUUID == "" {
+		return fmt.Errorf("cannot detect a hostname change: both kubelet machineID and systemUUID are empty")
+	}
+	if machineID == "" || systemUUID == "" {
+		logger.Warnf("only one machine identifier is available (machineID=%q, systemUUID=%q); "+
+			"detection will match on the available one only, which is less strict against cloned machines",
+			machineID, systemUUID)
+	}
+
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		if previouslyConfiguredName != "" && strings.EqualFold(previouslyConfiguredName, currentName) {
+			logger.Warnf("Kubernetes API is unavailable, but the configured node name %q is unchanged; continuing the original change-ip flow", currentName)
+			return nil
+		}
+		return errors.Wrap(err, "failed to create kube client for hostname change detection")
+	}
+	nodes, err := kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		if previouslyConfiguredName != "" && strings.EqualFold(previouslyConfiguredName, currentName) {
+			logger.Warnf("Kubernetes API is unavailable, but the configured node name %q is unchanged; continuing the original change-ip flow", currentName)
+			return nil
+		}
+		return errors.Wrap(err, "failed to list nodes for hostname change detection")
+	}
+
+	var currentNode *corev1.Node
+	var matchingOldNodes []*corev1.Node
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if strings.EqualFold(node.Name, currentName) {
+			currentNode = node
+			continue
+		}
+		if !nodeIdentityMatches(node, machineID, systemUUID) {
+			continue
+		}
+		matchingOldNodes = append(matchingOldNodes, node)
+	}
+
+	if currentNode != nil && !nodeIdentityMatches(currentNode, machineID, systemUUID) {
+		return fmt.Errorf("node %q already exists but belongs to a different machine identity", currentName)
+	}
+	if len(matchingOldNodes) > 1 {
+		names := make([]string, 0, len(matchingOldNodes))
+		for _, node := range matchingOldNodes {
+			names = append(names, node.Name)
+		}
+		sort.Strings(names)
+		return fmt.Errorf("cannot determine the old hostname: multiple nodes share this machine identity: %s", strings.Join(names, ", "))
+	}
+	if len(matchingOldNodes) == 0 {
+		if currentNode == nil {
+			return fmt.Errorf("cannot find a node matching current hostname %q or this machine identity", currentName)
+		}
+		logger.Infof("no former node found for this machine; hostname is unchanged (current=%q)", currentName)
+		return nil
+	}
+
+	oldNodeName := matchingOldNodes[0].Name
+	if previouslyConfiguredName != "" &&
+		!strings.EqualFold(previouslyConfiguredName, currentName) &&
+		!strings.EqualFold(previouslyConfiguredName, oldNodeName) {
+		return fmt.Errorf("machine identity matched node %q, but the service was configured for node %q", oldNodeName, previouslyConfiguredName)
+	}
+
+	logger.Warnf("node %q shares this machine's identity but differs from current hostname %q "+
+		"(old node ready=%v); treating this as a hostname change",
+		oldNodeName, currentName, nodeIsReady(matchingOldNodes[0]))
+	logger.Warnf("hostname change detected: old node=%q, new node=%q; change-ip will restore node "+
+		"labels, clean up node-local PVs bound to the old node, and delete the old node after restart",
+		oldNodeName, currentName)
+	t.PipelineCache.Set(common.CacheHostnameChanged, true)
+	t.PipelineCache.Set(common.CacheOldNodeName, oldNodeName)
+	t.PipelineCache.Set(common.CacheOldNodeUID, string(matchingOldNodes[0].UID))
+	return nil
+}
+
+// nodeIdentityMatches requires every machine identifier we could read locally to
+// match the corresponding field on the node. When both machineID and systemUUID
+// are available, both must match (strict, to avoid false positives on cloned
+// machines that share only one identifier).
+func nodeIdentityMatches(node *corev1.Node, machineID, systemUUID string) bool {
+	ni := node.Status.NodeInfo
+	matched := 0
+	if machineID != "" {
+		if !strings.EqualFold(ni.MachineID, machineID) {
+			return false
+		}
+		matched++
+	}
+	if systemUUID != "" {
+		if !strings.EqualFold(ni.SystemUUID, systemUUID) {
+			return false
+		}
+		matched++
+	}
+	return matched > 0
+}
+
+// RestoreLabelsFromRenamedNode copies the allowlisted labels/annotations from the
+// old (pre-rename) node onto the newly registered node, so metadata that Olares
+// applied during install (and that is not re-applied automatically) survives a
+// hostname change. It is idempotent.
+type RestoreLabelsFromRenamedNode struct {
+	common.KubeAction
+	OldNode string
+	NewNode string
+}
+
+func (a *RestoreLabelsFromRenamedNode) Execute(runtime connector.Runtime) error {
+	if a.OldNode == "" || a.NewNode == "" {
+		logger.Warnf("skipping label restore: old node=%q, new node=%q", a.OldNode, a.NewNode)
+		return nil
+	}
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	oldNode, err := kubeClient.CoreV1().Nodes().Get(ctx, a.OldNode, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// old node already gone (e.g. a re-run after labels were restored)
+			logger.Infof("old node %q not found, assuming labels were already restored", a.OldNode)
+			return nil
+		}
+		return errors.Wrapf(err, "failed to get old node %q", a.OldNode)
+	}
+
+	// the new node must exist before we can copy labels onto it; return an error
+	// so the task is retried until k3s has registered it.
+	newNode, err := kubeClient.CoreV1().Nodes().Get(ctx, a.NewNode, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get new node %q (may not be registered yet)", a.NewNode)
+	}
+	if !nodeIsReady(newNode) {
+		return fmt.Errorf("new node %q is not ready yet", a.NewNode)
+	}
+
+	if newNode.Labels == nil {
+		newNode.Labels = map[string]string{}
+	}
+	if newNode.Annotations == nil {
+		newNode.Annotations = map[string]string{}
+	}
+
+	changed := false
+	for k, v := range oldNode.Labels {
+		if !labelIsAllowlistedForRestore(k) {
+			continue
+		}
+		if existing, ok := newNode.Labels[k]; !ok || existing != v {
+			logger.Infof("restoring label %s=%s onto node %q (from old node %q)", k, v, a.NewNode, a.OldNode)
+			newNode.Labels[k] = v
+			changed = true
+		}
+	}
+	for k, v := range oldNode.Annotations {
+		if !annotationIsAllowlistedForRestore(k) {
+			continue
+		}
+		// The share-mode annotation key is sharemode.gpu.bytetrade.io/<deviceID>;
+		// for non-HAMI devices the deviceID embeds the node name, so the key must
+		// be rewritten to the new node (HAMI UUID keys are left unchanged).
+		targetKey := k
+		if suffix := strings.TrimPrefix(k, gpuShareModeAnnotationPrefix); suffix != k {
+			targetKey = gpuShareModeAnnotationPrefix + rewriteNodeScopedID(suffix, a.OldNode, a.NewNode)
+		}
+		if existing, ok := newNode.Annotations[targetKey]; !ok || existing != v {
+			logger.Infof("restoring annotation %s=%s onto node %q (from old node %q key %q)", targetKey, v, a.NewNode, a.OldNode, k)
+			newNode.Annotations[targetKey] = v
+			changed = true
+		}
+	}
+
+	if !changed {
+		logger.Infof("no labels/annotations need restoring onto node %q", a.NewNode)
+		return nil
+	}
+	if _, err := kubeClient.CoreV1().Nodes().Update(ctx, newNode, metav1.UpdateOptions{}); err != nil {
+		return errors.Wrapf(err, "failed to update node %q with restored labels", a.NewNode)
+	}
+	return nil
+}
+
+// MigrateRenamedNodeGPUAllocations rewrites the app-service GPU allocation store
+// (ConfigMap os-framework/app-gpu-allocations) so bound-GPU apps keep their
+// bindings after a hostname change. app-service matches an allocation row to a
+// device by exact (nodeName, deviceId) (compute.attachBindings), and for
+// non-HAMI devices the deviceId embeds the node name ("<node>-<mode>-0"), so
+// without this rewrite every binding would be dropped and share modes would
+// reset. Each row's nodeName is moved old->new and its node-scoped deviceId is
+// rewritten; HAMI GPU UUIDs are left unchanged. The row is parsed generically to
+// preserve any fields we do not model. Idempotent and tolerant of a
+// missing/empty ConfigMap.
+type MigrateRenamedNodeGPUAllocations struct {
+	common.KubeAction
+	OldNode string
+	NewNode string
+}
+
+func (a *MigrateRenamedNodeGPUAllocations) Execute(_ connector.Runtime) error {
+	if a.OldNode == "" || a.NewNode == "" {
+		return nil
+	}
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	cm, err := kubeClient.CoreV1().ConfigMaps(gpuAllocationsConfigMapNamespace).Get(ctx, gpuAllocationsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			logger.Infof("no %s/%s ConfigMap; no GPU allocations to migrate", gpuAllocationsConfigMapNamespace, gpuAllocationsConfigMapName)
+			return nil
+		}
+		return errors.Wrapf(err, "failed to get %s ConfigMap", gpuAllocationsConfigMapName)
+	}
+
+	raw := ""
+	if cm.Data != nil {
+		raw = cm.Data[gpuAllocationsConfigMapKey]
+	}
+	if strings.TrimSpace(raw) == "" {
+		logger.Infof("GPU allocation store is empty; nothing to migrate")
+		return nil
+	}
+
+	// Parse generically to preserve fields we do not model.
+	var allocations []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &allocations); err != nil {
+		return errors.Wrapf(err, "failed to parse %s", gpuAllocationsConfigMapKey)
+	}
+
+	changed := false
+	for i := range allocations {
+		row := allocations[i]
+		if newName, ok := rewriteStringField(row, "nodeName", func(v string) string {
+			if v == a.OldNode {
+				return a.NewNode
+			}
+			return v
+		}); ok {
+			logger.Infof("migrating GPU allocation nodeName -> %q", newName)
+			changed = true
+		}
+		if newID, ok := rewriteStringField(row, "deviceId", func(v string) string {
+			return rewriteNodeScopedID(v, a.OldNode, a.NewNode)
+		}); ok {
+			logger.Infof("migrating GPU allocation deviceId -> %q", newID)
+			changed = true
+		}
+	}
+	if !changed {
+		logger.Infof("no GPU allocations reference old node %q; nothing to migrate", a.OldNode)
+		return nil
+	}
+
+	updated, err := json.Marshal(allocations)
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize migrated GPU allocations")
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[gpuAllocationsConfigMapKey] = string(updated)
+	if _, err := kubeClient.CoreV1().ConfigMaps(gpuAllocationsConfigMapNamespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return errors.Wrapf(err, "failed to update %s ConfigMap", gpuAllocationsConfigMapName)
+	}
+	logger.Warnf("migrated GPU allocations from old node %q to new node %q", a.OldNode, a.NewNode)
+	return nil
+}
+
+// rewriteStringField applies fn to a string field of a generic JSON object and
+// writes it back when it changed. It returns the new value and whether it
+// changed. Non-string / missing fields are left untouched.
+func rewriteStringField(row map[string]json.RawMessage, field string, fn func(string) string) (string, bool) {
+	raw, ok := row[field]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	updated := fn(value)
+	if updated == value {
+		return value, false
+	}
+	encoded, err := json.Marshal(updated)
+	if err != nil {
+		return "", false
+	}
+	row[field] = encoded
+	return updated, true
+}
+
+// CleanupRenamedNodeLocalPVs removes node-local PersistentVolumes that are pinned
+// (via node affinity) to the old node name, together with their bound PVCs and
+// the pods consuming them. On a single-node Olares the only node-local PV belongs
+// to Prometheus (an operator-managed StatefulSet with a fixed PVC name); its data
+// is disposable monitoring data. The stale PV must be removed so that the
+// StatefulSet's recreated PVC (same fixed name) can bind to a fresh PV on the new
+// node instead of the old, now-unschedulable one.
+//
+// The action is idempotent (tolerates already-deleted objects). It first lets the
+// PVC/PV clear on their own: once the (scheduled) consuming pod terminates, the
+// pvc-protection finalizer is released naturally (the StatefulSet-recreated pod
+// is Pending/unscheduled and does not count as a consumer). Only if a PVC/PV is
+// still stuck terminating after a grace period does it force-remove the protection
+// finalizers as a fallback.
+type CleanupRenamedNodeLocalPVs struct {
+	common.KubeAction
+	OldNode string
+}
+
+func (a *CleanupRenamedNodeLocalPVs) Execute(runtime connector.Runtime) error {
+	if a.OldNode == "" {
+		logger.Warn("skipping node-local PV cleanup: old node name is empty")
+		return nil
+	}
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	pvs, err := kubeClient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to list persistent volumes")
+	}
+
+	var targets []corev1.PersistentVolume
+	var unsupported []string
+	for i := range pvs.Items {
+		pv := &pvs.Items[i]
+		if !pvPinnedToNode(pv, a.OldNode) {
+			continue
+		}
+		if !disposableRenamePV(pv) {
+			unsupported = append(unsupported, pv.Name)
+			continue
+		}
+		targets = append(targets, *pv)
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("refusing to delete non-disposable local PVs pinned to old node %q: %s", a.OldNode, strings.Join(unsupported, ", "))
+	}
+	if len(targets) == 0 {
+		logger.Infof("no node-local PVs pinned to old node %q, nothing to clean up", a.OldNode)
+		return nil
+	}
+
+	for i := range targets {
+		pv := &targets[i]
+		logger.Warnf("cleaning up node-local PV %q pinned to old node %q (reclaimPolicy=%s)",
+			pv.Name, a.OldNode, pv.Spec.PersistentVolumeReclaimPolicy)
+
+		if ref := pv.Spec.ClaimRef; ref != nil && ref.Name != "" {
+			if err := validatePVCBinding(ctx, kubeClient, ref.Namespace, ref.Name, pv.Name, ref.UID); err != nil {
+				return errors.Wrapf(err, "refusing to clean up stale binding for PV %q", pv.Name)
+			}
+			if err := deleteConsumingPods(ctx, kubeClient, ref.Namespace, ref.Name); err != nil {
+				return errors.Wrapf(err, "failed to delete pods consuming PVC %s/%s", ref.Namespace, ref.Name)
+			}
+			if err := forceDeletePVC(ctx, kubeClient, ref.Namespace, ref.Name); err != nil {
+				return errors.Wrapf(err, "failed to delete PVC %s/%s", ref.Namespace, ref.Name)
+			}
+		}
+		if err := forceDeletePV(ctx, kubeClient, pv.Name); err != nil {
+			return errors.Wrapf(err, "failed to delete PV %s", pv.Name)
+		}
+	}
+	return nil
+}
+
+func validatePVCBinding(ctx context.Context, kubeClient kubernetes.Interface, namespace, name, pvName string, claimUID types.UID) error {
+	pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if pvc.Spec.VolumeName != pvName {
+		return fmt.Errorf("PVC %s/%s is bound to PV %q, expected %q", namespace, name, pvc.Spec.VolumeName, pvName)
+	}
+	if claimUID != "" && pvc.UID != claimUID {
+		return fmt.Errorf("PVC %s/%s UID is %q, expected claim UID %q", namespace, name, pvc.UID, claimUID)
+	}
+	return nil
+}
+
+func deleteConsumingPods(ctx context.Context, kubeClient kubernetes.Interface, namespace, pvcName string) error {
+	if namespace == "" {
+		return nil
+	}
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !podUsesPVC(pod, pvcName) {
+			continue
+		}
+		logger.Infof("deleting pod %s/%s that consumes PVC %s", pod.Namespace, pod.Name, pvcName)
+		if err := kubeClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func podUsesPVC(pod *corev1.Pod, pvcName string) bool {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
+}
+
+// renamePVReclaimGrace is how long we let a PVC/PV clear on its own (via the
+// normal protection-finalizer machinery) after requesting deletion, before
+// force-removing the finalizers. It is intentionally short: the volume holds
+// disposable Prometheus monitoring data, and the consuming pod can have a large
+// terminationGracePeriodSeconds (e.g. 600s) that would otherwise keep the
+// pvc-protection finalizer held for a long time, so we prefer to force after a
+// brief wait rather than block the whole change-ip.
+const (
+	renamePVReclaimGrace  = 20 * time.Second
+	renamePVReclaimPoll   = 3 * time.Second
+	renamePVPostForceWait = 15 * time.Second
+)
+
+func forceDeletePVC(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
+	return deleteAndReclaim(ctx, "PVC", namespace+"/"+name,
+		func() (metav1.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		},
+		func() error {
+			return kubeClient.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		},
+		func(patch []byte) error {
+			_, err := kubeClient.CoreV1().PersistentVolumeClaims(namespace).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+			return err
+		})
+}
+
+func forceDeletePV(ctx context.Context, kubeClient kubernetes.Interface, name string) error {
+	return deleteAndReclaim(ctx, "PV", name,
+		func() (metav1.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumes().Get(ctx, name, metav1.GetOptions{})
+		},
+		func() error {
+			return kubeClient.CoreV1().PersistentVolumes().Delete(ctx, name, metav1.DeleteOptions{})
+		},
+		func(patch []byte) error {
+			_, err := kubeClient.CoreV1().PersistentVolumes().Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+			return err
+		})
+}
+
+// deleteAndReclaim requests deletion of an object, waits up to
+// renamePVReclaimGrace for it to disappear on its own (letting the protection
+// finalizers clear naturally once the terminating consumer is gone), and only
+// force-removes the finalizers if it is still stuck terminating after that.
+func deleteAndReclaim(ctx context.Context, kind, name string,
+	get func() (metav1.Object, error),
+	del func() error,
+	patch func([]byte) error) error {
+
+	obj, err := get()
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if obj.GetDeletionTimestamp() == nil {
+		logger.Infof("deleting %s %s", kind, name)
+		if err := del(); err != nil && !kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	// phase 1: give the normal finalizer machinery a chance to reclaim it.
+	gone, err := waitObjectGone(ctx, get, renamePVReclaimGrace, renamePVReclaimPoll)
+	if err != nil {
+		return err
+	}
+	if gone {
+		logger.Infof("%s %s reclaimed naturally", kind, name)
+		return nil
+	}
+
+	// phase 2: still terminating after the grace period -> force-remove finalizers.
+	obj, err = get()
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if len(obj.GetFinalizers()) > 0 {
+		logger.Warnf("%s %s still terminating after %s; force-removing finalizers %v",
+			kind, name, renamePVReclaimGrace, obj.GetFinalizers())
+		if err := patch([]byte(`{"metadata":{"finalizers":null}}`)); err != nil && !kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+	gone, err = waitObjectGone(ctx, get, renamePVPostForceWait, renamePVReclaimPoll)
+	if err != nil {
+		return err
+	}
+	if !gone {
+		return fmt.Errorf("%s %s still exists after finalizers were removed", kind, name)
+	}
+	return nil
+}
+
+// waitObjectGone polls until get() reports NotFound (returns true) or the timeout
+// elapses (returns false).
+func waitObjectGone(ctx context.Context, get func() (metav1.Object, error), timeout, poll time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		_, err := get()
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(poll):
+		}
+	}
+}
+
+// WaitForRenamedOldNodeDrained blocks until no live (non-terminating,
+// non-terminal) pods remain assigned to the old node, i.e. the old node's
+// workloads have started being garbage-collected and recreated elsewhere.
+//
+// This gate exists to prevent the subsequent cluster-wide readiness check from
+// passing prematurely: immediately after the old Node object is deleted, its
+// pods still report Running (stale status) for a short window, so a readiness
+// check run right away would trivially succeed before anything actually
+// migrated. Unlike a pre-captured pod count, this waits on real observed state,
+// so transient/Job/scaled-down pods that never come back cannot block it.
+type WaitForRenamedOldNodeDrained struct {
+	common.KubeAction
+	OldNode string
+}
+
+func (a *WaitForRenamedOldNodeDrained) Execute(_ connector.Runtime) error {
+	if a.OldNode == "" {
+		return nil
+	}
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		return err
+	}
+	pods, err := kubeClient.CoreV1().Pods(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to list pods while draining old node")
+	}
+	remaining := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		// A pod that is already terminating (DeletionTimestamp set) or terminal
+		// is on its way out and its replacement is being created, so it does not
+		// count as "still occupying" the old node.
+		if pod.Spec.NodeName != a.OldNode ||
+			pod.DeletionTimestamp != nil ||
+			pod.Status.Phase == corev1.PodSucceeded ||
+			pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		remaining++
+	}
+	if remaining > 0 {
+		return fmt.Errorf("waiting for %d pod(s) to drain from old node %q", remaining, a.OldNode)
+	}
+	logger.Infof("old node %q is drained; workloads are rescheduling onto the new node", a.OldNode)
+	return nil
+}
+
+// DeleteRenamedOldNode removes the stale Kubernetes Node object for the old
+// hostname. Deleting it triggers garbage collection of the pods still assigned to
+// it so their controllers reschedule them onto the new node. Idempotent.
+type DeleteRenamedOldNode struct {
+	common.KubeAction
+	OldNode string
+}
+
+func (a *DeleteRenamedOldNode) Execute(runtime connector.Runtime) error {
+	if a.OldNode == "" {
+		logger.Warn("skipping old node deletion: old node name is empty")
+		return nil
+	}
+	kubeClient, err := newChangeIPKubeClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	logger.Warnf("deleting old node %q", a.OldNode)
+	deleteOptions := metav1.DeleteOptions{}
+	if oldNodeUID, ok := a.PipelineCache.GetMustString(common.CacheOldNodeUID); ok && oldNodeUID != "" {
+		uid := types.UID(oldNodeUID)
+		deleteOptions.Preconditions = &metav1.Preconditions{UID: &uid}
+	}
+	if err := kubeClient.CoreV1().Nodes().Delete(ctx, a.OldNode, deleteOptions); err != nil && !kerrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete old node %q", a.OldNode)
+	}
+	return nil
+}

--- a/cli/pkg/terminus/hostname_test.go
+++ b/cli/pkg/terminus/hostname_test.go
@@ -98,6 +98,44 @@ func TestRewriteStringField(t *testing.T) {
 	}
 }
 
+func TestMigrateGPUAllocationRows(t *testing.T) {
+	rows := []map[string]json.RawMessage{
+		// old node, NVIDIA (stable UUID device id)
+		{"nodeName": json.RawMessage(`"olares-rn7"`), "deviceId": json.RawMessage(`"GPU-abc-123"`), "owner": json.RawMessage(`"alice"`)},
+		// old node, non-HAMI (node-scoped device id)
+		{"nodeName": json.RawMessage(`"olares-rn7"`), "deviceId": json.RawMessage(`"olares-rn7-intel-0"`)},
+		// a DIFFERENT node whose name shares the "olares-rn7-" prefix: must be untouched
+		{"nodeName": json.RawMessage(`"olares-rn7-worker"`), "deviceId": json.RawMessage(`"olares-rn7-worker-intel-0"`)},
+	}
+
+	changed := migrateGPUAllocationRows(rows, "olares-rn7", "olares-rn8")
+	if !changed {
+		t.Fatalf("expected changes")
+	}
+
+	get := func(i int, field string) string {
+		v, _ := stringField(rows[i], field)
+		return v
+	}
+	if get(0, "nodeName") != "olares-rn8" || get(0, "deviceId") != "GPU-abc-123" {
+		t.Fatalf("nvidia row = (%q,%q), want (olares-rn8, GPU-abc-123)", get(0, "nodeName"), get(0, "deviceId"))
+	}
+	if get(0, "owner") != "alice" {
+		t.Fatalf("unmodeled field must be preserved, got owner=%q", get(0, "owner"))
+	}
+	if get(1, "nodeName") != "olares-rn8" || get(1, "deviceId") != "olares-rn8-intel-0" {
+		t.Fatalf("intel row = (%q,%q), want (olares-rn8, olares-rn8-intel-0)", get(1, "nodeName"), get(1, "deviceId"))
+	}
+	if get(2, "nodeName") != "olares-rn7-worker" || get(2, "deviceId") != "olares-rn7-worker-intel-0" {
+		t.Fatalf("other-node row must be untouched, got (%q,%q)", get(2, "nodeName"), get(2, "deviceId"))
+	}
+
+	// idempotent: a second run against the (already migrated) rows is a no-op
+	if migrateGPUAllocationRows(rows, "olares-rn7", "olares-rn8") {
+		t.Fatalf("second migration should be a no-op")
+	}
+}
+
 func TestLabelAndAnnotationAllowlist(t *testing.T) {
 	if !labelIsAllowlistedForRestore("gpu.bytetrade.io/nvidia") {
 		t.Fatalf("gpu.bytetrade.io/* label should be allowlisted")

--- a/cli/pkg/terminus/hostname_test.go
+++ b/cli/pkg/terminus/hostname_test.go
@@ -1,0 +1,117 @@
+package terminus
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRewriteNodeScopedID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		oldNode string
+		newNode string
+		want    string
+	}{
+		{
+			name:    "non-HAMI device id embeds node name",
+			id:      "olares-rn5-intel-0",
+			oldNode: "olares-rn5",
+			newNode: "olares-rn6",
+			want:    "olares-rn6-intel-0",
+		},
+		{
+			name:    "HAMI gpu uuid is left unchanged",
+			id:      "GPU-be013ee7-f327-cd75-8020-e98e278cda45",
+			oldNode: "olares-rn5",
+			newNode: "olares-rn6",
+			want:    "GPU-be013ee7-f327-cd75-8020-e98e278cda45",
+		},
+		{
+			name:    "unrelated id left unchanged",
+			id:      "some-other-device",
+			oldNode: "olares-rn5",
+			newNode: "olares-rn6",
+			want:    "some-other-device",
+		},
+		{
+			name:    "empty node names are a no-op",
+			id:      "olares-rn5-intel-0",
+			oldNode: "",
+			newNode: "olares-rn6",
+			want:    "olares-rn5-intel-0",
+		},
+		{
+			name:    "node name as exact prefix but not a segment is not rewritten",
+			id:      "olares-rn5extra-intel-0",
+			oldNode: "olares-rn5",
+			newNode: "olares-rn6",
+			// "olares-rn5extra-..." does not start with "olares-rn5-", so unchanged
+			want: "olares-rn5extra-intel-0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rewriteNodeScopedID(tt.id, tt.oldNode, tt.newNode); got != tt.want {
+				t.Fatalf("rewriteNodeScopedID(%q,%q,%q) = %q, want %q", tt.id, tt.oldNode, tt.newNode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRewriteStringField(t *testing.T) {
+	row := map[string]json.RawMessage{
+		"nodeName": json.RawMessage(`"olares-rn5"`),
+		"deviceId": json.RawMessage(`"olares-rn5-intel-0"`),
+		"memory":   json.RawMessage(`123`),
+	}
+
+	got, changed := rewriteStringField(row, "nodeName", func(v string) string {
+		if v == "olares-rn5" {
+			return "olares-rn6"
+		}
+		return v
+	})
+	if !changed || got != "olares-rn6" {
+		t.Fatalf("nodeName rewrite = (%q,%v), want (olares-rn6,true)", got, changed)
+	}
+	if string(row["nodeName"]) != `"olares-rn6"` {
+		t.Fatalf("nodeName not written back: %s", row["nodeName"])
+	}
+
+	// no-op rewrite reports unchanged
+	if _, changed := rewriteStringField(row, "nodeName", func(v string) string { return v }); changed {
+		t.Fatalf("expected no change for identity rewrite")
+	}
+
+	// missing field is a no-op
+	if _, changed := rewriteStringField(row, "absent", func(v string) string { return "x" }); changed {
+		t.Fatalf("expected no change for missing field")
+	}
+
+	// non-string field is left alone
+	if _, changed := rewriteStringField(row, "memory", func(v string) string { return "x" }); changed {
+		t.Fatalf("expected no change for non-string field")
+	}
+	if string(row["memory"]) != `123` {
+		t.Fatalf("memory should be untouched, got %s", row["memory"])
+	}
+}
+
+func TestLabelAndAnnotationAllowlist(t *testing.T) {
+	if !labelIsAllowlistedForRestore("gpu.bytetrade.io/nvidia") {
+		t.Fatalf("gpu.bytetrade.io/* label should be allowlisted")
+	}
+	if !labelIsAllowlistedForRestore("node-role.kubernetes.io/worker") {
+		t.Fatalf("worker role label should be allowlisted")
+	}
+	if labelIsAllowlistedForRestore("kubernetes.io/hostname") {
+		t.Fatalf("kubernetes.io/hostname must not be restored")
+	}
+	if !annotationIsAllowlistedForRestore(gpuShareModeAnnotationPrefix + "GPU-abc") {
+		t.Fatalf("share-mode annotation should be allowlisted")
+	}
+	if annotationIsAllowlistedForRestore("projectcalico.org/IPv4Address") {
+		t.Fatalf("calico annotation must not be restored")
+	}
+}

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -707,8 +707,15 @@ func (m *ChangeIPModule) addRestartTasks() {
 		})
 
 	hostnameChanged, _ := m.PipelineCache.GetMustBool(common.CacheHostnameChanged)
+	// ensureNode scopes the final readiness check. For a same-node IP change we
+	// keep checking the (stable) local node. For a hostname change we check the
+	// whole cluster ("" = all nodes): right after the old node is deleted its
+	// pods are recreated as unscheduled Pending replacements (empty NodeName),
+	// which a new-node-scoped check would skip, so it could pass before the
+	// workloads actually reschedule and become ready.
 	ensureNode := newNodeName
 	if hostnameChanged {
+		ensureNode = ""
 		m.addRenamedNodeMigrationTasks(newNodeName)
 	} else {
 		m.addSameNodeRestartTasks(newNodeName)

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -697,10 +697,38 @@ func (m *ChangeIPModule) addKubernetesTasks() {
 }
 
 func (m *ChangeIPModule) addRestartTasks() {
+	newNodeName := m.Runtime.GetLocalHost().GetName()
+
+	m.Tasks = append(m.Tasks,
+		&task.LocalTask{
+			Name:   "WaitForKubeAPIServerUp",
+			Action: new(precheck.GetKubernetesNodesStatus),
+			Retry:  20,
+		})
+
+	hostnameChanged, _ := m.PipelineCache.GetMustBool(common.CacheHostnameChanged)
+	ensureNode := newNodeName
+	if hostnameChanged {
+		m.addRenamedNodeMigrationTasks(newNodeName)
+	} else {
+		m.addSameNodeRestartTasks(newNodeName)
+	}
+
+	m.Tasks = append(m.Tasks, &task.LocalTask{
+		Name:   "EnsurePodsUpAndRunningAgain",
+		Action: &CheckKeyPodsRunning{Node: ensureNode},
+		Delay:  10 * time.Second,
+		Retry:  60,
+	})
+}
+
+// addSameNodeRestartTasks is the original change-ip behavior: the node name is
+// unchanged, so pods pinned to the host IP are deleted and awaited for recreation.
+func (m *ChangeIPModule) addSameNodeRestartTasks(newNodeName string) {
 	restartPodsTasks := []task.Interface{
 		&task.LocalTask{
 			Name:   "RestartAllPods",
-			Action: &DeleteAllPods{Node: m.Runtime.GetLocalHost().GetName()},
+			Action: &DeleteAllPods{Node: newNodeName},
 			Retry:  5,
 			Delay:  15 * time.Second,
 		},
@@ -723,20 +751,59 @@ func (m *ChangeIPModule) addRestartTasks() {
 			},
 		}
 	}
+	m.Tasks = append(m.Tasks, restartPodsTasks...)
+}
+
+// addRenamedNodeMigrationTasks handles the case where the hostname changed before
+// change-ip ran: k3s registers a brand-new node under the new name. We restore
+// the labels Olares applied onto the new node, drop node-local PVs pinned to the
+// old node (disposable Prometheus monitoring data that would otherwise keep the
+// recreated PVC bound to an unschedulable PV), then delete the old node so its
+// controllers reschedule pods onto the new node. The host-IP pod dance is skipped
+// because deleting the old node already forces every pod to be recreated.
+func (m *ChangeIPModule) addRenamedNodeMigrationTasks(newNodeName string) {
+	oldNodeName, _ := m.PipelineCache.GetMustString(common.CacheOldNodeName)
 	m.Tasks = append(m.Tasks,
 		&task.LocalTask{
-			Name:   "WaitForKubeAPIServerUp",
-			Action: new(precheck.GetKubernetesNodesStatus),
+			Name:   "RestoreRenamedNodeLabels",
+			Action: &RestoreLabelsFromRenamedNode{OldNode: oldNodeName, NewNode: newNodeName},
+			Delay:  6 * time.Second,
 			Retry:  20,
-		})
-	m.Tasks = append(m.Tasks, restartPodsTasks...)
-
-	m.Tasks = append(m.Tasks, &task.LocalTask{
-		Name:   "EnsurePodsUpAndRunningAgain",
-		Action: &CheckKeyPodsRunning{Node: m.Runtime.GetLocalHost().GetName()},
-		Delay:  10 * time.Second,
-		Retry:  60,
-	})
+		},
+		&task.LocalTask{
+			Name:   "MigrateRenamedNodeGPUAllocations",
+			Action: &MigrateRenamedNodeGPUAllocations{OldNode: oldNodeName, NewNode: newNodeName},
+			Delay:  3 * time.Second,
+			Retry:  10,
+		},
+		&task.LocalTask{
+			Name:   "CleanupRenamedNodeLocalPVs",
+			Action: &CleanupRenamedNodeLocalPVs{OldNode: oldNodeName},
+			Delay:  10 * time.Second,
+			Retry:  10,
+		},
+		&task.LocalTask{
+			Name:   "DeleteRenamedOldNode",
+			Action: &DeleteRenamedOldNode{OldNode: oldNodeName},
+			Delay:  6 * time.Second,
+			Retry:  5,
+		},
+		// Wait for the old node's pods to actually drain before the shared
+		// EnsurePodsUpAndRunningAgain readiness check runs; otherwise that check
+		// would pass on the old node's stale (still-Running) pods immediately
+		// after the node object is deleted, before anything migrated.
+		&task.LocalTask{
+			Name:   "WaitForRenamedOldNodeDrained",
+			Action: &WaitForRenamedOldNodeDrained{OldNode: oldNodeName},
+			Delay:  10 * time.Second,
+			Retry:  60,
+		},
+	)
+	// Readiness of the recreated pods on the new node is then handled by the
+	// shared EnsurePodsUpAndRunningAgain step (cluster-wide scope). We
+	// intentionally do not pre-capture a pod count to wait against: a snapshot
+	// count is fragile (transient/Job/scaled-down pods may never come back, which
+	// would block forever).
 }
 
 type ChangeHostIPModule struct {


### PR DESCRIPTION
## Summary

A machine hostname change makes the kubelet register a brand-new Kubernetes node under the new name and abandon the old one. Recovering is complex: the workloads must be rebuilt on the new node, and a lot of per-node state (node metadata, node-local storage, GPU allocations) still points at the old node and has to be migrated first.

`change-ip` now detects and handles this. It identifies a hostname change by matching the machine's `machine-id` and system UUID against the registered nodes (after lowercasing the hostname), and then performs the migration:

- **Node metadata**: restores the labels/annotations Olares owns (GPU labels, worker role, GPU share-mode) onto the newly registered node.
- **GPU allocations**: migrates the app-service GPU allocation store and share-mode keys, rewriting the old node name in node-scoped device ids while leaving stable GPU UUIDs untouched.
- **Node-local storage**: removes node-local PersistentVolumes bound to the old node, then deletes the stale node object.
- **Convergence**: waits for the old node to drain and its workloads to come back ready on the new node.

When the hostname is unchanged, `change-ip` behaves exactly as before.

## Test plan

- [ ] `change-ip` with an unchanged hostname takes the original path (regression).
- [ ] `change-ip` after a hostname change (including uppercase normalization) migrates node metadata, GPU allocations/share-mode, and node-local PVs, deletes the old node, and waits for pods to become ready on the new node.
- [ ] GPU allocation rows and share-mode annotations for non-HAMi devices get their node-scoped ids rewritten; HAMi GPU UUIDs are left unchanged.

Made with [Cursor](https://cursor.com)