### PR TITLE
market: optimize startup caching, tighten upload auth

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -142,7 +142,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.76
+        image: beclab/market-backend:v0.6.77
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81
@@ -202,7 +202,7 @@ spec:
           - name: API_DETAIL_PATH
             value: /api/v1/applications/info
           - name: CHART_ROOT
-            value: /opt/app/data/v3
+            value: /opt/app/data
           - name: NATS_SUBJECT_SYSTEM_USER_STATE
             value: os.users
           - name: GO_ENV


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
optimize startup caching, tighten upload auth, and filter AppleDouble metadata

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/376
https://github.com/beclab/market/pull/377
https://github.com/beclab/market/pull/379


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys a new backend image and changes the chart filesystem root, which can affect chart discovery and startup behavior on upgrade; rollout is limited to the market deployment manifest.
> 
> **Overview**
> Updates the **market** cluster deployment to ship **`beclab/market-backend:v0.6.77`** (from v0.6.76), pulling in the linked market changes around startup caching, upload auth, and AppleDouble filtering.
> 
> Sets **`CHART_ROOT`** from `/opt/app/data/v3` to **`/opt/app/data`**, matching the existing volume mount at `/opt/app/data` so chart storage paths align with the on-disk cache layout (note **`IMAGE_INFOS`** still points at `/opt/app/data/v3/images-info`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d905c776bc54ec960505ec504fbd8496b3ad851d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->