### PR TITLE
fix(cli): support installation on Ubuntu 26

### DIFF
--- a/cli/pkg/bootstrap/patch/tasks.go
+++ b/cli/pkg/bootstrap/patch/tasks.go
@@ -113,7 +113,6 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 					return err
 				}
 			}
-			pre_reqs += " ntpdate "
 		}
 
 		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s update -qq", pkgManager), false, true); err != nil {
@@ -122,6 +121,14 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 		}
 
 		logger.Debug("apt update success")
+
+		// ntpdate has been dropped from newer Ubuntu releases (e.g. 26.04) where
+		// it no longer has an installation candidate. Resolve the time-sync
+		// package after the package index is refreshed so we can fall back to
+		// systemd-timesyncd, which the time-sync tasks already handle at runtime.
+		if systemInfo.IsUbuntu() {
+			pre_reqs += " " + getTimeSyncPackage(runtime) + " "
+		}
 
 		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s install -y -qq %s", pkgManager, pre_reqs), false, true); err != nil {
 			logger.Errorf("install deps %s error %v", pre_reqs, err)
@@ -150,6 +157,20 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 	}
 
 	return nil
+}
+
+// getTimeSyncPackage returns the package used to keep the system clock in sync.
+// Historically Olares relied on ntpdate, but it has been removed from newer
+// distributions (e.g. Ubuntu 26.04) where it has no installation candidate.
+// When ntpdate is unavailable we fall back to systemd-timesyncd, which the
+// time-sync tasks already use when the ntpdate binary is absent. This must be
+// called after the apt package index has been refreshed.
+func getTimeSyncPackage(runtime connector.Runtime) string {
+	out, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("apt-cache policy %s", common.CommandNtpdate), false, false)
+	if err == nil && strings.Contains(out, "Candidate:") && !strings.Contains(out, "Candidate: (none)") {
+		return common.CommandNtpdate
+	}
+	return "systemd-timesyncd"
 }
 
 type CorrectHostname struct {

--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -35,6 +35,10 @@ func (u UbuntuVersion) String() string {
 		return "22."
 	case Ubuntu24:
 		return "24."
+	case Ubuntu25:
+		return "25."
+	case Ubuntu26:
+		return "26."
 	}
 	return ""
 }
@@ -56,6 +60,7 @@ const (
 	Ubuntu22   UbuntuVersion = "22."
 	Ubuntu24   UbuntuVersion = "24."
 	Ubuntu25   UbuntuVersion = "25."
+	Ubuntu26   UbuntuVersion = "26."
 	Ubuntu2204 UbuntuVersion = "22.04"
 	Ubuntu2404 UbuntuVersion = "24.04"
 
@@ -146,7 +151,7 @@ func (s *SystemInfo) IsSupport() error {
 	//}
 
 	if s.IsUbuntu() {
-		if !s.IsUbuntuVersionEqual(Ubuntu22) && !s.IsUbuntuVersionEqual(Ubuntu24) && !s.IsUbuntuVersionEqual(Ubuntu25) {
+		if !s.IsUbuntuVersionEqual(Ubuntu22) && !s.IsUbuntuVersionEqual(Ubuntu24) && !s.IsUbuntuVersionEqual(Ubuntu25) && !s.IsUbuntuVersionEqual(Ubuntu26) {
 			return fmt.Errorf("unsupported ubuntu os version '%s'", s.GetOsVersion())
 		}
 	}


### PR DESCRIPTION
* **Background**
the `ntpdate` APT pkg we used to install for time sync is removed in Ubuntu 26 so in case it's not found, we fallback to the `systemd-timesyncd`

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted install/bootstrap changes for a new Ubuntu version; time-sync behavior reuses existing runtime fallbacks.
> 
> **Overview**
> **Ubuntu 26** is now treated as a supported release in OS validation (`Ubuntu26` constant and `IsSupport` allowlist).
> 
> Bootstrap **patch** deps no longer always install `ntpdate` on Ubuntu. After `apt update`, **`getTimeSyncPackage`** checks `apt-cache policy` for an install candidate; it installs `ntpdate` when available and **`systemd-timesyncd`** when not (e.g. Ubuntu 26.04). Existing time-sync tasks already fall back when the `ntpdate` binary is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b91ade14eaec5cb80d15b67e0d010bb0ab987e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->