### PR TITLE
feat(cli): add doctor thirdleveldomain conflict check

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -160,6 +160,9 @@ olares-cli cluster workload images docker.io/library/nginx:latest
 olares-cli doctor images -o json
 # Orphans only, biggest first, with reclaimable-size footer.
 olares-cli doctor images --unused
+# Per-user third_level_domain duplicates / reserved names (kubeconfig).
+olares-cli doctor thirdleveldomain
+olares-cli doctor thirdleveldomain --force-dedupe
 ```
 
 ## Output formats

--- a/cli/cmd/ctl/doctor/root.go
+++ b/cli/cmd/ctl/doctor/root.go
@@ -13,11 +13,13 @@ func NewDoctorCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run read-only Olares diagnostics",
-		Long: `Run read-only diagnostics that combine Olares API surfaces.
+		Long: `Run Olares diagnostics that combine API surfaces.
 
-Doctor commands do not mutate cluster, settings, market, or files state.`,
+Most doctor commands are read-only. Exceptions that mutate (when an
+explicit flag is set) are documented on the subcommand help.`,
 	}
 	cmd.SilenceUsage = true
 	cmd.AddCommand(workload.NewDoctorImagesCommand(f))
+	cmd.AddCommand(NewThirdLevelDomainCommand(f))
 	return cmd
 }

--- a/cli/cmd/ctl/doctor/root_test.go
+++ b/cli/cmd/ctl/doctor/root_test.go
@@ -15,4 +15,7 @@ func TestDoctorCommandRegistersImages(t *testing.T) {
 	if sub, _, err := cmd.Find([]string{"images"}); err != nil || sub == nil || sub.Name() != "images" {
 		t.Fatalf("doctor images not registered: sub=%v err=%v", sub, err)
 	}
+	if sub, _, err := cmd.Find([]string{"thirdleveldomain"}); err != nil || sub == nil || sub.Name() != "thirdleveldomain" {
+		t.Fatalf("doctor thirdleveldomain not registered: sub=%v err=%v", sub, err)
+	}
 }

--- a/cli/cmd/ctl/doctor/thirdleveldomain.go
+++ b/cli/cmd/ctl/doctor/thirdleveldomain.go
@@ -1,0 +1,214 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewThirdLevelDomainCommand backs `olares-cli doctor thirdleveldomain`.
+func NewThirdLevelDomainCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		kubeconfig  string
+		output      string
+		quiet       bool
+		noHeaders   bool
+		forceDedupe bool
+	)
+	cmd := &cobra.Command{
+		Use:     "thirdleveldomain",
+		Aliases: []string{"tld"},
+		Short:   "check per-user third_level_domain conflicts",
+		Long: `Audit Application customDomain.third_level_domain values for
+conflicts within each user zone (via kubeconfig).
+
+Reports:
+  - duplicate  same prefix used by 2+ app/entrance pairs in one zone
+  - reserved   prefix is auth, desktop, or wizard
+
+Shared apps use EffectiveSettings(user); per-user apps contribute only
+to their Owner's zone. Does not check default appid prefixes or
+third_party_domain.
+
+With --force-dedupe (writes Application CRs):
+  - duplicate: keep the lexicographically first (app, entrance) in each
+    user zone; clear third_level_domain on the rest
+  - reserved: clear every third_level_domain that is auth, desktop, or wizard`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return runThirdLevelDomain(c.Context(), kubeconfig, output, quiet, noHeaders, forceDedupe)
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "path to kubeconfig file (optional; falls back to KUBECONFIG / default)")
+	cmd.Flags().StringVarP(&output, "output", "o", "table", "output format: table, json")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress output; exit code indicates success/failure")
+	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "omit table headers")
+	cmd.Flags().BoolVar(&forceDedupe, "force-dedupe", false, "clear duplicate losers (keep one) and reserved auth/desktop/wizard third_level_domain values")
+	_ = f
+	return cmd
+}
+
+func runThirdLevelDomain(ctx context.Context, kubeconfig, output string, quiet, noHeaders, forceDedupe bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c, err := newAppClientFromKubeConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	apps, users, err := listAppsAndUsers(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	if forceDedupe {
+		ops := PlanForceDedupeClears(apps, users)
+		if len(ops) > 0 {
+			if err := applyForceDedupeClears(ctx, c, ops); err != nil {
+				return err
+			}
+			if !quiet && !strings.EqualFold(strings.TrimSpace(output), "json") {
+				renderClearOps(noHeaders, ops)
+			}
+			apps, users, err = listAppsAndUsers(ctx, c)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	issues := FindThirdLevelDomainIssues(apps, users)
+	if err := renderThirdLevelDomainIssues(output, quiet, noHeaders, issues); err != nil {
+		return err
+	}
+	if len(issues) > 0 {
+		return fmt.Errorf("found %d third_level_domain issue(s)", len(issues))
+	}
+	return nil
+}
+
+func listAppsAndUsers(ctx context.Context, c client.Client) ([]appv1alpha1.Application, []string, error) {
+	var appList appv1alpha1.ApplicationList
+	if err := c.List(ctx, &appList); err != nil {
+		return nil, nil, fmt.Errorf("list applications: %w", err)
+	}
+
+	var iamUsers []string
+	var userList iamv1alpha2.UserList
+	if err := c.List(ctx, &userList); err == nil {
+		iamUsers = make([]string, 0, len(userList.Items))
+		for i := range userList.Items {
+			iamUsers = append(iamUsers, userList.Items[i].Name)
+		}
+	}
+	return appList.Items, CollectZoneUsers(appList.Items, iamUsers), nil
+}
+
+func applyForceDedupeClears(ctx context.Context, c client.Client, ops []ClearThirdLevelOp) error {
+	byObject := make(map[string][]ClearThirdLevelOp)
+	for _, op := range ops {
+		byObject[op.ObjectName] = append(byObject[op.ObjectName], op)
+	}
+	for objectName, objectOps := range byObject {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var app appv1alpha1.Application
+			if err := c.Get(ctx, types.NamespacedName{Name: objectName}, &app); err != nil {
+				return err
+			}
+			original := app.DeepCopy()
+			if err := ApplyClearOpsToApp(&app, objectOps); err != nil {
+				return err
+			}
+			return c.Patch(ctx, &app, client.MergeFrom(original))
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("application %q not found while clearing third_level_domain: %w", objectName, err)
+			}
+			return fmt.Errorf("clear third_level_domain on application %q: %w", objectName, err)
+		}
+	}
+	return nil
+}
+
+func renderClearOps(noHeaders bool, ops []ClearThirdLevelOp) {
+	fmt.Fprintf(os.Stderr, "force-dedupe: cleared %d third_level_domain value(s)\n", len(ops))
+	w := tabwriter.NewWriter(os.Stderr, 0, 0, 2, ' ', 0)
+	if !noHeaders {
+		fmt.Fprintln(w, "USER\tCLEARED_APP\tENTRANCE\tTHIRD_LEVEL\tREASON\tKEPT")
+	}
+	for _, op := range ops {
+		kept := "-"
+		if op.Reason == "duplicate" {
+			kept = op.KeepApp + "/" + op.KeepEntrance
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			op.User, op.App, op.Entrance, op.ThirdLevel, op.Reason, kept)
+	}
+	_ = w.Flush()
+}
+
+func renderThirdLevelDomainIssues(output string, quiet, noHeaders bool, issues []DomainIssue) error {
+	if quiet {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(output), "json") {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(issues)
+	}
+	if len(issues) == 0 {
+		fmt.Fprintln(os.Stdout, "ok: no third_level_domain conflicts")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if !noHeaders {
+		fmt.Fprintln(w, "USER\tAPP\tENTRANCE\tTHIRD_LEVEL\tISSUE")
+	}
+	for _, iss := range issues {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			iss.User, iss.App, iss.Entrance, iss.ThirdLevel, iss.Issue)
+	}
+	return w.Flush()
+}
+
+func newAppClientFromKubeConfig(kubeconfig string) (client.Client, error) {
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			kubeconfig = clientcmd.RecommendedHomeFile
+		}
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+	scheme := runtime.NewScheme()
+	if err := appv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add application scheme: %w", err)
+	}
+	if err := iamv1alpha2.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add user scheme: %w", err)
+	}
+	c, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	return c, nil
+}

--- a/cli/cmd/ctl/doctor/thirdleveldomain_check.go
+++ b/cli/cmd/ctl/doctor/thirdleveldomain_check.go
@@ -1,0 +1,391 @@
+package doctor
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+)
+
+// reservedThirdLevelDomains mirrors app-service handler_settings.go.
+var reservedThirdLevelDomains = map[string]struct{}{
+	"auth":    {},
+	"desktop": {},
+	"wizard":  {},
+}
+
+// DomainIssue is one third-level-domain problem in a user zone.
+type DomainIssue struct {
+	User       string `json:"user"`
+	App        string `json:"app"`
+	Entrance   string `json:"entrance"`
+	ThirdLevel string `json:"third_level"`
+	Issue      string `json:"issue"` // "duplicate" | "reserved"
+}
+
+type thirdLevelClaim struct {
+	user       string
+	objectName string
+	app        string
+	entrance   string
+	thirdLevel string
+	shared     bool
+}
+
+// ClearThirdLevelOp clears one entrance's third_level_domain.
+// Reason is "duplicate" (loser of a keep-one conflict) or "reserved"
+// (auth/desktop/wizard — always cleared, nothing is kept).
+type ClearThirdLevelOp struct {
+	ObjectName   string `json:"object_name"`
+	App          string `json:"app"`
+	User         string `json:"user"`
+	Entrance     string `json:"entrance"`
+	ThirdLevel   string `json:"third_level"`
+	KeepApp      string `json:"keep_app,omitempty"`
+	KeepEntrance string `json:"keep_entrance,omitempty"`
+	Shared       bool   `json:"shared"`
+	Reason       string `json:"reason"` // "duplicate" | "reserved"
+}
+
+func collectThirdLevelClaims(apps []appv1alpha1.Application, users []string) []thirdLevelClaim {
+	claims := make([]thirdLevelClaim, 0)
+	for _, user := range users {
+		user = strings.TrimSpace(user)
+		if user == "" {
+			continue
+		}
+		for i := range apps {
+			app := &apps[i]
+			blob := callerCustomDomainBlob(app, user)
+			for entrance, cfg := range parseCustomDomain(blob) {
+				tl := strings.TrimSpace(cfg.thirdLevel)
+				if tl == "" {
+					continue
+				}
+				claims = append(claims, thirdLevelClaim{
+					user:       user,
+					objectName: app.Name,
+					app:        app.Spec.Name,
+					entrance:   entrance,
+					thirdLevel: tl,
+					shared:     appv1alpha1.IsShared(app),
+				})
+			}
+		}
+	}
+	return claims
+}
+
+// FindThirdLevelDomainIssues audits customDomain.third_level_domain values
+// per user zone (Approach 1): duplicates within a zone, and reserved names
+// auth/desktop/wizard. users is the set of zone owners to scan (typically
+// IAM usernames); empty users yields no issues.
+func FindThirdLevelDomainIssues(apps []appv1alpha1.Application, users []string) []DomainIssue {
+	claims := collectThirdLevelClaims(apps, users)
+
+	type key struct {
+		user   string
+		prefix string
+	}
+	counts := make(map[key]int)
+	for _, c := range claims {
+		counts[key{user: c.user, prefix: strings.ToLower(c.thirdLevel)}]++
+	}
+
+	issues := make([]DomainIssue, 0)
+	seen := make(map[string]struct{})
+	for _, c := range claims {
+		lower := strings.ToLower(c.thirdLevel)
+		if _, ok := reservedThirdLevelDomains[lower]; ok {
+			iss := DomainIssue{
+				User: c.user, App: c.app, Entrance: c.entrance,
+				ThirdLevel: c.thirdLevel, Issue: "reserved",
+			}
+			id := issueID(iss)
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				issues = append(issues, iss)
+			}
+		}
+		if counts[key{user: c.user, prefix: lower}] > 1 {
+			iss := DomainIssue{
+				User: c.user, App: c.app, Entrance: c.entrance,
+				ThirdLevel: c.thirdLevel, Issue: "duplicate",
+			}
+			id := issueID(iss)
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				issues = append(issues, iss)
+			}
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		if a.User != b.User {
+			return a.User < b.User
+		}
+		if a.App != b.App {
+			return a.App < b.App
+		}
+		if a.Entrance != b.Entrance {
+			return a.Entrance < b.Entrance
+		}
+		return a.Issue < b.Issue
+	})
+	return issues
+}
+
+// PlanForceDedupeClears returns clear ops for --force-dedupe:
+//   - reserved (auth/desktop/wizard): clear every matching claim
+//   - duplicate: keep the lexicographically first (app, entrance) in each
+//     user-zone prefix group; clear the rest
+func PlanForceDedupeClears(apps []appv1alpha1.Application, users []string) []ClearThirdLevelOp {
+	claims := collectThirdLevelClaims(apps, users)
+	ops := make([]ClearThirdLevelOp, 0)
+	seen := make(map[string]struct{})
+	add := func(op ClearThirdLevelOp) {
+		id := strings.Join([]string{op.ObjectName, op.User, op.Entrance, op.Reason}, "\x00")
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ops = append(ops, op)
+	}
+
+	for _, c := range claims {
+		if _, ok := reservedThirdLevelDomains[strings.ToLower(c.thirdLevel)]; !ok {
+			continue
+		}
+		add(ClearThirdLevelOp{
+			ObjectName: c.objectName,
+			App:        c.app,
+			User:       c.user,
+			Entrance:   c.entrance,
+			ThirdLevel: c.thirdLevel,
+			Shared:     c.shared,
+			Reason:     "reserved",
+		})
+	}
+
+	type key struct {
+		user   string
+		prefix string
+	}
+	groups := make(map[key][]thirdLevelClaim)
+	for _, c := range claims {
+		k := key{user: c.user, prefix: strings.ToLower(c.thirdLevel)}
+		groups[k] = append(groups[k], c)
+	}
+
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].app != group[j].app {
+				return group[i].app < group[j].app
+			}
+			return group[i].entrance < group[j].entrance
+		})
+		keep := group[0]
+		// If the kept claim is reserved it is already queued for clear;
+		// clear every claim in the group (including "keep") via reserved.
+		if _, reservedKeep := reservedThirdLevelDomains[strings.ToLower(keep.thirdLevel)]; reservedKeep {
+			continue
+		}
+		for _, c := range group[1:] {
+			if _, reserved := reservedThirdLevelDomains[strings.ToLower(c.thirdLevel)]; reserved {
+				continue // already covered by reserved clears
+			}
+			add(ClearThirdLevelOp{
+				ObjectName:   c.objectName,
+				App:          c.app,
+				User:         c.user,
+				Entrance:     c.entrance,
+				ThirdLevel:   c.thirdLevel,
+				KeepApp:      keep.app,
+				KeepEntrance: keep.entrance,
+				Shared:       c.shared,
+				Reason:       "duplicate",
+			})
+		}
+	}
+	sort.Slice(ops, func(i, j int) bool {
+		a, b := ops[i], ops[j]
+		if a.User != b.User {
+			return a.User < b.User
+		}
+		if a.App != b.App {
+			return a.App < b.App
+		}
+		if a.Entrance != b.Entrance {
+			return a.Entrance < b.Entrance
+		}
+		return a.Reason < b.Reason
+	})
+	return ops
+}
+
+// ApplyClearOpsToApp clears third_level_domain for ops targeting this app.
+// Shared apps write Spec.UserSettings[user]; per-user apps write Spec.Settings.
+// Shared clears always land in the per-user overlay (creating one from the
+// effective blob when needed) so global Spec.Settings is not rewritten.
+func ApplyClearOpsToApp(app *appv1alpha1.Application, ops []ClearThirdLevelOp) error {
+	if app == nil || len(ops) == 0 {
+		return nil
+	}
+	byUser := make(map[string][]ClearThirdLevelOp)
+	var settingsOps []ClearThirdLevelOp
+	for _, op := range ops {
+		if op.ObjectName != "" && op.ObjectName != app.Name {
+			continue
+		}
+		if op.App != "" && op.App != app.Spec.Name {
+			continue
+		}
+		if appv1alpha1.IsShared(app) {
+			byUser[op.User] = append(byUser[op.User], op)
+		} else {
+			settingsOps = append(settingsOps, op)
+		}
+	}
+
+	for user, userOps := range byUser {
+		entrances := make([]string, 0, len(userOps))
+		for _, op := range userOps {
+			entrances = append(entrances, op.Entrance)
+		}
+		// Source the base from the exact blob the audit reads
+		// (callerCustomDomainBlob → EffectiveSettings(user) for shared),
+		// so the cleared overlay matches what was scanned and what
+		// app-service's domain handler resolves. Writing it back into
+		// UserSettings[user] promotes an inherited global blob into the
+		// per-user overlay, leaving global Spec.Settings intact.
+		base := callerCustomDomainBlob(app, user)
+		updated, err := clearThirdLevelInBlob(base, entrances)
+		if err != nil {
+			return err
+		}
+		if app.Spec.UserSettings == nil {
+			app.Spec.UserSettings = make(map[string]map[string]string)
+		}
+		if app.Spec.UserSettings[user] == nil {
+			app.Spec.UserSettings[user] = make(map[string]string)
+		}
+		app.Spec.UserSettings[user]["customDomain"] = updated
+	}
+
+	if len(settingsOps) > 0 {
+		entrances := make([]string, 0, len(settingsOps))
+		for _, op := range settingsOps {
+			entrances = append(entrances, op.Entrance)
+		}
+		base := ""
+		if app.Spec.Settings != nil {
+			base = app.Spec.Settings["customDomain"]
+		}
+		updated, err := clearThirdLevelInBlob(base, entrances)
+		if err != nil {
+			return err
+		}
+		if app.Spec.Settings == nil {
+			app.Spec.Settings = make(map[string]string)
+		}
+		app.Spec.Settings["customDomain"] = updated
+	}
+	return nil
+}
+
+func clearThirdLevelInBlob(blob string, entrances []string) (string, error) {
+	raw := make(map[string]map[string]interface{})
+	if blob != "" {
+		if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+			return "", err
+		}
+	}
+	for _, entrance := range entrances {
+		cfg := raw[entrance]
+		if cfg == nil {
+			cfg = make(map[string]interface{})
+			raw[entrance] = cfg
+		}
+		cfg["third_level_domain"] = ""
+		if _, ok := cfg["third_party_domain"]; !ok {
+			cfg["third_party_domain"] = ""
+		}
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func issueID(i DomainIssue) string {
+	return strings.Join([]string{i.User, i.App, i.Entrance, i.ThirdLevel, i.Issue}, "\x00")
+}
+
+type entranceCustomDomain struct {
+	thirdLevel string
+	thirdParty string
+}
+
+func parseCustomDomain(blob string) map[string]entranceCustomDomain {
+	out := make(map[string]entranceCustomDomain)
+	if blob == "" {
+		return out
+	}
+	var raw map[string]map[string]interface{}
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return out
+	}
+	for entrance, cfg := range raw {
+		tl, _ := cfg["third_level_domain"].(string)
+		tp, _ := cfg["third_party_domain"].(string)
+		out[entrance] = entranceCustomDomain{thirdLevel: tl, thirdParty: tp}
+	}
+	return out
+}
+
+// callerCustomDomainBlob mirrors app-service handler_settings.go.
+func callerCustomDomainBlob(app *appv1alpha1.Application, caller string) string {
+	if appv1alpha1.IsShared(app) {
+		return app.EffectiveSettings(caller)["customDomain"]
+	}
+	if app.Spec.Owner == caller {
+		return app.Spec.Settings["customDomain"]
+	}
+	return ""
+}
+
+// CollectZoneUsers returns unique usernames to scan: explicit users plus
+// every Application owner and UserSettings key (covers overlays without
+// relying solely on the IAM list).
+func CollectZoneUsers(apps []appv1alpha1.Application, explicit []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(u string) {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			return
+		}
+		if _, ok := seen[u]; ok {
+			return
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	for _, u := range explicit {
+		add(u)
+	}
+	for i := range apps {
+		add(apps[i].Spec.Owner)
+		for u := range apps[i].Spec.UserSettings {
+			add(u)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/cmd/ctl/doctor/thirdleveldomain_check_test.go
+++ b/cli/cmd/ctl/doctor/thirdleveldomain_check_test.go
@@ -1,0 +1,251 @@
+package doctor
+
+import (
+	"testing"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func sharedApp(name, owner, settingsBlob string, userSettings map[string]map[string]string) appv1alpha1.Application {
+	return appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{appv1alpha1.AppSharedLabel: appv1alpha1.AppSharedTrue},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:  name,
+			Owner: owner,
+			Settings: map[string]string{
+				"customDomain": settingsBlob,
+			},
+			UserSettings: userSettings,
+		},
+	}
+}
+
+func perUserApp(name, owner, settingsBlob string) appv1alpha1.Application {
+	return appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:  name,
+			Owner: owner,
+			Settings: map[string]string{
+				"customDomain": settingsBlob,
+			},
+		},
+	}
+}
+
+func blob(entrance, thirdLevel string) string {
+	return `{"` + entrance + `":{"third_level_domain":"` + thirdLevel + `","third_party_domain":""}}`
+}
+
+func TestFindThirdLevelDomainIssues_clean(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("files", "alice", blob("file", "files")),
+		perUserApp("vault", "alice", blob("main", "vault")),
+	}
+	if got := FindThirdLevelDomainIssues(apps, []string{"alice"}); len(got) != 0 {
+		t.Fatalf("want no issues, got %#v", got)
+	}
+}
+
+func TestFindThirdLevelDomainIssues_duplicateInZone(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("files", "alice", blob("file", "same")),
+		perUserApp("vault", "alice", blob("main", "Same")), // case-insensitive
+		perUserApp("notes", "bob", blob("main", "same")),  // other zone — ok
+	}
+	got := FindThirdLevelDomainIssues(apps, []string{"alice", "bob"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 duplicate issues for alice, got %#v", got)
+	}
+	for _, iss := range got {
+		if iss.User != "alice" || iss.Issue != "duplicate" {
+			t.Fatalf("unexpected issue %#v", iss)
+		}
+	}
+}
+
+func TestFindThirdLevelDomainIssues_reserved(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("evil", "alice", blob("web", "Auth")),
+	}
+	got := FindThirdLevelDomainIssues(apps, []string{"alice"})
+	if len(got) != 1 || got[0].Issue != "reserved" || got[0].ThirdLevel != "Auth" {
+		t.Fatalf("want one reserved issue, got %#v", got)
+	}
+}
+
+func TestFindThirdLevelDomainIssues_sharedOverlayScopedPerUser(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		sharedApp("chat", "admin", blob("web", "chat"), map[string]map[string]string{
+			"alice": {"customDomain": blob("web", "dup")},
+			"bob":   {"customDomain": blob("web", "dup")},
+		}),
+		perUserApp("files", "alice", blob("file", "dup")),
+	}
+	got := FindThirdLevelDomainIssues(apps, []string{"alice", "bob"})
+	// alice: chat overlay + files both "dup" → 2 duplicate rows
+	// bob: only one "dup" → clean
+	alice := 0
+	for _, iss := range got {
+		if iss.User == "alice" && iss.Issue == "duplicate" {
+			alice++
+		}
+		if iss.User == "bob" {
+			t.Fatalf("bob should have no issues, got %#v", got)
+		}
+	}
+	if alice != 2 {
+		t.Fatalf("want 2 alice duplicates, got %#v", got)
+	}
+}
+
+func TestFindThirdLevelDomainIssues_perUserOtherOwnerIgnored(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("alice-app", "alice", blob("a", "x")),
+		perUserApp("bob-app", "bob", blob("b", "x")),
+	}
+	got := FindThirdLevelDomainIssues(apps, []string{"alice"})
+	if len(got) != 0 {
+		t.Fatalf("bob's app must not collide in alice zone, got %#v", got)
+	}
+}
+
+func TestCollectZoneUsers(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		sharedApp("chat", "admin", "", map[string]map[string]string{
+			"alice": {"customDomain": blob("web", "a")},
+		}),
+		perUserApp("files", "bob", blob("f", "b")),
+	}
+	got := CollectZoneUsers(apps, []string{"carol"})
+	want := []string{"admin", "alice", "bob", "carol"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestPlanForceDedupeClears_keepsFirstClearsRest(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("files", "alice", blob("file", "same")),
+		perUserApp("vault", "alice", blob("main", "Same")),
+	}
+	ops := PlanForceDedupeClears(apps, []string{"alice"})
+	if len(ops) != 1 {
+		t.Fatalf("want 1 clear op, got %#v", ops)
+	}
+	if ops[0].App != "vault" || ops[0].Entrance != "main" || ops[0].Reason != "duplicate" {
+		t.Fatalf("should clear vault/main (files kept first), got %#v", ops[0])
+	}
+	if ops[0].KeepApp != "files" || ops[0].KeepEntrance != "file" {
+		t.Fatalf("keep target %#v", ops[0])
+	}
+}
+
+func TestPlanForceDedupeClears_reserved(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		perUserApp("evil", "alice", blob("web", "Auth")),
+		perUserApp("ok", "alice", blob("main", "myapp")),
+	}
+	ops := PlanForceDedupeClears(apps, []string{"alice"})
+	if len(ops) != 1 || ops[0].Reason != "reserved" || ops[0].App != "evil" {
+		t.Fatalf("want one reserved clear on evil, got %#v", ops)
+	}
+	if err := ApplyClearOpsToApp(&apps[0], ops); err != nil {
+		t.Fatal(err)
+	}
+	if parseCustomDomain(apps[0].Spec.Settings["customDomain"])["web"].thirdLevel != "" {
+		t.Fatalf("reserved third_level should be cleared")
+	}
+	if remaining := FindThirdLevelDomainIssues(apps, []string{"alice"}); len(remaining) != 0 {
+		t.Fatalf("want clean after reserved clear, got %#v", remaining)
+	}
+}
+
+func TestApplyClearOpsToApp_perUserAndShared(t *testing.T) {
+	apps := []appv1alpha1.Application{
+		sharedApp("chat", "admin", blob("web", "chat"), map[string]map[string]string{
+			"alice": {"customDomain": blob("web", "dup")},
+		}),
+		perUserApp("files", "alice", blob("file", "dup")),
+	}
+	ops := PlanForceDedupeClears(apps, []string{"alice"})
+	if len(ops) != 1 {
+		t.Fatalf("want 1 op, got %#v", ops)
+	}
+	// keep chat (lexicographically before files), clear files
+	if ops[0].App != "files" {
+		t.Fatalf("want clear files, got %#v", ops[0])
+	}
+	if err := ApplyClearOpsToApp(&apps[1], ops); err != nil {
+		t.Fatal(err)
+	}
+	cfg := parseCustomDomain(apps[1].Spec.Settings["customDomain"])["file"]
+	if cfg.thirdLevel != "" {
+		t.Fatalf("files third_level should be cleared, got %q", cfg.thirdLevel)
+	}
+	if remaining := FindThirdLevelDomainIssues(apps, []string{"alice"}); len(remaining) != 0 {
+		t.Fatalf("want no issues after clear, got %#v", remaining)
+	}
+}
+
+func TestApplyClearOpsToApp_sharedExistingOverlayLoserCleared(t *testing.T) {
+	// Shared app whose per-user overlay already holds the duplicate and is
+	// the loser (aaa < zshared → keep aaa, clear the shared overlay). The
+	// clear must come off the effective/overlay blob, not diverge from it.
+	apps := []appv1alpha1.Application{
+		perUserApp("aaa", "alice", blob("file", "dup")),
+		sharedApp("zshared", "admin", blob("web", "other"), map[string]map[string]string{
+			"alice": {"customDomain": blob("web", "dup")},
+		}),
+	}
+	ops := PlanForceDedupeClears(apps, []string{"alice"})
+	if len(ops) != 1 || !ops[0].Shared || ops[0].App != "zshared" || ops[0].Reason != "duplicate" {
+		t.Fatalf("want clear shared zshared overlay, got %#v", ops)
+	}
+	if err := ApplyClearOpsToApp(&apps[1], ops); err != nil {
+		t.Fatal(err)
+	}
+	if parseCustomDomain(apps[1].Spec.UserSettings["alice"]["customDomain"])["web"].thirdLevel != "" {
+		t.Fatalf("alice overlay web third_level should be cleared, got %#v", apps[1].Spec.UserSettings)
+	}
+	// global Settings (admin's default) must be untouched
+	if parseCustomDomain(apps[1].Spec.Settings["customDomain"])["web"].thirdLevel != "other" {
+		t.Fatalf("global Settings must stay intact, got %#v", apps[1].Spec.Settings)
+	}
+	if remaining := FindThirdLevelDomainIssues(apps, []string{"alice"}); len(remaining) != 0 {
+		t.Fatalf("want clean after force-dedupe, got %#v", remaining)
+	}
+}
+
+func TestApplyClearOpsToApp_sharedInheritedWritesOverlay(t *testing.T) {
+	// aaa sorts before chat → keep per-user, clear shared inherited value via overlay
+	apps := []appv1alpha1.Application{
+		perUserApp("aaa", "alice", blob("file", "dup")),
+		sharedApp("chat", "admin", blob("web", "dup"), nil),
+	}
+	ops := PlanForceDedupeClears(apps, []string{"alice"})
+	if len(ops) != 1 || !ops[0].Shared || ops[0].App != "chat" {
+		t.Fatalf("want clear shared chat, got %#v", ops)
+	}
+	if err := ApplyClearOpsToApp(&apps[1], ops); err != nil {
+		t.Fatal(err)
+	}
+	if parseCustomDomain(apps[1].Spec.Settings["customDomain"])["web"].thirdLevel != "dup" {
+		t.Fatalf("global Settings must stay intact, got %#v", apps[1].Spec.Settings)
+	}
+	if parseCustomDomain(apps[1].Spec.UserSettings["alice"]["customDomain"])["web"].thirdLevel != "" {
+		t.Fatalf("alice overlay should clear third_level, got %#v", apps[1].Spec.UserSettings)
+	}
+	if remaining := FindThirdLevelDomainIssues(apps, []string{"alice"}); len(remaining) != 0 {
+		t.Fatalf("want clean after force-dedupe, got %#v", remaining)
+	}
+}

--- a/cli/skills/olares-doctor/SKILL.md
+++ b/cli/skills/olares-doctor/SKILL.md
@@ -55,6 +55,7 @@ Pick the row that matches the reported symptom; each reference carries the locat
 | Command | What it does | Reference |
 |---|---|---|
 | `doctor images` | Lists local containerd images annotated with how many workloads reference each one; `--unused` shows zero-reference prune candidates (largest-first, with reclaimable size). Always full-scans the control node; `-n` / `-l` scope the workload reference count. | [references/olares-doctor-image.md](references/olares-doctor-image.md) |
+| `doctor thirdleveldomain` | Audits Application `customDomain.third_level_domain` per user zone (kubeconfig): flags duplicate prefixes and reserved names (`auth` / `desktop` / `wizard`). `--force-dedupe` keeps one duplicate per zone, clears the rest, and clears reserved names. | — |
 
 ## How doctor gathers evidence (orchestration, not ownership)
 


### PR DESCRIPTION
## Summary
- Add `olares-cli doctor thirdleveldomain` — audits per-user `customDomain.third_level_domain` via kubeconfig and reports conflicts within each user zone.
- Detects **duplicate** prefixes (case-insensitive) within a zone and **reserved** names (`auth` / `desktop` / `wizard`), mirroring the write-path check in `app-service` `handler_settings.go`.
- Scope: shared apps use `EffectiveSettings(user)`; per-user apps contribute only to their Owner's zone.
- `--force-dedupe` (mutating): keeps the lexicographically first `(app, entrance)` per duplicate prefix and clears the rest, and clears any reserved `third_level_domain`. Shared apps are written via the per-user `UserSettings` overlay (global `Settings` left intact); per-user apps via `Spec.Settings`.
- Non-zero exit when issues remain; `-o json` / `-q` / `--no-headers` supported; `SilenceUsage` so a found-issues error doesn't print help.

## Test plan
- [x] `go test ./cmd/ctl/doctor/` (unit tests cover clean / duplicate / reserved / shared-overlay scoping / per-user owner isolation / force-dedupe plan + apply)
- [ ] Manual: `olares-cli doctor thirdleveldomain` on a cluster with duplicate third-level domains
- [ ] Manual: `olares-cli doctor thirdleveldomain --force-dedupe` then re-run to confirm clean

Made with [Cursor](https://cursor.com)