### PR TITLE
feat(docs): add organization schema to VitePress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -306,6 +306,31 @@ export default defineVersionedConfig2(withMermaid({
         href: (process.env.BASE_URL || "/") + "icon1.png",
       },
     ],
+    // Organization schema (shared with olares.com; single #organization entity).
+    [
+      "script",
+      { type: "application/ld+json" },
+      JSON.stringify({
+        "@context": "https://schema.org",
+        "@id": "https://www.olares.com/#organization",
+        "@type": "Organization",
+        name: "Olares",
+        url: "https://www.olares.com/",
+        logo: {
+          "@type": "ImageObject",
+          url: "https://www.olares.com/olares-logo.png",
+          width: 1000,
+          height: 236,
+        },
+        sameAs: [
+          "https://github.com/beclab/Olares",
+          "https://x.com/Olares_OS",
+          "https://www.linkedin.com/company/olarestech/",
+          "https://www.youtube.com/@OlaresOS/featured",
+          "https://www.facebook.com/people/Olares/61579156063357/",
+        ],
+      }),
+    ],
     [
       "script",
       {


### PR DESCRIPTION
* **Background**
Incorporated structured data for the Olares organization into the VitePress configuration. This includes details such as the organization's name, URL, logo, and social media links, enhancing SEO and providing better context for search engines.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5bc2d0d4299f4aba6c3256cba3825313b9d75cfb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->