### PR TITLE
market: fix cloning/version handling and restore app metadata fields

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -142,7 +142,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.77
+        image: beclab/market-backend:v0.6.78
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix cloning/version handling and restore app metadata fields

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/382


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in the market deployment; behavior changes come from the new backend image at rollout, with no config edits in this PR.
> 
> **Overview**
> Bumps the **appstore-backend** container image in `market_deploy.yaml` from `beclab/market-backend:v0.6.77` to **`v0.6.78`**, so clusters deploy the newer market backend build (aligned with [beclab/market#382](https://github.com/beclab/market/pull/382) for cloning/version handling and restored app metadata fields). No other manifest, env, or service changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946a1ea62afc2a9a326da302250dd0c25ef41364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->