### PR TITLE
fix(download-server): add download_status to inspect, improve file accuracy

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.4"
+        image: "beclab/download-server:v1.0.5"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Download inspect:  Adds a precise download_status and file_exists indicator for /api/url/inspect.
Aria2 Mount Fix: Probes file existence via the manager's mount path rather than the daemon's path.
HuggingFace:Persist the shared-cache location in the task's path / file_name so the UI reflects where cache-mode bytes actually land.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy; behavior changes are scoped to download inspect and path reporting, with no manifest or RBAC changes beyond the rollout.
> 
> **Overview**
> Rolls the download DaemonSet to **`beclab/download-server:v1.0.5`** (from `v1.0.4`) in `download_deploy.yaml`; no other manifest changes.
> 
> That image carries inspect and download-path fixes described for this release: **`/api/url/inspect`** returns clearer **`download_status`** and **`file_exists`**, Aria2 file checks use the manager mount path instead of the daemon path, and HuggingFace cache-mode tasks persist the shared-cache location in **`path`** / **`file_name`** for the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb05e7622d4cb1cb0229a62658a953a2372c86a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->