### PR TITLE
feat: upgrade search3 to v0.3.5

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.4
+        image: beclab/search3:v0.3.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -306,7 +306,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.4
+        image: beclab/search3monitor:v0.3.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081
@@ -435,10 +435,17 @@ spec:
           key: nats_password
           name: search-server-nats-secret
     subjects:
+      # os.search.* — one token after search (e.g. os.search.<user>)
       - name: "search.*"
         permission:
           pub: allow
           sub: allow
+      # os.search.> — multi-level under search (e.g. os.search.<user>.<reqid> for federated search)
+      - name: "search.>"
+        permission:
+          pub: allow
+          sub: allow
+      # exact os.search
       - name: search
         permission:
           pub: allow

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.4
+        image: beclab/search3validation:v0.3.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: async search
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
- Add async federated search over NATS (`POST /search/nats/init|more|cancel`, `GET /search/nats/state`, ops job list), gated by `NATS_SEARCH_ENABLED`.
- Stream hits from `files_v2`, Google Drive, and Dropbox to `os.search.{user}.{reqid}` with batching, publish retry/flush, cancel/timeout, isolated NATS cache, and TTL sweep.
- Harden cloud adapters (streaming search, PhaseReporter, network-error hints, Dropbox highlight parity) and add `clouddrivecmd nats-search` for in-cluster smoke tests against pod `NATS_*` env.



* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/203

<!-- CURSOR_SUMMARY -->
---

