### PR TITLE
feat: files streaming recursive directory usage API

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -210,7 +210,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.189
+          image: beclab/files-server:v0.2.190
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- feat: add GET /api/usage/*path streaming recursive file count and total size

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/346

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest or config changes beyond the version.
> 
> **Overview**
> Bumps the **files** DaemonSet container image from `beclab/files-server:v0.2.189` to **`v0.2.190`** in `files_deploy.yaml`, rolling out the build that includes the streaming recursive directory usage API (`GET /api/usage/*path`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f39897cf6b88e6e08be947a38c76c4e0a60b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->