### PR TITLE
docs: fix duplicate meta title tags and description

### DIFF
--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -587,6 +587,7 @@ const side = {
 
 export const zh = defineConfig({
   lang: "zh",
+  titleTemplate: ":title | Olares 中文文档",
   themeConfig: {
     editLink: {
       pattern: "https://github.com/beclab/Olares/edit/main/docs/:path",

--- a/docs/zh/manual/best-practices/local-access.md
+++ b/docs/zh/manual/best-practices/local-access.md
@@ -1,6 +1,6 @@
 ---
 outline: [2,3]
-description: Learn the different methods to access Olares services locally for improved speed and offline capability.
+description: 了解本地访问 Olares 服务的不同方式，以提升访问速度和离线可用性。
 ---
 # 本地访问 Olares 服务
 


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata changes with no runtime or security impact.
> 
> **Overview**
> Improves Chinese documentation SEO by aligning page metadata with the English site pattern.
> 
> **VitePress zh locale** now sets `titleTemplate` to `:title | Olares 中文文档`, so Chinese pages get a consistent browser/tab title suffix instead of duplicating or conflicting with the global default.
> 
> The **本地访问** best-practices page frontmatter `description` is switched from English to a Chinese summary matching the page topic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a5e1c79e945c9deeaaf5daa283d1da809966d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->