### PR TITLE
fix(app-service): pick helm values reuse mode per Upgrade/Scale/ApplyEnv

### DIFF
--- a/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
@@ -21,7 +21,8 @@ func (h *HelmOps) ApplyEnv() error {
 		return err
 	}
 
-	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, true)
+	// ReuseValues: only env-related overrides change; do not absorb new chart defaults.
+	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, helm.ReuseValues)
 	if err != nil {
 		klog.Errorf("Failed to upgrade chart name=%s err=%v", h.app.AppName, err)
 		return err

--- a/framework/app-service/pkg/appinstaller/helm_ops_scale.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_scale.go
@@ -13,10 +13,11 @@ import (
 // workloads to their final size.
 //
 // The implementation only sends the .workloads sub-tree and relies on
-// helm UpgradeCharts(reuseValue=true) to merge it over the previous
-// release's values — every other input (admin / userspace / domain /
-// service) is preserved by helm's reuse-values semantics. Behavior by
-// argument:
+// helm UpgradeCharts(ReuseValues) to merge it over the previous release's
+// values — every other input (admin / userspace / domain / service) is
+// preserved. ReuseValues (not ResetThenReuseValues) is intentional: Scale
+// must not pick up new chart defaults (e.g. image) just because the chart
+// on disk changed. Behavior by argument:
 //
 //   - replicas >= 0: every workload is forced to this exact value. Used
 //     by suspending_app to scale to 0, and by upgrading_app to land an
@@ -46,7 +47,7 @@ func (h *HelmOps) Scale(replicas int32) error {
 
 	if err := helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings,
 		h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace,
-		values, true /* reuseValue */); err != nil {
+		values, helm.ReuseValues); err != nil {
 		klog.Errorf("Failed to scale chart appName=%s replicas=%d err=%v", h.app.AppName, replicas, err)
 		return err
 	}

--- a/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
@@ -35,7 +35,9 @@ func (h *HelmOps) upgrade() error {
 		return err
 	}
 
-	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, true)
+	// ResetThenReuseValues: absorb new chart defaults (image/template) while
+	// keeping prior user overrides that SetValues does not re-emit.
+	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, helm.ResetThenReuseValues)
 	if err != nil {
 		klog.Errorf("Failed to upgrade chart name=%s err=%v", h.app.AppName, err)
 		return err

--- a/framework/app-service/pkg/appinstaller/v2/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/v2/helm_ops_upgrade.go
@@ -168,7 +168,7 @@ func (h *HelmOpsV2) upgrade(values map[string]interface{}) error {
 			h.App().RepoURL,
 			h.App().Namespace,
 			values,
-			true,
+			helm.ReuseValues,
 		)
 		if err != nil {
 			klog.Errorf("Failed to upgrade chart name=%s err=%v", chart.Name, err)

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -81,9 +81,27 @@ func InstallCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	return nil
 }
 
+// ValuesReuseMode selects how helm upgrade merges previous release values
+// with the new chart defaults.
+type ValuesReuseMode int
+
+const (
+	// NoReuseValues discards previous release values; only the supplied vals
+	// and the new chart defaults are used.
+	NoReuseValues ValuesReuseMode = iota
+	// ReuseValues keeps the previous release's computed values and merges
+	// supplied vals on top. Chart default changes are NOT picked up.
+	ReuseValues
+	// ResetThenReuseValues resets to the new chart's built-in defaults, then
+	// overlays the previous release's user-supplied values and the new vals.
+	// Suitable for version/image/template upgrades that should absorb chart
+	// default changes while preserving prior overrides.
+	ResetThenReuseValues
+)
+
 // UpgradeCharts upgrades helm chart using action config and environment settings.
 func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, settings *cli.EnvSettings,
-	appName, chartName, repoURL, namespace string, vals map[string]interface{}, reuseValue bool) error {
+	appName, chartName, repoURL, namespace string, vals map[string]interface{}, mode ValuesReuseMode) error {
 	ctrl.Log.Info("helm action config", "reachable", actionConfig.KubeClient.IsReachable())
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = namespace
@@ -91,8 +109,11 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	client.Recreate = false
 	// Do not use Atomic, this could cause helm wait all resource ready.
 	//client.Atomic = true
-	if reuseValue {
+	switch mode {
+	case ReuseValues:
 		client.ReuseValues = true
+	case ResetThenReuseValues:
+		client.ResetThenReuseValues = true
 	}
 	if repoURL != "" {
 		client.RepoURL = repoURL

--- a/framework/app-service/pkg/workflowinstaller/v1/helm_client.go
+++ b/framework/app-service/pkg/workflowinstaller/v1/helm_client.go
@@ -99,5 +99,5 @@ func (h *HelmClient) Uninstall(workflowName string) error {
 
 // Upgrade upgrade a release with specified values.
 func (h *HelmClient) Upgrade(workflowName, chartsName, repoURL, namespace string, vals map[string]interface{}) error {
-	return helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, workflowName, chartsName, repoURL, namespace, vals, false)
+	return helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, workflowName, chartsName, repoURL, namespace, vals, helm.NoReuseValues)
 }


### PR DESCRIPTION
* **Background**
pick helm values reuse mode per Upgrade/Scale/ApplyEnv
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Helm upgrade merge behavior for app upgrades (now ResetThenReuseValues), which can alter deployed images/templates on upgrade; env/scale paths are intentionally conservative.
> 
> **Overview**
> Replaces the boolean `reuseValue` flag on `helm.UpgradeCharts` with a **`ValuesReuseMode`** enum (`NoReuseValues`, `ReuseValues`, `ResetThenReuseValues`) and wires Helm’s `ReuseValues` / `ResetThenReuseValues` upgrade options accordingly.
> 
> **App upgrade** now uses **`ResetThenReuseValues`** so version bumps can pick up new chart defaults (e.g. image/templates) while still layering prior user overrides and the values from `SetValues`. **Apply env** and **Scale** use **`ReuseValues`** so partial upgrades only merge env or replica overrides and do not silently adopt new chart defaults. Workflow installer upgrades pass **`NoReuseValues`** (same behavior as the old `false`).
> 
> Comments on Scale/ApplyEnv/Upgrade document why each path chose its mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6c74a664d3a64640f61197bfdd0f5de39b5464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->