### PR TITLE
olares: bump system-frontend image to v1.11.12

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.9
+          image: beclab/system-frontend:v1.11.12
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  Bump the `olares-app-init` (system-frontend) image from `v1.11.9` to `v1.11.12`.

  This release ships two file-manager changes from TermiPass:

  - beclab/TermiPass#1300: stream folder size and item count in the file properties dialog. A new client for `GET /api/usage/*path` consumes NDJSON progress lines so large folders show a progressively-updating size and item count until `_done`, with the request aborted on dialog close/submit/unmount. Size and item count are hidden for Share / PublicShare, and covered for drive, data, common, cache, external, sync, and cloud path builders.
  - beclab/TermiPass#1299: decouple the file preview and apply several desktop UX fixes. The preview becomes capability-driven (`PreviewSource`/`PreviewAction`) so the desktop dialog and mobile preview page are purely presentational and download/delete/edit are supplied by the caller. Also adds a shared app-launch guard so opening an app from global search honors the same install/suspend/crash gating as the LaunchPad, fixes Files menu highlighting for Home subfolders without their own left-nav leaf (e.g. `pod_logs`), fixes a false-positive "unable to install update" after a long screen-off, and includes minor archive-icon sizing, menu typing, and CI cleanups.

* **Target Version for Merge**
  v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  beclab/TermiPass#1300
  beclab/TermiPass#1299

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.11.12
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.11.11...v1.11.12

Made with [Cursor](https://cursor.com)