### PR TITLE
fix(download-server): detect aria2 completions past the 200-row stopped window

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.5"
+        image: "beclab/download-server:v1.0.6"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Stop losing download completions once aria2's stopped queue grows past ~200.
Drop the <name>.aria2 control file on task removal.
Return file_name and task_id .

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches download completion and task lifecycle behavior, which affects user-visible download status, but the change is scoped to the download-server image tag with no manifest config changes.
> 
> **Overview**
> Bumps the **download-server** container image in the download DaemonSet from `beclab/download-server:v1.0.5` to **`v1.0.6`**, rolling out the application fix described in this PR.
> 
> That release is intended to **stop missing aria2 completions** when the stopped-task list grows beyond aria2’s ~200-row window, **remove the `<name>.aria2` control file** when a task is removed, and **expose `file_name` and `task_id`** in the relevant responses. No other deploy settings (env, resources, sidecars) change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ddac437e1046b1c65cf34857efdc10fe94e274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->