### PR TITLE
refactor(theme): enhance language auto-redirect logic for SEO compliance

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -54,22 +54,34 @@ enhanceApp({ app, router }: { app: App; router: Router }) {
     const router = useRouter();
     const { lang, site } = useData();
 
-    // Auto-redirect a fresh page load to the visitor's remembered language.
-    // router.route.path includes the site base (e.g. "/docs/" or
-    // "/docs/1.12.4/"); the version, when present, lives entirely in that base.
-    // We therefore strip the base first and match the language prefix on the
-    // base-relative path. (The previous implementation matched against the raw
-    // path without accounting for the base, so under a "/docs" deploy the
+    // Auto-redirect a fresh page load to the visitor's *remembered* language
+    // (set when they pick a locale in the language menu — see the `lang`
+    // watcher below). router.route.path includes the site base (e.g. "/docs/"
+    // or "/docs/1.12.4/"); the version, when present, lives entirely in that
+    // base. We therefore strip the base first and match the language prefix on
+    // the base-relative path. (The previous implementation matched against the
+    // raw path without accounting for the base, so under a "/docs" deploy the
     // default+en combination produced an empty prefix that matched everything
     // and corrupted the URL, e.g. /docs/zh/... -> /zh/docs/zh/...).
+    //
+    // Critical for SEO: do NOT default to 'en' when localStorage is empty.
+    // Crawlers (Googlebot Live Test / rendering) have no preference, and the
+    // old `|| 'en'` default JS-redirected every /zh/... URL to the English
+    // twin — so GSC reported the English page as the "user-declared
+    // canonical" on Chinese URLs even though the static HTML was correct.
+    // No stored preference → respect the URL the crawler (or first-time
+    // visitor) actually opened.
     const routerRedirect = () => {
-      let localLanguage = localStorage.getItem(LANGUAGE_LOCAL_KEY) || 'en';
+      const stored = localStorage.getItem(LANGUAGE_LOCAL_KEY);
+      if (!stored) return;
+
+      let localLanguage = stored;
 
       const languages = process.env.LANGUAGES ? process.env.LANGUAGES.split(",") : [];
       if (!languages.includes('en')) languages.push('en');
 
       if (!languages.includes(localLanguage)) {
-        localLanguage = 'en';
+        return;
       }
 
       const base = site.value.base || '/';


### PR DESCRIPTION
* **Background**
Updated the language auto-redirect functionality to respect the user's stored language preference only when available, preventing default redirection to 'en' for crawlers and first-time visitors. This change improves SEO by ensuring that the correct language version of the page is served based on the URL accessed, rather than a default setting that could mislead search engines.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single client-side redirect guard in docs theme; improves SEO with no auth or data impact, though returning users without a valid stored locale no longer get a silent `en` fallback redirect.
> 
> **Overview**
> **Docs language auto-redirect** now runs only when `localStorage` already has a language from the locale menu—not on empty storage.
> 
> Previously, missing storage defaulted to `en` and could JS-redirect `/zh/...` to English for crawlers and first-time visitors, which hurt SEO (e.g. GSC treating English as canonical on Chinese URLs). Invalid stored locales no longer fall back to `en`; the redirect is skipped instead.
> 
> Comments in `routerRedirect` document the remembered-language vs URL-respect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394678ef8d53616da9cb2da62ea966081a26defb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->