### PR TITLE
notifications: bump notifications-api image to v1.12.43

### DIFF
--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.42
+        image: beclab/notifications-api:v1.12.43
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**

  Bump the `notifications-api` image from `v1.12.42` to `v1.12.43`.

  This release ships the i18n changes from beclab/notifications#22:

  - Refine EN/ZH notification copy in the seed templates: replace user-facing `bind`/`unbind` wording with `connect`/`disconnect` for Ethereum address flows, add the missing "You can restart it anytime." hint to `stopped_hami_unschedulable` so it matches the other stopped templates, and fix internal template names for consistency (`Login Olares Web`, `Bind Olares Space`, `Remove Bind Ethereum Address`).
  - Add AI pretranslations for de-DE, es-ES, fr-FR, it-IT, and ja-JP.

* **Target Version for Merge**
  v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  beclab/notifications#22

* **Other information**
  Release: https://github.com/beclab/notifications/releases/tag/v1.12.43
  Full Changelog: https://github.com/beclab/notifications/compare/v1.12.42...v1.12.43

Made with [Cursor](https://cursor.com)