### PR TITLE
olares: bump system-frontend to v1.11.13 and user-service to v0.1.5

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.12
+          image: beclab/system-frontend:v1.11.13
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -423,7 +423,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.4
+          image: beclab/user-service:v0.1.5
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
Bump the bundled system application images to their latest releases:
- `beclab/system-frontend` (TermiPass): `v1.11.12` -> `v1.11.13`
- `beclab/user-service`: `v0.1.4` -> `v0.1.5`

These updates pull in the latest fixes and improvements from the TermiPass and user-service sub-systems.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
- https://github.com/beclab/TermiPass/pull/1303
- https://github.com/beclab/user-service/pull/89

TermiPass:
- Release: https://github.com/beclab/TermiPass/releases/tag/v1.11.13
- Full Changelog: https://github.com/beclab/TermiPass/compare/v1.11.12...v1.11.13

user-service:
- Release: https://github.com/beclab/user-service/releases/tag/v0.1.5
- Full Changelog: https://github.com/beclab/user-service/compare/v0.1.4...v0.1.5

* **Other information**:
Image references are updated in `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml` for the `olares-app-init` and `user-service` containers.

Made with [Cursor](https://cursor.com)