### PR TITLE
fix(daemon): disarm leftover NM checkpoint after overlay-bridge rollback failure

### DIFF
--- a/daemon/pkg/utils/network_bridge_test.go
+++ b/daemon/pkg/utils/network_bridge_test.go
@@ -163,20 +163,27 @@ func TestActivateBridgeSwitchSkipsUpWhenDownFails(t *testing.T) {
 func TestCommitNMCheckpointDestroyFailureTriggersRollback(t *testing.T) {
 	origDestroy := nmCheckpointDestroyFn
 	origRollback := nmCheckpointRollbackFn
+	origAdjust := nmCheckpointAdjustRollbackTimeoutFn
 	t.Cleanup(func() {
 		nmCheckpointDestroyFn = origDestroy
 		nmCheckpointRollbackFn = origRollback
+		nmCheckpointAdjustRollbackTimeoutFn = origAdjust
 	})
 
 	destroyCalls := 0
 	rollbackCalls := 0
 	manualCalls := 0
+	adjustCalls := 0
 	nmCheckpointDestroyFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath) error {
 		destroyCalls++
 		return errors.New("destroy boom")
 	}
 	nmCheckpointRollbackFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath) error {
 		rollbackCalls++
+		return nil
+	}
+	nmCheckpointAdjustRollbackTimeoutFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath, addTimeout uint32) error {
+		adjustCalls++
 		return nil
 	}
 
@@ -198,21 +205,36 @@ func TestCommitNMCheckpointDestroyFailureTriggersRollback(t *testing.T) {
 	if manualCalls != 0 {
 		t.Fatalf("manual rollback should not run when CheckpointRollback succeeds, got %d", manualCalls)
 	}
+	if adjustCalls != 0 {
+		t.Fatalf("disarm should not run when CheckpointRollback succeeds, got %d adjust calls", adjustCalls)
+	}
 }
 
 func TestCommitNMCheckpointDestroyFailureManualWhenRollbackFails(t *testing.T) {
 	origDestroy := nmCheckpointDestroyFn
 	origRollback := nmCheckpointRollbackFn
+	origAdjust := nmCheckpointAdjustRollbackTimeoutFn
 	t.Cleanup(func() {
 		nmCheckpointDestroyFn = origDestroy
 		nmCheckpointRollbackFn = origRollback
+		nmCheckpointAdjustRollbackTimeoutFn = origAdjust
 	})
 
+	destroyCalls := 0
+	adjustCalls := 0
 	nmCheckpointDestroyFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath) error {
-		return errors.New("destroy boom")
+		destroyCalls++
+		if destroyCalls <= checkpointDestroyRetries {
+			return errors.New("destroy boom")
+		}
+		return nil // disarm succeeds
 	}
 	nmCheckpointRollbackFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath) error {
 		return errors.New("rollback boom")
+	}
+	nmCheckpointAdjustRollbackTimeoutFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath, addTimeout uint32) error {
+		adjustCalls++
+		return nil
 	}
 	manualCalls := 0
 	err := commitNMCheckpoint(context.Background(), nil, dbus.ObjectPath("/cp/1"), func() {
@@ -223,5 +245,39 @@ func TestCommitNMCheckpointDestroyFailureManualWhenRollbackFails(t *testing.T) {
 	}
 	if manualCalls != 1 {
 		t.Fatalf("expected manual rollback once, got %d", manualCalls)
+	}
+	if destroyCalls != checkpointDestroyRetries+1 {
+		t.Fatalf("expected %d commit destroys + 1 disarm destroy, got %d", checkpointDestroyRetries, destroyCalls)
+	}
+	if adjustCalls != 0 {
+		t.Fatalf("adjust-timeout should not run when disarm destroy succeeds, got %d", adjustCalls)
+	}
+}
+
+func TestDisarmNMCheckpointFallsBackToDisableTimeout(t *testing.T) {
+	origDestroy := nmCheckpointDestroyFn
+	origAdjust := nmCheckpointAdjustRollbackTimeoutFn
+	t.Cleanup(func() {
+		nmCheckpointDestroyFn = origDestroy
+		nmCheckpointAdjustRollbackTimeoutFn = origAdjust
+	})
+
+	destroyCalls := 0
+	var gotTimeout uint32 = 99
+	nmCheckpointDestroyFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath) error {
+		destroyCalls++
+		return errors.New("destroy still failing")
+	}
+	nmCheckpointAdjustRollbackTimeoutFn = func(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath, addTimeout uint32) error {
+		gotTimeout = addTimeout
+		return nil
+	}
+
+	disarmNMCheckpoint(context.Background(), nil, dbus.ObjectPath("/cp/leftover"))
+	if destroyCalls != 2 {
+		t.Fatalf("expected destroy then retry after timeout-disable, got %d", destroyCalls)
+	}
+	if gotTimeout != 0 {
+		t.Fatalf("expected adjust-timeout 0, got %d", gotTimeout)
 	}
 }

--- a/daemon/pkg/utils/network_linux.go
+++ b/daemon/pkg/utils/network_linux.go
@@ -568,8 +568,9 @@ const (
 
 // Injectable for unit tests; production defaults to the real D-Bus helpers.
 var (
-	nmCheckpointDestroyFn  = nmCheckpointDestroy
-	nmCheckpointRollbackFn = nmCheckpointRollback
+	nmCheckpointDestroyFn               = nmCheckpointDestroy
+	nmCheckpointRollbackFn              = nmCheckpointRollback
+	nmCheckpointAdjustRollbackTimeoutFn = nmCheckpointAdjustRollbackTimeout
 )
 
 // nmcliCombinedOutput runs nmcli (or any argv[0]) and returns combined stdout.
@@ -762,6 +763,30 @@ func waitBridgeReady(ctx context.Context, timeout time.Duration) bool {
 	}
 }
 
+// disarmNMCheckpoint cancels a leftover NetworkManager auto-rollback timer.
+// Successful CheckpointRollback already removes the checkpoint inside NM;
+// Destroy then fails with "does not exist" and is ignored. When Rollback fails
+// (or never ran) the timer stays armed — Destroy (or timeout=0) clears it so a
+// later successful enable cannot be undone by the stale snapshot.
+func disarmNMCheckpoint(ctx context.Context, conn *dbus.Conn, checkpoint dbus.ObjectPath) {
+	if checkpoint == "" {
+		return
+	}
+	if err := nmCheckpointDestroyFn(ctx, conn, checkpoint); err == nil {
+		return
+	} else {
+		klog.Errorf("NM checkpoint disarm destroy failed for %s: %v", checkpoint, err)
+	}
+	if err := nmCheckpointAdjustRollbackTimeoutFn(ctx, conn, checkpoint, 0); err != nil {
+		klog.Errorf("NM checkpoint disarm adjust-timeout failed for %s: %v", checkpoint, err)
+		return
+	}
+	klog.Warningf("NM checkpoint %s auto-rollback disabled after destroy failure", checkpoint)
+	if err := nmCheckpointDestroyFn(ctx, conn, checkpoint); err != nil {
+		klog.Errorf("NM checkpoint disarm destroy after timeout-disable failed for %s: %v", checkpoint, err)
+	}
+}
+
 // commitNMCheckpoint discards the checkpoint after a successful bridge switch
 // (NM "commit"). On persistent Destroy failure it rolls the network back and
 // returns an error so callers never report success while NM still holds an
@@ -797,6 +822,9 @@ rollback:
 		if manualRollback != nil {
 			manualRollback()
 		}
+		// Rollback failure (often a D-Bus transport error) leaves the NM
+		// auto-rollback timer armed; disarm so a later enable cannot be undone.
+		disarmNMCheckpoint(ctx, conn, checkpoint)
 	}
 	return fmt.Errorf("checkpoint commit failed: %w", lastErr)
 }
@@ -964,6 +992,7 @@ func CreateBridgeConnection(ctx context.Context) error {
 			if e := nmCheckpointRollbackFn(ctx, dbusConn, checkpoint); e != nil {
 				klog.Errorf("NM checkpoint rollback failed (%v), applying manual rollback", e)
 				manualRollback()
+				disarmNMCheckpoint(ctx, dbusConn, checkpoint)
 			}
 			return cause
 		}

--- a/daemon/pkg/utils/nm_checkpoint_linux.go
+++ b/daemon/pkg/utils/nm_checkpoint_linux.go
@@ -88,3 +88,13 @@ func nmCheckpointRollback(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPa
 	}
 	return nil
 }
+
+// nmCheckpointAdjustRollbackTimeout resets how long NetworkManager waits before
+// auto-rolling back. addTimeout is seconds from now; 0 disables the timer.
+func nmCheckpointAdjustRollbackTimeout(ctx context.Context, conn *dbus.Conn, cp dbus.ObjectPath, addTimeout uint32) error {
+	if cp == "" {
+		return nil
+	}
+	obj := conn.Object(nmDBusDest, nmDBusPath)
+	return obj.CallWithContext(ctx, nmDBusInterface+".CheckpointAdjustRollbackTimeout", 0, cp, addTimeout).Err
+}


### PR DESCRIPTION
Disarm leftover NetworkManager checkpoints after overlay-bridge rollback failure so a later successful enable is not silently reverted.
