### PR TITLE
fix(daemon): require auth on registry mirrors and harden chpasswd

### DIFF
--- a/daemon/internel/apiserver/handlers/containerd_group.go
+++ b/daemon/internel/apiserver/handlers/containerd_group.go
@@ -13,10 +13,10 @@ func init() {
 	registry := containerd.Group("registry")
 	mirrors := registry.Group("mirrors")
 
-	mirrors.Get("/", handlers.RequireLocal(handlers.GetRegistryMirrors))
-	mirrors.Get("/:registry", handlers.RequireLocal(handlers.GetRegistryMirror))
-	mirrors.Put("/:registry", handlers.RequireLocal(handlers.UpdateRegistryMirror))
-	mirrors.Delete("/:registry", handlers.RequireLocal(handlers.DeleteRegistryMirror))
+	mirrors.Get("/", handlers.RequireAuthorization(handlers.RequireLocal(handlers.GetRegistryMirrors)))
+	mirrors.Get("/:registry", handlers.RequireAuthorization(handlers.RequireLocal(handlers.GetRegistryMirror)))
+	mirrors.Put("/:registry", handlers.RequireAuthorization(handlers.RequireLocal(handlers.UpdateRegistryMirror)))
+	mirrors.Delete("/:registry", handlers.RequireAuthorization(handlers.RequireLocal(handlers.DeleteRegistryMirror)))
 
 	image := containerd.Group("images")
 

--- a/daemon/pkg/utils/ssh_linux.go
+++ b/daemon/pkg/utils/ssh_linux.go
@@ -5,8 +5,8 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/beclab/Olares/daemon/cmd/terminusd/version"
 	"golang.org/x/crypto/ssh"
@@ -69,10 +69,11 @@ func SetSSHPassword(user, password string) error {
 		return errors.New(err)
 	}
 
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("echo '%s:%s' | chpasswd", user, password))
-	err := cmd.Run()
+	cmd := exec.Command("chpasswd")
+	cmd.Stdin = strings.NewReader(user + ":" + password + "\n")
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Error("set ssh password error: ", err)
+		klog.Errorf("set ssh password error: %v, output: %s", err, string(output))
 	}
 
 	return err


### PR DESCRIPTION
## Summary
- Add `RequireAuthorization` to the containerd registry mirrors API so requests cannot succeed with local-only checks
- Set SSH passwords via `chpasswd` stdin to avoid shell injection and quoting issues from string concatenation

## Test plan
- [ ] Unauthenticated requests to `/registry/mirrors` endpoints should be rejected
- [ ] Local and authorized requests can Get/Put/Delete registry mirrors successfully
- [ ] Setting an SSH password succeeds, including passwords with special characters that would break shell escaping