### PR TITLE
chore(app-service): add mesh-in/mesh-out agent Hub publish workflows

### DIFF
--- a/.github/workflows/module_appservice_publish_mesh_in_agent.yaml
+++ b/.github/workflows/module_appservice_publish_mesh_in_agent.yaml
@@ -1,0 +1,109 @@
+name: Publish app-service mesh-in-agent to Dockerhub
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Release Tags'
+        required: true
+        type: string
+
+jobs:
+  publish_dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Validate release tag input
+        run: |
+          set -euo pipefail
+          TAG='${{ github.event.inputs.tags }}'
+          TAG="$(echo -n "$TAG" | tr -d '[:space:]')"
+          test -n "$TAG"
+          if [ "$TAG" = "latest" ]; then
+            echo "FATAL: tag 'latest' is forbidden" >&2
+            exit 1
+          fi
+          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Build and push multi-arch mesh-in-agent
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: beclab/mesh-in-agent:${{ env.RELEASE_TAG }}
+          context: framework/app-service/build/mesh-in-agent
+          file: framework/app-service/build/mesh-in-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Verify multi-arch, arm64 ELF, and mesh-in core capabilities
+        run: |
+          set -euo pipefail
+          IMG="beclab/mesh-in-agent:${RELEASE_TAG}"
+          docker buildx imagetools inspect "$IMG"
+          INSPECT="$(docker buildx imagetools inspect "$IMG")"
+          echo "$INSPECT" | grep -q 'linux/amd64'
+          echo "$INSPECT" | grep -q 'linux/arm64'
+
+          verify_arch_elf() {
+            local platform="$1"
+            local expect="$2"
+            local cid bininfo
+            docker pull --platform="$platform" "$IMG"
+            cid="$(docker create --platform="$platform" --entrypoint /bin/true "$IMG")"
+            docker cp "$cid:/usr/sbin/nginx" "/tmp/nginx.${platform##*/}"
+            docker rm -f "$cid" >/dev/null
+            bininfo="$(file "/tmp/nginx.${platform##*/}")"
+            echo "$bininfo"
+            echo "$bininfo" | grep -qiE -- "$expect"
+          }
+          verify_arch_elf linux/amd64 'x86-64|x86_64|Intel 80386'
+          verify_arch_elf linux/arm64 'ARM aarch64|aarch64|ARM64'
+
+          verify_mesh_in_core() {
+            local platform="$1"
+            local nginx_v probe_conf probe_out
+            nginx_v="$(docker run --rm --platform="$platform" "$IMG" nginx -V 2>&1 || true)"
+            for flag in \
+              --with-stream \
+              --with-stream_ssl_module \
+              --with-stream_ssl_preread_module \
+              --with-http_ssl_module \
+              --with-http_v2_module; do
+              echo "$nginx_v" | tr ' ' '\n' | grep -qx -- "$flag" \
+                || (echo "FATAL: ${platform}: nginx -V missing ${flag}" >&2; exit 1)
+            done
+            for so in ngx_stream_js_module.so ngx_http_js_module.so; do
+              docker run --rm --platform="$platform" "$IMG" test -f "/etc/nginx/modules/${so}" \
+                || (echo "FATAL: ${platform}: missing /etc/nginx/modules/${so}" >&2; exit 1)
+            done
+            probe_conf='load_module modules/ngx_stream_js_module.so; load_module modules/ngx_http_js_module.so; events{} stream { js_import probe.js; js_set $probe_v probe.x; server { listen 127.0.0.1:18443; return ok; } } http { js_import probe.js; js_set $probe_h probe.x; server { listen 18080; location / { return 200 $probe_h; } } }'
+            probe_out="$(docker run --rm --platform="$platform" "$IMG" sh -c "printf %s '${probe_conf}' > /tmp/probe.conf && nginx -t -c /tmp/probe.conf 2>&1" || true)"
+            if echo "$probe_out" | grep -qE 'dlopen\(\) .*ngx_(stream|http)_js_module|unknown directive "js_(import|set)"'; then
+              echo "FATAL: ${platform}: njs load/recognition failed" >&2
+              echo "$probe_out" >&2
+              exit 1
+            fi
+            if ! echo "$probe_out" | grep -qEi 'syntax is ok|cannot load module|enoent.*probe\.js|open .*probe\.js'; then
+              echo "FATAL: ${platform}: unexpected nginx -t output" >&2
+              echo "$probe_out" >&2
+              exit 1
+            fi
+          }
+          verify_mesh_in_core linux/amd64
+          verify_mesh_in_core linux/arm64
+
+          docker run --rm --platform=linux/amd64 --entrypoint cat "$IMG" /usr/share/doc/mesh-in-agent/UPSTREAM_SOURCES.txt

--- a/.github/workflows/module_appservice_publish_mesh_out_agent.yaml
+++ b/.github/workflows/module_appservice_publish_mesh_out_agent.yaml
@@ -1,0 +1,89 @@
+name: Publish app-service mesh-out-agent to Dockerhub
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Release Tags'
+        required: true
+        type: string
+
+jobs:
+  publish_dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Validate release tag input
+        run: |
+          set -euo pipefail
+          TAG='${{ github.event.inputs.tags }}'
+          TAG="$(echo -n "$TAG" | tr -d '[:space:]')"
+          test -n "$TAG"
+          if [ "$TAG" = "latest" ]; then
+            echo "FATAL: tag 'latest' is forbidden" >&2
+            exit 1
+          fi
+          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Build and push multi-arch mesh-out-agent
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: beclab/mesh-out-agent:${{ env.RELEASE_TAG }}
+          context: framework/app-service/build/mesh-out-agent
+          file: framework/app-service/build/mesh-out-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Verify multi-arch, arm64 ELF, and mesh-out gates
+        run: |
+          set -euo pipefail
+          IMG="beclab/mesh-out-agent:${RELEASE_TAG}"
+          docker buildx imagetools inspect "$IMG"
+          INSPECT="$(docker buildx imagetools inspect "$IMG")"
+          echo "$INSPECT" | grep -q 'linux/amd64'
+          echo "$INSPECT" | grep -q 'linux/arm64'
+
+          verify_arch_elf() {
+            local platform="$1"
+            local expect="$2"
+            local cid bininfo
+            docker pull --platform="$platform" "$IMG"
+            cid="$(docker create --platform="$platform" --entrypoint /bin/true "$IMG")"
+            docker cp "$cid:/usr/sbin/nginx" "/tmp/nginx.${platform##*/}"
+            docker rm -f "$cid" >/dev/null
+            bininfo="$(file "/tmp/nginx.${platform##*/}")"
+            echo "$bininfo"
+            echo "$bininfo" | grep -qiE -- "$expect"
+          }
+          verify_arch_elf linux/amd64 'x86-64|x86_64|Intel 80386'
+          verify_arch_elf linux/arm64 'ARM aarch64|aarch64|ARM64'
+
+          verify_mesh_out_gate() {
+            local platform="$1"
+            local nginx_v
+            nginx_v="$(docker run --rm --platform="$platform" "$IMG" nginx -V 2>&1 || true)"
+            echo "$nginx_v" | tr ' ' '\n' | grep -qx -- '--with-http_ssl_module' \
+              || (echo "FATAL: ${platform}: nginx -V missing --with-http_ssl_module" >&2; exit 1)
+            docker run --rm --platform="$platform" "$IMG" sh -c \
+              'test ! -f /etc/nginx/modules/ngx_stream_js_module.so && test ! -f /etc/nginx/modules/ngx_http_js_module.so' \
+              || (echo "FATAL: ${platform}: unexpected njs modules in mesh-out image" >&2; exit 1)
+          }
+          verify_mesh_out_gate linux/amd64
+          verify_mesh_out_gate linux/arm64
+
+          docker run --rm --platform=linux/amd64 --entrypoint cat "$IMG" /usr/share/doc/mesh-out-agent/UPSTREAM_SOURCES.txt

--- a/framework/app-service/build/mesh-in-agent/Dockerfile
+++ b/framework/app-service/build/mesh-in-agent/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+ARG NGINX_ALPINE_TAG=1.30.0-alpine
+FROM nginx:${NGINX_ALPINE_TAG}
+
+ARG NGINX_ALPINE_TAG=1.30.0-alpine
+
+RUN set -eux; \
+    apk add --no-cache nginx-module-njs; \
+    NGINX_V="$(nginx -V 2>&1)"; \
+    for flag in \
+        --with-stream \
+        --with-stream_ssl_module \
+        --with-stream_ssl_preread_module \
+        --with-http_ssl_module \
+        --with-http_v2_module; do \
+      echo "$NGINX_V" | tr ' ' '\n' | grep -qx -- "$flag" \
+        || (echo "FATAL: nginx -V missing required flag: $flag" >&2; exit 1); \
+    done; \
+    test -f /etc/nginx/modules/ngx_stream_js_module.so; \
+    test -f /etc/nginx/modules/ngx_http_js_module.so; \
+    NGINX_VER="$(nginx -v 2>&1 | sed -n 's/^nginx version: nginx\///p')"; \
+    NJS_APK="$(apk info -e -v nginx-module-njs | head -n1)"; \
+    NJS_VER="$(printf '%s\n' "$NJS_APK" | sed -n 's/^nginx-module-njs-[0-9.]*\.0\.\([0-9.]*\)-r[0-9]*$/\1/p')"; \
+    if [ -z "$NJS_VER" ]; then NJS_VER="$(printf '%s\n' "$NJS_APK" | sed -n 's/^nginx-module-njs-//p')"; fi; \
+    mkdir -p /usr/share/doc/mesh-in-agent; \
+    { \
+      echo "base_image=nginx:${NGINX_ALPINE_TAG}"; \
+      echo "nginx_version=${NGINX_VER}"; \
+      echo "nginx_git=https://github.com/nginx/nginx"; \
+      echo "nginx_checkout=git clone https://github.com/nginx/nginx.git && git -C nginx checkout release-${NGINX_VER}"; \
+      echo "nginx_tarball=https://nginx.org/download/nginx-${NGINX_VER}.tar.gz"; \
+      echo "nginx_module_njs_apk=${NJS_APK}"; \
+      echo "njs_version=${NJS_VER}"; \
+      echo "njs_git=https://github.com/nginx/njs"; \
+      echo "njs_checkout=git clone https://github.com/nginx/njs.git && git -C njs checkout ${NJS_VER}"; \
+    } > /usr/share/doc/mesh-in-agent/UPSTREAM_SOURCES.txt

--- a/framework/app-service/build/mesh-out-agent/Dockerfile
+++ b/framework/app-service/build/mesh-out-agent/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+ARG NGINX_ALPINE_SLIM_TAG=1.30.0-alpine-slim
+FROM nginx:${NGINX_ALPINE_SLIM_TAG}
+
+ARG NGINX_ALPINE_SLIM_TAG=1.30.0-alpine-slim
+
+RUN set -eux; \
+    nginx -V 2>&1 | tr ' ' '\n' | grep -E -- '--with-http_ssl_module$' >/dev/null \
+        || (echo "FATAL: --with-http_ssl_module missing in alpine-slim base" >&2; exit 1); \
+    test ! -f /etc/nginx/modules/ngx_stream_js_module.so; \
+    test ! -f /etc/nginx/modules/ngx_http_js_module.so; \
+    NGINX_VER="$(nginx -v 2>&1 | sed -n 's/^nginx version: nginx\///p')"; \
+    mkdir -p /usr/share/doc/mesh-out-agent; \
+    { \
+      echo "base_image=nginx:${NGINX_ALPINE_SLIM_TAG}"; \
+      echo "nginx_version=${NGINX_VER}"; \
+      echo "nginx_git=https://github.com/nginx/nginx"; \
+      echo "nginx_checkout=git clone https://github.com/nginx/nginx.git && git -C nginx checkout release-${NGINX_VER}"; \
+      echo "nginx_tarball=https://nginx.org/download/nginx-${NGINX_VER}.tar.gz"; \
+    } > /usr/share/doc/mesh-out-agent/UPSTREAM_SOURCES.txt


### PR DESCRIPTION
Add multi-arch Hub publish workflows for mesh-in-agent and mesh-out-agent with tag/arch/njs release gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new CI workflows and container image definitions; no application runtime or security-sensitive logic is modified.
> 
> **Overview**
> Adds **manual Docker Hub publish** for `beclab/mesh-in-agent` and `beclab/mesh-out-agent`, each triggered via `workflow_dispatch` with a required release tag ( **`latest` is blocked** ).
> 
> New **Dockerfiles** under `framework/app-service/build/`: **mesh-in-agent** extends `nginx:1.30.0-alpine`, installs `nginx-module-njs`, asserts stream/SSL/v2 compile flags and njs `.so` files, and writes `UPSTREAM_SOURCES.txt`. **mesh-out-agent** uses `nginx:1.30.0-alpine-slim`, requires `--with-http_ssl_module`, and asserts njs modules are **absent**.
> 
> After push, workflows run **multi-arch checks** (`linux/amd64`, `linux/arm64`), **ELF verification** on bundled `nginx`, and role-specific gates (mesh-in: nginx flags, njs modules, `nginx -t` njs probe; mesh-out: SSL module present, no njs modules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015588a0f3dc707f9c2c0babfe1079eed5e92f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->