### PR TITLE
refactor(appservice): parse new format of containerd mirror config

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -244,7 +244,7 @@ spec:
           name: user-apps-template
         - mountPath: /etc/certs
           name: certs
-        - mountPath: /etc/containerd/config.toml
+        - mountPath: /etc/containerd
           name: configtoml
         - mountPath: /Cache
           name: app-cache
@@ -277,7 +277,8 @@ spec:
           type: DirectoryOrCreate
       - name: configtoml
         hostPath:
-          path: /etc/containerd/config.toml
+          path: /etc/containerd
+          type: Directory
       - name: charts-store
         persistentVolumeClaim:
           claimName: {{ default $charts_pvc .Values.charts_pvc }}

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.0
@@ -209,7 +210,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
-	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/framework/app-service/pkg/utils/k8sutil.go
+++ b/framework/app-service/pkg/utils/k8sutil.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/pelletier/go-toml"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/client/clientset"
@@ -24,7 +26,6 @@ import (
 	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
 	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
 
-	srvconfig "github.com/containerd/containerd/services/server/config"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,22 +164,45 @@ func IsNodeReady(node *corev1.Node) bool {
 	return false
 }
 
+// dockerHostsTOMLPath is containerd's registry hosts config for docker.io under
+// config_path (/etc/containerd/certs.d). Registry mirrors moved here in the
+// containerd v3 config; the inline registry.mirrors in config.toml is deprecated
+// and ignored by containerd 2.x once config_path is set.
+const dockerHostsTOMLPath = "/etc/containerd/certs.d/docker.io/hosts.toml"
+
+// GetMirrorsEndpoint returns the docker.io pull-through mirror endpoints
+// configured for containerd, in priority (file) order. They are read from
+// containerd's certs.d hosts.toml `[host."<url>"]` entries, the containerd v3
+// replacement for the deprecated inline registry.mirrors config.
 func GetMirrorsEndpoint() (ep []string) {
-	config := &srvconfig.Config{}
-	err := srvconfig.LoadConfig("/etc/containerd/config.toml", config)
+	data, err := os.ReadFile(dockerHostsTOMLPath)
 	if err != nil {
-		klog.Infof("load mirrors endpoint failed err=%v", err)
+		klog.Infof("load mirrors endpoint from %s failed err=%v", dockerHostsTOMLPath, err)
 		return
 	}
-	plugins := config.Plugins["io.containerd.grpc.v1.cri"]
-	r := plugins.GetPath([]string{"registry", "mirrors", "docker.io", "endpoint"})
-	if r == nil {
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		klog.Infof("parse %s failed err=%v", dockerHostsTOMLPath, err)
 		return
 	}
-	for _, e := range r.([]interface{}) {
-		ep = append(ep, e.(string))
+	hostTree, ok := tree.Get("host").(*toml.Tree)
+	if !ok {
+		return
 	}
-	return ep
+	// TOML tables are unordered; recover mirror precedence from source line number,
+	// the same way containerd's own resolver orders hosts.
+	hosts := hostTree.Keys()
+	// Note: use GetPath (single path element), not Get — Get treats the key as a
+	// dot-separated path, which would mangle host URLs that contain dots/colons.
+	sort.SliceStable(hosts, func(i, j int) bool {
+		ti, _ := hostTree.GetPath([]string{hosts[i]}).(*toml.Tree)
+		tj, _ := hostTree.GetPath([]string{hosts[j]}).(*toml.Tree)
+		if ti == nil || tj == nil {
+			return false
+		}
+		return ti.Position().Line < tj.Position().Line
+	})
+	return hosts
 }
 
 // ReplacedImageRef return replaced image ref and true if mirror is support http

--- a/framework/app-service/pkg/utils/registry/mirror_watcher.go
+++ b/framework/app-service/pkg/utils/registry/mirror_watcher.go
@@ -15,8 +15,12 @@ import (
 )
 
 var (
-	containerdConfigDir  = "/etc/containerd"
-	containerdConfigFile = filepath.Join(containerdConfigDir, "config.toml")
+	// Registry mirrors live in containerd's certs.d hosts.toml (config v3
+	// config_path), not the inline registry.mirrors of config.toml. Watch the
+	// docker.io host dir + hosts.toml so app-service picks up mirror changes made
+	// by the CLI (install seed) or olaresd (runtime reconcile).
+	containerdConfigDir  = "/etc/containerd/certs.d/docker.io"
+	containerdConfigFile = filepath.Join(containerdConfigDir, "hosts.toml")
 
 	instance *MirrorWatcher
 	once     sync.Once


### PR DESCRIPTION
* **Background**
Currently, app-service and image-service mount and read the host machine's `/etc/containerd/config.toml` to parse registry mirror config and override image reference when pre downloading, in https://github.com/beclab/Olares/pull/3735, we changed the now deprecated in-line `plugins."io.containerd.grpc.v1.cri".registry.configs."*".mirrors` to the standard drop-in files in `/etc/containerd/certs/*/hosts.toml`, so the mirror config parsing logic and mount path is changed accordingly.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pre-download image refs are rewritten from host mirror config; mis-parsing or a bad mount could break pulls until hosts.toml matches what containerd uses.
> 
> **Overview**
> Aligns **app-service** with containerd’s **certs.d** mirror layout (from the earlier platform change): mirror discovery no longer reads deprecated inline `registry.mirrors` in `config.toml`.
> 
> **`GetMirrorsEndpoint`** now loads `/etc/containerd/certs.d/docker.io/hosts.toml`, parses the `host` table keys as mirror URLs, and orders them by **source line** (matching containerd’s precedence). **`MirrorWatcher`** watches that `docker.io` directory and `hosts.toml` instead of `config.toml`. The StatefulSet mounts the host **`/etc/containerd`** directory (not a single file) so `certs.d` is visible in the pod. **`pelletier/go-toml`** is a direct dependency; containerd’s server config loader is dropped from this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b44811ff78da5231322d0b80dcb91b6aa379bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->