### PR TITLE
cli/market: gate resume cancel on Olares 1.12.7 and fix resume watch on stopped

### DIFF
--- a/cli/cmd/ctl/market/cancel.go
+++ b/cli/cmd/ctl/market/cancel.go
@@ -10,6 +10,34 @@ import (
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
+const (
+	// stateResuming mirrors the SPA's APP_STATUS.RESUME.DEFAULT: the
+	// per-user state-row value while a resume is in flight.
+	stateResuming = "resuming"
+	// resumeCancelMinVersion is the first Olares line whose resume-cancel
+	// UX the CLI mirrors. The SPA exposed the cancel button on a resuming
+	// app in 1.12.7 (reusing DELETE /apps/{name}/install); cancelling a
+	// resuming app on older / undetectable backends is rejected fail-closed
+	// so the CLI stays in lockstep with that rollout.
+	resumeCancelMinVersion = "1.12.7"
+)
+
+// gateResumeCancel enforces the 1.12.7 minimum for cancelling a *resuming*
+// app. It is a no-op for every other state — only resume cancellation is
+// version-gated; the rest of the in-flight pipeline (pending / downloading /
+// installing / upgrading / ...) cancels on any backend. Fail-closed on
+// older / undetectable backends via cmdutil.RequireMinVersion.
+func gateResumeCancel(ctx context.Context, f *cmdutil.Factory, state string) error {
+	if strings.TrimSpace(state) != stateResuming {
+		return nil
+	}
+	return cmdutil.RequireMinVersion(ctx, f, cmdutil.MinVersionGate{
+		Verb:       "market cancel",
+		MinVersion: resumeCancelMinVersion,
+		Reason:     "canceling a resuming app",
+	})
+}
+
 func NewCmdMarketCancel(f *cmdutil.Factory) *cobra.Command {
 	opts := newMarketOptions(f)
 	cmd := &cobra.Command{
@@ -31,6 +59,12 @@ a cancel races with downloadFailed / partial-rollback-to-stopped.
 The terminal row carries the *underlying* op (install / upgrade / ...)
 as its opType, not "cancel" — matchOpType is off, no race-tracking
 gate applies.
+
+Cancelling an app that is *resuming* requires Olares >= 1.12.7 (the
+resume-cancel UX the SPA shipped in 1.12.7, reusing this same DELETE).
+On older or undetectable backends the CLI rejects it fail-closed (pass
+--olares-version to override). Every other in-flight state is
+unaffected.
 
 Examples:
   olares-cli market cancel firefox                         # fire-and-forget; returns once backend accepts
@@ -88,6 +122,12 @@ func runCancel(opts *MarketOptions, appName string) error {
 			source = strings.TrimSpace(row.Source)
 		}
 		version = strings.TrimSpace(row.Version)
+		// Cancelling a resuming app is a 1.12.7 UX; reject it fail-closed
+		// on older/undetectable backends. Other in-flight states are
+		// unaffected (gateResumeCancel no-ops for them).
+		if err := gateResumeCancel(ctx, opts.factory, row.State); err != nil {
+			return opts.failOp("cancel", appName, err)
+		}
 	}
 
 	if atLeast126 && source == "" {

--- a/cli/cmd/ctl/market/cancel_test.go
+++ b/cli/cmd/ctl/market/cancel_test.go
@@ -1,0 +1,64 @@
+package market
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// TestGateResumeCancel pins the 1.12.7 fail-closed gate for cancelling a
+// resuming app. The gate reuses cmdutil.RequireMinVersion, whose version
+// resolution short-circuits on the --olares-version override (viper key
+// FlagOlaresVersion) BEFORE any profile / network access — so a zero-value
+// Factory plus a viper override is enough to drive every branch without a
+// fake backend. A fresh Factory per scenario avoids the per-Factory
+// memoization (backendVersionOnce) leaking a version across cases.
+func TestGateResumeCancel(t *testing.T) {
+	// Isolate the global viper override and restore it after the test so
+	// other market tests are unaffected.
+	prev := viper.GetString(cmdutil.FlagOlaresVersion)
+	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, prev) })
+
+	t.Run("non-resuming state is never gated", func(t *testing.T) {
+		// installing must pass regardless of backend version — the gate
+		// no-ops for it (returns before touching the factory), so even an
+		// empty override cannot make it fail.
+		viper.Set(cmdutil.FlagOlaresVersion, "1.12.5")
+		for _, state := range []string{"installing", "downloading", "pending", "upgrading", ""} {
+			if err := gateResumeCancel(context.Background(), &cmdutil.Factory{}, state); err != nil {
+				t.Fatalf("state %q must not be gated, got error: %v", state, err)
+			}
+		}
+	})
+
+	t.Run("resuming on 1.12.6 backend is rejected", func(t *testing.T) {
+		viper.Set(cmdutil.FlagOlaresVersion, "1.12.6")
+		err := gateResumeCancel(context.Background(), &cmdutil.Factory{}, stateResuming)
+		if err == nil {
+			t.Fatalf("cancelling a resuming app on 1.12.6 must be rejected")
+		}
+		if !strings.Contains(err.Error(), resumeCancelMinVersion) {
+			t.Fatalf("error should name the %s minimum, got %q", resumeCancelMinVersion, err.Error())
+		}
+	})
+
+	t.Run("resuming on 1.12.7 backend is allowed", func(t *testing.T) {
+		viper.Set(cmdutil.FlagOlaresVersion, "1.12.7")
+		if err := gateResumeCancel(context.Background(), &cmdutil.Factory{}, stateResuming); err != nil {
+			t.Fatalf("cancelling a resuming app on 1.12.7 must be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("resuming on a newer 1.12.7 daily build is allowed", func(t *testing.T) {
+		// Core (major.minor.patch) comparison: a dated build on the 1.12.7
+		// line counts as >= 1.12.7.
+		viper.Set(cmdutil.FlagOlaresVersion, "1.12.7-20260604")
+		if err := gateResumeCancel(context.Background(), &cmdutil.Factory{}, stateResuming); err != nil {
+			t.Fatalf("cancelling a resuming app on a 1.12.7 daily build must be allowed, got: %v", err)
+		}
+	})
+}

--- a/cli/cmd/ctl/market/resume.go
+++ b/cli/cmd/ctl/market/resume.go
@@ -21,11 +21,15 @@ func NewCmdMarketResume(f *cmdutil.Factory) *cobra.Command {
 Source is implicit: resume acts on whichever per-user state row matches
 the app name, regardless of source (no -s flag exposed).
 
---watch blocks until the row settles at 'running' (or one of the
-resumeFailed / resumingCanceled / resumingCancelFailed failure states).
-The watcher is idempotent: 'resume' against an already-running row
-returns immediately with success ({state=running, opType=""}), rather
-than hanging until --watch-timeout fires.
+--watch blocks until the row settles. Success is 'running'; a resume
+that gets cancelled (via 'market cancel' or a backend TTL) settles at
+'stopped' and is also treated as a terminal success. Failure is
+'resumeFailed' or 'resumingCancelFailed'. The watcher is idempotent:
+'resume' against an already-running row returns immediately with success
+({state=running, opType=""}), rather than hanging until --watch-timeout
+fires. To distinguish a freshly-cancelled 'stopped' from the app's
+pre-resume 'stopped' resting row, --watch captures the row's statusTime
+before the request and only accepts a strictly-newer 'stopped'.
 
 Compute binding (Olares 1.12.6+ only): apps that use a GPU/accelerator
 may need a device selected when resumed. Use --compute-binding
@@ -67,14 +71,20 @@ func runResume(opts *MarketOptions, appName string) error {
 
 	ctx := context.Background()
 
-	// Resolve the installed app's source: enforces the "only operate on an
+	// Resolve the installed app's row: enforces the "only operate on an
 	// installed app" guard (a bugfix applying to 1.12.5 and 1.12.6 alike)
-	// and yields the source the 1.12.6 body needs (resume exposes no -s).
-	// The resolved source also sharpens the --watch state-row match.
-	source, err := resolveInstalledSource(ctx, opts, mc, appName)
+	// and yields both the source the 1.12.6 body needs (resume exposes no
+	// -s) and the row's current statusTime. The source sharpens the --watch
+	// state-row match; the statusTime is captured as the baseline BEFORE the
+	// resume so the watcher can tell a freshly-cancelled `stopped` (resume
+	// cancelled -> stopped) from the byte-identical pre-resume stopped row
+	// (see watchResume / stoppedTerminalSuccess).
+	row, err := resolveInstalledRow(ctx, mc, appName)
 	if err != nil {
 		return opts.failOp("resume", appName, err)
 	}
+	source := row.Source
+	baselineStatusTime := parseStatusTime(row.StatusTime)
 
 	atLeast126, err := opts.factory.OlaresBackendAtLeast(ctx, "1.12.6")
 	if err != nil {
@@ -113,7 +123,9 @@ func runResume(opts *MarketOptions, appName string) error {
 	}
 
 	result := newOperationResult(mc, "resume", appName, "", "", "resume requested", resp)
-	return runWithWatch(opts, mc, result, newWatchTarget(watchResume, appName, source))
+	target := newWatchTarget(watchResume, appName, source)
+	target.baselineStatusTime = baselineStatusTime
+	return runWithWatch(opts, mc, result, target)
 }
 
 // sendResume builds the version-appropriate resume body (1.12.6 moved to

--- a/cli/cmd/ctl/market/uninstall.go
+++ b/cli/cmd/ctl/market/uninstall.go
@@ -25,7 +25,7 @@ var inFlightCancelableStates = map[string]bool{
 	"initializing": true,
 	"upgrading":    true,
 	"applyingEnv":  true,
-	"resuming":     true,
+	stateResuming:  true,
 }
 
 func NewCmdMarketUninstall(f *cmdutil.Factory) *cobra.Command {

--- a/cli/cmd/ctl/market/watch.go
+++ b/cli/cmd/ctl/market/watch.go
@@ -137,6 +137,22 @@ type watchTarget struct {
 	// alone, so we keep the strict gate for those.
 	idempotentSuccess bool
 
+	// stoppedTerminalSuccess treats a `stopped` row as a terminal SUCCESS,
+	// op-agnostically, but ONLY when its statusTime is strictly newer than
+	// baselineStatusTime. This is the resume watcher's cancel escape hatch:
+	// a resume that gets cancelled (by the user via `market cancel`, or by
+	// the backend's TTL) walks resuming -> resumingCanceling -> stopping ->
+	// stopped, so `stopped` is the settled outcome — but it is ALSO the
+	// pre-resume resting state (you resume a stopped app), byte-identical at
+	// tick zero. We reuse restart's statusTime-baseline trick to tell the
+	// freshly-cancelled `stopped` from the stale pre-resume row (strict `>`;
+	// a missing/unparseable statusTime -> effectiveTime 0 -> never terminal,
+	// mirroring the SPA). Unlike requireNewerThanBaseline this is scoped to
+	// the single `stopped` state, so the `running` success path (incl. the
+	// idempotentSuccess no-op shortcut) is unaffected. Only watchResume sets
+	// it; captured baseline comes from runResume, same as restart.
+	stoppedTerminalSuccess bool
+
 	// requireNewerThanBaseline gates BOTH success and failure on the row's
 	// statusTime being strictly newer than baselineStatusTime. This is the
 	// crux of the restart watcher: a completed restart rests at
@@ -200,14 +216,22 @@ func newWatchTarget(op watchOp, appName, source string) watchTarget {
 		t.idempotentSuccess = true
 	case watchResume:
 		t.successSet = map[string]bool{"running": true}
+		// resumingCanceled is intentionally omitted: that transition does
+		// not exist (a cancelled resume settles at `stopped`, handled by
+		// stoppedTerminalSuccess below). Failure is the resume dying
+		// (resumeFailed) or the cancel request itself being rejected
+		// (resumingCancelFailed).
 		t.failureSet = map[string]bool{
 			"resumeFailed":         true,
-			"resumingCanceled":     true,
 			"resumingCancelFailed": true,
 		}
 		// Symmetric to stop: `resume` on an already-running row is a
 		// backend no-op and would otherwise hang the watcher.
 		t.idempotentSuccess = true
+		// A resume that gets cancelled lands on `stopped`; accept it as a
+		// terminal (baseline-gated so the pre-resume stopped row at tick
+		// zero is not a false positive). See stoppedTerminalSuccess.
+		t.stoppedTerminalSuccess = true
 	case watchRestart:
 		// restart = backend stop THEN resume once stop succeeds. The row
 		// therefore passes through `OpType=stop` (stop phase) and
@@ -446,6 +470,13 @@ func waitForTerminal(parentCtx context.Context, mc *MarketClient, opts *MarketOp
 			rowCopy := row
 			last = &rowCopy
 
+			// Resume-cancel escape hatch: a cancelled resume settles at
+			// `stopped`, op-agnostically, but only a row strictly newer
+			// than the pre-resume baseline is the fresh cancel (the tick-
+			// zero pre-resume `stopped` row shares the baseline statusTime).
+			if t.stoppedTerminalSuccess && row.State == appStateStopped && effectiveTime(row) > t.baselineStatusTime {
+				return row, nil
+			}
 			if t.successSet[row.State] && t.passesBaseline(row) {
 				switch {
 				case t.matchesOpType(row):

--- a/cli/cmd/ctl/market/watch_test.go
+++ b/cli/cmd/ctl/market/watch_test.go
@@ -26,6 +26,9 @@ import (
 // helper local avoids growing the package's exported surface just for unit
 // coverage.
 func classifyForTest(t watchTarget, row statusRow) string {
+	if t.stoppedTerminalSuccess && row.State == appStateStopped && effectiveTime(row) > t.baselineStatusTime {
+		return "success"
+	}
 	if t.successSet[row.State] && t.passesBaseline(row) {
 		if t.matchesOpType(row) {
 			return "success"
@@ -364,6 +367,57 @@ func TestClassifierStopAlreadyStopped(t *testing.T) {
 	// must not be misclassified as a fresh failure of our request.
 	if got := classifyForTest(stopT, statusRow{State: "stopFailed", OpType: ""}); got != "progressing" {
 		t.Fatalf("stopFailed with empty op should stay progressing (no idempotent shortcut for failure), got %s", got)
+	}
+}
+
+// resumeTarget builds a watchResume target with the given baseline statusTime,
+// mirroring what runResume does (capture the pre-resume row's statusTime, then
+// stamp it onto the target so the stopped-terminal gate can tell a freshly-
+// cancelled stopped from the pre-resume resting row).
+func resumeTarget(baseline string) watchTarget {
+	tgt := newWatchTarget(watchResume, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+	return tgt
+}
+
+func TestClassifierResumeCancelStoppedBaselineGate(t *testing.T) {
+	const baseline = "2026-07-01T08:28:00Z"
+	tgt := resumeTarget(baseline)
+	if !tgt.stoppedTerminalSuccess {
+		t.Fatalf("watchResume must enable stoppedTerminalSuccess")
+	}
+	// resumingCanceled must NOT be a failure state (the transition doesn't
+	// exist; a cancelled resume lands on stopped).
+	if tgt.failureSet["resumingCanceled"] {
+		t.Fatalf("watchResume failureSet must not contain the dead state resumingCanceled")
+	}
+
+	// tick-zero pre-resume stopped row (SAME statusTime as baseline) is the
+	// exact false-positive the baseline gate exists to prevent — strict `>`.
+	if got := classifyForTest(tgt, statusRow{State: "stopped", OpType: "", StatusTime: baseline}); got != "progressing" {
+		t.Fatalf("pre-resume stopped at baseline must be progressing, got %s", got)
+	}
+	// Older stopped → not terminal.
+	if got := classifyForTest(tgt, statusRow{State: "stopped", OpType: "", StatusTime: "2026-07-01T08:27:00Z"}); got != "progressing" {
+		t.Fatalf("stopped older than baseline must be progressing, got %s", got)
+	}
+	// Missing statusTime (effectiveTime 0) → not terminal (mirrors the SPA).
+	if got := classifyForTest(tgt, statusRow{State: "stopped", OpType: ""}); got != "progressing" {
+		t.Fatalf("stopped with missing statusTime must be progressing, got %s", got)
+	}
+	// A strictly-newer stopped = the resume was cancelled and settled;
+	// op-agnostic (the cancel-driven row may carry any/empty OpType).
+	if got := classifyForTest(tgt, statusRow{State: "stopped", OpType: "cancel", StatusTime: "2026-07-01T08:29:03Z"}); got != "success" {
+		t.Fatalf("newer stopped (cancelled resume) must be success, got %s", got)
+	}
+	// running remains success via the normal successSet path, regardless of
+	// statusTime (resume is not baseline-gated for its running terminal).
+	if got := classifyForTest(tgt, statusRow{State: "running", OpType: "resume", StatusTime: baseline}); got != "success" {
+		t.Fatalf("running must remain success regardless of baseline, got %s", got)
+	}
+	// The cancel request being rejected still fails the resume watch.
+	if got := classifyForTest(tgt, statusRow{State: "resumingCancelFailed", OpType: "resume", StatusTime: "2026-07-01T08:29:03Z"}); got != "failure" {
+		t.Fatalf("resumingCancelFailed must be failure, got %s", got)
 	}
 }
 
@@ -928,6 +982,89 @@ func TestWaitForTerminalResumeOnAlreadyRunning(t *testing.T) {
 	}
 	if row.State != "running" || row.OpType != "" {
 		t.Fatalf("expected running/empty-op terminal row, got %+v", row)
+	}
+}
+
+func TestWaitForTerminalResumeCancelledLandsOnStopped(t *testing.T) {
+	// A resume that gets cancelled walks resuming -> resumingCanceling ->
+	// stopping -> stopped, each row strictly newer than the pre-resume
+	// baseline. The watcher must accept the final `stopped` as terminal
+	// success instead of hanging until --watch-timeout (the old watchResume
+	// had no `stopped` terminal at all).
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "resuming", OpType: "resume", StatusTime: "2026-07-01T08:28:10Z"},
+		{State: "resumingCanceling", OpType: "cancel", StatusTime: "2026-07-01T08:28:20Z"},
+		{State: "stopping", OpType: "cancel", StatusTime: "2026-07-01T08:28:30Z"},
+		{State: "stopped", OpType: "", StatusTime: "2026-07-01T08:28:40Z"},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(5*time.Second, 5*time.Millisecond)
+
+	tgt := newWatchTarget(watchResume, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	row, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err != nil {
+		t.Fatalf("expected cancelled-resume to settle at stopped (success), got %v", err)
+	}
+	if row.State != "stopped" {
+		t.Fatalf("expected terminal stopped row, got %s", row.State)
+	}
+}
+
+func TestWaitForTerminalResumeStalePreResumeStoppedTimesOut(t *testing.T) {
+	// The false-positive guard end-to-end: if the resume POST silently
+	// no-op'd and the row never advances past its pre-resume `stopped`
+	// resting state (statusTime stuck at the baseline), the watcher must
+	// NOT report success — it should time out.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "stopped", OpType: "", StatusTime: baseline},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(120*time.Millisecond, 10*time.Millisecond)
+
+	tgt := newWatchTarget(watchResume, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	_, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err == nil {
+		t.Fatalf("expected timeout on stale pre-resume stopped row, got nil (false success)")
+	}
+	var to *watchTimeoutError
+	if !errors.As(err, &to) {
+		t.Fatalf("expected watchTimeoutError, got %T: %v", err, err)
+	}
+}
+
+func TestWaitForTerminalResumeCancelRequestRejected(t *testing.T) {
+	// The cancel request itself being rejected surfaces as a resume-watch
+	// failure (non-zero exit), not a hang.
+	baseline := "2026-07-01T08:28:00Z"
+	seq := []statusRow{
+		{State: "resuming", OpType: "resume", StatusTime: "2026-07-01T08:28:10Z"},
+		{State: "resumingCancelFailed", OpType: "resume", StatusTime: "2026-07-01T08:28:20Z", Message: "cannot cancel"},
+	}
+	srv := newFakeStateServer(t, "myapp", "market.olares", seq)
+	mc := newTestMarketClient(t, srv.srv.URL)
+	opts := quietOpts(5*time.Second, 5*time.Millisecond)
+
+	tgt := newWatchTarget(watchResume, "myapp", "market.olares")
+	tgt.baselineStatusTime = parseStatusTime(baseline)
+
+	_, err := waitForTerminal(context.Background(), mc, opts, tgt)
+	if err == nil {
+		t.Fatalf("expected resumingCancelFailed to surface as failure, got nil")
+	}
+	var fail *watchFailureError
+	if !errors.As(err, &fail) {
+		t.Fatalf("expected watchFailureError, got %T: %v", err, err)
+	}
+	if fail.row.State != "resumingCancelFailed" {
+		t.Fatalf("expected resumingCancelFailed in error row, got %s", fail.row.State)
 	}
 }
 

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -143,6 +143,7 @@ olares-cli market cancel firefox --watch               # block until row stops m
 ```
 
 - Source is normally implicit (read from the per-user state row). On **1.12.6+** the cancel body requires a source; if the row is gone (or `/market/state` is unreadable) the CLI reports an idempotent `nothing to cancel` — pass `--source <id>` to still send the request. On 1.12.5 the body needs no source, so a failed state read never blocks cancel.
+- **Cancelling a `resuming` app requires Olares >= 1.12.7** (the resume-cancel UX the SPA shipped in 1.12.7, reusing this same `DELETE /apps/{name}/install`). On older / undetectable backends the CLI rejects it fail-closed (pass `--olares-version` to override). Every other in-flight state (`pending` / `downloading` / `installing` / `upgrading` / ...) is unaffected and cancels on any backend. A cancelled resume settles at `stopped` (it never reaches a `resumingCanceled` state — that transition does not exist); a rejected cancel request lands at `resumingCancelFailed`.
 - **The widest watcher in the tree**: any "row stopped moving" state counts as success, including `*Canceled`, `*Failed` (the underlying op died, cancel "won by default"), and stable resting states `running` / `stopped` / `uninstalled` (cancel raced and lost, OR rollback landed).
 - Failure is ONLY surfaced for `*CancelFailed` (the cancel request itself was rejected).
 - The terminal row carries the **underlying op** (install / upgrade / ...) as its `opType`, not `cancel`. `matchOpType` is OFF — no race-tracking gate applies.


### PR DESCRIPTION
* **Background**

  Termipass 1.12.7 exposed resume-cancel in the Market UI, reusing the existing `DELETE /apps/{name}/install` endpoint. The olares-cli `market cancel` command had no version gate for cancelling a `resuming` app, so it could attempt the operation on backends where the SPA does not offer that UX yet.

  This PR aligns the CLI with the 1.12.7 rollout:

  1. **`market cancel` version gate** — When the per-user state row is `resuming`, `runCancel` calls `cmdutil.RequireMinVersion` with Olares ≥ 1.12.7 (fail-closed; `--olares-version` override supported). Other in-flight states (`installing`, `downloading`, `upgrading`, …) are unchanged. `market uninstall`'s implicit cancel path is intentionally **not** gated, to preserve uninstall on older backends.

  2. **`watchResume` stopped terminal fix** — `market resume --watch` hung when a resume was cancelled and the row settled at `stopped` (`resuming → resumingCanceling → stopping → stopped`). `watchResume` now treats `stopped` as a success terminal when the row's `statusTime` is strictly newer than the pre-resume baseline (avoids a tick-zero false positive on an already-stopped app). Dead state `resumingCanceled` is removed from the failure set; `resumingCancelFailed` remains the cancel-request failure state.

  3. **Docs & tests** — Help text and `olares-market-lifecycle.md` updated; unit tests added for the version gate (`cancel_test.go`) and resume-watch classifier / end-to-end cases (`watch_test.go`).

* **Target Version for Merge**

  1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  None

* **Other information**

  None

## Test plan

- [ ] `cd cli && CGO_ENABLED=0 go build ./... && go test ./cmd/ctl/market/...`
- [ ] On Olares 1.12.6: `market cancel <resuming-app>` is rejected with a version message; `market cancel <installing-app>` still works
- [ ] On Olares 1.12.7+: `market cancel <resuming-app>` sends DELETE and `--watch` terminates when the row settles (including `stopped`)
- [ ] `market resume <app> --watch` during an in-flight cancel exits successfully when the row lands on `stopped` (not `--watch-timeout`)


Made with [Cursor](https://cursor.com)