### PR TITLE
fix(appservice): unify mem reserve of timeslice both in install and resume

### DIFF
--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -153,7 +153,7 @@ func makeDeviceOption(req Requirement, node Node, device Device, pressure Pressu
 		option.Health = deviceHealthYes
 	}
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
-		fits, _ := deviceFitsLevel(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes)
+		fits, _ := deviceFitsLevel(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes, 0)
 		if fits {
 			option.FitLevel = level
 			break
@@ -473,17 +473,7 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 	}
 	for nodeName := range selectedNodes {
 		node := findResolvedNode(nodeName, resolved)
-		hasTimeSlice := false
-		for _, item := range resolved {
-			if item.node.NodeName == nodeName && item.device.SupportType == SupportTypeTimeSlice {
-				hasTimeSlice = true
-				break
-			}
-		}
-		addedGPU := int64(0)
-		if req.Mode == utils.NvidiaCardType && hasTimeSlice {
-			addedGPU = req.LimitedGPU
-		}
+		addedGPU := nodeTimeSliceAddedMemory(req, nodeName, resolved)
 		if dims := pressure.PressuredDimensions(node, AddedResources{
 			CPU:    req.RequiredCPU,
 			Memory: req.RequiredMemory + addedGPU,
@@ -494,6 +484,23 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 		}
 	}
 	return &BindingValidationResult{OK: true, Code: BindingValidationReasonValid}
+}
+
+// nodeTimeSliceAddedMemory sums the full physical memory of every time-slice
+// card selected on a single node. It deliberately ignores the app's GPU
+// request and limit, matching the install scheduler's pressure accounting.
+func nodeTimeSliceAddedMemory(req Requirement, nodeName string, resolved []resolvedSelection) int64 {
+	if req.Mode != utils.NvidiaCardType {
+		return 0
+	}
+	var total int64
+	for _, item := range resolved {
+		if item.node.NodeName != nodeName {
+			continue
+		}
+		total += timeSliceAddedMemory(item.device)
+	}
+	return total
 }
 
 type resolvedSelection struct {

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -195,6 +195,45 @@ func TestValidateBindingSelectionTopologyAndMemorySlice(t *testing.T) {
 	}
 }
 
+func TestTimeSlicePressureUsesFullMemoryOfEverySelectedCard(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "trainer", OwnerName: "alice"}
+	req := Requirement{
+		Mode:              utils.NvidiaCardType,
+		RequiredGPU:       24 * gi,
+		LimitedGPU:        24 * gi,
+		RequiredMemory:    gi,
+		LimitedMemory:     gi,
+		SupportMultiCards: true,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice},
+			Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice},
+		),
+	}
+	pressure := PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			// 29Gi is already used. The app's 1Gi plus its 24Gi GPU limit
+			// would stay below the 57.6Gi threshold, while reserving both
+			// selected cards' full 32Gi correctly exceeds it.
+			"nvidia-a": {MemoryCapacity: 64 * gi, MemoryAvailable: 35 * gi},
+		},
+	}
+
+	if picked, ok := PickAllocations(app, req, nodes, pressure); ok {
+		t.Fatalf("install scheduling must account for both full time-slice cards, got %#v", picked)
+	}
+
+	result := ValidateBindingSelection(req, []BindingSelection{
+		{NodeName: "nvidia-a", DeviceID: "gpu0"},
+		{NodeName: "nvidia-a", DeviceID: "gpu1"},
+	}, nodes, pressure)
+	if result.OK || result.Code != "node-pressure:nvidia-a" {
+		t.Fatalf("resume validation must account for both full time-slice cards, got %#v", result)
+	}
+}
+
 // TestAllocationsFromResolvedSelectionMultiCardWholeCard is a regression test
 // for the multi-card binding bug: when the frontend submitted two whole-card
 // (Exclusive / TimeSlice) selections, allocationsFromResolvedSelection folded

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -239,7 +239,7 @@ func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, 
 					if supportType != "" && device.SupportType != supportType {
 						continue
 					}
-					fits, amount := deviceFitsLevel(req, node, device, pressure, level, false)
+					fits, amount := deviceFitsLevel(req, node, device, pressure, level, false, 0)
 					if fits {
 						assigned := requiredTargetForMode(req)
 						if assigned == 0 {
@@ -284,16 +284,18 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 	fitRemaining := target
 	allocationRemaining := allocationTarget
 	var out []Allocation
+	timeSliceMemoryByNode := make(map[string]int64)
 	for _, supportType := range supportTypeOrder(req.Mode) {
 		for _, node := range nodes {
 			for _, device := range node.Devices {
 				if supportType != "" && device.SupportType != supportType {
 					continue
 				}
-				fits, amount := deviceFitsLevel(req, node, device, pressure, level, true)
+				fits, amount := deviceFitsLevel(req, node, device, pressure, level, true, timeSliceMemoryByNode[node.NodeName])
 				if !fits || amount <= 0 {
 					continue
 				}
+				timeSliceMemoryByNode[node.NodeName] += timeSliceAddedMemory(device)
 				if allocationRemaining > 0 {
 					assigned := minInt64(amount, allocationRemaining)
 					out = append(out, buildAllocation(appConfig, req, node, device, assigned))
@@ -309,7 +311,7 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 	return nil, false
 }
 
-func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool) (bool, int64) {
+func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64) (bool, int64) {
 	if device.Health != "" && device.Health != deviceHealthYes {
 		return false, 0
 	}
@@ -328,10 +330,7 @@ func deviceFitsLevel(req Requirement, node Node, device Device, pressure Pressur
 	if available < required && !(allowPartial && req.Mode == utils.NvidiaCardType) {
 		return false, available
 	}
-	addedGPU := int64(0)
-	if req.Mode == utils.NvidiaCardType && device.SupportType == SupportTypeTimeSlice {
-		addedGPU = minInt64(available, required)
-	}
+	addedGPU := priorTimeSliceMemory + timeSliceAddedMemory(device)
 	if pressure.WouldPressure(node, AddedResources{
 		CPU:    req.RequiredCPU,
 		Memory: levelMemory(req, level) + addedGPU,
@@ -340,6 +339,25 @@ func deviceFitsLevel(req Requirement, node Node, device Device, pressure Pressur
 		return false, available
 	}
 	return true, available
+}
+
+// timeSliceAddedMemory returns the extra host RAM that must be reserved on the
+// node for a time-slice GPU card.
+//
+// A HAMI time-slice pod is handed the whole card during its slice
+// (buildAllocation records Memory=0, so HAMI leaves it unrestricted), so the
+// node needs system-memory headroom equal to the card's full physical memory,
+// regardless of the app's requiredGPU or limitedGPU. Non-time-slice devices
+// carry no such host-memory backing requirement.
+//
+// This is the single source of truth shared by the install scheduler
+// (deviceFitsLevel) and the resume/binding validator
+// (nodeTimeSliceAddedMemory) so the two paths can never drift.
+func timeSliceAddedMemory(device Device) int64 {
+	if device.SupportType != SupportTypeTimeSlice {
+		return 0
+	}
+	return device.Memory
 }
 
 func targetForMode(req Requirement, level string) int64 {


### PR DESCRIPTION
* **Background**
During auto card allocation in app installation and manual card allocation in app resuming, for every timeslice card selected or candidated, the card's memory is counted as memory reservation for the corresponding node.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compute scheduling and binding validation logic; behavior is stricter (more rejections under pressure) but limited to NVIDIA time-slice multi-card paths.
> 
> **Overview**
> **Time-slice GPU placement** now reserves **each selected card’s full physical memory** against node RAM pressure, instead of counting only the app’s GPU request/limit once per node.
> 
> Install scheduling (`deviceFitsLevel` / `collectDevicesForTarget`) accumulates per-node time-slice reservations as cards are considered, and resume/manual binding validation uses shared helper `timeSliceAddedMemory` via `nodeTimeSliceAddedMemory` so install and resume paths stay aligned.
> 
> A regression test covers multi-card time-slice picks where the old math would pass pressure checks but the unified accounting correctly rejects them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b5ac489bedc569a59c5b924e552dd18dc8d293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->