### PR TITLE
market: add llm-gateway adaptor API surface, add lldap, market provider

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/lldap_backend_provider.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/lldap_backend_provider.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lldap-provider-svc
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  type: ClusterIP
+  selector:
+    app: system-provider
+  ports:
+    - name: server
+      protocol: TCP
+      port: 28080
+      targetPort: 28080
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backend:lldap-provider
+  annotations:
+    provider-registry-ref: {{ .Release.Namespace }}/lldap-provider-svc
+    provider-service-ref: lldap-service.os-platform:17171
+rules:
+  - nonResourceURLs:
+      - "/readonly/snapshot"
+    verbs: ["*"]
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: lldap-provider-nginx-config
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    kubesphere.io/creator: bytetrade.io
+data:
+  lldap.conf: |-
+    server {
+        listen 8080;
+        server_name  lldap-provider-svc.{{ .Release.Namespace }};
+        # Gzip Settings
+        gzip on;
+        gzip_disable "msie6";
+        gzip_min_length 1k;
+        gzip_buffers 16 64k;
+        gzip_http_version 1.1;
+        gzip_comp_level 6;
+        gzip_types *;
+        index index.html;
+        location / {
+          proxy_pass http://lldap-service.os-platform:17171;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection '$connection_upgrade';
+        }
+    }

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -10,7 +10,7 @@
 {{- $pg_secret := (lookup "v1" "Secret" .Release.Namespace "market-pg-secrets") -}}
 {{- $pg_password := "" -}}
 {{ if $pg_secret -}}
-{{ $pg_password = (index $pg_secret "data" "pg_password") }}
+{{ $pg_password = (index $pg_secret "data" "pg-passwords") }}
 {{ else -}}
 {{ $pg_password = randAlphaNum 16 | b64enc }}
 {{- end -}}

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -1,12 +1,3 @@
-{{- $market_secret := (lookup "v1" "Secret" .Release.Namespace "market-secrets") -}}
-
-{{- $redis_password := "" -}}
-{{ if $market_secret -}}
-{{ $redis_password = (index $market_secret "data" "redis-passwords") }}
-{{ else -}}
-{{ $redis_password = randAlphaNum 16 | b64enc }}
-{{- end -}}
-
 {{- $market_backend_nats_secret := (lookup "v1" "Secret" .Release.Namespace "market-backend-nats-secret") -}}
 {{- $nats_password := "" -}}
 {{ if $market_backend_nats_secret -}}
@@ -95,7 +86,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  pg-passwords: {{ $redis_password }}
+  pg-passwords: {{ $pg_password }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -142,7 +133,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.78
+        image: beclab/market-backend:v0.6.79
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_provider.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_provider.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: market-provider-svc
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  type: ClusterIP
+  selector:
+    app: system-provider
+  ports:
+    - name: server
+      protocol: TCP
+      port: 28080
+      targetPort: 28080
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backend:market-provider
+  annotations:
+    provider-registry-ref: {{ .Release.Namespace }}/market-provider-svc
+    provider-service-ref: appstore-svc.{{ .Release.Namespace }}:81
+rules:
+  - nonResourceURLs:
+      - "/healthz"
+      - "/app-store/api/v2/applications"
+      - "/app-store/api/v2/applications/*"
+      - "/app-store/api/v2/tasks"
+      - "/app-store/api/v2/tasks/*"
+      - "/app-store/api/v2/llm-providers"
+      - "/app-store/api/v2/llm-providers/*"
+    verbs: ["*"]
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: market-provider-nginx-config
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    kubesphere.io/creator: bytetrade.io
+data:
+  market.conf: |-
+    server {
+        listen 8080;
+        server_name  market-provider-svc.{{ .Release.Namespace }};
+        # Gzip Settings
+        gzip on;
+        gzip_disable "msie6";
+        gzip_min_length 1k;
+        gzip_buffers 16 64k;
+        gzip_http_version 1.1;
+        gzip_comp_level 6;
+        gzip_types *;
+        index index.html;
+        location / {
+          proxy_pass http://appstore-svc.{{ .Release.Namespace }}:81;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection '$connection_upgrade';
+        }
+    }

--- a/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
+++ b/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
@@ -33,7 +33,7 @@ spec:
             - --insecure-listen-address=:28080
             - --upstream=http://127.0.0.1:8080/
             - -v
-            - '6'
+            - "6"
           ports:
             - containerPort: 28080
           resources:
@@ -61,6 +61,12 @@ spec:
             - name: system-app-nginx-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: market-provider-nginx-config
+              mountPath: /etc/nginx/conf.d/market.conf
+              subPath: market.conf
+            - name: lldap-provider-nginx-config
+              mountPath: /etc/nginx/conf.d/lldap.conf
+              subPath: lldap.conf
             - name: download-provider-nginx-config
               mountPath: /etc/nginx/conf.d/download.conf
               subPath: download.conf
@@ -77,6 +83,18 @@ spec:
             items:
               - key: nginx.conf
                 path: nginx.conf
+        - name: market-provider-nginx-config
+          configMap:
+            name: market-provider-nginx-config
+            items:
+              - key: market.conf
+                path: market.conf
+        - name: lldap-provider-nginx-config
+          configMap:
+            name: lldap-provider-nginx-config
+            items:
+              - key: lldap.conf
+                path: lldap.conf
         - name: download-provider-nginx-config
           configMap:
             name: download-provider-nginx-config
@@ -223,5 +241,3 @@ data:
 
         include /etc/nginx/conf.d/*.conf;
     }
-
-


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
add llm-gateway adaptor API surface, add lldap, market provider, bug fixs

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/383
https://github.com/beclab/market/pull/387


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Provider RBAC and routing changes affect how external systems reach market and LDAP; the PG secret fix is critical for correct DB auth on upgrade but corrects a prior misconfiguration.
> 
> **Overview**
> **Adds cluster backend providers** so external consumers can reach the app store and LLDAP through the shared `system-provider` gateway, and **fixes a market deploy secret bug** that could break Postgres.
> 
> New **market** and **lldap** provider manifests define a `*-provider-svc` on port 28080, a `backend:*-provider` `ClusterRole` with `provider-registry-ref` / `provider-service-ref` annotations, and nginx `ConfigMap`s that proxy to `appstore-svc` and `lldap-service.os-platform:17171`. The market role exposes app-store v2 APIs including **`/app-store/api/v2/llm-providers`** (and related paths) for the llm-gateway adaptor surface. `system_provider` mounts both configs into the nginx sidecar alongside existing providers.
> 
> **Market deploy** stops generating/reading a separate Redis password block, reads existing PG credentials from the `pg-passwords` key (not `pg_password`), and stores the generated password in `market-pg-secrets` under **`pg-passwords`** instead of mistakenly reusing the Redis value. **`beclab/market-backend`** is bumped **v0.6.78 → v0.6.79**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5375c2e27ef0dcd2b26e13b1aa970257496f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->