### PR TITLE
fix(cli): clear iptable rules completely

### DIFF
--- a/cli/pkg/bootstrap/os/tasks.go
+++ b/cli/pkg/bootstrap/os/tasks.go
@@ -438,8 +438,8 @@ var (
 		"ipvsadm -C",
 		"ip link del kube-ipvs0",
 		"rm -rf /var/lib/cni",
-		"iptables-save | grep -v KUBE- | grep -v CALICO- | iptables-restore",
-		"ip6tables-save | grep -v KUBE- | grep -v CALICO- | ip6tables-restore",
+		"iptables-save | grep -v KUBE- | grep -iv cali | grep -v OLARES-LPVPN-DNS | iptables-restore",
+		"ip6tables-save | grep -v KUBE- | grep -iv cali | grep -v OLARES-LPVPN-DNS | ip6tables-restore",
 		"ipset x",
 		// BIRD is configured with "persist", so the Calico-managed overlay routes
 		// (proto bird, via tunl0) are NOT removed when calico-node stops. They


### PR DESCRIPTION
* **Background**
The iptable rules for VPN dns resolution written by olaresd and the lower case rules written by calico should both be cleared in olares uninstallation.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to uninstall-time iptables filtering on the node; no runtime cluster path, with minor risk only if unrelated rules matched `cali` or `OLARES-LPVPN-DNS` substrings.
> 
> **Overview**
> During Olares uninstall, **`ResetNetworkConfig`** rebuilds host `iptables`/`ip6tables` by saving rules and restoring everything except cluster-related chains. The filter pipeline in `networkResetCmds` is tightened so teardown actually drops the leftovers described in the PR.
> 
> **Calico:** `grep -v CALICO-` is replaced with **`grep -iv cali`** so lowercase Calico chain names are stripped, not only `CALICO-`-prefixed ones.
> 
> **VPN DNS:** **`grep -v OLARES-LPVPN-DNS`** is added on both IPv4 and IPv6 so `olaresd` VPN DNS rules are removed with the rest of the Olares networking state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f292eeb30a9a60f38d2f90fe28a84060cdb49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->