### PR TITLE
fix(oac): validate service port manifests

### DIFF
--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -53,6 +53,7 @@ var (
 	validDependencyTypes = []any{"system", "application", "middleware"}
 	validAuthLevels      = []any{"", "public", "private", "internal"}
 	validOpenMethods     = []any{"", "default", "iframe", "window"}
+	validPortProtocols   = []any{"", "tcp", "udp"}
 	// validOverlayProtocols enumerates the protocols an overlayGateway
 	// entrance may declare. An empty value is allowed and means the
 	// entrance is reachable over both tcp and udp.
@@ -99,6 +100,10 @@ func ValidateAppConfiguration(c *AppConfiguration) error {
 			validation.Length(1, 10).Error("entrances must have between 1 and 10 items"),
 			validation.Each(validation.By(validateEntranceValue)),
 			validation.By(uniqueEntranceNames),
+		),
+		validation.Field(&c.Ports,
+			validation.Each(validation.By(validateServicePortValue)),
+			validation.By(uniquePortNames),
 		),
 		validation.Field(&c.Spec,
 			validation.Required.Error("spec is required"),
@@ -202,6 +207,39 @@ func validateEntranceValue(v interface{}) error {
 		),
 		validation.Field(&e.OpenMethod,
 			validation.In(validOpenMethods...).Error(`entrance.openMethod must be one of "", "default", "iframe", "window"`),
+		),
+	)
+}
+
+func validateServicePortValue(v interface{}) error {
+	p, ok := v.(appv1.ServicePort)
+	if !ok {
+		return fmt.Errorf("port: unexpected type %T", v)
+	}
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.Name,
+			validation.Required.Error("port.name is required"),
+			validation.Match(entranceNameRegex).Error("port.name must match ^[a-z0-9A-Z-]*$"),
+			validation.Length(1, 63).Error("port.name must be 1-63 characters"),
+		),
+		validation.Field(&p.Host,
+			validation.Required.Error("port.host is required"),
+			validation.Match(entranceHostRegex).Error("port.host must match ^[a-z]([-a-z0-9]*[a-z0-9])$"),
+			validation.Length(1, 63).Error("port.host must be 1-63 characters"),
+		),
+		validation.Field(&p.Port,
+			validation.Required.Error("port.port is required"),
+			validation.Min(int32(1)).Error("port.port must be between 1 and 65535"),
+			validation.Max(int32(65535)).Error("port.port must be between 1 and 65535"),
+		),
+		validation.Field(&p.ExposePort,
+			validation.When(p.ExposePort != 0,
+				validation.Min(int32(1)).Error("port.exposePort must be between 1 and 65535"),
+				validation.Max(int32(65535)).Error("port.exposePort must be between 1 and 65535"),
+			),
+		),
+		validation.Field(&p.Protocol,
+			validation.In(validPortProtocols...).Error(`port.protocol must be one of "", "tcp", "udp"`),
 		),
 	)
 }
@@ -970,6 +1008,21 @@ func uniqueEntranceNames(value interface{}) error {
 			return fmt.Errorf("entrances[%d].name: duplicate entrance name %q", i, e.Name)
 		}
 		seen[e.Name] = struct{}{}
+	}
+	return nil
+}
+
+func uniquePortNames(value interface{}) error {
+	ports, ok := value.([]appv1.ServicePort)
+	if !ok {
+		return fmt.Errorf("ports: unexpected type %T", value)
+	}
+	seen := make(map[string]struct{}, len(ports))
+	for i, p := range ports {
+		if _, dup := seen[p.Name]; dup {
+			return fmt.Errorf("ports[%d].name: duplicate port name %q", i, p.Name)
+		}
+		seen[p.Name] = struct{}{}
 	}
 	return nil
 }

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -256,6 +256,75 @@ func TestEntrance_PortNegative(t *testing.T) {
 	}
 }
 
+func TestServicePortsValidation(t *testing.T) {
+	validPort := ServicePort{Name: "api", Host: "api", Port: 4712}
+	cases := []struct {
+		name    string
+		ports   []ServicePort
+		wantErr string
+	}{
+		{name: "omitted"},
+		{name: "default protocol and automatic expose port", ports: []ServicePort{validPort}},
+		{name: "tcp with explicit expose port", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 4712, ExposePort: 4712, Protocol: "tcp",
+		}}},
+		{name: "udp", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 4712, Protocol: "udp",
+		}}},
+		{name: "missing name", ports: []ServicePort{{
+			Host: "api", Port: 4712,
+		}}, wantErr: "port.name is required"},
+		{name: "invalid name", ports: []ServicePort{{
+			Name: "bad_name", Host: "api", Port: 4712,
+		}}, wantErr: "port.name must match"},
+		{name: "missing host", ports: []ServicePort{{
+			Name: "api", Port: 4712,
+		}}, wantErr: "port.host is required"},
+		{name: "invalid host", ports: []ServicePort{{
+			Name: "api", Host: "API", Port: 4712,
+		}}, wantErr: "port.host must match"},
+		{name: "missing port", ports: []ServicePort{{
+			Name: "api", Host: "api",
+		}}, wantErr: "port.port is required"},
+		{name: "port above range", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 65536,
+		}}, wantErr: "port.port must be between 1 and 65535"},
+		{name: "negative expose port", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 4712, ExposePort: -1,
+		}}, wantErr: "port.exposePort must be between 1 and 65535"},
+		{name: "expose port above range", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 4712, ExposePort: 65536,
+		}}, wantErr: "port.exposePort must be between 1 and 65535"},
+		{name: "uppercase protocol", ports: []ServicePort{{
+			Name: "api", Host: "api", Port: 4712, Protocol: "TCP",
+		}}, wantErr: `port.protocol must be one of "", "tcp", "udp"`},
+		{name: "duplicate name", ports: []ServicePort{
+			validPort,
+			{Name: "api", Host: "peer", Port: 4713},
+		}, wantErr: `duplicate port name "api"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newValidConfig()
+			c.Ports = tc.ports
+			err := ValidateAppConfiguration(c)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error should contain %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestAppSpec_QuantityFields(t *testing.T) {
 	c := newValidConfig()
 	c.Spec.RequiredMemory = "not-a-quantity"


### PR DESCRIPTION
## Summary
- validate `ports[]` names, hosts, port ranges, expose-port ranges, and lowercase protocols before install
- reject duplicate port names so upgrade port preservation remains deterministic
- cover valid automatic allocation and malformed service-port configurations with regression tests

## Compatibility
- `protocol` now rejects uppercase `TCP`/`UDP`; use lowercase `tcp`/`udp` to match app-service allocation semantics
- non-empty port entries now require `name`, `host`, and `port`, matching the Application CRD

## Test plan
- [x] `cd framework/oac && go test ./internal/manifest ./...`
- [x] searched `beclab/apps` for uppercase `protocol: TCP` / `protocol: UDP` usages (none found)

Made with [Cursor](https://cursor.com)