### PR TITLE
files: Common support SMB share

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -151,6 +151,8 @@ spec:
             runAsUser: 0
             privileged: true
           volumeMounts:
+            - mountPath: /appcommon/
+              name: common-data
             - mountPath: /data/appcache/
               name: upload-appdata
             - name: fb-data
@@ -210,7 +212,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.190
+          image: beclab/files-server:v0.2.191
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
drive/Common support SMB share

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/files/pull/356


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds host Common data to the privileged SMB path on port 445; scope is limited to deploy wiring plus a minor image bump.
> 
> **Overview**
> Enables **drive/Common** to be available over SMB by wiring the existing `common-data` host path (`rootfs/Common`) into the **samba-server** sidecar at `/appcommon/`, matching how **rclone** and **files** already mount that volume.
> 
> The **files** container image is bumped from `beclab/files-server:v0.2.190` to **v0.2.191** (paired with application changes in the related files repo PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b77620833a6946457b549db53e39b2970d5b584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->