### PR TITLE
fix(translator): order node-scoped file routes before master catch-all

### DIFF
--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -652,6 +652,19 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 		},
 	}
 
+	// Pass 1: node-scoped routes for every node. These carry the node name in
+	// the path (e.g. /api/resources/external/<node>/ or the regex share form
+	// ^/api/resources/share/<node>_.*) and are the MORE SPECIFIC matches.
+	//
+	// They MUST all be emitted before the master's generic catch-all prefixes
+	// (pass 2), because Envoy evaluates routes top-to-bottom and stops at the
+	// first match. A generic master prefix like /api/resources/external/ is a
+	// strict prefix of /api/resources/external/<node>/, so if it came first it
+	// would swallow every non-master node's request and misroute it to the
+	// master node. The old single-pass loop emitted the master routes right
+	// after the master node's own scoped routes, which — since FileserverNodes
+	// is sorted by name and the master usually sorts first — placed them ahead
+	// of later nodes' scoped routes and caused exactly that misrouting.
 	for _, node := range user.FileserverNodes {
 		proxyCluster := fmt.Sprintf("files_%s_%s", user.Name, node.NodeName)
 		proxyHost := fmt.Sprintf(fileserverHostFormat, node.NodeName, user.Name)
@@ -688,22 +701,29 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 				WebSocketUpgrade: true,
 			})
 		}
+	}
 
-		if node.IsMaster {
-			for _, pfx := range masterLocationPrefixes {
-				routes = append(routes, &ir.HTTPRouteIR{
-					Name:       fmt.Sprintf("files_master_%s_%s", user.Name, sanitizeName(pfx)),
-					PathPrefix: pfx,
-					Cluster:    proxyCluster,
-					RequestHeaders: map[string]string{
-						"X-BFL-USER":       user.Name,
-						"X-Terminus-Node":  node.NodeName,
-						"X-Provider-Proxy": proxyHost,
-					},
-					ExtAuth:          extAuthCfg,
-					WebSocketUpgrade: true,
-				})
-			}
+	// Pass 2: master node generic catch-all prefixes (no node name), emitted
+	// last so the node-scoped routes above always take precedence.
+	for _, node := range user.FileserverNodes {
+		if !node.IsMaster {
+			continue
+		}
+		proxyCluster := fmt.Sprintf("files_%s_%s", user.Name, node.NodeName)
+		proxyHost := fmt.Sprintf(fileserverHostFormat, node.NodeName, user.Name)
+		for _, pfx := range masterLocationPrefixes {
+			routes = append(routes, &ir.HTTPRouteIR{
+				Name:       fmt.Sprintf("files_master_%s_%s", user.Name, sanitizeName(pfx)),
+				PathPrefix: pfx,
+				Cluster:    proxyCluster,
+				RequestHeaders: map[string]string{
+					"X-BFL-USER":       user.Name,
+					"X-Terminus-Node":  node.NodeName,
+					"X-Provider-Proxy": proxyHost,
+				},
+				ExtAuth:          extAuthCfg,
+				WebSocketUpgrade: true,
+			})
 		}
 	}
 

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/beclab/l4-bfl-proxy/internal/ir"
@@ -759,5 +760,73 @@ func TestBuildCustomDomainVirtualHosts_SharedApp_OpenToAllUsers(t *testing.T) {
 			assert.NotEmpty(t, clusterSet)
 			assert.Equal(t, []string{"shareme.example.io"}, vhosts[0].Domains)
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildFileserverRoutes
+// ---------------------------------------------------------------------------
+
+// Regression: a non-master node's scoped prefix (e.g.
+// /api/resources/external/olares-work/) overlaps with the master node's
+// generic catch-all prefix (/api/resources/external/). Envoy matches routes
+// top-to-bottom and stops at the first match, so every node-scoped route MUST
+// be emitted before the generic master routes — otherwise the master prefix
+// swallows the request and misroutes it to the master node.
+func TestBuildFileserverRoutes_NodeScopedBeforeMasterGeneric(t *testing.T) {
+	tr := &Translator{cfg: &Config{}}
+
+	// "olares" sorts first and is the master; "olares-work" is a worker node.
+	// (buildFileserverRoutes relies on FileserverNodes being pre-sorted, which
+	// is what triggered the original bug — the master's generic routes landed
+	// ahead of the worker's scoped routes.)
+	user := &message.UserInfo{
+		Name: "testip162",
+		FileserverNodes: []*message.FileserverNodeInfo{
+			{NodeName: "olares", IsMaster: true},
+			{NodeName: "olares-work", IsMaster: false},
+		},
+	}
+
+	clusterSet := make(map[string]*ir.ClusterIR)
+	routes := tr.buildFileserverRoutes(user, clusterSet)
+
+	indexOfPrefix := func(prefix string) int {
+		for i, r := range routes {
+			if r.PathPrefix == prefix {
+				return i
+			}
+		}
+		return -1
+	}
+
+	nodeExternal := indexOfPrefix("/api/resources/external/olares-work/")
+	masterExternal := indexOfPrefix("/api/resources/external/")
+	require.GreaterOrEqual(t, nodeExternal, 0, "olares-work node route must exist")
+	require.GreaterOrEqual(t, masterExternal, 0, "master generic route must exist")
+	assert.Less(t, nodeExternal, masterExternal,
+		"node-scoped /api/resources/external/olares-work/ must be ordered before the generic /api/resources/external/")
+
+	// The node-scoped route must target the worker node's cluster, and the
+	// generic master route the master node's cluster.
+	assert.Equal(t, "files_testip162_olares-work", routes[nodeExternal].Cluster)
+	assert.Equal(t, "files_testip162_olares", routes[masterExternal].Cluster)
+	assert.Equal(t, "olares-work", routes[nodeExternal].RequestHeaders["X-Terminus-Node"])
+
+	// Every node-scoped prefix that overlaps a master prefix must precede ALL
+	// master generic routes. Compute the first master-route index and assert
+	// no node-scoped route appears after it.
+	firstMaster := len(routes)
+	for i, r := range routes {
+		if strings.HasPrefix(r.Name, "files_master_") {
+			firstMaster = i
+			break
+		}
+	}
+	for i, r := range routes {
+		if strings.HasPrefix(r.Name, "files_node_") {
+			assert.Less(t, i, firstMaster,
+				"node-scoped route %q must come before any master generic route", r.Name)
+		}
 	}
 }


### PR DESCRIPTION
* **Background**
Emit all fileserver node-scoped routes before the master node's generic catch-all prefixes. Previously the master's /api/resources/external/ was placed ahead of worker nodes' /api/resources/external/<node>/ routes, so Envoy's first-match-wins swallowed the request and misrouted it to the master node. Split route generation into two passes so more specific node routes always take precedence. Add a regression test.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L4 proxy route ordering for file APIs—affects live request routing in multi-node clusters, but scope is limited to translator output with a targeted regression test.
> 
> **Overview**
> Fixes **multi-node fileserver traffic** being sent to the master when worker paths overlap the master's generic API prefixes.
> 
> `buildFileserverRoutes` now builds routes in **two passes**: first every **node-scoped** prefix (and share regex routes) for all fileserver nodes, then the master node's **generic catch-all** prefixes. Envoy uses first-match routing, so a generic path like `/api/resources/external/` must not appear before `/api/resources/external/<node>/` or worker requests hit the master cluster.
> 
> A regression test asserts ordering, correct clusters, and `X-Terminus-Node` on the worker route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e63cbd9b5ac36e7f79855d068363eb2e3bf73c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->