### PR TITLE
feat(cli): distinguish Intel iGPU/dGPU and install discrete GPU drivers

### DIFF
--- a/cli/pkg/core/connector/intel.go
+++ b/cli/pkg/core/connector/intel.go
@@ -5,32 +5,128 @@ import (
 	"strings"
 )
 
-// hasIntelGPU reports whether the machine exposes an Intel GPU (PCI vendor
-// 8086) on a display-class controller.
-func hasIntelGPU(cmdExec func(s string) (string, error)) bool {
-	// lspci -nn prints the vendor:device id in brackets, e.g.
-	//   00:02.0 VGA compatible controller [0300]: Intel Corporation ... [8086:7d55]
-	out, err := cmdExec("lspci -nn 2>/dev/null | grep -iE 'VGA compatible controller|3D controller|Display controller' | grep -i '\\[8086:' || true")
+// IntelGPU is a single Intel display-class PCI device detected on the host.
+type IntelGPU struct {
+	// ID is the PCI device id in uppercase hex without the 0x prefix (e.g. "7D55").
+	ID string
+	// Discrete reports whether the GPU is discrete (dGPU); false means it is an
+	// integrated GPU (iGPU).
+	Discrete bool
+}
+
+// intelGPUDetectScript walks the PCI devices in sysfs and, for every Intel
+// (vendor 0x8086) display-class controller (VGA 0x0300, 3D 0x0302 or Display
+// 0x0380), prints a line "<kind> <deviceid>" where kind is iGPU or dGPU and
+// deviceid is the PCI device id without the 0x prefix (e.g. "iGPU 7d55").
+//
+// The integrated vs discrete decision mirrors the PCI topology: an integrated
+// GPU hangs directly off the root complex (its parent in sysfs is the
+// "pci0000:00" host bridge), whereas a discrete GPU sits behind a PCIe root
+// port / bridge (any other parent).
+const intelGPUDetectScript = `
+for d in /sys/bus/pci/devices/*; do
+  [ -e "$d/class" ] || continue
+  cls=$(cat "$d/class" 2>/dev/null)
+  case "$cls" in 0x0300*|0x0302*|0x0380*) ;; *) continue;; esac
+  ven=$(cat "$d/vendor" 2>/dev/null)
+  [ "$ven" = "0x8086" ] || continue
+  dev=$(cat "$d/device" 2>/dev/null)
+  dev=${dev#0x}
+  parent=$(basename "$(dirname "$(readlink -f "$d")")")
+  case "$parent" in
+    pci0000:00) echo "iGPU $dev" ;;
+    *)          echo "dGPU $dev" ;;
+  esac
+done
+`
+
+// detectIntelGPUs runs intelGPUDetectScript and returns every Intel display-class
+// GPU on the host, classified as integrated or discrete.
+func detectIntelGPUs(cmdExec func(s string) (string, error)) []IntelGPU {
+	out, err := cmdExec(intelGPUDetectScript)
 	if err != nil {
-		return false
+		return nil
 	}
-	return strings.TrimSpace(out) != ""
-}
-
-// HasIntelGPULocal runs the Intel GPU detection against the local machine.
-func HasIntelGPULocal() bool {
-	return hasIntelGPU(func(s string) (string, error) {
-		out, err := exec.Command("sh", "-c", s).Output()
-		if err != nil {
-			return "", err
+	var gpus []IntelGPU
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
 		}
-		return string(out), nil
-	})
+		kind, id := fields[0], strings.ToUpper(fields[1])
+		switch kind {
+		case "iGPU":
+			gpus = append(gpus, IntelGPU{ID: id, Discrete: false})
+		case "dGPU":
+			gpus = append(gpus, IntelGPU{ID: id, Discrete: true})
+		}
+	}
+	return gpus
 }
 
-// HasIntelGPU runs the Intel GPU detection against the given runtime's host.
-func HasIntelGPU(execRuntime Runtime) bool {
-	return hasIntelGPU(func(s string) (string, error) {
+// intelLocalExec runs a shell snippet against the local machine.
+func intelLocalExec(s string) (string, error) {
+	out, err := exec.Command("sh", "-c", s).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func intelRuntimeExec(execRuntime Runtime) func(string) (string, error) {
+	return func(s string) (string, error) {
 		return execRuntime.GetRunner().SudoCmd(s, false, false)
-	})
+	}
+}
+
+// IntelGPUsLocal returns the Intel GPUs detected on the local machine.
+func IntelGPUsLocal() []IntelGPU {
+	return detectIntelGPUs(intelLocalExec)
+}
+
+// IntelGPUs returns the Intel GPUs detected on the given runtime's host.
+func IntelGPUs(execRuntime Runtime) []IntelGPU {
+	return detectIntelGPUs(intelRuntimeExec(execRuntime))
+}
+
+func hasIntelIGPU(gpus []IntelGPU) bool {
+	for _, g := range gpus {
+		if !g.Discrete {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIntelDGPU(gpus []IntelGPU) bool {
+	for _, g := range gpus {
+		if g.Discrete {
+			return true
+		}
+	}
+	return false
+}
+
+// HasIntelIGPULocal reports whether the local machine exposes an Intel
+// integrated GPU (the "intel" unified-memory mode).
+func HasIntelIGPULocal() bool {
+	return hasIntelIGPU(IntelGPUsLocal())
+}
+
+// HasIntelIGPU reports whether the given runtime's host exposes an Intel
+// integrated GPU (the "intel" unified-memory mode).
+func HasIntelIGPU(execRuntime Runtime) bool {
+	return hasIntelIGPU(IntelGPUs(execRuntime))
+}
+
+// HasIntelDGPULocal reports whether the local machine exposes an Intel discrete
+// GPU (e.g. Arc/Data Center GPU on a PCIe slot).
+func HasIntelDGPULocal() bool {
+	return hasIntelDGPU(IntelGPUsLocal())
+}
+
+// HasIntelDGPU reports whether the given runtime's host exposes an Intel
+// discrete GPU (e.g. Arc/Data Center GPU on a PCIe slot).
+func HasIntelDGPU(execRuntime Runtime) bool {
+	return hasIntelDGPU(IntelGPUs(execRuntime))
 }

--- a/cli/pkg/core/connector/intel_gpu_kernel.go
+++ b/cli/pkg/core/connector/intel_gpu_kernel.go
@@ -1,0 +1,264 @@
+package connector
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// KernelVersion is a parsed Linux kernel version (major.minor).
+type KernelVersion struct {
+	Major int
+	Minor int
+}
+
+// String renders the version as "major.minor" (e.g. "6.9").
+func (v KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// semver returns the version as a semver value (patch fixed at 0), so kernel
+// versions can be compared with the shared Masterminds/semver library.
+func (v KernelVersion) semver() *semver.Version {
+	return semver.New(uint64(v.Major), uint64(v.Minor), 0, "", "")
+}
+
+// Compare returns -1 if v < o, 0 if v == o, and 1 if v > o.
+func (v KernelVersion) Compare(o KernelVersion) int {
+	return v.semver().Compare(o.semver())
+}
+
+// Sentinel values used in the Intel "Initial support" / "Full support" columns.
+const (
+	intelSupportUnavailable = "Unavailable"
+	intelSupportOutOfTree   = "Out-of-tree"
+)
+
+// intelGPUSupportInfo holds the per-GPU columns transcribed verbatim from the
+// Intel docs. Only initial/full drive the kernel lookup today; name,
+// architecture and codename are carried for potential future use.
+type intelGPUSupportInfo struct {
+	name         string
+	architecture string
+	codename     string
+	initial      string
+	full         string
+}
+
+// intelGPUSupportRow groups one or more PCI device ids that share the same
+// support columns (multi-id rows in the source tables). name, architecture and
+// codename are carried verbatim from the source tables for potential future use
+// (e.g. user-facing messages), even though only initial/full drive the kernel
+// lookup today.
+type intelGPUSupportRow struct {
+	ids          []string
+	name         string
+	architecture string
+	codename     string
+	initial      string
+	full         string
+}
+
+// intelGPUSupportRows is transcribed from the two Intel driver-support tables
+// (as of 2026-07). Kernel numbers are guidance only: vendor kernels may
+// backport support to older kernels, matching the disclaimer on the source
+// pages.
+//   - i915: https://dgpu-docs.intel.com/overview/supported-hardware/i915-driver-gpus.html
+//   - xe:   https://dgpu-docs.intel.com/overview/supported-hardware/xe-driver-gpus.html
+var intelGPUSupportRows = []intelGPUSupportRow{
+	// i915 KMD driver GPUs
+	{ids: []string{"7D51"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-H", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
+	{ids: []string{"7D67"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-S", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"7D41"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-U", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
+	{ids: []string{"7DD5"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"7D45"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"7D40"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"7D55"}, name: "Intel® Arc™ Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"0BD5"}, name: "Intel® Data Center GPU Max 1550", architecture: "Xe-HPC", codename: "Ponte Vecchio", initial: "Out-of-tree", full: "Out-of-tree"},
+	{ids: []string{"0BDA"}, name: "Intel® Data Center GPU Max 1100", architecture: "Xe-HPC", codename: "Ponte Vecchio", initial: "Out-of-tree", full: "Out-of-tree"},
+	{ids: []string{"56C0"}, name: "Intel® Data Center GPU Flex 170", architecture: "Xe-HPG", codename: "Alchemist", initial: "Out-of-tree", full: "Out-of-tree"},
+	{ids: []string{"56C1"}, name: "Intel® Data Center GPU Flex 140", architecture: "Xe-HPG", codename: "Alchemist", initial: "Out-of-tree", full: "Out-of-tree"},
+	{ids: []string{"5690"}, name: "Intel® Arc™ A770M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5691"}, name: "Intel® Arc™ A730M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5696"}, name: "Intel® Arc™ A570M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5692"}, name: "Intel® Arc™ A550M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5697"}, name: "Intel® Arc™ A530M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5693"}, name: "Intel® Arc™ A370M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"5694"}, name: "Intel® Arc™ A350M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56A0"}, name: "Intel® Arc™ A770 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56A1"}, name: "Intel® Arc™ A750 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56A2"}, name: "Intel® Arc™ A580 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56A5"}, name: "Intel® Arc™ A380 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56A6"}, name: "Intel® Arc™ A310 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56B3"}, name: "Intel® Arc™ Pro A60 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56B2"}, name: "Intel® Arc™ Pro A60M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56B1"}, name: "Intel® Arc™ Pro A40/A50 Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56B0"}, name: "Intel® Arc™ Pro A30M Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Kernel 5.19", full: "Ubuntu 24.04+ (6.2)"},
+	{ids: []string{"56BA"}, name: "Intel® Arc™ A380E Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"56BC"}, name: "Intel® Arc™ A370E Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"56BD"}, name: "Intel® Arc™ A350E Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"56BB"}, name: "Intel® Arc™ A310E Graphics", architecture: "Xe-HPG", codename: "Alchemist", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"A780"}, name: "Intel® UHD Graphics 770", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"A781", "A788", "A789"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"A78A"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"A782"}, name: "Intel® UHD Graphics 730", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"A78B"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"A783"}, name: "Intel® UHD Graphics 710", architecture: "Xe", codename: "Raptor Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"A7A0", "A7A1"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"A7A8"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"A7AA"}, name: "Intel® Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"A7AB"}, name: "Intel® Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"A7AC"}, name: "Intel® Graphics", architecture: "Xe", codename: "Raptor Lake-U", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"A7AD"}, name: "Intel® Graphics", architecture: "Xe", codename: "Raptor Lake-U", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"A7A9"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"A721"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Raptor Lake-P", initial: "Unavailable", full: "Ubuntu 22.04+ (5.19)"},
+	{ids: []string{"4905"}, name: "Intel® Iris® Xe MAX Graphics", architecture: "Xe", codename: "DG1", initial: "Kernel 5.16", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"4907"}, name: "Intel Server GPU SG-18M", architecture: "Xe", codename: "DG1", initial: "Kernel 5.16", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"4908"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "DG1", initial: "Kernel 5.16", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"4909"}, name: "Intel® Iris® Xe MAX 100 Graphics", architecture: "Xe", codename: "DG1", initial: "Kernel 5.16", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"4680", "4690"}, name: "Intel® UHD Graphics 770", architecture: "Xe", codename: "Alder Lake-S", initial: "Kernel 5.13", full: "Ubuntu 22.04+ (5.16)"},
+	{ids: []string{"4688"}, name: "Intel® UHD Graphics 770", architecture: "Xe", codename: "Alder Lake-S", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.16)"},
+	{ids: []string{"468A"}, name: "Intel® UHD Graphics 770", architecture: "Xe", codename: "Alder Lake-S", initial: "Unavailable", full: "Ubuntu 22.04+ (5.16)"},
+	{ids: []string{"468B"}, name: "Intel® UHD Graphics 770", architecture: "Xe", codename: "Alder Lake-S", initial: "Unavailable", full: "Ubuntu 24.04+ (6.1)"},
+	{ids: []string{"4682", "4692"}, name: "Intel® UHD Graphics 730", architecture: "Xe", codename: "Alder Lake-S", initial: "Kernel 5.13", full: "Ubuntu 22.04+ (5.16)"},
+	{ids: []string{"4693"}, name: "Intel® UHD Graphics 710", architecture: "Xe", codename: "Alder Lake-S", initial: "Kernel 5.13", full: "Ubuntu 22.04+ (5.16)"},
+	{ids: []string{"46D3"}, name: "Intel® Graphics", architecture: "Xe", codename: "Twin Lake", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
+	{ids: []string{"46D4"}, name: "Intel® Graphics", architecture: "Xe", codename: "Twin Lake", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
+	{ids: []string{"46D0"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-N", initial: "Unavailable", full: "Ubuntu 22.04+ (5.18)"},
+	{ids: []string{"46D1"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-N", initial: "Unavailable", full: "Ubuntu 22.04+ (5.18)"},
+	{ids: []string{"46D2"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-N", initial: "Unavailable", full: "Ubuntu 22.04+ (5.18)"},
+	{ids: []string{"4626", "4628", "462A"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"46A2", "46B3", "46C2"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"46A3", "46B2", "46C3"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"46A0", "46B0", "46C0"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"46A6", "46AA", "46A8"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"46A1", "46B1", "46C1"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "Alder Lake-P", initial: "Kernel 5.14", full: "Ubuntu 22.04+ (5.17)"},
+	{ids: []string{"4C8A"}, name: "Intel® UHD Graphics 750", architecture: "Xe", codename: "Rocket Lake", initial: "Kernel 5.9", full: "5.13"},
+	{ids: []string{"4C8B"}, name: "Intel® UHD Graphics 730", architecture: "Xe", codename: "Rocket Lake", initial: "Kernel 5.9", full: "5.13"},
+	{ids: []string{"4C90", "4C9A"}, name: "Intel® UHD Graphics P750", architecture: "Xe", codename: "Rocket Lake", initial: "Kernel 5.9", full: "5.13"},
+	{ids: []string{"4E71"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Jasper Lake", initial: "Kernel 5.6", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4E61"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Jasper Lake", initial: "Kernel 5.6", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4E57"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Jasper Lake", initial: "Kernel 5.9", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4E55"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Jasper Lake", initial: "Kernel 5.9", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4E51"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Jasper Lake", initial: "Kernel 5.6", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4557"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Elkhart Lake", initial: "Kernel 5.9", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4555"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Elkhart Lake", initial: "Kernel 5.9", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4571"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Elkhart Lake", initial: "Kernel 5.2", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4551"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Elkhart Lake", initial: "Kernel 5.2", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"4541"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Elkhart Lake", initial: "Kernel 5.2", full: "Ubuntu 22.04+ (5.15)"},
+	{ids: []string{"9A59"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Tiger Lake", initial: "Kernel 5.4", full: "5.7"},
+	{ids: []string{"9A78"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Tiger Lake", initial: "Kernel 5.4", full: "5.7"},
+	{ids: []string{"9A60", "9A70"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Tiger Lake", initial: "Kernel 5.4", full: "5.7"},
+	{ids: []string{"9A68"}, name: "Intel® UHD Graphics", architecture: "Xe", codename: "Tiger Lake", initial: "Kernel 5.4", full: "5.7"},
+	{ids: []string{"9A40", "9A49"}, name: "Intel® Iris® Xe Graphics", architecture: "Xe", codename: "Tiger Lake", initial: "Kernel 5.4", full: "5.7"},
+
+	// Xe KMD driver GPUs
+	{ids: []string{"E223"}, name: "Intel® Arc™ Pro B70 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Unavailable", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"E222"}, name: "Intel® Arc™ Pro B65 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Unavailable", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"B080", "B082", "B084", "B086"}, name: "Intel® Arc™ B390 GPU", architecture: "Xe3", codename: "Panther Lake", initial: "Kernel 6.13", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"B081", "B083", "B085", "B087"}, name: "Intel® Arc™ B370 GPU", architecture: "Xe3", codename: "Panther Lake", initial: "Kernel 6.15", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"B090", "B0A0"}, name: "Intel® Graphics", architecture: "Xe3", codename: "Panther Lake", initial: "Kernel 6.13", full: "Ubuntu 25.10+ (6.17)"},
+	{ids: []string{"E212"}, name: "Intel® Arc™ Pro B50 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Kernel 6.11", full: "Ubuntu 24.04+ (6.14)"},
+	{ids: []string{"E211"}, name: "Intel® Arc™ Pro B60 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Unavailable", full: "Ubuntu 24.04+ (6.15)"},
+	{ids: []string{"E20B"}, name: "Intel® Arc™ B580 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Kernel 6.11", full: "Ubuntu 24.04+ (6.12)"},
+	{ids: []string{"E20C"}, name: "Intel® Arc™ B570 Graphics", architecture: "Xe2", codename: "Battlemage", initial: "Kernel 6.11", full: "Ubuntu 24.04+ (6.12)"},
+	{ids: []string{"64A0"}, name: "Intel® Arc™ Graphics", architecture: "Xe2", codename: "Lunar Lake", initial: "Kernel 6.8", full: "Ubuntu 24.04+ (6.11)"},
+	{ids: []string{"6420"}, name: "Intel® Graphics", architecture: "Xe2", codename: "Lunar Lake", initial: "Kernel 6.8", full: "Ubuntu 24.04+ (6.11)"},
+}
+
+// intelGPUSupportByID maps each individual PCI device id (uppercase) to its
+// support columns, expanded from intelGPUSupportRows.
+var intelGPUSupportByID = func() map[string]intelGPUSupportInfo {
+	m := make(map[string]intelGPUSupportInfo)
+	for _, r := range intelGPUSupportRows {
+		for _, id := range r.ids {
+			m[strings.ToUpper(id)] = intelGPUSupportInfo{
+				name:         r.name,
+				architecture: r.architecture,
+				codename:     r.codename,
+				initial:      r.initial,
+				full:         r.full,
+			}
+		}
+	}
+	return m
+}()
+
+var (
+	kernelParenRe = regexp.MustCompile(`\(([^)]+)\)`)
+	kernelNumRe   = regexp.MustCompile(`(\d+)\.(\d+)`)
+)
+
+// ParseKernelVersion extracts the major.minor KernelVersion from an arbitrary
+// kernel string, e.g. the running kernel "6.8.0-45-generic" -> 6.8.
+func ParseKernelVersion(s string) (KernelVersion, error) {
+	return parseKernelToken(s)
+}
+
+// parseKernelToken extracts a KernelVersion from the three formats observed in
+// the Intel tables:
+//   - "Kernel 6.0"          -> 6.0
+//   - "Ubuntu 24.04+ (6.9)" -> 6.9 (number inside parentheses)
+//   - "5.13"                -> 5.13 (bare number)
+func parseKernelToken(s string) (KernelVersion, error) {
+	s = strings.TrimSpace(s)
+	// Prefer the parenthesised kernel number so we don't accidentally match the
+	// Ubuntu release (e.g. "24.04") that precedes it.
+	if m := kernelParenRe.FindStringSubmatch(s); m != nil {
+		s = m[1]
+	}
+	m := kernelNumRe.FindStringSubmatch(s)
+	if m == nil {
+		return KernelVersion{}, fmt.Errorf("cannot parse kernel version from %q", s)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return KernelVersion{}, fmt.Errorf("invalid major version in %q: %w", s, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return KernelVersion{}, fmt.Errorf("invalid minor version in %q: %w", s, err)
+	}
+	return KernelVersion{Major: major, Minor: minor}, nil
+}
+
+// minKernelForSupport applies the rule:
+//   - Initial support is "Unavailable"  -> minimum kernel is the Full support number.
+//   - Initial support is "Out-of-tree"  -> outOfTree (no upstream kernel applies).
+//   - otherwise                         -> minimum kernel is the Initial support number.
+func minKernelForSupport(initial, full string) (min KernelVersion, outOfTree bool, err error) {
+	initial = strings.TrimSpace(initial)
+	full = strings.TrimSpace(full)
+
+	if strings.EqualFold(initial, intelSupportOutOfTree) || strings.EqualFold(full, intelSupportOutOfTree) {
+		return KernelVersion{}, true, nil
+	}
+	if strings.EqualFold(initial, intelSupportUnavailable) {
+		v, err := parseKernelToken(full)
+		return v, false, err
+	}
+	v, err := parseKernelToken(initial)
+	return v, false, err
+}
+
+// IntelGPUMinKernel returns the minimum upstream Linux kernel version required
+// to support the Intel GPU identified by its PCI device id (case-insensitive,
+// e.g. "7d55" or "7D55" from lspci's "[8086:7d55]").
+//
+//   - found=false    -> the id is not present in the i915/xe tables.
+//   - outOfTree=true -> the GPU requires the out-of-tree intel-i915-dkms module;
+//     no upstream kernel version applies and min is the zero value.
+func IntelGPUMinKernel(pciID string) (min KernelVersion, outOfTree bool, found bool) {
+	info, ok := intelGPUSupportByID[strings.ToUpper(strings.TrimSpace(pciID))]
+	if !ok {
+		return KernelVersion{}, false, false
+	}
+	v, oot, err := minKernelForSupport(info.initial, info.full)
+	if err != nil {
+		return KernelVersion{}, false, false
+	}
+	return v, oot, true
+}

--- a/cli/pkg/core/connector/intel_gpu_kernel_test.go
+++ b/cli/pkg/core/connector/intel_gpu_kernel_test.go
@@ -1,0 +1,106 @@
+package connector
+
+import "testing"
+
+func TestIntelGPUMinKernel(t *testing.T) {
+	tests := []struct {
+		name      string
+		pciID     string
+		wantMin   KernelVersion
+		wantOOT   bool
+		wantFound bool
+	}{
+		// Initial support == "Unavailable" -> use Full support number.
+		{name: "unavailable uses full (i915)", pciID: "A780", wantMin: KernelVersion{5, 17}, wantFound: true},
+		{name: "unavailable uses full paren 6.9", pciID: "7D51", wantMin: KernelVersion{6, 9}, wantFound: true},
+		{name: "unavailable uses full 6.17 (xe)", pciID: "E223", wantMin: KernelVersion{6, 17}, wantFound: true},
+		{name: "unavailable full 6.15 (xe)", pciID: "E211", wantMin: KernelVersion{6, 15}, wantFound: true},
+
+		// Initial support present -> use Initial support number.
+		{name: "initial kernel 6.0", pciID: "7D55", wantMin: KernelVersion{6, 0}, wantFound: true},
+		{name: "initial kernel 5.19", pciID: "5690", wantMin: KernelVersion{5, 19}, wantFound: true},
+		{name: "initial kernel 6.11 (xe)", pciID: "E20B", wantMin: KernelVersion{6, 11}, wantFound: true},
+
+		// Bare Full support number (no Ubuntu prefix / parentheses).
+		{name: "bare full 5.13", pciID: "468A", wantMin: KernelVersion{5, 16}, wantFound: true}, // Unavailable -> full 5.16
+		{name: "initial 5.9 not bare full", pciID: "4C8A", wantMin: KernelVersion{5, 9}, wantFound: true},
+		{name: "initial 5.4 not bare full 5.7", pciID: "9A59", wantMin: KernelVersion{5, 4}, wantFound: true},
+
+		// Multi-id row members resolve individually.
+		{name: "multi-id member A788", pciID: "A788", wantMin: KernelVersion{5, 17}, wantFound: true},
+		{name: "multi-id member B084 (xe)", pciID: "B084", wantMin: KernelVersion{6, 13}, wantFound: true},
+
+		// Case-insensitive / whitespace-trimmed input.
+		{name: "lowercase input", pciID: "7d55", wantMin: KernelVersion{6, 0}, wantFound: true},
+		{name: "padded input", pciID: "  7D55  ", wantMin: KernelVersion{6, 0}, wantFound: true},
+
+		// Out-of-tree rows.
+		{name: "out-of-tree ponte vecchio", pciID: "0BD5", wantOOT: true, wantFound: true},
+		{name: "out-of-tree flex", pciID: "56C1", wantOOT: true, wantFound: true},
+
+		// Unknown id.
+		{name: "unknown id", pciID: "FFFF", wantFound: false},
+		{name: "empty id", pciID: "", wantFound: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMin, gotOOT, gotFound := IntelGPUMinKernel(tt.pciID)
+			if gotFound != tt.wantFound {
+				t.Fatalf("found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if gotOOT != tt.wantOOT {
+				t.Fatalf("outOfTree = %v, want %v", gotOOT, tt.wantOOT)
+			}
+			if tt.wantFound && !tt.wantOOT && gotMin != tt.wantMin {
+				t.Fatalf("min = %s, want %s", gotMin, tt.wantMin)
+			}
+		})
+	}
+}
+
+func TestParseKernelToken(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    KernelVersion
+		wantErr bool
+	}{
+		{in: "Kernel 6.0", want: KernelVersion{6, 0}},
+		{in: "Kernel 5.19", want: KernelVersion{5, 19}},
+		{in: "Ubuntu 24.04+ (6.9)", want: KernelVersion{6, 9}},
+		{in: "Ubuntu 22.04+ (5.17)", want: KernelVersion{5, 17}},
+		{in: "5.13", want: KernelVersion{5, 13}},
+		{in: "5.7", want: KernelVersion{5, 7}},
+		{in: "nonsense", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseKernelToken(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKernelVersionCompare(t *testing.T) {
+	tests := []struct {
+		a, b KernelVersion
+		want int
+	}{
+		{KernelVersion{6, 0}, KernelVersion{6, 0}, 0},
+		{KernelVersion{5, 19}, KernelVersion{6, 0}, -1},
+		{KernelVersion{6, 0}, KernelVersion{5, 19}, 1},
+		{KernelVersion{6, 9}, KernelVersion{6, 17}, -1},
+		{KernelVersion{6, 17}, KernelVersion{6, 9}, 1},
+		{KernelVersion{6, 2}, KernelVersion{6, 2}, 0},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Compare(tt.b); got != tt.want {
+			t.Errorf("%s.Compare(%s) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/cli/pkg/core/connector/system.go
+++ b/cli/pkg/core/connector/system.go
@@ -89,6 +89,7 @@ type Systems interface {
 	IsMThreadsM1000() bool
 	IsRyzenAIMax() bool
 	IsIntelGPU() bool
+	IsIntelDGPU() bool
 
 	IsUbuntu() bool
 	IsDebian() bool
@@ -102,6 +103,7 @@ type Systems interface {
 	GetHostname() string
 	GetOsType() string
 	GetOsArch() string
+	GetOsKernel() string
 	GetUsername() string
 	GetHomeDir() string
 	GetOsVersion() string
@@ -208,6 +210,10 @@ func (s *SystemInfo) GetOsVersion() string {
 	return s.HostInfo.OsVersion
 }
 
+func (s *SystemInfo) GetOsKernel() string {
+	return s.HostInfo.OsKernel
+}
+
 func (s *SystemInfo) GetOsPlatformFamily() string {
 	return s.HostInfo.OsPlatformFamily
 }
@@ -267,10 +273,16 @@ func (s *SystemInfo) IsRyzenAIMax() bool {
 	return s.CpuInfo.IsRyzenAIMax
 }
 
-// IsIntelGPU reports whether the node exposes an Intel GPU (drives the "intel"
-// node mode label)
+// IsIntelGPU reports whether the node exposes an Intel integrated GPU (drives
+// the "intel" unified-memory node mode label)
 func (s *SystemInfo) IsIntelGPU() bool {
 	return s.CpuInfo.IsIntelGPU
+}
+
+// IsIntelDGPU reports whether the node exposes an Intel discrete GPU (drives the
+// "intel-gpu" node mode label)
+func (s *SystemInfo) IsIntelDGPU() bool {
+	return s.CpuInfo.IsIntelDGPU
 }
 
 func (s *SystemInfo) IsAmdGPUOrAPU() bool {
@@ -496,6 +508,7 @@ type CpuInfo struct {
 	IsMThreadsM1000  bool   `json:"is_mthreads_m1000,omitempty"`
 	IsRyzenAIMax     bool   `json:"is_ryzen_ai_max,omitempty"`
 	IsIntelGPU       bool   `json:"is_intel_gpu,omitempty"`
+	IsIntelDGPU      bool   `json:"is_intel_dgpu,omitempty"`
 }
 
 // Not considering the case where AMD GPU and AMD APU coexist.
@@ -571,8 +584,11 @@ func getCpu() *CpuInfo {
 		isRyzenAIMax = false
 	}
 
-	// check if it has an Intel GPU
-	isIntelGPU := HasIntelGPULocal()
+	// check if it has an Intel integrated GPU (unified-memory "intel" mode) and
+	// an Intel discrete GPU ("intel-gpu" mode)
+	intelGPUs := IntelGPUsLocal()
+	isIntelGPU := hasIntelIGPU(intelGPUs)
+	isIntelDGPU := hasIntelDGPU(intelGPUs)
 
 	// check if it is mthreads m1000
 	ret.IsMThreadsM1000 = IsMThreadsAIBookM1000Local()
@@ -581,6 +597,7 @@ func getCpu() *CpuInfo {
 	ret.HasAmdAPU = hasAmdAPU
 	ret.IsRyzenAIMax = isRyzenAIMax
 	ret.IsIntelGPU = isIntelGPU
+	ret.IsIntelDGPU = isIntelDGPU
 
 	return ret
 }

--- a/cli/pkg/gpu/intelgpu/module.go
+++ b/cli/pkg/gpu/intelgpu/module.go
@@ -23,11 +23,21 @@ func (m *InstallIntelPluginModule) IsSkip() bool {
 func (m *InstallIntelPluginModule) Init() {
 	m.Name = "InstallIntelPlugin"
 
-	// update node with Intel GPU label
-	updateNode := &task.LocalTask{
-		Name:   "UpdateNodeIntelGPUInfo",
-		Action: new(UpdateNodeIntelGPUInfo),
+	// label the node with the intel / intel-gpu modes based on the detected
+	// integrated / discrete Intel GPUs that meet the kernel requirement
+	labelNode := &task.LocalTask{
+		Name:   "LabelIntelGPUs",
+		Action: new(LabelIntelGPUs),
 		Retry:  1,
+	}
+
+	// install the discrete-GPU host driver stack; only runs when a discrete Intel
+	// GPU is present, in-tree and kernel-supported
+	installDGPUDrivers := &task.LocalTask{
+		Name:    "InstallIntelDGPUDrivers",
+		Action:  new(InstallIntelDGPUDrivers),
+		Prepare: new(HasQualifyingIntelDGPU),
+		Retry:   1,
 	}
 
 	// nfd.yaml installs CRDs; keep it in its own task and retry so the CRDs are
@@ -62,7 +72,8 @@ func (m *InstallIntelPluginModule) Init() {
 	}
 
 	m.Tasks = []task.Interface{
-		updateNode,
+		labelNode,
+		installDGPUDrivers,
 		applyNFD,
 		applyNodeFeatureRules,
 		applyGPUPlugin,

--- a/cli/pkg/gpu/intelgpu/tasks.go
+++ b/cli/pkg/gpu/intelgpu/tasks.go
@@ -21,24 +21,203 @@ import (
 // manifests (mirrors infrastructure/gpu/.olares/config/gpu/intel).
 const intelConfigDir = "wizard/config/gpu/intel"
 
-// UpdateNodeIntelGPUInfo labels the node as supporting the "intel" mode (Intel
-// integrated GPU)
-type UpdateNodeIntelGPUInfo struct {
+// intelPlan is the per-node decision derived from the detected Intel GPUs and
+// the running kernel: which mode labels to apply and whether a discrete GPU
+// qualifies for the host driver packages.
+type intelPlan struct {
+	labelIntel        bool // apply the "intel" (integrated) mode label
+	labelIntelGPU     bool // apply the "intel-gpu" (discrete) mode label
+	hasQualifyingDGPU bool // a discrete GPU is present, in-tree and kernel-supported
+}
+
+// classifyIntelGPUs enumerates the host's Intel GPUs. Labels are applied purely
+// by device kind: an integrated GPU always yields the "intel" label and a
+// discrete GPU always yields the "intel-gpu" label, regardless of the kernel
+// requirement or Out-of-tree status. The kernel / Out-of-tree / table-presence
+// checks only emit warnings and decide whether a discrete GPU qualifies for the
+// host driver packages (in-tree and kernel-supported).
+func classifyIntelGPUs(runtime connector.Runtime) intelPlan {
+	var plan intelPlan
+
+	gpus := connector.IntelGPUs(runtime)
+	if len(gpus) == 0 {
+		return plan
+	}
+
+	kernelStr := runtime.GetSystemInfo().GetOsKernel()
+	running, kerr := connector.ParseKernelVersion(kernelStr)
+
+	for _, g := range gpus {
+		kind := "integrated"
+		if g.Discrete {
+			kind = "discrete"
+		}
+
+		// Label by device kind, independent of kernel / Out-of-tree / table presence.
+		if g.Discrete {
+			plan.labelIntelGPU = true
+		} else {
+			plan.labelIntel = true
+		}
+
+		min, outOfTree, found := connector.IntelGPUMinKernel(g.ID)
+		if !found {
+			logger.Warnf("Intel %s GPU [%s] is not in the known support table; labeled but driver packages skipped", kind, g.ID)
+			continue
+		}
+		if outOfTree {
+			// Out-of-tree parts (Data Center GPU Max/Flex) need the intel-i915-dkms
+			// module, which we do not install automatically.
+			logger.Warnf("Intel %s GPU [%s] requires the out-of-tree intel-i915-dkms module; it is not installed automatically", kind, g.ID)
+			continue
+		}
+		if kerr != nil {
+			logger.Warnf("cannot parse running kernel version %q: %v; skipping driver packages for Intel %s GPU [%s]", kernelStr, kerr, kind, g.ID)
+			continue
+		}
+		if running.Compare(min) < 0 {
+			logger.Warnf("running kernel %s is below the minimum %s required for Intel %s GPU [%s]; skipping driver packages", running, min, kind, g.ID)
+			continue
+		}
+
+		if g.Discrete {
+			plan.hasQualifyingDGPU = true
+		}
+	}
+
+	return plan
+}
+
+// LabelIntelGPUs labels the node with the "intel" and/or "intel-gpu" modes based
+// on the detected integrated/discrete Intel GPUs that meet the kernel
+// requirement (Out-of-tree discrete parts are labeled too).
+type LabelIntelGPUs struct {
 	common.KubeAction
 }
 
-func (u *UpdateNodeIntelGPUInfo) Execute(runtime connector.Runtime) error {
+func (u *LabelIntelGPUs) Execute(runtime connector.Runtime) error {
 	client, err := clientset.NewKubeClient()
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 	}
 
-	if !connector.HasIntelGPU(runtime) {
-		logger.Info("Intel GPU is not detected")
+	plan := classifyIntelGPUs(runtime)
+	if !plan.labelIntel && !plan.labelIntelGPU {
+		logger.Info("No qualifying Intel GPU to label")
 		return nil
 	}
 
-	return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelType, nil, nil, nil)
+	if plan.labelIntel {
+		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelType, nil, nil, nil); err != nil {
+			return err
+		}
+	}
+	if plan.labelIntelGPU {
+		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelGpuType, nil, nil, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// HasQualifyingIntelDGPU is a task Prepare that only lets the discrete-GPU driver
+// install run when there is a discrete Intel GPU that is in-tree and whose
+// running kernel meets the minimum requirement.
+type HasQualifyingIntelDGPU struct {
+	common.KubePrepare
+}
+
+func (p *HasQualifyingIntelDGPU) PreCheck(runtime connector.Runtime) (bool, error) {
+	return classifyIntelGPUs(runtime).hasQualifyingDGPU, nil
+}
+
+// InstallIntelDGPUDrivers installs the Intel discrete-GPU host driver stack on
+// supported Ubuntu by configuring the Intel GPU repository and installing
+// intel-omix (the unified discrete-GPU driver stack). Only noble / 24.04 is
+// supported. The kobuk-team/intel-graphics PPA is deliberately not used: it
+// ships the same compute libraries at newer pinned versions, which conflict with
+// intel-omix's exact-version dependencies.
+type InstallIntelDGPUDrivers struct {
+	common.KubeAction
+}
+
+func (t *InstallIntelDGPUDrivers) Execute(runtime connector.Runtime) error {
+	si := runtime.GetSystemInfo()
+	if !si.IsUbuntu() {
+		logger.Warn("Intel discrete GPU host packages are only supported on Ubuntu; skipping package installation")
+		return nil
+	}
+	// intel-omix is only published for noble / 24.04.
+	if !si.IsUbuntuVersionEqual(connector.Ubuntu2404) {
+		logger.Warnf("Ubuntu version %s is not supported for intel-omix (requires noble/24.04); skipping Intel discrete GPU driver installation", si.GetOsVersion())
+		return nil
+	}
+
+	run := func(cmd string) error {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
+			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("failed to run %q", cmd))
+		}
+		return nil
+	}
+
+	// A previous install may have configured the kobuk-team/intel-graphics PPA and
+	// installed its newer compute libraries (libze1, libze-intel-gpu1,
+	// intel-opencl-icd, intel-ocloc). Those pinned versions conflict with
+	// intel-omix's exact-version dependencies, so remove any leftover PPA source
+	// before configuring the Intel repository. rm -f is a no-op when absent.
+	if err := run("rm -f /etc/apt/sources.list.d/*kobuk*intel-graphics*.list /etc/apt/sources.list.d/*kobuk*intel-graphics*.sources"); err != nil {
+		return err
+	}
+
+	// Prerequisites for fetching the repository key.
+	if err := run("apt-get update"); err != nil {
+		return err
+	}
+	if err := run("DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget"); err != nil {
+		return err
+	}
+
+	// Install the Intel GPU repository signing key referenced by the apt source.
+	if err := run("install -d -m 0755 /usr/share/keyrings"); err != nil {
+		return err
+	}
+	keyCmd := "wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg"
+	if err := run(keyCmd); err != nil {
+		return err
+	}
+
+	// Configure the Intel GPU repository and install intel-omix (the unified
+	// discrete-GPU driver stack). We intentionally do NOT add the
+	// kobuk-team/intel-graphics PPA: it ships the same compute libraries at newer
+	// pinned versions, which conflict with intel-omix's exact-version dependencies.
+	const codename = "noble"
+	srcLine := fmt.Sprintf("deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu %s/intel-omix/0.2 unified", codename)
+	writeSrc := fmt.Sprintf("echo '%s' | tee /etc/apt/sources.list.d/intel-gpu-%s.list", srcLine, codename)
+	if err := run(writeSrc); err != nil {
+		return err
+	}
+	if err := run("apt-get update"); err != nil {
+		return err
+	}
+
+	// --allow-downgrades lets apt replace any newer kobuk-installed compute libs
+	// left over from a previous run with intel-omix's pinned versions.
+	const installOmix = "DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades intel-omix"
+	if _, err := runtime.GetRunner().SudoCmd(installOmix, false, true); err != nil {
+		// The first attempt can still fail on a machine where the leftover
+		// kobuk-versioned compute libs cannot be downgraded in place. Purge the
+		// conflicting packages (best-effort) and let intel-omix reinstall its own
+		// pinned versions, then retry.
+		logger.Warn("intel-omix install failed; purging leftover conflicting Intel compute packages and retrying")
+		_, _ = runtime.GetRunner().SudoCmd("DEBIAN_FRONTEND=noninteractive apt-get purge -y libze1 libze-dev libze-intel-gpu1 intel-opencl-icd intel-ocloc || true", false, true)
+		_, _ = runtime.GetRunner().SudoCmd("apt-get update", false, true)
+		if err := run(installOmix); err != nil {
+			return err
+		}
+	}
+
+	logger.Info("Intel discrete GPU host packages (intel-omix) installed successfully")
+	return nil
 }
 
 // applyIntelManifest kubectl-applies a single manifest under intelConfigDir.

--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -75,7 +75,8 @@ func (l *linuxInstallPhaseBuilder) installGpuPlugin() phase {
 			return true
 		}()},
 		&intelgpu.InstallIntelPluginModule{Skip: func() bool {
-			if l.runtime.GetSystemInfo().IsIntelGPU() {
+			si := l.runtime.GetSystemInfo()
+			if si.IsIntelGPU() || si.IsIntelDGPU() {
 				return false
 			}
 			return true

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -932,7 +932,7 @@ func labelIntelAMDGPUNode() []task.Interface {
 	return []task.Interface{
 		&task.LocalTask{
 			Name:   "LabelIntelGPUNode",
-			Action: new(intelgpu.UpdateNodeIntelGPUInfo),
+			Action: new(intelgpu.LabelIntelGPUs),
 			Retry:  3,
 			Delay:  5 * time.Second,
 		},


### PR DESCRIPTION



* **Background**
Detect Intel integrated vs discrete GPUs from PCI topology and drive per-kind node labeling, kernel checks, and discrete-GPU driver install.

- connector: rework Intel detection to enumerate display-class PCI devices (IntelGPU{ID,Discrete}) via sysfs, classifying integrated vs discrete by whether the device hangs off the root complex; expose HasIntelIGPU/HasIntelDGPU on top of it.
- connector: add IntelGPUMinKernel, a lookup of the minimum supported kernel per PCI id built from Intel's i915/xe driver support tables (Initial vs Full support rule, Out-of-tree handling), with tests, and a KernelVersion type comparing via Masterminds/semver.
- connector: add ParseKernelVersion, GetOsKernel(), IsIntelDGPU() and the CpuInfo.IsIntelDGPU system-info flag.
- intelgpu: label the node by device kind (intel for iGPU, intel-gpu for dGPU) regardless of kernel/Out-of-tree; warn and skip driver packages when a device is unknown, Out-of-tree, or below its minimum kernel.
- intelgpu: install the discrete-GPU stack (intel-omix from the Intel GPU repository, noble only) when a qualifying dGPU is present; clean up any leftover kobuk-team/intel-graphics PPA and use --allow-downgrades with a purge-and-retry fallback to resolve conflicting compute libs.
- intelgpu: always install the NFD + intel-gpu-plugin stack whenever any Intel GPU is present (device plugin no longer gated on kernel).
- run the Intel plugin module for iGPU or dGPU; backfill labels on upgrade via LabelIntelGPUs.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install/upgrade runs privileged apt changes (external Intel repo, package purges) on nodes with discrete Intel GPUs; mis-detection or kernel-table gaps could skip drivers or label nodes incorrectly for scheduling.
> 
> **Overview**
> **Intel GPU handling** moves from a single “any Intel GPU” check to per-device detection and scheduling modes.
> 
> Detection now walks **sysfs PCI** (replacing `lspci` grep), returns each Intel display controller with **PCI ID** and **integrated vs discrete** (topology: root complex vs behind a bridge). System info exposes separate **`IsIntelGPU` (iGPU)** and **`IsIntelDGPU`**, and the Intel plugin module runs when either is present.
> 
> A new **Intel i915/xe support table** drives **`IntelGPUMinKernel`** per PCI ID (initial/full/out-of-tree rules), with **`ParseKernelVersion`** / **`GetOsKernel()`** used at install time.
> 
> **Node labeling** applies **`intel`** for iGPU and **`intel-gpu`** for dGPU by device kind (not gated on kernel). Kernel/table/out-of-tree checks only **warn** and decide whether **host driver packages** run.
> 
> For qualifying in-tree dGPUs on **Ubuntu 24.04**, install adds **`intel-omix`** from Intel’s repo (with kobuk PPA cleanup and downgrade/purge retry). **`LabelIntelGPUs`** replaces **`UpdateNodeIntelGPUInfo`**; upgrades backfill labels the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88290ce4322288a0927b39e9d19648bdc58c428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->