### PR TITLE
fix: dev entrance acls and enhance session revocation logic

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.56
+        image: beclab/auth:0.2.58
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -204,7 +204,7 @@ spec:
             - name: LLDAP_HTTP_READONLY_PORT
               value: "17171"
 
-          image: beclab/lldap:0.0.19
+          image: beclab/lldap:0.0.20
           imagePullPolicy: IfNotPresent
           name: lldap
           ports:


### PR DESCRIPTION


* **Background**
dev entrance acls and enhance session revocation logic
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/61
https://github.com/beclab/authelia/pull/60

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth and identity directory image upgrades can affect login, ACLs, and session behavior; scope is limited to tag bumps but targets security-critical services.
> 
> **Overview**
> Bumps the **Authelia** auth backend image from `beclab/auth:0.2.56` to **`beclab/auth:0.2.58`** in `auth_backend_deploy.yaml`, and the **LLDAP** image from `beclab/lldap:0.0.19` to **`beclab/lldap:0.0.20`** in `lldap-deployment.yaml`. No other manifest fields change in this diff.
> 
> This rolls out the application fixes referenced in the PR title (dev entrance ACLs and stronger session revocation) via new image builds rather than in-repo config edits here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f725b752813141858cc9487b50b43fcde837d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->