### PR TITLE
fix(daemon): stop olaresd mDNS on worker nodes

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -118,8 +118,19 @@ func main() {
 		lpvpndns.NewWatcher(),
 	}, func() {
 		if s != nil {
-			if err := s.Restart(); err != nil {
-				klog.Error(err)
+			startMDNS := true
+			if client, err := utils.GetKubeClient(); err == nil {
+				if _, _, nodeRole, err := utils.GetThisNodeName(mainCtx, client); err == nil && nodeRole != "master" {
+					startMDNS = false
+				}
+			}
+
+			if startMDNS {
+				if err := s.Restart(); err != nil {
+					klog.Error(err)
+				}
+			} else {
+				s.Close()
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Close the olaresd `_terminus._tcp` mDNS service on worker nodes once the node role is confirmed as non-master.
- Keep restarting/advertising when the role cannot be determined yet (e.g. kube client unavailable), so discovery still works during early startup.
- Aligns worker behavior with the existing sunshine mDNS master-only gate for multi-node clusters.

## Test plan
- [ ] On a master node, confirm olaresd mDNS still restarts/advertises after status watch ticks
- [ ] On a worker node, after kube is ready and role resolves, confirm mDNS is closed and no longer advertised
- [ ] Before cluster join / when role cannot be resolved, confirm mDNS remains available
- [ ] Restart olaresd on worker and verify mDNS eventually stops after role detection


Made with [Cursor](https://cursor.com)