### PR TITLE
feat(app-service): materialize manifest secrets[] as kubernetes secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@
 
 # Go workspace file
 go.work
+go.work.sum
+
+# Local checkouts of upstream Go deps worked on alongside this repo
+# (e.g. github.com/beclab/api), wired in via go.work.
+.deps/
 
 .dist
 .manifest

--- a/framework/app-service/controllers/appenv_controller.go
+++ b/framework/app-service/controllers/appenv_controller.go
@@ -69,6 +69,25 @@ func (r *AppEnvController) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// appEnvReferences reports whether the AppEnv references the named
+// SystemEnv/UserEnv, through either an envs[] entry or a secrets[] declaration.
+// Shared by the SystemEnv and UserEnv controllers so both propagate changes to
+// secret-backed variables as well as plain ones; missing the secrets[] half
+// would mean a rotated credential silently never reaches the app.
+func appEnvReferences(appEnv *sysv1alpha1.AppEnv, envName string) bool {
+	for _, envVar := range appEnv.Envs {
+		if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == envName {
+			return true
+		}
+	}
+	for _, secret := range appEnv.Secrets {
+		if secret.ValueFrom != nil && secret.ValueFrom.EnvName == envName {
+			return true
+		}
+	}
+	return false
+}
+
 // appEnvRequestForAppMgr maps an ApplicationManager to its backing AppEnv so a
 // pending env change can be re-evaluated when the app's state changes.
 func appEnvRequestForAppMgr(_ context.Context, obj client.Object) []reconcile.Request {
@@ -121,6 +140,13 @@ func (r *AppEnvController) reconcileAppEnv(ctx context.Context, appEnv *sysv1alp
 		return ctrl.Result{}, err
 	}
 
+	// Must run before the NeedApply check below so a rotated secret can request
+	// the same redeploy an env change would.
+	if err := r.syncSecretValues(ctx, appEnv); err != nil {
+		klog.Errorf("Failed to sync secrets for AppEnv %s/%s: %v", appEnv.Namespace, appEnv.Name, err)
+		return ctrl.Result{}, err
+	}
+
 	if appEnv.NeedApply {
 		appMgr, err := r.getAppMgr(ctx, appEnv)
 		if err != nil {
@@ -165,6 +191,57 @@ func (r *AppEnvController) reconcileAppEnv(ctx context.Context, appEnv *sysv1alp
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// syncSecretValues re-resolves the app's secrets[] declarations and rewrites the
+// backing Kubernetes Secrets, so rotating a SystemEnv/UserEnv reaches apps that
+// consume it as a secret rather than as a plain env var.
+//
+// The resolved value is deliberately never written back onto the AppEnv — that
+// is the whole point of declaring the variable as a secret, and AppSecretVar has
+// no field to hold it. Change detection instead compares against the existing
+// Secret, which already holds the previous value.
+//
+// A changed secret only requests a redeploy when the declaration opted in via
+// applyOnChange. Secret values are injected into pods at start time, so without
+// that redeploy the Secret is refreshed while running pods keep serving the old
+// value until they restart for some other reason.
+func (r *AppEnvController) syncSecretValues(ctx context.Context, appEnv *sysv1alpha1.AppEnv) error {
+	if len(appEnv.Secrets) == 0 {
+		return nil
+	}
+
+	changed, err := apputils.ApplySecretsFor(ctx, r.Client, appEnv.Namespace, appEnv.AppName, appEnv.AppOwner, appEnv.Secrets)
+	if err != nil {
+		return err
+	}
+
+	changedSet := make(map[string]struct{}, len(changed))
+	for _, name := range changed {
+		changedSet[name] = struct{}{}
+	}
+
+	original := appEnv.DeepCopy()
+	updated := false
+	for i := range appEnv.Secrets {
+		secret := &appEnv.Secrets[i]
+		if _, didChange := changedSet[secret.Name]; didChange && secret.ApplyOnChange {
+			appEnv.NeedApply = true
+			updated = true
+		}
+		if secret.ValueFrom != nil && secret.ValueFrom.Status != constants.EnvRefStatusSynced {
+			secret.ValueFrom.Status = constants.EnvRefStatusSynced
+			updated = true
+		}
+	}
+
+	if !updated {
+		return nil
+	}
+	if err := r.Patch(ctx, appEnv, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to update AppEnv %s/%s secrets: %v", appEnv.Namespace, appEnv.Name, err)
+	}
+	return nil
 }
 
 func (r *AppEnvController) syncEnvValues(ctx context.Context, appEnv *sysv1alpha1.AppEnv) error {

--- a/framework/app-service/controllers/appenv_secrets_test.go
+++ b/framework/app-service/controllers/appenv_secrets_test.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+
+	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+)
+
+// TestAppEnvReferencesCoversSecrets guards the discovery step that makes live
+// propagation work. The SystemEnv/UserEnv controllers use this to decide which
+// AppEnvs to flag for sync when a variable is rotated. It originally scanned
+// only Envs, which meant an app consuming a rotated credential as a secret was
+// never flagged and silently kept the stale value until someone reinstalled.
+func TestAppEnvReferencesCoversSecrets(t *testing.T) {
+	envRef := &sysv1alpha1.AppEnv{
+		Envs: []sysv1alpha1.AppEnvVar{{
+			EnvVarSpec: sysv1alpha1.EnvVarSpec{EnvName: "APP_CDN"},
+			ValueFrom:  &sysv1alpha1.ValueFrom{EnvName: "OLARES_SYSTEM_CDN_SERVICE"},
+		}},
+	}
+	secretRef := &sysv1alpha1.AppEnv{
+		Secrets: []sysv1alpha1.AppSecretVar{{
+			Name:      "smtp-password",
+			ValueFrom: &sysv1alpha1.ValueFrom{EnvName: "OLARES_USER_SMTP_PASSWORD"},
+		}},
+	}
+	both := &sysv1alpha1.AppEnv{Envs: envRef.Envs, Secrets: secretRef.Secrets}
+
+	cases := []struct {
+		name    string
+		appEnv  *sysv1alpha1.AppEnv
+		envName string
+		want    bool
+	}{
+		{"env reference matches", envRef, "OLARES_SYSTEM_CDN_SERVICE", true},
+		{"env reference does not match", envRef, "OLARES_UNRELATED", false},
+		{"secret reference matches", secretRef, "OLARES_USER_SMTP_PASSWORD", true},
+		{"secret reference does not match", secretRef, "OLARES_UNRELATED", false},
+		{"mixed, matches via env", both, "OLARES_SYSTEM_CDN_SERVICE", true},
+		{"mixed, matches via secret", both, "OLARES_USER_SMTP_PASSWORD", true},
+		{"empty appenv", &sysv1alpha1.AppEnv{}, "OLARES_ANYTHING", false},
+		{
+			"declaration without valueFrom is not a reference",
+			&sysv1alpha1.AppEnv{Secrets: []sysv1alpha1.AppSecretVar{{Name: "orphan"}}},
+			"OLARES_ANYTHING",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appEnvReferences(tc.appEnv, tc.envName); got != tc.want {
+				t.Errorf("appEnvReferences(%q) = %v, want %v", tc.envName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppSecretVarHasNoValueField is a structural guard on the privacy property
+// the design depends on: the resolved value must live only in the Kubernetes
+// Secret. If a value-bearing field is ever added to AppSecretVar, the AppEnv CR
+// becomes a place where plaintext secrets can accumulate, which is exactly what
+// declaring a variable as a secret is meant to avoid.
+func TestAppSecretVarHasNoValueField(t *testing.T) {
+	forbidden := map[string]struct{}{
+		"Value": {}, "Default": {}, "Data": {}, "Secret": {},
+	}
+
+	typ := reflect.TypeOf(sysv1alpha1.AppSecretVar{})
+	for i := 0; i < typ.NumField(); i++ {
+		if _, bad := forbidden[typ.Field(i).Name]; bad {
+			t.Errorf("AppSecretVar gained a value-bearing field %q; resolved secret "+
+				"values must never be persisted on the AppEnv CR", typ.Field(i).Name)
+		}
+	}
+}

--- a/framework/app-service/controllers/systemenv_controller.go
+++ b/framework/app-service/controllers/systemenv_controller.go
@@ -81,12 +81,7 @@ func (r *SystemEnvController) reconcileSystemEnv(ctx context.Context, systemEnv 
 }
 
 func (r *SystemEnvController) isReferenced(appEnv *sysv1alpha1.AppEnv, systemEnvName string) bool {
-	for _, envVar := range appEnv.Envs {
-		if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == systemEnvName {
-			return true
-		}
-	}
-	return false
+	return appEnvReferences(appEnv, systemEnvName)
 }
 
 func (r *SystemEnvController) annotateAppEnvForSync(ctx context.Context, appEnv *sysv1alpha1.AppEnv, systemEnv *sysv1alpha1.SystemEnv) (bool, error) {

--- a/framework/app-service/controllers/userenv_controller.go
+++ b/framework/app-service/controllers/userenv_controller.go
@@ -83,12 +83,7 @@ func (r *UserEnvController) reconcileUserEnv(ctx context.Context, userEnv *sysv1
 }
 
 func (r *UserEnvController) isReferenced(appEnv *sysv1alpha1.AppEnv, userEnvName string) bool {
-	for _, envVar := range appEnv.Envs {
-		if envVar.ValueFrom != nil && envVar.ValueFrom.EnvName == userEnvName {
-			return true
-		}
-	}
-	return false
+	return appEnvReferences(appEnv, userEnvName)
 }
 
 func (r *UserEnvController) annotateAppEnvForSync(ctx context.Context, appEnv *sysv1alpha1.AppEnv, userEnv *sysv1alpha1.UserEnv) (bool, error) {

--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -943,9 +943,18 @@ func (h *installHandlerHelper) setAppEnv(overrides []sysv1alpha1.AppEnvVar) (err
 	return nil
 }
 
+// applyAppEnv resolves the app's Olares-provided configuration before the chart
+// is installed: envs[] into the AppEnv CR (surfaced to the chart as plaintext
+// .Values.olaresEnv) and secrets[] into Kubernetes Secrets in the app namespace
+// (referenced by the chart via a plain secretKeyRef). Both must run here, ahead
+// of the helm install, so the values exist by the time pods start.
 func (h *installHandlerHelper) applyAppEnv(ctx context.Context) (err error) {
 	_, err = apputils.ApplyAppEnv(ctx, h.h.ctrlClient, h.appConfig)
 	if err != nil {
+		api.HandleError(h.resp, h.req, err)
+		return
+	}
+	if err = apputils.ApplySecrets(ctx, h.h.ctrlClient, h.appConfig); err != nil {
 		api.HandleError(h.resp, h.req, err)
 	}
 	return

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -206,9 +206,16 @@ func (h *upgradeHandlerHelper) setAndEncodingAppCofnig(prevCfg *appcfg.Applicati
 	return string(encoding), nil
 }
 
+// applyAppEnv mirrors the install-path helper: envs[] go to the AppEnv CR and
+// secrets[] are (re)materialized as Kubernetes Secrets, so an upgrade picks up
+// changed SystemEnv/UserEnv values before the chart is upgraded.
 func (h *upgradeHandlerHelper) applyAppEnv(ctx context.Context) (err error) {
 	_, err = apputils.ApplyAppEnv(ctx, h.h.ctrlClient, h.appConfig)
 	if err != nil {
+		api.HandleError(h.resp, h.req, err)
+		return
+	}
+	if err = apputils.ApplySecrets(ctx, h.h.ctrlClient, h.appConfig); err != nil {
 		api.HandleError(h.resp, h.req, err)
 	}
 	return

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -103,10 +103,12 @@ type ApplicationConfig struct {
 	Envs                 []manifestsysv1alpha1.AppEnvVar
 	// Secrets mirrors the top-level secrets[] block of OlaresManifest.yaml.
 	// Each entry is materialized into its own Kubernetes Secret in the app
-	// namespace at install/upgrade time (see pkg/utils/app.ApplySecrets), so
-	// the chart can reference the value with a plain secretKeyRef rather than
-	// receiving it as a plaintext env var via olaresEnv.
-	Secrets              []AppSecret
+	// namespace (see pkg/utils/app.ApplySecrets), so the chart can reference
+	// the value with a plain secretKeyRef rather than receiving it as a
+	// plaintext env var via olaresEnv. The declarations are also recorded on
+	// the AppEnv CR so the SystemEnv/UserEnv controllers can propagate later
+	// changes to the referenced variables.
+	Secrets              []AppSecretVar
 	Images               []string
 	AllowMultipleInstall bool
 	RawAppName           string

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -101,6 +101,12 @@ type ApplicationConfig struct {
 	Provider             []Provider
 	Type                 string
 	Envs                 []manifestsysv1alpha1.AppEnvVar
+	// Secrets mirrors the top-level secrets[] block of OlaresManifest.yaml.
+	// Each entry is materialized into its own Kubernetes Secret in the app
+	// namespace at install/upgrade time (see pkg/utils/app.ApplySecrets), so
+	// the chart can reference the value with a plain secretKeyRef rather than
+	// receiving it as a plaintext env var via olaresEnv.
+	Secrets              []AppSecret
 	Images               []string
 	AllowMultipleInstall bool
 	RawAppName           string

--- a/framework/app-service/pkg/appcfg/types.go
+++ b/framework/app-service/pkg/appcfg/types.go
@@ -42,7 +42,7 @@ type (
 	Application             = appv1alpha1.Application
 	ApplicationSpec         = appv1alpha1.ApplicationSpec
 	AppEnvVar               = manifestsysv1alpha1.AppEnvVar
-	AppSecret               = manifest.AppSecret
+	AppSecretVar            = manifestsysv1alpha1.AppSecretVar
 	ACL                     = appv1alpha1.ACL
 	ApplicationManager      = appv1alpha1.ApplicationManager
 	ApplicationManagerState = appv1alpha1.ApplicationManagerState
@@ -52,9 +52,9 @@ type (
 )
 
 // AppSecretValueKey is the data key each generated app Secret stores its value
-// under. Re-exported from the shared manifest package so chart-facing callers
-// don't need to import it directly.
-const AppSecretValueKey = manifest.AppSecretValueKey
+// under. Re-exported from the shared api package so chart-facing callers don't
+// need to import it directly.
+const AppSecretValueKey = manifestsysv1alpha1.AppSecretValueKey
 
 func ChartNamespace(c *Chart, owner string) string {
 	if c.Shared {

--- a/framework/app-service/pkg/appcfg/types.go
+++ b/framework/app-service/pkg/appcfg/types.go
@@ -42,6 +42,7 @@ type (
 	Application             = appv1alpha1.Application
 	ApplicationSpec         = appv1alpha1.ApplicationSpec
 	AppEnvVar               = manifestsysv1alpha1.AppEnvVar
+	AppSecret               = manifest.AppSecret
 	ACL                     = appv1alpha1.ACL
 	ApplicationManager      = appv1alpha1.ApplicationManager
 	ApplicationManagerState = appv1alpha1.ApplicationManagerState
@@ -49,6 +50,11 @@ type (
 	OverlayGateway          = manifest.OverlayGateway
 	WorkloadReplicas        = manifest.WorkloadReplicas
 )
+
+// AppSecretValueKey is the data key each generated app Secret stores its value
+// under. Re-exported from the shared manifest package so chart-facing callers
+// don't need to import it directly.
+const AppSecretValueKey = manifest.AppSecretValueKey
 
 func ChartNamespace(c *Chart, owner string) string {
 	if c.Shared {

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -232,14 +233,36 @@ func UpdateAppMgrStatus(name string, status v1alpha1.ApplicationManagerStatus, m
 // ApplyAppEnv applies the environment variable configuration of the app:
 // if no existing AppEnv is found for the app, the AppEnv is created
 // if existing AppEnv is found for the app, any new configured env is added to the AppEnv
+//
+// The app's secrets[] declarations are recorded here too. Their values are NOT
+// stored on the AppEnv — only the declaration — but keeping them alongside Envs
+// is what lets the SystemEnv/UserEnv controllers discover which apps reference a
+// changed variable and drive the existing sync/apply chain for secrets as well.
 func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (*sysv1alpha1.AppEnv, error) {
 	if appConfig == nil {
 		return nil, fmt.Errorf("app config is nil")
 	}
 
-	if len(appConfig.Envs) == 0 {
-		klog.Infof("No envs found for app: %s owner: %s, skip app env apply", appConfig.AppName, appConfig.OwnerName)
+	if len(appConfig.Envs) == 0 && len(appConfig.Secrets) == 0 {
+		klog.Infof("No envs or secrets found for app: %s owner: %s, skip app env apply", appConfig.AppName, appConfig.OwnerName)
 		return nil, nil
+	}
+
+	if err := validateAppSecretDecls(appConfig.Secrets, appConfig.AppName); err != nil {
+		return nil, err
+	}
+
+	desiredAppSecrets := make([]sysv1alpha1.AppSecretVar, 0, len(appConfig.Secrets))
+	for _, s := range appConfig.Secrets {
+		// Copy the reference rather than writing through the shared pointer,
+		// which would mutate the caller's appConfig. Status is tracked on the
+		// reference mirroring envs[]: it starts pending and moves to synced
+		// once the Secret has been written.
+		s.ValueFrom = &sysv1alpha1.ValueFrom{
+			EnvName: s.ValueFrom.EnvName,
+			Status:  constants.EnvRefStatusPending,
+		}
+		desiredAppSecrets = append(desiredAppSecrets, s)
 	}
 
 	var desiredAppEnvs []sysv1alpha1.AppEnvVar
@@ -284,6 +307,7 @@ func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.Applica
 			AppName:  appConfig.AppName,
 			AppOwner: appConfig.OwnerName,
 			Envs:     desiredAppEnvs,
+			Secrets:  desiredAppSecrets,
 		}
 		if err := c.Create(ctx, newAppEnv); err != nil {
 			return nil, err
@@ -307,6 +331,22 @@ func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.Applica
 		}
 	}
 
+	// Secret declarations are reconciled by name the same way: new ones are
+	// appended, existing ones left alone. Nothing here carries a value, so
+	// there is no user-set state to preserve — only the declaration itself.
+	if len(desiredAppSecrets) > 0 {
+		existingSecrets := make(map[string]struct{}, len(appEnv.Secrets))
+		for _, s := range appEnv.Secrets {
+			existingSecrets[s.Name] = struct{}{}
+		}
+		for _, s := range desiredAppSecrets {
+			if _, ok := existingSecrets[s.Name]; !ok {
+				appEnv.Secrets = append(appEnv.Secrets, s)
+				updated = true
+			}
+		}
+	}
+
 	if !updated {
 		return appEnv, nil
 	}
@@ -318,71 +358,98 @@ func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.Applica
 	return appEnv, nil
 }
 
-// ApplySecrets materializes the manifest's secrets[] block into Kubernetes
-// Secrets in the app namespace. Each entry pulls one Olares-provided env var
-// (a SystemEnv or UserEnv, referenced exactly like envs[].valueFrom) into its
-// own Secret, named verbatim after the entry, holding the value under
-// manifest.AppSecretValueKey. The chart then consumes it with a plain
-// secretKeyRef, so the value never lands in the pod spec as a literal env var
-// the way olaresEnv values do.
-//
-// Unlike ApplyAppEnv, nothing is persisted into an AppEnv CR: the Secret is
-// the storage. Values are re-resolved and rewritten on every install/upgrade
-// so a changed SystemEnv/UserEnv propagates.
-//
-// TODO(structured-secrets): one entry == one single-valued Secret. Once the
-// Olares UX can author multi-key secrets, group entries sharing a name into a
-// single Secret with one key each.
+// validateAppSecretDecls rejects declarations that cannot be materialized.
+// Shared by the install path and the controller path so a declaration is never
+// recorded on the AppEnv that ApplySecrets would then refuse to act on.
+func validateAppSecretDecls(secrets []sysv1alpha1.AppSecretVar, appName string) error {
+	seen := make(map[string]struct{}, len(secrets))
+	for _, s := range secrets {
+		if s.Name == "" {
+			return fmt.Errorf("app %s declares a secret without a name", appName)
+		}
+		if _, dup := seen[s.Name]; dup {
+			// Two entries writing the same Secret would silently clobber each
+			// other, so reject rather than pick a winner.
+			return fmt.Errorf("app %s declares secret %q more than once", appName, s.Name)
+		}
+		seen[s.Name] = struct{}{}
+
+		if s.ValueFrom == nil || s.ValueFrom.EnvName == "" {
+			return fmt.Errorf("secret %q of app %s must set valueFrom.envName", s.Name, appName)
+		}
+	}
+	return nil
+}
+
+// ApplySecrets materializes an app's secrets[] declarations into Kubernetes
+// Secrets in its namespace, from the app config. See ApplySecretsFor.
 func ApplySecrets(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) error {
 	if appConfig == nil {
 		return fmt.Errorf("app config is nil")
 	}
+	_, err := ApplySecretsFor(ctx, c, appConfig.Namespace, appConfig.AppName, appConfig.OwnerName, appConfig.Secrets)
+	return err
+}
 
-	if len(appConfig.Secrets) == 0 {
-		klog.Infof("No secrets found for app: %s owner: %s, skip app secret apply", appConfig.AppName, appConfig.OwnerName)
-		return nil
+// ApplySecretsFor materializes the given secret declarations into Kubernetes
+// Secrets in namespace. Each declaration pulls one Olares-provided env var (a
+// SystemEnv or UserEnv, referenced exactly like envs[].valueFrom) into its own
+// Secret, named verbatim, holding the value under AppSecretValueKey. The chart
+// consumes it with a plain secretKeyRef, so the value never lands in the pod
+// spec as a literal env var the way olaresEnv values do.
+//
+// It returns the names of the Secrets whose data actually changed. That is what
+// lets the AppEnv controller decide whether a redeploy is warranted after a
+// referenced variable is rotated: the existing Secret holds the previous value,
+// so it doubles as the change-detection store and no value (or hash of one)
+// needs to be persisted anywhere else.
+//
+// Safe to call repeatedly: rewriting identical data reports no change.
+//
+// TODO(structured-secrets): one declaration == one single-valued Secret. Once
+// the Olares UX can author multi-key secrets, group declarations sharing a name
+// into a single Secret with one key each.
+func ApplySecretsFor(ctx context.Context, c client.Client, namespace, appName, owner string, secrets []sysv1alpha1.AppSecretVar) ([]string, error) {
+	if len(secrets) == 0 {
+		klog.Infof("No secrets found for app: %s owner: %s, skip app secret apply", appName, owner)
+		return nil, nil
 	}
 
-	refEnvs, err := listReferenceableEnvs(ctx, c, appConfig.OwnerName)
+	if err := validateAppSecretDecls(secrets, appName); err != nil {
+		return nil, err
+	}
+
+	refEnvs, err := listReferenceableEnvs(ctx, c, owner)
 	if err != nil {
-		return fmt.Errorf("failed to list referenced envs: %w", err)
+		return nil, fmt.Errorf("failed to list referenced envs: %w", err)
 	}
 
 	// The namespace normally already exists (ApplyAppEnv creates it), but an
 	// app may declare secrets[] without any envs[], so ensure it here too.
 	appNS := new(corev1.Namespace)
-	appNS.SetName(appConfig.Namespace)
+	appNS.SetName(namespace)
 	if err := c.Create(ctx, appNS); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+		return nil, err
 	}
 
-	seen := make(map[string]struct{}, len(appConfig.Secrets))
-	for _, s := range appConfig.Secrets {
-		if s.Name == "" {
-			return fmt.Errorf("app %s declares a secret without a name", appConfig.AppName)
-		}
-		if _, dup := seen[s.Name]; dup {
-			// Two entries writing the same Secret would silently clobber each
-			// other, so reject rather than pick a winner.
-			return fmt.Errorf("app %s declares secret %q more than once", appConfig.AppName, s.Name)
-		}
-		seen[s.Name] = struct{}{}
-
-		if s.ValueFrom == nil || s.ValueFrom.EnvName == "" {
-			return fmt.Errorf("secret %q of app %s must set valueFrom.envName", s.Name, appConfig.AppName)
-		}
+	var changed []string
+	for _, s := range secrets {
 		value, ok := refEnvs[s.ValueFrom.EnvName]
 		if !ok {
-			return fmt.Errorf("secret %q of app %s references unknown env %q", s.Name, appConfig.AppName, s.ValueFrom.EnvName)
+			return nil, fmt.Errorf("secret %q of app %s references unknown env %q", s.Name, appName, s.ValueFrom.EnvName)
 		}
 
-		if err := createOrUpdateAppSecret(ctx, c, appConfig, s.Name, value); err != nil {
-			return fmt.Errorf("failed to apply secret %q of app %s: %w", s.Name, appConfig.AppName, err)
+		didChange, err := createOrUpdateAppSecret(ctx, c, namespace, appName, owner, s.Name, value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply secret %q of app %s: %w", s.Name, appName, err)
+		}
+		if didChange {
+			changed = append(changed, s.Name)
 		}
 	}
 
-	klog.Infof("applied %d secret(s) for app: %s, owner: %s", len(appConfig.Secrets), appConfig.AppName, appConfig.OwnerName)
-	return nil
+	klog.Infof("applied %d secret(s) (%d changed) for app: %s, owner: %s", len(secrets), len(changed), appName, owner)
+	return changed, nil
 }
 
 // listReferenceableEnvs returns the Olares-provided env vars a manifest may
@@ -412,38 +479,47 @@ func listReferenceableEnvs(ctx context.Context, c client.Client, owner string) (
 }
 
 // createOrUpdateAppSecret writes a single-valued Opaque Secret into the app
-// namespace. On update only Data is replaced, so labels or annotations added
-// by anything else survive.
-func createOrUpdateAppSecret(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, name, value string) error {
+// namespace, reporting whether the stored value actually changed. On update
+// only Data is replaced, so labels or annotations added by anything else
+// survive. A write with identical data is skipped entirely, so a no-op
+// reconcile never reports a change and cannot trigger a spurious redeploy.
+func createOrUpdateAppSecret(ctx context.Context, c client.Client, namespace, appName, owner, name, value string) (bool, error) {
 	data := map[string][]byte{appcfg.AppSecretValueKey: []byte(value)}
 
 	existing := new(corev1.Secret)
-	err := c.Get(ctx, client.ObjectKey{Namespace: appConfig.Namespace, Name: name}, existing)
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, existing)
 	if err == nil {
+		if bytes.Equal(existing.Data[appcfg.AppSecretValueKey], data[appcfg.AppSecretValueKey]) &&
+			len(existing.Data) == len(data) {
+			return false, nil
+		}
 		original := existing.DeepCopy()
 		existing.Data = data
-		return c.Patch(ctx, existing, client.MergeFrom(original))
+		if err := c.Patch(ctx, existing, client.MergeFrom(original)); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return err
+		return false, err
 	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: appConfig.Namespace,
+			Namespace: namespace,
 			Labels: map[string]string{
-				constants.ApplicationNameLabel:  appConfig.AppName,
-				constants.ApplicationOwnerLabel: appConfig.OwnerName,
+				constants.ApplicationNameLabel:  appName,
+				constants.ApplicationOwnerLabel: owner,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
 	}
 	if err := c.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 // GetDeployedReleaseVersion check whether app has been deployed and return release chart version

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -318,6 +318,134 @@ func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.Applica
 	return appEnv, nil
 }
 
+// ApplySecrets materializes the manifest's secrets[] block into Kubernetes
+// Secrets in the app namespace. Each entry pulls one Olares-provided env var
+// (a SystemEnv or UserEnv, referenced exactly like envs[].valueFrom) into its
+// own Secret, named verbatim after the entry, holding the value under
+// manifest.AppSecretValueKey. The chart then consumes it with a plain
+// secretKeyRef, so the value never lands in the pod spec as a literal env var
+// the way olaresEnv values do.
+//
+// Unlike ApplyAppEnv, nothing is persisted into an AppEnv CR: the Secret is
+// the storage. Values are re-resolved and rewritten on every install/upgrade
+// so a changed SystemEnv/UserEnv propagates.
+//
+// TODO(structured-secrets): one entry == one single-valued Secret. Once the
+// Olares UX can author multi-key secrets, group entries sharing a name into a
+// single Secret with one key each.
+func ApplySecrets(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) error {
+	if appConfig == nil {
+		return fmt.Errorf("app config is nil")
+	}
+
+	if len(appConfig.Secrets) == 0 {
+		klog.Infof("No secrets found for app: %s owner: %s, skip app secret apply", appConfig.AppName, appConfig.OwnerName)
+		return nil
+	}
+
+	refEnvs, err := listReferenceableEnvs(ctx, c, appConfig.OwnerName)
+	if err != nil {
+		return fmt.Errorf("failed to list referenced envs: %w", err)
+	}
+
+	// The namespace normally already exists (ApplyAppEnv creates it), but an
+	// app may declare secrets[] without any envs[], so ensure it here too.
+	appNS := new(corev1.Namespace)
+	appNS.SetName(appConfig.Namespace)
+	if err := c.Create(ctx, appNS); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(appConfig.Secrets))
+	for _, s := range appConfig.Secrets {
+		if s.Name == "" {
+			return fmt.Errorf("app %s declares a secret without a name", appConfig.AppName)
+		}
+		if _, dup := seen[s.Name]; dup {
+			// Two entries writing the same Secret would silently clobber each
+			// other, so reject rather than pick a winner.
+			return fmt.Errorf("app %s declares secret %q more than once", appConfig.AppName, s.Name)
+		}
+		seen[s.Name] = struct{}{}
+
+		if s.ValueFrom == nil || s.ValueFrom.EnvName == "" {
+			return fmt.Errorf("secret %q of app %s must set valueFrom.envName", s.Name, appConfig.AppName)
+		}
+		value, ok := refEnvs[s.ValueFrom.EnvName]
+		if !ok {
+			return fmt.Errorf("secret %q of app %s references unknown env %q", s.Name, appConfig.AppName, s.ValueFrom.EnvName)
+		}
+
+		if err := createOrUpdateAppSecret(ctx, c, appConfig, s.Name, value); err != nil {
+			return fmt.Errorf("failed to apply secret %q of app %s: %w", s.Name, appConfig.AppName, err)
+		}
+	}
+
+	klog.Infof("applied %d secret(s) for app: %s, owner: %s", len(appConfig.Secrets), appConfig.AppName, appConfig.OwnerName)
+	return nil
+}
+
+// listReferenceableEnvs returns the Olares-provided env vars a manifest may
+// pull from, keyed by env name: cluster-scoped SystemEnvs overlaid with the
+// owner's UserEnvs. Mirrors the resolution the AppEnv handler performs for
+// envs[].valueFrom so both pull mechanisms see the same value space.
+func listReferenceableEnvs(ctx context.Context, c client.Client, owner string) (map[string]string, error) {
+	refEnvs := make(map[string]string)
+
+	sysenvs := new(sysv1alpha1.SystemEnvList)
+	if err := c.List(ctx, sysenvs); err != nil {
+		return nil, err
+	}
+	for _, sysenv := range sysenvs.Items {
+		refEnvs[sysenv.EnvName] = sysenv.GetEffectiveValue()
+	}
+
+	userenvs := new(sysv1alpha1.UserEnvList)
+	if err := c.List(ctx, userenvs, client.InNamespace(utils.UserspaceName(owner))); err != nil {
+		return nil, err
+	}
+	for _, userenv := range userenvs.Items {
+		refEnvs[userenv.EnvName] = userenv.GetEffectiveValue()
+	}
+
+	return refEnvs, nil
+}
+
+// createOrUpdateAppSecret writes a single-valued Opaque Secret into the app
+// namespace. On update only Data is replaced, so labels or annotations added
+// by anything else survive.
+func createOrUpdateAppSecret(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig, name, value string) error {
+	data := map[string][]byte{appcfg.AppSecretValueKey: []byte(value)}
+
+	existing := new(corev1.Secret)
+	err := c.Get(ctx, client.ObjectKey{Namespace: appConfig.Namespace, Name: name}, existing)
+	if err == nil {
+		original := existing.DeepCopy()
+		existing.Data = data
+		return c.Patch(ctx, existing, client.MergeFrom(original))
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: appConfig.Namespace,
+			Labels: map[string]string{
+				constants.ApplicationNameLabel:  appConfig.AppName,
+				constants.ApplicationOwnerLabel: appConfig.OwnerName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	if err := c.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
 // GetDeployedReleaseVersion check whether app has been deployed and return release chart version
 func GetDeployedReleaseVersion(actionConfig *action.Configuration, appName string) (string, int, error) {
 	client := action.NewGet(actionConfig)
@@ -1112,6 +1240,7 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		Provider:             cfg.Provider,
 		Type:                 cfg.ConfigType,
 		Envs:                 cfg.Envs,
+		Secrets:              cfg.Secrets,
 		Images:               cfg.Options.Images,
 		AllowMultipleInstall: cfg.Options.AllowMultipleInstall,
 		PodsSelectors:        podSelectors,

--- a/framework/app-service/pkg/utils/app/secrets_test.go
+++ b/framework/app-service/pkg/utils/app/secrets_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
@@ -97,7 +98,7 @@ func userEnv(owner, name, value string) *sysv1alpha1.UserEnv {
 	}
 }
 
-func secretsAppConfig(secrets ...appcfg.AppSecret) *appcfg.ApplicationConfig {
+func secretsAppConfig(secrets ...appcfg.AppSecretVar) *appcfg.ApplicationConfig {
 	return &appcfg.ApplicationConfig{
 		AppName:   testAppName,
 		OwnerName: testOwner,
@@ -106,8 +107,8 @@ func secretsAppConfig(secrets ...appcfg.AppSecret) *appcfg.ApplicationConfig {
 	}
 }
 
-func appSecret(name, envName string) appcfg.AppSecret {
-	return appcfg.AppSecret{
+func appSecret(name, envName string) appcfg.AppSecretVar {
+	return appcfg.AppSecretVar{
 		Name:      name,
 		ValueFrom: &sysv1alpha1.ValueFrom{EnvName: envName},
 	}
@@ -207,25 +208,25 @@ func TestApplySecretsUserEnvOverridesSystemEnv(t *testing.T) {
 func TestApplySecretsErrors(t *testing.T) {
 	cases := []struct {
 		name    string
-		secrets []appcfg.AppSecret
+		secrets []appcfg.AppSecretVar
 	}{
 		{
 			name:    "unknown env reference",
-			secrets: []appcfg.AppSecret{appSecret("api-token", "NOPE")},
+			secrets: []appcfg.AppSecretVar{appSecret("api-token", "NOPE")},
 		},
 		{
 			name:    "missing valueFrom",
-			secrets: []appcfg.AppSecret{{Name: "api-token"}},
+			secrets: []appcfg.AppSecretVar{{Name: "api-token"}},
 		},
 		{
 			name:    "empty name",
-			secrets: []appcfg.AppSecret{appSecret("", "OLARES_API_TOKEN")},
+			secrets: []appcfg.AppSecretVar{appSecret("", "OLARES_API_TOKEN")},
 		},
 		{
 			// Two entries targeting one Secret would clobber each other; the
 			// single-value-per-Secret model has no way to merge them.
 			name: "duplicate secret name",
-			secrets: []appcfg.AppSecret{
+			secrets: []appcfg.AppSecretVar{
 				appSecret("api-token", "OLARES_API_TOKEN"),
 				appSecret("api-token", "OLARES_API_TOKEN"),
 			},
@@ -239,6 +240,135 @@ func TestApplySecretsErrors(t *testing.T) {
 				t.Fatal("expected an error, got nil")
 			}
 		})
+	}
+}
+
+// TestApplySecretsForReportsOnlyRealChanges pins the change-detection contract
+// the AppEnv controller relies on to decide whether a rotation warrants a
+// redeploy. Re-applying identical data must report nothing, otherwise every
+// no-op reconcile would trigger a spurious helm upgrade.
+func TestApplySecretsForReportsOnlyRealChanges(t *testing.T) {
+	ctx := context.Background()
+	c := newSecretsTestClient(
+		systemEnv("OLARES_API_TOKEN", "tok"),
+		systemEnv("OLARES_OTHER", "other"),
+	)
+	secrets := []appcfg.AppSecretVar{
+		appSecret("api-token", "OLARES_API_TOKEN"),
+		appSecret("other", "OLARES_OTHER"),
+	}
+
+	changed, err := ApplySecretsFor(ctx, c, testNamespace, testAppName, testOwner, secrets)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if len(changed) != 2 {
+		t.Fatalf("first apply changed = %v, want both secrets created", changed)
+	}
+
+	changed, err = ApplySecretsFor(ctx, c, testNamespace, testAppName, testOwner, secrets)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("re-applying identical data changed = %v, want none", changed)
+	}
+
+	env := new(sysv1alpha1.SystemEnv)
+	if err := c.Get(ctx, client.ObjectKey{Name: "OLARES_API_TOKEN"}, env); err != nil {
+		t.Fatalf("get systemenv: %v", err)
+	}
+	env.Value = "rotated"
+	if err := c.Update(ctx, env); err != nil {
+		t.Fatalf("update systemenv: %v", err)
+	}
+
+	changed, err = ApplySecretsFor(ctx, c, testNamespace, testAppName, testOwner, secrets)
+	if err != nil {
+		t.Fatalf("third apply: %v", err)
+	}
+	if len(changed) != 1 || changed[0] != "api-token" {
+		t.Fatalf("after rotating one env, changed = %v, want [api-token]", changed)
+	}
+}
+
+// TestApplyAppEnvRecordsSecretDeclarations covers the link that makes live
+// propagation possible at all: the declarations must land on the AppEnv CR,
+// because that is the only thing the SystemEnv/UserEnv controllers can scan to
+// discover which apps reference a rotated variable.
+func TestApplyAppEnvRecordsSecretDeclarations(t *testing.T) {
+	ctx := context.Background()
+	c := newSecretsTestClient(systemEnv("OLARES_API_TOKEN", "tok"))
+
+	cfg := secretsAppConfig(appSecret("api-token", "OLARES_API_TOKEN"))
+	appEnv, err := ApplyAppEnv(ctx, c, cfg)
+	if err != nil {
+		t.Fatalf("ApplyAppEnv: %v", err)
+	}
+	if appEnv == nil {
+		t.Fatal("ApplyAppEnv returned nil for an app declaring only secrets")
+	}
+
+	stored := new(sysv1alpha1.AppEnv)
+	key := client.ObjectKey{Namespace: testNamespace, Name: FormatAppEnvName(testAppName, testOwner)}
+	if err := c.Get(ctx, key, stored); err != nil {
+		t.Fatalf("get appenv: %v", err)
+	}
+	if len(stored.Secrets) != 1 {
+		t.Fatalf("appEnv.Secrets = %+v, want one declaration", stored.Secrets)
+	}
+	if stored.Secrets[0].Name != "api-token" {
+		t.Errorf("recorded name = %q, want api-token", stored.Secrets[0].Name)
+	}
+	if stored.Secrets[0].ValueFrom == nil || stored.Secrets[0].ValueFrom.EnvName != "OLARES_API_TOKEN" {
+		t.Errorf("recorded valueFrom = %+v, want OLARES_API_TOKEN", stored.Secrets[0].ValueFrom)
+	}
+}
+
+// TestApplyAppEnvDoesNotRecordSecretValues is the guard on the core privacy
+// property: the AppEnv CR must never carry a resolved secret value. AppSecretVar
+// has no value field today; this fails loudly if one is ever added and populated.
+func TestApplyAppEnvDoesNotRecordSecretValues(t *testing.T) {
+	ctx := context.Background()
+	const secretValue = "super-secret-value"
+	c := newSecretsTestClient(systemEnv("OLARES_API_TOKEN", secretValue))
+
+	cfg := secretsAppConfig(appSecret("api-token", "OLARES_API_TOKEN"))
+	if _, err := ApplyAppEnv(ctx, c, cfg); err != nil {
+		t.Fatalf("ApplyAppEnv: %v", err)
+	}
+	if err := ApplySecrets(ctx, c, cfg); err != nil {
+		t.Fatalf("ApplySecrets: %v", err)
+	}
+
+	stored := new(sysv1alpha1.AppEnv)
+	key := client.ObjectKey{Namespace: testNamespace, Name: FormatAppEnvName(testAppName, testOwner)}
+	if err := c.Get(ctx, key, stored); err != nil {
+		t.Fatalf("get appenv: %v", err)
+	}
+
+	serialized, err := yaml.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal appenv: %v", err)
+	}
+	if strings.Contains(string(serialized), secretValue) {
+		t.Fatalf("resolved secret value leaked into the AppEnv CR:\n%s", serialized)
+	}
+}
+
+// TestApplyAppEnvSecretsDoNotMutateConfig guards against writing the pending
+// status through the shared ValueFrom pointer, which would mutate the caller's
+// ApplicationConfig.
+func TestApplyAppEnvSecretsDoNotMutateConfig(t *testing.T) {
+	ctx := context.Background()
+	c := newSecretsTestClient(systemEnv("OLARES_API_TOKEN", "tok"))
+
+	cfg := secretsAppConfig(appSecret("api-token", "OLARES_API_TOKEN"))
+	if _, err := ApplyAppEnv(ctx, c, cfg); err != nil {
+		t.Fatalf("ApplyAppEnv: %v", err)
+	}
+	if s := cfg.Secrets[0].ValueFrom.Status; s != "" {
+		t.Errorf("caller's config was mutated: ValueFrom.Status = %q, want empty", s)
 	}
 }
 

--- a/framework/app-service/pkg/utils/app/secrets_test.go
+++ b/framework/app-service/pkg/utils/app/secrets_test.go
@@ -1,0 +1,260 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+const (
+	testOwner     = "alice"
+	testAppName   = "mailer"
+	testNamespace = "mailer-alice"
+)
+
+// TestSecretsBlockParses pins the manifest schema: a top-level secrets[] block
+// must survive the same YAML decoding the oac loader performs. Without the
+// struct tags on manifest.AppConfiguration the block is silently dropped rather
+// than rejected, so this guards against a regression that would fail closed and
+// leave apps with no secret at all.
+func TestSecretsBlockParses(t *testing.T) {
+	const manifestYAML = `
+olaresManifest.version: 0.12.0
+apiVersion: v3
+metadata:
+  name: mailer
+  title: Mailer
+  version: 1.0.0
+spec:
+  namespace: mailer
+secrets:
+  - name: smtp-password
+    valueFrom:
+      envName: OLARES_USER_SMTP_PASSWORD
+  - name: api-token
+    valueFrom:
+      envName: OLARES_API_TOKEN
+`
+
+	var cfg appcfg.AppConfiguration
+	if err := yaml.Unmarshal([]byte(manifestYAML), &cfg); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+
+	if len(cfg.Secrets) != 2 {
+		t.Fatalf("expected 2 secrets, got %d (%+v)", len(cfg.Secrets), cfg.Secrets)
+	}
+	if cfg.Secrets[0].Name != "smtp-password" {
+		t.Errorf("secret[0].name = %q, want smtp-password", cfg.Secrets[0].Name)
+	}
+	if cfg.Secrets[0].ValueFrom == nil || cfg.Secrets[0].ValueFrom.EnvName != "OLARES_USER_SMTP_PASSWORD" {
+		t.Errorf("secret[0].valueFrom = %+v, want envName OLARES_USER_SMTP_PASSWORD", cfg.Secrets[0].ValueFrom)
+	}
+	if cfg.Secrets[1].Name != "api-token" {
+		t.Errorf("secret[1].name = %q, want api-token", cfg.Secrets[1].Name)
+	}
+}
+
+// newSecretsTestScheme builds the scheme inline rather than using pkg/testutil,
+// which would introduce an import cycle back into this package via appinstaller.
+func newSecretsTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(sysv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newSecretsTestClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newSecretsTestScheme()).
+		WithObjects(objs...).
+		Build()
+}
+
+func systemEnv(name, value string) *sysv1alpha1.SystemEnv {
+	return &sysv1alpha1.SystemEnv{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		EnvVarSpec: sysv1alpha1.EnvVarSpec{EnvName: name, Value: value},
+	}
+}
+
+func userEnv(owner, name, value string) *sysv1alpha1.UserEnv {
+	return &sysv1alpha1.UserEnv{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: utils.UserspaceName(owner)},
+		EnvVarSpec: sysv1alpha1.EnvVarSpec{EnvName: name, Value: value},
+	}
+}
+
+func secretsAppConfig(secrets ...appcfg.AppSecret) *appcfg.ApplicationConfig {
+	return &appcfg.ApplicationConfig{
+		AppName:   testAppName,
+		OwnerName: testOwner,
+		Namespace: testNamespace,
+		Secrets:   secrets,
+	}
+}
+
+func appSecret(name, envName string) appcfg.AppSecret {
+	return appcfg.AppSecret{
+		Name:      name,
+		ValueFrom: &sysv1alpha1.ValueFrom{EnvName: envName},
+	}
+}
+
+// TestApplySecretsCreatesOnePerEntry covers the core contract: each entry
+// becomes its own Secret, named verbatim, holding the resolved value under the
+// constant key a chart's secretKeyRef hardcodes.
+func TestApplySecretsCreatesOnePerEntry(t *testing.T) {
+	c := newSecretsTestClient(
+		systemEnv("OLARES_API_TOKEN", "tok-123"),
+		userEnv(testOwner, "OLARES_USER_SMTP_PASSWORD", "hunter2"),
+	)
+
+	cfg := secretsAppConfig(
+		appSecret("smtp-password", "OLARES_USER_SMTP_PASSWORD"),
+		appSecret("api-token", "OLARES_API_TOKEN"),
+	)
+
+	if err := ApplySecrets(context.Background(), c, cfg); err != nil {
+		t.Fatalf("ApplySecrets: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"smtp-password": "hunter2",
+		"api-token":     "tok-123",
+	} {
+		got := new(corev1.Secret)
+		if err := c.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: name}, got); err != nil {
+			t.Fatalf("get secret %s: %v", name, err)
+		}
+		if v := string(got.Data[appcfg.AppSecretValueKey]); v != want {
+			t.Errorf("secret %s[%s] = %q, want %q", name, appcfg.AppSecretValueKey, v, want)
+		}
+		if got.Type != corev1.SecretTypeOpaque {
+			t.Errorf("secret %s type = %q, want Opaque", name, got.Type)
+		}
+	}
+}
+
+// TestApplySecretsUpdatesExistingValue ensures a changed SystemEnv propagates on
+// re-apply (upgrade), rather than the first value sticking forever.
+func TestApplySecretsUpdatesExistingValue(t *testing.T) {
+	c := newSecretsTestClient(systemEnv("OLARES_API_TOKEN", "old"))
+	cfg := secretsAppConfig(appSecret("api-token", "OLARES_API_TOKEN"))
+
+	ctx := context.Background()
+	if err := ApplySecrets(ctx, c, cfg); err != nil {
+		t.Fatalf("first ApplySecrets: %v", err)
+	}
+
+	env := new(sysv1alpha1.SystemEnv)
+	if err := c.Get(ctx, client.ObjectKey{Name: "OLARES_API_TOKEN"}, env); err != nil {
+		t.Fatalf("get systemenv: %v", err)
+	}
+	env.Value = "new"
+	if err := c.Update(ctx, env); err != nil {
+		t.Fatalf("update systemenv: %v", err)
+	}
+
+	if err := ApplySecrets(ctx, c, cfg); err != nil {
+		t.Fatalf("second ApplySecrets: %v", err)
+	}
+
+	got := new(corev1.Secret)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "api-token"}, got); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if v := string(got.Data[appcfg.AppSecretValueKey]); v != "new" {
+		t.Errorf("value = %q, want %q (re-apply must refresh)", v, "new")
+	}
+}
+
+// TestApplySecretsUserEnvOverridesSystemEnv documents the precedence inherited
+// from the envs[] resolution: the owner's UserEnv wins over a same-named
+// cluster SystemEnv.
+func TestApplySecretsUserEnvOverridesSystemEnv(t *testing.T) {
+	c := newSecretsTestClient(
+		systemEnv("OLARES_SHARED", "system-value"),
+		userEnv(testOwner, "OLARES_SHARED", "user-value"),
+	)
+	cfg := secretsAppConfig(appSecret("shared", "OLARES_SHARED"))
+
+	if err := ApplySecrets(context.Background(), c, cfg); err != nil {
+		t.Fatalf("ApplySecrets: %v", err)
+	}
+
+	got := new(corev1.Secret)
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "shared"}, got); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if v := string(got.Data[appcfg.AppSecretValueKey]); v != "user-value" {
+		t.Errorf("value = %q, want user-value", v)
+	}
+}
+
+func TestApplySecretsErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		secrets []appcfg.AppSecret
+	}{
+		{
+			name:    "unknown env reference",
+			secrets: []appcfg.AppSecret{appSecret("api-token", "NOPE")},
+		},
+		{
+			name:    "missing valueFrom",
+			secrets: []appcfg.AppSecret{{Name: "api-token"}},
+		},
+		{
+			name:    "empty name",
+			secrets: []appcfg.AppSecret{appSecret("", "OLARES_API_TOKEN")},
+		},
+		{
+			// Two entries targeting one Secret would clobber each other; the
+			// single-value-per-Secret model has no way to merge them.
+			name: "duplicate secret name",
+			secrets: []appcfg.AppSecret{
+				appSecret("api-token", "OLARES_API_TOKEN"),
+				appSecret("api-token", "OLARES_API_TOKEN"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newSecretsTestClient(systemEnv("OLARES_API_TOKEN", "tok"))
+			if err := ApplySecrets(context.Background(), c, secretsAppConfig(tc.secrets...)); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}
+
+// TestApplySecretsNoOpWithoutDeclaration keeps apps that declare no secrets[]
+// completely untouched.
+func TestApplySecretsNoOpWithoutDeclaration(t *testing.T) {
+	c := newSecretsTestClient()
+	if err := ApplySecrets(context.Background(), c, secretsAppConfig()); err != nil {
+		t.Fatalf("ApplySecrets: %v", err)
+	}
+
+	list := new(corev1.SecretList)
+	if err := c.List(context.Background(), list); err != nil {
+		t.Fatalf("list secrets: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected no secrets created, got %d", len(list.Items))
+	}
+}


### PR DESCRIPTION
**Repo:** `beclab/Olares` · **Branch:** `feat/manifest-secrets-block` · **Lands:** SECOND

> [!IMPORTANT]
> **Blocked on beclab/api#5** — "feat(manifest): add top-level `secrets[]` block to OlaresManifest".
> This branch does **not** compile in CI until that merges *and* the one-line `go.mod` bump below is
> applied. See [Before merging](#before-merging).

## What

Implements the top-level `secrets:` block of `OlaresManifest.yaml`:

```yaml
secrets:
  - name: smtp-password
    valueFrom:
      envName: OLARES_USER_SMTP_PASSWORD
    applyOnChange: true
```

Each declaration becomes its own Opaque Secret in the app namespace, named verbatim, holding the
resolved value under the constant key `value`. The chart references it with nothing templated:

```yaml
env:
  - name: SMTP_PASSWORD
    valueFrom:
      secretKeyRef:
        name: smtp-password
        key: value
```

## Why

The existing `envs[].valueFrom` path resolves a SystemEnv/UserEnv and renders it into
`.Values.olaresEnv.<NAME>`, which charts drop into the container `env:` as a **literal value** — so
it is visible to anyone who can read the Deployment or its ReplicaSet. `secrets[]` keeps such values
in a Secret instead, letting authors write meaningfully safer charts.

This mirrors the model middleware credentials already use (`tapr` renders `secretKeyRef` against a
provisioned Secret) rather than inventing a new one.

## Change propagation

Rotating a referenced SystemEnv/UserEnv reaches secret-backed apps through the **same chain that
already propagates env changes** — not a parallel mechanism:

```
SystemEnv/UserEnv change
  → SystemEnv/UserEnv controller: appEnvReferences(appEnv)   ← now scans Secrets, not just Envs
  → annotate AppEnv → AppEnvController.syncSecretValues
  → ApplySecretsFor rewrites the Secret, reports what changed
  → if the declaration set applyOnChange → NeedApply → ApplyEnvOp → helm upgrade → pods restart
```

Recording the declarations on the `AppEnv` CR (the api PR) is what makes the affected apps
discoverable; `appEnvReferences` — shared by both env controllers so they cannot drift — now matches
`secrets[]` as well as `envs[]`. This inherits the operational guards already proven on that path:
deferral while an app is `Stopped`, the `env-batch-lock` lease, and re-enqueue on resume.

## Design notes

- **No new CRD.** The Kubernetes Secret is the storage.
- **The resolved value is never written onto the `AppEnv` CR** — only the declaration. `AppSecretVar`
  has no field to hold a value. Change detection compares against the existing Secret, which already
  holds the previous value, so nothing sensitive (nor a hash of it) is persisted for that purpose.
  A test serializes the CR and fails if the value ever appears in it.
- **`applyOnChange` gates the redeploy.** Secret values are injected into pods at start time, so
  without a redeploy the Secret is refreshed while running pods keep serving the old value. A changed
  secret without `applyOnChange` refreshes the Secret silently and takes effect on the next restart.
- **No spurious redeploys.** Re-applying identical data reports no change, so a no-op reconcile
  cannot trigger a helm upgrade.
- **Precedence** follows `envs[]`: the owner's UserEnv overrides a same-named cluster SystemEnv.
- **Fails closed** on a bad declaration (unknown env reference, missing `valueFrom.envName`, empty
  name, duplicate names) rather than silently producing an empty Secret.
- **Cleanup is inherited**: uninstall deletes the app namespace (`helm_ops_uninstall.go:79`), which
  removes the Secrets. No teardown code added.

`TODO(structured-secrets)` marks the single-value-per-Secret shape; multi-key secrets are deferred
until the Olares UX can author them.

## Changes

| File | Change |
|---|---|
| `pkg/appcfg/types.go` | `AppSecretVar` alias + re-exported `AppSecretValueKey` |
| `pkg/appcfg/application.go` | `Secrets` on `ApplicationConfig` (round-trips through the JSON `Spec.Config`) |
| `pkg/utils/app/app.go` | record `secrets[]` on the AppEnv CR in `ApplyAppEnv`; change-aware `ApplySecretsFor` returning the names that changed; shared `validateAppSecretDecls` |
| `controllers/appenv_controller.go` | `syncSecretValues` (→ `NeedApply` on real change when `applyOnChange`); shared `appEnvReferences` helper |
| `controllers/systemenv_controller.go`, `controllers/userenv_controller.go` | `isReferenced` delegates to `appEnvReferences`, which now scans `Secrets` |
| `pkg/utils/app/secrets_test.go`, `controllers/appenv_secrets_test.go` | new tests |
| `.gitignore` | ignore `.deps/` + `go.work.sum` for the cross-repo workflow (see below) |

## Tests

- schema block decodes into the config (guards a silent-drop regression: the loader is non-strict, so
  a missing struct tag would fail *closed* with no secret at all)
- one Secret per declaration; correct name/key/value/type
- `ApplySecretsFor` reports only real changes (create → change; identical re-apply → none; rotate one
  of two → just that one) — the contract the redeploy decision rests on
- declarations are recorded on the `AppEnv` CR; the resolved value is **not** (serialize-and-scan)
- the pending status write does not mutate the caller's `ApplicationConfig`
- `appEnvReferences` matches via env, via secret, and mixed; ignores a declaration without `valueFrom`
- structural guard: `AppSecretVar` has no value-bearing field
- UserEnv overrides SystemEnv; four failure modes; no-op when no `secrets[]`

## Before merging

1. Merge beclab/api#5.
2. Bump the pin in `framework/app-service/go.mod`:
   `cd framework/app-service && go get github.com/beclab/api@<merge-sha>`
3. Re-run: `go build ./framework/app-service/...` and
   `go test ./framework/app-service/pkg/appcfg/... ./framework/app-service/pkg/utils/app/... ./framework/app-service/controllers/...`
4. `gh pr ready` this PR.

The bump is intentionally **not** in this branch: the target pseudo-version does not exist yet, so
committing a placeholder would only produce a misleading diff.

## Verification so far

Verified locally with a gitignored `go.work` pointing at a local `beclab/api` checkout of the api PR:

- `go build ./framework/app-service/...` passes; `vet` clean on the touched packages
- `appcfg`, `utils/app`, `controllers` suites pass, including the new tests
- `framework/oac` builds and its full suite passes against the same schema

Two failures in the wider app-service suite — `TestMatchVersion` and a 600s hang in `pkg/task` — are
**pre-existing**, confirmed by stashing this branch's changes and reproducing them at `main`.

> On this machine the build needs `-tags exclude_graphdriver_btrfs`; `containers/storage` wants btrfs
> headers. Unrelated to this change.

## Not included (follow-ups)

- **`oac` validation for `secrets[]`.** oac parses non-strictly, so a typo'd entry currently passes
  `chart lint` silently and only surfaces at install. Natural rules: non-empty `name`, valid
  DNS-1123 subdomain, `valueFrom.envName` required, no duplicates. Own PR (also needs oac's `v0.0.17`
  pin bumped); benefits `cli` immediately via its local `replace`.
- **Docs** for chart authors (`docs/developer/develop/package/manifest.md` + the `zh` counterpart),
  and a pointer from the existing `type: password` env example toward `secrets[]`.

## Note on the `.gitignore` hunk

Adds `.deps/` and `go.work.sum` so a local checkout of `github.com/beclab/api` can be wired in via a
(gitignored) `go.work` while developing across both repos. Unrelated to the runtime change and easy
to drop if you'd rather not carry it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
