### PR TITLE
olares, notifications: bump user-service to v0.1.7 and notifications-api to v1.12.44

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -420,10 +420,12 @@ spec:
               value: os.files.{{ .Values.bfl.username}}
             - name: NATS_SUBJECT_KNOWLEDGE
               value: os.knowledge.{{ .Values.bfl.username}}
+            - name: NATS_SUBJECT_DOWNLOAD_STATUS
+              value: os.download_status
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.6
+          image: beclab/user-service:v0.1.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -475,6 +477,8 @@ spec:
               value: os.application.{{ .Values.bfl.username}}
             - name: NATS_SUBJECT_USER_NOTIFICATION
               value: os.notification.{{ .Values.bfl.username}}
+            - name: NATS_SUBJECT_DOWNLOAD_STATUS
+              value: os.download_status
             - name: NATS_SUBJECT_FILES
               value: os.files.{{ .Values.bfl.username}}
             - name: NATS_SUBJECT_KNOWLEDGE
@@ -1389,6 +1393,10 @@ spec:
           pub: allow
           sub: allow
       - name: seahub.{{ .Values.bfl.username }}
+        permission:
+          sub: allow
+          pub: allow
+      - name: download_status
         permission:
           sub: allow
           pub: allow

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.43
+        image: beclab/notifications-api:v1.12.44
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**
Bump the bundled sub-system images to their latest releases:
- `beclab/user-service`: `v0.1.6` -> `v0.1.7`
- `beclab/notifications-api`: `v1.12.43` -> `v1.12.44`

These updates pull in the latest fixes and improvements from the user-service and notifications sub-systems.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
None

* **Other information**:
Image references are updated in:
- `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml`
- `framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml`