### PR TITLE
feat(cli): add listing-asset production to olares-publish skill

### DIFF
--- a/cli/skills/README.md
+++ b/cli/skills/README.md
@@ -36,7 +36,8 @@ cli/skills/
 │   └── references/    # one file per refinement area / capability
 └── olares-publish/    # public Olares Market distribution (beclab/apps PR, paid apps)
     ├── SKILL.md
-    └── references/    # market-ready targets / submit / paid-apps
+    ├── references/    # market-ready targets / submit / paid-apps / listing assets
+    └── scripts/       # executable helpers for producing listing assets
 ```
 
 **Install the whole suite together.** These skills are designed as one set and cross-reference each other by relative path (e.g. `../olares-shared/SKILL.md`, `../olares-shared/references/olares-platform.md`). Installing only a subset leaves those links dangling. `olares-shared` is the foundation — every runtime skill cross-references it for profile selection, login, and HTTP 401/403 recovery, **and it hosts the cross-skill platform model** ([`olares-shared/references/olares-platform.md`](olares-shared/references/olares-platform.md)) that `files` / `chart` / `cluster` link to (one hop from their `SKILL.md`) instead of re-describing it.
@@ -44,6 +45,8 @@ cli/skills/
 `olares-chart` is a partial exception on **login**, not on linking: its authoring verbs (`from-compose` / `lint` / `package`) are local-only and need **no profile / login / cluster**, so it never logs in to author a chart. It still reads `olares-platform.md` for platform facts (no login needed) and only requires `olares-shared` login when **deploying a chart to a real Olares** (`market upload` + `install`). `olares-publish` is the public-distribution counterpart: it picks up after the app already runs locally (via `olares-chart`) and covers market-ready polish, the `beclab/apps` PR, and paid apps.
 
 ClawHub publishes the entire skill directory (including `references/`), so reference files ship automatically without any change to `publish.sh`.
+
+**`olares-publish/scripts/` is the one deliberate exception to markdown-only.** Producing a Market icon is deterministic pixel work — corner sampling, edge flood-fill to strip a white backplate, gradient backplate, safe-zone fit — and prose that asks each agent to re-derive it yields a different icon every run. Shipping the script makes the output reproducible. Same mechanism as `references/`: `publish.sh` runs `clawhub skill publish "$dir"` on the whole folder, so scripts upload with no change to the publish helper. Keep this rare — a script earns its place only when the task is exactly specified and the agent would otherwise improvise.
 
 ## Writing style
 

--- a/cli/skills/olares-publish/SKILL.md
+++ b/cli/skills/olares-publish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-publish
-version: 4.3.2
-description: "Publish an Olares app that already runs locally to a public Olares Market listing — release targets, market-ready metadata/images/architectures, the beclab/apps PR and GitBot lifecycle, and paid listings. Use for submitting, distributing, 上架, opening a beclab/apps PR, or selling an app; not for browsing `market list` or managing installed apps."
+version: 4.4.0
+description: "Publish an Olares app that already runs locally to a public Olares Market listing — release targets, market-ready metadata/architectures, producing the listing assets (256x256 icon, 1440x900 featured/promote images), the beclab/apps PR and GitBot lifecycle, and paid listings. Use for submitting, distributing, 上架, opening a beclab/apps PR, generating an app icon or Market screenshots, or selling an app; not for browsing `market list` or managing installed apps."
 compatibility: Requires olares-cli on PATH; PR submission needs a GitHub account
 metadata:
   openclaw:
@@ -21,7 +21,8 @@ metadata:
 - Publish / publicly list / submit / distribute / 上架 an app to the **public** Olares Market
 - Open or fix a PR to [`beclab/apps`](https://github.com/beclab/apps)
 - Sell an app (pay-to-download / paid listing)
-- Keywords: publish to Market, submit to beclab/apps, app store listing, `featuredImage` / `promoteImage`, `spec.supportArch`, multi-arch, GitBot, `owners` file, `price.yaml`, paid app
+- Produce the listing assets themselves — app icon, Market screenshots / 宣传图
+- Keywords: publish to Market, submit to beclab/apps, app store listing, app icon, `metadata.icon`, `featuredImage` / `promoteImage`, `spec.supportArch`, multi-arch, GitBot, `owners` file, `price.yaml`, paid app
 
 > **Prerequisite — the app must already run on your Olares.** Public submission without a working local install wastes GitBot cycles and reviewer time. Do the deploy loop in the [`olares-chart`](../olares-chart/SKILL.md) skill (its Deploy step) first.
 
@@ -31,15 +32,20 @@ metadata:
 
 Publishing is a **one-way diff against `beclab/apps`**, not a CLI lifecycle. There is no `olares-cli publish` verb: the only command you run is `olares-cli chart lint` (flags owned by [`../olares-chart/SKILL.md`](../olares-chart/SKILL.md)); everything else is git/GitHub plus a metadata/image/PR checklist that `lint` does **not** enforce. So the work is: take a chart that already installs and runs locally, layer on market-ready metadata + multi-arch images, then open a PR that GitBot will gate and a human will merge. You own the chart edits and PR authoring; you never run on-chain or wallet writes for the developer.
 
+**The Market is permissionless**, and that changes the job in two ways. There is no review board, so the gate is mechanical — GitBot checks title format, file scope, duplicate PRs, and category enums; it never judges whether the app is any good. Which means, first, that **only a short list can actually reject you** and everything else can ship later via an `UPDATE` PR, so treating the requirements as one flat checklist makes submission feel far heavier than it is — sort them by consequence instead ([olares-publish-targets.md](references/olares-publish-targets.md)). And second, that the honesty bar a reviewed store enforces institutionally lands on the submitter here: nothing stops a fabricated icon or a fake screenshot from reaching the catalog except the person filing the PR.
+
 ## What publishing adds on top of a working local chart
 
-A chart that installs and runs locally is **functionally** done (storage / middleware / entrances / a pullable image are all settled in `olares-chart`). Public distribution adds three layers, none of which `chart lint` enforces:
+A chart that installs and runs locally is **functionally** done (storage / middleware / entrances / a pullable image are all settled in `olares-chart`). Public distribution adds four layers, none of which `chart lint` enforces:
 
 | Layer | What it adds | Reference |
 |---|---|---|
-| **Market-ready metadata & assets** | full `metadata.*` + `spec.{developer,website,sourceCode,submitter,fullDescription}`, custom icon, dual-version `categories`, listing images, `spec.locale` | [olares-publish-targets.md](references/olares-publish-targets.md) |
+| **Market-ready metadata** | full `metadata.*` + `spec.{developer,website,sourceCode,submitter,fullDescription}`, dual-version `categories`, `spec.locale` — sorted there by what actually blocks a merge | [olares-publish-targets.md](references/olares-publish-targets.md) |
+| **Listing assets** | the 256x256 app icon (`lint`-required), and the 1440x900 hero + screenshot set (optional, deferrable) — fetched and composited, never invented | [olares-publish-icon.md](references/olares-publish-icon.md), [olares-publish-listing-images.md](references/olares-publish-listing-images.md), [olares-publish-listing-layout.md](references/olares-publish-listing-layout.md) |
 | **Multi-arch images** | build `--platform linux/amd64,linux/arm64` and declare matching `spec.supportArch` (local deploy only needs this node's arch) | [olares-publish-targets.md](references/olares-publish-targets.md) |
 | **The `beclab/apps` PR** | `owners` file, strict PR title, GitBot rules, lifecycle (`NEW`/`UPDATE`/`SUSPEND`/`REMOVE`) | [olares-publish-submit.md](references/olares-publish-submit.md) |
+
+> **Assets are fetched, not generated.** Icons and screenshots must come from the project's repo, its site, or your own running instance — a public catalog entry showing an invented mark or a fabricated UI misrepresents the upstream project, and no reviewer will catch it. Diagrams are the one thing you may draw.
 
 > **Paid (pay-to-download)** is a public-Market app plus `price.yaml` + a `VERIFIABLE_CREDENTIAL` license check — see [olares-publish-paid-apps.md](references/olares-publish-paid-apps.md).
 
@@ -47,7 +53,8 @@ A chart that installs and runs locally is **functionally** done (storage / middl
 
 ```mermaid
 flowchart TD
-  runs["app runs locally (olares-chart deploy)"] --> polish["market-ready polish: metadata, assets, multi-arch + supportArch"]
+  runs["app runs locally (olares-chart deploy)"] --> icon["icon 256x256 -- metadata.icon is lint-required"]
+  icon --> polish["market-ready polish: metadata, multi-arch + supportArch"]
   polish --> relint["chart lint after edits"]
   relint --> owners["add owners file, verify folder name"]
   owners --> pr["fork beclab/apps, draft PR [NEW][app][ver]"]
@@ -55,12 +62,16 @@ flowchart TD
   gitbot -->|waiting to submit| fix["push fixes"]
   fix --> gitbot
   gitbot -->|waiting to merge| merged["merged -> indexed in public Market"]
+  polish -.->|"optional, or later via UPDATE PR"| images["listing images 1440x900"]
+  images -.-> relint
 ```
 
-1. **Polish to market-ready** — work the requirements matrix + checklist in [olares-publish-targets.md](references/olares-publish-targets.md).
-2. **Re-lint** — `olares-cli chart lint ./<app>` after every metadata/image edit.
-3. **Submit the PR** — fork, add the OAC + `owners` file, open a `[NEW][<app>][<ver>]` PR to `beclab/apps:main`, then track GitBot labels — [olares-publish-submit.md](references/olares-publish-submit.md).
-4. **Paid?** — add `price.yaml` + license enforcement on top — [olares-publish-paid-apps.md](references/olares-publish-paid-apps.md).
+1. **Produce the icon** — on the critical path, because `metadata.icon` is required by `lint` and an app cannot merge without it. Runs fully offline, no API key — [olares-publish-icon.md](references/olares-publish-icon.md).
+2. **Produce the listing images, if you have the material** — nothing enforces these and they can ship later via an `UPDATE` PR, but they are most of what decides whether anyone clicks Install. Degrades gracefully when no image model is available — [olares-publish-listing-images.md](references/olares-publish-listing-images.md).
+3. **Polish to market-ready** — work the requirements matrix + checklist in [olares-publish-targets.md](references/olares-publish-targets.md).
+4. **Re-lint** — `olares-cli chart lint ./<app>` after every metadata/image edit.
+5. **Submit the PR** — fork, add the OAC + `owners` file, open a `[NEW][<app>][<ver>]` PR to `beclab/apps:main`, then track GitBot labels — [olares-publish-submit.md](references/olares-publish-submit.md).
+6. **Paid?** — add `price.yaml` + license enforcement on top — [olares-publish-paid-apps.md](references/olares-publish-paid-apps.md).
 
 ## Agent boundaries
 

--- a/cli/skills/olares-publish/references/olares-publish-icon.md
+++ b/cli/skills/olares-publish/references/olares-publish-icon.md
@@ -1,0 +1,113 @@
+# Produce the app icon
+
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
+> This file is *how to make* `metadata.icon`. Where it sits among the requirement tiers is in the market-ready targets from the parent SKILL.
+
+`metadata.icon` is the only listing asset the platform **requires**: `chart lint` fails without it. Note that `lint` only checks the URL is well-formed `http(s)` — a typo'd host passes validation and shows a broken image in the Market, so confirm the URL actually resolves before submitting.
+
+Target: **PNG or WEBP, 256x256, <=512 KB.** The default CDN icon is fine for local deploy and wrong for a public listing.
+
+Runs entirely offline after fetching: no API key, no hosted model. [`../scripts/generate_icon.py`](../scripts/generate_icon.py) does the compositing.
+
+## Rule zero: never generate the icon
+
+The icon must be the project's **real** mark, fetched from its GitHub repo or official site. An invented or AI-drawn icon misrepresents the upstream project in a public catalog. If no icon can be found, **stop and ask the user** — do not substitute one.
+
+## Step 1: fetch the source
+
+Search in this order, taking the first usable hit:
+
+1. Logo/icon files in the GitHub repo — usually `/`, `assets/`, `docs/`, `.github/`
+2. Logo images referenced from the README
+3. Official site favicon (SVG favicon first)
+4. Official site `og:image` or `apple-touch-icon`
+5. Logo element in the page markup
+
+Format preference: **SVG > PNG > JPG > ICO**. Save as `source_icon.svg` / `source_icon.png` before processing.
+
+### Keep the mark, drop the wordmark
+
+The icon must be a **single graphic with no text**.
+
+| What you fetched | What to do |
+|---|---|
+| Pure graphic mark | Use directly |
+| Graphic + text side by side (wordmark) | Crop to the graphic only — find the graphic's bounding box, crop, re-center |
+| Graphic and text overlapping (can't crop) | Re-fetch from `favicon` / `apple-touch-icon` — those are almost always the pure mark |
+| Text-only logo, no graphic at all | **Ask the user** whether to use it; if yes, treat as a colored background (fill 256x256) |
+
+### Resolution floor: 200px
+
+Check resolution immediately after fetching. Anything **< 200px is unusable** — scaling it up to the 180px safe zone shows visible blur. Climb this ladder instead:
+
+1. Favicon too small (e.g. 48px) -> look for the project's Flutter / mobile repo, which carries 192–512px launcher icons
+2. Main repo has nothing high-res -> try `android/app/src/main/res/mipmap-xxxhdpi/`, `assets/images/logo.png`, `public/logo512.png`
+3. Still nothing -> check Docker Hub, npm, or Flathub pages (all require a high-res icon at publish time)
+4. Genuinely low-res only -> upscale with Real-ESRGAN to >=200px, then composite
+5. Still blurry after upscaling, or source < 64px -> report back to the user and ask for a better source
+
+## Step 2: classify the background
+
+Everything downstream branches on this. The script samples a 5x5 block at each of the four corners and averages it:
+
+| Corner reading | Type | Treatment |
+|---|---|---|
+| alpha < 128 | Transparent | Default gradient + centered in the safe zone |
+| alpha >= 128, RGB all >= 240 | White / near-white | **Remove the white**, then gradient + safe zone |
+| alpha >= 128, RGB not white | Colored | Icon carries its own background — scale to fill 256x256, safe zone does not apply |
+
+White backgrounds must be removed, never kept — a white square on the Launchpad reads as a rendering bug. Removal uses **edge flood-fill**: only white regions connected to the border go transparent, so white *inside* the mark survives.
+
+Two shapes that look transparent but behave as colored: a circular or rounded-square icon (macOS style), and a transparent PNG whose mark sits on its own rounded-rect plate. Both fill 256x256.
+
+### Glow icons are the exception
+
+Some icons report transparent corners but are designed against dark: outward glow, edge bloom, warm gradients, a light mark ringed by colored halo, or the project's own site always showing it on dark. On the light gradient those go invisible and look like they're floating.
+
+Composite them onto solid `#000000` first, then run the script with `--force-bg` so it fills 256x256 and the glow survives.
+
+## Step 3: composite
+
+Constants — canvas 256x256, safe-zone margin 38px on each side (so a 180x180 centered box), vertical gradient `#FBFBFB` (top) to `#F1F1F1` (bottom). The gradient and the safe zone apply **only** to the transparent/white branch; colored icons ignore both.
+
+```bash
+python3 ../scripts/generate_icon.py source_icon.svg MyApp.png
+python3 ../scripts/generate_icon.py source_icon.png MyApp.png --force-bg          # glow / known colored
+python3 ../scripts/generate_icon.py source_icon.png MyApp.png --force-transparent # override misdetection
+```
+
+Name the output after the app (`MongoDB.png`, `sglang.png`). Needs `Pillow` and `numpy`, plus `cairosvg` for SVG input.
+
+## Step 4: verify before delivery
+
+The script self-checks and exits non-zero on failure, so a clean exit already means 256x256 / RGBA / <=512 KB. To re-check a file you did not just generate:
+
+```bash
+python3 -c "
+from PIL import Image; import os,sys
+p='MyApp.png'; img=Image.open(p); kb=os.path.getsize(p)/1024
+assert img.size==(256,256), img.size
+assert img.mode=='RGBA', img.mode
+assert kb<=512, f'{kb:.0f} KB'
+print(f'OK {p}: {img.size[0]}x{img.size[1]}, {img.mode}, {kb:.0f} KB')"
+```
+
+A 256x256 PNG rarely approaches 512 KB. If one does, re-export as WEBP — the platform accepts it for icons and it cuts size sharply. The check above is the PNG one; a fully opaque WEBP legitimately reports `RGB`, because the encoder drops an all-255 alpha channel. Only treat a missing alpha channel as a failure when the icon actually has transparent pixels.
+
+## Step 5: wire it into the manifest
+
+Upload to [imghost.olares.com](https://imghost.olares.com/) (pick **app icon**) or host it yourself, then put the URL in `metadata.icon` **and** in each `entrances[].icon` — the same URL is fine unless entrances genuinely differ:
+
+```yaml
+metadata:
+  icon: https://<your-host>/myapp-icon.png
+entrances:
+  - name: myapp
+    icon: https://<your-host>/myapp-icon.png
+```
+
+Re-run `olares-cli chart lint ./<app>` afterwards. For an app already in the Market, shipping a new icon needs an `UPDATE` PR with a version bump.
+
+## Batch mode
+
+For several apps at once: fetch, classify, and composite each one separately — background type is per-icon and a batch default will be wrong for some. Write all outputs to one directory, run the check on every file, then zip.

--- a/cli/skills/olares-publish/references/olares-publish-listing-images.md
+++ b/cli/skills/olares-publish/references/olares-publish-listing-images.md
@@ -1,0 +1,116 @@
+# Produce the listing images
+
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
+> This file is the material -> delivery pipeline for `spec.featuredImage` and `spec.promoteImage[]`. Composition, typography, and the render contract are in [olares-publish-listing-layout.md](olares-publish-listing-layout.md), its companion. The app icon is a separate asset with its own reference from the parent SKILL.
+
+Target: **JPEG, PNG or WEBP, 1440x900, <=8 MB each.** Neither field is enforced by anything — they cost you installs, not the merge. Plan for **2–6 images**: one hero plus one per feature. That is what a coherent set looks like; the platform ceiling is 8.
+
+| Image | Manifest field |
+|---|---|
+| Hero — overview copy, richest full-view screenshot | `spec.featuredImage` (exactly one) |
+| The whole set, hero first | `spec.promoteImage[]` (>=2 recommended) |
+
+## Step 1: collect the material
+
+### Screenshots — shoot your own instance first
+
+Publishing presupposes the app **already installs and reaches `running` on your Olares**. So open its entrance and capture there. Upstream marketing screenshots are the fallback, not the default: they are often stale, arbitrarily sized, and show a deployment that isn't Olares. Your own instance gives current UI at whatever resolution you want.
+
+Fall back to the official site, then README images, only when a live capture isn't possible. Never pull frames out of a low-res GIF.
+
+Whatever the source, screenshots must be **real UI**. Do not have a model draw a fake interface.
+
+### Upscale to the floor
+
+Screenshots render 700–1000px wide inside the 1440x900 frame, so the bar is "sharp enough", not "as large as possible":
+
+| Source width | Action |
+|---|---|
+| >= 1000px | Use as-is |
+| 500–999px | Real-ESRGAN 2x |
+| < 500px | Real-ESRGAN 4x, **and** tell the user detail may be soft and a better source would help |
+
+Real-ESRGAN is a local model (`pip install realesrgan basicsr`, `RealESRGANer` with `RealESRGAN_x4plus`) — no API key, but it pulls in torch.
+
+### Copy — English, lifted not written
+
+- **Headline:** the site's hero slogan, or the README's one-line description. English even for China-facing apps; it typesets better. Never write a paragraph.
+- **Features:** 2–6 core points from the features page or README list. **This count decides how many images you make.**
+- **Subhead:** optional, distilled from the feature point. Drop it if the frame gets crowded.
+
+### Brand
+
+Pull the primary color, background preference, and overall feel from the site. This feeds the per-app style prompts in the layout reference.
+
+### Icon
+
+Also grab the real icon (SVG > PNG > JPG) into `icon/`. Same rule as everywhere: fetched, never generated. Full procedure in the icon reference from the parent SKILL.
+
+## Step 2: match copy to visuals, both directions
+
+Every image's words and picture must describe the same thing. The failure to avoid is a headline about "real-time collaboration" over a screenshot of a static report.
+
+- **Hero:** platform-level value proposition + the screenshot that shows the most at once.
+- **Feature images:** one feature each. The copy names precisely what is visible.
+- **Screenshot-led:** when you have the screenshots, write copy from what they actually show. Two images may come from one interface if you crop to different regions — focus one on the comparison pane, another on the output panel and deploy button, then write to each crop.
+- **Copy-led:** when screenshots can't cover a feature, build a diagram instead — architecture, flow, node graph, data path. A generated diagram is a legitimate substitute for a screenshot; a generated *screenshot* is not.
+
+## Step 3: compose and render
+
+See [olares-publish-listing-layout.md](olares-publish-listing-layout.md) — wireframe choice, the two-frameworks-maximum rule, typography, and the render contract.
+
+## Step 4: deliver in this structure
+
+```
+{app}/
+├── 1.png              # hero -> featuredImage
+├── 2.png              # feature images, numbered
+├── 3.png
+├── screenshots/       # real captures used as source
+│   ├── screenshot_1.png
+│   └── screenshot_2.png
+└── icon/
+    └── icon.svg       # or icon.png
+```
+
+Before delivering, open every file and confirm the frame is exactly 1440x900 and under 8 MB:
+
+```bash
+python3 -c "
+from PIL import Image; import glob,os,sys
+bad=0
+for p in sorted(sum((glob.glob(e) for e in ('*.png','*.jpg','*.jpeg','*.webp')), [])):
+    im=Image.open(p); mb=os.path.getsize(p)/1048576
+    ok = im.size==(1440,900) and mb<=8
+    print(('OK  ' if ok else 'BAD '), p, f'{im.size[0]}x{im.size[1]}', f'{mb:.1f} MB')
+    bad += not ok
+sys.exit(bad)"
+```
+
+Also open each file under `screenshots/` — that check is there to catch a screenshot that was described but never actually downloaded.
+
+Ship a short note alongside the images saying where the copy came from and why the layout was chosen. If the user dislikes the result, have them pin down a color, layout, or headline and regenerate rather than re-rolling blind.
+
+## Step 5: wire into the manifest
+
+Upload to [imghost.olares.com](https://imghost.olares.com/) (pick **featured image** / **promotional image**) or host them yourself, then:
+
+```yaml
+spec:
+  featuredImage: https://<your-host>/myapp-1.png
+  promoteImage:
+    - https://<your-host>/myapp-1.png
+    - https://<your-host>/myapp-2.png
+    - https://<your-host>/myapp-3.png
+```
+
+URLs must be reachable by the Market CDN. Re-run `olares-cli chart lint ./<app>`; for a listed app, images ship via an `UPDATE` PR with a version bump.
+
+## Stop and ask when
+
+Do not improvise around any of these — pause and put it to the user:
+
+- Official site and GitHub both unreachable
+- No screenshot obtainable in any form — UI, architecture diagram, or terminal
+- No icon obtainable
+- App too unusual to extract normal feature points from (bare CLI tools often land here)

--- a/cli/skills/olares-publish/references/olares-publish-listing-layout.md
+++ b/cli/skills/olares-publish/references/olares-publish-listing-layout.md
@@ -1,0 +1,133 @@
+# Listing image composition and render contract
+
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first.
+> Material collection, copy, delivery structure, and manifest wiring are in [olares-publish-listing-images.md](olares-publish-listing-images.md). This file covers how the 1440x900 frame is laid out and rendered.
+
+## How far you can get depends on your tools
+
+Split the work at the point where a hosted image model becomes necessary. Only the last stage needs one.
+
+| Tier | Work | Needs |
+|---|---|---|
+| **Deterministic** | Collect, upscale, pre-composite, resize to exactly 1440x900, verify | Pillow only. No key. |
+| **Rendered** | Backdrop, typography, decoration generated around the screenshot region, with the real capture composited back in | An image model |
+
+The deterministic tier already delivers something shippable: real screenshot with rounded corners and a soft shadow, brand-colored gradient backdrop, headline set in a local sans with the key word highlighted. That satisfies most of the layout rules below. The rendered tier buys polish — organic lighting, 3D accents, designed decoration.
+
+Reach the rendered tier by, in order: the host agent's own image tool, then [`../scripts/render_promo.py`](../scripts/render_promo.py) if `OPENAI_API_KEY` is set. If neither is available, **say so and hand over the deterministic output** — don't quietly ship a lesser result as if it were the intended one.
+
+## Wireframes
+
+Seven frames distilled from real app-store listings:
+
+| Frame | Composition | Use when |
+|---|---|---|
+| **A** | Centered headline, full-width screenshot along the bottom | Default. Screenshot is content-rich. |
+| **B** | Headline on top, main screenshot, floating feature cards | Showing layered functionality |
+| **C** | Text left, angled screenshot right, badge | Squarish screenshot, or you want depth |
+| **D** | Text left, upright screenshot right, vertically centered | Longer copy |
+| **E** | Headline on top, mascot/brand element upper right, screenshot below | Brand has a character |
+| **F** | Centered headline, two screenshots side by side | Comparisons — dark/light, two views |
+| **G** | Full-bleed screenshot, text overlaid on top | UI is visually striking on its own |
+
+**At most two frames per app.** One frame means hero and all feature images share it. Two means the hero takes one and *every* feature image takes the other. More than that and the set stops reading as a set.
+
+## Layout rules
+
+Frame is 1440x900 (8:5).
+
+**Top-text / bottom-image is the default** — highest tolerance for varied content. Text sits in the upper third to half, headline very large, 1–3 lines, centered or edge-aligned. The screenshot occupies the lower area and may bleed off the bottom edge for a sense of continuation. Works best with wide screenshots such as dashboards.
+
+**Side-by-side** suits phone screenshots and tall panels: text on one side at roughly a third of the width, screenshot on the other, either one tall capture or several overlapping.
+
+Alignment and whether to show the icon are both judgment calls — pick what looks right. But **however you present screenshots, present them the same way across one app's set.**
+
+### Background
+
+Never flat black or flat white. Take the base tone from the site's primary color and add texture — fine grid, dot matrix, faint gradient bloom, or geometric shapes. Light or dark follows the brand and legibility. Backgrounds may vary across a set (per-feature tinting is fine) as long as the family resemblance holds.
+
+### Type
+
+- Dark background, white headline. Light background, near-black — not pure black.
+- **Highlight one or two key words in the brand accent color.** Cheap to do, and it is what separates a designed frame from a plain one.
+- One sans family (Inter, SF Pro, Roboto) across every image of the app, no exceptions.
+- Subhead optional: smaller, lower contrast — grey, or white at partial opacity.
+
+### Screenshots in frame
+
+Rounded corners and a soft drop shadow, always, so they separate from the backdrop. A macOS window chrome or a minimal device shell adds realism. Full-screen captures are not required — crop to the region that matters, or scatter several panels as overlapping cards. Blurring a full screenshot into a backdrop and floating sharp detail cards on top is a good trick when one capture has to carry two jobs.
+
+### Decoration
+
+Allowed: icons, geometric patterns, waves, scattered dots, 3D shapes, floating cards, grids, glows, gradient overlays.
+
+**Never any text** — no labels, no badges with words, no fake code. Decoration carries zero readable content.
+
+One or two elements, placed where the frame is empty. They must not crowd the headline or cover the screenshot.
+
+## Render contract
+
+Three stages. **The shipped screenshot pixels are placed by Pillow, not by the model.**
+
+This is not a stylistic preference. `POST /v1/images/edits` does not composite — it regenerates the entire canvas, so whatever the model returns in the screenshot area is its *reconstruction* of the UI, no matter how firmly the prompt says otherwise. Shipping that would violate the hard rule in the parent SKILL against fabricated UI. So the model builds the frame, and the real capture goes in afterwards.
+
+**Stage 1 — pre-composite.** With Pillow, scale and crop the real screenshot into the chosen wireframe's screenshot region. Two outputs: a pre-composited reference that fixes the spatial layout, and **the region's bounding box**, which stage 3 needs. Keep the box.
+
+**Stage 2 — render once.** Pass the references in this exact order — order is what the prompt refers to as "image 1 / image 2 / image 3":
+
+1. **Pre-composited reference** — spatial layout only. State explicitly that its greys are to be ignored.
+2. **The full-resolution screenshot** — the UI the frame is being built around. The model's rendering of it is scaffolding that stage 3 overwrites; asking for fidelity here still helps, because it keeps the surrounding lighting and perspective consistent with what finally lands there.
+3. **The first finished image** — from image 2 of the set onward, as the lock for typeface and overall tone.
+
+**Stage 3 — re-composite.** Downsample the output to exactly 1440x900, then paste the real screenshot back at the stage-1 bounding box, applying the rounded corners and drop shadow deterministically. Now every UI pixel in the deliverable is authentic.
+
+Both stages that touch the box must use the same numbers, which is why [`../scripts/render_promo.py`](../scripts/render_promo.py) owns it rather than leaving it to be re-derived.
+
+> If the model's rendered screenshot area drifts noticeably from the box — different angle, different proportions — **re-render instead of pasting over it.** A paste onto a mismatched area leaves a visible double edge, which looks worse than the reconstruction it was meant to fix.
+
+The prompt must carry:
+
+- The app's own style prompts — material, lighting, spatial feel — derived from its brand, applied identically across the whole set.
+- The typeface family, plus: *"Maintain strict font aspect ratio. DO NOT compress or stretch text horizontally or vertically to fit space."*
+- The decoration request, **inside this same single generation**. Do not run a second image-to-image pass to add decoration — that is what produces the fibrous, linty background texture.
+- Explicit reference by index, e.g. *"use image 1 ONLY for spatial layout and composition, ignore its colors; embed the UI from image 2 faithfully, DO NOT redraw it."*
+
+### Running it
+
+```bash
+# hero image; accent is sampled from the screenshot when omitted
+python3 ../scripts/render_promo.py --screenshot screenshots/dashboard.png --out 1.png \
+  --frame A --headline "Self-hosted search that respects your data" --highlight search
+
+# every later image of the set locks onto the first one
+python3 ../scripts/render_promo.py --screenshot screenshots/detail.png --out 2.png \
+  --frame C --headline "Index everything you own" --highlight everything \
+  --accent "#3B7CE6" --reference 1.png --style "soft studio lighting, matte surfaces"
+
+# force the deterministic tier even where a key exists
+python3 ../scripts/render_promo.py --screenshot shot.png --out 1.png --deterministic
+```
+
+Needs `Pillow`; the rendered tier additionally needs `OPENAI_API_KEY`. Pass `--font` to pin the exact typeface file across a set. When the model runs, the untouched output is also written to `<out>.render.png` so you can compare it against the delivered file and catch drift.
+
+### Model constraints worth knowing
+
+These bite when calling `POST /v1/images/edits` directly (the script handles them):
+
+- **Omit `input_fidelity`.** `gpt-image-2` is high-fidelity by default and rejects the parameter. Only the older `gpt-image-1` family wants an explicit `high`.
+- **You cannot request 1440x900.** Both edges must be multiples of 16, and 900 is not. Ask for **1536x960** — exactly 8:5, both edges divisible by 16, within the pixel bounds — then downsample to 1440x900. Downsampling only, no stretch.
+- Reference order maps to "image 1/2/3" in the prompt. Up to 16 references; keep each around 1.5 MB.
+- Responses come back base64 (`b64_json`).
+- GPT Image models require organization verification on the OpenAI account. A 400 on model validation is a configuration problem — report it, don't retry into a timeout.
+
+## What good sets do
+
+From reviewing 80+ images across 18 published listings:
+
+Copy is short and lifted straight from the hero slogan or README one-liner — 1–3 lines at large size, with about half adding a brief subhead. Bullet lists are rare.
+
+The image area is not required to be a UI screenshot. Infrastructure and backend tools are better served by an architecture diagram; developer tools by a terminal or code window with syntax highlighting.
+
+Background color tracks the brand primary closely, and nearly every set uses texture or geometric decoration to break up flat color. Two-color headline highlighting shows up constantly and is the single highest-leverage detail.
+
+Layout can shift within one set — a platform overview in side-by-side, a specific feature in top-text/bottom-image — as long as it stays within the two-frame budget.

--- a/cli/skills/olares-publish/references/olares-publish-submit.md
+++ b/cli/skills/olares-publish/references/olares-publish-submit.md
@@ -7,11 +7,12 @@
 
 **The app must already run locally first.** Upload + install on the developer's Olares and confirm `running` — see the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow. Market submission without a working install wastes GitBot cycles and reviewer time.
 
-**Market-ready checklist must be complete** before this final step. In particular:
+**Clear the hard gates first** — the market-ready tiers from the parent SKILL. What blocks you here specifically:
 
 - Dual-version `metadata.categories` (GitBot rejects invalid values; local `lint` does not enum-check)
-- Multi-arch images + matching `spec.supportArch`
-- Full metadata and listing images
+- `metadata.icon` present and a valid `http(s)` URL — `lint` requires it outright
+
+Multi-arch images, listing images, and the marketing fields are **not** gates. Missing ones cost you installs, not the merge — ship without them and refresh via a later `UPDATE` PR if you prefer.
 
 ## Agent boundaries
 
@@ -113,18 +114,6 @@ All post-publish actions are PRs to `beclab/apps:main`. See [Manage the app life
 **REMOVE is irreversible** — after merge the chart **folder name can no longer be reused by the owners**. Existing installs keep working; the app just disappears from the catalog and the name is burned.
 
 Before any lifecycle PR: sync the fork and rebase onto latest `main` to reduce conflicts.
-
-## Optimize listing (optional, post-merge)
-
-Improve Market presentation with [promote-apps](https://docs.olares.com/developer/develop/promote-apps.html):
-
-- `metadata.icon` — **required**; PNG/WEBP, 256x256, <=512 KB
-- `spec.promoteImage[]` — screenshot carousel on the detail page; JPEG/PNG/WEBP, 1440x900, <=8 MB each, up to 8 (>=2 recommended)
-- `spec.featuredImage` — hero image (recommendations / "My Olares"); JPEG/PNG/WEBP, 1440x900, <=8 MB, exactly one
-
-Host assets yourself or use the **Olares Market image hosting** service (pick app icon / featured / promotional, upload, copy the generated URL into `OlaresManifest.yaml`).
-
-Submit these via an `UPDATE` PR with a version bump.
 
 ## Common errors (GitBot rejection)
 

--- a/cli/skills/olares-publish/references/olares-publish-targets.md
+++ b/cli/skills/olares-publish/references/olares-publish-targets.md
@@ -1,68 +1,83 @@
 # Market-ready requirements: what public distribution demands
 
 > **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first, and confirm the app already installs and reaches `running` on your Olares via the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow.
-> This file is the requirements matrix + checklist for a **public Market** listing. It assumes the chart is already functionally complete (storage / middleware / entrances / a pullable image) from `olares-chart`.
+> This file sorts the requirements for a **public Market** listing by what happens when you get them wrong. It assumes the chart is already functionally complete (storage / middleware / entrances / a pullable image) from `olares-chart`.
 
-## What local deploy gives you vs. what the Market demands
+## Sort by consequence, not by checkbox
 
-Local deploy (in `olares-chart`) proves the app **runs**: `chart lint` OK, a pullable image for **this node's** arch, and an install that reaches `running`. The public Market demands more — none of it is enforced by `chart lint`:
+Olares Market is **permissionless** — there is no review board deciding whether your app is good enough. Automated checks judge form; nothing judges substance. So the requirements are not one flat list, and treating them as one is why submissions feel heavier than they are:
 
-| Concern | Already done by local deploy | Public Market demands |
+| Tier | If you get it wrong | Can you fix it later? |
 |---|---|---|
-| **Functional refine** (storage / middleware / entrances) | Required — done | Same, no change |
-| **`chart lint` passes** | Required — done | Same, re-run after market polish |
-| **Image arch** | Single-arch matching the target node (`olares-cli cluster node list`) | Multi-arch build (`--platform linux/amd64,linux/arm64`); declare matching `spec.supportArch` |
-| **`metadata.title`** | Stub (`title=name`) OK | Human-readable, <=30 chars |
-| **`metadata.description`** | One-line stub OK | Accurate summary for the Market listing |
-| **`metadata.icon`** | Default CDN icon OK | Custom PNG/WEBP 256x256, <=512 KB |
-| **`metadata.categories`** | `Utilities` stub OK (`lint` does not enum-check) | Valid categories for **both** OS 1.11 and 1.12 (GitBot `CheckWithTitle` enforces) |
-| **`spec.developer` / `website` / `sourceCode` / `submitter`** | Optional | Required for a credible listing |
-| **`spec.fullDescription`** | Optional | Required — longer Market body text |
-| **`spec.featuredImage` / `promoteImage`** | Skip | Strongly recommended — see [promote-apps](https://docs.olares.com/developer/develop/promote-apps.html) |
-| **`spec.locale`** | Skip | Recommended (`en` at minimum) |
-| **`spec.supportArch`** | Optional (omit unless using accelerator modes) | Required — must match image platforms (`amd64`, `arm64`, or both) |
-| **`spec.accelerator` / GPU resources** | Only if the app needs GPU on **this** node | Fully declared when the app uses GPU/NPU; mode -> arch cross-check applies at `lint` |
-| **`owners` file** | Not needed | Required in the OAC root for the `beclab/apps` PR |
-| **Validate** | `lint` + upload + install | Same, then submit the `beclab/apps` PR |
+| **Hard gates** | Rejected — `lint` fails or GitBot blocks the PR | Must fix before merge |
+| **Functional reach** | Merges fine, then fails to install for some users | Yes, `UPDATE` PR — but users hit it meanwhile |
+| **Listing quality** | Merges and installs fine, but few people try it | Yes, `UPDATE` PR, any time |
 
-## What `lint` does NOT check (market-only)
+Only the first tier blocks you. **A minimal but honest listing can go live and improve afterwards** — a path that reviewed stores like Google Play do not offer, and the main reason publishing here is lighter than it looks.
 
-Local `chart lint` runs `CheckConsistency` — structural and cross-field validation. It does **not**:
+## Tier 1: hard gates
 
-- Validate `metadata.categories` against the Market enum (GitBot `CheckWithTitle` does this at PR time)
-- Require `featuredImage`, `promoteImage`, `fullDescription`, or `developer`
-- Require multi-arch images or non-empty `spec.supportArch`
+### Enforced by `olares-cli chart lint`
 
-So a chart can pass `lint` (and run fine locally) with stub metadata and still fail Market submission.
+| Field | Rule |
+|---|---|
+| `metadata.name` | 1–30 chars; matches the folder name and `Chart.yaml` `name` |
+| `metadata.title` | Required, 1–30 chars |
+| `metadata.description` | Required |
+| `metadata.icon` | Required, and must be a valid `http(s)` URL — producing one: the icon reference from the parent SKILL |
+| `metadata.version` | Required, valid semver; equals `Chart.yaml` `version` |
 
-## Market-ready checklist
+`lint` validates the icon **URL's form, not that it resolves**. A typo'd host passes `lint` and shows a broken image in the Market.
 
-Complete **after** the app runs locally. Use this as a pre-PR gate.
+### Enforced by GitBot at PR time
 
-- [ ] **Metadata:** `title`, `description`, custom `icon`, dual-version `categories`
-- [ ] **Spec marketing:** `developer`, `website`, `sourceCode`, `submitter`, `fullDescription`
-- [ ] **Listing assets:** `featuredImage`, `promoteImage[]` (URLs reachable by the Market CDN)
-- [ ] **Locale:** `spec.locale: [en]` (add more if translated)
-- [ ] **Architecture:** multi-arch images pushed; `spec.supportArch` lists every supported arch
-- [ ] **Resources:** if GPU/NPU needed, `spec.accelerator[]` complete with quantities
-- [ ] **Versions:** `metadata.version` = `Chart.yaml` `version`; bump together for updates
+Folder name (lowercase letters and digits only, **no hyphens**, <=30 chars), PR title format, the version segment of the PR title matching `Chart.yaml` `version`, file scope, no duplicate open PR, no stray `.suspend` / `.remove`, and **valid `metadata.categories`** — categories are the one metadata field GitBot enum-checks and local `lint` does not, so a chart that lints clean still gets blocked here. Details in the submit flow from the parent SKILL.
+
+## Tier 2: functional reach
+
+Nothing checks these. They do not block the merge — they decide whether the app actually installs for the user who clicks Install.
+
+| Concern | Local deploy needed | Public Market needs |
+|---|---|---|
+| **Image arch** | Single-arch matching this node (`olares-cli cluster node list`) | Multi-arch build (`--platform linux/amd64,linux/arm64`) |
+| **`spec.supportArch`** | Optional | Must list every arch your image actually supports |
+| **`spec.accelerator`** | Only if the app needs GPU on **this** node | Fully declared with quantities when the app uses GPU/NPU; the mode -> arch cross-check applies at `lint` |
+
+`supportArch` and the image platforms must agree in **both** directions. Declaring an arch you did not build fails the install; omitting one you did build hides the app from those users.
+
+## Tier 3: listing quality
+
+Nothing enforces any of this. It is what makes the difference between a listing people install and one they scroll past.
+
+| Field | Why it matters |
+|---|---|
+| `spec.fullDescription` | The Market body text — the only place to explain what the app is for |
+| `spec.developer` / `website` / `sourceCode` / `submitter` | Credibility; a listing with no visible author reads as abandonware |
+| `spec.featuredImage` / `promoteImage[]` | JPEG/PNG/WEBP 1440x900, <=8 MB each; one featured, up to 8 promote (>=2 recommended). Producing them: the listing-images reference from the parent SKILL |
+| `spec.locale` | `[en]` at minimum; add more only if actually translated |
+| `entrances[].icon` | Optional per-entrance icon; reuse `metadata.icon` unless entrances genuinely differ |
+
+Since none of this is enforced, it is also the safest thing to defer. Ship, then improve.
+
+## Pre-PR gate
+
+- [ ] **Tier 1 clean:** `olares-cli chart lint ./<app>` passes; folder name valid; `categories` uses accepted values for **both** OS 1.11 and 1.12
+- [ ] **Tier 2 honest:** images built for every arch in `spec.supportArch`, and no arch omitted
+- [ ] **Tier 3 as far as you care to go** — none of it blocks you
 - [ ] **`owners` file** in the chart root with the submitter's GitHub username
-- [ ] **Folder name** valid for `beclab/apps` (lowercase alphanumeric, no hyphens, <=30 chars)
-- [ ] **Re-lint:** `olares-cli chart lint ./<app>` after all edits
-- [ ] **Runs locally** on a real Olares (upload + install -> `running`)
+- [ ] **Versions:** `metadata.version` = `Chart.yaml` `version`; bump both together for updates
+- [ ] **Re-lint** after every edit, and confirm the app still installs to `running` on a real Olares
 
 Then proceed to the submit flow from the parent SKILL.
 
 ## From "runs locally" to "in the public Market"
 
-Common path: get the app running locally first (in `olares-chart`), then polish for public listing.
-
-1. Confirm local install already reached `running` (via the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow).
-2. Work through the market-ready checklist above.
-3. Rebuild images multi-arch if currently single-arch.
-4. Add `spec.supportArch` matching the image platforms.
+1. Confirm the local install already reached `running` (via the [`../../olares-chart/SKILL.md`](../../olares-chart/SKILL.md) deploy flow).
+2. Fix Tier 1 — this is the short list, and the only one that can reject you.
+3. Rebuild multi-arch if currently single-arch, then set `spec.supportArch` to match.
+4. Add as much of Tier 3 as you have material for.
 5. Re-run `lint` -> `package`.
-6. Open the PR to `beclab/apps` — do **not** skip re-validation; Market ingest may reject charts that ran locally but lack valid categories.
+6. Open the PR. Do **not** skip re-validation: a chart that ran locally can still carry stub categories that GitBot rejects.
 
 Functional refine (storage / middleware / entrances) should already be done from the local phase — usually no changes needed there.
 

--- a/cli/skills/olares-publish/scripts/generate_icon.py
+++ b/cli/skills/olares-publish/scripts/generate_icon.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Composite a fetched project logo into an Olares Market app icon.
+
+Output is 256x256 RGBA, <=512 KB, PNG or WEBP. Runs fully offline: the
+source mark must already have been fetched from the project's repo or site.
+This script never invents artwork.
+
+    generate_icon.py source_icon.svg MyApp.png
+    generate_icon.py source_icon.png MyApp.png --force-bg
+    generate_icon.py source_icon.png MyApp.png --force-transparent
+
+Requires Pillow, numpy, scipy; cairosvg additionally for SVG input.
+"""
+
+import argparse
+import io
+import os
+import sys
+
+CANVAS = 256
+SAFE_MARGIN = 38
+GRADIENT_TOP = (0xFB, 0xFB, 0xFB)
+GRADIENT_BOTTOM = (0xF1, 0xF1, 0xF1)
+MAX_KB = 512
+ALPHA_OPAQUE = 128
+NEAR_WHITE = 240
+CORNER_SAMPLE = 5
+RESOLUTION_FLOOR = 200
+SVG_RASTER_SIZE = 1024
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_source(path):
+    from PIL import Image
+
+    if not os.path.exists(path):
+        die(f"source not found: {path}")
+
+    if path.lower().endswith(".svg"):
+        try:
+            import cairosvg
+        except ImportError:
+            die("SVG input needs cairosvg (pip install cairosvg)")
+        png = cairosvg.svg2png(
+            url=path, output_width=SVG_RASTER_SIZE, output_height=SVG_RASTER_SIZE
+        )
+        return Image.open(io.BytesIO(png)).convert("RGBA")
+
+    try:
+        return Image.open(path).convert("RGBA")
+    except Exception as exc:
+        die(f"cannot open {path}: {exc}")
+
+
+def classify_background(img):
+    """Average a 5x5 block at each corner and branch on the result."""
+    import numpy as np
+
+    arr = np.asarray(img, dtype=np.float64)
+    h, w = arr.shape[:2]
+    n = min(CORNER_SAMPLE, h, w)
+    corners = [
+        arr[:n, :n],
+        arr[:n, w - n :],
+        arr[h - n :, :n],
+        arr[h - n :, w - n :],
+    ]
+    mean = np.mean([c.reshape(-1, 4).mean(axis=0) for c in corners], axis=0)
+
+    if mean[3] < ALPHA_OPAQUE:
+        return "transparent"
+    if all(mean[i] >= NEAR_WHITE for i in range(3)):
+        return "white"
+    return "colored"
+
+
+def remove_white_background(img):
+    """Clear near-white pixels connected to the border, keeping white inside the mark.
+
+    Flood-fills inward from the edges rather than clearing every white pixel,
+    which is what preserves white counters inside a glyph.
+    """
+    from collections import deque
+
+    import numpy as np
+    from PIL import Image
+
+    arr = np.array(img)
+    h, w = arr.shape[:2]
+    white = (arr[:, :, :3] >= NEAR_WHITE).all(axis=2) & (arr[:, :, 3] >= ALPHA_OPAQUE)
+    if not white.any():
+        return img
+
+    seen = np.zeros((h, w), dtype=bool)
+    queue = deque()
+    border = [(0, x) for x in range(w)] + [(h - 1, x) for x in range(w)]
+    border += [(y, 0) for y in range(h)] + [(y, w - 1) for y in range(h)]
+    for y, x in border:
+        if white[y, x] and not seen[y, x]:
+            seen[y, x] = True
+            queue.append((y, x))
+
+    while queue:
+        y, x = queue.popleft()
+        for ny, nx in ((y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1)):
+            if 0 <= ny < h and 0 <= nx < w and white[ny, nx] and not seen[ny, nx]:
+                seen[ny, nx] = True
+                queue.append((ny, nx))
+
+    if not seen.any():
+        return img
+    arr[seen, 3] = 0
+    return Image.fromarray(arr)
+
+
+def trim_transparent(img):
+    bbox = img.getbbox()
+    return img.crop(bbox) if bbox else img
+
+
+def gradient_canvas():
+    from PIL import Image
+
+    img = Image.new("RGBA", (CANVAS, CANVAS))
+    px = img.load()
+    for y in range(CANVAS):
+        t = y / (CANVAS - 1)
+        row = tuple(
+            round(GRADIENT_TOP[i] + (GRADIENT_BOTTOM[i] - GRADIENT_TOP[i]) * t)
+            for i in range(3)
+        )
+        for x in range(CANVAS):
+            px[x, y] = row + (255,)
+    return img
+
+
+def fit_safe_zone(mark):
+    """Centre the mark inside the 180x180 safe zone over the standard gradient."""
+    from PIL import Image
+
+    canvas = gradient_canvas()
+    box = CANVAS - 2 * SAFE_MARGIN
+    mark = trim_transparent(mark)
+    scale = min(box / mark.width, box / mark.height)
+    size = (max(1, round(mark.width * scale)), max(1, round(mark.height * scale)))
+    mark = mark.resize(size, Image.LANCZOS)
+    canvas.alpha_composite(
+        mark, ((CANVAS - size[0]) // 2, (CANVAS - size[1]) // 2)
+    )
+    return canvas
+
+
+def scale_to_fill(mark):
+    """Cover the full 256x256 canvas; used when the icon carries its own background."""
+    from PIL import Image
+
+    scale = max(CANVAS / mark.width, CANVAS / mark.height)
+    size = (max(1, round(mark.width * scale)), max(1, round(mark.height * scale)))
+    mark = mark.resize(size, Image.LANCZOS)
+    left = (size[0] - CANVAS) // 2
+    top = (size[1] - CANVAS) // 2
+    return mark.crop((left, top, left + CANVAS, top + CANVAS))
+
+
+def save(img, path):
+    fmt = "WEBP" if path.lower().endswith(".webp") else "PNG"
+    if fmt == "WEBP":
+        img.save(path, "WEBP", quality=90, method=6)
+    else:
+        img.save(path, "PNG", optimize=True)
+
+    return os.path.getsize(path) / 1024
+
+
+def verify(path, needs_alpha):
+    from PIL import Image
+
+    img = Image.open(path)
+    kb = os.path.getsize(path) / 1024
+    problems = []
+    if img.size != (CANVAS, CANVAS):
+        problems.append(f"size {img.size[0]}x{img.size[1]}, want {CANVAS}x{CANVAS}")
+    # A fully opaque icon may legitimately come back as RGB from the WEBP
+    # encoder, which drops an all-255 alpha channel. Only insist on alpha
+    # when the composite actually has transparent pixels to lose.
+    if needs_alpha and img.mode != "RGBA":
+        problems.append(f"mode {img.mode}, want RGBA — transparency was lost")
+    elif img.mode not in ("RGBA", "RGB"):
+        problems.append(f"mode {img.mode}, want RGBA or RGB")
+    if kb > MAX_KB:
+        problems.append(f"{kb:.0f} KB, want <={MAX_KB} KB — re-export as .webp")
+    if problems:
+        die("output rejected: " + "; ".join(problems))
+    print(f"OK {path}: {img.size[0]}x{img.size[1]}, {img.mode}, {kb:.0f} KB")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("source", help="fetched logo: .svg, .png, .jpg, .ico")
+    ap.add_argument("output", help="destination .png or .webp, named after the app")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--force-bg",
+        action="store_true",
+        help="treat as colored: fill 256x256, no safe zone (glow icons, rounded plates)",
+    )
+    mode.add_argument(
+        "--force-transparent",
+        action="store_true",
+        help="treat as transparent: gradient backdrop plus safe zone",
+    )
+    args = ap.parse_args()
+
+    src = load_source(args.source)
+
+    if max(src.size) < RESOLUTION_FLOOR:
+        print(
+            f"warning: source is {src.width}x{src.height}, below the {RESOLUTION_FLOOR}px "
+            "floor — the result will look blurry. Find a higher-res source or upscale "
+            "with Real-ESRGAN first.",
+            file=sys.stderr,
+        )
+
+    if args.force_bg:
+        kind = "colored"
+    elif args.force_transparent:
+        kind = "transparent"
+    else:
+        kind = classify_background(src)
+
+    if kind == "colored":
+        out = scale_to_fill(src)
+    else:
+        if kind == "white":
+            src = remove_white_background(src)
+        out = fit_safe_zone(src)
+
+    print(f"background: {kind}")
+    needs_alpha = out.getchannel("A").getextrema()[0] < 255
+    save(out, args.output)
+    verify(args.output, needs_alpha)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/skills/olares-publish/scripts/render_promo.py
+++ b/cli/skills/olares-publish/scripts/render_promo.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Render a 1440x900 Olares Market listing image around a real screenshot.
+
+Three stages, per the render contract in
+references/olares-publish-listing-layout.md:
+
+  1. pre-composite  Pillow places the real screenshot into the frame's
+                    screenshot region, producing the layout reference.
+  2. render         an image model generates backdrop, typography and
+                    decoration around that region (skipped without a key).
+  3. re-composite   Pillow pastes the real screenshot back at the same box.
+
+Stage 3 is why the shipped UI pixels are authentic: the model regenerates the
+whole canvas, so its version of the screenshot is a reconstruction and must
+not be delivered. This script owns the bounding box so stages 1 and 3 cannot
+disagree.
+
+    render_promo.py --screenshot shot.png --out 1.png --frame A \
+        --headline "Self-hosted search that respects you" --highlight search
+
+Requires Pillow. Uses OPENAI_API_KEY when set; without it, emits the
+deterministic tier and says so.
+"""
+
+import argparse
+import base64
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+W, H = 1440, 900
+RENDER_W, RENDER_H = 1536, 960
+MAX_MB = 8
+CORNER_RADIUS = 18
+SHADOW_BLUR = 26
+SHADOW_OFFSET = 18
+REFERENCE_MAX_BYTES = 1_500_000
+API_URL = "https://api.openai.com/v1/images/edits"
+DEFAULT_MODEL = "gpt-image-2"
+
+# Boxes are (x, y, w, h) on the 1440x900 frame. A box may extend past the
+# bottom edge, which is the intended bleed for frame A.
+FRAMES = {
+    "A": {"shot": (160, 330, 1120, 640), "text": (120, 92, 1200, 200), "align": "center"},
+    "B": {"shot": (250, 320, 940, 560), "text": (120, 80, 1200, 190), "align": "center"},
+    "C": {"shot": (700, 210, 640, 480), "text": (100, 280, 520, 340), "align": "left"},
+    "D": {"shot": (740, 120, 580, 660), "text": (100, 250, 540, 400), "align": "left"},
+    "E": {"shot": (170, 350, 1100, 550), "text": (110, 90, 820, 200), "align": "left"},
+    "F": {"shot": (95, 320, 610, 500), "text": (120, 80, 1200, 180), "align": "center"},
+    "G": {"shot": (0, 0, 1440, 900), "text": (120, 620, 1200, 200), "align": "center"},
+}
+
+FONT_CANDIDATES = [
+    "/System/Library/Fonts/Supplemental/Helvetica.ttc",
+    "/System/Library/Fonts/HelveticaNeue.ttc",
+    "/System/Library/Fonts/SFNS.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+]
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def note(msg):
+    print(f"note: {msg}", file=sys.stderr)
+
+
+def load_font(path, size):
+    from PIL import ImageFont
+
+    candidates = [path] if path else []
+    candidates += FONT_CANDIDATES
+    for p in candidates:
+        if p and os.path.exists(p):
+            try:
+                return ImageFont.truetype(p, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def dominant_accent(img):
+    """Pick the most saturated frequent color, used when --accent is omitted."""
+    import colorsys
+
+    small = img.convert("RGB").resize((64, 64))
+    counts = {}
+    for px in small.getdata():
+        r, g, b = (c / 255 for c in px)
+        h_, l_, s_ = colorsys.rgb_to_hls(r, g, b)
+        if s_ < 0.25 or l_ < 0.15 or l_ > 0.9:
+            continue
+        key = tuple(c // 24 for c in px)
+        counts.setdefault(key, [0, px])
+        counts[key][0] += 1
+    if not counts:
+        return (64, 110, 220)
+    return max(counts.values(), key=lambda v: v[0])[1]
+
+
+def parse_color(text, fallback):
+    if not text:
+        return fallback
+    t = text.strip().lstrip("#")
+    if len(t) != 6:
+        die(f"--accent must be #RRGGBB, got {text}")
+    return tuple(int(t[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def mix(a, b, t):
+    return tuple(round(a[i] + (b[i] - a[i]) * t) for i in range(3))
+
+
+def backdrop(accent):
+    """Dark brand-tinted gradient with a faint dot grid: never flat color."""
+    from PIL import Image, ImageDraw
+
+    top = mix(accent, (10, 12, 20), 0.72)
+    bottom = mix(accent, (4, 5, 12), 0.88)
+    img = Image.new("RGB", (W, H))
+    draw = ImageDraw.Draw(img)
+    for y in range(H):
+        draw.line([(0, y), (W, y)], fill=mix(top, bottom, y / (H - 1)))
+
+    dots = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    d = ImageDraw.Draw(dots)
+    tint = mix(accent, (255, 255, 255), 0.5)
+    for y in range(0, H, 40):
+        for x in range(0, W, 40):
+            d.ellipse([x, y, x + 2, y + 2], fill=tint + (26,))
+    img = Image.alpha_composite(img.convert("RGBA"), dots)
+
+    glow = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    ImageDraw.Draw(glow).ellipse(
+        [W * 0.55, -H * 0.35, W * 1.25, H * 0.75], fill=accent + (46,)
+    )
+    from PIL import ImageFilter
+
+    glow = glow.filter(ImageFilter.GaussianBlur(160))
+    return Image.alpha_composite(img, glow)
+
+
+def rounded(img, radius):
+    from PIL import Image, ImageDraw
+
+    mask = Image.new("L", img.size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle([0, 0, img.width - 1, img.height - 1], radius, fill=255)
+    out = img.convert("RGBA")
+    out.putalpha(mask)
+    return out
+
+
+def cover(img, box_w, box_h):
+    from PIL import Image
+
+    scale = max(box_w / img.width, box_h / img.height)
+    size = (max(1, round(img.width * scale)), max(1, round(img.height * scale)))
+    img = img.resize(size, Image.LANCZOS)
+    left = (size[0] - box_w) // 2
+    top = (size[1] - box_h) // 2
+    return img.crop((left, top, left + box_w, top + box_h))
+
+
+def place_screenshot(canvas, shot, box, radius=CORNER_RADIUS, shadow=True):
+    """Paste the real capture at box with rounded corners and a soft shadow."""
+    from PIL import Image, ImageDraw, ImageFilter
+
+    x, y, bw, bh = box
+    full_bleed = (x, y, bw, bh) == (0, 0, W, H)
+    panel = cover(shot, bw, bh)
+    panel = rounded(panel, 0 if full_bleed else radius)
+
+    if shadow and not full_bleed:
+        layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+        ImageDraw.Draw(layer).rounded_rectangle(
+            [x, y + SHADOW_OFFSET, x + bw, y + bh + SHADOW_OFFSET], radius, fill=(0, 0, 0, 150)
+        )
+        canvas.alpha_composite(layer.filter(ImageFilter.GaussianBlur(SHADOW_BLUR)))
+
+    canvas.alpha_composite(panel, (x, y))
+    return canvas
+
+
+def text_scrim(canvas, textbox):
+    """Darken behind overlaid text; without it, copy on a busy capture is unreadable."""
+    from PIL import Image, ImageDraw, ImageFilter
+
+    x, y, bw, bh = textbox
+    pad = 90
+    layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    ImageDraw.Draw(layer).rectangle(
+        [x - pad, y - pad, x + bw + pad, y + bh + pad], fill=(6, 8, 14, 205)
+    )
+    canvas.alpha_composite(layer.filter(ImageFilter.GaussianBlur(60)))
+    return canvas
+
+
+def draw_headline(canvas, frame, headline, highlight, accent, font_path, scrim=False):
+    """Wrap the headline into the text box, tinting highlighted words."""
+    from PIL import ImageDraw
+
+    if not headline:
+        return canvas
+
+    x, y, bw, bh = frame["text"]
+    if scrim:
+        canvas = text_scrim(canvas, frame["text"])
+    align = frame["align"]
+    draw = ImageDraw.Draw(canvas)
+    words = headline.split()
+    marks = {w.lower().strip(".,:;!?") for w in (highlight or "").split(",") if w.strip()}
+
+    size = 76
+    while size > 28:
+        font = load_font(font_path, size)
+        space = draw.textlength(" ", font=font)
+        lines, cur, cur_w = [], [], 0.0
+        for word in words:
+            ww = draw.textlength(word, font=font)
+            if cur and cur_w + space + ww > bw:
+                lines.append((cur, cur_w))
+                cur, cur_w = [word], ww
+            else:
+                cur_w = cur_w + space + ww if cur else ww
+                cur.append(word)
+        if cur:
+            lines.append((cur, cur_w))
+        line_h = size * 1.22
+        if len(lines) <= 3 and len(lines) * line_h <= bh:
+            break
+        size -= 4
+
+    for i, (line, line_w) in enumerate(lines):
+        ly = y + i * line_h
+        lx = x + (bw - line_w) / 2 if align == "center" else x
+        for word in line:
+            color = accent if word.lower().strip(".,:;!?") in marks else (255, 255, 255)
+            draw.text((lx, ly), word, font=font, fill=color + (255,))
+            lx += draw.textlength(word, font=font) + draw.textlength(" ", font=font)
+    return canvas
+
+
+def boxes_overlap(a, b):
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    return ax < bx + bw and bx < ax + aw and ay < by + bh and by < ay + ah
+
+
+def to_png_bytes(img, max_bytes=REFERENCE_MAX_BYTES):
+    from PIL import Image
+
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, "PNG", optimize=True)
+    if buf.tell() <= max_bytes:
+        return buf.getvalue()
+    scaled = img.convert("RGB")
+    while buf.tell() > max_bytes and scaled.width > 400:
+        scaled = scaled.resize((int(scaled.width * 0.8), int(scaled.height * 0.8)), Image.LANCZOS)
+        buf = io.BytesIO()
+        scaled.save(buf, "PNG", optimize=True)
+    return buf.getvalue()
+
+
+def build_prompt(args, frame_letter):
+    typeface = args.typeface
+    parts = [
+        f"Design a polished {W}x{H} app-store listing image, 8:5, wireframe {frame_letter}.",
+        "Use image 1 ONLY for spatial layout and composition — ignore its colors entirely.",
+        "Embed the UI from image 2 faithfully in the same region; DO NOT redraw or restyle it.",
+    ]
+    if args.reference:
+        parts.append(
+            "Image 3 is the first image of this set: match its typeface, palette and overall tone exactly."
+        )
+    if args.headline:
+        parts.append(f'Headline text, rendered exactly: "{args.headline}".')
+    if args.highlight:
+        parts.append(f"Render these words in the brand accent color: {args.highlight}.")
+    parts += [
+        f"Typeface: {typeface}. Maintain strict font aspect ratio. "
+        "DO NOT compress or stretch text horizontally or vertically to fit space.",
+        f"Brand accent color {args.accent_hex}. Backdrop must carry texture — "
+        "fine grid, dot matrix or gradient bloom — never flat black or flat white.",
+        "Add one or two decorative elements (geometric shapes, glow, floating cards) "
+        "in the empty area of the frame, in this same generation. "
+        "Decoration must contain NO readable text of any kind.",
+    ]
+    if args.style:
+        parts.append(args.style)
+    return " ".join(parts)
+
+
+def call_model(api_key, model, prompt, images):
+    boundary = uuid.uuid4().hex
+    body = bytearray()
+
+    def field(name, value):
+        body.extend(f"--{boundary}\r\n".encode())
+        body.extend(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
+        body.extend(f"{value}\r\n".encode())
+
+    field("model", model)
+    field("prompt", prompt)
+    field("size", f"{RENDER_W}x{RENDER_H}")
+    field("n", "1")
+
+    for i, payload in enumerate(images):
+        body.extend(f"--{boundary}\r\n".encode())
+        body.extend(
+            f'Content-Disposition: form-data; name="image[]"; filename="ref{i}.png"\r\n'.encode()
+        )
+        body.extend(b"Content-Type: image/png\r\n\r\n")
+        body.extend(payload)
+        body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode())
+
+    req = urllib.request.Request(
+        API_URL,
+        data=bytes(body),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            payload = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:600]
+        if exc.code == 400 and "model" in detail:
+            die(
+                "the API rejected the model. GPT Image models require organization "
+                f"verification on the OpenAI account — this is a configuration problem, "
+                f"not a transient one. Response: {detail}"
+            )
+        die(f"images/edits returned HTTP {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        die(f"cannot reach the API: {exc.reason}")
+
+    try:
+        return base64.b64decode(payload["data"][0]["b64_json"])
+    except (KeyError, IndexError) as exc:
+        die(f"unexpected response shape: {exc}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--screenshot", required=True, help="real capture, never a mockup")
+    ap.add_argument("--out", required=True, help="destination .png / .jpg / .webp")
+    ap.add_argument("--frame", default="A", choices=sorted(FRAMES), help="wireframe, default A")
+    ap.add_argument("--headline", default="", help="1-3 lines, lifted from the hero slogan")
+    ap.add_argument("--highlight", default="", help="comma-separated words to tint with the accent")
+    ap.add_argument("--accent", default="", help="#RRGGBB; sampled from the screenshot if omitted")
+    ap.add_argument("--style", default="", help="extra style prompt: material, lighting, spatial feel")
+    ap.add_argument("--reference", default="", help="first finished image of the set, for consistency")
+    ap.add_argument("--font", default="", help="path to the sans used across the whole set")
+    ap.add_argument("--typeface", default="Inter", help="typeface name passed to the model")
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="skip the model even if a key is present",
+    )
+    args = ap.parse_args()
+
+    from PIL import Image
+
+    if not os.path.exists(args.screenshot):
+        die(f"screenshot not found: {args.screenshot}")
+    shot = Image.open(args.screenshot).convert("RGBA")
+
+    frame = FRAMES[args.frame]
+    box = frame["shot"]
+    accent = parse_color(args.accent, dominant_accent(shot))
+    args.accent_hex = "#%02X%02X%02X" % accent
+
+    # Stage 1: pre-composite. The box recorded here is the one stage 3 reuses.
+    overlaid = boxes_overlap(box, frame["text"])
+    reference = place_screenshot(backdrop(accent), shot, box)
+    reference = draw_headline(
+        reference, frame, args.headline, args.highlight, accent, args.font, scrim=overlaid
+    )
+
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    rendered = None
+
+    if args.deterministic:
+        note("--deterministic set: skipping the model.")
+    elif not api_key:
+        note(
+            "OPENAI_API_KEY is not set, so the rendered tier is unavailable. "
+            "Delivering the deterministic composition — real screenshot, brand gradient, "
+            "typeset headline. Say so when handing this over; do not present it as the "
+            "fully rendered result."
+        )
+    else:
+        images = [to_png_bytes(reference), to_png_bytes(shot)]
+        if args.reference:
+            if not os.path.exists(args.reference):
+                die(f"--reference not found: {args.reference}")
+            images.append(to_png_bytes(Image.open(args.reference)))
+        raw = call_model(api_key, args.model, build_prompt(args, args.frame), images)
+        rendered = Image.open(io.BytesIO(raw)).convert("RGBA")
+
+    if rendered is None:
+        final = reference
+    else:
+        # Stage 3: downsample, then put the authentic pixels back.
+        final = rendered.resize((W, H), Image.LANCZOS)
+        raw_path = os.path.splitext(args.out)[0] + ".render.png"
+        rendered.save(raw_path)
+        note(f"raw model output kept at {raw_path} — compare it against {args.out}.")
+        final = place_screenshot(final, shot, box)
+        if overlaid:
+            final = draw_headline(
+                final, frame, args.headline, args.highlight, accent, args.font, scrim=True
+            )
+
+    fmt = os.path.splitext(args.out)[1].lower()
+    if fmt in (".jpg", ".jpeg"):
+        final.convert("RGB").save(args.out, quality=92, optimize=True)
+    elif fmt == ".webp":
+        final.save(args.out, "WEBP", quality=92, method=6)
+    else:
+        final.convert("RGB").save(args.out, "PNG", optimize=True)
+
+    check = Image.open(args.out)
+    mb = os.path.getsize(args.out) / 1048576
+    if check.size != (W, H):
+        die(f"output is {check.size[0]}x{check.size[1]}, want {W}x{H}")
+    if mb > MAX_MB:
+        die(f"output is {mb:.1f} MB, want <={MAX_MB} MB")
+    print(f"OK {args.out}: {check.size[0]}x{check.size[1]}, {mb:.1f} MB, frame {args.frame}, accent {args.accent_hex}")
+    if rendered is not None:
+        print(
+            "Check that the model's screenshot area matches the box; if it drifted, "
+            "re-render rather than shipping a paste over a mismatch."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/zh/developer/develop/promote-apps.md
+++ b/docs/zh/developer/develop/promote-apps.md
@@ -43,7 +43,7 @@ description: 使用图片和图标优化你在 Olares 应用市场中的应用�
 
 你可以将图片托管在自己的服务器上，或使用 Olares 图片托管服务：
 
-1. 打开 [Olares Market 图片托管](https://imghost.olares.cn/)。
+1. 打开 [Olares Market 图片托管](https://imghost.olares.com/)。
 2. 选择图片类型：**应用图标**、**头图**或**宣传图**。
 3. 上传并预览图片。
 4. 复制生成的 URL，并粘贴到 `OlaresManifest.yaml` 对应字段中。


### PR DESCRIPTION
## Summary

`olares-publish` documented *what* `metadata.icon` and `spec.promoteImage[]` must look like, but never *how* to produce them. Every run improvised, so the same app got a different icon each time. This adds the production pipeline as reference docs plus two executable helpers, and re-sorts the market-ready requirements by whether they actually block a merge.

Three reference files, both scripts, and the requirement re-tiering:

- `references/olares-publish-icon.md` + `scripts/generate_icon.py` — fetch the project's real mark, classify its background by corner sampling, strip a white backplate via edge flood-fill (white *inside* a glyph survives), fit the safe zone over the standard gradient, and self-check 256x256 / <=512 KB. Fully offline, no API key.
- `references/olares-publish-listing-images.md` and `references/olares-publish-listing-layout.md` + `scripts/render_promo.py` — the 1440x900 pipeline: seven wireframes, copy extraction, brand analysis, and the render contract.
- `references/olares-publish-targets.md` — rewritten to sort requirements into hard gates / functional reach / listing quality, since the Market is permissionless and only a short list can actually reject a PR. Treating them as one flat checklist made submission feel much heavier than it is.

## The render pipeline does not let the model draw the UI

Worth calling out because it drove the design. `POST /v1/images/edits` does not composite — it regenerates the entire canvas, so whatever the model returns in the screenshot area is its *reconstruction* of the UI, however firmly the prompt says otherwise. Shipping that would violate the skill's own rule against fabricated UI.

So the pipeline is three stages, and `render_promo.py` owns the screenshot bounding box so stages 1 and 3 cannot disagree:

1. Pillow pre-composites the real screenshot into the frame's screenshot region, recording the box.
2. The model generates only backdrop, typography and decoration, at 1536x960 (1440x900 is not requestable — both edges must be multiples of 16).
3. Pillow downsamples to 1440x900 and pastes the real screenshot back at the same box, applying rounded corners and shadow deterministically.

Every UI pixel in the deliverable is therefore authentic. The untouched model output is kept alongside as `<out>.render.png` so drift is easy to spot.

Without `OPENAI_API_KEY` the script emits the deterministic tier — real screenshot, brand gradient, typeset headline — and says so rather than passing it off as the rendered result.

## Notes

- `scripts/` is a deliberate exception to the markdown-only rule for `cli/skills/`, justified in `cli/skills/README.md`: producing an icon is exactly specified pixel work, and prose asking each agent to re-derive it yields a different result every run.
- Dependencies are Pillow and numpy only, plus `cairosvg` for SVG input. An earlier draft used `scipy.ndimage.label` for one connected-component call; that is now a numpy BFS flood fill, which drops a heavy dependency and runs in 0.2 s.
- Also fixes a broken image-host URL in the zh docs (`imghost.olares.cn` does not resolve).

## Test plan

- [x] Both scripts compile and pass lint clean
- [x] All seven wireframes produce valid 1440x900 output; frame G (text overlaid on a full-bleed capture) gets a feathered scrim, without which the accent-colored words are unreadable
- [x] Icon script verified on all three background branches — a white backplate is removed while white inside the glyph is preserved, transparent sources get the gradient plus safe zone, colored sources fill the canvas
- [x] Error paths exit non-zero with actionable messages: missing source, malformed `--accent`, mutually exclusive flags, oversized or wrong-dimension output
- [x] Fully opaque WEBP output correctly accepted as `RGB` (the encoder drops an all-255 alpha channel), while transparency loss is still rejected
- [x] `./publish.sh --dry-run` passes for all 11 skills
- [x] Every relative link across the skill resolves
- [ ] Render tier against the live API — not exercised here, no key available in this environment

Made with [Cursor](https://cursor.com)