### PR TITLE
docs: add guide on how to upgrade a two-node Olares cluster

### DIFF
--- a/docs/.vitepress/one.en.ts
+++ b/docs/.vitepress/one.en.ts
@@ -166,7 +166,11 @@ export const oneSidebar: DefaultTheme.Sidebar = {
         {
           text: "Update OS",
           link: "/one/update",
-        },        
+        },
+        {
+          text: "Upgrade a two-node Olares cluster",
+          link: "/one/upgrade-multi-node-cluster",
+        },
         {
           text: "Restore Olares One",
           items: [

--- a/docs/.vitepress/one.zh.ts
+++ b/docs/.vitepress/one.zh.ts
@@ -166,7 +166,11 @@ export const oneSidebar: DefaultTheme.Sidebar = {
         {
           text: "更新 OS",
           link: "/zh/one/update",
-        },       
+        },
+        {
+          text: "升级双节点 Olares 集群",
+          link: "/zh/one/upgrade-multi-node-cluster",
+        },
         {
           text: "恢复 Olares One",
           items: [

--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -141,3 +141,4 @@ olares-worker   Ready    worker                        50m   v1.33.3+k3s1
 ## Resources
 - [Olares CLI](../developer/install/cli/node.md): Explore the Olares CLI.
 - [Olares environment variables](../developer/install/environment-variables.md): Learn about the environment variables that enable advanced configurations of Olares.
+- [Upgrade a two-node Olares cluster](./upgrade-multi-node-cluster): Learn how to manually upgrade a two-node cluster from version 1.12.5 to 1.12.6.

--- a/docs/one/upgrade-multi-node-cluster.md
+++ b/docs/one/upgrade-multi-node-cluster.md
@@ -170,3 +170,7 @@ If your SSH session to the master node times out, reconnect before proceeding.
    ```bash
    kubectl get nodes
    ```
+
+## Resources
+
+- [Connect two Olares One](./connect-two-olares-one): Learn how to set up a two-node Olares cluster.

--- a/docs/one/upgrade-multi-node-cluster.md
+++ b/docs/one/upgrade-multi-node-cluster.md
@@ -9,7 +9,7 @@ head:
 
 # Upgrade a two-node Olares cluster
 
-This guide walks you through manually upgrading a two-node Olares cluster from 1.12.5 to 1.12.6.
+This guide walks you through manually upgrading a two-node Olares cluster from version 1.12.5 to 1.12.6.
 
 The procedure involves downloading upgrade packages on both nodes, upgrading the Olares CLI and daemon, and upgrading the master and worker nodes separately.
 
@@ -27,13 +27,13 @@ The procedure involves downloading upgrade packages on both nodes, upgrading the
 
 Open two separate terminal windows or tabs on your computer. Use SSH to connect to each node in its own window.
 
-1. In the first window, connect to the master node:
+1. In the first window, connect to the master node via SSH using its local IP address:
 
    ```bash
    ssh olares@<master-node-ip-address>
    ```
 
-2. In the second window, connect to the worker node:
+2. In the second window, connect to the worker node via SSH using its local IP address:
 
    ```bash
    ssh olares@<worker-node-ip-address>
@@ -79,7 +79,7 @@ Before proceeding to Step 3, ensure that `upgradingDownloadState` shows `complet
 
 After the downloads finish, import the new images and update the core management tools, including the Olares CLI and the `olaresd` daemon. Run the following commands in both your master and worker SSH windows.
 
-1. Ensure you are still logged in as root:
+1. Ensure that you are still logged in as root:
 
    ```bash
    sudo su
@@ -119,7 +119,7 @@ With both nodes prepared, upgrade the master node first.
    sudo olares-cli upgrade
    ```
 
-   The master node will automatically reboot once the upgrade script finishes. Your SSH session will disconnect.
+   The master node reboots when the upgrade finishes.
 
 2. After the reboot, verify that all system services have successfully restarted and are in the `Running` status:
 
@@ -135,7 +135,7 @@ With both nodes prepared, upgrade the master node first.
 
 ## Step 5: Upgrade the worker node
 
-Now that the master node is upgraded and patched, you can upgrade the worker.
+Now that the master node is upgraded and patched, you can upgrade the worker node.
 
 1. In the worker node SSH window, start the upgrade:
 
@@ -143,11 +143,11 @@ Now that the master node is upgraded and patched, you can upgrade the worker.
    sudo olares-cli upgrade
    ```
 
-2. The worker node reboots when the upgrade finishes. Wait for the rebooting to finish.
+2. The worker node reboots when the upgrade finishes. Wait for the reboot to finish.
 
 ## Step 6: Restore the cluster version on the master node
 
-After the worker node has finished upgrading, restore the version on the master node to `1.12.6` to complete the process.
+After the worker node finishes upgrading, restore the version on the master node to `1.12.6` to complete the process.
 
 1. In the master node SSH window, run the following command:
 

--- a/docs/one/upgrade-multi-node-cluster.md
+++ b/docs/one/upgrade-multi-node-cluster.md
@@ -1,0 +1,164 @@
+---
+outline: [2, 3]
+description: Upgrade a two-node Olares cluster from version 1.12.5 to 1.12.6.
+head:
+  - - meta
+    - name: keywords
+      content: Olares One, multi-node, two-node, upgrade, 1.12.5, 1.12.6
+---
+
+# Upgrade a two-node Olares cluster
+
+This guide walks you through manually upgrading a two-node Olares cluster from 1.12.5 to 1.12.6.
+
+The procedure involves downloading upgrade packages on both nodes, upgrading the Olares CLI and daemon, and upgrading the master and worker nodes separately.
+
+## Prerequisites
+
+**Cluster**
+- You have a two-node Olares cluster with one master node and one worker node.
+- Both nodes are powered on and connected to the same local area network.
+- You know the local IP addresses of both nodes.
+
+**Access**
+- You can access both nodes via SSH as a user with `sudo` privileges.
+
+## Step 1: Connect to both nodes
+
+Open two separate terminal windows or tabs on your computer. Use SSH to connect to each node in its own window.
+
+1. In the first window, connect to the master node:
+
+   ```bash
+   ssh olares@<master-node-ip-address>
+   ```
+
+2. In the second window, connect to the worker node:
+
+   ```bash
+   ssh olares@<worker-node-ip-address>
+   ```
+
+3. Keep both SSH connection windows open throughout this process. Some steps must be run on both nodes, and some steps must be run while both nodes are accessible.
+
+## Step 2: Download upgrade packages on both nodes
+
+Download the upgrade files without installing them. Run the following commands in both your master and worker SSH windows.
+
+1. Switch to the root user:
+
+   ```bash
+   sudo su
+   ```
+
+2. Load the Olares environment variables:
+
+   ```bash
+   source /etc/olares/release
+   ```
+
+3. Create the upgrade target file to trigger the download:
+
+   ```bash
+   echo '{"version":"1.12.6", "downloadOnly": true}' > $OLARES_BASE_DIR/upgrade.target
+   ```
+
+4. Check the download progress:
+
+   ```bash
+   curl localhost:18088/system/status | jq | grep -i download
+   ```
+
+5. Wait until the `upgradingDownloadState` value changes to `completed`.
+
+:::warning Wait for downloads to complete
+Before proceeding to Step 3, ensure that `upgradingDownloadState` shows `completed` on both nodes.
+:::
+
+## Step 3: Upgrade Olares CLI and daemon on both nodes
+
+After the downloads finish, import the new images and update the core management tools, including the Olares CLI and the `olaresd` daemon. Run the following commands in both your master and worker SSH windows.
+
+1. Ensure you are still logged in as root:
+
+   ```bash
+   sudo su
+   ```
+
+2. Ensure the environment variables are loaded:
+
+   ```bash
+   source /etc/olares/release
+   ```
+
+3. Update the Olares CLI to the new version:
+
+   ```bash
+   cp -f $OLARES_BASE_DIR/pkg/components/olares-cli-v1.12.6 /usr/local/bin/olares-cli
+   ```
+
+4. Import the new container images:
+
+   ```bash
+   olares-cli prepare images
+   ```
+
+5. Upgrade the `olaresd` daemon:
+
+   ```bash
+   olares-cli prepare olaresd
+   ```
+
+## Step 4: Upgrade the master node
+
+With both nodes prepared, upgrade the master node first.
+
+1. In the master node SSH window, start the upgrade:
+
+   ```bash
+   sudo olares-cli upgrade
+   ```
+
+   The master node will automatically reboot once the upgrade script finishes. Your SSH session will disconnect.
+
+2. After the reboot, verify that all system services have successfully restarted and are in the `Running` status:
+
+   ```bash
+   kubectl get pod -o wide -A
+   ```
+
+3. Temporarily set the cluster version back to `1.12.5` so the worker node can be upgraded:
+
+   ```bash
+   kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.5"}}'
+   ```
+
+## Step 5: Upgrade the worker node
+
+Now that the master node is upgraded and patched, you can upgrade the worker.
+
+1. In the worker node SSH window, start the upgrade:
+
+   ```bash
+   sudo olares-cli upgrade
+   ```
+
+2. The worker node reboots when the upgrade finishes. Wait for the rebooting to finish.
+
+## Step 6: Restore the cluster version on the master node
+
+After the worker node has finished upgrading, restore the version on the master node to `1.12.6` to complete the process.
+
+1. In the master node SSH window, run the following command:
+
+   ```bash
+   kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.6"}}'
+   ```
+
+   The two-node cluster is now running Olares 1.12.6.
+
+2. To verify the final status of both nodes in the cluster, run the following command:
+
+   ```bash
+   kubectl get nodes
+   ```

--- a/docs/one/upgrade-multi-node-cluster.md
+++ b/docs/one/upgrade-multi-node-cluster.md
@@ -119,15 +119,21 @@ With both nodes prepared, upgrade the master node first.
    sudo olares-cli upgrade
    ```
 
-   The master node reboots when the upgrade finishes.
+   The master node reboots when the upgrade finishes, and your SSH session will disconnect.
 
-2. After the reboot, verify that all system services have successfully restarted and are in the `Running` status:
+2. After the reboot, reconnect to the master node via SSH:
+
+   ```bash
+   ssh olares@<master-node-ip-address>
+   ```
+
+3. Verify that all system services have successfully restarted and are in the `Running` status:
 
    ```bash
    kubectl get pod -o wide -A
    ```
 
-3. Temporarily set the cluster version back to `1.12.5` so the worker node can be upgraded:
+4. Temporarily set the cluster version back to `1.12.5` so the worker node can be upgraded:
 
    ```bash
    kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.5"}}'
@@ -148,6 +154,8 @@ Now that the master node is upgraded and patched, you can upgrade the worker nod
 ## Step 6: Restore the cluster version on the master node
 
 After the worker node finishes upgrading, restore the version on the master node to `1.12.6` to complete the process.
+
+If your SSH session to the master node times out, reconnect before proceeding.
 
 1. In the master node SSH window, run the following command:
 

--- a/docs/one/upgrade-multi-node-cluster.md
+++ b/docs/one/upgrade-multi-node-cluster.md
@@ -7,7 +7,7 @@ head:
       content: Olares One, multi-node, two-node, upgrade, 1.12.5, 1.12.6
 ---
 
-# Upgrade a two-node Olares cluster
+# Upgrade a two-node Olares cluster from 1.12.5 to 1.12.6
 
 This guide walks you through manually upgrading a two-node Olares cluster from version 1.12.5 to 1.12.6.
 

--- a/docs/zh/one/connect-two-olares-one.md
+++ b/docs/zh/one/connect-two-olares-one.md
@@ -146,3 +146,4 @@ olares-worker   Ready    worker                        50m   v1.33.3+k3s1
 ## 资源
 - [Olares CLI](../developer/install/cli/node.md)：探索 Olares CLI。
 - [Olares 环境变量](../developer/install/environment-variables.md)：了解支持 Olares 高级配置的环境变量。
+- [升级双节点 Olares 集群](./upgrade-multi-node-cluster)：了解如何手动将双节点集群从 1.12.5 升级到 1.12.6。

--- a/docs/zh/one/upgrade-multi-node-cluster.md
+++ b/docs/zh/one/upgrade-multi-node-cluster.md
@@ -7,7 +7,7 @@ head:
       content: Olares One, 多节点, 双节点, 升级, 1.12.5, 1.12.6
 ---
 
-# 升级双节点 Olares 集群
+# 将双节点 Olares 集群从 1.12.5 升级到 1.12.6
 
 :::warning
 当前文档由 AI 翻译生成，若发现术语或表述不准确，请查看[英文原文](../../one/upgrade-multi-node-cluster.md)。

--- a/docs/zh/one/upgrade-multi-node-cluster.md
+++ b/docs/zh/one/upgrade-multi-node-cluster.md
@@ -1,0 +1,166 @@
+---
+outline: [2, 3]
+description: 将双节点 Olares 集群从 1.12.5 升级到 1.12.6。
+head:
+  - - meta
+    - name: keywords
+      content: Olares One, 多节点, 双节点, 升级, 1.12.5, 1.12.6
+---
+
+# 升级双节点 Olares 集群
+
+:::warning
+当前文档由 AI 翻译生成，若发现术语或表述不准确，请查看[英文原文](../../one/upgrade-multi-node-cluster.md)。
+:::
+
+本教程介绍如何手动将双节点 Olares 集群从 1.12.5 升级到 1.12.6。升级过程包括在两个节点上下载升级包、升级 Olares CLI 和守护进程，以及分别升级 master 节点和 worker 节点。
+
+## 准备工作
+
+**集群**
+- 你有一个双节点 Olares 集群，包含一个 master 节点和一个 worker 节点。
+- 两个节点都已开机，并连接到同一局域网。
+- 你知道两个节点的本地 IP 地址。
+
+**访问**
+- 你可以通过 SSH 以具有 `sudo` 权限的用户访问两个节点。
+
+## 步骤 1：连接到两个节点
+
+在你的电脑上打开两个独立的终端窗口或标签页，分别通过 SSH 连接到两个节点。
+
+1. 在第一个窗口中，使用 master 节点的本地 IP 地址通过 SSH 连接：
+
+   ```bash
+   ssh olares@<master-node-ip-address>
+   ```
+
+2. 在第二个窗口中，使用 worker 节点的本地 IP 地址通过 SSH 连接：
+
+   ```bash
+   ssh olares@<worker-node-ip-address>
+   ```
+
+3. 在整个过程中保持两个 SSH 连接窗口处于打开状态。某些步骤需要在两个节点上分别执行，某些步骤则需要在两个节点都可访问时执行。
+
+## 步骤 2：在两个节点上下载升级包
+
+先下载升级文件，但暂不安装。在 master 和 worker 两个 SSH 窗口中分别执行以下命令。
+
+1. 切换到 root 用户：
+
+   ```bash
+   sudo su
+   ```
+
+2. 加载 Olares 环境变量：
+
+   ```bash
+   source /etc/olares/release
+   ```
+
+3. 创建升级目标文件以触发下载：
+
+   ```bash
+   echo '{"version":"1.12.6", "downloadOnly": true}' > $OLARES_BASE_DIR/upgrade.target
+   ```
+
+4. 检查下载进度：
+
+   ```bash
+   curl localhost:18088/system/status | jq | grep -i download
+   ```
+
+5. 等待 `upgradingDownloadState` 的值变为 `completed`。
+
+:::warning 等待下载完成
+进入步骤 3 之前，请确保两个节点上的 `upgradingDownloadState` 都显示为 `completed`。
+:::
+
+## 步骤 3：在两个节点上升级 Olares CLI 和守护进程
+
+下载完成后，导入新镜像并更新核心管理工具，包括 Olares CLI 和 `olaresd` 守护进程。在 master 和 worker 两个 SSH 窗口中分别执行以下命令。
+
+1. 确保你当前仍以 root 用户登录：
+
+   ```bash
+   sudo su
+   ```
+
+2. 确保环境变量已加载：
+
+   ```bash
+   source /etc/olares/release
+   ```
+
+3. 将 Olares CLI 更新到新版本：
+
+   ```bash
+   cp -f $OLARES_BASE_DIR/pkg/components/olares-cli-v1.12.6 /usr/local/bin/olares-cli
+   ```
+
+4. 导入新容器镜像：
+
+   ```bash
+   olares-cli prepare images
+   ```
+
+5. 升级 `olaresd` 守护进程：
+
+   ```bash
+   olares-cli prepare olaresd
+   ```
+
+## 步骤 4：升级 master 节点
+
+两个节点都准备好后，先升级 master 节点。
+
+1. 在 master 节点的 SSH 窗口中，开始升级：
+
+   ```bash
+   sudo olares-cli upgrade
+   ```
+
+   升级脚本执行完毕后，master 节点会自动重启。
+
+2. 重启后，验证所有系统服务是否已成功重启并处于 `Running` 状态：
+
+   ```bash
+   kubectl get pod -o wide -A
+   ```
+
+3. 临时将集群版本号改回 `1.12.5`，以便升级 worker 节点：
+
+   ```bash
+   kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.5"}}'
+   ```
+
+## 步骤 5：升级 worker 节点
+
+master 节点升级完成并临时修改版本号后，即可升级 worker 节点。
+
+1. 在 worker 节点的 SSH 窗口中，开始升级：
+
+   ```bash
+   sudo olares-cli upgrade
+   ```
+
+2. 升级完成后，worker 节点会重启。等待重启完成。
+
+## 步骤 6：在 master 节点上恢复集群版本
+
+worker 节点升级完成后，将 master 节点上的版本号恢复为 `1.12.6`，以完成整个升级过程。
+
+1. 在 master 节点的 SSH 窗口中，执行以下命令：
+
+   ```bash
+   kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.6"}}'
+   ```
+
+   此时，双节点集群已运行在 Olares 1.12.6 上。
+
+2. 要验证集群中两个节点的最终状态，请执行以下命令：
+
+   ```bash
+   kubectl get nodes
+   ```

--- a/docs/zh/one/upgrade-multi-node-cluster.md
+++ b/docs/zh/one/upgrade-multi-node-cluster.md
@@ -121,15 +121,21 @@ head:
    sudo olares-cli upgrade
    ```
 
-   升级脚本执行完毕后，master 节点会自动重启。
+   升级脚本执行完毕后，master 节点会自动重启，SSH 连接会断开。
 
-2. 重启后，验证所有系统服务是否已成功重启并处于 `Running` 状态：
+2. 重启后，重新通过 SSH 连接到 master 节点：
+
+   ```bash
+   ssh olares@<master-node-ip-address>
+   ```
+
+3. 验证所有系统服务是否已成功重启并处于 `Running` 状态：
 
    ```bash
    kubectl get pod -o wide -A
    ```
 
-3. 临时将集群版本号改回 `1.12.5`，以便升级 worker 节点：
+4. 临时将集群版本号改回 `1.12.5`，以便升级 worker 节点：
 
    ```bash
    kubectl patch terminus terminus --type=merge -p '{"spec":{"version":"1.12.5"}}'
@@ -150,6 +156,8 @@ master 节点升级完成并临时修改版本号后，即可升级 worker 节�
 ## 步骤 6：在 master 节点上恢复集群版本
 
 worker 节点升级完成后，将 master 节点上的版本号恢复为 `1.12.6`，以完成整个升级过程。
+
+如果到 master 节点的 SSH 连接已超时，请先重新连接再继续。
 
 1. 在 master 节点的 SSH 窗口中，执行以下命令：
 

--- a/docs/zh/one/upgrade-multi-node-cluster.md
+++ b/docs/zh/one/upgrade-multi-node-cluster.md
@@ -172,3 +172,7 @@ worker 节点升级完成后，将 master 节点上的版本号恢复为 `1.12.6
    ```bash
    kubectl get nodes
    ```
+
+## 参考资料
+
+- [连接两台 Olares One](./connect-two-olares-one)：了解如何搭建双节点 Olares 集群。


### PR DESCRIPTION
Title: Guide on upgrading a two-node Olares cluster

* **Background**
See title.

* **Target Version for Merge**
1.12

* **Related Issues**
None.

* **PRs Involving Sub-Systems** 
None.

* **Other information**:
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or product code paths affected.
> 
> **Overview**
> Adds **English and Chinese** Olares One docs for **manually upgrading a two-node cluster from 1.12.5 to 1.12.6**, and surfaces them in the **System update** sidebar plus a link from the two-node setup guide.
> 
> The new procedure covers parallel **download-only** upgrades on master and worker, **CLI/`olaresd` prep** on both nodes, then **master `olares-cli upgrade`** (reboot), a temporary **`kubectl patch terminus`** to **`1.12.5`** so the worker can upgrade, **worker upgrade**, and a final patch back to **`1.12.6`** with **`kubectl get nodes`** verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d544b3114e24d23d3ac5d1b39a8f70f04014c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->