### PR TITLE
fix(authelia): dev entrance acls and enhance session revocation logic

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.58
+        image: beclab/auth:0.2.59
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION

* **Background**
dev entrance acls and enhance session revocation logic
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/pull/61
https://github.com/beclab/authelia/pull/60
* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth service image upgrades can affect access control and session handling; scope here is a single version bump with no local config edits.
> 
> **Overview**
> Bumps the **Authelia** backend container image from `beclab/auth:0.2.58` to **`beclab/auth:0.2.59`** in `auth_backend_deploy.yaml`. No other manifest or config changes are in this diff.
> 
> That image tag is the vehicle for upstream fixes referenced in the PR (dev entrance ACLs and stronger session revocation); those behaviors live in the image build, not in this repository’s YAML beyond the version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec5b2b6e095796bb03701a9a3b02245414a3df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->