### PR TITLE
authelia: return the refresh token generated in first factor

### DIFF
--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.59
+        image: beclab/auth:0.2.60
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
* **Background**
Return the refresh token generated in the first factor upon TOTP signs

* **Target Version for Merge**
v1.12.7

* **Related Issues**

* **PRs Involving Sub-Systems** 
https://github.com/beclab/authelia/commit/ec84a9ffdfe7366cb03c178acc997465c34da6eb

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth image bump affects login/token behavior; scope is limited to a single image tag change with no config edits.
> 
> **Overview**
> Bumps the **authelia-backend** container image from `beclab/auth:0.2.59` to **`beclab/auth:0.2.60`** in `auth_backend_deploy.yaml`. No Helm values, ConfigMap, or other deployment settings change.
> 
> This rolls out the upstream auth build that **returns the refresh token from the first-factor flow after TOTP sign-in**, matching the linked Authelia commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d49961a673c819d892b6bb89259b8afa7eae055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->