### PR TITLE
daemon: handle CPU name retrieval error gracefully

### DIFF
--- a/daemon/pkg/utils/system.go
+++ b/daemon/pkg/utils/system.go
@@ -324,7 +324,7 @@ func computeCPUName() string {
 
 	// try to get AIBOOK M1000 model name
 	if brandName == "" {
-		cmd := exec.Command("sh", "-c", "command -v dmidecode 1>/dev/null && dmidecode -s processor-version")
+		cmd := exec.Command("sh", "-c", "command -v dmidecode 1>/dev/null && dmidecode -s processor-version || true")
 		output, err := cmd.Output()
 		if err != nil {
 			klog.Error("get CPU name error, ", err)


### PR DESCRIPTION
* **Background**
Fix `get CPU name error` in the Rockchip devices

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change to optional CPU branding detection with no security or data-handling impact.
> 
> **Overview**
> Fixes spurious **`get CPU name error`** logs on Rockchip (and similar) hosts where **`dmidecode`** is missing or fails after the **`lscpu`** path leaves the brand name empty.
> 
> The **`dmidecode`** shell fallback in **`computeCPUName`** now ends with **`|| true`**, matching the existing Rockchip **`/proc/device-tree/model`** probe so a non-zero exit does not make **`cmd.Output()`** fail before later fallbacks can run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7943f633748e2033ec6929d87abac08536d62be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->