### PR TITLE
olares, vault: bump system-frontend and vault-server images to v1.11.17

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.15
+          image: beclab/system-frontend:v1.11.17
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
+++ b/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
@@ -102,7 +102,7 @@ spec:
             value: os_framework_vault
       containers:
       - name: vault-server
-        image: beclab/vault-server:v1.6.23
+        image: beclab/vault-server:v1.11.17
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000


### PR DESCRIPTION
* **Background**

  Bump the bundled TermiPass images to the `v1.11.17` release:

  - `beclab/system-frontend` (the `olares-app-init` init container in the system-apps chart): `v1.11.15` -> `v1.11.17`
  - `beclab/vault-server`: `v1.6.23` -> `v1.11.17`, realigning the tag with the TermiPass release versioning so both images track the same upstream tag

  The release ships the following changes:

  - beclab/TermiPass#1313 — third-party custom domains are now validated (full multi-label domain, HTTPS cert/key PEM blocks), and add/edit/delete is gated on a committed **Public** auth level plus an upgradable app state. Non-public auth levels are disabled in the selector while a third-party domain exists, and the auth-level snap-back is fixed so a committed Private/Internal entrance is never silently dirtied or persisted as Public. Also hardens entrance policy store error handling and adds the `app_status_operation_wait` copy for the "config applying / app restarting" guard across all locales.
  - beclab/TermiPass#1314 — three Files/LarePass fixes: 0-byte files uploaded as part of a folder no longer land in a literal `Seahub/` folder (the sync path prefix is now stripped structurally instead of via live UI state); opening a file from the desktop download card no longer renders a blank preview (the layout switch happens before the preview opens, so `initIdState` no longer wipes `previewItem`); and `/api/refresh` no longer fails CORS in dev builds, which now route the token refresh through a same-origin dev-server proxy while native and prod keep the absolute URL.
  - beclab/TermiPass#1317 — stop writing credentials to device logs on Android, iOS and macOS. Auth tokens, cookies, VPN preauth keys, SDK state private keys, wallet mnemonics and plaintext autofill passwords were being emitted verbatim (`tp_log` uses `os_log("%{public}s", ...)`, so nothing was OS-redacted), making them readable via `adb logcat`, `Console.app` or any `sysdiagnose` attached to a bug report. The hooked Capacitor HTTP layer logged full request headers on every request on both platforms, and the accessibility helper logged third-party `EditText` contents before the `isPassword` check. Source changes are log statements only; value-free status logs are kept so these paths stay diagnosable.

* **Target Version for Merge**
  v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1313
  https://github.com/beclab/TermiPass/pull/1314
  https://github.com/beclab/TermiPass/pull/1317

* **Other information**
  Release: https://github.com/beclab/TermiPass/releases/tag/v1.11.17
  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.11.16...v1.11.17

Made with [Cursor](https://cursor.com)