### PR TITLE
fix(l4): source custom-domain certs from Application, not ConfigMap

### DIFF
--- a/framework/l4-bfl-proxy/internal/provider/provider.go
+++ b/framework/l4-bfl-proxy/internal/provider/provider.go
@@ -43,16 +43,13 @@ const (
 	settingsCustomDomain                 = "customDomain"
 	settingsCustomDomainThirdLevelDomain = "third_level_domain"
 	settingsCustomDomainThirdPartyDomain = "third_party_domain"
+	settingsCustomDomainCert             = "cert"
+	settingsCustomDomainKey              = "key"
 	applicationAuthLevelPublic           = "public"
 
-	nameSSLConfigMapName                     = "zone-ssl-config"
-	applicationThirdPartyDomainCertKeySuffix = "-domain-ssl-config"
-	appEntranceCertConfigMapLabel            = "app.bytetrade.io/custom-domain-cert"
-	appEntranceCertConfigMapCertKey          = "cert"
-	appEntranceCertConfigMapKeyKey           = "key"
-	appEntranceCertConfigMapZoneKey          = "zone"
-	userEnvLanguage                          = "olares-user-language"
-	defaultUserLanguage                      = "en-US"
+	nameSSLConfigMapName = "zone-ssl-config"
+	userEnvLanguage      = "olares-user-language"
+	defaultUserLanguage  = "en-US"
 )
 
 type Config struct {
@@ -122,7 +119,7 @@ func (p *Provider) SetupWithManager(ctx context.Context) error {
 			if !ok {
 				return false
 			}
-			return isSSLConfigMap(cm, p.cfg.UserNamespacePrefix) || isCustomDomainCertConfigMap(cm)
+			return isSSLConfigMap(cm, p.cfg.UserNamespacePrefix)
 		},
 		Handler: baseHandler,
 	}); err != nil {
@@ -500,10 +497,6 @@ func (p *Provider) listUsers(ctx context.Context, userList []iamv1alpha2.User, r
 	var result []*message.UserInfo
 
 	// Fetch cluster-wide data once; reused for every user below.
-	allCerts, err := p.getCustomDomainCerts(ctx)
-	if err != nil {
-		return nil, err
-	}
 	fsGlobal, err := p.getFileserverGlobalData(ctx)
 	if err != nil {
 		return nil, err
@@ -640,7 +633,7 @@ func (p *Provider) listUsers(ctx context.Context, userList []iamv1alpha2.User, r
 			Language:          language,
 			Apps:              p.buildAppInfos(user.Name, rawAppsMap[user.Name]),
 			SSL:               sslConfig,
-			CustomDomainCerts: allCerts[user.Name],
+			CustomDomainCerts: customDomainCertsForUser(user.Name, rawAppsMap[user.Name]),
 			FileserverNodes:   fileserverNodes,
 			MasterNodeCIDR:    masterNodeCIDR,
 		}
@@ -650,38 +643,45 @@ func (p *Provider) listUsers(ctx context.Context, userList []iamv1alpha2.User, r
 	return result, nil
 }
 
-func (p *Provider) getCustomDomainCerts(ctx context.Context) (map[string][]*message.CertInfo, error) {
-	var cmList corev1.ConfigMapList
-	if err := p.cache.List(ctx, &cmList, client.MatchingLabels{
-		appEntranceCertConfigMapLabel: "true",
-	}); err != nil {
-		return nil, fmt.Errorf("list custom domain cert configmaps: %w", err)
-	}
-
-	certs := make(map[string][]*message.CertInfo)
-	for _, cm := range cmList.Items {
-		owner := strings.TrimPrefix(cm.Namespace, "user-space-")
-		domain := cm.Data[appEntranceCertConfigMapZoneKey]
-		certData := cm.Data[appEntranceCertConfigMapCertKey]
-		keyData := cm.Data[appEntranceCertConfigMapKeyKey]
-		if domain == "" || certData == "" || keyData == "" {
-			continue
+// customDomainCertsForUser derives the user's custom-domain TLS certs from the
+// per-user `customDomain` settings on their apps, instead of from standalone
+// cert ConfigMaps. Sourcing the cert (and therefore the filter-chain SNI) from
+// the same JSON that drives the routing virtual host guarantees the two never
+// desync: a domain the app no longer configures (empty third_party_domain) or
+// one whose cert has not been issued yet (empty cert/key) produces no cert and
+// thus no filter chain, so it can never 421 nor steal another user's SNI.
+//
+// Certs are de-duped by domain (first wins) and sorted by domain for stable
+// output. CreatedAt is the app's creation time, feeding the xDS de-dup
+// tie-break when two users legitimately claim the same domain.
+func customDomainCertsForUser(username string, appList []*appv1alpha1.Application) []*message.CertInfo {
+	var certs []*message.CertInfo
+	seen := make(map[string]bool)
+	for _, app := range appList {
+		customDomainMap := getSettingsKeyMap(app, username, settingsCustomDomain)
+		for _, entranceCustomDomain := range customDomainMap {
+			domain := entranceCustomDomain[settingsCustomDomainThirdPartyDomain]
+			certData := entranceCustomDomain[settingsCustomDomainCert]
+			keyData := entranceCustomDomain[settingsCustomDomainKey]
+			if domain == "" || certData == "" || keyData == "" {
+				continue
+			}
+			if seen[domain] {
+				continue
+			}
+			seen[domain] = true
+			certs = append(certs, &message.CertInfo{
+				Domain:    domain,
+				CertData:  certData,
+				KeyData:   keyData,
+				CreatedAt: app.CreationTimestamp.Time,
+			})
 		}
-		certs[owner] = append(certs[owner], &message.CertInfo{
-			Domain:    domain,
-			CertData:  certData,
-			KeyData:   keyData,
-			CreatedAt: cm.CreationTimestamp.Time,
-		})
 	}
-	for owner := range certs {
-		ownerCerts := certs[owner]
-		sort.Slice(ownerCerts, func(i, j int) bool {
-			return ownerCerts[i].Domain < ownerCerts[j].Domain
-		})
-	}
-
-	return certs, nil
+	sort.Slice(certs, func(i, j int) bool {
+		return certs[i].Domain < certs[j].Domain
+	})
+	return certs
 }
 
 func (p *Provider) getSSLConfig(ctx context.Context, username string) (*message.SSLConfig, error) {
@@ -903,10 +903,6 @@ func parseAllowCIDRs(raw string) []string {
 
 func isSSLConfigMap(cm *corev1.ConfigMap, namespacePrefix string) bool {
 	return strings.HasPrefix(cm.Namespace, namespacePrefix) && cm.Name == nameSSLConfigMapName
-}
-
-func isCustomDomainCertConfigMap(cm *corev1.ConfigMap) bool {
-	return strings.Contains(cm.Name, applicationThirdPartyDomainCertKeySuffix)
 }
 
 func isFileServerPod(pod *corev1.Pod) bool {

--- a/framework/l4-bfl-proxy/internal/provider/provider_test.go
+++ b/framework/l4-bfl-proxy/internal/provider/provider_test.go
@@ -1,0 +1,212 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// customDomainJSON marshals a per-entrance customDomain settings blob.
+func customDomainJSON(t *testing.T, m map[string]map[string]string) string {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal customDomain: %v", err)
+	}
+	return string(b)
+}
+
+func sharedApp(name, appid string, userSettings map[string]map[string]string) *appv1alpha1.Application {
+	return &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{appv1alpha1.AppSharedLabel: appv1alpha1.AppSharedTrue},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:         name,
+			Appid:        appid,
+			UserSettings: userSettings,
+		},
+	}
+}
+
+func nonSharedApp(name, appid, owner string, settings map[string]string) *appv1alpha1.Application {
+	return &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:     name,
+			Appid:    appid,
+			Owner:    owner,
+			Settings: settings,
+		},
+	}
+}
+
+func TestCustomDomainCertsForUser(t *testing.T) {
+	t.Run("shared app with domain+cert+key in user overlay yields one cert", func(t *testing.T) {
+		app := sharedApp("ollamaclient", "ollama123", map[string]map[string]string{
+			"myxzxcvb": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"ollamaclient": {
+						settingsCustomDomainThirdPartyDomain: "www.app-test-mayuxing.cn",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+				}),
+			},
+		})
+
+		certs := customDomainCertsForUser("myxzxcvb", []*appv1alpha1.Application{app})
+		if len(certs) != 1 {
+			t.Fatalf("want 1 cert, got %d", len(certs))
+		}
+		if certs[0].Domain != "www.app-test-mayuxing.cn" {
+			t.Errorf("domain = %q, want www.app-test-mayuxing.cn", certs[0].Domain)
+		}
+		if certs[0].CertData != "cert-pem" || certs[0].KeyData != "key-pem" {
+			t.Errorf("cert/key = %q/%q, want cert-pem/key-pem", certs[0].CertData, certs[0].KeyData)
+		}
+	})
+
+	t.Run("shared app not configured by this user yields nothing", func(t *testing.T) {
+		app := sharedApp("ollamaclient", "ollama123", map[string]map[string]string{
+			"myxzxcvb": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"ollamaclient": {
+						settingsCustomDomainThirdPartyDomain: "www.app-test-mayuxing.cn",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+				}),
+			},
+		})
+
+		// A different user viewing the same fanned-out shared app has no overlay.
+		if certs := customDomainCertsForUser("myx05202", []*appv1alpha1.Application{app}); len(certs) != 0 {
+			t.Fatalf("want 0 certs for user without overlay, got %d", len(certs))
+		}
+	})
+
+	t.Run("empty third_party_domain yields nothing (orphaned-cert case)", func(t *testing.T) {
+		app := sharedApp("ollamaclient", "ollama123", map[string]map[string]string{
+			"myx05202": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"ollamaclient": {
+						settingsCustomDomainThirdPartyDomain: "",
+						settingsCustomDomainCert:             "",
+						settingsCustomDomainKey:              "",
+					},
+				}),
+			},
+		})
+
+		if certs := customDomainCertsForUser("myx05202", []*appv1alpha1.Application{app}); len(certs) != 0 {
+			t.Fatalf("want 0 certs, got %d", len(certs))
+		}
+	})
+
+	t.Run("domain set but cert not yet issued yields nothing", func(t *testing.T) {
+		app := sharedApp("ollamaclient", "ollama123", map[string]map[string]string{
+			"myxzxcvb": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"ollamaclient": {
+						settingsCustomDomainThirdPartyDomain: "www.app-test-mayuxing.cn",
+						settingsCustomDomainCert:             "",
+						settingsCustomDomainKey:              "",
+					},
+				}),
+			},
+		})
+
+		if certs := customDomainCertsForUser("myxzxcvb", []*appv1alpha1.Application{app}); len(certs) != 0 {
+			t.Fatalf("want 0 certs, got %d", len(certs))
+		}
+	})
+
+	t.Run("non-shared app reads customDomain from Spec.Settings", func(t *testing.T) {
+		app := nonSharedApp("vault", "vault123", "alice", map[string]string{
+			settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+				"vault-frontend": {
+					settingsCustomDomainThirdPartyDomain: "vault.example.com",
+					settingsCustomDomainCert:             "cert-pem",
+					settingsCustomDomainKey:              "key-pem",
+				},
+			}),
+		})
+
+		certs := customDomainCertsForUser("alice", []*appv1alpha1.Application{app})
+		if len(certs) != 1 {
+			t.Fatalf("want 1 cert, got %d", len(certs))
+		}
+		if certs[0].Domain != "vault.example.com" {
+			t.Errorf("domain = %q, want vault.example.com", certs[0].Domain)
+		}
+	})
+
+	t.Run("duplicate domain across entrances and apps is de-duped", func(t *testing.T) {
+		app1 := sharedApp("app1", "app1id", map[string]map[string]string{
+			"alice": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"e1": {
+						settingsCustomDomainThirdPartyDomain: "dup.example.com",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+					"e2": {
+						settingsCustomDomainThirdPartyDomain: "dup.example.com",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+				}),
+			},
+		})
+		app2 := sharedApp("app2", "app2id", map[string]map[string]string{
+			"alice": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"e1": {
+						settingsCustomDomainThirdPartyDomain: "dup.example.com",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+				}),
+			},
+		})
+
+		certs := customDomainCertsForUser("alice", []*appv1alpha1.Application{app1, app2})
+		if len(certs) != 1 {
+			t.Fatalf("want 1 de-duped cert, got %d", len(certs))
+		}
+		if certs[0].Domain != "dup.example.com" {
+			t.Errorf("domain = %q, want dup.example.com", certs[0].Domain)
+		}
+	})
+
+	t.Run("multiple distinct domains are sorted by domain", func(t *testing.T) {
+		app := sharedApp("multi", "multiid", map[string]map[string]string{
+			"alice": {
+				settingsCustomDomain: customDomainJSON(t, map[string]map[string]string{
+					"e1": {
+						settingsCustomDomainThirdPartyDomain: "b.example.com",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+					"e2": {
+						settingsCustomDomainThirdPartyDomain: "a.example.com",
+						settingsCustomDomainCert:             "cert-pem",
+						settingsCustomDomainKey:              "key-pem",
+					},
+				}),
+			},
+		})
+
+		certs := customDomainCertsForUser("alice", []*appv1alpha1.Application{app})
+		if len(certs) != 2 {
+			t.Fatalf("want 2 certs, got %d", len(certs))
+		}
+		if certs[0].Domain != "a.example.com" || certs[1].Domain != "b.example.com" {
+			t.Errorf("domains = %q,%q, want a.example.com,b.example.com", certs[0].Domain, certs[1].Domain)
+		}
+	})
+}


### PR DESCRIPTION




* **Background**

Custom-domain filter-chain SNIs were built from standalone cert ConfigMaps (user.CustomDomainCerts), while the routing virtual host was built from the app's `third_party_domain` setting. These two independent sources could desync: when a user cleared `third_party_domain`, the routing vhost disappeared but the orphaned cert ConfigMap remained, so the proxy still emitted a filter chain for that SNI. The xDS de-dup then kept that earliest-created black-hole chain and dropped the real owner's chain, sending every request to the `*` default vhost -> HTTP 421.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Envoy xDS custom-domain certs and SNIs are built on the L4 proxy data path; behavior is well-tested but mis-synced app settings could still omit certs until issued.
> 
> **Overview**
> **Custom-domain TLS certs and SNI filter chains now come from the same `customDomain` app settings as routing**, instead of separate cert ConfigMaps.
> 
> `listUsers` calls `customDomainCertsForUser` per user from that user's Application list (via `getSettingsKeyMap` / `third_party_domain`, `cert`, `key`). Entries missing domain or PEM material are skipped so orphaned ConfigMaps can no longer emit SNIs after `third_party_domain` is cleared. Certs are de-duped by domain and sorted; `CreatedAt` uses the app's creation time for xDS tie-breaks.
> 
> The provider **stops** cluster-wide cert ConfigMap listing, custom-domain ConfigMap watch filtering, and related constants/helpers. **Adds** unit tests for shared vs non-shared apps, per-user overlays, empty domain/cert cases, and de-duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b72d042485b3dbe9be2e66d953c1d7dd33d90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->