### PR TITLE
feat(app-service): add resource preflight API

### DIFF
--- a/framework/app-service/pkg/apiserver/compute_preflight_types.go
+++ b/framework/app-service/pkg/apiserver/compute_preflight_types.go
@@ -1,0 +1,43 @@
+package apiserver
+
+import (
+	"context"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+)
+
+const (
+	maxComputePreflightBodyBytes = 1 << 20
+	maxComputePreflightDemands   = 64
+	maxComputePreflightString    = 256
+)
+
+type ComputePreflightRequest struct {
+	Demands []ComputePreflightDemand `json:"demands"`
+}
+
+type ComputePreflightDemand struct {
+	ID                string `json:"id"`
+	AppID             string `json:"appId,omitempty"`
+	Application       string `json:"application"`
+	Owner             string `json:"owner"`
+	Mode              string `json:"mode"`
+	RequiredCPU       string `json:"requiredCPU"`
+	RequiredGPU       string `json:"requiredGPU"`
+	LimitedGPU        string `json:"limitedGPU"`
+	RequiredMemory    string `json:"requiredMemory"`
+	LimitedMemory     string `json:"limitedMemory"`
+	RequiredDisk      string `json:"requiredDisk"`
+	SupportMultiCards bool   `json:"supportMultiCards"`
+	SupportMultiNodes bool   `json:"supportMultiNodes"`
+}
+
+type ComputePreflightResponse struct {
+	api.Response `json:",inline"`
+	Data         compute.PreflightReport `json:"data"`
+}
+
+type preflightSnapshotCollector interface {
+	Collect(ctx context.Context, token string, owners []string) (compute.PreflightSnapshot, error)
+}

--- a/framework/app-service/pkg/apiserver/handler.go
+++ b/framework/app-service/pkg/apiserver/handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	computevalidation "github.com/beclab/Olares/framework/app-service/pkg/compute/validation"
+	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
 	"github.com/beclab/api/pkg/generated/informers/externalversions"
 	lister_v1alpha1 "github.com/beclab/api/pkg/generated/listers/app.bytetrade.io/v1alpha1"
@@ -22,18 +24,20 @@ import (
 
 // Handler include several fields that used for managing interactions with associated services.
 type Handler struct {
-	kubeHost         string
-	serviceCtx       context.Context
-	userspaceManager *userspace.Manager
-	kubeConfig       *rest.Config // helm's kubeConfig. TODO: insecure
-	sidecarWebhook   *webhook.Webhook
-	ctrlClient       client.Client
-	informer         externalversions.SharedInformerFactory
-	appLister        lister_v1alpha1.ApplicationLister
-	appmgrLister     lister_v1alpha1.ApplicationManagerLister
-	appSynced        cache.InformerSynced
-	appmgrSynced     cache.InformerSynced
-	opController     *OpController
+	kubeHost           string
+	serviceCtx         context.Context
+	userspaceManager   *userspace.Manager
+	kubeConfig         *rest.Config // helm's kubeConfig. TODO: insecure
+	sidecarWebhook     *webhook.Webhook
+	ctrlClient         client.Client
+	informer           externalversions.SharedInformerFactory
+	appLister          lister_v1alpha1.ApplicationLister
+	appmgrLister       lister_v1alpha1.ApplicationManagerLister
+	appSynced          cache.InformerSynced
+	appmgrSynced       cache.InformerSynced
+	opController       *OpController
+	preflightCollector preflightSnapshotCollector
+	preflightIsAdmin   func(context.Context, string) (bool, error)
 }
 
 type handlerBuilder struct {
@@ -142,18 +146,22 @@ func (b *handlerBuilder) Build() (*Handler, error) {
 	}
 
 	return &Handler{
-		kubeHost:         b.ksHost,
-		serviceCtx:       b.ctx,
-		kubeConfig:       b.kubeConfig,
-		userspaceManager: userspace.NewManager(b.ctx),
-		sidecarWebhook:   wh,
-		ctrlClient:       b.ctrlClient,
-		informer:         b.informer,
-		appLister:        b.informer.App().V1alpha1().Applications().Lister(),
-		appmgrLister:     b.informer.App().V1alpha1().ApplicationManagers().Lister(),
-		appSynced:        b.informer.App().V1alpha1().Applications().Informer().HasSynced,
-		appmgrSynced:     b.informer.App().V1alpha1().ApplicationManagers().Informer().HasSynced,
-		opController:     NewQueue(b.ctx),
+		kubeHost:           b.ksHost,
+		serviceCtx:         b.ctx,
+		kubeConfig:         b.kubeConfig,
+		userspaceManager:   userspace.NewManager(b.ctx),
+		sidecarWebhook:     wh,
+		ctrlClient:         b.ctrlClient,
+		informer:           b.informer,
+		appLister:          b.informer.App().V1alpha1().Applications().Lister(),
+		appmgrLister:       b.informer.App().V1alpha1().ApplicationManagers().Lister(),
+		appSynced:          b.informer.App().V1alpha1().Applications().Informer().HasSynced,
+		appmgrSynced:       b.informer.App().V1alpha1().ApplicationManagers().Informer().HasSynced,
+		opController:       NewQueue(b.ctx),
+		preflightCollector: computevalidation.NewPreflightSnapshotCollector(b.ctrlClient),
+		preflightIsAdmin: func(ctx context.Context, user string) (bool, error) {
+			return kubesphere.IsAdmin(ctx, b.kubeConfig, user)
+		},
 	}, nil
 
 }

--- a/framework/app-service/pkg/apiserver/handler_compute_preflight.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_preflight.go
@@ -1,0 +1,221 @@
+package apiserver
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"github.com/emicklei/go-restful/v3"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func (h *Handler) computeResourcesPreflight(req *restful.Request, resp *restful.Response) {
+	if req.Request.ContentLength > maxComputePreflightBodyBytes {
+		handleComputePreflightBodyTooLarge(req, resp)
+		return
+	}
+	req.Request.Body = http.MaxBytesReader(resp.ResponseWriter, req.Request.Body, maxComputePreflightBodyBytes)
+	var request ComputePreflightRequest
+	if err := req.ReadEntity(&request); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			handleComputePreflightBodyTooLarge(req, resp)
+			return
+		}
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+	if len(request.Demands) == 0 {
+		api.HandleBadRequest(resp, req, fmt.Errorf("at least one demand is required"))
+		return
+	}
+	if len(request.Demands) > maxComputePreflightDemands {
+		api.HandleBadRequest(resp, req, fmt.Errorf("at most %d demands are allowed", maxComputePreflightDemands))
+		return
+	}
+
+	user, ok := req.Attribute(constants.UserContextAttribute).(string)
+	if !ok || user == "" {
+		api.HandleUnauthorized(resp, req, fmt.Errorf("authenticated user is required"))
+		return
+	}
+	if h.preflightIsAdmin == nil {
+		api.HandleInternalError(resp, req, fmt.Errorf("compute preflight admin checker is not configured"))
+		return
+	}
+	isAdmin, err := h.preflightIsAdmin(req.Request.Context(), user)
+	if err != nil {
+		api.HandleInternalError(resp, req, err)
+		return
+	}
+
+	demands := make([]compute.PreflightDemand, 0, len(request.Demands))
+	owners := make([]string, 0, len(request.Demands))
+	seenOwners := make(map[string]struct{}, len(request.Demands))
+	seenIDs := make(map[string]struct{}, len(request.Demands))
+	for i, wire := range request.Demands {
+		if !isAdmin && wire.Owner != user {
+			api.HandleForbidden(resp, req, fmt.Errorf("demand %d owner %q is not authorized", i, wire.Owner))
+			return
+		}
+		demand, err := wire.toCompute()
+		if err != nil {
+			api.HandleBadRequest(resp, req, fmt.Errorf("demand %d: %w", i, err))
+			return
+		}
+		if _, exists := seenIDs[demand.ID]; exists {
+			api.HandleBadRequest(resp, req, fmt.Errorf("demand %d: duplicate id %q", i, demand.ID))
+			return
+		}
+		seenIDs[demand.ID] = struct{}{}
+		demands = append(demands, demand)
+		if _, exists := seenOwners[demand.Owner]; !exists {
+			seenOwners[demand.Owner] = struct{}{}
+			owners = append(owners, demand.Owner)
+		}
+	}
+
+	if h.preflightCollector == nil {
+		api.HandleInternalError(resp, req, fmt.Errorf("compute preflight snapshot collector is not configured"))
+		return
+	}
+	token := ""
+	if h.kubeConfig != nil {
+		token = h.kubeConfig.BearerToken
+	}
+	snapshot, err := h.preflightCollector.Collect(req.Request.Context(), token, owners)
+	if err != nil {
+		api.HandleInternalError(resp, req, fmt.Errorf("collect compute preflight snapshot: %w", err))
+		return
+	}
+	report, err := compute.SimulatePreflight(demands, snapshot)
+	if err != nil {
+		api.HandleInternalError(resp, req, fmt.Errorf("simulate compute preflight: %w", err))
+		return
+	}
+	resp.WriteAsJson(ComputePreflightResponse{
+		Response: api.Response{Code: api.CodeSuccess},
+		Data:     report,
+	})
+}
+
+func (d ComputePreflightDemand) toCompute() (compute.PreflightDemand, error) {
+	if d.ID == "" || d.Application == "" || d.Owner == "" || d.Mode == "" {
+		return compute.PreflightDemand{}, fmt.Errorf("id, application, owner, and mode are required")
+	}
+	if !validComputePreflightMode(d.Mode) {
+		return compute.PreflightDemand{}, fmt.Errorf("unsupported mode %q", d.Mode)
+	}
+	for _, item := range []struct{ field, value string }{
+		{field: "id", value: d.ID},
+		{field: "appId", value: d.AppID},
+		{field: "application", value: d.Application},
+		{field: "owner", value: d.Owner},
+		{field: "mode", value: d.Mode},
+		{field: "requiredCPU", value: d.RequiredCPU},
+		{field: "requiredGPU", value: d.RequiredGPU},
+		{field: "limitedGPU", value: d.LimitedGPU},
+		{field: "requiredMemory", value: d.RequiredMemory},
+		{field: "limitedMemory", value: d.LimitedMemory},
+		{field: "requiredDisk", value: d.RequiredDisk},
+	} {
+		if len(item.value) > maxComputePreflightString {
+			return compute.PreflightDemand{}, fmt.Errorf("%s exceeds %d bytes", item.field, maxComputePreflightString)
+		}
+	}
+	var requiredCPU, requiredGPU, limitedGPU int64
+	var requiredMemory, limitedMemory, requiredDisk int64
+	quantities := [...]struct {
+		field, value string
+		milli        bool
+		out          *int64
+	}{
+		{"requiredCPU", d.RequiredCPU, true, &requiredCPU},
+		{"requiredGPU", d.RequiredGPU, false, &requiredGPU},
+		{"limitedGPU", d.LimitedGPU, false, &limitedGPU},
+		{"requiredMemory", d.RequiredMemory, false, &requiredMemory},
+		{"limitedMemory", d.LimitedMemory, false, &limitedMemory},
+		{"requiredDisk", d.RequiredDisk, false, &requiredDisk},
+	}
+	for _, item := range quantities {
+		value, err := parseWireQuantity(item.field, item.value, item.milli)
+		if err != nil {
+			return compute.PreflightDemand{}, err
+		}
+		*item.out = value
+	}
+	if limitedGPU != 0 && limitedGPU < requiredGPU {
+		return compute.PreflightDemand{}, fmt.Errorf("limitedGPU must be zero or at least requiredGPU")
+	}
+	if limitedMemory != 0 && limitedMemory < requiredMemory {
+		return compute.PreflightDemand{}, fmt.Errorf("limitedMemory must be zero or at least requiredMemory")
+	}
+	supportMultiNodes := d.Mode == utils.NvidiaCardType && d.SupportMultiNodes
+	supportMultiCards := d.Mode == utils.NvidiaCardType && (d.SupportMultiCards || supportMultiNodes)
+	return compute.PreflightDemand{
+		ID:          d.ID,
+		AppID:       d.AppID,
+		Application: d.Application,
+		Owner:       d.Owner,
+		Requirement: compute.Requirement{
+			Mode:              d.Mode,
+			RequiredCPU:       requiredCPU,
+			RequiredGPU:       requiredGPU,
+			LimitedGPU:        limitedGPU,
+			RequiredMemory:    requiredMemory,
+			LimitedMemory:     limitedMemory,
+			RequiredDisk:      requiredDisk,
+			SupportMultiCards: supportMultiCards,
+			SupportMultiNodes: supportMultiNodes,
+		},
+	}, nil
+}
+
+func validComputePreflightMode(mode string) bool {
+	switch mode {
+	case utils.CPUType, utils.NvidiaCardType, utils.GB10ChipType, utils.AppleMChipType,
+		utils.IntelType, utils.AMDType, utils.IntelGPUType, utils.AMDGPUType, utils.MooreSocType:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseWireQuantity(field, value string, milli bool) (int64, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, fmt.Errorf("%s is required", field)
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", field, err)
+	}
+	if quantity.Sign() < 0 {
+		return 0, fmt.Errorf("%s must not be negative", field)
+	}
+	var max *resource.Quantity
+	if milli {
+		max = resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
+	} else {
+		max = resource.NewQuantity(math.MaxInt64, resource.DecimalSI)
+	}
+	if quantity.Cmp(*max) > 0 {
+		return 0, fmt.Errorf("%s overflows int64", field)
+	}
+	if milli {
+		return quantity.MilliValue(), nil
+	}
+	return quantity.Value(), nil
+}
+
+func handleComputePreflightBodyTooLarge(req *restful.Request, resp *restful.Response) {
+	api.HandleError(resp, req, restful.ServiceError{
+		Code:    http.StatusRequestEntityTooLarge,
+		Message: fmt.Sprintf("request body exceeds %d bytes", maxComputePreflightBodyBytes),
+	})
+}

--- a/framework/app-service/pkg/apiserver/handler_compute_preflight_test.go
+++ b/framework/app-service/pkg/apiserver/handler_compute_preflight_test.go
@@ -1,0 +1,217 @@
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	"github.com/emicklei/go-restful/v3"
+)
+
+type fakePreflightCollector struct {
+	snapshot compute.PreflightSnapshot
+	err      error
+	owners   []string
+}
+
+func (f *fakePreflightCollector) Collect(_ context.Context, _ string, owners []string) (compute.PreflightSnapshot, error) {
+	f.owners = append([]string(nil), owners...)
+	return f.snapshot, f.err
+}
+
+func callComputePreflight(t *testing.T, h *Handler, user, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := restful.NewRequest(httptest.NewRequest(http.MethodPost, "/app-service/v1/compute-resources/preflight", strings.NewReader(body)))
+	req.Request.Header.Set("Content-Type", restful.MIME_JSON)
+	req.SetAttribute(constants.UserContextAttribute, user)
+	rec := httptest.NewRecorder()
+	resp := restful.NewResponse(rec)
+	resp.SetRequestAccepts(restful.MIME_JSON)
+	h.computeResourcesPreflight(req, resp)
+	return rec
+}
+
+func installableSnapshot() compute.PreflightSnapshot {
+	return compute.PreflightSnapshot{
+		Nodes: []compute.Node{{
+			NodeName: "gpu-a",
+			GPUTypes: []string{utils.NvidiaCardType},
+			Devices: []compute.Device{{
+				ID: "gpu0", NodeName: "gpu-a", Mode: utils.NvidiaCardType,
+				Memory: 16 << 30, Health: "yes", SupportType: compute.SupportTypeExclusive,
+			}},
+		}},
+		Pressure: compute.PressureSnapshot{
+			Threshold: 0.9,
+			UsageByNode: map[string]prometheus.NodeResourceUsage{
+				"gpu-a": {
+					CPUCapacity: 8000, MemoryCapacity: 64 << 30, MemoryAvailable: 48 << 30,
+					DiskCapacity: 1 << 40, DiskAvailable: 900 << 30,
+				},
+			},
+		},
+		Cluster: &prometheus.ClusterMetrics{
+			CPU:    prometheus.Value{Total: 64},
+			Memory: prometheus.Value{Total: 128 << 30},
+			Disk:   prometheus.Value{Total: 1 << 40},
+		},
+		Owners:       map[string]*prometheus.ClusterMetrics{"alice": {}, "bob": {}},
+		K8sAvailable: apputils.ResourceState{CPU: 64000, Memory: 128 << 30},
+	}
+}
+
+func validDemandJSON(id, owner string) string {
+	return `{
+		"id":"` + id + `","appId":"app-id","application":"model","owner":"` + owner + `",
+		"mode":"nvidia","requiredCPU":"500m","requiredGPU":"8Gi","limitedGPU":"8Gi",
+		"requiredMemory":"1Gi","limitedMemory":"2Gi","requiredDisk":"10Gi",
+		"supportMultiCards":false,"supportMultiNodes":false
+	}`
+}
+
+func testPreflightHandler(snapshot compute.PreflightSnapshot, admin bool) *Handler {
+	return &Handler{
+		preflightCollector: &fakePreflightCollector{snapshot: snapshot},
+		preflightIsAdmin:   func(context.Context, string) (bool, error) { return admin, nil },
+	}
+}
+
+func TestComputeResourcesPreflightReturnsOverallReport(t *testing.T) {
+	collector := &fakePreflightCollector{snapshot: installableSnapshot()}
+	h := &Handler{
+		preflightCollector: collector,
+		preflightIsAdmin:   func(context.Context, string) (bool, error) { return false, nil },
+	}
+	rec := callComputePreflight(t, h, "alice", `{"demands":[`+validDemandJSON("one", "alice")+`]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response ComputePreflightResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !response.Data.Installable || response.Data.FailedDemandID != "" {
+		t.Fatalf("unexpected report: %#v", response.Data)
+	}
+	if strings.Contains(rec.Body.String(), "placement") || strings.Contains(rec.Body.String(), "demands") {
+		t.Fatalf("response leaked internal/per-demand details: %s", rec.Body.String())
+	}
+	if len(collector.owners) != 1 || collector.owners[0] != "alice" {
+		t.Fatalf("owners=%v", collector.owners)
+	}
+}
+
+func TestComputeResourcesPreflightOwnerAuthorization(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		admin      bool
+		owner      string
+		wantStatus int
+	}{
+		{name: "regular user own", owner: "alice", wantStatus: http.StatusOK},
+		{name: "regular user cross owner", owner: "bob", wantStatus: http.StatusForbidden},
+		{name: "admin cross owner", admin: true, owner: "bob", wantStatus: http.StatusOK},
+		{name: "admin shared", admin: true, owner: "shared", wantStatus: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := callComputePreflight(t, testPreflightHandler(installableSnapshot(), tc.admin), "alice",
+				`{"demands":[`+validDemandJSON("one", tc.owner)+`]}`)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestComputeResourcesPreflightRejectsInvalidWireDemands(t *testing.T) {
+	h := testPreflightHandler(installableSnapshot(), false)
+	tests := []string{
+		`{"demands":[]}`,
+		`{"demands":[` + validDemandJSON("same", "alice") + `,` + validDemandJSON("same", "alice") + `]}`,
+		`{"demands":[` + strings.Replace(validDemandJSON("one", "alice"), `"mode":"nvidia"`, `"mode":"mystery"`, 1) + `]}`,
+		`{"demands":[` + strings.Replace(validDemandJSON("one", "alice"), `"requiredMemory":"1Gi"`, `"requiredMemory":"wat"`, 1) + `]}`,
+		`{"demands":[` + strings.Replace(validDemandJSON("one", "alice"), `"requiredDisk":"10Gi"`, `"requiredDisk":"-1Gi"`, 1) + `]}`,
+		`{"demands":[` + strings.Replace(validDemandJSON("one", "alice"), `"id":"one"`, `"id":"`+strings.Repeat("x", 257)+`"`, 1) + `]}`,
+	}
+	for _, body := range tests {
+		rec := callComputePreflight(t, h, "alice", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestComputeResourcesPreflightLimitsRequestSizeAndCount(t *testing.T) {
+	h := testPreflightHandler(installableSnapshot(), false)
+	demands := make([]string, 65)
+	for i := range demands {
+		demands[i] = validDemandJSON(string(rune('a'+i%26))+string(rune('A'+i/26)), "alice")
+	}
+	rec := callComputePreflight(t, h, "alice", `{"demands":[`+strings.Join(demands, ",")+`]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("count status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := `{"demands":[` + validDemandJSON("one", "alice") + `],"padding":"` + strings.Repeat("x", 1<<20) + `"}`
+	rec = callComputePreflight(t, h, "alice", body)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("size status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestComputePreflightDemandNormalizesMultiNodeToMultiCard(t *testing.T) {
+	wire := ComputePreflightDemand{
+		ID: "app", Application: "app", Owner: "alice", Mode: utils.NvidiaCardType,
+		RequiredCPU: "0", RequiredGPU: "8Gi", LimitedGPU: "8Gi",
+		RequiredMemory: "1Gi", LimitedMemory: "1Gi", RequiredDisk: "0",
+		SupportMultiNodes: true,
+	}
+	demand, err := wire.toCompute()
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if !demand.Requirement.SupportMultiNodes || !demand.Requirement.SupportMultiCards {
+		t.Fatalf("multi-node must imply multi-card: %#v", demand.Requirement)
+	}
+
+	wire.Mode = utils.CPUType
+	demand, err = wire.toCompute()
+	if err != nil {
+		t.Fatalf("convert cpu: %v", err)
+	}
+	if demand.Requirement.SupportMultiNodes || demand.Requirement.SupportMultiCards {
+		t.Fatalf("non-nvidia mode must ignore multi-card flags: %#v", demand.Requirement)
+	}
+}
+
+func TestComputeResourcesPreflightInternalFailuresAreServerErrors(t *testing.T) {
+	tests := []*Handler{
+		{
+			preflightCollector: &fakePreflightCollector{err: errors.New("metrics unavailable")},
+			preflightIsAdmin:   func(context.Context, string) (bool, error) { return false, nil },
+		},
+		testPreflightHandler(compute.PreflightSnapshot{}, false),
+		{preflightCollector: &fakePreflightCollector{snapshot: installableSnapshot()}},
+		{preflightIsAdmin: func(context.Context, string) (bool, error) { return false, nil }},
+		{
+			preflightCollector: &fakePreflightCollector{snapshot: installableSnapshot()},
+			preflightIsAdmin: func(context.Context, string) (bool, error) {
+				return false, restful.ServiceError{Code: http.StatusBadRequest, Message: "role lookup failed"}
+			},
+		},
+	}
+	for _, h := range tests {
+		rec := callComputePreflight(t, h, "alice", `{"demands":[`+validDemandJSON("one", "alice")+`]}`)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -259,6 +259,13 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
 		Returns(http.StatusOK, "Success to list compute resources", &ComputeResourcesResponse{}))
 
+	ws.Route(ws.POST("/compute-resources/preflight").
+		To(handler.computeResourcesPreflight).
+		Reads(ComputePreflightRequest{}).
+		Doc("simulate compute resource demands against the current cluster snapshot").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Returns(http.StatusOK, "Compute resource preflight report", &ComputePreflightResponse{}))
+
 	ws.Route(ws.PUT("/compute-resources/nodes/{"+ParamNodeName+"}/devices/{"+ParamDeviceID+"}/support-type").
 		To(handler.updateDeviceSupportType).
 		Doc("switch compute device support type").

--- a/framework/app-service/pkg/compute/calculator_test.go
+++ b/framework/app-service/pkg/compute/calculator_test.go
@@ -432,6 +432,82 @@ func TestPickAggregateAllocationsAcrossNodes(t *testing.T) {
 	}
 }
 
+func TestPickAllocationsSkipsUnhealthyDevices(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice"}
+	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi}
+	nodes := []Node{
+		nvidiaNode("unhealthy", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthNo, SupportType: SupportTypeExclusive}),
+		nvidiaNode("healthy", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+	}
+
+	picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+	if !ok || len(picked) != 1 || picked[0].NodeName != "healthy" {
+		t.Fatalf("expected only the healthy device to be selected, got ok=%v picked=%#v", ok, picked)
+	}
+}
+
+func TestPickAllocationsHonorsDeviceMemoryAndBindings(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice"}
+	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi}
+	cases := []struct {
+		name   string
+		device Device
+	}{
+		{
+			name: "exclusive device already bound",
+			device: Device{
+				ID:          "gpu0",
+				Memory:      16 * gi,
+				Health:      deviceHealthYes,
+				SupportType: SupportTypeExclusive,
+				Bindings:    []Allocation{{AppName: "other", Memory: 1}},
+			},
+		},
+		{
+			name: "memory slice has insufficient remaining memory",
+			device: Device{
+				ID:          "gpu0",
+				Memory:      16 * gi,
+				Health:      deviceHealthYes,
+				SupportType: SupportTypeMemorySlice,
+				Bindings:    []Allocation{{AppName: "other", Memory: 9 * gi}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if picked, ok := PickAllocations(app, req, []Node{nvidiaNode("nvidia-a", tc.device)}, PressureSnapshot{}); ok || len(picked) != 0 {
+				t.Fatalf("expected allocation to fail, got ok=%v picked=%#v", ok, picked)
+			}
+		})
+	}
+}
+
+func TestPickAllocationsReturnsFailureWhenPressureRejectsFittingDevice(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice"}
+	req := Requirement{
+		Mode:           utils.NvidiaCardType,
+		RequiredGPU:    8 * gi,
+		LimitedGPU:     8 * gi,
+		RequiredMemory: gi,
+		LimitedMemory:  gi,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a", Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive}),
+	}
+	pressure := PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			"nvidia-a": {MemoryCapacity: 8 * gi, MemoryAvailable: 0},
+		},
+	}
+
+	picked, ok := PickAllocations(app, req, nodes, pressure)
+	if ok || len(picked) != 0 {
+		t.Fatalf("expected pressure to reject an otherwise fitting device, got ok=%v picked=%#v", ok, picked)
+	}
+}
+
 // TestPickSingleAllocationGB10MemorySlice guards the GB10 single-card
 // allocation path: a GB10 node's device is decoded with the MemorySlice
 // support type by default (shareModeToSupportType), so PickAllocations must

--- a/framework/app-service/pkg/compute/preflight.go
+++ b/framework/app-service/pkg/compute/preflight.go
@@ -1,0 +1,321 @@
+package compute
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func SimulatePreflight(demands []PreflightDemand, snapshot PreflightSnapshot) (PreflightReport, error) {
+	state := clonePreflightSnapshot(snapshot)
+	if err := validatePreflightInputs(demands, state); err != nil {
+		return PreflightReport{}, err
+	}
+	for _, demand := range demands {
+		failure, placement, err := simulateDemand(demand, &state)
+		if err != nil {
+			return PreflightReport{}, fmt.Errorf("simulate demand %q: %w", demand.ID, err)
+		}
+		if failure != nil {
+			failure.FailedDemandID = demand.ID
+			return *failure, nil
+		}
+		if err := applyDemand(demand, placement, &state); err != nil {
+			return PreflightReport{}, fmt.Errorf("apply demand %q: %w", demand.ID, err)
+		}
+	}
+	return PreflightReport{Installable: true}, nil
+}
+
+func simulateDemand(demand PreflightDemand, state *PreflightSnapshot) (*PreflightReport, PreflightPlacement, error) {
+	added := addedResourcesFromRequirement(demand.Requirement)
+	required := apputils.ResourceState{CPU: added.CPU, Memory: added.Memory, Disk: added.Disk}
+	// Preflight intentionally checks current pressure on every dimension,
+	// including dimensions the demand leaves at zero.
+	dimensions := apputils.AllResourceDimensions
+
+	resourcePressure, evalErr := apputils.EvaluatePhysicalCapacity(required, state.Cluster, dimensions)
+	if failure, err := resourceFailure(PreflightReasonClusterCapacity, resourcePressure, evalErr); failure != nil || err != nil {
+		return failure, PreflightPlacement{}, err
+	}
+	resourcePressure, evalErr = apputils.EvaluateClusterPressure(required, state.Cluster, dimensions)
+	if failure, err := resourceFailure(PreflightReasonClusterPressure, resourcePressure, evalErr); failure != nil || err != nil {
+		return failure, PreflightPlacement{}, err
+	}
+	if demand.Owner != PreflightSharedOwner {
+		resourcePressure, evalErr = apputils.EvaluateOwnerPressure(required, state.Owners[demand.Owner], dimensions)
+		if failure, err := resourceFailure(PreflightReasonOwnerQuota, resourcePressure, evalErr); failure != nil || err != nil {
+			return failure, PreflightPlacement{}, err
+		}
+	}
+	cpu := *resource.NewMilliQuantity(state.K8sAvailable.CPU, resource.DecimalSI)
+	memory := *resource.NewQuantity(state.K8sAvailable.Memory, resource.BinarySI)
+	resourcePressure, evalErr = apputils.EvaluateK8sRequest(required, dimensions, cpu, memory)
+	if failure, err := resourceFailure(PreflightReasonK8sRequest, resourcePressure, evalErr); failure != nil || err != nil {
+		return failure, PreflightPlacement{}, err
+	}
+
+	hardPlacement, ok := pickPreflightPlacement(demand, added, state.Nodes, PressureSnapshot{}, false)
+	if !ok {
+		return &PreflightReport{Reason: PreflightReasonUnschedulable}, PreflightPlacement{}, nil
+	}
+	placement, ok := pickPreflightPlacement(demand, added, state.Nodes, state.Pressure, true)
+	if ok {
+		return nil, placement, nil
+	}
+	pressure, err := placementPressure(added, hardPlacement, state)
+	if err != nil {
+		return nil, PreflightPlacement{}, err
+	}
+	return &PreflightReport{Reason: PreflightReasonNodePressure, Pressure: pressure}, PreflightPlacement{}, nil
+}
+
+func resourceFailure(reason string, pressure []apputils.ResourcePressure, err error) (*PreflightReport, error) {
+	if err != nil {
+		return nil, err
+	}
+	if len(pressure) == 0 {
+		return nil, nil
+	}
+	return &PreflightReport{Reason: reason, Pressure: []PreflightPressure{{Source: reason, Dimensions: pressure}}}, nil
+}
+
+func pickPreflightPlacement(demand PreflightDemand, added AddedResources, nodes []Node, pressure PressureSnapshot, checkPressure bool) (PreflightPlacement, bool) {
+	if demand.Requirement.Mode == utils.CPUType {
+		for _, node := range nodes {
+			if usableCPUNodeMemory(node.memoryCapacity) < demand.Requirement.RequiredMemory {
+				continue
+			}
+			if checkPressure && pressure.WouldPressure(node, added) {
+				continue
+			}
+			return PreflightPlacement{NodeNames: []string{node.NodeName}}, true
+		}
+		return PreflightPlacement{}, false
+	}
+	app := &appcfg.ApplicationConfig{
+		AppID: demand.AppID, AppName: demand.Application, OwnerName: demand.Owner,
+		SelectedGpuType: demand.Requirement.Mode,
+	}
+	allocations, ok := pickAllocations(app, demand.Requirement, nodes, pressure, allocationOptions{
+		checkPressure: checkPressure,
+		deterministic: true,
+		pressureAdded: &added,
+	})
+	if !ok {
+		return PreflightPlacement{}, false
+	}
+	return placementFromAllocations(allocations), true
+}
+
+func placementFromAllocations(allocations []Allocation) PreflightPlacement {
+	nodeSet := make(map[string]struct{})
+	for _, allocation := range allocations {
+		nodeSet[allocation.NodeName] = struct{}{}
+	}
+	nodeNames := make([]string, 0, len(nodeSet))
+	for nodeName := range nodeSet {
+		nodeNames = append(nodeNames, nodeName)
+	}
+	sort.Strings(nodeNames)
+	return PreflightPlacement{NodeNames: nodeNames, Allocations: allocations}
+}
+
+func placementPressure(added AddedResources, placement PreflightPlacement, state *PreflightSnapshot) ([]PreflightPressure, error) {
+	out := make([]PreflightPressure, 0, len(placement.NodeNames))
+	for _, nodeName := range placement.NodeNames {
+		node, ok := findNode(state.Nodes, nodeName)
+		if !ok {
+			return nil, fmt.Errorf("placement node %q is missing", nodeName)
+		}
+		projected, err := placementAddedResources(added, nodeName, placement.Allocations, state.Nodes)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateNodeProjection(state.Pressure.UsageByNode[nodeName], projected); err != nil {
+			return nil, fmt.Errorf("node %q: %w", nodeName, err)
+		}
+		dimensions := state.Pressure.PressuredDimensions(node, projected)
+		if len(dimensions) > 0 {
+			out = append(out, PreflightPressure{Source: "node/" + nodeName, Dimensions: dimensions})
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("pressure placement failed without pressured dimensions")
+	}
+	return out, nil
+}
+
+func validateNodeProjection(usage prometheus.NodeResourceUsage, added AddedResources) error {
+	values := [][2]int64{
+		{nodeUsedCPU(usage), added.CPU},
+		{usage.MemoryCapacity - usage.MemoryAvailable, added.Memory},
+		{usage.DiskCapacity - usage.DiskAvailable, added.Disk},
+	}
+	for _, value := range values {
+		if _, ok := checkedAdd(value[0], value[1]); !ok {
+			return fmt.Errorf("resource projection overflows")
+		}
+	}
+	return nil
+}
+
+func placementAddedResources(added AddedResources, nodeName string, allocations []Allocation, nodes []Node) (AddedResources, error) {
+	for _, allocation := range allocations {
+		if allocation.NodeName != nodeName {
+			continue
+		}
+		node, ok := findNode(nodes, nodeName)
+		if !ok {
+			return AddedResources{}, fmt.Errorf("node %q is missing", nodeName)
+		}
+		device, ok := findDevice(node, allocation.DeviceID)
+		if !ok {
+			return AddedResources{}, fmt.Errorf("device %q is missing", allocation.DeviceID)
+		}
+		var valid bool
+		added.Memory, valid = checkedAdd(added.Memory, timeSliceAddedMemory(device))
+		if !valid {
+			return AddedResources{}, fmt.Errorf("host memory projection overflows")
+		}
+	}
+	return added, nil
+}
+
+func applyDemand(demand PreflightDemand, placement PreflightPlacement, state *PreflightSnapshot) error {
+	added := addedResourcesFromRequirement(demand.Requirement)
+	if err := applyPlacement(added, placement, state); err != nil {
+		return err
+	}
+	if err := addMetricUsage(state.Cluster, added); err != nil {
+		return err
+	}
+	if demand.Owner != PreflightSharedOwner {
+		if err := addMetricUsage(state.Owners[demand.Owner], added); err != nil {
+			return err
+		}
+	}
+	if added.CPU > state.K8sAvailable.CPU || added.Memory > state.K8sAvailable.Memory {
+		return fmt.Errorf("kubernetes availability underflows")
+	}
+	state.K8sAvailable.CPU -= added.CPU
+	state.K8sAvailable.Memory -= added.Memory
+	return nil
+}
+
+func applyPlacement(added AddedResources, placement PreflightPlacement, state *PreflightSnapshot) error {
+	for _, nodeName := range placement.NodeNames {
+		projected, err := placementAddedResources(added, nodeName, placement.Allocations, state.Nodes)
+		if err != nil {
+			return err
+		}
+		if err := projectPressure(&state.Pressure, nodeName, projected); err != nil {
+			return err
+		}
+	}
+	for _, allocation := range placement.Allocations {
+		for nodeIndex := range state.Nodes {
+			if state.Nodes[nodeIndex].NodeName != allocation.NodeName {
+				continue
+			}
+			for deviceIndex := range state.Nodes[nodeIndex].Devices {
+				if state.Nodes[nodeIndex].Devices[deviceIndex].ID == allocation.DeviceID {
+					state.Nodes[nodeIndex].Devices[deviceIndex].Bindings = append(
+						state.Nodes[nodeIndex].Devices[deviceIndex].Bindings, allocation)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func projectPressure(snapshot *PressureSnapshot, nodeName string, added AddedResources) error {
+	usage, ok := snapshot.UsageByNode[nodeName]
+	if !ok {
+		return fmt.Errorf("node metrics for %q are missing", nodeName)
+	}
+	projectedCPU, ok := checkedAdd(nodeUsedCPU(usage), added.CPU)
+	if !ok {
+		return fmt.Errorf("cpu projection overflows")
+	}
+	if usage.CPUCapacity > 0 {
+		usage.CPUUtilization = float64(projectedCPU) / float64(usage.CPUCapacity)
+	}
+	if added.Memory > usage.MemoryAvailable || added.Disk > usage.DiskAvailable {
+		return fmt.Errorf("node availability underflows")
+	}
+	usage.MemoryAvailable -= added.Memory
+	usage.DiskAvailable -= added.Disk
+	snapshot.UsageByNode[nodeName] = usage
+	return nil
+}
+
+func validatePreflightInputs(demands []PreflightDemand, snapshot PreflightSnapshot) error {
+	if snapshot.Cluster == nil {
+		return fmt.Errorf("cluster metrics are missing")
+	}
+	if snapshot.K8sAvailable.CPU < 0 || snapshot.K8sAvailable.Memory < 0 {
+		return fmt.Errorf("kubernetes availability is invalid")
+	}
+	if err := ValidatePressureSnapshot(snapshot.Nodes, snapshot.Pressure); err != nil {
+		return err
+	}
+	if _, err := apputils.EvaluateClusterPressure(apputils.ResourceState{}, snapshot.Cluster, apputils.AllResourceDimensions); err != nil {
+		return fmt.Errorf("cluster metrics are invalid: %w", err)
+	}
+	for _, demand := range demands {
+		if err := validatePreflightDemand(demand); err != nil {
+			return err
+		}
+		if demand.Owner == PreflightSharedOwner {
+			continue
+		}
+		metrics, ok := snapshot.Owners[demand.Owner]
+		if !ok {
+			return fmt.Errorf("owner metrics for %q are missing", demand.Owner)
+		}
+		if _, err := apputils.EvaluateOwnerPressure(apputils.ResourceState{}, metrics, apputils.AllResourceDimensions); err != nil {
+			return fmt.Errorf("owner metrics for %q are invalid: %w", demand.Owner, err)
+		}
+	}
+	return nil
+}
+
+func validatePreflightDemand(demand PreflightDemand) error {
+	req := demand.Requirement
+	if demand.ID == "" || demand.Owner == "" || demand.Application == "" || req.Mode == "" {
+		return fmt.Errorf("demand identity is incomplete")
+	}
+	if req.RequiredCPU < 0 || req.RequiredGPU < 0 || req.LimitedGPU < 0 ||
+		req.RequiredMemory < 0 || req.LimitedMemory < 0 || req.RequiredDisk < 0 {
+		return fmt.Errorf("demand resources must not be negative")
+	}
+	if (req.LimitedGPU != 0 && req.LimitedGPU < req.RequiredGPU) ||
+		(req.LimitedMemory != 0 && req.LimitedMemory < req.RequiredMemory) {
+		return fmt.Errorf("demand limits must cover requirements")
+	}
+	return nil
+}
+
+func addMetricUsage(metrics *prometheus.ClusterMetrics, added AddedResources) error {
+	if metrics == nil {
+		return fmt.Errorf("metrics are missing")
+	}
+	metrics.CPU.Usage += float64(added.CPU) / 1000
+	metrics.Memory.Usage += float64(added.Memory)
+	metrics.Disk.Usage += float64(added.Disk)
+	if math.IsInf(metrics.CPU.Usage, 0) || math.IsInf(metrics.Memory.Usage, 0) || math.IsInf(metrics.Disk.Usage, 0) {
+		return fmt.Errorf("metric projection overflows")
+	}
+	return nil
+}
+
+func addedResourcesFromRequirement(req Requirement) AddedResources {
+	return AddedResources{CPU: req.RequiredCPU, Memory: req.RequiredMemory, Disk: req.RequiredDisk}
+}

--- a/framework/app-service/pkg/compute/preflight_test.go
+++ b/framework/app-service/pkg/compute/preflight_test.go
@@ -1,0 +1,315 @@
+package compute
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+)
+
+func TestSimulatePreflightSingleDemand(t *testing.T) {
+	report, err := SimulatePreflight([]PreflightDemand{cpuDemand("app", "alice", 100)}, installablePreflightSnapshot())
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if !report.Installable || report.FailedDemandID != "" || report.Reason != "" || len(report.Pressure) != 0 {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+func TestSimulatePreflightAccumulatesInInputOrder(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Pressure.UsageByNode["cpu-a"] = prometheus.NodeResourceUsage{CPUCapacity: 1000}
+	b := cpuDemand("b", "alice", 600)
+	a := cpuDemand("a", "alice", 400)
+
+	report, err := SimulatePreflight([]PreflightDemand{b, a}, snapshot)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if report.Installable || report.FailedDemandID != "a" || report.Reason != PreflightReasonNodePressure {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+func TestSimulatePreflightStopsAtFirstFailure(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Owners["alice"] = &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 1},
+		Memory: prometheus.Value{Total: 8 * float64(gi)},
+	}
+
+	report, err := SimulatePreflight([]PreflightDemand{
+		cpuDemand("first", "alice", 1000),
+		cpuDemand("never", "bob", 100000),
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if report.Installable || report.FailedDemandID != "first" || report.Reason != PreflightReasonOwnerQuota {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+func TestSimulatePreflightValidatesAllOwnerFactsBeforeSimulation(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	delete(snapshot.Owners, "bob")
+	snapshot.Cluster.CPU.Usage = snapshot.Cluster.CPU.Total
+
+	_, err := SimulatePreflight([]PreflightDemand{
+		cpuDemand("blocked", "alice", 1),
+		cpuDemand("missing-owner", "bob", 1),
+	}, snapshot)
+	if err == nil {
+		t.Fatal("missing facts for any demand must fail before simulation")
+	}
+}
+
+func TestSimulatePreflightExclusiveGPUCompetition(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Nodes = []Node{nvidiaNode("gpu-a", Device{
+		ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive,
+	})}
+	snapshot.Pressure = nodePressure("gpu-a")
+
+	report, err := SimulatePreflight([]PreflightDemand{
+		gpuDemand("a", "alice", 8*gi),
+		gpuDemand("b", "bob", 8*gi),
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if report.Installable || report.FailedDemandID != "b" || report.Reason != PreflightReasonUnschedulable {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+func TestSimulatePreflightTimeSliceHostMemory(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Nodes = []Node{nvidiaNode("gpu-a",
+		Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice},
+		Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice},
+	)}
+	snapshot.Pressure = PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			"gpu-a": {MemoryCapacity: 32 * gi, MemoryAvailable: 32 * gi},
+		},
+	}
+	demand := gpuDemand("multi", "alice", 24*gi)
+	demand.Requirement.RequiredMemory = gi
+	demand.Requirement.LimitedMemory = gi
+	demand.Requirement.SupportMultiCards = true
+
+	report, err := SimulatePreflight([]PreflightDemand{demand}, snapshot)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if report.Installable || report.FailedDemandID != "multi" || report.Reason != PreflightReasonNodePressure {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+	if len(report.Pressure) != 1 || len(report.Pressure[0].Dimensions) != 1 ||
+		report.Pressure[0].Dimensions[0].Required != 33*gi {
+		t.Fatalf("expected pod plus both cards in host memory pressure: %#v", report.Pressure)
+	}
+}
+
+func TestSimulatePreflightResourceChecks(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*PreflightSnapshot, *PreflightDemand)
+		reason string
+	}{
+		{
+			name: "physical capacity",
+			mutate: func(s *PreflightSnapshot, d *PreflightDemand) {
+				d.Requirement.RequiredMemory = 65 * gi
+				d.Requirement.LimitedMemory = 65 * gi
+			},
+			reason: PreflightReasonClusterCapacity,
+		},
+		{
+			name: "cluster pressure",
+			mutate: func(s *PreflightSnapshot, d *PreflightDemand) {
+				s.Cluster.Memory.Usage = 58 * float64(gi)
+				d.Requirement.RequiredMemory = gi
+				d.Requirement.LimitedMemory = gi
+			},
+			reason: PreflightReasonClusterPressure,
+		},
+		{
+			name: "owner quota",
+			mutate: func(s *PreflightSnapshot, d *PreflightDemand) {
+				s.Owners["alice"] = &prometheus.ClusterMetrics{
+					CPU:    prometheus.Value{Total: 1},
+					Memory: prometheus.Value{Total: 8 * float64(gi)},
+				}
+				d.Requirement.RequiredCPU = 1000
+			},
+			reason: PreflightReasonOwnerQuota,
+		},
+		{
+			name: "k8s strict comparison",
+			mutate: func(s *PreflightSnapshot, d *PreflightDemand) {
+				s.K8sAvailable.CPU = 100
+				d.Requirement.RequiredCPU = 100
+			},
+			reason: PreflightReasonK8sRequest,
+		},
+		{
+			name: "node pressure",
+			mutate: func(s *PreflightSnapshot, d *PreflightDemand) {
+				s.Pressure.UsageByNode["cpu-a"] = prometheus.NodeResourceUsage{CPUCapacity: 100}
+				d.Requirement.RequiredCPU = 100
+			},
+			reason: PreflightReasonNodePressure,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := installablePreflightSnapshot()
+			demand := cpuDemand("app", "alice", 1)
+			tc.mutate(&snapshot, &demand)
+			report, err := SimulatePreflight([]PreflightDemand{demand}, snapshot)
+			if err != nil {
+				t.Fatalf("simulate: %v", err)
+			}
+			if report.Installable || report.FailedDemandID != "app" || report.Reason != tc.reason ||
+				len(report.Pressure) == 0 {
+				t.Fatalf("unexpected report: %#v", report)
+			}
+		})
+	}
+}
+
+func TestSimulatePreflightChecksPressureOnUndeclaredDimensions(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Cluster.Memory.Usage = 60 * float64(gi)
+	demand := cpuDemand("strict", "alice", 1)
+
+	installPressure, err := apputils.EvaluateClusterPressure(
+		apputils.ResourceState{CPU: demand.Requirement.RequiredCPU},
+		snapshot.Cluster,
+		apputils.ResourceDimensions{CPU: true},
+	)
+	if err != nil {
+		t.Fatalf("evaluate install pressure: %v", err)
+	}
+	if len(installPressure) != 0 {
+		t.Fatalf("real install dimensions should skip undeclared memory: %#v", installPressure)
+	}
+
+	report, err := SimulatePreflight([]PreflightDemand{demand}, snapshot)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if report.Installable || report.FailedDemandID != demand.ID || report.Reason != PreflightReasonClusterPressure {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+	if len(report.Pressure) != 1 || len(report.Pressure[0].Dimensions) != 1 ||
+		report.Pressure[0].Dimensions[0].Resource != PressureResourceMemory {
+		t.Fatalf("expected memory pressure: %#v", report.Pressure)
+	}
+}
+
+func TestSimulatePreflightRejectsInvalidSnapshotAndOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot PreflightSnapshot
+		demand   PreflightDemand
+	}{
+		{
+			name:     "missing cluster metrics",
+			snapshot: PreflightSnapshot{},
+			demand:   cpuDemand("missing", "alice", 1),
+		},
+		{
+			name: "missing node metrics",
+			snapshot: func() PreflightSnapshot {
+				s := installablePreflightSnapshot()
+				s.Pressure.UsageByNode = nil
+				return s
+			}(),
+			demand: cpuDemand("missing-node", "alice", 1),
+		},
+		{
+			name: "overflow",
+			snapshot: func() PreflightSnapshot {
+				s := installablePreflightSnapshot()
+				s.Pressure.UsageByNode["cpu-a"] = prometheus.NodeResourceUsage{
+					CPUCapacity: math.MaxInt64, CPUUtilization: 1,
+				}
+				return s
+			}(),
+			demand: cpuDemand("overflow", "alice", 1),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := SimulatePreflight([]PreflightDemand{tc.demand}, tc.snapshot); err == nil {
+				t.Fatal("invalid internal state must return an error")
+			}
+		})
+	}
+}
+
+func TestSimulatePreflightDoesNotMutateSnapshot(t *testing.T) {
+	snapshot := installablePreflightSnapshot()
+	snapshot.Nodes = []Node{nvidiaNode("gpu-a", Device{
+		ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive,
+	})}
+	snapshot.Pressure = nodePressure("gpu-a")
+	before := clonePreflightSnapshot(snapshot)
+
+	if _, err := SimulatePreflight([]PreflightDemand{gpuDemand("app", "alice", 8*gi)}, snapshot); err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if !reflect.DeepEqual(snapshot, before) {
+		t.Fatalf("input snapshot was mutated:\nbefore=%#v\nafter=%#v", before, snapshot)
+	}
+}
+
+func installablePreflightSnapshot() PreflightSnapshot {
+	return PreflightSnapshot{
+		Nodes:    []Node{computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice)},
+		Pressure: nodePressure("cpu-a"),
+		Cluster: &prometheus.ClusterMetrics{
+			CPU:    prometheus.Value{Total: 64},
+			Memory: prometheus.Value{Total: 64 * float64(gi)},
+			Disk:   prometheus.Value{Total: 1024 * float64(gi)},
+		},
+		Owners: map[string]*prometheus.ClusterMetrics{
+			"alice": {},
+			"bob":   {},
+		},
+		K8sAvailable: apputils.ResourceState{CPU: 64000, Memory: 64 * gi},
+	}
+}
+
+func cpuDemand(id, owner string, cpu int64) PreflightDemand {
+	return PreflightDemand{
+		ID: id, Application: id, Owner: owner,
+		Requirement: Requirement{Mode: utils.CPUType, RequiredCPU: cpu},
+	}
+}
+
+func gpuDemand(id, owner string, gpu int64) PreflightDemand {
+	return PreflightDemand{
+		ID: id, Application: id, Owner: owner,
+		Requirement: Requirement{Mode: utils.NvidiaCardType, RequiredGPU: gpu, LimitedGPU: gpu},
+	}
+}
+
+func nodePressure(nodeNames ...string) PressureSnapshot {
+	usage := make(map[string]prometheus.NodeResourceUsage, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		usage[nodeName] = prometheus.NodeResourceUsage{
+			CPUCapacity: 100000, MemoryCapacity: 128 * gi, MemoryAvailable: 128 * gi,
+			DiskCapacity: 128 * gi, DiskAvailable: 128 * gi,
+		}
+	}
+	return PressureSnapshot{Threshold: 0.9, UsageByNode: usage}
+}

--- a/framework/app-service/pkg/compute/preflight_types.go
+++ b/framework/app-service/pkg/compute/preflight_types.go
@@ -1,0 +1,82 @@
+package compute
+
+import (
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+)
+
+const (
+	// PreflightSharedOwner identifies cluster-scoped shared applications.
+	PreflightSharedOwner           = "shared"
+	PreflightReasonClusterCapacity = "cluster_capacity"
+	PreflightReasonClusterPressure = "cluster_pressure"
+	PreflightReasonOwnerQuota      = "owner_quota"
+	PreflightReasonK8sRequest      = "k8s_request"
+	PreflightReasonNodePressure    = "node_pressure"
+	PreflightReasonUnschedulable   = "unschedulable"
+)
+
+type PreflightDemand struct {
+	ID          string      `json:"id"`
+	Owner       string      `json:"owner"`
+	Application string      `json:"application"`
+	AppID       string      `json:"appId,omitempty"`
+	Requirement Requirement `json:"requirement"`
+}
+
+type PreflightSnapshot struct {
+	Nodes        []Node
+	Pressure     PressureSnapshot
+	Cluster      *prometheus.ClusterMetrics
+	Owners       map[string]*prometheus.ClusterMetrics
+	K8sAvailable apputils.ResourceState
+}
+
+type PreflightPlacement struct {
+	NodeNames   []string
+	Allocations []Allocation
+}
+
+type PreflightPressure struct {
+	Source     string              `json:"source"`
+	Dimensions []DimensionPressure `json:"dimensions"`
+}
+
+type PreflightReport struct {
+	Installable    bool                `json:"installable"`
+	FailedDemandID string              `json:"failedDemandId,omitempty"`
+	Reason         string              `json:"reason,omitempty"`
+	Pressure       []PreflightPressure `json:"pressure,omitempty"`
+}
+
+func clonePreflightSnapshot(snapshot PreflightSnapshot) PreflightSnapshot {
+	cloned := snapshot
+	cloned.Nodes = make([]Node, len(snapshot.Nodes))
+	for i, node := range snapshot.Nodes {
+		cloned.Nodes[i] = node
+		cloned.Nodes[i].GPUTypes = append([]string(nil), node.GPUTypes...)
+		cloned.Nodes[i].Devices = make([]Device, len(node.Devices))
+		for j, device := range node.Devices {
+			cloned.Nodes[i].Devices[j] = device
+			cloned.Nodes[i].Devices[j].AvailableSupportTypes = append([]string(nil), device.AvailableSupportTypes...)
+			cloned.Nodes[i].Devices[j].Bindings = append([]Allocation(nil), device.Bindings...)
+		}
+	}
+	cloned.Pressure.UsageByNode = make(map[string]prometheus.NodeResourceUsage, len(snapshot.Pressure.UsageByNode))
+	for nodeName, usage := range snapshot.Pressure.UsageByNode {
+		cloned.Pressure.UsageByNode[nodeName] = usage
+	}
+	if snapshot.Cluster != nil {
+		cluster := *snapshot.Cluster
+		cloned.Cluster = &cluster
+	}
+	cloned.Owners = make(map[string]*prometheus.ClusterMetrics, len(snapshot.Owners))
+	for owner, metrics := range snapshot.Owners {
+		if metrics != nil {
+			clonedMetrics := *metrics
+			metrics = &clonedMetrics
+		}
+		cloned.Owners[owner] = metrics
+	}
+	return cloned
+}

--- a/framework/app-service/pkg/compute/pressure.go
+++ b/framework/app-service/pkg/compute/pressure.go
@@ -2,9 +2,11 @@ package compute
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 )
 
 const defaultPressureThreshold = 0.90
@@ -15,26 +17,7 @@ const (
 	PressureResourceDisk   = "disk"
 )
 
-// DimensionPressure describes, for a single resource dimension, how the
-// node's current usage plus the app's requested amount compares against
-// the pressure threshold:
-//
-//   - Required is how much the app wants to add on this dimension.
-//   - Used / Capacity are the node's current consumption and total.
-//   - Available is the remaining headroom UNDER the threshold before the
-//     request is added (capacity*threshold - used), clamped to >= 0. This
-//     is the "how much can still be placed" figure the frontend renders.
-//   - Pressured reports whether adding Required would push the dimension
-//     past the threshold (or the node reports unusable capacity for a
-//     dimension the app needs).
-type DimensionPressure struct {
-	Resource  string `json:"resource"`
-	Required  int64  `json:"required"`
-	Used      int64  `json:"used"`
-	Capacity  int64  `json:"capacity"`
-	Available int64  `json:"available"`
-	Pressured bool   `json:"pressured"`
-}
+type DimensionPressure = apputils.ResourcePressure
 
 func FetchPressureSnapshot(ctx context.Context) (PressureSnapshot, error) {
 	usage, err := prometheus.GetNodeResourceUsage(ctx)
@@ -57,20 +40,7 @@ func (p PressureSnapshot) Evaluate(node Node, added AddedResources) []DimensionP
 		threshold = defaultPressureThreshold
 	}
 	usage, known := p.UsageByNode[node.NodeName]
-	// Sanitise the CPU utilisation before converting to a used-core count. A
-	// 0/0 monitoring ratio yields NaN (and a misbehaving exporter can produce
-	// Inf or a negative value); int64(NaN) is implementation-defined in Go, so
-	// an unsanitised value makes the whole pressure decision undefined. Assume
-	// the node is fully used when the metric is non-finite, so a broken metric
-	// never looks like free headroom.
-	util := usage.CPUUtilization
-	if math.IsNaN(util) || math.IsInf(util, 0) {
-		util = 1.0
-	}
-	if util < 0 {
-		util = 0
-	}
-	usedCPU := int64(float64(usage.CPUCapacity) * util)
+	usedCPU := nodeUsedCPU(usage)
 	usedMemory := usage.MemoryCapacity - usage.MemoryAvailable
 	if usedMemory < 0 {
 		usedMemory = 0
@@ -84,6 +54,17 @@ func (p PressureSnapshot) Evaluate(node Node, added AddedResources) []DimensionP
 		evaluateDimension(PressureResourceMemory, added.Memory, usedMemory, usage.MemoryCapacity, threshold, known),
 		evaluateDimension(PressureResourceDisk, added.Disk, usedDisk, usage.DiskCapacity, threshold, known),
 	}
+}
+
+func nodeUsedCPU(usage prometheus.NodeResourceUsage) int64 {
+	util := usage.CPUUtilization
+	if math.IsNaN(util) || math.IsInf(util, 0) {
+		util = 1.0
+	}
+	if util < 0 {
+		util = 0
+	}
+	return int64(float64(usage.CPUCapacity) * util)
 }
 
 func evaluateDimension(resource string, required, used, capacity int64, threshold float64, known bool) DimensionPressure {
@@ -105,7 +86,12 @@ func evaluateDimension(resource string, required, used, capacity int64, threshol
 		d.Pressured = true
 		return d
 	}
-	d.Pressured = exceedsPressure(used+required, capacity, threshold)
+	projected, ok := checkedAdd(used, required)
+	if !ok {
+		d.Pressured = true
+		return d
+	}
+	d.Pressured = exceedsPressure(projected, capacity, threshold)
 	return d
 }
 
@@ -131,6 +117,34 @@ func (p PressureSnapshot) PressuredDimensions(node Node, added AddedResources) [
 		}
 	}
 	return out
+}
+
+func ValidatePressureSnapshot(nodes []Node, pressure PressureSnapshot) error {
+	threshold := pressure.Threshold
+	if threshold != 0 && (math.IsNaN(threshold) || math.IsInf(threshold, 0) || threshold <= 0 || threshold > 1) {
+		return fmt.Errorf("node pressure threshold is invalid")
+	}
+	for _, node := range nodes {
+		usage, ok := pressure.UsageByNode[node.NodeName]
+		if !ok || !validNodeUsage(usage) {
+			return fmt.Errorf("node metrics for %q are invalid", node.NodeName)
+		}
+	}
+	return nil
+}
+
+func validNodeUsage(usage prometheus.NodeResourceUsage) bool {
+	return usage.CPUCapacity >= 0 && !math.IsNaN(usage.CPUUtilization) && !math.IsInf(usage.CPUUtilization, 0) &&
+		usage.CPUUtilization >= 0 && usage.CPUUtilization <= 1 &&
+		usage.MemoryCapacity >= 0 && usage.MemoryAvailable >= 0 && usage.MemoryAvailable <= usage.MemoryCapacity &&
+		usage.DiskCapacity >= 0 && usage.DiskAvailable >= 0 && usage.DiskAvailable <= usage.DiskCapacity
+}
+
+func checkedAdd(a, b int64) (int64, bool) {
+	if b > 0 && a > math.MaxInt64-b || b < 0 && a < math.MinInt64-b {
+		return 0, false
+	}
+	return a + b, true
 }
 
 func exceedsPressure(used, total int64, threshold float64) bool {

--- a/framework/app-service/pkg/compute/pressure.go
+++ b/framework/app-service/pkg/compute/pressure.go
@@ -64,7 +64,11 @@ func nodeUsedCPU(usage prometheus.NodeResourceUsage) int64 {
 	if util < 0 {
 		util = 0
 	}
-	return int64(float64(usage.CPUCapacity) * util)
+	used := float64(usage.CPUCapacity) * util
+	if used >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(used)
 }
 
 func evaluateDimension(resource string, required, used, capacity int64, threshold float64, known bool) DimensionPressure {

--- a/framework/app-service/pkg/compute/pressure_test.go
+++ b/framework/app-service/pkg/compute/pressure_test.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"math"
 	"testing"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
@@ -78,6 +79,23 @@ func TestWouldPressure_ZeroThresholdUsesDefault(t *testing.T) {
 	}
 }
 
+func TestWouldPressure_OverflowFailsClosed(t *testing.T) {
+	snap, node := oneNodeSnapshot(1, prometheus.NodeResourceUsage{
+		CPUCapacity:     math.MaxInt64,
+		CPUUtilization:  1,
+		MemoryCapacity:  math.MaxInt64,
+		MemoryAvailable: 0,
+		DiskCapacity:    math.MaxInt64,
+		DiskAvailable:   0,
+	})
+	got := snap.Evaluate(node, AddedResources{CPU: 1, Memory: 1, Disk: 1})
+	for _, dimension := range got {
+		if !dimension.Pressured {
+			t.Fatalf("overflow must fail closed: %#v", got)
+		}
+	}
+}
+
 // Pressure is monotonic in the added request: if a smaller request
 // already pressures the node, any larger request must pressure it too.
 func TestWouldPressure_MonotonicInAddedRequest(t *testing.T) {
@@ -114,14 +132,63 @@ func TestAddedResourcesFromAppConfig(t *testing.T) {
 		t.Errorf("nil config: got %+v, want zero", got)
 	}
 
-	cfg := &appcfg.ApplicationConfig{AppName: "legacy"}
-	cfg.Requirement.CPU = resource.NewMilliQuantity(1500, resource.DecimalSI)
-	cfg.Requirement.Memory = resource.NewQuantity(2<<30, resource.BinarySI)
-	cfg.Requirement.Disk = resource.NewQuantity(4<<30, resource.BinarySI)
+	legacy := &appcfg.ApplicationConfig{AppName: "legacy"}
+	legacy.Requirement.CPU = resource.NewMilliQuantity(1500, resource.DecimalSI)
+	legacy.Requirement.Memory = resource.NewQuantity(2<<30, resource.BinarySI)
+	legacy.Requirement.Disk = resource.NewQuantity(4<<30, resource.BinarySI)
 
-	got := AddedResourcesFromAppConfig(cfg)
-	want := AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 4 << 30}
-	if got != want {
-		t.Errorf("legacy requirement: got %+v, want %+v", got, want)
+	mode := &appcfg.ApplicationConfig{
+		AppName:         "mode",
+		SelectedGpuType: "nvidia",
+		Accelerator: []appcfg.ResourceMode{{
+			Mode: "nvidia",
+			ResourceRequirement: appcfg.ResourceRequirement{
+				RequiredCPU:    "2500m",
+				RequiredMemory: "3Gi",
+				RequiredDisk:   "5Gi",
+			},
+		}},
+	}
+
+	cases := []struct {
+		name string
+		cfg  *appcfg.ApplicationConfig
+		want AddedResources
+	}{
+		{"legacy quantities", legacy, AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 4 << 30}},
+		{"selected resource mode", mode, AddedResources{CPU: 2500, Memory: 3 << 30, Disk: 5 << 30}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AddedResourcesFromAppConfig(tc.cfg); got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPressureSnapshotEvaluateReportsDimensionDetails(t *testing.T) {
+	snap, node := oneNodeSnapshot(0.9, prometheus.NodeResourceUsage{
+		CPUCapacity:     2000,
+		CPUUtilization:  0.25,
+		MemoryCapacity:  1000,
+		MemoryAvailable: 400,
+		DiskCapacity:    1000,
+		DiskAvailable:   1200,
+	})
+
+	got := snap.Evaluate(node, AddedResources{CPU: 1400, Memory: 300, Disk: 901})
+	want := []DimensionPressure{
+		{Resource: PressureResourceCPU, Required: 1400, Used: 500, Capacity: 2000, Available: 1300, Pressured: true},
+		{Resource: PressureResourceMemory, Required: 300, Used: 600, Capacity: 1000, Available: 300, Pressured: false},
+		{Resource: PressureResourceDisk, Required: 901, Used: 0, Capacity: 1000, Available: 900, Pressured: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Evaluate returned %d dimensions, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("dimension %d: got %#v, want %#v", i, got[i], want[i])
+		}
 	}
 }

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -155,17 +155,27 @@ func EvaluateInstallMode(req Requirement, nodes []Node) ModePlanResult {
 }
 
 func PickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
+	return pickAllocations(appConfig, req, nodes, pressure, allocationOptions{checkPressure: true})
+}
+
+type allocationOptions struct {
+	checkPressure bool
+	deterministic bool
+	pressureAdded *AddedResources
+}
+
+func pickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
 	if req.Mode == utils.CPUType {
 		return nil, false
 	}
 	matching := matchingNodes(req.Mode, nodes)
 	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, true)
+		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, true)
 	}
 	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, false)
+		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, false)
 	}
-	return pickSingleAllocation(appConfig, req, matching, pressure)
+	return pickSingleAllocation(appConfig, req, matching, pressure, pressureOptions)
 }
 
 // matchingNodes returns the nodes that support `mode`, each projected onto that
@@ -183,11 +193,18 @@ func matchingNodes(mode string, nodes []Node) []Node {
 
 func evaluateCPUInstallMode(req Requirement, nodes []Node) ModePlanResult {
 	for _, node := range nodes {
-		if node.memoryCapacity*75/100 >= req.RequiredMemory {
+		if usableCPUNodeMemory(node.memoryCapacity) >= req.RequiredMemory {
 			return ModePlanResult{ComputeType: utils.CPUType, Status: StatusInstallable}
 		}
 	}
 	return ModePlanResult{ComputeType: utils.CPUType, Status: StatusInsufficientResources, Reason: "insufficient_resources"}
+}
+
+func usableCPUNodeMemory(capacity int64) int64 {
+	if capacity < 0 {
+		return -1
+	}
+	return capacity/4*3 + (capacity%4)*3/4
 }
 
 func installCapacityFits(req Requirement, nodes []Node) bool {
@@ -230,7 +247,7 @@ func installCapacityFits(req Requirement, nodes []Node) bool {
 	return false
 }
 
-func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
+func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		for _, supportType := range supportTypeOrder(req.Mode) {
 			candidates := make([]Allocation, 0)
@@ -239,7 +256,7 @@ func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, 
 					if supportType != "" && device.SupportType != supportType {
 						continue
 					}
-					fits, amount := deviceFitsLevel(req, node, device, pressure, level, false, 0)
+					fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, false, 0, pressureOptions)
 					if fits {
 						assigned := requiredTargetForMode(req)
 						if assigned == 0 {
@@ -250,6 +267,9 @@ func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, 
 				}
 			}
 			if len(candidates) > 0 {
+				if pressureOptions.deterministic {
+					return []Allocation{candidates[0]}, true
+				}
 				return []Allocation{candidates[rand.Intn(len(candidates))]}, true
 			}
 		}
@@ -257,21 +277,21 @@ func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, 
 	return nil, false
 }
 
-func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, crossNode bool) ([]Allocation, bool) {
+func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, crossNode bool) ([]Allocation, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		target := targetGPU(req, level)
 		if target <= 0 {
 			continue
 		}
 		if crossNode {
-			picked, ok := collectDevicesForTarget(appConfig, req, nodes, pressure, level, target, req.RequiredGPU)
+			picked, ok := collectDevicesForTarget(appConfig, req, nodes, pressure, pressureOptions, level, target, req.RequiredGPU)
 			if ok {
 				return picked, ok
 			}
 			continue
 		}
 		for _, node := range nodes {
-			picked, ok := collectDevicesForTarget(appConfig, req, []Node{node}, pressure, level, target, req.RequiredGPU)
+			picked, ok := collectDevicesForTarget(appConfig, req, []Node{node}, pressure, pressureOptions, level, target, req.RequiredGPU)
 			if ok {
 				return picked, ok
 			}
@@ -280,7 +300,7 @@ func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requireme
 	return nil, false
 }
 
-func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, level string, target, allocationTarget int64) ([]Allocation, bool) {
+func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, level string, target, allocationTarget int64) ([]Allocation, bool) {
 	fitRemaining := target
 	allocationRemaining := allocationTarget
 	var out []Allocation
@@ -291,11 +311,15 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 				if supportType != "" && device.SupportType != supportType {
 					continue
 				}
-				fits, amount := deviceFitsLevel(req, node, device, pressure, level, true, timeSliceMemoryByNode[node.NodeName])
+				fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, true, timeSliceMemoryByNode[node.NodeName], pressureOptions)
 				if !fits || amount <= 0 {
 					continue
 				}
-				timeSliceMemoryByNode[node.NodeName] += timeSliceAddedMemory(device)
+				nextMemory, ok := checkedAdd(timeSliceMemoryByNode[node.NodeName], timeSliceAddedMemory(device))
+				if !ok {
+					continue
+				}
+				timeSliceMemoryByNode[node.NodeName] = nextMemory
 				if allocationRemaining > 0 {
 					assigned := minInt64(amount, allocationRemaining)
 					out = append(out, buildAllocation(appConfig, req, node, device, assigned))
@@ -312,16 +336,19 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 }
 
 func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64) (bool, int64) {
+	return deviceFitsLevelWithPressure(req, node, device, pressure, level, allowPartial, priorTimeSliceMemory, allocationOptions{checkPressure: true})
+}
+
+func deviceFitsLevelWithPressure(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64, pressureOptions allocationOptions) (bool, int64) {
 	if device.Health != "" && device.Health != deviceHealthYes {
 		return false, 0
 	}
 	required := targetForMode(req, level)
 	if required <= 0 {
-		return !pressure.WouldPressure(node, AddedResources{
-			CPU:    req.RequiredCPU,
-			Memory: levelMemory(req, level),
-			Disk:   req.RequiredDisk,
-		}), 0
+		if !pressureOptions.checkPressure {
+			return true, 0
+		}
+		return !pressure.WouldPressure(node, levelAddedResources(req, level, pressureOptions)), 0
 	}
 	available := deviceAvailableMemory(device)
 	if available <= 0 {
@@ -330,29 +357,41 @@ func deviceFitsLevel(req Requirement, node Node, device Device, pressure Pressur
 	if available < required && !(allowPartial && req.Mode == utils.NvidiaCardType) {
 		return false, available
 	}
-	addedGPU := priorTimeSliceMemory + timeSliceAddedMemory(device)
-	if pressure.WouldPressure(node, AddedResources{
-		CPU:    req.RequiredCPU,
-		Memory: levelMemory(req, level) + addedGPU,
-		Disk:   req.RequiredDisk,
-	}) {
+	if allocationWouldPressure(req, node, device, pressure, level, priorTimeSliceMemory, pressureOptions) {
 		return false, available
 	}
 	return true, available
 }
 
-// timeSliceAddedMemory returns the extra host RAM that must be reserved on the
-// node for a time-slice GPU card.
-//
-// A HAMI time-slice pod is handed the whole card during its slice
-// (buildAllocation records Memory=0, so HAMI leaves it unrestricted), so the
-// node needs system-memory headroom equal to the card's full physical memory,
-// regardless of the app's requiredGPU or limitedGPU. Non-time-slice devices
-// carry no such host-memory backing requirement.
-//
-// This is the single source of truth shared by the install scheduler
-// (deviceFitsLevel) and the resume/binding validator
-// (nodeTimeSliceAddedMemory) so the two paths can never drift.
+func allocationWouldPressure(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, priorTimeSliceMemory int64, options allocationOptions) bool {
+	if !options.checkPressure {
+		return false
+	}
+	added := levelAddedResources(req, level, options)
+	timeSliceMemory, ok := checkedAdd(priorTimeSliceMemory, timeSliceAddedMemory(device))
+	if !ok {
+		return true
+	}
+	added.Memory, ok = checkedAdd(added.Memory, timeSliceMemory)
+	if !ok {
+		return true
+	}
+	return pressure.WouldPressure(node, added)
+}
+
+func levelAddedResources(req Requirement, level string, options allocationOptions) AddedResources {
+	if options.pressureAdded != nil {
+		return *options.pressureAdded
+	}
+	return AddedResources{
+		CPU:    req.RequiredCPU,
+		Memory: levelMemory(req, level),
+		Disk:   req.RequiredDisk,
+	}
+}
+
+// A time-slice GPU with a positive target needs host-memory headroom equal to
+// the card's physical memory. Zero-target fit checks preserve legacy behavior.
 func timeSliceAddedMemory(device Device) int64 {
 	if device.SupportType != SupportTypeTimeSlice {
 		return 0

--- a/framework/app-service/pkg/compute/scheduler_test.go
+++ b/framework/app-service/pkg/compute/scheduler_test.go
@@ -1,0 +1,47 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+func TestDeviceFitsLevelTimeSliceMemoryForZeroRequirement(t *testing.T) {
+	const gib = int64(1 << 30)
+	node := Node{NodeName: "gpu-node"}
+	device := Device{
+		ID:          "gpu0",
+		Memory:      10 * gib,
+		Health:      deviceHealthYes,
+		SupportType: SupportTypeTimeSlice,
+	}
+	pressure := PressureSnapshot{
+		Threshold: 0.9,
+		UsageByNode: map[string]prometheus.NodeResourceUsage{
+			node.NodeName: {
+				CPUCapacity:     10_000,
+				MemoryCapacity:  100 * gib,
+				MemoryAvailable: 20 * gib,
+				DiskCapacity:    100 * gib,
+				DiskAvailable:   100 * gib,
+				CPUUtilization:  0,
+			},
+		},
+	}
+	req := Requirement{
+		Mode:           utils.NvidiaCardType,
+		RequiredMemory: 5 * gib,
+	}
+
+	fits, _ := deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	if !fits {
+		t.Fatal("zero GPU requirement should preserve the legacy fit decision without time-slice host memory")
+	}
+
+	req.RequiredGPU = gib
+	fits, _ = deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	if fits {
+		t.Fatal("positive GPU requirement must include time-slice host memory")
+	}
+}

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -34,6 +34,19 @@ func FetchNodeComputeAllocations(ctx context.Context, c client.Client) ([]Node, 
 	return nodes, nil
 }
 
+func FetchSchedulableNodeComputeAllocations(ctx context.Context, c client.Client) ([]Node, error) {
+	nodes, err := loadSchedulableNodeResources(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	allocations, err := loadAllocations(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	attachBindings(nodes, allocations)
+	return nodes, nil
+}
+
 // FetchNodeComputeAllocationsExcludingApp returns the node view with the given
 // app's own allocation rows excluded, so a re-allocation / re-binding of that
 // app does not count its current claim against availability (an exclusive card
@@ -196,6 +209,21 @@ func loadNodeResources(ctx context.Context, c client.Client) ([]Node, error) {
 	}
 	out := make([]Node, 0, len(nodes.Items))
 	for i := range nodes.Items {
+		out = append(out, buildNodeResource(&nodes.Items[i]))
+	}
+	return out, nil
+}
+
+func loadSchedulableNodeResources(ctx context.Context, c client.Client) ([]Node, error) {
+	var nodes corev1.NodeList
+	if err := c.List(ctx, &nodes); err != nil {
+		return nil, err
+	}
+	out := make([]Node, 0, len(nodes.Items))
+	for i := range nodes.Items {
+		if !utils.IsNodeReady(&nodes.Items[i]) || nodes.Items[i].Spec.Unschedulable {
+			continue
+		}
 		out = append(out, buildNodeResource(&nodes.Items[i]))
 	}
 	return out, nil

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func k8sNode(name string, memory string, labels map[string]string) *corev1.Node {
@@ -139,5 +141,32 @@ func TestBuildNodeResourceDiscreteGPULabel(t *testing.T) {
 	}
 	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.AMDGPUType {
 		t.Fatalf("expected a single amd-gpu device, got %+v", n.Devices)
+	}
+}
+
+func TestFetchSchedulableNodeComputeAllocationsExcludesNotReadyAndCordonedGPU(t *testing.T) {
+	labels := map[string]string{utils.NodeGPUTypeLabelPrefix + utils.NvidiaCardType: "true"}
+	ready := k8sNode("ready", "16Gi", labels)
+	notReady := k8sNode("not-ready", "16Gi", labels)
+	notReady.Status.Conditions[0].Status = corev1.ConditionFalse
+	cordoned := k8sNode("cordoned", "16Gi", labels)
+	cordoned.Spec.Unschedulable = true
+	c := fake.NewClientBuilder().WithObjects(ready, notReady, cordoned).Build()
+
+	all, err := FetchNodeComputeAllocations(context.Background(), c)
+	if err != nil {
+		t.Fatalf("fetch all nodes: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("install allocation view changed, got nodes %#v", all)
+	}
+
+	schedulable, err := FetchSchedulableNodeComputeAllocations(context.Background(), c)
+	if err != nil {
+		t.Fatalf("fetch schedulable nodes: %v", err)
+	}
+	if len(schedulable) != 1 || schedulable[0].NodeName != "ready" ||
+		!schedulable[0].SupportsMode(utils.NvidiaCardType) {
+		t.Fatalf("schedulable nodes=%#v", schedulable)
 	}
 }

--- a/framework/app-service/pkg/compute/validation/cluster_capacity_test.go
+++ b/framework/app-service/pkg/compute/validation/cluster_capacity_test.go
@@ -222,6 +222,25 @@ func TestClusterCapacityValidator_PropagatesProviderError(t *testing.T) {
 	}
 }
 
+func TestClusterCapacityValidator_ReturnsMetricsUnavailableDecision(t *testing.T) {
+	withMetricsProvider(t, constantMetrics(0, 16<<30, 200<<30, nil))
+
+	decision, err := clusterCapacityValidator{}.Validate(context.Background(), Input{
+		AppConfig: appWithLegacyReq(1000, 0, 0),
+		Op:        v1alpha1.InstallOp,
+	})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if decision.OK || decision.Resource != constants.CPU || decision.Reason != constants.MetricsUnavailable {
+		t.Fatalf("unexpected decision: %#v", decision)
+	}
+	want := "Resource metrics are temporarily unavailable. Unable to install the application. Please try again later."
+	if decision.Message != want {
+		t.Fatalf("message=%q, want %q", decision.Message, want)
+	}
+}
+
 // TestClusterCapacityValidator_ForwardsToken verifies that the
 // Input.Token reaches the metrics provider unchanged. The kubesphere
 // monitoring endpoint authenticates with the caller's service account

--- a/framework/app-service/pkg/compute/validation/preflight.go
+++ b/framework/app-service/pkg/compute/validation/preflight.go
@@ -1,0 +1,83 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PreflightSnapshotCollector struct {
+	client         client.Client
+	nodes          func(context.Context, client.Client) ([]compute.Node, error)
+	pressure       func(context.Context) (compute.PressureSnapshot, error)
+	clusterMetrics func(string) (*prometheus.ClusterMetrics, []string, error)
+	userMetrics    func(context.Context, string) (*prometheus.ClusterMetrics, error)
+	k8sAvailable   func() (resource.Quantity, resource.Quantity, error)
+}
+
+func NewPreflightSnapshotCollector(ctrlClient client.Client) *PreflightSnapshotCollector {
+	return &PreflightSnapshotCollector{
+		client:         ctrlClient,
+		nodes:          compute.FetchSchedulableNodeComputeAllocations,
+		pressure:       compute.FetchPressureSnapshot,
+		clusterMetrics: apputils.GetClusterResource,
+		userMetrics:    prometheus.GetCurUserResource,
+		k8sAvailable:   apputils.GetClusterAvailableResourceQuantities,
+	}
+}
+
+func (c *PreflightSnapshotCollector) Collect(ctx context.Context, token string, owners []string) (compute.PreflightSnapshot, error) {
+	nodes, err := c.nodes(ctx, c.client)
+	if err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("collect nodes and allocations: %w", err)
+	}
+	pressure, err := c.pressure(ctx)
+	if err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("collect node pressure: %w", err)
+	}
+	if err := compute.ValidatePressureSnapshot(nodes, pressure); err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("validate node pressure: %w", err)
+	}
+	cluster, _, err := c.clusterMetrics(token)
+	if err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("collect cluster metrics: %w", err)
+	}
+	if _, err := apputils.EvaluateClusterPressure(apputils.ResourceState{}, cluster, apputils.AllResourceDimensions); err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("validate cluster metrics: %w", err)
+	}
+
+	ownerMetrics := make(map[string]*prometheus.ClusterMetrics)
+	for _, owner := range owners {
+		if owner == compute.PreflightSharedOwner {
+			continue
+		}
+		if _, exists := ownerMetrics[owner]; exists {
+			continue
+		}
+		metrics, err := c.userMetrics(ctx, owner)
+		if err != nil {
+			return compute.PreflightSnapshot{}, fmt.Errorf("collect metrics for owner %q: %w", owner, err)
+		}
+		if _, err := apputils.EvaluateOwnerPressure(apputils.ResourceState{}, metrics, apputils.AllResourceDimensions); err != nil {
+			return compute.PreflightSnapshot{}, fmt.Errorf("validate metrics for owner %q: %w", owner, err)
+		}
+		ownerMetrics[owner] = metrics
+	}
+
+	cpu, memory, err := c.k8sAvailable()
+	if err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("collect kubernetes request availability: %w", err)
+	}
+	if _, err := apputils.EvaluateK8sRequest(apputils.ResourceState{}, apputils.AllResourceDimensions, cpu, memory); err != nil {
+		return compute.PreflightSnapshot{}, fmt.Errorf("validate kubernetes request availability: %w", err)
+	}
+	return compute.PreflightSnapshot{
+		Nodes: nodes, Pressure: pressure, Cluster: cluster, Owners: ownerMetrics,
+		K8sAvailable: apputils.ResourceState{CPU: cpu.MilliValue(), Memory: memory.Value()},
+	}, nil
+}

--- a/framework/app-service/pkg/compute/validation/preflight_test.go
+++ b/framework/app-service/pkg/compute/validation/preflight_test.go
@@ -1,0 +1,138 @@
+package validation
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestPreflightSnapshotCollectorCollectsRawFacts(t *testing.T) {
+	var nodesCalls, pressureCalls, clusterCalls, k8sCalls int
+	userCalls := map[string]int{}
+	cpu := resource.MustParse("3500m")
+	memory := resource.MustParse("12Gi")
+	cluster := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 8, Usage: 2},
+		Memory: prometheus.Value{Total: 32 << 30, Usage: 8 << 30},
+		Disk:   prometheus.Value{Total: 1 << 40, Usage: 100 << 30},
+	}
+	collector := &PreflightSnapshotCollector{
+		nodes: func(context.Context, client.Client) ([]compute.Node, error) {
+			nodesCalls++
+			return []compute.Node{{NodeName: "node-a"}}, nil
+		},
+		pressure: func(context.Context) (compute.PressureSnapshot, error) {
+			pressureCalls++
+			return compute.PressureSnapshot{
+				Threshold: 0.9,
+				UsageByNode: map[string]prometheus.NodeResourceUsage{
+					"node-a": {},
+				},
+			}, nil
+		},
+		clusterMetrics: func(string) (*prometheus.ClusterMetrics, []string, error) {
+			clusterCalls++
+			return cluster, nil, nil
+		},
+		userMetrics: func(_ context.Context, owner string) (*prometheus.ClusterMetrics, error) {
+			userCalls[owner]++
+			return &prometheus.ClusterMetrics{CPU: prometheus.Value{Total: 4}}, nil
+		},
+		k8sAvailable: func() (resource.Quantity, resource.Quantity, error) {
+			k8sCalls++
+			return cpu, memory, nil
+		},
+	}
+
+	snapshot, err := collector.Collect(context.Background(), "token", []string{"alice", "shared", "bob", "alice"})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if nodesCalls != 1 || pressureCalls != 1 || clusterCalls != 1 || k8sCalls != 1 {
+		t.Fatalf("source calls nodes=%d pressure=%d cluster=%d k8s=%d", nodesCalls, pressureCalls, clusterCalls, k8sCalls)
+	}
+	if !reflect.DeepEqual(userCalls, map[string]int{"alice": 1, "bob": 1}) {
+		t.Fatalf("user calls=%v", userCalls)
+	}
+	if snapshot.Cluster != cluster || len(snapshot.Nodes) != 1 || snapshot.Pressure.Threshold != 0.9 {
+		t.Fatalf("raw snapshot facts not preserved: %#v", snapshot)
+	}
+	if len(snapshot.Owners) != 2 || snapshot.Owners["alice"].CPU.Total != 4 {
+		t.Fatalf("owner facts=%#v", snapshot.Owners)
+	}
+	if snapshot.K8sAvailable.CPU != 3500 || snapshot.K8sAvailable.Memory != 12<<30 {
+		t.Fatalf("k8s facts=%#v", snapshot.K8sAvailable)
+	}
+}
+
+func TestPreflightSnapshotCollectorRejectsInvalidMetrics(t *testing.T) {
+	tests := []prometheus.ClusterMetrics{
+		{Memory: prometheus.Value{Total: 1}, Disk: prometheus.Value{Total: 1}},
+		{CPU: prometheus.Value{Total: math.NaN()}, Memory: prometheus.Value{Total: 1}, Disk: prometheus.Value{Total: 1}},
+		{CPU: prometheus.Value{Total: 1}, Memory: prometheus.Value{Total: 1}, Disk: prometheus.Value{Total: 1, Usage: -1}},
+	}
+	for _, metrics := range tests {
+		collector := validCollector(&metrics)
+		if _, err := collector.Collect(context.Background(), "", nil); err == nil {
+			t.Fatalf("invalid metrics must fail: %#v", metrics)
+		}
+	}
+}
+
+func TestPreflightSnapshotCollectorRejectsInvalidOwnerMetrics(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 1},
+		Memory: prometheus.Value{Total: 1},
+		Disk:   prometheus.Value{Total: 1},
+	}
+	collector := validCollector(metrics)
+	collector.userMetrics = func(context.Context, string) (*prometheus.ClusterMetrics, error) {
+		return nil, nil
+	}
+	if _, err := collector.Collect(context.Background(), "", []string{"alice"}); err == nil {
+		t.Fatal("missing owner metrics must fail closed")
+	}
+}
+
+func TestPreflightSnapshotCollectorRejectsMissingNodeMetrics(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 1},
+		Memory: prometheus.Value{Total: 1},
+		Disk:   prometheus.Value{Total: 1},
+	}
+	collector := validCollector(metrics)
+	collector.pressure = func(context.Context) (compute.PressureSnapshot, error) {
+		return compute.PressureSnapshot{Threshold: 0.9}, nil
+	}
+	if _, err := collector.Collect(context.Background(), "", nil); err == nil {
+		t.Fatal("missing node metrics must fail snapshot collection")
+	}
+}
+
+func validCollector(metrics *prometheus.ClusterMetrics) *PreflightSnapshotCollector {
+	return &PreflightSnapshotCollector{
+		nodes: func(context.Context, client.Client) ([]compute.Node, error) {
+			return []compute.Node{{NodeName: "node-a"}}, nil
+		},
+		pressure: func(context.Context) (compute.PressureSnapshot, error) {
+			return compute.PressureSnapshot{
+				Threshold: 0.9,
+				UsageByNode: map[string]prometheus.NodeResourceUsage{
+					"node-a": {},
+				},
+			}, nil
+		},
+		clusterMetrics: func(string) (*prometheus.ClusterMetrics, []string, error) {
+			return metrics, nil, nil
+		},
+		k8sAvailable: func() (resource.Quantity, resource.Quantity, error) {
+			return resource.MustParse("1"), resource.MustParse("1"), nil
+		},
+	}
+}

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 )
 
@@ -135,18 +137,105 @@ func TestRun_AppliesToFilter(t *testing.T) {
 // name so caller logs can attribute the failure.
 func TestRun_ErrorPropagates(t *testing.T) {
 	wantErr := errors.New("kubesphere unreachable")
-	var counter int
-	v := newFake("cluster-pressure", []Op{v1alpha1.InstallOp}, Decision{}, wantErr, &counter)
+	var counter, neverCount int
+	v := newFake("cluster-pressure", []Op{v1alpha1.InstallOp}, Decision{
+		Resource: "memory",
+		Reason:   "unknown",
+		Message:  "pressure unavailable",
+	}, wantErr, &counter)
+	never := newFake("later", []Op{v1alpha1.InstallOp}, Decision{OK: true}, nil, &neverCount)
 
-	d, err := Run(context.Background(), Input{Op: v1alpha1.InstallOp}, v)
+	d, err := Run(context.Background(), Input{Op: v1alpha1.InstallOp}, v, never)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected wrapped error, got %v", err)
 	}
 	if d.Validator != "cluster-pressure" {
 		t.Fatalf("Decision.Validator=%q on error path, want %q", d.Validator, "cluster-pressure")
 	}
+	if d.Resource != "memory" || d.Reason != "unknown" || d.Message != "pressure unavailable" {
+		t.Fatalf("Decision fields not propagated on error: %+v", d)
+	}
 	if counter != 1 {
 		t.Fatalf("validator should have run exactly once before erroring, got %d", counter)
+	}
+	if neverCount != 0 {
+		t.Fatalf("validators after an error must not run, got %d calls", neverCount)
+	}
+}
+
+func TestRuntimePressureRunsK8sAfterClusterPressurePasses(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+	})
+
+	var clusterCalls, k8sCalls int
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		clusterCalls++
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(*appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		k8sCalls++
+		return constants.CPU, constants.K8sRequestCPUPressure, errors.New("k8s cpu pressure")
+	}
+
+	decision, err := Run(context.Background(), Input{
+		AppConfig: &appcfg.ApplicationConfig{},
+		Op:        v1alpha1.InstallOp,
+	}, RuntimePressureValidators()...)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if clusterCalls != 1 || k8sCalls != 1 {
+		t.Fatalf("calls cluster=%d k8s=%d", clusterCalls, k8sCalls)
+	}
+	if decision.Validator != NameK8sRequest || decision.Reason != constants.K8sRequestCPUPressure {
+		t.Fatalf("unexpected decision: %#v", decision)
+	}
+}
+
+func TestMetricUnavailableValidatorsReturnFriendlyDecision(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalUser := checkUserResRequirement
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkUserResRequirement = originalUser
+	})
+
+	message := errors.New("Resource metrics are temporarily unavailable. Unable to install the application. Please try again later.")
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		return constants.CPU, constants.MetricsUnavailable, message
+	}
+	checkUserResRequirement = func(context.Context, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		return constants.Memory, constants.MetricsUnavailable, message
+	}
+
+	tests := []struct {
+		name      string
+		validator Validator
+		resource  constants.ResourceType
+	}{
+		{name: "cluster", validator: clusterPressureValidator{}, resource: constants.CPU},
+		{name: "user", validator: userQuotaValidator{}, resource: constants.Memory},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := tt.validator.Validate(context.Background(), Input{
+				AppConfig: &appcfg.ApplicationConfig{},
+				Op:        v1alpha1.InstallOp,
+			})
+			if err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+			if decision.OK || decision.Resource != tt.resource || decision.Reason != constants.MetricsUnavailable {
+				t.Fatalf("unexpected decision: %#v", decision)
+			}
+			if decision.Message != message.Error() {
+				t.Fatalf("message=%q, want %q", decision.Message, message)
+			}
+		})
 	}
 }
 

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -19,6 +19,9 @@ import (
 // Mirroring apputils.GetClusterResource's signature exactly keeps the
 // indirection lossless — same return shape, same error semantics.
 var clusterMetricsProvider = apputils.GetClusterResource
+var checkAppRequirement = apputils.CheckAppRequirement
+var checkUserResRequirement = apputils.CheckUserResRequirement
+var checkAppK8sRequestResource = apputils.CheckAppK8sRequestResource
 
 // clusterCapacityValidator answers the most fundamental feasibility
 // question: "is the cluster physically big enough to host this app at
@@ -98,28 +101,42 @@ func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decisio
 		return Decision{}, fmt.Errorf("cluster metrics provider returned nil result with no error")
 	}
 
-	totalCPUMilli := int64(metrics.CPU.Total * 1000) // cores → milli
-	totalMemBytes := int64(metrics.Memory.Total)
-	totalDiskBytes := int64(metrics.Disk.Total)
-
 	op := string(in.Op)
-	if added.CPU > totalCPUMilli {
+	pressure, err := apputils.EvaluatePhysicalCapacity(apputils.ResourceState{
+		CPU: added.CPU, Memory: added.Memory, Disk: added.Disk,
+	}, metrics, apputils.ResourceDimensions{
+		CPU: added.CPU > 0, Memory: added.Memory > 0, Disk: added.Disk > 0,
+	})
+	if err != nil {
+		if resourceType, ok := apputils.MetricsFailureResource(err); ok {
+			return Decision{
+				OK:       false,
+				Resource: resourceType,
+				Reason:   constants.MetricsUnavailable,
+				Message:  fmt.Sprintf(constants.MetricsUnavailableMessage, op),
+			}, nil
+		}
+		return Decision{}, fmt.Errorf("evaluate cluster capacity: %w", err)
+	}
+	if len(pressure) == 0 {
+		return ok(), nil
+	}
+	switch pressure[0].Resource {
+	case string(constants.CPU):
 		return Decision{
 			OK:       false,
 			Resource: constants.CPU,
 			Reason:   constants.ClusterCPUInsufficient,
 			Message:  fmt.Sprintf(constants.ClusterCPUInsufficientMessage, op),
 		}, nil
-	}
-	if added.Memory > totalMemBytes {
+	case string(constants.Memory):
 		return Decision{
 			OK:       false,
 			Resource: constants.Memory,
 			Reason:   constants.ClusterMemoryInsufficient,
 			Message:  fmt.Sprintf(constants.ClusterMemoryInsufficientMessage, op),
 		}, nil
-	}
-	if added.Disk > totalDiskBytes {
+	default:
 		return Decision{
 			OK:       false,
 			Resource: constants.Disk,
@@ -127,7 +144,6 @@ func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decisio
 			Message:  fmt.Sprintf(constants.ClusterDiskInsufficientMessage, op),
 		}, nil
 	}
-	return ok(), nil
 }
 
 // clusterPressureValidator wraps apputils.CheckAppRequirement which
@@ -149,7 +165,7 @@ func (clusterPressureValidator) AppliesTo(op Op) bool {
 }
 
 func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := apputils.CheckAppRequirement(in.Token, in.AppConfig, in.Op)
+	resource, reason, err := checkAppRequirement(in.Token, in.AppConfig, in.Op)
 	if err != nil {
 		// CheckAppRequirement returns an empty resource/reason only when
 		// the check itself couldn't be evaluated (e.g. the kubesphere
@@ -188,7 +204,7 @@ func (userQuotaValidator) AppliesTo(op Op) bool {
 }
 
 func (userQuotaValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := apputils.CheckUserResRequirement(ctx, in.AppConfig, in.Op)
+	resource, reason, err := checkUserResRequirement(ctx, in.AppConfig, in.Op)
 	if err != nil {
 		// Empty resource/reason means the prometheus user-metrics call
 		// failed, not that the user is over quota. Treat it as a fatal
@@ -226,7 +242,7 @@ func (k8sRequestValidator) AppliesTo(op Op) bool {
 }
 
 func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := apputils.CheckAppK8sRequestResource(in.AppConfig, in.Op)
+	resource, reason, err := checkAppK8sRequestResource(in.AppConfig, in.Op)
 	if err != nil {
 		// Empty resource/reason means the node/allocatable lookup failed
 		// (or appConfig was nil), not that the cluster lacks room. Surface

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -266,6 +266,7 @@ const (
 	ClusterCPUInsufficient    ResourceConditionType = "ClusterCPUInsufficient"
 	ClusterMemoryInsufficient ResourceConditionType = "ClusterMemoryInsufficient"
 	ClusterDiskInsufficient   ResourceConditionType = "ClusterDiskInsufficient"
+	MetricsUnavailable        ResourceConditionType = "MetricsUnavailable"
 
 	// ComputeAllocationFailed is emitted by computeAllocationValidator
 	// when compute.AllocateForInstall cannot place the app's
@@ -295,6 +296,7 @@ const (
 	ClusterCPUInsufficientMessage    string = "Cluster total schedulable CPU is smaller than the app's request. Unable to %s this application."
 	ClusterMemoryInsufficientMessage string = "Cluster total schedulable memory is smaller than the app's request. Unable to %s this application."
 	ClusterDiskInsufficientMessage   string = "Cluster total schedulable ephemeral storage is smaller than the app's request. Unable to %s this application."
+	MetricsUnavailableMessage        string = "Resource metrics are temporarily unavailable. Unable to %s the application. Please try again later."
 )
 
 func (rct ResourceConditionType) String() string {

--- a/framework/app-service/pkg/utils/app/validate.go
+++ b/framework/app-service/pkg/utils/app/validate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,6 +40,204 @@ import (
 )
 
 var getNodeInfo = utils.GetNodeInfo
+
+const resourcePressureThreshold = 0.9
+const minimumDiskAvailable int64 = 5 << 30
+
+type ResourceState struct{ CPU, Memory, Disk int64 }
+
+type ResourceDimensions struct{ CPU, Memory, Disk bool }
+
+var AllResourceDimensions = ResourceDimensions{CPU: true, Memory: true, Disk: true}
+
+// MetricsUnavailableError identifies an invalid resource metric.
+type MetricsUnavailableError struct {
+	Resource constants.ResourceType
+	Detail   string
+}
+
+func (e *MetricsUnavailableError) Error() string {
+	return fmt.Sprintf("%s %s is invalid", e.Resource, e.Detail)
+}
+
+// MetricsFailureResource extracts the resource dimension from a metric error.
+func MetricsFailureResource(err error) (constants.ResourceType, bool) {
+	var target *MetricsUnavailableError
+	if errors.As(err, &target) {
+		return target.Resource, true
+	}
+	return "", false
+}
+
+func metricRequirementFailure(err error, op v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error, bool) {
+	resourceType, ok := MetricsFailureResource(err)
+	if !ok {
+		return "", "", nil, false
+	}
+	return resourceType, constants.MetricsUnavailable, fmt.Errorf(constants.MetricsUnavailableMessage, op), true
+}
+
+type ResourcePressure struct {
+	Resource  string `json:"resource"`
+	Required  int64  `json:"required"`
+	Used      int64  `json:"used"`
+	Capacity  int64  `json:"capacity"`
+	Available int64  `json:"available"`
+	Pressured bool   `json:"pressured"`
+}
+
+func EvaluatePhysicalCapacity(required ResourceState, metrics *prometheus.ClusterMetrics, dimensions ResourceDimensions) ([]ResourcePressure, error) {
+	if metrics == nil {
+		return nil, fmt.Errorf("metrics are nil")
+	}
+	values := []struct {
+		enabled      bool
+		resource     constants.ResourceType
+		required     int64
+		total, scale float64
+	}{
+		{dimensions.CPU, constants.CPU, required.CPU, metrics.CPU.Total, 1000},
+		{dimensions.Memory, constants.Memory, required.Memory, metrics.Memory.Total, 1},
+		{dimensions.Disk, constants.Disk, required.Disk, metrics.Disk.Total, 1},
+	}
+	var out []ResourcePressure
+	for _, value := range values {
+		if !value.enabled {
+			continue
+		}
+		capacity, err := metricValue(value.resource, "total", value.total, value.scale, false)
+		if err != nil {
+			return nil, err
+		}
+		appendPressure(&out, resourcePressure(string(value.resource), value.required, 0, capacity, false), true)
+	}
+	return out, nil
+}
+
+func EvaluateClusterPressure(required ResourceState, metrics *prometheus.ClusterMetrics, dimensions ResourceDimensions) ([]ResourcePressure, error) {
+	if metrics == nil {
+		return nil, fmt.Errorf("metrics are nil")
+	}
+	cpuTotal, cpuUsed, err := metricState(dimensions.CPU, constants.CPU, metrics.CPU, 1000, false)
+	if err != nil {
+		return nil, err
+	}
+	memoryTotal, memoryUsed, err := metricState(dimensions.Memory, constants.Memory, metrics.Memory, 1, false)
+	if err != nil {
+		return nil, err
+	}
+	diskTotal, diskUsed, err := metricState(true, constants.Disk, metrics.Disk, 1, false)
+	if err != nil {
+		return nil, err
+	}
+	disk := resourcePressure(string(constants.Disk), required.Disk, diskUsed, thresholdValue(diskTotal), false)
+	disk.Pressured = disk.Pressured && dimensions.Disk || disk.Available < minimumDiskAvailable
+	memory := resourcePressure(string(constants.Memory), required.Memory, memoryUsed, thresholdValue(memoryTotal), false)
+	cpu := resourcePressure(string(constants.CPU), required.CPU, cpuUsed, thresholdValue(cpuTotal), false)
+	var out []ResourcePressure
+	appendPressure(&out, disk, true)
+	appendPressure(&out, memory, dimensions.Memory)
+	appendPressure(&out, cpu, dimensions.CPU)
+	return out, nil
+}
+
+func EvaluateOwnerPressure(required ResourceState, metrics *prometheus.ClusterMetrics, dimensions ResourceDimensions) ([]ResourcePressure, error) {
+	if metrics == nil {
+		return nil, fmt.Errorf("metrics are nil")
+	}
+	cpuTotal, cpuUsed, err := metricState(dimensions.CPU, constants.CPU, metrics.CPU, 1000, true)
+	if err != nil {
+		return nil, err
+	}
+	memoryTotal, memoryUsed, err := metricState(dimensions.Memory, constants.Memory, metrics.Memory, 1, true)
+	if err != nil {
+		return nil, err
+	}
+	memory := resourcePressure(string(constants.Memory), required.Memory, memoryUsed, thresholdValue(memoryTotal), false)
+	cpu := resourcePressure(string(constants.CPU), required.CPU, cpuUsed, thresholdValue(cpuTotal), false)
+	var out []ResourcePressure
+	appendPressure(&out, memory, dimensions.Memory && memoryTotal > 0)
+	appendPressure(&out, cpu, dimensions.CPU && cpuTotal > 0)
+	return out, nil
+}
+
+func EvaluateK8sRequest(required ResourceState, dimensions ResourceDimensions, cpu, memory resource.Quantity) ([]ResourcePressure, error) {
+	if cpu.Sign() < 0 || memory.Sign() < 0 {
+		return nil, fmt.Errorf("kubernetes available resources must not be negative")
+	}
+	maxCPU := resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
+	maxMemory := resource.NewQuantity(math.MaxInt64, resource.DecimalSI)
+	if cpu.Cmp(*maxCPU) > 0 || memory.Cmp(*maxMemory) > 0 {
+		return nil, fmt.Errorf("kubernetes available resources overflow int64")
+	}
+	cpuPressure := resourcePressure(string(constants.CPU), required.CPU, 0, cpu.MilliValue(), true)
+	memoryPressure := resourcePressure(string(constants.Memory), required.Memory, 0, memory.Value(), true)
+	var out []ResourcePressure
+	appendPressure(&out, cpuPressure, dimensions.CPU)
+	appendPressure(&out, memoryPressure, dimensions.Memory)
+	return out, nil
+}
+
+func metricState(enabled bool, resource constants.ResourceType, metric prometheus.Value, scale float64, allowZero bool) (int64, int64, error) {
+	if !enabled {
+		return 0, 0, nil
+	}
+	total, err := metricValue(resource, "total", metric.Total, scale, allowZero)
+	if err != nil || total == 0 && allowZero {
+		return total, 0, err
+	}
+	used, err := metricValue(resource, "usage", metric.Usage, scale, true)
+	return total, used, err
+}
+
+func metricValue(resource constants.ResourceType, detail string, value, multiplier float64, allowZero bool) (int64, error) {
+	scaled := value * multiplier
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || !allowZero && value == 0 ||
+		math.IsNaN(scaled) || math.IsInf(scaled, 0) || scaled >= math.MaxInt64 {
+		return 0, &MetricsUnavailableError{Resource: resource, Detail: detail}
+	}
+	return int64(scaled), nil
+}
+
+func thresholdValue(value int64) int64 {
+	return value/10*9 + value%10*9/10
+}
+
+func resourcePressure(name string, required, used, capacity int64, strict bool) ResourcePressure {
+	headroom := capacity - used
+	if headroom < 0 {
+		headroom = 0
+	}
+	pressured := used > capacity || required > headroom
+	if strict {
+		pressured = required >= headroom
+	}
+	return ResourcePressure{Resource: name, Required: required, Used: used, Capacity: capacity, Available: headroom, Pressured: pressured}
+}
+
+func appendPressure(out *[]ResourcePressure, pressure ResourcePressure, enabled bool) {
+	if enabled && pressure.Pressured {
+		*out = append(*out, pressure)
+	}
+}
+
+func resourceStateFromConfig(appConfig *appcfg.ApplicationConfig) (ResourceState, ResourceDimensions) {
+	if appConfig == nil {
+		return ResourceState{}, ResourceDimensions{}
+	}
+	var state ResourceState
+	var dimensions ResourceDimensions
+	if appConfig.Requirement.CPU != nil {
+		state.CPU, dimensions.CPU = appConfig.Requirement.CPU.MilliValue(), true
+	}
+	if appConfig.Requirement.Memory != nil {
+		state.Memory, dimensions.Memory = appConfig.Requirement.Memory.Value(), true
+	}
+	if appConfig.Requirement.Disk != nil {
+		state.Disk, dimensions.Disk = appConfig.Requirement.Disk.Value(), true
+	}
+	return state, dimensions
+}
 
 func CheckChartSource(source api.AppSource) error {
 	if source != api.Market && source != api.Custom && source != api.DevBox && source != api.System {
@@ -218,28 +417,25 @@ func CheckAppRequirement(token string, appConfig *appcfg.ApplicationConfig, op v
 	klog.Infof("Current resource=%s", utils.PrettyJSON(metrics))
 	klog.Infof("App required resource=%s", utils.PrettyJSON(appConfig.Requirement))
 
-	if appConfig.Requirement.Disk != nil &&
-		appConfig.Requirement.Disk.CmpInt64(int64(metrics.Disk.Total*0.9-metrics.Disk.Usage)) > 0 ||
-		int64(metrics.Disk.Total*0.9-metrics.Disk.Usage) < 5*1024*1024*1024 {
-		return constants.Disk, constants.DiskPressure, fmt.Errorf(constants.DiskPressureMessage, op)
-	}
-
-	if appConfig.Requirement.Memory != nil &&
-		appConfig.Requirement.Memory.CmpInt64(int64(metrics.Memory.Total*0.9-metrics.Memory.Usage)) > 0 {
-		return constants.Memory, constants.SystemMemoryPressure, fmt.Errorf(constants.SystemMemoryPressureMessage, op)
-	}
-	if appConfig.Requirement.CPU != nil {
-		availableCPU, _ := resource.ParseQuantity(strconv.FormatFloat(metrics.CPU.Total*0.9-metrics.CPU.Usage, 'f', -1, 64))
-		if appConfig.Requirement.CPU.Cmp(availableCPU) > 0 {
-			return constants.CPU, constants.SystemCPUPressure, fmt.Errorf(constants.SystemCPUPressureMessage, op)
+	required, dimensions := resourceStateFromConfig(appConfig)
+	pressure, err := EvaluateClusterPressure(required, metrics, dimensions)
+	if err != nil {
+		if resourceType, reason, responseErr, ok := metricRequirementFailure(err, op); ok {
+			return resourceType, reason, responseErr
 		}
+		return "", "", err
 	}
-
-	// GPU availability (per-mode, per-node) is now checked upfront by
-	// compute.BuildInstallComputePlan during install pre-check, so we no
-	// longer reject installs here based on aggregate cluster GPU memory.
-
-	return CheckAppK8sRequestResource(appConfig, op)
+	if len(pressure) == 0 {
+		return "", "", nil
+	}
+	switch pressure[0].Resource {
+	case string(constants.Disk):
+		return constants.Disk, constants.DiskPressure, fmt.Errorf(constants.DiskPressureMessage, op)
+	case string(constants.Memory):
+		return constants.Memory, constants.SystemMemoryPressure, fmt.Errorf(constants.SystemMemoryPressureMessage, op)
+	default:
+		return constants.CPU, constants.SystemCPUPressure, fmt.Errorf(constants.SystemCPUPressureMessage, op)
+	}
 }
 
 func GetRequestResources() (map[string]resources, error) {
@@ -406,17 +602,21 @@ func CheckUserResRequirement(ctx context.Context, appConfig *appcfg.ApplicationC
 	if err != nil {
 		return "", "", err
 	}
-	switch {
-	case appConfig.Requirement.Memory != nil && metrics.Memory.Total != 0 &&
-		appConfig.Requirement.Memory.CmpInt64(int64(metrics.Memory.Total*0.9-metrics.Memory.Usage)) > 0:
-		return constants.Memory, constants.UserMemoryPressure, fmt.Errorf(constants.UserMemoryPressureMessage, op)
-	case appConfig.Requirement.CPU != nil && metrics.CPU.Total != 0:
-		availableCPU, _ := resource.ParseQuantity(strconv.FormatFloat(metrics.CPU.Total*0.9-metrics.CPU.Usage, 'f', -1, 64))
-		if appConfig.Requirement.CPU.Cmp(availableCPU) > 0 {
-			return constants.CPU, constants.UserCPUPressure, fmt.Errorf(constants.UserCPUPressureMessage, op)
+	required, dimensions := resourceStateFromConfig(appConfig)
+	pressure, err := EvaluateOwnerPressure(required, metrics, dimensions)
+	if err != nil {
+		if resourceType, reason, responseErr, ok := metricRequirementFailure(err, op); ok {
+			return resourceType, reason, responseErr
 		}
+		return "", "", err
 	}
-	return "", "", nil
+	if len(pressure) == 0 {
+		return "", "", nil
+	}
+	if pressure[0].Resource == string(constants.Memory) {
+		return constants.Memory, constants.UserMemoryPressure, fmt.Errorf(constants.UserMemoryPressureMessage, op)
+	}
+	return constants.CPU, constants.UserCPUPressure, fmt.Errorf(constants.UserCPUPressureMessage, op)
 }
 
 func CheckMiddlewareRequirement(ctx context.Context, ctrlClient client.Client, middleware *tapr.Middleware) (bool, error) {
@@ -732,6 +932,14 @@ func GetClusterAvailableResource() (*resources, error) {
 	return &availableResources, nil
 }
 
+func GetClusterAvailableResourceQuantities() (resource.Quantity, resource.Quantity, error) {
+	available, err := GetClusterAvailableResource()
+	if err != nil {
+		return resource.Quantity{}, resource.Quantity{}, err
+	}
+	return available.cpu.allocatable.DeepCopy(), available.memory.allocatable.DeepCopy(), nil
+}
+
 func CheckAppK8sRequestResource(appConfig *appcfg.ApplicationConfig, op v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
 	availableResources, err := GetClusterAvailableResource()
 	if err != nil {
@@ -741,25 +949,16 @@ func CheckAppK8sRequestResource(appConfig *appcfg.ApplicationConfig, op v1alpha1
 		return "", "", errors.New("nil appConfig")
 	}
 
-	sufficientCPU, sufficientMemory := false, false
-
-	if appConfig.Requirement.CPU == nil {
-		sufficientCPU = true
+	required, dimensions := resourceStateFromConfig(appConfig)
+	pressure, err := EvaluateK8sRequest(required, dimensions, *availableResources.cpu.allocatable, *availableResources.memory.allocatable)
+	if err != nil {
+		return "", "", err
 	}
-	if appConfig.Requirement.Memory == nil {
-		sufficientMemory = true
+	if len(pressure) == 0 {
+		return "", "", nil
 	}
-	if appConfig.Requirement.CPU != nil && availableResources.cpu.allocatable.Cmp(*appConfig.Requirement.CPU) > 0 {
-		sufficientCPU = true
-	}
-	if appConfig.Requirement.Memory != nil && availableResources.memory.allocatable.Cmp(*appConfig.Requirement.Memory) > 0 {
-		sufficientMemory = true
-	}
-	if !sufficientCPU {
+	if pressure[0].Resource == string(constants.CPU) {
 		return constants.CPU, constants.K8sRequestCPUPressure, fmt.Errorf(constants.K8sRequestCPUPressureMessage, op)
 	}
-	if !sufficientMemory {
-		return constants.Memory, constants.K8sRequestMemoryPressure, fmt.Errorf(constants.K8sRequestMemoryPressureMessage, op)
-	}
-	return "", "", nil
+	return constants.Memory, constants.K8sRequestMemoryPressure, fmt.Errorf(constants.K8sRequestMemoryPressureMessage, op)
 }

--- a/framework/app-service/pkg/utils/app/validate_resource_test.go
+++ b/framework/app-service/pkg/utils/app/validate_resource_test.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
+	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const testGi int64 = 1 << 30
+
+func TestEvaluatePhysicalCapacity(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 2},
+		Memory: prometheus.Value{Total: 4 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 10 * float64(testGi)},
+	}
+	pressure, err := EvaluatePhysicalCapacity(ResourceState{CPU: 2001}, metrics, AllResourceDimensions)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 1 || pressure[0].Resource != "cpu" || !pressure[0].Pressured {
+		t.Fatalf("unexpected pressure: %#v", pressure)
+	}
+}
+
+func TestEvaluateClusterPressureUsesThresholdAndDiskReserve(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 10, Usage: 8},
+		Memory: prometheus.Value{Total: 10 * float64(testGi), Usage: 8 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi), Usage: 86 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(ResourceState{CPU: 1001}, metrics, AllResourceDimensions)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 2 || pressure[0].Resource != "disk" || pressure[1].Resource != "cpu" {
+		t.Fatalf("unexpected pressure: %#v", pressure)
+	}
+}
+
+func TestEvaluateOwnerPressureTreatsZeroTotalsAsUnlimited(t *testing.T) {
+	pressure, err := EvaluateOwnerPressure(ResourceState{CPU: 1000, Memory: testGi}, &prometheus.ClusterMetrics{}, AllResourceDimensions)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 0 {
+		t.Fatalf("zero owner quota should be unlimited: %#v", pressure)
+	}
+}
+
+func TestEvaluateClusterPressureBlocksExistingOveruse(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 10, Usage: 10},
+		Memory: prometheus.Value{Total: 10 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(ResourceState{}, metrics, AllResourceDimensions)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 1 || pressure[0].Resource != "cpu" {
+		t.Fatalf("existing overuse must remain pressure: %#v", pressure)
+	}
+}
+
+func TestEvaluateK8sRequestUsesStrictComparison(t *testing.T) {
+	cpu := resource.MustParse("1000m")
+	memory := resource.MustParse("1Gi")
+	pressure, err := EvaluateK8sRequest(ResourceState{CPU: 1000, Memory: testGi}, AllResourceDimensions, cpu, memory)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 2 || pressure[0].Resource != "cpu" || pressure[1].Resource != "memory" {
+		t.Fatalf("equal availability must fail: %#v", pressure)
+	}
+}
+
+func TestResourceEvaluatorsRejectInvalidMetrics(t *testing.T) {
+	if _, err := EvaluateClusterPressure(ResourceState{}, nil, AllResourceDimensions); err == nil {
+		t.Fatal("nil metrics must fail")
+	}
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 1},
+		Memory: prometheus.Value{Total: 1},
+		Disk:   prometheus.Value{Total: 1, Usage: -1},
+	}
+	if _, err := EvaluateClusterPressure(ResourceState{}, metrics, AllResourceDimensions); err == nil {
+		t.Fatal("negative usage must fail")
+	}
+}
+
+func TestMetricErrorsIdentifyResource(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 0},
+		Memory: prometheus.Value{Total: 10 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi)},
+	}
+	_, err := EvaluatePhysicalCapacity(ResourceState{CPU: 1}, metrics, ResourceDimensions{CPU: true})
+	var metricErr *MetricsUnavailableError
+	if !errors.As(err, &metricErr) || metricErr.Resource != constants.CPU {
+		t.Fatalf("physical capacity error=%v, want cpu MetricsUnavailableError", err)
+	}
+
+	metrics.CPU.Total = 10
+	metrics.CPU.Usage = math.NaN()
+	_, err = EvaluateClusterPressure(ResourceState{}, metrics, ResourceDimensions{CPU: true})
+	if !errors.As(err, &metricErr) || metricErr.Resource != constants.CPU {
+		t.Fatalf("cluster pressure error=%v, want cpu MetricsUnavailableError", err)
+	}
+}
+
+func TestMetricRequirementFailureUsesStructuredFriendlyResponse(t *testing.T) {
+	resourceType, reason, err, ok := metricRequirementFailure(
+		&MetricsUnavailableError{Resource: constants.Memory, Detail: "usage"},
+		v1alpha1.InstallOp,
+	)
+	if !ok {
+		t.Fatal("metric error should be recognized")
+	}
+	if resourceType != constants.Memory || reason != constants.MetricsUnavailable {
+		t.Fatalf("resource=%q reason=%q", resourceType, reason)
+	}
+	if got, want := err.Error(), "Resource metrics are temporarily unavailable. Unable to install the application. Please try again later."; got != want {
+		t.Fatalf("message=%q, want %q", got, want)
+	}
+}
+
+func TestResourceDimensionsPreserveOptionalRequirementSemantics(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 10, Usage: 10},
+		Memory: prometheus.Value{Total: 10 * float64(testGi), Usage: 10 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(ResourceState{}, metrics, ResourceDimensions{})
+	if err != nil {
+		t.Fatalf("cluster pressure: %v", err)
+	}
+	if len(pressure) != 0 {
+		t.Fatalf("absent cpu and memory requirements must be skipped: %#v", pressure)
+	}
+
+	pressure, err = EvaluateOwnerPressure(ResourceState{}, metrics, ResourceDimensions{})
+	if err != nil {
+		t.Fatalf("owner pressure: %v", err)
+	}
+	if len(pressure) != 0 {
+		t.Fatalf("absent owner requirements must be skipped: %#v", pressure)
+	}
+}
+
+func TestClusterDiskReserveDoesNotRequireDiskPresence(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 10},
+		Memory: prometheus.Value{Total: 10 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi), Usage: 86 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(ResourceState{}, metrics, ResourceDimensions{})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 1 || pressure[0].Resource != "disk" {
+		t.Fatalf("disk reserve must always apply: %#v", pressure)
+	}
+}
+
+func TestClusterPressureSkipsAbsentDiskRequirement(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 10},
+		Memory: prometheus.Value{Total: 10 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 100 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(ResourceState{Disk: 100 * testGi}, metrics, ResourceDimensions{})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 0 {
+		t.Fatalf("absent disk requirement must be skipped while reserve still applies: %#v", pressure)
+	}
+}
+
+func TestClusterPressureChecksPresentDiskRequirement(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		Disk: prometheus.Value{Total: 100 * float64(testGi), Usage: 40 * float64(testGi)},
+	}
+	pressure, err := EvaluateClusterPressure(
+		ResourceState{Disk: 51 * testGi},
+		metrics,
+		ResourceDimensions{Disk: true},
+	)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(pressure) != 1 || pressure[0].Resource != "disk" {
+		t.Fatalf("present disk requirement must respect headroom: %#v", pressure)
+	}
+}
+
+func TestEvaluatePhysicalCapacityIgnoresUsage(t *testing.T) {
+	metrics := &prometheus.ClusterMetrics{
+		CPU:    prometheus.Value{Total: 2, Usage: -1},
+		Memory: prometheus.Value{Total: 4 * float64(testGi)},
+		Disk:   prometheus.Value{Total: 10 * float64(testGi)},
+	}
+	if _, err := EvaluatePhysicalCapacity(ResourceState{CPU: 1}, metrics, ResourceDimensions{CPU: true}); err != nil {
+		t.Fatalf("usage must not affect physical capacity: %v", err)
+	}
+	metrics.CPU.Total = 0
+	if _, err := EvaluatePhysicalCapacity(ResourceState{CPU: 1}, metrics, ResourceDimensions{CPU: true}); err == nil {
+		t.Fatal("selected total must fail closed")
+	}
+}
+
+func TestEvaluateK8sRequestDistinguishesAbsentAndExplicitZero(t *testing.T) {
+	zero := resource.MustParse("0")
+	if pressure, err := EvaluateK8sRequest(ResourceState{}, ResourceDimensions{}, zero, zero); err != nil || len(pressure) != 0 {
+		t.Fatalf("absent requirements must be skipped: pressure=%#v err=%v", pressure, err)
+	}
+	pressure, err := EvaluateK8sRequest(ResourceState{}, ResourceDimensions{CPU: true, Memory: true}, zero, zero)
+	if err != nil {
+		t.Fatalf("explicit zero: %v", err)
+	}
+	if len(pressure) != 2 {
+		t.Fatalf("explicit zero still requires positive availability: %#v", pressure)
+	}
+}


### PR DESCRIPTION
## Summary
- add a read-only app-service preflight endpoint for single or sequential multi-app resource simulation
- reuse existing capacity, pressure, quota, Kubernetes request, and compute placement validation paths
- return structured placement and pressure failures while keeping simulation deterministic and side-effect free

## Test plan
- [x] `go test ./pkg/compute/... ./pkg/utils/app/... ./pkg/apiserver/... -count=1`
- [x] `go test -race ./pkg/compute/... ./pkg/utils/app/... ./pkg/apiserver/... -count=1`
- [x] `go vet ./pkg/compute/... ./pkg/utils/app/... ./pkg/apiserver/...`
- [x] `gofmt` check for changed Go packages
- [ ] `go test -timeout 2m ./... -count=1` — retains existing baseline failures in `pkg/gateway`, `pkg/gateway/routecontrol`, `pkg/kubesphere`, `pkg/task`, and `pkg/utils`; changed packages pass

Made with [Cursor](https://cursor.com)