### PR TITLE
fix: resolve Intel GPU driver resource from node register annotation

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -422,11 +422,16 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		hamiFormatGpuRequired := resource.NewQuantity(gpuRequiredValue, resource.DecimalSI)
 		hamiGpuMemory = ptr.To(hamiFormatGpuRequired.String())
 	}
+	gpuResourceKey, err := h.resolveIntelDriverResource(ctx, GPUType)
+	if err != nil {
+		klog.Errorf("resolve intel driver resource error %v", err)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
 	patchBytes, err := webhook.CreatePatchForDeployment(
 		tpl,
 		injectAll,
 		injectContainer,
-		h.getGPUResourceTypeKey(GPUType),
+		gpuResourceKey,
 		hamiGpuMemory,
 		envs,
 	)
@@ -476,6 +481,95 @@ func (h *Handler) getGPUResourceTypeKey(gpuType string) string {
 	case utils.CPUType:
 		klog.Info("CPU type is selected, no GPU resource will be injected")
 		return ""
+	default:
+		return ""
+	}
+}
+
+// resolveIntelDriverResource picks the correct Intel extended resource
+// (gpu.intel.com/i915 vs gpu.intel.com/xe) for the given compute mode by
+// reading the real bound driver from the cluster's node register annotations
+// (bytetrade.io/node-intel-register), instead of assuming intel(igpu)->i915 /
+// intel-gpu(dgpu)->xe. iGPU and dGPU can each be bound to either driver, so the
+// hardcoded mapping is wrong.
+//
+// For non-Intel modes it delegates to getGPUResourceTypeKey. When no matching
+// card is found in the cluster, it falls back to the legacy mapping so
+// behaviour degrades gracefully rather than dropping the resource. Listing the
+// nodes is a hard dependency, so a list failure is returned as an error rather
+// than silently resolved to a possibly-wrong resource.
+func (h *Handler) resolveIntelDriverResource(ctx context.Context, mode string) (string, error) {
+	var wantKind string
+	switch mode {
+	case utils.IntelType:
+		wantKind = utils.IntelGPUKindIntegrated
+	case utils.IntelGPUType:
+		wantKind = utils.IntelGPUKindDiscrete
+	default:
+		return h.getGPUResourceTypeKey(mode), nil
+	}
+
+	var nodes corev1.NodeList
+	if err := h.ctrlClient.List(ctx, &nodes); err != nil {
+		return "", fmt.Errorf("[gpu-limit] list nodes for intel driver resolution (mode %s) failed: %w", mode, err)
+	}
+
+	resource, distinct := selectIntelDriverResource(nodes.Items, wantKind)
+	if resource == "" {
+		klog.Warningf("[gpu-limit] no intel %s (mode %s) card found in cluster register; falling back to legacy mapping", wantKind, mode)
+		return h.getGPUResourceTypeKey(mode), nil
+	}
+
+	if len(distinct) > 1 {
+		klog.Warningf("[gpu-limit] intel %s cards use multiple drivers %v across the cluster; a single extended resource can't express both, picking deterministically -> %s", wantKind, distinct, resource)
+	}
+
+	return resource, nil
+}
+
+// selectIntelDriverResource scans node register entries for cards of the given
+// kind (igpu/dgpu) and returns the extended resource for the chosen driver plus
+// the sorted set of distinct drivers seen (len>1 means a mixed cluster). The
+// driver is picked by a fixed priority (xe then i915) so the decision is stable
+// across scheduling passes. It returns ("", nil) when no matching card exists.
+func selectIntelDriverResource(nodes []corev1.Node, wantKind string) (string, []string) {
+	seen := make(map[string]struct{})
+	for i := range nodes {
+		entries, err := utils.IntelRegisterFromNode(&nodes[i])
+		if err != nil {
+			klog.Warningf("[gpu-limit] node %s has malformed %s annotation: %v", nodes[i].Name, constants.NodeIntelRegisterKey, err)
+			continue
+		}
+		for _, e := range entries {
+			if e.Kind == wantKind {
+				seen[e.Driver] = struct{}{}
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		return "", nil
+	}
+
+	distinct := make([]string, 0, len(seen))
+	// Fixed priority so both the returned resource and the reported set order
+	// are deterministic.
+	for _, drv := range []string{utils.IntelDriverXe, utils.IntelDriverI915} {
+		if _, ok := seen[drv]; ok {
+			distinct = append(distinct, drv)
+		}
+	}
+
+	return intelDriverResource(distinct[0]), distinct
+}
+
+// intelDriverResource maps a bound Intel kernel driver to its extended resource.
+func intelDriverResource(driver string) string {
+	switch driver {
+	case utils.IntelDriverI915:
+		return constants.IntelIGPU
+	case utils.IntelDriverXe:
+		return constants.IntelGPU
 	default:
 		return ""
 	}

--- a/framework/app-service/pkg/apiserver/handler_webhook_intel_test.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook_intel_test.go
@@ -1,0 +1,96 @@
+package apiserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func nodeWithRegister(name, register string) corev1.Node {
+	n := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if register != "" {
+		n.Annotations = map[string]string{constants.NodeIntelRegisterKey: register}
+	}
+	return n
+}
+
+func TestSelectIntelDriverResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodes        []corev1.Node
+		wantKind     string
+		wantResource string
+		wantDistinct []string
+	}{
+		{
+			name:         "igpu on i915",
+			nodes:        []corev1.Node{nodeWithRegister("n0", "igpu,card0,i915,Intel® UHD Graphics,Xe,Tiger Lake,0")},
+			wantKind:     utils.IntelGPUKindIntegrated,
+			wantResource: constants.IntelIGPU,
+			wantDistinct: []string{utils.IntelDriverI915},
+		},
+		{
+			name:         "igpu on xe (driver differs from kind)",
+			nodes:        []corev1.Node{nodeWithRegister("n0", "igpu,card0,xe,,,,0")},
+			wantKind:     utils.IntelGPUKindIntegrated,
+			wantResource: constants.IntelGPU,
+			wantDistinct: []string{utils.IntelDriverXe},
+		},
+		{
+			name:         "dgpu on i915 (driver differs from kind)",
+			nodes:        []corev1.Node{nodeWithRegister("n0", "dgpu,card0,i915,,,,0")},
+			wantKind:     utils.IntelGPUKindDiscrete,
+			wantResource: constants.IntelIGPU,
+			wantDistinct: []string{utils.IntelDriverI915},
+		},
+		{
+			name: "only matching kind considered",
+			nodes: []corev1.Node{
+				nodeWithRegister("n0", "igpu,card0,i915,,,,0:dgpu,card1,xe,Intel® Arc™ B580 Graphics,Xe2,Battlemage,12884901888"),
+			},
+			wantKind:     utils.IntelGPUKindDiscrete,
+			wantResource: constants.IntelGPU,
+			wantDistinct: []string{utils.IntelDriverXe},
+		},
+		{
+			name: "mixed cluster picks xe by priority",
+			nodes: []corev1.Node{
+				nodeWithRegister("n0", "igpu,card0,xe,,,,0"),
+				nodeWithRegister("n1", "igpu,card0,i915,,,,0"),
+			},
+			wantKind:     utils.IntelGPUKindIntegrated,
+			wantResource: constants.IntelGPU,
+			wantDistinct: []string{utils.IntelDriverXe, utils.IntelDriverI915},
+		},
+		{
+			name:         "no matching kind -> empty",
+			nodes:        []corev1.Node{nodeWithRegister("n0", "dgpu,card0,xe,,,,0")},
+			wantKind:     utils.IntelGPUKindIntegrated,
+			wantResource: "",
+			wantDistinct: nil,
+		},
+		{
+			name:         "malformed annotation skipped -> empty",
+			nodes:        []corev1.Node{nodeWithRegister("n0", "garbage,entry")},
+			wantKind:     utils.IntelGPUKindIntegrated,
+			wantResource: "",
+			wantDistinct: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, distinct := selectIntelDriverResource(tc.nodes, tc.wantKind)
+			if resource != tc.wantResource {
+				t.Errorf("resource = %q, want %q", resource, tc.wantResource)
+			}
+			if !reflect.DeepEqual(distinct, tc.wantDistinct) {
+				t.Errorf("distinct = %v, want %v", distinct, tc.wantDistinct)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -226,14 +227,66 @@ func buildNodeResource(node *corev1.Node) Node {
 	}
 
 	for _, mode := range modes {
-		if IsHAMIMode(mode) {
+		switch {
+		case IsHAMIMode(mode):
 			n.Devices = append(n.Devices, decodeHAMINvidiaDevices(node, mode)...)
-			continue
+		case mode == utils.IntelGPUType:
+			// Discrete Intel GPUs are one Exclusive card each, with their own
+			// VRAM read from the node register annotation. Fall back to the
+			// legacy single system-memory device when the annotation carries no
+			// usable discrete entry, so a node that advertises intel-gpu still
+			// has a schedulable device.
+			if devices := decodeIntelDiscreteDevices(node, mode, totalMemory); len(devices) > 0 {
+				n.Devices = append(n.Devices, devices...)
+			} else {
+				n.Devices = append(n.Devices, nonHAMIDevice(node, mode, totalMemory))
+			}
+		default:
+			n.Devices = append(n.Devices, nonHAMIDevice(node, mode, totalMemory))
 		}
-		n.Devices = append(n.Devices, nonHAMIDevice(node, mode, totalMemory))
 	}
 
 	return n
+}
+
+// decodeIntelDiscreteDevices builds one Exclusive device per discrete Intel GPU
+// (dgpu) advertised in the node's bytetrade.io/node-intel-register annotation,
+// using each card's real VRAM (the entry's mem field, in bytes) as its Memory
+// instead of the node's system RAM. Integrated Intel GPUs (igpu) are unified
+// memory and stay on the nonHAMIDevice path, so they are skipped here. When a
+// discrete entry's VRAM is unknown (mem=0, e.g. the xe driver doesn't expose it
+// via sysfs yet) it falls back to the node's usable system memory so the card
+// remains schedulable. Returns nil when the annotation is missing, malformed,
+// or advertises no discrete card, letting the caller use the legacy device.
+func decodeIntelDiscreteDevices(node *corev1.Node, mode string, totalMemory int64) []Device {
+	entries, err := utils.IntelRegisterFromNode(node)
+	if err != nil {
+		klog.Warningf("compute: node %s has malformed %s annotation: %v", node.Name, constants.NodeIntelRegisterKey, err)
+		return nil
+	}
+
+	var devices []Device
+	for _, e := range entries {
+		if e.Kind != utils.IntelGPUKindDiscrete {
+			continue
+		}
+		deviceID := fmt.Sprintf("%s-%s-%s", node.Name, mode, e.Card)
+		memory := int64(e.Mem)
+		if memory <= 0 {
+			memory = totalMemory * 75 / 100
+		}
+		devices = append(devices, Device{
+			ID:                    deviceID,
+			NodeName:              node.Name,
+			Mode:                  mode,
+			CardModel:             e.Name,
+			Memory:                memory,
+			Health:                nodeHealth(node),
+			SupportType:           nonHAMISupportType(mode, node.Annotations[shareModeAnnotationKey(deviceID)]),
+			AvailableSupportTypes: AvailableSupportTypes(mode),
+		})
+	}
+	return devices
 }
 
 // nonHAMIDevice builds the single synthetic device used for unified-memory

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -280,7 +280,7 @@ func IsHAMIMode(mode string) bool {
 // and rely on nodeSelector to reach the correct node.
 func UsesGPUExtendedResource(mode string) bool {
 	switch mode {
-	case utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.AMDGPUType, utils.IntelType:
+	case utils.NvidiaCardType, utils.GB10ChipType, utils.AMDType, utils.AMDGPUType, utils.IntelType, utils.IntelGPUType:
 		return true
 	default:
 		return false

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -100,6 +100,14 @@ const (
 	IntelIGPU = "gpu.intel.com/i915"
 	IntelGPU  = "gpu.intel.com/xe"
 
+	// NodeIntelRegisterKey is the node annotation written by the Intel GPU
+	// device plugin. Its value lists each Intel card as
+	// "<igpu|dgpu>,<cardN>,<i915|xe>,<name>,<architecture>,<codename>,<mem>"
+	// entries joined by ':' (mem is discrete VRAM bytes, 0 for integrated). It
+	// lets the gpu-limit webhook pick gpu.intel.com/i915 vs gpu.intel.com/xe
+	// from the real bound driver instead of guessing from integrated/discrete.
+	NodeIntelRegisterKey = "bytetrade.io/node-intel-register"
+
 	AuthorizationLevelOfPublic   = "public"
 	AuthorizationLevelOfPrivate  = "private"
 	AuthorizationLevelOfInternal = "internal"

--- a/framework/app-service/pkg/utils/intel_register.go
+++ b/framework/app-service/pkg/utils/intel_register.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Intel GPU kinds and drivers as published in the node register annotation.
+const (
+	IntelGPUKindIntegrated = "igpu"
+	IntelGPUKindDiscrete   = "dgpu"
+
+	IntelDriverI915 = "i915"
+	IntelDriverXe   = "xe"
+)
+
+// IntelGPUEntry is a single Intel GPU card as advertised by the device plugin
+// in the bytetrade.io/node-intel-register node annotation.
+type IntelGPUEntry struct {
+	Kind         string // igpu | dgpu
+	Card         string // e.g. card0
+	Driver       string // i915 | xe
+	Name         string // product name, may be empty for unknown PCI ids
+	Architecture string // e.g. Xe-HPG, may be empty
+	Codename     string // e.g. Alchemist, may be empty
+	Mem          uint64 // discrete VRAM in bytes; 0 for integrated
+}
+
+// ParseNodeIntelRegister parses the bytetrade.io/node-intel-register annotation
+// value. The format is a ':'-separated list of entries, each a ','-separated
+// tuple "<igpu|dgpu>,<cardN>,<i915|xe>,<name>,<architecture>,<codename>,<mem>".
+// name/architecture/codename may be empty (unknown PCI id); mem is a byte count
+// (0 for integrated). Empty input yields an empty slice with no error. A
+// malformed entry (wrong field count, unknown kind/driver, non-numeric mem) is
+// an error; callers may choose to log and fall back.
+func ParseNodeIntelRegister(s string) ([]IntelGPUEntry, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	entries := make([]IntelGPUEntry, 0)
+	for _, raw := range strings.Split(s, ":") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		fields := strings.Split(raw, ",")
+		if len(fields) != 7 {
+			return nil, fmt.Errorf("invalid intel register entry %q: expected 7 fields, got %d", raw, len(fields))
+		}
+
+		mem, err := strconv.ParseUint(strings.TrimSpace(fields[6]), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid intel register entry %q: bad mem %q: %w", raw, fields[6], err)
+		}
+
+		entry := IntelGPUEntry{
+			Kind:         strings.TrimSpace(fields[0]),
+			Card:         strings.TrimSpace(fields[1]),
+			Driver:       strings.TrimSpace(fields[2]),
+			Name:         strings.TrimSpace(fields[3]),
+			Architecture: strings.TrimSpace(fields[4]),
+			Codename:     strings.TrimSpace(fields[5]),
+			Mem:          mem,
+		}
+
+		switch entry.Kind {
+		case IntelGPUKindIntegrated, IntelGPUKindDiscrete:
+		default:
+			return nil, fmt.Errorf("invalid intel register entry %q: unknown kind %q", raw, entry.Kind)
+		}
+
+		switch entry.Driver {
+		case IntelDriverI915, IntelDriverXe:
+		default:
+			return nil, fmt.Errorf("invalid intel register entry %q: unknown driver %q", raw, entry.Driver)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+// IntelRegisterFromNode parses the register annotation off a node, returning an
+// empty slice when the annotation is absent.
+func IntelRegisterFromNode(node *corev1.Node) ([]IntelGPUEntry, error) {
+	if node == nil {
+		return nil, nil
+	}
+
+	return ParseNodeIntelRegister(node.Annotations[constants.NodeIntelRegisterKey])
+}

--- a/framework/app-service/pkg/utils/intel_register_test.go
+++ b/framework/app-service/pkg/utils/intel_register_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseNodeIntelRegister(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []IntelGPUEntry
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "single igpu i915 (mem 0)",
+			in:   "igpu,card0,i915,Intel® Iris® Xe Graphics,Xe,Tiger Lake,0",
+			want: []IntelGPUEntry{{
+				Kind: "igpu", Card: "card0", Driver: "i915",
+				Name: "Intel® Iris® Xe Graphics", Architecture: "Xe", Codename: "Tiger Lake", Mem: 0,
+			}},
+		},
+		{
+			name: "multiple mixed with discrete mem",
+			in:   "igpu,card0,i915,Intel® UHD Graphics,Xe,Alder Lake-P,0:dgpu,card1,xe,Intel® Arc™ B580 Graphics,Xe2,Battlemage,12884901888",
+			want: []IntelGPUEntry{
+				{Kind: "igpu", Card: "card0", Driver: "i915", Name: "Intel® UHD Graphics", Architecture: "Xe", Codename: "Alder Lake-P", Mem: 0},
+				{Kind: "dgpu", Card: "card1", Driver: "xe", Name: "Intel® Arc™ B580 Graphics", Architecture: "Xe2", Codename: "Battlemage", Mem: 12884901888},
+			},
+		},
+		{
+			name: "empty metadata fields allowed",
+			in:   "dgpu,card0,xe,,,,0",
+			want: []IntelGPUEntry{{Kind: "dgpu", Card: "card0", Driver: "xe", Mem: 0}},
+		},
+		{
+			name: "whitespace and trailing separators tolerated",
+			in:   " igpu, card0, xe , Intel Graphics , Xe , Tiger Lake , 0 : ",
+			want: []IntelGPUEntry{{Kind: "igpu", Card: "card0", Driver: "xe", Name: "Intel Graphics", Architecture: "Xe", Codename: "Tiger Lake", Mem: 0}},
+		},
+		{
+			name:    "wrong field count",
+			in:      "igpu,card0,i915",
+			wantErr: true,
+		},
+		{
+			name:    "unknown kind",
+			in:      "vgpu,card0,i915,name,arch,code,0",
+			wantErr: true,
+		},
+		{
+			name:    "unknown driver",
+			in:      "igpu,card0,amdgpu,name,arch,code,0",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric mem",
+			in:      "dgpu,card0,xe,name,arch,code,lots",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseNodeIntelRegister(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseNodeIntelRegister(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIntelRegisterFromNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "n0",
+			Annotations: map[string]string{constants.NodeIntelRegisterKey: "dgpu,card0,xe,Intel® Arc™ A770 Graphics,Xe-HPG,Alchemist,17179869184"},
+		},
+	}
+
+	got, err := IntelRegisterFromNode(node)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []IntelGPUEntry{{Kind: "dgpu", Card: "card0", Driver: "xe", Name: "Intel® Arc™ A770 Graphics", Architecture: "Xe-HPG", Codename: "Alchemist", Mem: 17179869184}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IntelRegisterFromNode = %+v, want %+v", got, want)
+	}
+
+	// Absent annotation -> empty, no error.
+	empty := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	got, err = IntelRegisterFromNode(empty)
+	if err != nil || got != nil {
+		t.Errorf("IntelRegisterFromNode(no annotation) = (%+v, %v), want (nil, nil)", got, err)
+	}
+}

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -592,6 +592,8 @@ var gpuResourceKeys = []string{
 	constants.NvidiaGPUMem,
 	constants.AMDGPU,
 	constants.AMDAPU,
+	constants.IntelIGPU,
+	constants.IntelGPU,
 }
 
 // jsonPointerEscape escapes a string per RFC 6901 so it is safe to use


### PR DESCRIPTION
* **Background**
The gpu-limit webhook hardcoded intel(igpu)->gpu.intel.com/i915 and intel-gpu(dgpu)->gpu.intel.com/xe, but iGPU and dGPU can each bind to either the i915 or xe kernel driver, so the extended resource was often wrong. Resolve it from the real bound driver instead, published per-node by the Intel device plugin in the bytetrade.io/node-intel-register annotation.

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission webhook behavior and GPU scheduling for Intel workloads; wrong driver resolution or mixed-cluster picks could cause unschedulable pods, though legacy fallback and tests reduce that risk.
> 
> **Overview**
> Fixes incorrect **Intel GPU extended resource** injection in the gpu-limit webhook by reading each node's `bytetrade.io/node-intel-register` annotation instead of assuming integrated → `gpu.intel.com/i915` and discrete → `gpu.intel.com/xe`.
> 
> For **intel** / **intel-gpu** modes, `resolveIntelDriverResource` scans cluster nodes for matching `igpu` or `dgpu` entries, maps the bound driver (`i915` or `xe`) to the right limit key, and uses deterministic driver priority when the cluster is mixed. Missing register data falls back to the old mapping; **node list failures fail admission** rather than guessing.
> 
> **Compute scheduling** now models discrete Intel GPUs as one device per `dgpu` card with VRAM from the register (with fallback when `mem` is 0), and treats **intel-gpu** like other extended-resource modes so the webhook does not add a conflicting `nodeSelector`. GPU cleanup patches also remove stale Intel limit keys on upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba6e1d51ea572170cef68cb9379baac0935a00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->