### PR TITLE
market: preinstall allow explicit tar directory entries in chart

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -133,7 +133,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.80
+        image: beclab/market-backend:v0.6.82
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
allow explicit tar directory entries in chart archives, and ticket bug fixes

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/396
https://github.com/beclab/market/pull/395
https://github.com/beclab/market/pull/394


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in a deployment manifest; behavior changes come from the new backend image at rollout, not from config edits here.
> 
> **Overview**
> Bumps the **appstore-backend** container image in `market_deploy.yaml` from `beclab/market-backend:v0.6.80` to **`v0.6.82`**.
> 
> This pins the cluster market deployment to the backend release that includes preinstall handling for explicit tar directory entries in chart archives and related fixes (see linked `beclab/market` PRs). No other manifest fields change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cade4aa8655ada00cff9cfa804a83b133f7abf87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->