### PR TITLE
feat(cli): add sidecar container for intel gpu memory

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
@@ -1,3 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: intel-gpu-plugin
+  name: intel-gpu-plugin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: intel-gpu-plugin
+  name: intel-gpu-plugin-node-register
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: intel-gpu-plugin
+  name: intel-gpu-plugin-node-register
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: intel-gpu-plugin-node-register
+subjects:
+  - kind: ServiceAccount
+    name: intel-gpu-plugin
+    namespace: kube-system
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -14,7 +48,40 @@ spec:
       labels:
         app: intel-gpu-plugin
     spec:
+      serviceAccountName: intel-gpu-plugin
       containers:
+      - args:
+        - -v=4
+        image: beclab/intel-gpu-levelzero:1.1.1
+        imagePullPolicy: IfNotPresent
+        name: intel-gpu-levelzero
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 50Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/levelzero
+          name: levelzerosocket
+        - mountPath: /dev/dri
+          name: dev-dri-fs
+        - mountPath: /sys/class/drm
+          name: sysfsdrm
+        - mountPath: /var/lib/kubelet/device-plugins
+          name: kubeletsockets
+        - mountPath: /var/run/cdi
+          name: cdipath
+        - mountPath: /dev/accel
+          name: dev-accel-fs
+        - mountPath: /sys/class/accel
+          name: sysfsaccel
       - args:
         - -enable-monitoring
         - -shared-dev-num=50
@@ -28,7 +95,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: beclab/intel-device-plugin:1.1
+        image: beclab/intel-device-plugin:1.1.1
         imagePullPolicy: IfNotPresent
         name: intel-gpu-plugin
         resources:
@@ -64,6 +131,8 @@ spec:
           readOnly: true
         - mountPath: /sys/class/accel
           name: sysfsaccel
+        - mountPath: /var/lib/levelzero
+          name: levelzerosocket
       nodeSelector:
         intel.feature.node.kubernetes.io/gpu: "true"
         kubernetes.io/arch: amd64
@@ -87,6 +156,8 @@ spec:
       - hostPath:
           path: /sys/class/accel
         name: sysfsaccel
+      - emptyDir: {}
+        name: levelzerosocket
   updateStrategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION

* **Background**
feat(cli): add sidecar container for intel gpu memory
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/intel-device-plugins-for-kubernetes/pull/2

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes kube-system GPU DaemonSet rollout with a privileged sidecar and node patch RBAC; misconfiguration could affect GPU scheduling on Intel GPU nodes.
> 
> **Overview**
> Extends the **Intel GPU device plugin** DaemonSet with a second container and RBAC so Level Zero can support GPU memory–related behavior alongside the existing plugin.
> 
> A dedicated **ServiceAccount** plus **ClusterRole/Binding** (`nodes` **get/patch**) is added, and the pod is wired to use that account. A new **`intel-gpu-levelzero`** sidecar (`beclab/intel-gpu-levelzero:1.1.1`) runs **privileged** with DRI/accel/CDI/device-plugin mounts and shares an **`emptyDir`** volume at `/var/lib/levelzero` with the main **`intel-gpu-plugin`** container (image bumped **1.1 → 1.1.1**), which also mounts that socket path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ffb04b5766d651db43333ac28f02e90e6eb76c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->