### PR TITLE
fix(appservice): converge Application state in entrance-status controller

### DIFF
--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -504,38 +504,13 @@ func (r *ApplicationReconciler) updateApplication(ctx context.Context, req ctrl.
 		return err
 	}
 
-	klog.Infof("appCopy.Status: %v", appCopy.Status)
-	newAppState := r.calAppState(&appCopy.Status)
-	klog.Infof("application controller newAppState: %v", newAppState)
-	klog.Infof("application controller oldAppState: %v", appCopy.Status.State)
-
-	if appCopy.Status.State != newAppState {
-		klog.Infof("set appCopy.State:.......new: %v", newAppState)
-		appCopy.Status.State = newAppState
-		now := metav1.Now()
-		appCopy.Status.LastTransitionTime = &now
-
-		err = r.Status().Patch(ctx, appCopy, client.MergeFrom(app))
-		if err != nil {
-			klog.Infof("update xxx error: %v", err)
-			return err
-		}
-	}
-
-	// merge settings
-	//for k, v := range settings {
-	//	if setting, ok := appCopy.Spec.Settings[k]; !ok || setting != v {
-	//		appCopy.Spec.Settings[k] = v
-	//	}
-	//}
-
-	//var a appv1alpha1.Application
-	//err = r.Get(ctx, types.NamespacedName{Name: app.Name}, &a)
-	//if err != nil {
-	//	klog.Infof("get app failed %v", err)
-	//	return err
-	//}
-	//klog.Infof("appState: ..%v", a.Status.State)
+	// NOTE: the aggregate Status.State is intentionally NOT recomputed here.
+	// It is derived from the entrance statuses and converged by the
+	// EntranceStatusManagerController whenever it updates EntranceStatuses
+	// (see calAppState usage there). Recomputing it on Deployment changes was
+	// both redundant and buggy: this path is short-circuited when the
+	// deployment is unchanged, so the last entrance-ready transition after a
+	// rollout could leave State stuck (entrances running but State=notReady).
 	return err
 }
 
@@ -835,7 +810,7 @@ func (r *ApplicationReconciler) getAppTailScale(deployment client.Object) (*appv
 	return &tailScale, nil
 }
 
-func (r *ApplicationReconciler) calAppState(status *appv1alpha1.ApplicationStatus) string {
+func calAppState(status *appv1alpha1.ApplicationStatus) string {
 	entranceLen := len(status.EntranceStatuses)
 	klog.Infof("entranceLen: %v", entranceLen)
 	if entranceLen == 0 {

--- a/framework/app-service/controllers/entrancestatus_controller.go
+++ b/framework/app-service/controllers/entrancestatus_controller.go
@@ -226,6 +226,19 @@ func (r *EntranceStatusManagerController) updateEntranceStatus(ctx context.Conte
 				}
 			}
 		}
+
+		// Recompute the aggregate app state from the just-updated entrance
+		// statuses. The ApplicationReconciler only recomputes it on Deployment
+		// changes and skips when the deployment is unchanged, so a pod becoming
+		// ready after a rollout settles would otherwise leave State stuck (e.g.
+		// entrances all running but State=notReady). Converging it here keeps
+		// State consistent with the entrance statuses this controller owns.
+		if newState := calAppState(&appCopy.Status); appCopy.Status.State != newState {
+			appCopy.Status.State = newState
+			now := metav1.Now()
+			appCopy.Status.LastTransitionTime = &now
+		}
+
 		patchApp := client.MergeFrom(&selectedApp)
 		err = r.Status().Patch(ctx, appCopy, patchApp)
 		klog.Infof("updateEntrances ...:name: %v", appCopy.Name)


### PR DESCRIPTION


* **Background**

The Application status.State (running/notReady/stopped) is derived from entrance statuses, but it was only recomputed in
ApplicationReconciler.updateApplication, which is short-circuited when the Deployment is unchanged. So the final entrance-ready transition after a rollout settled (a pod becoming Ready without a further Deployment change) only updated EntranceStatuses and never re-aggregated State, leaving apps stuck with all entrances running but State=notReady.

- entrancestatus_controller: after updating EntranceStatuses, recompute the aggregate state via calAppState and patch Status.State (updating LastTransitionTime on change) in the same status patch, so State always converges with the entrance statuses this controller owns.
- application_controller: make calAppState a package-level function and drop the now-redundant State recompute/patch from updateApplication; that path was both duplicated and the source of the stuck-state bug. updateApplication now only reconciles Spec.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how and when Application status.State is updated, which affects user-visible app readiness and downstream events, but the logic is localized and matches entrance-owned status updates.
> 
> **Overview**
> Fixes **Application `Status.State`** staying **`notReady`** after rollouts when all entrances are already **running**.
> 
> **`EntranceStatusManagerController`** now recomputes aggregate state with **`calAppState`** whenever it patches **`EntranceStatuses`**, updating **`State`** and **`LastTransitionTime`** in the same status patch. **`ApplicationReconciler.updateApplication`** no longer recomputes or patches **`Status.State`** (only spec); **`calAppState`** is a package-level helper shared by both controllers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e62f832239a20772b7994782e4c316fd6004042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->