### PR TITLE
feat(daemon): return all detected GPUs in system status gpu_list

### DIFF
--- a/cli/cmd/ctl/settings/advanced/status.go
+++ b/cli/cmd/ctl/settings/advanced/status.go
@@ -111,6 +111,7 @@ func renderStatusTable(w io.Writer, raw json.RawMessage) error {
 		"memory",
 		"disk",
 		"gpu_info",
+		"gpu_list",
 		"updateTime",
 	}
 	printed := map[string]struct{}{}

--- a/cli/pkg/daemon/state/types.go
+++ b/cli/pkg/daemon/state/types.go
@@ -87,6 +87,10 @@ type State struct {
 	// GpuInfo is the GPU model name when one is detected.
 	GpuInfo *string `json:"gpu_info,omitempty"`
 
+	// GPUList lists all detected GPU model names as "Vendor Product".
+	// Empty when no GPU is detected; always present as an array on the wire.
+	GPUList []string `json:"gpu_list"`
+
 	// Memory is the total physical memory, formatted as "<n> G".
 	Memory string `json:"memory"`
 

--- a/cli/pkg/daemon/state/types_test.go
+++ b/cli/pkg/daemon/state/types_test.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStateGPUFieldsKeepLegacyInfoAndExposeFullList(t *testing.T) {
+	primary := "NVIDIA Corporation GeForce RTX 4070"
+	s := State{
+		GpuInfo: &primary,
+		GPUList: []string{
+			primary,
+			"Intel Corporation Arc Graphics",
+		},
+	}
+
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["gpu_info"] != primary {
+		t.Fatalf("gpu_info = %#v, want %q", got["gpu_info"], primary)
+	}
+	list, ok := got["gpu_list"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("gpu_list = %#v, want two-element array", got["gpu_list"])
+	}
+}
+
+func TestStateGPUListIsEmptyArrayWhenNoGPUDetected(t *testing.T) {
+	raw, err := json.Marshal(State{GPUList: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	list, ok := got["gpu_list"].([]any)
+	if !ok || len(list) != 0 {
+		t.Fatalf("gpu_list = %#v, want empty array", got["gpu_list"])
+	}
+	if _, exists := got["gpu_info"]; exists {
+		t.Fatalf("gpu_info should be omitted when nil, got %#v", got["gpu_info"])
+	}
+}

--- a/cli/pkg/dashboard/client.go
+++ b/cli/pkg/dashboard/client.go
@@ -436,6 +436,7 @@ type SystemStatus struct {
 	HostName   string
 	CPUInfo    string
 	GPUInfo    string
+	GPUList    []string
 }
 
 // IsOlaresOne reports whether this Olares instance is running on an
@@ -463,10 +464,11 @@ func (c *Client) EnsureSystemStatus(ctx context.Context) (*SystemStatus, error) 
 			Code    int    `json:"code"`
 			Message string `json:"message"`
 			Data    struct {
-				DeviceName string `json:"device_name"`
-				HostName   string `json:"host_name"`
-				CPUInfo    string `json:"cpu_info"`
-				GPUInfo    string `json:"gpu_info"`
+				DeviceName string   `json:"device_name"`
+				HostName   string   `json:"host_name"`
+				CPUInfo    string   `json:"cpu_info"`
+				GPUInfo    string   `json:"gpu_info"`
+				GPUList    []string `json:"gpu_list"`
 			} `json:"data"`
 		}
 		if err := c.DoJSON(ctx, http.MethodGet, "/user-service/api/system/status", nil, nil, &raw); err != nil {
@@ -478,6 +480,7 @@ func (c *Client) EnsureSystemStatus(ctx context.Context) (*SystemStatus, error) 
 			HostName:   raw.Data.HostName,
 			CPUInfo:    raw.Data.CPUInfo,
 			GPUInfo:    raw.Data.GPUInfo,
+			GPUList:    raw.Data.GPUList,
 		}
 	})
 	return c.systemStatus, c.systemStatusErr

--- a/cli/pkg/dashboard/dashboard_test.go
+++ b/cli/pkg/dashboard/dashboard_test.go
@@ -686,13 +686,13 @@ func TestIsPartitionOfDisk(t *testing.T) {
 		child, disk string
 		want        bool
 	}{
-		{"sda", "sda", true},        // disk itself
-		{"sda1", "sda", true},       // plain-suffix partition
-		{"sdaa", "sda", false},      // sibling device, not a partition
-		{"nvme0n1p1", "nvme0n1", true},  // digit-ending disk → "p" separator
-		{"nvme0n1", "nvme0n1", true},    // disk itself
-		{"nvme0n10", "nvme0n1", false},  // sibling, not a partition of nvme0n1
-		{"nvme0n1p", "nvme0n1", false},  // "p" without a number
+		{"sda", "sda", true},                  // disk itself
+		{"sda1", "sda", true},                 // plain-suffix partition
+		{"sdaa", "sda", false},                // sibling device, not a partition
+		{"nvme0n1p1", "nvme0n1", true},        // digit-ending disk → "p" separator
+		{"nvme0n1", "nvme0n1", true},          // disk itself
+		{"nvme0n10", "nvme0n1", false},        // sibling, not a partition of nvme0n1
+		{"nvme0n1p", "nvme0n1", false},        // "p" without a number
 		{"olares--vg-root", "nvme0n1", false}, // LVM device (no prefix match)
 		{"", "sda", false},
 		{"sda1", "", false},
@@ -841,7 +841,7 @@ func TestClient_EnsureSystemStatus_CachesResult(t *testing.T) {
 		}
 		hits++
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"code":0,"message":null,"data":{"device_name":"Olares One","host_name":"box","cpu_info":"i9-14900K","gpu_info":"RTX 4070"}}`))
+		_, _ = w.Write([]byte(`{"code":0,"message":null,"data":{"device_name":"Olares One","host_name":"box","cpu_info":"i9-14900K","gpu_info":"RTX 4070","gpu_list":["RTX 4070","Intel Arc"]}}`))
 	}))
 	defer srv.Close()
 
@@ -856,6 +856,9 @@ func TestClient_EnsureSystemStatus_CachesResult(t *testing.T) {
 		}
 		if !s.IsOlaresOne() {
 			t.Fatalf("iter %d: IsOlaresOne() = false", i)
+		}
+		if s.GPUInfo != "RTX 4070" || len(s.GPUList) != 2 {
+			t.Fatalf("iter %d: GPUInfo = %q, GPUList = %#v", i, s.GPUInfo, s.GPUList)
 		}
 	}
 	if hits != 1 {

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -51,6 +51,13 @@ func bToGb(b uint64) string {
 	return fmt.Sprintf("%d G", b/1024/1024/1024)
 }
 
+func primaryGPU(gpuList []string) *string {
+	if len(gpuList) == 0 {
+		return nil
+	}
+	return pointer.String(gpuList[0])
+}
+
 func CheckCurrentStatus(ctx context.Context) error {
 	TerminusStateMu.Lock()
 	name, err := utils.GetOlaresNameFromReleaseFile()
@@ -103,9 +110,12 @@ func CheckCurrentStatus(ctx context.Context) error {
 		klog.Error("get node filesystem total size error, ", err)
 	}
 
-	gpu, err := utils.GetGpuInfo()
+	gpuList, err := utils.GetGpuInfo()
 	if err != nil {
 		klog.Error("get gpu info error, ", err)
+	}
+	if gpuList == nil {
+		gpuList = []string{}
 	}
 
 	hostname, err := os.Hostname()
@@ -121,7 +131,8 @@ func CheckCurrentStatus(ctx context.Context) error {
 	CurrentState.CpuInfo = utils.GetCPUName()
 	CurrentState.Memory = bToGb(memory.TotalMemory())
 	CurrentState.Disk = bToGb(diskSize)
-	CurrentState.GpuInfo = gpu
+	CurrentState.GPUList = gpuList
+	CurrentState.GpuInfo = primaryGPU(gpuList)
 	CurrentState.HostName = &hostname
 
 	// get network info

--- a/daemon/pkg/cluster/state/current_test.go
+++ b/daemon/pkg/cluster/state/current_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/beclab/Olares/daemon/pkg/utils"
 )
 
+func TestPrimaryGPUUsesFirstListEntry(t *testing.T) {
+	got := primaryGPU([]string{"NVIDIA RTX 4070", "Intel Arc"})
+	if got == nil || *got != "NVIDIA RTX 4070" {
+		t.Fatalf("primaryGPU() = %#v, want first GPU", got)
+	}
+	if got := primaryGPU(nil); got != nil {
+		t.Fatalf("primaryGPU(nil) = %#v, want nil", got)
+	}
+}
+
 func TestCurrentState(t *testing.T) {
 	err := CheckCurrentStatus(context.Background())
 	if err != nil {

--- a/daemon/pkg/utils/gpu.go
+++ b/daemon/pkg/utils/gpu.go
@@ -5,8 +5,8 @@ package utils
 
 import "k8s.io/klog/v2"
 
-func GetGpuInfo() (*string, error) {
+func GetGpuInfo() ([]string, error) {
 	klog.Warning("not implement")
 
-	return nil, nil
+	return []string{}, nil
 }

--- a/daemon/pkg/utils/gpu_info.go
+++ b/daemon/pkg/utils/gpu_info.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jaypipes/ghw"
+)
+
+// collectGpuInfos returns "Vendor Product" for every graphics card that has
+// complete device metadata. NVIDIA cards come first; order is otherwise
+// preserved. Always returns a non-nil slice (empty when nothing qualifies).
+func collectGpuInfos(cards []*ghw.GraphicsCard) []string {
+	nvidia := make([]string, 0, len(cards))
+	others := make([]string, 0, len(cards))
+	for _, card := range cards {
+		if card == nil || card.DeviceInfo == nil || card.DeviceInfo.Vendor == nil || card.DeviceInfo.Product == nil {
+			continue
+		}
+		info := fmt.Sprintf("%s %s", card.DeviceInfo.Vendor.Name, card.DeviceInfo.Product.Name)
+		if strings.Contains(strings.ToLower(info), "nvidia") {
+			nvidia = append(nvidia, info)
+		} else {
+			others = append(others, info)
+		}
+	}
+	return append(nvidia, others...)
+}

--- a/daemon/pkg/utils/gpu_info_test.go
+++ b/daemon/pkg/utils/gpu_info_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/jaypipes/pcidb"
+)
+
+func TestCollectGpuInfos_PutsNvidiaCardsFirst(t *testing.T) {
+	cards := []*ghw.GraphicsCard{
+		gpuCard("Intel Corporation", "Arc Graphics"),
+		gpuCard("NVIDIA Corporation", "GeForce RTX 4070"),
+		gpuCard("AMD", "Radeon RX 7900"),
+		gpuCard("NVIDIA Corporation", "GeForce RTX 4090"),
+	}
+
+	got := collectGpuInfos(cards)
+	want := []string{
+		"NVIDIA Corporation GeForce RTX 4070",
+		"NVIDIA Corporation GeForce RTX 4090",
+		"Intel Corporation Arc Graphics",
+		"AMD Radeon RX 7900",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collectGpuInfos() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectGpuInfos_SkipsIncompleteCards(t *testing.T) {
+	cards := []*ghw.GraphicsCard{
+		nil,
+		{DeviceInfo: nil},
+		{DeviceInfo: &pci.Device{Vendor: &pcidb.Vendor{Name: "Intel"}}},
+		{DeviceInfo: &pci.Device{Product: &pcidb.Product{Name: "Arc"}}},
+		gpuCard("AMD", "Radeon RX 7900"),
+	}
+
+	got := collectGpuInfos(cards)
+	want := []string{"AMD Radeon RX 7900"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collectGpuInfos() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectGpuInfos_Empty(t *testing.T) {
+	got := collectGpuInfos(nil)
+	if got == nil {
+		t.Fatal("collectGpuInfos(nil) returned nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("collectGpuInfos(nil) = %#v, want empty slice", got)
+	}
+}
+
+func gpuCard(vendor, product string) *ghw.GraphicsCard {
+	return &ghw.GraphicsCard{
+		DeviceInfo: &pci.Device{
+			Vendor:  &pcidb.Vendor{Name: vendor},
+			Product: &pcidb.Product{Name: product},
+		},
+	}
+}

--- a/daemon/pkg/utils/gpu_linux.go
+++ b/daemon/pkg/utils/gpu_linux.go
@@ -4,16 +4,13 @@
 package utils
 
 import (
-	"fmt"
 	"io"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/jaypipes/ghw"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 )
 
 // gpuEmptyRescanInterval bounds how often an empty GPU scan is retried, so a
@@ -24,16 +21,16 @@ const gpuEmptyRescanInterval = 5 * time.Minute
 var (
 	gpuInfoMu     sync.Mutex
 	gpuInfoCached bool
-	gpuInfoValue  *string
+	gpuInfoValue  []string
 	gpuLastScan   time.Time
 )
 
-// GetGpuInfo returns the primary GPU description. GPUs are not hot-plugged at
-// runtime, but scanning the PCI bus via ghw on every status tick is expensive.
-// A found GPU is cached for the process lifetime; an empty scan is retried at
-// most once per gpuEmptyRescanInterval, and a failed scan is retried on the
-// next call.
-func GetGpuInfo() (*string, error) {
+// GetGpuInfo returns descriptions for all detected GPUs. GPUs are not
+// hot-plugged at runtime, but scanning the PCI bus via ghw on every status
+// tick is expensive. A non-empty result is cached for the process lifetime; an
+// empty scan is retried at most once per gpuEmptyRescanInterval, and a failed
+// scan is retried on the next call. The returned slice is never nil.
+func GetGpuInfo() ([]string, error) {
 	gpuInfoMu.Lock()
 	defer gpuInfoMu.Unlock()
 	if gpuInfoCached {
@@ -50,29 +47,9 @@ func GetGpuInfo() (*string, error) {
 	}
 	gpuLastScan = time.Now()
 
-	var first string
-	var result *string
-	for _, card := range gpu.GraphicsCards {
-		if card.DeviceInfo == nil || card.DeviceInfo.Vendor == nil || card.DeviceInfo.Product == nil {
-			continue
-		}
-		info := fmt.Sprintf("%s %s", card.DeviceInfo.Vendor.Name, card.DeviceInfo.Product.Name)
-		if strings.Contains(strings.ToLower(info), "nvidia") {
-			first = info
-			break
-		}
-
-		if first == "" {
-			first = info
-		}
-	}
-
-	if first != "" {
-		result = ptr.To(first)
-	}
-
+	result := collectGpuInfos(gpu.GraphicsCards)
 	gpuInfoValue = result
-	if result != nil {
+	if len(result) > 0 {
 		gpuInfoCached = true
 	}
 	return result, nil

--- a/daemon/pkg/utils/utils_test.go
+++ b/daemon/pkg/utils/utils_test.go
@@ -72,12 +72,12 @@ func TestGetGpu(t *testing.T) {
 		return
 	}
 
-	if s == nil {
+	if len(s) == 0 {
 		t.Log("no gpu info")
 		return
 	}
 
-	t.Log(*s)
+	t.Log(s)
 }
 
 func TestFindCommand(t *testing.T) {

--- a/docs/developer/install/cli/status.md
+++ b/docs/developer/install/cli/status.md
@@ -76,7 +76,8 @@ The table below lists the fields returned by `olaresd` (the `data` object of the
 | CPU         | `cpu_info`    | CPU model name.                                                      |
 | Memory      | `memory`      | Total physical memory, formatted as `<N> G`.                         |
 | Disk        | `disk`        | Total filesystem size of the data partition, formatted as `<N> G`.   |
-| GPU         | `gpu_info`    | GPU model name when one is detected.                                 |
+| GPU         | `gpu_info`    | GPU model name when one is detected.                       |
+| GPUList     | `gpu_list`    | All detected GPU model names.                |
 
 ### Network
 

--- a/docs/zh/developer/install/cli/status.md
+++ b/docs/zh/developer/install/cli/status.md
@@ -77,6 +77,7 @@ olares-cli status --endpoint http://127.0.0.1:18088 --timeout 10s
 | Memory     | `memory`      | 物理内存总量，格式为 `<N> G`。             |
 | Disk       | `disk`        | 数据分区的文件系统总容量，格式为 `<N> G`。 |
 | GPU        | `gpu_info`    | 检测到的 GPU 型号（若有）。                |
+| GPUList   | `gpu_list`    | 检测到的全部 GPU 型号。   |
 
 ### Network
 

--- a/framework/app-service/pkg/utils/k8sutil.go
+++ b/framework/app-service/pkg/utils/k8sutil.go
@@ -478,6 +478,7 @@ type SystemStatusResponse struct {
 		OsVersion                 string `json:"os_version"`
 		CpuInfo                   string `json:"cpu_info"`
 		GpuInfo                   string `json:"gpu_info"`
+		GPUList                   []string `json:"gpu_list"`
 		Memory                    string `json:"memory"`
 		Disk                      string `json:"disk"`
 		WifiConnected             bool   `json:"wifiConnected"`

--- a/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
@@ -85,6 +85,7 @@ spec:
       - args:
         - -enable-monitoring
         - -shared-dev-num=50
+        - -health-management
         - -v=4
         env:
         - name: NODE_NAME


### PR DESCRIPTION




* **Background**
Expose gpu_list as a string array instead of a single preferred GPU so multi-GPU hosts report every complete device in /system/status.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API field with backward-compatible gpu_info; GPU detection logic is refactored but covered by tests. Intel plugin flag is a small operational tweak.
> 
> **Overview**
> **Multi-GPU hosts** now report every detected graphics device on `/system/status` via a new **`gpu_list`** string array (`"Vendor Product"` per card), while **`gpu_info`** stays as the legacy primary GPU (first list entry, NVIDIA preferred).
> 
> GPU discovery is refactored: **`GetGpuInfo()`** returns a non-nil `[]string` (shared **`collectGpuInfos`** on Linux; same caching/rescan behavior). Daemon status polling sets **`GPUList`** and derives **`GpuInfo`** with **`primaryGPU`**. Shared **`State`** JSON, CLI advanced **status** headline output, dashboard **`SystemStatus`**, and app-service **`SystemStatusResponse`** all wire through **`gpu_list`**.
> 
> Docs (EN/ZH) document the field; unit tests cover JSON shape, ordering, and client parsing.
> 
> **Separate change:** Intel GPU device plugin DaemonSet adds **`-health-management`** to plugin args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c5fa8a834adbad2de7d211b2699d12a8cd84a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->