### PR TITLE
fix(cli): do not enable certs renew service on K3s

### DIFF
--- a/cli/pkg/certs/tasks.go
+++ b/cli/pkg/certs/tasks.go
@@ -59,6 +59,11 @@ func (u *UninstallAutoRenewCerts) Execute(runtime connector.Runtime) error {
 		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
 	}
 
+	// a oneshot unit that exited non-zero keeps showing up in `systemctl --failed`
+	// even after its unit file is gone, until its state is explicitly reset
+	_, _ = runtime.GetRunner().SudoCmd("systemctl reset-failed k8s-certs-renew.service k8s-certs-renew.timer 1>/dev/null 2>/dev/null", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl daemon-reload 1>/dev/null 2>/dev/null", false, false)
+
 	return nil
 }
 

--- a/cli/pkg/phase/cluster/create_cluster.go
+++ b/cli/pkg/phase/cluster/create_cluster.go
@@ -78,7 +78,6 @@ func NewK3sCreateClusterPhase(runtime *common.KubeRuntime, manifestMap manifest.
 		&network.DeployNetworkPluginModule{},
 		&kubernetes.ConfigureKubernetesModule{},
 		&filesystem.ChownModule{},
-		&certs.AutoRenewCertsModule{Skip: !runtime.Cluster.Kubernetes.EnableAutoRenewCerts()},
 		&storage.DeployLocalVolumeModule{},
 		&kubesphere.DeployModule{},
 		&ksplugins.DeployKsCoreConfigModule{},

--- a/cli/pkg/upgrade/1_12_7_20260729.go
+++ b/cli/pkg/upgrade/1_12_7_20260729.go
@@ -1,0 +1,34 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/certs"
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+// upgrader_1_12_7_20260729 removes the kubeadm-only k8s-certs-renew timer and
+// service from k3s nodes, which earlier installs enabled there even though no
+// kubeadm binary exists to run.
+type upgrader_1_12_7_20260729 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260729) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260729")
+}
+
+func (u upgrader_1_12_7_20260729) PrepareForUpgrade() []task.Interface {
+	tasks := []task.Interface{
+		&task.LocalTask{
+			Name:    "CleanupK3sCertsRenewService",
+			Prepare: new(common.OnlyK3s),
+			Action:  new(certs.UninstallAutoRenewCerts),
+		},
+	}
+	return append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260729{})
+}


### PR DESCRIPTION
* **Background**
Currently, the `k8s-certs-renew` service that's intended for use only with Kubernetes is installed regardlessly of K3s/Kubernetes chosen, with no harm but prints a "failed" systemd service, this service is no longer installed in case of K3s, and an upgrade task is added to clear this service for K3s.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to K3s install/upgrade paths and systemd cleanup of a non-functional kubeadm renew service; no changes to kubeadm cert renew behavior or auth/data handling.
> 
> **Overview**
> **K3s installs no longer deploy the kubeadm-only `k8s-certs-renew` systemd timer/service**, which previously showed up as failed because there is no kubeadm on those nodes. The K3s create-cluster phase drops `AutoRenewCertsModule`; kubeadm-based installs still use it when auto-renew is enabled.
> 
> **Uninstall/cleanup is more thorough**: after removing the renew script and unit files, the CLI runs `systemctl reset-failed` and `daemon-reload` so stale failed oneshot state does not linger in `systemctl --failed`.
> 
> **Upgrade `1.12.7-20260729`** runs `CleanupK3sCertsRenewService` on K3s only (`OnlyK3s`), reusing `certs.UninstallAutoRenewCerts` to remove leftovers from earlier versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23cdae5634a08d5f25d091b96deca8e7726e41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->