### PR TITLE
fix(cli): preserve market-preinstall on uninstall to install phase

### DIFF
--- a/cli/pkg/storage/tasks.go
+++ b/cli/pkg/storage/tasks.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -330,11 +331,46 @@ type DeleteTerminusUserData struct {
 	common.KubeAction
 }
 
-func (t *DeleteTerminusUserData) Execute(runtime connector.Runtime) error {
-	userdataDirs := []string{
-		OlaresUserDataDir,
-		JuiceFsCacheDir,
+func removeUserDataPreservingMarketPreinstall() error {
+	cacheDir := filepath.Join(OlaresUserDataDir, "Cache")
+	marketPreinstallDir := filepath.Join(cacheDir, "market-preinstall")
+	if !util.IsExist(marketPreinstallDir) {
+		return util.RemoveDir(OlaresUserDataDir)
 	}
+
+	userdataEntries, err := os.ReadDir(OlaresUserDataDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range userdataEntries {
+		if entry.Name() != "Cache" {
+			if err := util.RemoveDir(filepath.Join(OlaresUserDataDir, entry.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	cacheEntries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range cacheEntries {
+		if entry.Name() != "market-preinstall" {
+			if err := util.RemoveDir(filepath.Join(cacheDir, entry.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *DeleteTerminusUserData) Execute(runtime connector.Runtime) error {
+	if err := removeUserDataPreservingMarketPreinstall(); err != nil {
+		logger.Errorf("remove %s failed %v", OlaresUserDataDir, err)
+	}
+
+	userdataDirs := []string{JuiceFsCacheDir}
 
 	if util.IsExist(RedisServiceFile) {
 		userdataDirs = append(userdataDirs, OlaresJuiceFSRootDir)

--- a/cli/pkg/storage/tasks_test.go
+++ b/cli/pkg/storage/tasks_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeleteTerminusUserDataPreservesMarketPreinstall(t *testing.T) {
+	root := t.TempDir()
+	oldUserDataDir := OlaresUserDataDir
+	oldJuiceFsCacheDir := JuiceFsCacheDir
+	oldJuiceFsRootDir := OlaresJuiceFSRootDir
+	oldRedisServiceFile := RedisServiceFile
+	t.Cleanup(func() {
+		OlaresUserDataDir = oldUserDataDir
+		JuiceFsCacheDir = oldJuiceFsCacheDir
+		OlaresJuiceFSRootDir = oldJuiceFsRootDir
+		RedisServiceFile = oldRedisServiceFile
+	})
+
+	OlaresUserDataDir = filepath.Join(root, "userdata")
+	JuiceFsCacheDir = filepath.Join(root, "jfscache")
+	OlaresJuiceFSRootDir = filepath.Join(root, "rootfs")
+	RedisServiceFile = filepath.Join(root, "redis-server.service")
+
+	preinstallFile := filepath.Join(OlaresUserDataDir, "Cache", "market-preinstall", "bundle.json")
+	removedFile := filepath.Join(OlaresUserDataDir, "Home", "user-data")
+	for _, file := range []string{preinstallFile, removedFile, filepath.Join(JuiceFsCacheDir, "cache")} {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte("test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := (&DeleteTerminusUserData{}).Execute(nil); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if _, err := os.Stat(preinstallFile); err != nil {
+		t.Errorf("market preinstall file was not preserved: %v", err)
+	}
+	if _, err := os.Stat(removedFile); !os.IsNotExist(err) {
+		t.Errorf("regular userdata still exists, stat error = %v", err)
+	}
+	if _, err := os.Stat(JuiceFsCacheDir); !os.IsNotExist(err) {
+		t.Errorf("juicefs cache still exists, stat error = %v", err)
+	}
+}
+
+func TestDeleteTerminusDataRemovesMarketPreinstall(t *testing.T) {
+	root := t.TempDir()
+	oldOlaresRootDir := OlaresRootDir
+	oldOlaresSharedLibDir := OlaresSharedLibDir
+	oldStorageDataDir := StorageDataDir
+	t.Cleanup(func() {
+		OlaresRootDir = oldOlaresRootDir
+		OlaresSharedLibDir = oldOlaresSharedLibDir
+		StorageDataDir = oldStorageDataDir
+	})
+
+	OlaresRootDir = filepath.Join(root, "olares")
+	OlaresSharedLibDir = filepath.Join(OlaresRootDir, "share")
+	StorageDataDir = filepath.Join(root, "osdata")
+	preinstallFile := filepath.Join(OlaresRootDir, "userdata", "Cache", "market-preinstall", "bundle.json")
+	if err := os.MkdirAll(filepath.Dir(preinstallFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(preinstallFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&DeleteTerminusData{}).Execute(nil); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if _, err := os.Stat(OlaresRootDir); !os.IsNotExist(err) {
+		t.Errorf("Olares root still exists after full deletion, stat error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Keep `userdata/Cache/market-preinstall` when `olares-cli uninstall --phase install` rolls back to prepare, so prepare-phase preinstall charts survive reinstall.
- Full uninstall (`--all` / prepare+) still deletes the entire Olares data tree via `DeleteTerminusData`.
- Add unit tests covering preserve-on-partial-uninstall and remove-on-full-uninstall behavior.

## Test plan
- [ ] `cd cli && go test ./pkg/storage -count=1`
- [ ] After prepare (with market-preinstall present), run `olares-cli uninstall --phase install` and confirm `userdata/Cache/market-preinstall` remains while other userdata is removed
- [ ] Run `olares-cli uninstall --all` and confirm `market-preinstall` is deleted with the rest of Olares data


Made with [Cursor](https://cursor.com)