### PR TITLE
feat(cli): add market download to recover a stored chart

### DIFF
--- a/cli/cmd/ctl/market/client.go
+++ b/cli/cmd/ctl/market/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -125,6 +126,125 @@ func (c *MarketClient) doMultipart(ctx context.Context, path, filename string, d
 	// http.NewRequest sets GetBody automatically — refresh+retry on 401
 	// works here.
 	return c.executeRequest(c.uploadClient, req)
+}
+
+// ChartPackage is an open stream of a chart .tgz served by
+// GET /apps/{name}/package. Body is the caller's to close.
+type ChartPackage struct {
+	Body io.ReadCloser
+
+	// Filename is the name the backend suggested through
+	// Content-Disposition (`<chart>-<version>.tgz`), empty when the header
+	// is absent or unparseable.
+	Filename string
+
+	// Size is the announced Content-Length, or -1 when the response was
+	// chunked.
+	Size int64
+}
+
+// downloadStream issues a GET whose success body is bytes rather than the
+// app-store JSON envelope, so it cannot go through executeRequest: that
+// helper reads the whole body into memory and insists on parsing it as
+// APIResponse. Failures still arrive as the envelope, and are decoded here
+// with the same wording so a 404 reads the same whichever verb hit it.
+//
+// The caller closes the returned body.
+func (c *MarketClient) downloadStream(ctx context.Context, path string, query url.Values) (*http.Response, error) {
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	// The error path answers JSON, the success path octet-stream.
+	req.Header.Set("Accept", "application/octet-stream, application/json")
+
+	// The no-timeout client, for the same reason uploads use it: a chart is
+	// large enough that the standard 30s deadline can cut a healthy transfer
+	// off partway through.
+	resp, err := c.uploadClient.Do(req)
+	if err != nil {
+		var inv *credential.ErrTokenInvalidated
+		if errors.As(err, &inv) {
+			return nil, inv
+		}
+		var nli *credential.ErrNotLoggedIn
+		if errors.As(err, &nli) {
+			return nil, nli
+		}
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		resp.Body.Close()
+		return nil, reformatMarketAuthErr(resp.StatusCode, body, c.olaresID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		resp.Body.Close()
+		return nil, fmt.Errorf("API error (HTTP %d): %s", resp.StatusCode, envelopeMessage(body, resp.StatusCode))
+	}
+	// A 200 carrying the JSON envelope means the backend answered a
+	// different question than the one asked. Writing that to a .tgz would
+	// produce a file that only fails later, at `helm install` time.
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(strings.ToLower(ct), "application/json") {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		resp.Body.Close()
+		return nil, fmt.Errorf("expected chart bytes but got a JSON response: %s", envelopeMessage(body, http.StatusOK))
+	}
+	return resp, nil
+}
+
+// errorBodyLimit caps how much of a failure body is read for the message.
+// The edge proxy can answer an HTML page, and a whole one in a terminal
+// buries the line that matters.
+const errorBodyLimit = 8 << 10
+
+// envelopeMessage extracts the human-readable part of an app-store error
+// body: the envelope's `message` when it parses, the trimmed body when it
+// doesn't, and the bare status when there is nothing at all.
+func envelopeMessage(body []byte, status int) string {
+	var apiResp APIResponse
+	if err := json.Unmarshal(body, &apiResp); err == nil {
+		if msg := strings.TrimSpace(apiResp.Message); msg != "" {
+			return msg
+		}
+	}
+	if msg := strings.TrimSpace(string(body)); msg != "" {
+		return msg
+	}
+	return fmt.Sprintf("HTTP %d", status)
+}
+
+// DownloadChart opens GET /apps/{name}/package for reading. An empty version
+// lets the backend pick the current one; an empty source falls back to the
+// client's default, and then to the backend's (`upload`).
+//
+// The returned ChartPackage owns an open connection — close its Body.
+func (c *MarketClient) DownloadChart(ctx context.Context, appName, source, version string) (*ChartPackage, error) {
+	if source == "" {
+		source = c.source
+	}
+	query := url.Values{}
+	if source != "" {
+		query.Set("source", source)
+	}
+	if version != "" {
+		query.Set("version", version)
+	}
+	resp, err := c.downloadStream(ctx, "/apps/"+url.PathEscape(appName)+"/package", query)
+	if err != nil {
+		return nil, err
+	}
+	return &ChartPackage{
+		Body:     resp.Body,
+		Filename: parseContentDispositionFilename(resp.Header.Get("Content-Disposition")),
+		Size:     resp.ContentLength,
+	}, nil
 }
 
 func (c *MarketClient) executeRequest(hc *http.Client, req *http.Request) (*APIResponse, error) {

--- a/cli/cmd/ctl/market/download.go
+++ b/cli/cmd/ctl/market/download.go
@@ -1,0 +1,285 @@
+package market
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// chartDownloadResult is the `-o json` shape of `market download`. It is not
+// OperationResult: what a caller wants back here is where the file landed and
+// how big it is, and neither has a home in the lifecycle result type.
+type chartDownloadResult struct {
+	App       string `json:"app"`
+	Operation string `json:"operation"`
+	Status    string `json:"status"`
+	Source    string `json:"source"`
+	Version   string `json:"version,omitempty"`
+	Path      string `json:"path"`
+	Bytes     int64  `json:"bytes"`
+	User      string `json:"user,omitempty"`
+}
+
+func NewCmdMarketDownload(f *cmdutil.Factory) *cobra.Command {
+	opts := newMarketOptions(f)
+	overwrite := false
+	cmd := &cobra.Command{
+		Use:     "download {app-name} [local-path]",
+		Aliases: []string{"pull"},
+		Short:   "Download an app's chart package (.tgz) from a market source",
+		Long: `Download the chart package the market holds for an app.
+
+This is the read side of 'market upload': it fetches the exact .tgz the
+market serves to the installer, so a chart that only exists on the
+Olares side — the local working copy was deleted, or the upload happened
+from another machine — can be recovered and edited, re-packaged and
+re-uploaded.
+
+Source defaults to the SPA's "Local Sources → Upload" bucket ('upload'),
+the same bucket 'upload' writes to and 'delete' removes from. Pass
+-s/--source to read a chart out of another source (e.g. market.olares)
+when that source's chart has been cached on this Olares.
+
+If --version is omitted the market serves the version it currently holds
+for the app, which is what you want when recovering a chart: it does not
+depend on the app being installed, or on the install having succeeded.
+
+Local destination semantics mirror 'olares-cli files download':
+
+  omitted        -> ./<chart>-<version>.tgz (the name the server suggests)
+  existing dir   -> that directory, using the server-suggested name
+  any other path -> the full local target path
+
+An existing local file is not overwritten unless --overwrite is passed;
+the download writes to <path>.tmp and renames on success, so a failure
+part-way through leaves any previous chart intact.
+
+Examples:
+  olares-cli market download myapp                     # ./myapp-1.0.0.tgz
+  olares-cli market download myapp ./charts/           # into a directory
+  olares-cli market download myapp ./myapp.tgz         # exact filename
+  olares-cli market download myapp --version 1.0.0     # a specific version
+  olares-cli market download myapp -s market.olares    # another source
+  olares-cli market download myapp -o json             # structured result`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			localArg := ""
+			if len(args) == 2 {
+				localArg = args[1]
+			}
+			return runDownload(cmd.Context(), opts, args[0], localArg, overwrite)
+		},
+	}
+	opts.addSourceFlag(cmd, fmt.Sprintf("market source id to read the chart from (default %q)", chartUploadSource))
+	opts.addVersionFlag(cmd)
+	opts.addOutputFlags(cmd)
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false,
+		"replace an existing local file (writes to <path>.tmp + rename)")
+	return cmd
+}
+
+func runDownload(ctx context.Context, opts *MarketOptions, appName, localArg string, overwrite bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	mc, err := opts.prepare()
+	if err != nil {
+		return opts.failOp("download", appName, err)
+	}
+
+	source := strings.TrimSpace(opts.Source)
+	if source == "" {
+		source = chartUploadSource
+		opts.info("Using source: %s", source)
+	}
+
+	version := strings.TrimSpace(opts.Version)
+	if version != "" {
+		if err := validateVersion(version); err != nil {
+			return opts.failOp("download", appName, err)
+		}
+	}
+
+	result, err := fetchChartToDisk(ctx, mc, appName, source, version, localArg, overwrite)
+	if err != nil {
+		return opts.failOp("download", appName, err)
+	}
+	result.User = mc.olaresID
+
+	if opts.Quiet {
+		return nil
+	}
+	if opts.isJSON() {
+		return opts.printJSON(result)
+	}
+	fmt.Fprintf(os.Stdout, "download '%s': wrote %d bytes to %s\n", result.App, result.Bytes, result.Path)
+	fmt.Fprintf(os.Stdout, "  source: %s\n", result.Source)
+	if result.Version != "" {
+		fmt.Fprintf(os.Stdout, "  version: %s\n", result.Version)
+	}
+	return nil
+}
+
+// fetchChartToDisk streams the chart into its local destination and reports
+// what landed there. Split out of runDownload so the wire + filesystem
+// behaviour is testable without a resolved profile.
+func fetchChartToDisk(ctx context.Context, mc *MarketClient, appName, source, version, localArg string, overwrite bool) (chartDownloadResult, error) {
+	result := chartDownloadResult{
+		App:       appName,
+		Operation: "download",
+		Status:    "success",
+		Source:    source,
+		Version:   version,
+	}
+
+	pkg, err := mc.DownloadChart(ctx, appName, source, version)
+	if err != nil {
+		return result, err
+	}
+	defer pkg.Body.Close()
+
+	if result.Version == "" {
+		result.Version = versionFromChartFilename(pkg.Filename, appName)
+	}
+	dst, err := resolveChartDestination(localArg, pkg.Filename, appName, result.Version)
+	if err != nil {
+		return result, err
+	}
+	written, err := writeChartFile(dst, pkg.Body, overwrite)
+	if err != nil {
+		return result, err
+	}
+	result.Path = dst
+	result.Bytes = written
+	return result, nil
+}
+
+// resolveChartDestination applies the same local-path rules as
+// `files download` (see resolveLocalFile there): an omitted or
+// directory-shaped argument means "use the server's filename in that
+// directory", anything else is the full target path.
+func resolveChartDestination(localArg, serverFilename, appName, version string) (string, error) {
+	base := strings.TrimSpace(serverFilename)
+	if base == "" || base != filepath.Base(base) || base == "." || base == ".." {
+		// No usable suggestion, or one carrying path separators — a
+		// server-chosen name must never be able to steer the write out of
+		// the directory the user named.
+		base = defaultChartFilename(appName, version)
+	}
+	if localArg == "" {
+		return base, nil
+	}
+	st, err := os.Stat(localArg)
+	switch {
+	case err == nil && st.IsDir():
+		return filepath.Join(localArg, base), nil
+	case err == nil:
+		return localArg, nil
+	case errors.Is(err, os.ErrNotExist):
+		// Trailing slash means "a directory, even though it does not exist
+		// yet" — the `cp` / `rsync` convention.
+		if strings.HasSuffix(localArg, "/") || strings.HasSuffix(localArg, string(os.PathSeparator)) {
+			return filepath.Join(localArg, base), nil
+		}
+		return localArg, nil
+	default:
+		return "", fmt.Errorf("stat %s: %w", localArg, err)
+	}
+}
+
+func defaultChartFilename(appName, version string) string {
+	if version == "" {
+		return appName + ".tgz"
+	}
+	return fmt.Sprintf("%s-%s.tgz", appName, version)
+}
+
+// versionFromChartFilename recovers the version from the server's
+// `<chart>-<version>.tgz` suggestion. Chart names contain hyphens, so this
+// only trusts a filename that starts with the app name; anything else leaves
+// the version unreported rather than guessed.
+func versionFromChartFilename(filename, appName string) string {
+	base := strings.TrimSuffix(strings.TrimSpace(filename), ".tgz")
+	if base == "" || !strings.HasPrefix(base, appName+"-") {
+		return ""
+	}
+	return strings.TrimPrefix(base, appName+"-")
+}
+
+// writeChartFile streams the body through <dst>.tmp and renames it into
+// place, so an interrupted transfer cannot leave a truncated chart where a
+// good one used to be.
+func writeChartFile(dst string, body io.Reader, overwrite bool) (int64, error) {
+	if _, err := os.Stat(dst); err == nil {
+		if !overwrite {
+			return 0, fmt.Errorf("%s already exists (pass --overwrite to replace it)", dst)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("stat %s: %w", dst, err)
+	}
+
+	if parent := filepath.Dir(dst); parent != "" {
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return 0, fmt.Errorf("mkdir parent of %s: %w", dst, err)
+		}
+	}
+
+	tmp := dst + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", tmp, err)
+	}
+	written, copyErr := io.Copy(f, body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmp)
+		return written, fmt.Errorf("write %s: %w", tmp, copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmp)
+		return written, fmt.Errorf("close %s: %w", tmp, closeErr)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return written, fmt.Errorf("rename %s -> %s: %w", tmp, dst, err)
+	}
+	return written, nil
+}
+
+// parseContentDispositionFilename pulls the basename out of a
+// `Content-Disposition: attachment; filename="<basename>"` header.
+//
+// Mirrors the helper of the same name in internal/files/archive: a
+// best-effort substring extractor rather than mime.ParseMediaType, which
+// rejects the partially-escaped filenames these backends emit. The two are
+// separate copies because a string helper is not worth a dependency from the
+// market verbs onto the files internals.
+func parseContentDispositionFilename(cd string) string {
+	if cd == "" {
+		return ""
+	}
+	const key = "filename="
+	idx := strings.Index(strings.ToLower(cd), key)
+	if idx < 0 {
+		return ""
+	}
+	val := strings.TrimSpace(cd[idx+len(key):])
+	if strings.HasPrefix(val, "\"") {
+		if end := strings.Index(val[1:], "\""); end >= 0 {
+			return val[1 : 1+end]
+		}
+		return val[1:]
+	}
+	if i := strings.Index(val, ";"); i >= 0 {
+		val = val[:i]
+	}
+	return strings.TrimSpace(val)
+}

--- a/cli/cmd/ctl/market/download_test.go
+++ b/cli/cmd/ctl/market/download_test.go
@@ -1,0 +1,331 @@
+package market
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// chartBytes stands in for a real .tgz: the CLI never parses the payload, it
+// only has to arrive on disk byte-for-byte.
+var chartBytes = []byte("\x1f\x8b\x08 not really gzip, but opaque to the CLI")
+
+type packageRequest struct {
+	path    string
+	source  string
+	version string
+	accept  string
+}
+
+// newFakeChartPackageServer answers GET /apps/{name}/package with chart bytes
+// and records what was asked for. filename is sent through
+// Content-Disposition; pass "" to omit the header.
+func newFakeChartPackageServer(t *testing.T, filename string, seen *packageRequest) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/package") {
+			http.NotFound(w, r)
+			return
+		}
+		if seen != nil {
+			*seen = packageRequest{
+				path:    r.URL.Path,
+				source:  r.URL.Query().Get("source"),
+				version: r.URL.Query().Get("version"),
+				accept:  r.Header.Get("Accept"),
+			}
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if filename != "" {
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(chartBytes)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(chartBytes)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newFakeChartErrorServer answers with the app-store JSON envelope, the way
+// the backend reports a chart it does not hold.
+func newFakeChartErrorServer(t *testing.T, status int, message string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprintf(w, `{"success":false,"message":%q}`, message)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDownloadChartWritesServerSuggestedFilename(t *testing.T) {
+	var seen packageRequest
+	srv := newFakeChartPackageServer(t, "amule-0.0.7.tgz", &seen)
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, false)
+	if err != nil {
+		t.Fatalf("fetchChartToDisk: %v", err)
+	}
+
+	want := filepath.Join(dir, "amule-0.0.7.tgz")
+	if result.Path != want {
+		t.Fatalf("path = %q, want %q", result.Path, want)
+	}
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read downloaded chart: %v", err)
+	}
+	if string(got) != string(chartBytes) {
+		t.Fatalf("chart bytes differ: got %q", got)
+	}
+	if result.Bytes != int64(len(chartBytes)) {
+		t.Fatalf("bytes = %d, want %d", result.Bytes, len(chartBytes))
+	}
+	// Version is unreported by the caller here, so it has to come back from
+	// the filename the server chose.
+	if result.Version != "0.0.7" {
+		t.Fatalf("version = %q, want 0.0.7", result.Version)
+	}
+	if seen.path != "/app-store/api/v2/apps/amule/package" {
+		t.Fatalf("path = %q", seen.path)
+	}
+	if seen.source != "upload" {
+		t.Fatalf("source = %q, want upload", seen.source)
+	}
+	if seen.version != "" {
+		t.Fatalf("version query = %q, want it omitted so the server picks the current one", seen.version)
+	}
+	if !strings.Contains(seen.accept, "application/octet-stream") {
+		t.Fatalf("Accept = %q, want it to allow octet-stream", seen.accept)
+	}
+	if _, err := os.Stat(want + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file was left behind: %v", err)
+	}
+}
+
+func TestDownloadChartForwardsSourceAndVersion(t *testing.T) {
+	var seen packageRequest
+	srv := newFakeChartPackageServer(t, "amule-0.0.5.tgz", &seen)
+	mc := newTestMarketClient(t, srv.URL)
+
+	result, err := fetchChartToDisk(context.Background(), mc, "amule", "market.olares", "0.0.5", t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("fetchChartToDisk: %v", err)
+	}
+	if seen.source != "market.olares" {
+		t.Fatalf("source = %q, want market.olares", seen.source)
+	}
+	if seen.version != "0.0.5" {
+		t.Fatalf("version = %q, want 0.0.5", seen.version)
+	}
+	if result.Version != "0.0.5" {
+		t.Fatalf("result version = %q, want 0.0.5", result.Version)
+	}
+}
+
+func TestDownloadChartLocalPathModes(t *testing.T) {
+	srv := newFakeChartPackageServer(t, "amule-0.0.7.tgz", nil)
+	mc := newTestMarketClient(t, srv.URL)
+
+	t.Run("explicit file path is used verbatim", func(t *testing.T) {
+		dst := filepath.Join(t.TempDir(), "custom.tgz")
+		result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dst, false)
+		if err != nil {
+			t.Fatalf("fetchChartToDisk: %v", err)
+		}
+		if result.Path != dst {
+			t.Fatalf("path = %q, want %q", result.Path, dst)
+		}
+	})
+
+	t.Run("trailing slash creates the directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "charts") + "/"
+		result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, false)
+		if err != nil {
+			t.Fatalf("fetchChartToDisk: %v", err)
+		}
+		want := filepath.Join(strings.TrimSuffix(dir, "/"), "amule-0.0.7.tgz")
+		if result.Path != want {
+			t.Fatalf("path = %q, want %q", result.Path, want)
+		}
+		if _, err := os.Stat(want); err != nil {
+			t.Fatalf("chart not written: %v", err)
+		}
+	})
+}
+
+func TestDownloadChartWithoutServerFilenameFallsBackToAppAndVersion(t *testing.T) {
+	srv := newFakeChartPackageServer(t, "", nil)
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "0.0.7", dir, false)
+	if err != nil {
+		t.Fatalf("fetchChartToDisk: %v", err)
+	}
+	if want := filepath.Join(dir, "amule-0.0.7.tgz"); result.Path != want {
+		t.Fatalf("path = %q, want %q", result.Path, want)
+	}
+}
+
+// A filename is a suggestion from the server, and a suggestion carrying path
+// separators must not be able to decide where the write lands.
+func TestDownloadChartIgnoresFilenameWithPathSeparators(t *testing.T) {
+	srv := newFakeChartPackageServer(t, "../../etc/amule.tgz", nil)
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "0.0.7", dir, false)
+	if err != nil {
+		t.Fatalf("fetchChartToDisk: %v", err)
+	}
+	if want := filepath.Join(dir, "amule-0.0.7.tgz"); result.Path != want {
+		t.Fatalf("path = %q, want the download to stay under %q", result.Path, dir)
+	}
+}
+
+func TestDownloadChartRefusesToClobberWithoutOverwrite(t *testing.T) {
+	srv := newFakeChartPackageServer(t, "amule-0.0.7.tgz", nil)
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "amule-0.0.7.tgz")
+	if err := os.WriteFile(dst, []byte("previous chart"), 0o644); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+
+	_, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, false)
+	if err == nil {
+		t.Fatal("expected the download to refuse an existing file")
+	}
+	if !strings.Contains(err.Error(), "--overwrite") {
+		t.Fatalf("error = %v, want it to point at --overwrite", err)
+	}
+	got, _ := os.ReadFile(dst)
+	if string(got) != "previous chart" {
+		t.Fatalf("existing file was modified: %q", got)
+	}
+
+	result, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, true)
+	if err != nil {
+		t.Fatalf("fetchChartToDisk with overwrite: %v", err)
+	}
+	got, _ = os.ReadFile(result.Path)
+	if string(got) != string(chartBytes) {
+		t.Fatalf("overwrite left %q", got)
+	}
+}
+
+func TestDownloadChartReportsBackendError(t *testing.T) {
+	srv := newFakeChartErrorServer(t, http.StatusNotFound, "Chart not found")
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	_, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, false)
+	if err == nil {
+		t.Fatal("expected an error for a chart the market does not hold")
+	}
+	if !strings.Contains(err.Error(), "404") || !strings.Contains(err.Error(), "Chart not found") {
+		t.Fatalf("error = %v, want the status and the backend message", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("a failed download wrote %d file(s)", len(entries))
+	}
+}
+
+func TestDownloadChartRewritesAuthFailure(t *testing.T) {
+	srv := newFakeChartErrorServer(t, http.StatusUnauthorized, "unauthorized")
+	mc := newTestMarketClient(t, srv.URL)
+
+	_, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", t.TempDir(), false)
+	if err == nil {
+		t.Fatal("expected an error on 401")
+	}
+	if !strings.Contains(err.Error(), "profile login") {
+		t.Fatalf("error = %v, want the profile login CTA", err)
+	}
+}
+
+// A 200 carrying the JSON envelope means the request reached something other
+// than the package route. Writing that body into a .tgz would only fail later,
+// at helm install time.
+func TestDownloadChartRejectsJSONSuccessBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"message":"not implemented"}`)
+	}))
+	t.Cleanup(srv.Close)
+	mc := newTestMarketClient(t, srv.URL)
+
+	dir := t.TempDir()
+	_, err := fetchChartToDisk(context.Background(), mc, "amule", "upload", "", dir, false)
+	if err == nil {
+		t.Fatal("expected an error for a JSON body on the package route")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("error = %v, want the envelope message", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("wrote %d file(s) for a JSON response", len(entries))
+	}
+}
+
+func TestParseContentDispositionFilename(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`attachment; filename="amule-0.0.7.tgz"`, "amule-0.0.7.tgz"},
+		{`attachment; filename=amule-0.0.7.tgz`, "amule-0.0.7.tgz"},
+		{`attachment; filename=amule.tgz; foo=bar`, "amule.tgz"},
+		{`attachment`, ""},
+		{``, ""},
+	}
+	for _, tc := range cases {
+		if got := parseContentDispositionFilename(tc.in); got != tc.want {
+			t.Fatalf("parseContentDispositionFilename(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestVersionFromChartFilename(t *testing.T) {
+	cases := []struct {
+		filename string
+		app      string
+		want     string
+	}{
+		{"amule-0.0.7.tgz", "amule", "0.0.7"},
+		{"my-app-1.2.3.tgz", "my-app", "1.2.3"},
+		{"other-1.0.0.tgz", "amule", ""},
+		{"", "amule", ""},
+	}
+	for _, tc := range cases {
+		if got := versionFromChartFilename(tc.filename, tc.app); got != tc.want {
+			t.Fatalf("versionFromChartFilename(%q, %q) = %q, want %q", tc.filename, tc.app, got, tc.want)
+		}
+	}
+}
+
+func TestMarketDownloadIsRegistered(t *testing.T) {
+	cmd := NewMarketCommand(nil)
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "download" {
+			if sub.Flag("source") == nil || sub.Flag("version") == nil || sub.Flag("overwrite") == nil {
+				t.Fatal("download is missing one of --source / --version / --overwrite")
+			}
+			return
+		}
+	}
+	t.Fatal("market download is not registered on the market command")
+}

--- a/cli/cmd/ctl/market/root.go
+++ b/cli/cmd/ctl/market/root.go
@@ -39,14 +39,15 @@ Verb families:
   lifecycle (mutating)  install, upgrade, uninstall,  POST/PUT/DELETE on
                         clone, stop, resume, restart,  /apps/{name}/*
                         cancel
-  charts (mutating)     upload, delete                 SPA Local Sources
+  charts                upload, download, delete       SPA Local Sources
+                        (download is read-only)
 
 Universal flags:
 
   -o, --output {table,json}   every verb. JSON output is parseable.
   -q, --quiet                 every verb. Suppress output; exit code wins.
   -s, --source <id>           source-aware verbs (catalog + install /
-                              upgrade / clone / upload / delete).
+                              upgrade / clone / download).
                               Valid ids: market.olares, cli, upload, studio.
   -a, --all-sources           list, categories, status.
       --no-headers            list, categories (row-oriented browse only;
@@ -85,6 +86,7 @@ cli/skills/olares-market/SKILL.md.`,
 	cmd.AddCommand(NewCmdMarketResume(f))
 	cmd.AddCommand(NewCmdMarketRestart(f))
 	cmd.AddCommand(NewCmdMarketUpload(f))
+	cmd.AddCommand(NewCmdMarketDownload(f))
 	cmd.AddCommand(NewCmdMarketDelete(f))
 	cmd.AddCommand(NewCmdMarketStatus(f))
 	return cmd

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-chart
-version: 4.12.0
+version: 4.13.0
 description: "Olares app packaging and chart authoring via olares-cli chart — port a repo, docker-compose, or generic Helm chart; build/push the image; author, lint, package, and deploy an OlaresManifest; wire storage, middleware, entrances, env, and GPU; edit the chart after diagnosis. Runtime failure diagnosis is olares-doctor; public Market submission is olares-publish."
 compatibility: Requires olares-cli on PATH; chart authoring is local-only, deploy needs login
 metadata:

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -58,6 +58,7 @@ The target is a `lint`-passing Olares chart. `from-compose` (kompose) is **just 
 | Source only (no compose) | author a docker-compose from the code ([compose.md](references/olares-chart-compose.md)) | — |
 | A docker-compose | `chart from-compose` then refine ([from-compose.md](references/olares-chart-from-compose.md)) | — |
 | A generic Helm chart (no OlaresManifest) | hand-author `OlaresManifest.yaml` + refine (skip `from-compose`) | — |
+| Uploaded to the Olares, but no local copy left | `market download <app>` + unpack the `.tgz`, then refine that ([olares-market-charts.md](../olares-market/references/olares-market-charts.md#download)) | — |
 | Already an Olares chart | go straight to validation | a chart that passes `chart lint` |
 
 ## Deploy to your Olares (the done step)

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -49,6 +49,17 @@ olares-cli market upload ./<app>-<version>.tgz   # use the new <version> in the 
 - `upload` always lands the chart in the `upload` source (see [`../../olares-market/SKILL.md`](../../olares-market/SKILL.md)). `-s` is intentionally not exposed.
 - Upload runs the server-side ingest, so a chart that passed local `lint` can still be rejected here (e.g. cluster-specific checks). Surface that message as a chart problem and go back to refine.
 
+### Lost the local chart? Download the stored one instead of re-authoring it
+
+When the app exists in the `upload` source but the local working copy is gone — deleted, or uploaded from another machine — **pull the stored `.tgz` back** rather than reconstructing the chart from scratch. It is the same archive the installer is served, so unpacking it recovers the manifest and templates exactly as uploaded:
+
+```bash
+olares-cli market download <app> ./recovered/        # -> ./recovered/<app>-<version>.tgz
+tar -xzf ./recovered/<app>-<version>.tgz -C ./recovered/
+```
+
+Then continue the normal loop: edit, `chart lint`, bump the version, `chart package`, `market upload`, and re-apply with `upgrade` (§3). This works regardless of the app's install state — the chart is read from the stored artifact, so a chart behind an `installFailed` / `installingCanceled` row is still recoverable. Details and flags: [`../../olares-market/references/olares-market-charts.md`](../../olares-market/references/olares-market-charts.md#download).
+
 ## 3. Actually run it
 
 Upload only stores the chart; installing it is what proves it runs:

--- a/cli/skills/olares-chart/references/olares-chart-deploy.md
+++ b/cli/skills/olares-chart/references/olares-chart-deploy.md
@@ -48,17 +48,7 @@ olares-cli market upload ./<app>-<version>.tgz   # use the new <version> in the 
 
 - `upload` always lands the chart in the `upload` source (see [`../../olares-market/SKILL.md`](../../olares-market/SKILL.md)). `-s` is intentionally not exposed.
 - Upload runs the server-side ingest, so a chart that passed local `lint` can still be rejected here (e.g. cluster-specific checks). Surface that message as a chart problem and go back to refine.
-
-### Lost the local chart? Download the stored one instead of re-authoring it
-
-When the app exists in the `upload` source but the local working copy is gone — deleted, or uploaded from another machine — **pull the stored `.tgz` back** rather than reconstructing the chart from scratch. It is the same archive the installer is served, so unpacking it recovers the manifest and templates exactly as uploaded:
-
-```bash
-olares-cli market download <app> ./recovered/        # -> ./recovered/<app>-<version>.tgz
-tar -xzf ./recovered/<app>-<version>.tgz -C ./recovered/
-```
-
-Then continue the normal loop: edit, `chart lint`, bump the version, `chart package`, `market upload`, and re-apply with `upgrade` (§3). This works regardless of the app's install state — the chart is read from the stored artifact, so a chart behind an `installFailed` / `installingCanceled` row is still recoverable. Details and flags: [`../../olares-market/references/olares-market-charts.md`](../../olares-market/references/olares-market-charts.md#download).
+- Nothing left locally to package? `market download <app>` pulls the stored `.tgz` back — never re-author a chart the Olares still holds ([olares-market-charts.md](../../olares-market/references/olares-market-charts.md#download)).
 
 ## 3. Actually run it
 

--- a/cli/skills/olares-market/SKILL.md
+++ b/cli/skills/olares-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-market
-version: 4.5.2
-description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume, restart apps; catalog, status, chart upload, --watch. Use for Olares app store, my apps, 我的应用, install app, restart app, upload chart."
+version: 4.6.0
+description: "Olares Market via olares-cli market — install, upgrade, uninstall, clone, stop, resume, restart apps; catalog, status, chart upload/download, --watch. Use for Olares app store, my apps, 我的应用, install app, restart app, upload chart, download an app chart."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
   openclaw:
@@ -35,7 +35,7 @@ metadata:
 | **catalog** | `list`, `get`, `categories` | no |
 | **runtime** | `status` | no |
 | **lifecycle** | `install`, `upgrade`, `uninstall`, `clone`, `stop`, `resume`, `restart`, `cancel` | yes |
-| **charts** | `upload`, `delete` | yes |
+| **charts** | `upload`, `download`, `delete` | `upload` / `delete` only (`download` reads) |
 
 For verb-specific behavior, **always start with `olares-cli market <verb> --help`**. Then drill into a reference if listed:
 
@@ -45,7 +45,7 @@ For verb-specific behavior, **always start with `olares-cli market <verb> --help
 | lifecycle | [references/olares-market-lifecycle.md](references/olares-market-lifecycle.md) (`install` / `upgrade` / `uninstall` / `clone` / `stop` / `resume` / `cancel`) |
 | `restart` | [references/olares-market-restart.md](references/olares-market-restart.md) (Olares 1.12.6+, implicit source, compute binding, statusTime-baseline watch); it also backs the auto-restart in `settings network overlay app enable/disable` |
 | `--watch` / stuck / errors | [references/olares-market-watch.md](references/olares-market-watch.md) (per-verb watch buckets, foreground windows, stuck-state handling, common errors) |
-| charts | [references/olares-market-charts.md](references/olares-market-charts.md) (`upload` / `delete`) |
+| charts | [references/olares-market-charts.md](references/olares-market-charts.md) (`upload` / `download` / `delete`) |
 
 ## Source resolution (cross-cutting)
 
@@ -54,7 +54,7 @@ The market backend serves multiple "sources" of charts. The CLI resolves which o
 | Source id | What it is | Used by |
 |---|---|---|
 | `market.olares` | Public catalog (read-only browse) | default for `list`, `get`, `categories`, `install`, `upgrade`, `clone`, `status` |
-| `upload` | SPA "Local Sources → Upload" bucket | **hard-coded for `upload` / `delete`** — `-s` is intentionally NOT exposed on those two verbs |
+| `upload` | SPA "Local Sources → Upload" bucket | **hard-coded for `upload` / `delete`** — `-s` is intentionally NOT exposed on those two verbs; **default (overridable) for `download`** |
 | `cli` | Legacy CLI-upload bucket | read-only (`list`, `status`) |
 | `studio` | Devbox / Studio bucket | read-only (`list`, `status`) |
 
@@ -66,7 +66,7 @@ The market backend serves multiple "sources" of charts. The CLI resolves which o
 
 | Flag | Read-only browse | Lifecycle (mutating) | Chart management |
 |---|---|---|---|
-| `-s / --source` | `list`, `categories`, `status`, `get` | `install`, `upgrade`, `clone` | — (hard-coded `upload`) |
+| `-s / --source` | `list`, `categories`, `status`, `get` | `install`, `upgrade`, `clone` | `download` (defaults to `upload`); NOT on `upload` / `delete` (hard-coded `upload`) |
 | `-a / --all-sources` | `list`, `categories`, `status` | — | — |
 
 > **`-s` is NOT on `uninstall` / `stop` / `resume` / `restart`:** they act on whichever per-user state row matches the app name, regardless of source.

--- a/cli/skills/olares-market/references/olares-market-charts.md
+++ b/cli/skills/olares-market/references/olares-market-charts.md
@@ -1,15 +1,17 @@
-# market upload / delete (local chart management)
+# market upload / download / delete (local chart management)
 
 > **Prerequisite:** Read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
-> **Flags & examples:** `olares-cli market upload --help`, `olares-cli market delete --help`.
+> **Flags & examples:** `olares-cli market upload --help`, `olares-cli market download --help`, `olares-cli market delete --help`.
 
-Manage helm chart packages in the SPA's "Local Sources → Upload" bucket.
+Manage helm chart packages in the SPA's "Local Sources → Upload" bucket: push one in (`upload`), pull one back out (`download`), remove one (`delete`).
 
 ## Hard-coded source (`upload`)
 
-Both verbs **hard-code the target source to `upload`** — the same bucket the SPA's "Local Sources → Upload" tab writes to. **`-s / --source` is intentionally NOT exposed.**
+`upload` and `delete` **hard-code the target source to `upload`** — the same bucket the SPA's "Local Sources → Upload" tab writes to. **`-s / --source` is intentionally NOT exposed on those two.**
 
 The history: an earlier revision exposed `-s` on these verbs, and users pushed charts to `cli` or `studio` that were then invisible to the SPA's Local Sources tab (different buckets, same backend). Pinning the source eliminates that footgun. To install/delete from a different bucket, use `market install -s <id>` separately.
+
+`download` is the exception: it only reads, so pointing it at another source cannot desynchronize anything. It **defaults** to `upload` and accepts `-s <id>`.
 
 ## `upload`
 
@@ -40,6 +42,23 @@ olares-cli market list -s upload
 # Detail of one uploaded chart:
 olares-cli market get mychart -s upload -o json
 ```
+
+## `download`
+
+```bash
+olares-cli market download mychart                     # ./mychart-1.0.0.tgz
+olares-cli market download mychart ./charts/           # into a directory, server-chosen name
+olares-cli market download mychart ./mychart.tgz        # exact local filename
+olares-cli market download mychart --version 1.0.0     # a specific stored version
+olares-cli market download mychart -s market.olares    # read another source
+olares-cli market download mychart -o json             # {app, source, version, path, bytes}
+```
+
+- **The read side of `upload`.** It serves the exact `.tgz` the market hands the installer, so a chart whose only remaining copy is on the Olares — local working copy deleted, or the upload happened from another machine — can be recovered, edited, re-packaged and re-uploaded.
+- **`--version` omitted → whatever version the market currently holds.** Resolution happens server-side against the stored artifact, so it does **not** depend on the app being installed, or on the install having succeeded: a chart behind an `installFailed` / `installingCanceled` row is still downloadable.
+- **Local path rules mirror `files download`:** omitted → `./<chart>-<version>.tgz` (the name the server suggests); an existing directory (or a path ending in `/`) → that directory with the server-chosen name; anything else → the exact target path.
+- **An existing local file is never silently replaced.** Without `--overwrite` the command fails and leaves the file alone. The write goes to `<path>.tmp` and renames on success, so an interrupted transfer cannot truncate a chart you still needed.
+- Streams through the no-timeout HTTP client, like `upload`, so a large chart over a slow WAN link is not cut off at 30s.
 
 ## `delete`
 
@@ -73,6 +92,16 @@ olares-cli market upload ./dist/ -o json | jq '.[] | select(.status != "success"
 ```
 
 ```bash
+# Recover a chart that only exists on the Olares, then iterate on it.
+olares-cli market download mychart ./recovered/                     # pull the stored .tgz back
+tar -xzf ./recovered/mychart-1.0.0.tgz -C ./recovered/              # unpack to edit
+# ... edit the chart, bump metadata.version == Chart.yaml version ...
+olares-cli chart package ./recovered/mychart                        # repackage
+olares-cli market upload ./mychart-1.0.1.tgz                        # push the new version
+olares-cli market upgrade mychart -s upload --version 1.0.1 --watch
+```
+
+```bash
 # Spring cleaning: remove every version of a chart from the upload bucket.
 olares-cli market delete mychart                                   # all versions
 olares-cli market list -s upload                                   # confirm
@@ -90,5 +119,9 @@ olares-cli market list -s upload                                   # confirm
 | `unsupported file extension: must be .tgz or .tar.gz` | Wrong file type | Repackage with `helm package` |
 | `failed to upload: HTTP 413 (Payload Too Large)` | Chart exceeds the server's upload size limit | Slim the chart's contents; ask the operator about the limit |
 | `chart not found in source 'upload'` (delete) | The chart was never uploaded, or was uploaded to a different bucket | `market list -s upload` to confirm |
+| `API error (HTTP 404): Chart not found` (download) | No stored chart for that app in that source | `market list -s upload` to confirm the bucket; pass `-s <id>` for another source |
+| `API error (HTTP 501)` (download) | The Olares predates the chart-package endpoint | Upgrade the Olares; there is no client-side fallback |
+| `<path> already exists (pass --overwrite to replace it)` | A local file is already at the destination | Pass `--overwrite`, or give a different local path |
+| `expected chart bytes but got a JSON response` (download) | The request reached something other than the package route (proxy or version mismatch) | Verify the profile's market URL and the Olares version |
 | `delete` removed the chart but the app keeps running | `delete` only removes the chart from the `upload` bucket; it never uninstalls | Expected — run `market uninstall X` separately to stop/remove the app |
 | Exit non-zero on directory upload despite some files succeeding | Partial failure | Inspect the per-file JSON report for which files failed |

--- a/cli/skills/olares-market/references/olares-market-charts.md
+++ b/cli/skills/olares-market/references/olares-market-charts.md
@@ -58,7 +58,7 @@ olares-cli market download mychart -o json             # {app, source, version, 
 - **`--version` omitted → whatever version the market currently holds.** Resolution happens server-side against the stored artifact, so it does **not** depend on the app being installed, or on the install having succeeded: a chart behind an `installFailed` / `installingCanceled` row is still downloadable.
 - **Local path rules mirror `files download`:** omitted → `./<chart>-<version>.tgz` (the name the server suggests); an existing directory (or a path ending in `/`) → that directory with the server-chosen name; anything else → the exact target path.
 - **An existing local file is never silently replaced.** Without `--overwrite` the command fails and leaves the file alone. The write goes to `<path>.tmp` and renames on success, so an interrupted transfer cannot truncate a chart you still needed.
-- Streams through the no-timeout HTTP client, like `upload`, so a large chart over a slow WAN link is not cut off at 30s.
+- Streams through the no-timeout HTTP client, like `upload`.
 
 ## `delete`
 
@@ -121,6 +121,7 @@ olares-cli market list -s upload                                   # confirm
 | `chart not found in source 'upload'` (delete) | The chart was never uploaded, or was uploaded to a different bucket | `market list -s upload` to confirm |
 | `API error (HTTP 404): Chart not found` (download) | No stored chart for that app in that source | `market list -s upload` to confirm the bucket; pass `-s <id>` for another source |
 | `API error (HTTP 501)` (download) | The Olares predates the chart-package endpoint | Upgrade the Olares; there is no client-side fallback |
+| `unexpected EOF` partway through a download | The transfer outlived the market's write timeout — an Olares that predates the longer deadline on this route | Retry on a faster link, or upgrade the Olares; no partial file is left behind |
 | `<path> already exists (pass --overwrite to replace it)` | A local file is already at the destination | Pass `--overwrite`, or give a different local path |
 | `expected chart bytes but got a JSON response` (download) | The request reached something other than the package route (proxy or version mismatch) | Verify the profile's market URL and the Olares version |
 | `delete` removed the chart but the app keeps running | `delete` only removes the chart from the `upload` bucket; it never uninstalls | Expected — run `market uninstall X` separately to stop/remove the app |


### PR DESCRIPTION
* **Background**

`olares-cli market` could push a chart into the `upload` bucket and delete one, but never read one back. So a developer whose local working copy was gone — deleted, or the upload happened from another machine — either re-authored the chart by hand or copied the `.tgz` out of the chart-repo pod with `cluster pod exec`. This adds the read side.

* **What this does**

`olares-cli market download <app> [local-path]` writes the stored `.tgz` to disk:

```
olares-cli market download mychart                  # ./mychart-1.0.0.tgz
olares-cli market download mychart ./charts/        # into a directory, server-chosen name
olares-cli market download mychart --version 1.0.0  # a specific stored version
olares-cli market download mychart -s market.olares # read another source
olares-cli market download mychart -o json          # {app, source, version, path, bytes}
```

- Path rules mirror `files download`: omitted gives the name the server suggests, an existing directory gives that directory with the server-chosen name, anything else is the exact target.
- An existing file is never silently replaced. Without `--overwrite` the command fails and leaves it alone, and the write goes to `<path>.tmp` and renames on success, so an interrupted transfer cannot truncate a chart that was still needed.
- It is the one chart verb that accepts `-s`. `upload` and `delete` hard-code the `upload` bucket on purpose — an earlier revision exposed `-s` there and users pushed charts into buckets the SPA does not show. `download` only reads, so pointing it elsewhere cannot desynchronize anything; it defaults to `upload`.
- The transfer uses the no-timeout client that `upload` already uses, and decodes a JSON error envelope back into a message rather than writing it to the file.

Skills: the `olares-market` reference documents the verb, the source matrix and the errors a download can produce. In `olares-chart`, the recovery lands where an agent decides what it is working with — the Axis 2 deployment state table gains "uploaded to the Olares, but no local copy left" — and the deploy reference keeps a one-line pointer rather than a second copy of the recipe.

* **Target Version for Merge**

next

* **Related Issues**

None.

* **PRs Involving Sub-Systems**

Needs the market side, which implements the route this calls: https://github.com/beclab/market/pull/398. Against an Olares that predates it the command reports the backend's `501` as-is; there is no client-side fallback, and the skill reference says so.

* **Other information**

Tests: `cli/cmd/ctl/market/download_test.go` covers the server-suggested filename, source and version forwarding, the three local-path modes, refusing to clobber without `--overwrite`, a backend 404, an authentication failure reformatted for the user, and rejecting a JSON body where chart bytes were expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI feature with atomic local writes and path sanitization; depends on backend market PR #398 (501 on older Olares). No changes to mutating market or auth paths beyond reusing existing transport.
> 
> **Overview**
> Adds **`olares-cli market download`** (alias `pull`) so charts stored in the market can be written back to disk—the complement to `market upload`.
> 
> **`MarketClient`** gains a streaming **`GET /apps/{name}/package`** path via `downloadStream` / `DownloadChart`, using the no-timeout upload client and decoding JSON error envelopes instead of buffering chart bytes like `executeRequest`. **`download.go`** wires the Cobra command with `-s` (defaults to `upload`, unlike upload/delete), `--version`, `--overwrite`, and `-o json`; local paths follow **`files download`** semantics, with `.tmp` + rename and guards against malicious `Content-Disposition` paths.
> 
> **`olares-market`** and **`olares-chart`** skills document the verb, source matrix, recovery workflows, and a new deployment-state row when only the Olares copy remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f4271cf854a37c50cb226ff50d386b3ce8bd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->