### PR TITLE
feat(files usage): recursive dir_count & file_count for all drives (except share)

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -212,7 +212,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.191
+          image: beclab/files-server:v0.2.192
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
Background
- fix: /api/usage now returns recursive dir_count and file_count (count = dir_count + file_count) for posix/sync/cloud.

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/357

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no config changes; risk is limited to whatever behavior ships in the new files-server build.
> 
> **Overview**
> **Bumps the `files` container image** in the cluster `files` DaemonSet from `beclab/files-server:v0.2.191` to `v0.2.192`, rolling out the application build that implements the usage API changes described in the linked `beclab/files` PR.
> 
> No manifest structure, env, or routing changes—only the image tag on the `files` container in `files_deploy.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebefefdfe38cad523265eff24488be99163306d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->