### PR TITLE
docs: fix Space sidebar link to use trailing slash

### DIFF
--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -502,7 +502,7 @@ const side = {
     },
       {
         text: "Olares Space",
-        link: "/zh/manual/space/index",
+        link: "/zh/manual/space/",
         collapsed: true,
         items: [
           {


### PR DESCRIPTION
Fixes an hreflang/canonical conflict on the Chinese Space overview page.

The sidebar linked to , which created an extra, non-canonical URL that SEMrush flagged because its canonical and self-referencing hreflang both point to . Updating the link to the directory index form removes the duplicate URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation navigation URL change with no runtime or security impact.
> 
> **Overview**
> Fixes the **Olares Space** sidebar link in the Chinese VitePress config (`docs/.vitepress/zh.ts`) by changing it from `/zh/manual/space/index` to `/zh/manual/space/`.
> 
> This matches how other section roots in the same sidebar use directory-style URLs (e.g. `get-started/`, `larepass/`) and avoids a duplicate non-canonical path that conflicted with hreflang/canonical signals on the Space overview page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8fe88c6e4040211e71babc6c0c594b508c8ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->