### PR TITLE
fix(appservice): converge Application state in entrance-status controller

### DIFF
--- a/framework/app-service/controllers/application_controller.go
+++ b/framework/app-service/controllers/application_controller.go
@@ -504,38 +504,13 @@ func (r *ApplicationReconciler) updateApplication(ctx context.Context, req ctrl.
 		return err
 	}
 
-	klog.Infof("appCopy.Status: %v", appCopy.Status)
-	newAppState := r.calAppState(&appCopy.Status)
-	klog.Infof("application controller newAppState: %v", newAppState)
-	klog.Infof("application controller oldAppState: %v", appCopy.Status.State)
-
-	if appCopy.Status.State != newAppState {
-		klog.Infof("set appCopy.State:.......new: %v", newAppState)
-		appCopy.Status.State = newAppState
-		now := metav1.Now()
-		appCopy.Status.LastTransitionTime = &now
-
-		err = r.Status().Patch(ctx, appCopy, client.MergeFrom(app))
-		if err != nil {
-			klog.Infof("update xxx error: %v", err)
-			return err
-		}
-	}
-
-	// merge settings
-	//for k, v := range settings {
-	//	if setting, ok := appCopy.Spec.Settings[k]; !ok || setting != v {
-	//		appCopy.Spec.Settings[k] = v
-	//	}
-	//}
-
-	//var a appv1alpha1.Application
-	//err = r.Get(ctx, types.NamespacedName{Name: app.Name}, &a)
-	//if err != nil {
-	//	klog.Infof("get app failed %v", err)
-	//	return err
-	//}
-	//klog.Infof("appState: ..%v", a.Status.State)
+	// NOTE: the aggregate Status.State is intentionally NOT recomputed here.
+	// It is derived from the entrance statuses and converged by the
+	// EntranceStatusManagerController whenever it updates EntranceStatuses
+	// (see calAppState usage there). Recomputing it on Deployment changes was
+	// both redundant and buggy: this path is short-circuited when the
+	// deployment is unchanged, so the last entrance-ready transition after a
+	// rollout could leave State stuck (entrances running but State=notReady).
 	return err
 }
 
@@ -835,7 +810,7 @@ func (r *ApplicationReconciler) getAppTailScale(deployment client.Object) (*appv
 	return &tailScale, nil
 }
 
-func (r *ApplicationReconciler) calAppState(status *appv1alpha1.ApplicationStatus) string {
+func calAppState(status *appv1alpha1.ApplicationStatus) string {
 	entranceLen := len(status.EntranceStatuses)
 	klog.Infof("entranceLen: %v", entranceLen)
 	if entranceLen == 0 {

--- a/framework/app-service/controllers/entrancestatus_controller.go
+++ b/framework/app-service/controllers/entrancestatus_controller.go
@@ -226,6 +226,19 @@ func (r *EntranceStatusManagerController) updateEntranceStatus(ctx context.Conte
 				}
 			}
 		}
+
+		// Recompute the aggregate app state from the just-updated entrance
+		// statuses. The ApplicationReconciler only recomputes it on Deployment
+		// changes and skips when the deployment is unchanged, so a pod becoming
+		// ready after a rollout settles would otherwise leave State stuck (e.g.
+		// entrances all running but State=notReady). Converging it here keeps
+		// State consistent with the entrance statuses this controller owns.
+		if newState := calAppState(&appCopy.Status); appCopy.Status.State != newState {
+			appCopy.Status.State = newState
+			now := metav1.Now()
+			appCopy.Status.LastTransitionTime = &now
+		}
+
 		patchApp := client.MergeFrom(&selectedApp)
 		err = r.Status().Patch(ctx, appCopy, patchApp)
 		klog.Infof("updateEntrances ...:name: %v", appCopy.Name)


### PR DESCRIPTION
* **Background**
converge Application state in entrance-status controller
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how Application aggregate status is written; behavior should improve correctness but affects status visible to users and event publishing after pod readiness.
> 
> **Overview**
> Fixes **Application `Status.State`** staying **`notReady`** after rollouts when all entrances are already **running**.
> 
> **`ApplicationReconciler.updateApplication`** no longer recomputes aggregate state or patches status after spec updates. That path could be skipped when the deployment resource version is unchanged, so the last pod-ready transition never updated **`State`**.
> 
> **`EntranceStatusManagerController`** now calls shared **`calAppState`** whenever it updates **`EntranceStatuses`**, setting **`State`** and **`LastTransitionTime`** before the status patch. **`calAppState`** is a package-level helper in `application_controller.go` (no longer a reconciler method).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0b7fa9232898864c330c3a6ee8aab0df98f266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->