### PR TITLE
olares: bump system-frontend to v1.11.19 and user-service to v0.1.10

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.17
+          image: beclab/system-frontend:v1.11.19
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -425,7 +425,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.8
+          image: beclab/user-service:v0.1.10
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

  Bump the bundled sub-system images in the system-apps chart:

  - `beclab/system-frontend` (the `olares-app-init` init container): `v1.11.17` -> `v1.11.19`
  - `beclab/user-service`: `v0.1.8` -> `v0.1.10`

  **TermiPass v1.11.19**

  - beclab/TermiPass#1323 — device info uploads now retry with exponential backoff and re-collect the info on each attempt, because `tailScale_id` and `firebase_token` only appear some time after the VPN reports itself as on; a single failed attempt used to leave the server holding a stale VPN status. The root cause of the hangs was `httpProxy` sending only `setConnectTimeout`, which on Android covers just the TCP/TLS handshake, so a connection waited forever for response bytes and the axios timeout never fired — `readTimeout` is now sent too and each attempt is raced against a wall-clock deadline. A refreshed access token also rebuilds the websocket instead of being swallowed by same-user de-duplication and the early return in `start()`. On the settings side the current device is badged in the device list and detail page with its "remove from account" entry hidden, folder attributes break the item count down into files / folders / total from the new `dir_count` / `file_count` fields, and the VPN status dot reads the reported `online` flag instead of inferring from `lastSeen`.
  - beclab/TermiPass#1324 — the download add-task flow now probes `file-exists` for every source, with probe and submit both derived from a single `buildPayload()` call, so the probe can never test a landing the submit would not use (a stale HuggingFace path was false-positive blocking Common-cache downloads). HuggingFace destination is expressed to the server via an optional `hf_dest`; older download-server builds ignore it and fall back to local-dir semantics. The transfer list no longer grows duplicate rows for a single task — `wiseInsertTransferItem`'s find-then-add was not atomic and is now serialized per task id. Parse failures render in one error card through a `parseFailure` union, so codeless rejections get localized messages. Also raises nginx `client_max_body_size` to 32M so an oversized settings request is rejected as JSON by the app rather than as an nginx HTML error page.

  **TermiPass v1.11.18**, which was never bundled and is picked up by the same bump:

  - beclab/TermiPass#1315 — `canCancel()` covered the install pipeline and `resuming` but not `upgrading`, so an upgrade stuck pulling images offered no way out: the card rendered "Updating" with a progress bar frozen at 0% and no close icon. Adds `canUpgradingCancel()`, maps `upgrading -> upgradingCanceling` so the optimistic state matches what the backend pushes back, and keys the cancel icon off `showDownloadProgress()`.
  - beclab/TermiPass#1318 — add-task dialog rewritten as a single-task provider flow behind an `AddTaskProvider` adapter, with `file-exists` as the only dedup authority and per-provider options (ytdlp quality presets, HuggingFace token and destination, torrent file selection). The user-service websocket and the `/download/sync` cursor poll now reconcile through a `downloadRecordMirror` module instead of racing, so a late frame can no longer walk displayed progress backwards, and the collect card, Wise download list and LarePass transfer table all read one shared `taskActions` module so the same row no longer offers Cancel in one place and Retry in another. Adopts download-server's `err_category` model end to end across all seven locales.

  **user-service**

  - beclab/user-service#93 (`v0.1.9`) — bootstraps a `NestExpressApplication` and raises the body-parser limits to 20mb for JSON and URL-encoded payloads. This is the server half of the nginx `client_max_body_size` change in TermiPass#1324; both are needed for an oversized settings request to be answered by the app instead of being cut off in front of it.
  - beclab/user-service#94 (`v0.1.10`) — removing a device from the account used to leave its websocket connections open, so the client kept receiving pushes and the server kept holding a connection for a device that no longer exists. `DELETE /api/device/:id` now resolves the device's `conn_id`s before `deleteDevice` (the lookup reads `device.sso`, which the delete drops) and closes the matching sockets after the record is gone, so `handleDisconnect` does not broadcast an offline update for a deleted device. The lookup consults both `conns` (keyed by sso token) and `connMeta` (keyed by the `deviceId` the client logged in with) because they can disagree. It also refuses to delete the device holding the request token, which pairs with the hidden "remove from account" entry in TermiPass#1323, and makes the provider client timeout configurable so `search3` gets 30s while other providers keep 3s.

* **Target Version for Merge**
  v1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  https://github.com/beclab/TermiPass/pull/1323
  https://github.com/beclab/TermiPass/pull/1324
  https://github.com/beclab/user-service/pull/93
  https://github.com/beclab/user-service/pull/94

* **Other information**
  Image references are updated in `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml`.

  Full Changelog:
  https://github.com/beclab/TermiPass/compare/v1.11.18...v1.11.19,
  https://github.com/beclab/user-service/compare/v0.1.8...v0.1.10

  Note: the system-frontend image moves from `v1.11.17`, so this also brings in the v1.11.18 release (https://github.com/beclab/TermiPass/compare/v1.11.17...v1.11.18).

Made with [Cursor](https://cursor.com)