### PR TITLE
fix(appservice): log env var names, not their values

### DIFF
--- a/framework/app-service/pkg/appinstaller/helm_utils.go
+++ b/framework/app-service/pkg/appinstaller/helm_utils.go
@@ -442,11 +442,15 @@ func addEnvironmentVariables(ctx context.Context, kubeConfig *rest.Config, appCo
 		return err
 	}
 
+	envNames := make([]string, 0, len(appEnv.Envs))
 	for _, env := range appEnv.Envs {
 		values[constants.OlaresEnvHelmValuesKey].(map[string]interface{})[env.EnvName] = env.GetEffectiveValue()
+		envNames = append(envNames, env.EnvName)
 	}
 
-	klog.Infof("Added environment variables to Helm values: %+v", values[constants.OlaresEnvHelmValuesKey])
+	// Names only: an env declared type=password carries what the user typed at install.
+	klog.Infof("Added %d environment variables to Helm values for %s/%s: %v",
+		len(envNames), appConfig.Namespace, appConfig.AppName, envNames)
 	return nil
 }
 


### PR DESCRIPTION
* **Background**

`addEnvironmentVariables` logged the whole `olaresEnv` map with `%+v` on every install and upgrade. An env declared `type: password` in `OlaresManifest.yaml` — an admin password, an API key the user pasted into the install screen — is masked in the UI and then arrives here as the value it resolved to, so the line wrote it into the app-service log verbatim.

* **What this does**

Logs the count, the namespace/app, and the variable names:

```
Added 3 environment variables to Helm values for user-space-alice/myapp: [ADMIN_USERNAME ADMIN_PASSWORD SITE_TITLE]
```

The line is read to answer which variables reached the chart and whether one is missing, and the names answer both. A short comment records why the values are not there, since `%+v` is the natural thing to reach for next time.

* **Target Version for Merge**

next

* **Related Issues**

None.

* **PRs Involving Sub-Systems**

Companion documentation change in the chart-authoring skills, which teaches charts to route credentials through a Secret: https://github.com/beclab/Olares/pull/3800

* **Other information**

`pkg/appinstaller/helm_utils.go` is the only place in app-service that printed a values map wholesale; the rest of the `klog` calls near it log errors. `go build`, `go vet` and `go test ./pkg/appinstaller/...` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no impact on Helm value injection or install behavior; reduces credential exposure in logs.
> 
> **Overview**
> **`addEnvironmentVariables`** no longer logs the full `olaresEnv` Helm values map with `%+v` on install/upgrade. That map still receives the same effective values for the chart; only observability changes.
> 
> Logging now records the variable **count**, **namespace/app**, and **env names** (e.g. `ADMIN_PASSWORD` without the secret). A short comment explains why values are omitted so future edits do not reintroduce credential leakage in app-service logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc2346018b0c7037946ffa9cb74baec955906d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->