### PR TITLE
fix(app-service): avoid stopFailed on webhook cold-start after reboot

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -235,6 +235,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: OLARESD_HOST
           value: master-node:18088
         volumeMounts:

--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/gateway/routecontrol"
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 	"github.com/beclab/Olares/framework/app-service/pkg/images"
+	"github.com/beclab/Olares/framework/app-service/pkg/webhook"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
@@ -26,6 +27,7 @@ import (
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	kbopv1alphav1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -352,6 +354,24 @@ func main() {
 	case <-webhookReady:
 		setupLog.Info("Webhook server is listening, starting controllers")
 	case <-ictx.Done():
+		os.Exit(1)
+	}
+
+	// Wait until Service Endpoints/EndpointSlice point at this pod before
+	// reconciling stop/scale paths that must pass admission webhooks.
+	kubeClient := kubernetes.NewForConfigOrDie(config)
+	epTimeout, epInterval := webhook.ParseServiceEndpointWaitConfig()
+	if err := webhook.WaitForServiceEndpointReady(
+		ictx,
+		kubeClient,
+		"os-framework",
+		"app-service",
+		webhook.ResolvePodIP(),
+		8433,
+		epTimeout,
+		epInterval,
+	); err != nil {
+		setupLog.Error(err, "Waiting for webhook service endpoint interrupted")
 		os.Exit(1)
 	}
 

--- a/framework/app-service/pkg/appstate/suspending_app.go
+++ b/framework/app-service/pkg/appstate/suspending_app.go
@@ -51,6 +51,12 @@ func (p *SuspendingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 	err := p.exec(ctx)
 	if err != nil {
 		klog.Errorf("suspend app %s failed %v", p.manager.Spec.AppName, err)
+		if IsRetryableWebhookError(err) {
+			// Keep Stopping so cold-start webhook/Service lag can recover without
+			// permanently landing in StopFailed. TTL Cancel still applies.
+			klog.Infof("suspend app %s hit retryable webhook error, requeue: %v", p.manager.Spec.AppName, err)
+			return nil, NewWaitingInLine(5)
+		}
 		opRecord := makeRecord(p.manager, appsv1.StopFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
 		updateErr := p.updateStatus(ctx, p.manager, appsv1.StopFailed, opRecord, err.Error(), appsv1.StopFailed.String())
 		if updateErr != nil {

--- a/framework/app-service/pkg/appstate/webhook_retry.go
+++ b/framework/app-service/pkg/appstate/webhook_retry.go
@@ -1,0 +1,33 @@
+package appstate
+
+import (
+	"strings"
+)
+
+// IsRetryableWebhookError reports whether err is a transient admission-webhook
+// reachability failure (e.g. Service Endpoints still pointing at a dead pod IP
+// after reboot). Callers should requeue instead of transitioning to StopFailed.
+func IsRetryableWebhookError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "webhook") && !strings.Contains(msg, "8433") {
+		return false
+	}
+	for _, needle := range retryableWebhookNeedles {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+var retryableWebhookNeedles = []string{
+	"failed calling webhook",
+	"502 bad gateway",
+	"code 502",
+	"connection refused",
+	"no endpoints available",
+	"no endpoints",
+}

--- a/framework/app-service/pkg/appstate/webhook_retry_test.go
+++ b/framework/app-service/pkg/appstate/webhook_retry_test.go
@@ -1,0 +1,66 @@
+package appstate
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsRetryableWebhookError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "generic", err: errors.New("something else"), want: false},
+		{name: "not found", err: errors.New(`deployments.apps "foo" not found`), want: false},
+		{
+			name: "dial without webhook context",
+			err:  errors.New(`dial tcp 10.233.24.114:8080: connect: connection refused`),
+			want: false,
+		},
+		{
+			name: "invalid argument alone is not retryable",
+			err:  errors.New(`dial tcp 10.233.98.192:8433: connect: invalid argument`),
+			want: false,
+		},
+		{
+			name: "failed calling webhook",
+			err:  errors.New(`Internal error occurred: failed calling webhook "gpu-limit-inject-webhook.bytetrade.io"`),
+			want: true,
+		},
+		{
+			name: "502 bad gateway",
+			err:  errors.New(`proxy error from 127.0.0.1:6443 while dialing 10.233.98.192:8433, code 502: 502 Bad Gateway`),
+			want: true,
+		},
+		{
+			name: "connection refused on webhook port",
+			err:  errors.New(`failed calling webhook: dial tcp 10.233.98.55:8433: connect: connection refused`),
+			want: true,
+		},
+		{
+			name: "no endpoints available",
+			err:  errors.New(`failed calling webhook: no endpoints available for service "app-service"`),
+			want: true,
+		},
+		{
+			name: "no endpoints",
+			err:  errors.New(`failed calling webhook: no endpoints for service "app-service"`),
+			want: true,
+		},
+		{
+			name: "wrapped",
+			err:  fmt.Errorf("suspend app studio failed %w", errors.New(`failed calling webhook "gpu-limit-inject-webhook.bytetrade.io"`)),
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRetryableWebhookError(tc.err); got != tc.want {
+				t.Fatalf("IsRetryableWebhookError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/webhook/service_endpoint.go
+++ b/framework/app-service/pkg/webhook/service_endpoint.go
@@ -1,0 +1,148 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	envWebhookServiceEndpointTimeout      = "WEBHOOK_SERVICE_ENDPOINT_TIMEOUT"
+	envWebhookServiceEndpointPollInterval = "WEBHOOK_SERVICE_ENDPOINT_POLL_INTERVAL"
+	envPodIP                              = "POD_IP"
+)
+
+// WaitForServiceEndpointReady polls EndpointSlices until podIP appears as a
+// ready address for the given service port, or until timeout. On timeout it
+// returns nil after logging so callers can still start controllers (Parts 2/3
+// provide safety nets).
+func WaitForServiceEndpointReady(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	namespace, serviceName, podIP string,
+	port int32,
+	timeout, interval time.Duration,
+) error {
+	if podIP == "" {
+		klog.Warning("POD_IP empty; skip waiting for webhook service endpoint")
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = 90 * time.Second
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+	klog.Infof("Waiting for service endpoint namespace=%s service=%s podIP=%s port=%d timeout=%v",
+		namespace, serviceName, podIP, port, timeout)
+
+	for {
+		ready, err := serviceEndpointHasPodIP(ctx, kubeClient, namespace, serviceName, podIP, port)
+		if err != nil {
+			klog.Warningf("list EndpointSlice for %s/%s failed: %v", namespace, serviceName, err)
+		} else if ready {
+			klog.Infof("Service webhook endpoint ready, podIP=%s service=%s/%s", podIP, namespace, serviceName)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			klog.Errorf("timed out waiting for webhook service endpoint podIP=%s service=%s/%s after %v; starting controllers anyway",
+				podIP, namespace, serviceName, timeout)
+			return nil
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func serviceEndpointHasPodIP(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	namespace, serviceName, podIP string,
+	port int32,
+) (bool, error) {
+	selector := labels.Set{"kubernetes.io/service-name": serviceName}.AsSelector().String()
+	slices, err := kubeClient.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return false, err
+	}
+	for i := range slices.Items {
+		if endpointSliceHasReadyPodIP(&slices.Items[i], podIP, port) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func endpointSliceHasReadyPodIP(slice *discoveryv1.EndpointSlice, podIP string, port int32) bool {
+	portOK := false
+	for _, p := range slice.Ports {
+		if p.Port != nil && *p.Port == port {
+			portOK = true
+			break
+		}
+	}
+	if !portOK && len(slice.Ports) > 0 {
+		// Some slices list multiple ports; require an explicit match when ports are present.
+		return false
+	}
+	for _, ep := range slice.Endpoints {
+		if ep.Conditions.Ready != nil && !*ep.Conditions.Ready {
+			continue
+		}
+		for _, addr := range ep.Addresses {
+			if addr == podIP {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ResolvePodIP returns POD_IP from the environment (Downward API).
+func ResolvePodIP() string {
+	return os.Getenv(envPodIP)
+}
+
+// ParseServiceEndpointWaitConfig reads timeout/interval envs with defaults.
+func ParseServiceEndpointWaitConfig() (timeout, interval time.Duration) {
+	timeout = 90 * time.Second
+	interval = time.Second
+	if v := os.Getenv(envWebhookServiceEndpointTimeout); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			timeout = d
+		} else {
+			klog.Warningf("invalid %s=%q: %v", envWebhookServiceEndpointTimeout, v, err)
+		}
+	}
+	if v := os.Getenv(envWebhookServiceEndpointPollInterval); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			interval = d
+		} else {
+			klog.Warningf("invalid %s=%q: %v", envWebhookServiceEndpointPollInterval, v, err)
+		}
+	}
+	return timeout, interval
+}
+
+// FormatWaitSummary is used by tests.
+func FormatWaitSummary(namespace, service, podIP string, port int32) string {
+	return fmt.Sprintf("%s/%s podIP=%s port=%d", namespace, service, podIP, port)
+}

--- a/framework/app-service/pkg/webhook/service_endpoint_test.go
+++ b/framework/app-service/pkg/webhook/service_endpoint_test.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+func TestEndpointSliceHasReadyPodIP(t *testing.T) {
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-service-xyz",
+			Namespace: "os-framework",
+			Labels:    map[string]string{"kubernetes.io/service-name": "app-service"},
+		},
+		Ports: []discoveryv1.EndpointPort{{
+			Name: ptr.To("webhook"),
+			Port: ptr.To[int32](8433),
+		}},
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{"10.233.98.55"},
+			Conditions: discoveryv1.EndpointConditions{
+				Ready: ptr.To(true),
+			},
+		}},
+	}
+	if !endpointSliceHasReadyPodIP(slice, "10.233.98.55", 8433) {
+		t.Fatal("expected ready match for .55:8433")
+	}
+	if endpointSliceHasReadyPodIP(slice, "10.233.98.192", 8433) {
+		t.Fatal("did not expect match for stale IP")
+	}
+	if endpointSliceHasReadyPodIP(slice, "10.233.98.55", 6755) {
+		t.Fatal("did not expect match for wrong port")
+	}
+
+	notReady := slice.DeepCopy()
+	notReady.Endpoints[0].Conditions.Ready = ptr.To(false)
+	if endpointSliceHasReadyPodIP(notReady, "10.233.98.55", 8433) {
+		t.Fatal("did not expect match for not-ready endpoint")
+	}
+}
+
+func TestWaitForServiceEndpointReadySeesSlice(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-service-xyz",
+			Namespace: "os-framework",
+			Labels:    map[string]string{"kubernetes.io/service-name": "app-service"},
+		},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](8433)}},
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses:  []string{"10.233.98.55"},
+			Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+		}},
+	}
+	if _, err := client.DiscoveryV1().EndpointSlices("os-framework").Create(ctx, slice, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := WaitForServiceEndpointReady(ctx, client, "os-framework", "app-service", "10.233.98.55", 8433, time.Second, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForServiceEndpointReady: %v", err)
+	}
+}
+
+func TestWaitForServiceEndpointReadyTimeoutStillNil(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	err := WaitForServiceEndpointReady(ctx, client, "os-framework", "app-service", "10.233.98.55", 8433, 150*time.Millisecond, 40*time.Millisecond)
+	if err != nil {
+		t.Fatalf("timeout should not fail hard: %v", err)
+	}
+}
+
+func TestWaitForServiceEndpointReadyEmptyPodIP(t *testing.T) {
+	err := WaitForServiceEndpointReady(context.Background(), fake.NewSimpleClientset(), "os-framework", "app-service", "", 8433, time.Second, time.Millisecond)
+	if err != nil {
+		t.Fatalf("empty pod IP should skip: %v", err)
+	}
+}


### PR DESCRIPTION




* **Background**
Wait for app-service Service EndpointSlice before starting controllers, retry transient webhook dial failures while stopping.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-service startup ordering and app stop failure handling for a cluster-critical controller; mitigations are polling, soft timeout, and narrow retry heuristics with tests.
> 
> **Overview**
> Reduces **StopFailed** after node reboot when admission webhooks are briefly unreachable because the `app-service` Service still points at a stale pod IP.
> 
> **Startup:** The deployment injects **`POD_IP`** via the downward API. After the webhook listener is up but **before** controllers start, `main` polls EndpointSlices for `os-framework/app-service` until this pod’s IP is a ready endpoint on port **8433** (configurable timeout/interval via env). Timeout logs an error and still starts the manager.
> 
> **Suspend path:** New **`IsRetryableWebhookError`** classifies transient webhook/8433 failures (502, connection refused, no endpoints, etc.). **`SuspendingApp`** requeues with **`NewWaitingInLine(5)`** instead of moving to **StopFailed**, so stop can succeed once endpoints catch up; stop TTL cancel behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7169be83ebf1f507ec95fad7d817e71cd0d31a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->