### PR TITLE
fix(app-gateway): finish half-done Linkerd issuer rotation

### DIFF
--- a/framework/app-gateway/.olares/Olares.yaml
+++ b/framework/app-gateway/.olares/Olares.yaml
@@ -11,4 +11,4 @@ output:
     - 
       name: cr.l5d.io/linkerd/controller:edge-26.5.1
     - 
-      name: beclab/linkerd-pki-guardian@sha256:0e45311245b70b6f2b04c0577e32f7408cfb38915e2731b82f1d55583380a83f
+      name: beclab/linkerd-pki-guardian@sha256:50b18ca1c8ee703e157cf530be9aae48a35198974203aca54c69622af66bf556

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: guardian
-          image: beclab/linkerd-pki-guardian@sha256:0e45311245b70b6f2b04c0577e32f7408cfb38915e2731b82f1d55583380a83f
+          image: beclab/linkerd-pki-guardian@sha256:50b18ca1c8ee703e157cf530be9aae48a35198974203aca54c69622af66bf556
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-init.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-init.yaml
@@ -81,7 +81,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: linkerd-pki-init
-          image: beclab/linkerd-pki-guardian@sha256:0e45311245b70b6f2b04c0577e32f7408cfb38915e2731b82f1d55583380a83f
+          image: beclab/linkerd-pki-guardian@sha256:50b18ca1c8ee703e157cf530be9aae48a35198974203aca54c69622af66bf556
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/linkerd-pki-guardian

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-webhook-certgen.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-webhook-certgen.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: webhook-certgen
-          image: beclab/linkerd-pki-guardian@sha256:0e45311245b70b6f2b04c0577e32f7408cfb38915e2731b82f1d55583380a83f
+          image: beclab/linkerd-pki-guardian@sha256:50b18ca1c8ee703e157cf530be9aae48a35198974203aca54c69622af66bf556
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/linkerd-pki-guardian

--- a/framework/app-gateway/pkg/linkerdpki/constants.go
+++ b/framework/app-gateway/pkg/linkerdpki/constants.go
@@ -26,16 +26,23 @@ const (
 )
 
 const (
-	identityIssuerSecret   = "linkerd-identity-issuer"
-	identityTrustRootsCM   = "linkerd-identity-trust-roots"
+	identityIssuerSecret = "linkerd-identity-issuer"
+	identityTrustRootsCM = "linkerd-identity-trust-roots"
 	// helmResourcePolicyKeep prevents Helm from deleting hook-managed PKI objects when
 	// they are removed from the os-framework chart manifest on brownfield upgrade.
-	helmResourcePolicyKeep = "helm.sh/resource-policy"
+	helmResourcePolicyKeep      = "helm.sh/resource-policy"
 	helmResourcePolicyKeepValue = "keep"
-	identityTrustRootsKey  = "ca-bundle.crt"
-	identityDeployment     = "linkerd-identity"
-	identityIssuerCrtKey   = "crt.pem"
-	identityIssuerKeyKey   = "key.pem"
+	identityTrustRootsKey       = "ca-bundle.crt"
+	identityDeployment          = "linkerd-identity"
+	identityIssuerCrtKey        = "crt.pem"
+	identityIssuerKeyKey        = "key.pem"
+
+	// identityIssuerFingerprintAnnotation records which vault issuer the
+	// linkerd-identity Deployment was last rolled out for. Stored on the
+	// Deployment object (not the pod template) so writing it alone does not
+	// trigger a rollout; restartedAt on the template does.
+	identityIssuerFingerprintAnnotation = "gateway.olares.io/linkerd-issuer-fingerprint"
+	restartedAtAnnotation               = "kubectl.kubernetes.io/restartedAt"
 
 	pkiCACrtKey     = "ca.crt"
 	pkiCAKeyKey     = "ca.key"

--- a/framework/app-gateway/pkg/linkerdpki/controller.go
+++ b/framework/app-gateway/pkg/linkerdpki/controller.go
@@ -135,7 +135,9 @@ func classifyReason(err error) string {
 		return "secret_not_found"
 	case strings.Contains(msg, "rotate"):
 		return "rotate"
-	case strings.Contains(msg, "identity"):
+	case strings.Contains(msg, "sync identity"):
+		return "sync"
+	case strings.Contains(msg, "rollout"), strings.Contains(msg, "identity"):
 		return "identity_restart"
 	case strings.Contains(msg, "patch"), strings.Contains(msg, "update"):
 		return "patch"

--- a/framework/app-gateway/pkg/linkerdpki/identity.go
+++ b/framework/app-gateway/pkg/linkerdpki/identity.go
@@ -2,36 +2,48 @@ package linkerdpki
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"log/slog"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func patchIdentityIssuerSecret(ctx context.Context, c client.Client, ns string, mat *Material) error {
-	var sec corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityIssuerSecret}, &sec); err != nil {
-		return fmt.Errorf("get linkerd-identity-issuer: %w", err)
-	}
-	if sec.Data == nil {
-		sec.Data = map[string][]byte{}
-	}
-	sec.Data[identityIssuerCrtKey] = mat.IssuerCrt
-	sec.Data[identityIssuerKeyKey] = mat.IssuerKey
-	return c.Update(ctx, &sec)
+func issuerFingerprint(issuerCrt []byte) string {
+	sum := sha256.Sum256(issuerCrt)
+	return fmt.Sprintf("%x", sum)
 }
 
-func restartIdentity(ctx context.Context, c client.Client, ns string) error {
+// ensureIdentityRollout restarts linkerd-identity when its recorded issuer
+// fingerprint does not match the vault. No-op when already matched.
+func ensureIdentityRollout(ctx context.Context, c client.Client, ns string, issuerCrt []byte) error {
 	var dep appsv1.Deployment
 	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &dep); err != nil {
+		slog.Error("linkerd pki get identity deployment failed",
+			"op", "maintain", "namespace", ns, "error", err)
 		return fmt.Errorf("get linkerd-identity deployment: %w", err)
 	}
+	want := issuerFingerprint(issuerCrt)
+	if dep.Annotations[identityIssuerFingerprintAnnotation] == want {
+		return nil
+	}
+	if dep.Annotations == nil {
+		dep.Annotations = map[string]string{}
+	}
+	dep.Annotations[identityIssuerFingerprintAnnotation] = want
 	if dep.Spec.Template.Annotations == nil {
 		dep.Spec.Template.Annotations = map[string]string{}
 	}
-	dep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().UTC().Format(time.RFC3339)
-	return c.Update(ctx, &dep)
+	dep.Spec.Template.Annotations[restartedAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	if err := c.Update(ctx, &dep); err != nil {
+		slog.Error("linkerd pki identity rollout update failed",
+			"op", "maintain", "namespace", ns, "error", err)
+		return fmt.Errorf("rollout linkerd-identity: %w", err)
+	}
+	slog.Info("linkerd identity rollout scheduled",
+		"op", "maintain", "namespace", ns, "issuer_fingerprint", want)
+	return nil
 }

--- a/framework/app-gateway/pkg/linkerdpki/maintain.go
+++ b/framework/app-gateway/pkg/linkerdpki/maintain.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MaintainLinkerdPKI performs one level-triggered check/rotate cycle. It reads
-// the in-cluster olares-linkerd-pki Secret only and rotates the identity issuer
-// when its remaining validity drops below IssuerRotateThreshold.
+// MaintainLinkerdPKI checks whether the vault issuer needs rotation, then
+// always syncs linkerd-identity-issuer and restarts linkerd-identity when
+// it still lags the vault.
 func MaintainLinkerdPKI(ctx context.Context, c client.Client, linkerdNS string) error {
 	mat, ok, err := loadPKISecret(ctx, c, linkerdNS)
 	if err != nil {
@@ -28,36 +28,48 @@ func MaintainLinkerdPKI(ctx context.Context, c client.Client, linkerdNS string) 
 	if err != nil {
 		return err
 	}
-	if !need {
+	if need {
+		slog.Info("linkerd issuer needs rotation", "remaining_hours", remaining.Round(time.Hour).Hours())
+		rotated, err := rotateIssuer(mat.CACrt, mat.CAKey)
+		if err != nil {
+			slog.Error("linkerd pki rotate issuer failed",
+				"op", "maintain", "namespace", linkerdNS, "error", err)
+			return fmt.Errorf("rotate linkerd issuer: %w", err)
+		}
+		version := nextPKIVersion(ctx, c, linkerdNS)
+		if err := writePKISecret(ctx, c, linkerdNS, rotated, version); err != nil {
+			slog.Error("linkerd pki write vault failed",
+				"op", "maintain", "namespace", linkerdNS, "error", err)
+			return err
+		}
+		mat = rotated
+		slog.Info("linkerd pki vault rotated", "op", "maintain", "namespace", linkerdNS, "version", version)
+	} else {
 		slog.Info("linkerd issuer ok", "remaining_hours", remaining.Round(time.Hour).Hours())
-		return nil
-	}
-	slog.Info("linkerd issuer needs rotation", "remaining_hours", remaining.Round(time.Hour).Hours())
-
-	rotated, err := rotateIssuer(mat.CACrt, mat.CAKey)
-	if err != nil {
-		return fmt.Errorf("rotate linkerd issuer: %w", err)
 	}
 
+	if _, err := syncIdentityIssuerSecret(ctx, c, linkerdNS, mat); err != nil {
+		slog.Error("linkerd pki sync identity issuer failed",
+			"op", "maintain", "namespace", linkerdNS, "error", err)
+		return fmt.Errorf("sync identity issuer: %w", err)
+	}
+	if err := ensureIdentityRollout(ctx, c, linkerdNS, mat.IssuerCrt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func nextPKIVersion(ctx context.Context, c client.Client, ns string) int {
 	version := 1
 	var sec corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: linkerdNS, Name: PKISecretName}, &sec); err == nil {
-		if metaBytes := sec.Data[pkiMetadataKey]; len(metaBytes) > 0 {
-			var meta metadata
-			if json.Unmarshal(metaBytes, &meta) == nil {
-				version = meta.Version + 1
-			}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: PKISecretName}, &sec); err != nil {
+		return version
+	}
+	if metaBytes := sec.Data[pkiMetadataKey]; len(metaBytes) > 0 {
+		var meta metadata
+		if json.Unmarshal(metaBytes, &meta) == nil {
+			version = meta.Version + 1
 		}
 	}
-	if err := writePKISecret(ctx, c, linkerdNS, rotated, version); err != nil {
-		return err
-	}
-	if err := patchIdentityIssuerSecret(ctx, c, linkerdNS, rotated); err != nil {
-		return err
-	}
-	if err := restartIdentity(ctx, c, linkerdNS); err != nil {
-		return err
-	}
-	slog.Info("linkerd identity issuer rotated", "version", version)
-	return nil
+	return version
 }

--- a/framework/app-gateway/pkg/linkerdpki/maintain_test.go
+++ b/framework/app-gateway/pkg/linkerdpki/maintain_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -18,11 +19,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-// TC-PKI-G04: when olares-linkerd-pki is absent, MaintainLinkerdPKI returns a
-// transient error and never terminates the process.
 func TestMaintainLinkerdPKISecretNotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -46,12 +47,14 @@ func TestMaintainLinkerdPKI_FreshIssuerNoRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fp := issuerFingerprint(mat.IssuerCrt)
 	secret := testPKISecret(ns, mat)
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	identityIssuer := testIdentityIssuerSecret(ns, mat, true)
+	identityDep := testIdentityDeployment(ns, fp, "already-rolled")
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(secret, identityIssuer, identityDep).
+		Build()
 
 	before := string(secret.Data[pkiIssuerCrtKey])
 	if err := MaintainLinkerdPKI(ctx, c, ns); err != nil {
@@ -64,6 +67,13 @@ func TestMaintainLinkerdPKI_FreshIssuerNoRotation(t *testing.T) {
 	if string(got.Data[pkiIssuerCrtKey]) != before {
 		t.Fatal("expected fresh issuer to remain unchanged")
 	}
+	var gotDep appsv1.Deployment
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &gotDep); err != nil {
+		t.Fatalf("get identity deployment: %v", err)
+	}
+	if gotDep.Spec.Template.Annotations[restartedAtAnnotation] != "already-rolled" {
+		t.Fatal("expected no identity rollout when vault and fingerprint already match")
+	}
 }
 
 func TestMaintainLinkerdPKI_NearExpiryRotatesIssuer(t *testing.T) {
@@ -74,29 +84,9 @@ func TestMaintainLinkerdPKI_NearExpiryRotatesIssuer(t *testing.T) {
 		t.Fatal(err)
 	}
 	secret := testPKISecret(ns, mat)
-	identityIssuer := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: identityIssuerSecret, Namespace: ns},
-		Type:       corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			identityIssuerCrtKey: mat.IssuerCrt,
-			identityIssuerKeyKey: mat.IssuerKey,
-		},
-	}
-	identityDep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: identityDeployment, Namespace: ns},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
-			},
-		},
-	}
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
+	identityIssuer := testIdentityIssuerSecret(ns, mat, false)
+	identityDep := testIdentityDeployment(ns, "", "")
+	scheme := testScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(secret, identityIssuer, identityDep).
 		Build()
@@ -112,13 +102,230 @@ func TestMaintainLinkerdPKI_NearExpiryRotatesIssuer(t *testing.T) {
 	if string(gotSecret.Data[pkiIssuerCrtKey]) == before {
 		t.Fatal("expected issuer certificate to rotate when near expiry")
 	}
+	var gotIdentity corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityIssuerSecret}, &gotIdentity); err != nil {
+		t.Fatalf("get identity issuer: %v", err)
+	}
+	if string(gotIdentity.Data[identityIssuerCrtKey]) != string(gotSecret.Data[pkiIssuerCrtKey]) {
+		t.Fatal("expected identity issuer to match rotated vault")
+	}
 	var gotDep appsv1.Deployment
 	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &gotDep); err != nil {
 		t.Fatalf("get identity deployment: %v", err)
 	}
-	if gotDep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] == "" {
+	if gotDep.Spec.Template.Annotations[restartedAtAnnotation] == "" {
 		t.Fatal("expected linkerd-identity deployment restart annotation after rotation")
 	}
+	wantFP := issuerFingerprint(gotSecret.Data[pkiIssuerCrtKey])
+	if gotDep.Annotations[identityIssuerFingerprintAnnotation] != wantFP {
+		t.Fatalf("fingerprint = %q, want %q", gotDep.Annotations[identityIssuerFingerprintAnnotation], wantFP)
+	}
+}
+
+func TestMaintainLinkerdPKI_HealsStaleIdentityIssuer(t *testing.T) {
+	ctx := context.Background()
+	ns := DefaultLinkerdNamespace
+	vault, err := testCAAndIssuerMaterial(time.Now().UTC().Add(200 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := testCAAndIssuerMaterial(time.Now().UTC().Add(190 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := testPKISecret(ns, vault)
+	identityIssuer := testIdentityIssuerSecret(ns, stale, false)
+	identityDep := testIdentityDeployment(ns, issuerFingerprint(stale.IssuerCrt), "old")
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(secret, identityIssuer, identityDep).
+		Build()
+
+	beforeVault := string(secret.Data[pkiIssuerCrtKey])
+	if err := MaintainLinkerdPKI(ctx, c, ns); err != nil {
+		t.Fatalf("heal stale identity: %v", err)
+	}
+	var gotVault corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: PKISecretName}, &gotVault); err != nil {
+		t.Fatalf("get vault: %v", err)
+	}
+	if string(gotVault.Data[pkiIssuerCrtKey]) != beforeVault {
+		t.Fatal("expected fresh vault issuer to remain unchanged")
+	}
+	var gotIdentity corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityIssuerSecret}, &gotIdentity); err != nil {
+		t.Fatalf("get identity issuer: %v", err)
+	}
+	if string(gotIdentity.Data[identityIssuerCrtKey]) != beforeVault {
+		t.Fatal("expected identity issuer to be rewritten from vault")
+	}
+	var gotDep appsv1.Deployment
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &gotDep); err != nil {
+		t.Fatalf("get identity deployment: %v", err)
+	}
+	if gotDep.Annotations[identityIssuerFingerprintAnnotation] != issuerFingerprint(vault.IssuerCrt) {
+		t.Fatal("expected fingerprint updated to vault issuer")
+	}
+	if gotDep.Spec.Template.Annotations[restartedAtAnnotation] == "old" {
+		t.Fatal("expected identity rollout when fingerprint lagged vault")
+	}
+}
+
+func TestMaintainLinkerdPKI_IdempotentWhenConverged(t *testing.T) {
+	ctx := context.Background()
+	ns := DefaultLinkerdNamespace
+	mat, err := testCAAndIssuerMaterial(time.Now().UTC().Add(200 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := issuerFingerprint(mat.IssuerCrt)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(
+			testPKISecret(ns, mat),
+			testIdentityIssuerSecret(ns, mat, true),
+			testIdentityDeployment(ns, fp, "stable"),
+		).
+		Build()
+
+	if err := MaintainLinkerdPKI(ctx, c, ns); err != nil {
+		t.Fatalf("maintain converged state: %v", err)
+	}
+	var gotDep appsv1.Deployment
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &gotDep); err != nil {
+		t.Fatalf("get identity deployment: %v", err)
+	}
+	if gotDep.Spec.Template.Annotations[restartedAtAnnotation] != "stable" {
+		t.Fatal("expected no rollout when already converged")
+	}
+}
+
+func TestMaintainLinkerdPKI_PartialSyncHealsOnRetry(t *testing.T) {
+	ctx := context.Background()
+	ns := DefaultLinkerdNamespace
+	vault, err := testCAAndIssuerMaterial(time.Now().UTC().Add(200 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := testCAAndIssuerMaterial(time.Now().UTC().Add(190 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheme := testScheme(t)
+	objs := []client.Object{
+		testPKISecret(ns, vault),
+		testIdentityIssuerSecret(ns, stale, false),
+		testIdentityDeployment(ns, issuerFingerprint(stale.IssuerCrt), "old"),
+	}
+	failing := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if sec, ok := obj.(*corev1.Secret); ok && sec.Name == identityIssuerSecret {
+					return errors.New("simulated identity issuer update failure")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	err = MaintainLinkerdPKI(ctx, failing, ns)
+	if err == nil || !strings.Contains(err.Error(), "sync identity issuer") {
+		t.Fatalf("expected sync identity issuer error, got %v", err)
+	}
+
+	healing := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	if err := MaintainLinkerdPKI(ctx, healing, ns); err != nil {
+		t.Fatalf("heal after failed sync: %v", err)
+	}
+	var gotIdentity corev1.Secret
+	if err := healing.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityIssuerSecret}, &gotIdentity); err != nil {
+		t.Fatalf("get identity issuer: %v", err)
+	}
+	if string(gotIdentity.Data[identityIssuerCrtKey]) != string(vault.IssuerCrt) {
+		t.Fatal("expected identity issuer to converge to vault on retry")
+	}
+}
+
+func TestMaintainLinkerdPKI_RolloutFailureRetried(t *testing.T) {
+	ctx := context.Background()
+	ns := DefaultLinkerdNamespace
+	vault, err := testCAAndIssuerMaterial(time.Now().UTC().Add(200 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := testCAAndIssuerMaterial(time.Now().UTC().Add(190 * 24 * time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheme := testScheme(t)
+	objs := []client.Object{
+		testPKISecret(ns, vault),
+		testIdentityIssuerSecret(ns, stale, false),
+		testIdentityDeployment(ns, issuerFingerprint(stale.IssuerCrt), "old"),
+	}
+	failing := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if dep, ok := obj.(*appsv1.Deployment); ok && dep.Name == identityDeployment {
+					return errors.New("simulated identity deployment update failure")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	err = MaintainLinkerdPKI(ctx, failing, ns)
+	if err == nil || !strings.Contains(err.Error(), "rollout linkerd-identity") {
+		t.Fatalf("expected rollout error, got %v", err)
+	}
+
+	// Identity sync succeeded on the failing client; fingerprint did not.
+	var syncedIdentity corev1.Secret
+	if err := failing.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityIssuerSecret}, &syncedIdentity); err != nil {
+		t.Fatalf("get identity after partial success: %v", err)
+	}
+	if string(syncedIdentity.Data[identityIssuerCrtKey]) != string(vault.IssuerCrt) {
+		t.Fatal("expected identity issuer synced before rollout failure")
+	}
+	var stuckDep appsv1.Deployment
+	if err := failing.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &stuckDep); err != nil {
+		t.Fatalf("get deployment after partial success: %v", err)
+	}
+	if stuckDep.Annotations[identityIssuerFingerprintAnnotation] == issuerFingerprint(vault.IssuerCrt) {
+		t.Fatal("fingerprint must not persist when deployment update failed")
+	}
+
+	// Rebuild from post-sync state and confirm rollout retries.
+	retryObjs := []client.Object{
+		testPKISecret(ns, vault),
+		&syncedIdentity,
+		&stuckDep,
+	}
+	healing := fake.NewClientBuilder().WithScheme(scheme).WithObjects(retryObjs...).Build()
+	if err := MaintainLinkerdPKI(ctx, healing, ns); err != nil {
+		t.Fatalf("retry rollout: %v", err)
+	}
+	var gotDep appsv1.Deployment
+	if err := healing.Get(ctx, types.NamespacedName{Namespace: ns, Name: identityDeployment}, &gotDep); err != nil {
+		t.Fatalf("get deployment after heal: %v", err)
+	}
+	if gotDep.Annotations[identityIssuerFingerprintAnnotation] != issuerFingerprint(vault.IssuerCrt) {
+		t.Fatal("expected fingerprint set on retry")
+	}
+	if gotDep.Spec.Template.Annotations[restartedAtAnnotation] == "old" ||
+		gotDep.Spec.Template.Annotations[restartedAtAnnotation] == "" {
+		t.Fatal("expected restartedAt updated on rollout retry")
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
 }
 
 func testPKISecret(ns string, mat *Material) *corev1.Secret {
@@ -133,6 +340,46 @@ func testPKISecret(ns string, mat *Material) *corev1.Secret {
 			pkiMetadataKey:  []byte(`{"version":1}`),
 		},
 	}
+}
+
+func testIdentityIssuerSecret(ns string, mat *Material, withHelmKeep bool) *corev1.Secret {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: identityIssuerSecret, Namespace: ns},
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			identityIssuerCrtKey: mat.IssuerCrt,
+			identityIssuerKeyKey: mat.IssuerKey,
+		},
+	}
+	if withHelmKeep {
+		sec.Annotations = map[string]string{
+			helmResourcePolicyKeep: helmResourcePolicyKeepValue,
+		}
+	}
+	return sec
+}
+
+func testIdentityDeployment(ns, fingerprint, restartedAt string) *appsv1.Deployment {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      identityDeployment,
+			Namespace: ns,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			},
+		},
+	}
+	if fingerprint != "" {
+		dep.Annotations = map[string]string{
+			identityIssuerFingerprintAnnotation: fingerprint,
+		}
+	}
+	if restartedAt != "" {
+		dep.Spec.Template.Annotations[restartedAtAnnotation] = restartedAt
+	}
+	return dep
 }
 
 func testCAAndIssuerMaterial(issuerNotAfter time.Time) (*Material, error) {


### PR DESCRIPTION
## Summary
- When issuer rotation writes the vault but fails to update `linkerd-identity-issuer` or restart `linkerd-identity`, the next pass used to skip recovery because the vault already looked fresh.
- Always sync the identity issuer from the vault, and restart identity only when it still lags, so a half-done rotation can recover.
- Pin `beclab/linkerd-pki-guardian` to `@sha256:50b18ca1…` (`0.1.5`), verified on a local cluster.

## Test plan
- [x] `GOWORK=off go test ./pkg/linkerdpki/ -run MaintainLinkerdPKI`
- [x] Unit coverage: stale identity heal, no-op when synced, sync failure retry, rollout failure retry
- [x] Local cluster: import `0.1.5`, break `linkerd-identity-issuer`, confirm sync + fingerprint rollout while `issuer ok`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mesh identity PKI sync and controlled `linkerd-identity` restarts; behavior is well-tested but mis-rollout could briefly affect identity issuance.
> 
> **Overview**
> Fixes a recovery gap where **MaintainLinkerdPKI** could exit early after a fresh vault issuer, leaving `linkerd-identity-issuer` or `linkerd-identity` out of sync when rotation had only partially succeeded.
> 
> Each reconcile pass now **always** syncs the identity issuer from the vault via `syncIdentityIssuerSecret`, then rolls out `linkerd-identity` only when needed. Rollouts compare a SHA-256 **issuer fingerprint** stored on the Deployment annotation `gateway.olares.io/linkerd-issuer-fingerprint` to the vault cert; `kubectl.kubernetes.io/restartedAt` is set on the pod template only when the fingerprint lags, avoiding unnecessary restarts when already converged.
> 
> Deploy manifests and **Olares.yaml** pin `beclab/linkerd-pki-guardian` to digest `50b18ca1…` (0.1.5). Reconcile error classification adds a `sync` reason; **maintain** tests cover stale-issuer heal, idempotency, and retry after sync/rollout failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef8171dd77a7b391037d2d9faa52d824fb69c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->