### PR TITLE
fix(ci): do not use release id in join script

### DIFF
--- a/build/base-package/joincluster.sh
+++ b/build/base-package/joincluster.sh
@@ -131,13 +131,8 @@ cli_is_current() {
 
 install_cli() {
     local target="$1" cdn_url="$2"
-    local release_suffix="" cli_file cli_url
-
-    if [[ -n "$RELEASE_ID" ]]; then
-        release_suffix=".$RELEASE_ID"
-    fi
-
-    cli_file="olares-cli-v${VERSION}_linux_${ARCH}${release_suffix}.tar.gz"
+    local cli_file cli_url
+    cli_file="olares-cli-v${VERSION}_linux_${ARCH}.tar.gz"
     cli_url="${cdn_url}${REPO_PATH}${cli_file}"
 
     WORK_DIR="$(mktemp -d)"
@@ -165,14 +160,6 @@ main() {
     cdn_url="${OLARES_SYSTEM_CDN_SERVICE:-$DEFAULT_CDN_SERVICE}"
     cdn_url="${cdn_url%/}"
     export OLARES_SYSTEM_CDN_SERVICE="$cdn_url"
-
-    if [[ -z "$RELEASE_ID" ]]; then
-        RELEASE_ID="#__RELEASE_ID__"
-        if [[ "${RELEASE_ID:3}" == "RELEASE_ID__" ]]; then
-            RELEASE_ID=""
-        fi
-    fi
-    export RELEASE_ID
 
     target="/usr/local/bin/olares-cli"
     if cli_is_current "$target"; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -63,7 +63,6 @@ fi
 if [ ! -z $RELEASE_ID ]; then
     sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' install.sh"
     sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' install.ps1"
-    sh -c "$SED 's/#__RELEASE_ID__/${RELEASE_ID}/' joincluster.sh"
 fi
 
 # replace repo path placeholder in scripts if provided


### PR DESCRIPTION
* **Background**
The `joincluster.sh` script is designed to serve both Olares One machines and other machines to join an Olares cluster, since for a same version the release id differs in both vendors, it should not be statically injected.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and join-script download URL only; install paths still use RELEASE_ID, with low blast radius if CDN serves the unsuffixed tarball for join use cases.
> 
> **Overview**
> **Join-cluster installs no longer use a build-time `RELEASE_ID` when fetching `olares-cli`.** The script always downloads `olares-cli-v${VERSION}_linux_${ARCH}.tar.gz` and drops the placeholder export and `.$RELEASE_ID` filename suffix logic.
> 
> **Release packaging** no longer runs `sed` on `joincluster.sh` for `#__RELEASE_ID__`, while `install.sh` / `install.ps1` still get that substitution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2d6a233cc1717fb486a90088baefe8f2bdec9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->