### PR TITLE
opa: add trusted image for linkerd proxy

### DIFF
--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -257,6 +257,7 @@ data:
         not startswith(image, "kldtks/")
         not startswith(image, "alpine:")
         not startswith(image, "mariadb:")
+        not startswith(image, "cr.l5d.io/linkerd/proxy")
     }
         
     is_root_user(ctx) if {

--- a/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
+++ b/platform/open-policy-agent/.olares/config/cluster/deploy/deployment.yaml
@@ -257,7 +257,7 @@ data:
         not startswith(image, "kldtks/")
         not startswith(image, "alpine:")
         not startswith(image, "mariadb:")
-        not startswith(image, "cr.l5d.io/linkerd/proxy")
+        not startswith(image, "cr.l5d.io/linkerd/proxy:")
     }
         
     is_root_user(ctx) if {


### PR DESCRIPTION
* **Background**
Add trusted image for linkerd proxy sidecar

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry in admission policy; no change to auth or core cluster logic, same risk profile as other trusted image prefixes.
> 
> **Overview**
> **Expands the OPA admission allowlist** so pods using the official Linkerd proxy sidecar image are no longer treated as untrusted when they run as root or privileged.
> 
> The `untrusted-pod-check` Rego policy’s `is_untrusted_image` rule gains a `not startswith(image, "cr.l5d.io/linkerd/proxy:")` exception, matching the existing pattern for other trusted registries (e.g. `busybox:`, `redis:`). Linkerd injects the proxy from `cr.l5d.io`, which would otherwise fail validation alongside root/privileged checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca0fd4acd44541c554bf412bb481128b8b118cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->