### PR TITLE
fix(download-server): torrent seed-control, HuggingFace & yt-dlp lifecycle, and dedup landing fixes

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.6"
+        image: "beclab/download-server:v1.0.7"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Add Username, App and UpdatedAt to the DownloadProgress / UpdateProgressInput NATS payloads.
Land aria2 direct-link repeats as ".<n>".
Re-seed completed torrents instead of surfacing "cannot be unpaused now".
Resolve HuggingFace shared-cache landing for the dedup pre-check.
Honor remove_flag for seeding torrents and clean torrent metadata on delete.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single container image tag bump in cluster deploy config; no RBAC, env, or resource changes in the diff.
> 
> **Overview**
> Rolls out **`beclab/download-server:v1.0.7`** on the download DaemonSet by updating the `download-server` container image in `download_deploy.yaml` from **v1.0.6**.
> 
> This deploy-only change ships the application fixes described for v1.0.7 (progress NATS fields, torrent re-seed/remove behavior, HuggingFace dedup landing, aria2 duplicate naming, yt-dlp lifecycle) without other manifest edits in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6632845ed2f9705cccda924723176082574b5e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->