### PR TITLE
fix(app-service): shared caller-jwt and mesh-in 443 scope

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.11
+        image: beclab/app-service:0.6.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -397,7 +397,7 @@ func (h *Handler) gpuLimitMutate(ctx context.Context, req *admissionv1.Admission
 		return resp
 	}
 
-	_, appcfg, _, err := h.sidecarWebhook.GetAppConfig(req.Namespace)
+	_, appcfg, _, _, err := h.sidecarWebhook.GetAppConfig(req.Namespace)
 	if err != nil {
 		klog.Error(err)
 		return resp
@@ -1082,7 +1082,7 @@ func (h *Handler) appLabelMutate(ctx context.Context, req *admissionv1.Admission
 		UID:     req.UID,
 	}
 
-	_, appCfg, _, _ := h.sidecarWebhook.GetAppConfig(req.Namespace)
+	_, appCfg, _, _, _ := h.sidecarWebhook.GetAppConfig(req.Namespace)
 	if appCfg == nil {
 		klog.Error("get appcfg is empty")
 		return resp

--- a/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
@@ -159,8 +159,8 @@ func TestShouldIssueCallerJWTSharedAppRefAndOptOut(t *testing.T) {
 			},
 		},
 	}
-	if shouldIssueCallerJWT(optOut) {
-		t.Fatal("shared app with mesh-inject opt-out must not issue JWT")
+	if !shouldIssueCallerJWT(optOut) {
+		t.Fatal("shared app always issues JWT even with mesh-inject opt-out")
 	}
 	intentOnly := &appv1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{Name: "agg", Labels: sharedLabels},
@@ -171,8 +171,20 @@ func TestShouldIssueCallerJWTSharedAppRefAndOptOut(t *testing.T) {
 			Settings:  map[string]string{settingNeedsSharedAccess: "true"},
 		},
 	}
-	if shouldIssueCallerJWT(intentOnly) {
-		t.Fatal("shared app with needsSharedAccess alone must not issue JWT")
+	if !shouldIssueCallerJWT(intentOnly) {
+		t.Fatal("shared app always issues JWT even with needsSharedAccess alone")
+	}
+	pureCallee := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine", Labels: sharedLabels},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:      "engine",
+			Appid:     "82f26852",
+			Namespace: "engine-shared",
+			Settings:  map[string]string{settingSharedCallerDecide: "false"},
+		},
+	}
+	if !shouldIssueCallerJWT(pureCallee) {
+		t.Fatal("shared pure callee (decide=false) must still issue JWT")
 	}
 }
 
@@ -416,6 +428,75 @@ func TestIssueRequestFromSharedApplicationUsesAppid(t *testing.T) {
 	}
 	if req.Viewer != "" {
 		t.Fatalf("Viewer = %q, want empty for shared caller", req.Viewer)
+	}
+}
+
+func TestIssuerReconcilerIssuesJWTForSharedPureCallee(t *testing.T) {
+	scheme := testScheme(t)
+	ring, err := NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "engine",
+			Namespace: "user-system",
+			Labels:    map[string]string{"app.bytetrade.io/app-shared": "true"},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:      "engine",
+			Appid:     "82f26852",
+			Namespace: "engine-shared",
+			Settings:  map[string]string{settingSharedCallerDecide: "false"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r := &IssuerReconciler{Client: c, Scheme: scheme, issuer: issuer}
+	if err := r.reconcileApplication(context.Background(), app); err != nil {
+		t.Fatalf("reconcileApplication: %v", err)
+	}
+	secret := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: app.Spec.Namespace,
+		Name:      AppJWTSecretName,
+	}, secret); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if len(secret.Data[AppJWTSecretDataKey]) == 0 {
+		t.Fatal("expected non-empty caller-jwt token")
+	}
+}
+
+func TestIssuerReconcilerSharedMissingAppidErrors(t *testing.T) {
+	scheme := testScheme(t)
+	ring, err := NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "engine",
+			Namespace: "user-system",
+			Labels:    map[string]string{"app.bytetrade.io/app-shared": "true"},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:      "engine",
+			Namespace: "engine-shared",
+			Settings:  map[string]string{settingSharedCallerDecide: "false"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r := &IssuerReconciler{Client: c, Scheme: scheme, issuer: issuer}
+	if err := r.reconcileApplication(context.Background(), app); err == nil {
+		t.Fatal("expected error when shared app has empty spec.appid")
 	}
 }
 

--- a/framework/app-service/pkg/gateway/callerjwt/metrics.go
+++ b/framework/app-service/pkg/gateway/callerjwt/metrics.go
@@ -1,0 +1,23 @@
+package callerjwt
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var callerJWTIssueFailTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "olares_caller_jwt_issue_fail_total",
+		Help: "Caller JWT issue failures by application namespace (e.g. missing spec.appid on Shared apps)",
+	},
+	[]string{"namespace"},
+)
+
+func init() {
+	prometheus.MustRegister(callerJWTIssueFailTotal)
+}
+
+// RecordIssueFail increments the Shared/caller JWT issue failure counter.
+func RecordIssueFail(namespace string) {
+	if namespace == "" {
+		namespace = "unknown"
+	}
+	callerJWTIssueFailTotal.WithLabelValues(namespace).Inc()
+}

--- a/framework/app-service/pkg/gateway/callerjwt/reconcile.go
+++ b/framework/app-service/pkg/gateway/callerjwt/reconcile.go
@@ -87,8 +87,9 @@ func (r *IssuerReconciler) reconcileApplication(ctx context.Context, app *appv1a
 	}
 	req := issueRequestFromApplication(app)
 	if appcfg.IsShared(app) && strings.TrimSpace(req.Appid) == "" {
-		err := fmt.Errorf("callerjwt: shared caller requires spec.appid")
-		klog.Warningf("caller_jwt_issue_fail app=%s ns=%s err=%v", app.Spec.Name, app.Spec.Namespace, err)
+		err := fmt.Errorf("callerjwt: shared app requires spec.appid")
+		klog.Errorf("caller_jwt_issue_fail app=%s ns=%s err=%v", app.Spec.Name, app.Spec.Namespace, err)
+		RecordIssueFail(app.Spec.Namespace)
 		return err
 	}
 	token, err := r.issuer.Issue(req)
@@ -99,7 +100,11 @@ func (r *IssuerReconciler) reconcileApplication(ctx context.Context, app *appv1a
 	if err := upsertAppJWTSecret(ctx, r.Client, r.Scheme, app, token); err != nil {
 		return err
 	}
-	klog.V(1).Infof("caller jwt issued app=%s ns=%s", app.Spec.Name, app.Spec.Namespace)
+	if appcfg.IsShared(app) {
+		klog.V(1).Infof("caller_jwt_issued_all shared=true ns=%s app=%s", app.Spec.Namespace, app.Spec.Name)
+	} else {
+		klog.V(1).Infof("caller jwt issued app=%s ns=%s", app.Spec.Name, app.Spec.Namespace)
+	}
 	return nil
 }
 
@@ -242,22 +247,6 @@ func applicationDeclaresSharedAccess(app *appv1alpha1.Application) bool {
 	return hasNamedSharedCallee(s)
 }
 
-// sharedDeclaresCaller is the Shared-app gate for issuing caller-jwt: decide=true
-// or named callee refs only (needsSharedAccess alone is not enough). Kept in this
-// package because importing meshinagent would create a cycle.
-func sharedDeclaresCaller(settings map[string]string) bool {
-	if settings == nil || meshInjectOptedOut(settings) {
-		return false
-	}
-	if d := strings.TrimSpace(settings[settingSharedCallerDecide]); strings.EqualFold(d, "false") {
-		return false
-	}
-	if strings.EqualFold(strings.TrimSpace(settings[settingSharedCallerDecide]), "true") {
-		return true
-	}
-	return hasNamedSharedCallee(settings)
-}
-
 func meshInjectOptedOut(settings map[string]string) bool {
 	if settings == nil {
 		return false
@@ -279,12 +268,15 @@ func hasNamedSharedCallee(settings map[string]string) bool {
 	return strings.TrimSpace(settings[settingAppRef]) != ""
 }
 
+// shouldIssueCallerJWT reports whether caller-jwt must exist for this Application.
+// Shared apps always issue: decide only controls mesh-in inject, not JWT issuance.
+// Ordinary apps issue when they declare shared access.
 func shouldIssueCallerJWT(app *appv1alpha1.Application) bool {
 	if app == nil {
 		return false
 	}
 	if appcfg.IsShared(app) {
-		return sharedDeclaresCaller(app.Spec.Settings)
+		return true
 	}
 	return applicationDeclaresSharedAccess(app)
 }

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
@@ -180,8 +180,13 @@ function authDeny(r) {
 }
 
 function decideOffload(s) {
+  // Empty SNI means the connection was redirected by IP (no hostname). Under
+  // REDIRECT the original destination is unrecoverable — log and fail closed.
   const host = normalizeHost(s.variables.ssl_preread_server_name);
-  if (!host) { return passthrough(host); }
+  if (!host) {
+    s.error('mesh-in: no SNI on hijacked 443; original destination unrecoverable under REDIRECT, connection dropped');
+    return passthrough(host);
+  }
   if (!isPlatformHost(host)) { return passthrough(host); }
   const hosts = reloadTLSHosts();
   if (hosts[host]) { return TERMINATE; }

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
@@ -1,0 +1,41 @@
+package meshinagent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBearerJSNoSNILogsError(t *testing.T) {
+	js := BearerJS()
+	if !strings.Contains(js, `s.error('mesh-in: no SNI on hijacked 443`) {
+		t.Fatal("decideOffload must log empty SNI via s.error")
+	}
+	idx := strings.Index(js, "function decideOffload")
+	if idx < 0 {
+		t.Fatal("missing decideOffload")
+	}
+	fn := js[idx:]
+	end := strings.Index(fn, "\nexport default")
+	if end > 0 {
+		fn = fn[:end]
+	}
+	if !strings.Contains(fn, "if (!host)") {
+		t.Fatal("empty host branch required")
+	}
+	if !strings.Contains(fn, "return passthrough(host)") {
+		t.Fatal("empty host must still passthrough to invalid.local")
+	}
+}
+
+func TestBearerJSDecideOffloadKeepsPlatformPath(t *testing.T) {
+	js := BearerJS()
+	for _, want := range []string{
+		"isPlatformHost(host)",
+		"reloadTLSHosts()",
+		"return TERMINATE",
+	} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("decideOffload missing %q", want)
+		}
+	}
+}

--- a/framework/app-service/pkg/gateway/meshinagent/container.go
+++ b/framework/app-service/pkg/gateway/meshinagent/container.go
@@ -114,63 +114,111 @@ exec nginx -c /tmp/mesh-in/nginx.conf -g 'daemon off;'
 `, PlaceholderCertDir, jsB64, httpsB64, CertsMountPath, PlaceholderCertDir)
 }
 
-// InitContainerSpec installs OUTPUT REDIRECT rules for Shared gateway HTTP and
-// all outbound HTTPS. mesh-in upstream to gateway:80 must NOT use a blanket
-// uid RETURN so Linkerd (uid 2102) can intercept plaintext after JWT inject.
+// InitContainerSpec installs OUTPUT REDIRECT rules for Shared gateway HTTP/HTTPS.
+// Every REDIRECT must pin -d to the gateway data-plane IP (same constraint for
+// 80 and 443): mesh-in always forwards to the gateway and cannot recover the
+// original destination under REDIRECT when SNI is absent.
 //
 // Exclusions on REDIRECT owners: mesh-in 1651 (no self-loop), linkerd 2102,
 // envoy 1555 (legacy oes coexistence).
+//
+// Resolve failure must not block the workload (exit 0 after retries).
 func InitContainerSpec() corev1.Container {
-	envoyUID := strconv.FormatInt(constants.EnvoyUID, 10)
-	linkerdUID := strconv.FormatInt(constants.LinkerdProxyUID, 10)
+	return InitContainerSpecWithGatewayIPs("")
+}
+
+// InitContainerSpecWithGatewayIPs is InitContainerSpec with an optional
+// comma/space-separated ClusterIP list (admission snapshot). Empty falls back
+// to DNS inside the init script.
+func InitContainerSpecWithGatewayIPs(gatewayIPs string) corev1.Container {
 	root := int64(0)
-	script := fmt.Sprintf(`set -eu
-GW_HOST="${MESH_IN_AGENT_GATEWAY_HOST:-%s}"
-GW_IP=""
-NGINX_UID="%s"
-ENVOY_UID="%s"
-LINKERD_UID="%s"
-HTTP_PORT="%d"
-HTTPS_PORT="%d"
-# Prefer configured host; fall back to legacy app-gateway NS for older installs.
-for h in "$GW_HOST" "app-gateway-data.os-gateway.svc" "app-gateway-data.os-gateway.svc.cluster.local" \
-  "app-gateway-data.app-gateway.svc" "app-gateway-data.app-gateway.svc.cluster.local"; do
-  if command -v getent >/dev/null 2>&1; then
-    GW_IP=$(getent ahosts "$h" 2>/dev/null | awk '{print $1; exit}')
-  fi
-  if [ -z "$GW_IP" ] && command -v nslookup >/dev/null 2>&1; then
-    GW_IP=$(nslookup "$h" 2>/dev/null | awk '/^Address: / { a=$2 } END { print a }')
-  fi
-  if [ -n "$GW_IP" ]; then
-    echo "mesh-in-agent: resolved $h -> $GW_IP"
-    break
-  fi
-done
-if [ -z "$GW_IP" ]; then
-  echo "mesh-in-agent: cannot resolve gateway host $GW_HOST" >&2
-  exit 1
-fi
-OWNER_SKIP="-m owner ! --uid-owner $NGINX_UID -m owner ! --uid-owner $ENVOY_UID -m owner ! --uid-owner $LINKERD_UID"
-echo "mesh-in-agent: redirect $GW_IP:80 -> $HTTP_PORT; *:443 -> $HTTPS_PORT (skip uid $NGINX_UID/$ENVOY_UID/$LINKERD_UID)"
-iptables -t nat -C OUTPUT -p tcp -d "$GW_IP" --dport 80 $OWNER_SKIP -j REDIRECT --to-ports "$HTTP_PORT" 2>/dev/null \
-  || iptables -t nat -I OUTPUT 1 -p tcp -d "$GW_IP" --dport 80 $OWNER_SKIP -j REDIRECT --to-ports "$HTTP_PORT"
-iptables -t nat -C OUTPUT -p tcp --dport 443 $OWNER_SKIP -j REDIRECT --to-ports "$HTTPS_PORT" 2>/dev/null \
-  || iptables -t nat -I OUTPUT 2 -p tcp --dport 443 $OWNER_SKIP -j REDIRECT --to-ports "$HTTPS_PORT"
-`, DefaultGatewayHost, NginxWorkerUID(), envoyUID, linkerdUID, HTTPListenPort, HTTPSListenPort)
+	env := []corev1.EnvVar{
+		{Name: "MESH_IN_AGENT_GATEWAY_HOST", Value: DefaultGatewayHost},
+	}
+	if ips := strings.TrimSpace(gatewayIPs); ips != "" {
+		env = append(env, corev1.EnvVar{Name: GatewayIPsEnv, Value: ips})
+	}
 
 	return corev1.Container{
 		Name:            InitContainerName,
 		Image:           meshInAgentImage(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/bin/sh", "-c", script},
-		Env: []corev1.EnvVar{
-			{Name: "MESH_IN_AGENT_GATEWAY_HOST", Value: DefaultGatewayHost},
-		},
+		Command:         []string{"/bin/sh", "-c", IptablesInitScript()},
+		Env:             env,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &root,
 			Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"}},
 		},
 	}
+}
+
+// IptablesInitScript renders the mesh-in iptables bootstrap shell (unit-tested).
+func IptablesInitScript() string {
+	envoyUID := strconv.FormatInt(constants.EnvoyUID, 10)
+	linkerdUID := strconv.FormatInt(constants.LinkerdProxyUID, 10)
+	return fmt.Sprintf(`set -u
+GW_HOST="${MESH_IN_AGENT_GATEWAY_HOST:-%s}"
+NGINX_UID="%s"
+ENVOY_UID="%s"
+LINKERD_UID="%s"
+HTTP_PORT="%d"
+HTTPS_PORT="%d"
+GW_IPS=""
+
+normalize_ips() {
+  echo "$1" | tr ',;' '  ' | tr -s '[:space:]' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' '
+}
+
+if [ -n "${MESH_IN_AGENT_GATEWAY_IPS:-}" ]; then
+  GW_IPS=$(normalize_ips "$MESH_IN_AGENT_GATEWAY_IPS")
+  echo "mesh-in-agent: using gateway IPs from env: $GW_IPS"
+fi
+
+if [ -z "$GW_IPS" ]; then
+  attempt=1
+  while [ "$attempt" -le 3 ]; do
+    resolved=""
+    for h in "$GW_HOST" "app-gateway-data.os-gateway.svc.cluster.local"; do
+      ip=""
+      if command -v getent >/dev/null 2>&1; then
+        ip=$(getent ahosts "$h" 2>/dev/null | awk '{print $1; exit}')
+      fi
+      if [ -z "$ip" ] && command -v nslookup >/dev/null 2>&1; then
+        ip=$(nslookup "$h" 2>/dev/null | awk '/^Address: / { a=$2 } END { print a }')
+      fi
+      if [ -n "$ip" ]; then
+        echo "mesh-in-agent: resolved $h -> $ip"
+        resolved="$resolved $ip"
+      fi
+    done
+    GW_IPS=$(normalize_ips "$resolved")
+    if [ -n "$GW_IPS" ]; then
+      break
+    fi
+    echo "mesh-in-agent: gateway resolve attempt $attempt/3 failed" >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le 3 ]; then
+      sleep 1
+    fi
+  done
+fi
+
+if [ -z "$GW_IPS" ]; then
+  echo "mesh-in-agent: cannot resolve gateway host $GW_HOST; continuing without redirects (workload not blocked)" >&2
+  exit 0
+fi
+
+OWNER_SKIP="-m owner ! --uid-owner $NGINX_UID -m owner ! --uid-owner $ENVOY_UID -m owner ! --uid-owner $LINKERD_UID"
+echo "mesh-in-agent: redirect ips=[$GW_IPS] :80->$HTTP_PORT :443->$HTTPS_PORT (skip uid $NGINX_UID/$ENVOY_UID/$LINKERD_UID)"
+for ip in $GW_IPS; do
+  iptables -t nat -C OUTPUT -p tcp -d "$ip" --dport 80 $OWNER_SKIP -j REDIRECT --to-ports "$HTTP_PORT" 2>/dev/null \
+    || iptables -t nat -I OUTPUT 1 -p tcp -d "$ip" --dport 80 $OWNER_SKIP -j REDIRECT --to-ports "$HTTP_PORT"
+  iptables -t nat -C OUTPUT -p tcp -d "$ip" --dport 443 $OWNER_SKIP -j REDIRECT --to-ports "$HTTPS_PORT" 2>/dev/null \
+    || iptables -t nat -I OUTPUT 1 -p tcp -d "$ip" --dport 443 $OWNER_SKIP -j REDIRECT --to-ports "$HTTPS_PORT"
+done
+echo "mesh-in-agent: installed OUTPUT redirects:"
+iptables -t nat -S OUTPUT 2>/dev/null || true
+`, DefaultGatewayHost, NginxWorkerUID(), envoyUID, linkerdUID, HTTPListenPort, HTTPSListenPort)
 }
 
 // JWTSecretVolume mounts the caller JWT-SVID Secret issued by callerjwt (name must match AppJWTSecretName).

--- a/framework/app-service/pkg/gateway/meshinagent/container.go
+++ b/framework/app-service/pkg/gateway/meshinagent/container.go
@@ -174,13 +174,15 @@ iptables -t nat -C OUTPUT -p tcp --dport 443 $OWNER_SKIP -j REDIRECT --to-ports 
 }
 
 // JWTSecretVolume mounts the caller JWT-SVID Secret issued by callerjwt (name must match AppJWTSecretName).
+// Optional is true so a missing Secret does not block Pod startup; fail-closed for
+// allowlisted hosts is enforced by njs authDeny (401) when the token file is absent.
 func JWTSecretVolume() corev1.Volume {
 	return corev1.Volume{
 		Name: JWTSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: callerjwt.AppJWTSecretName,
-				Optional:   boolPtr(false),
+				Optional:   boolPtr(true),
 			},
 		},
 	}

--- a/framework/app-service/pkg/gateway/meshinagent/container_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/container_test.go
@@ -1,0 +1,95 @@
+package meshinagent
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestIptablesInitScriptEveryRedirectHasDestination(t *testing.T) {
+	script := IptablesInitScript()
+	lines := strings.Split(script, "\n")
+	redirectRe := regexp.MustCompile(`-j\s+REDIRECT`)
+	destRe := regexp.MustCompile(`-d\s+"\$ip"`)
+	var redirectLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if redirectRe.MatchString(trimmed) {
+			redirectLines = append(redirectLines, trimmed)
+			if !destRe.MatchString(trimmed) {
+				t.Fatalf("REDIRECT without -d: %s", trimmed)
+			}
+		}
+	}
+	if len(redirectLines) < 2 {
+		t.Fatalf("expected at least 80 and 443 REDIRECT lines, got %d", len(redirectLines))
+	}
+	has80, has443 := false, false
+	for _, line := range redirectLines {
+		if strings.Contains(line, "--dport 80") {
+			has80 = true
+		}
+		if strings.Contains(line, "--dport 443") {
+			has443 = true
+		}
+	}
+	if !has80 || !has443 {
+		t.Fatalf("missing dport coverage: 80=%v 443=%v lines=%v", has80, has443, redirectLines)
+	}
+}
+
+func TestIptablesInitScriptEnvPreferredAndFailOpen(t *testing.T) {
+	script := IptablesInitScript()
+	for _, want := range []string{
+		`MESH_IN_AGENT_GATEWAY_IPS`,
+		`using gateway IPs from env`,
+		`continuing without redirects`,
+		`exit 0`,
+		`attempt=1`,
+		`while [ "$attempt" -le 3 ]`,
+		`for ip in $GW_IPS`,
+		`--dport 443`,
+		`-d "$ip"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q", want)
+		}
+	}
+	if strings.Contains(script, "*:443") {
+		t.Fatal("must not log blanket *:443")
+	}
+	if strings.Contains(script, "app-gateway-data.app-gateway.svc") {
+		t.Fatal("must only resolve app-gateway-data from os-gateway")
+	}
+	if strings.Contains(script, "exit 1") {
+		t.Fatal("resolve failure must not exit 1")
+	}
+	// No REDIRECT line may omit -d (guard against future port additions).
+	for _, line := range strings.Split(script, "\n") {
+		if strings.Contains(line, "-j REDIRECT") && !strings.Contains(line, `-d "$ip"`) {
+			t.Fatalf("AC-2: REDIRECT without destination: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+func TestInitContainerSpecWithGatewayIPs(t *testing.T) {
+	c := InitContainerSpecWithGatewayIPs("10.96.0.10,10.96.0.11")
+	found := false
+	for _, e := range c.Env {
+		if e.Name == GatewayIPsEnv {
+			found = true
+			if e.Value != "10.96.0.10,10.96.0.11" {
+				t.Fatalf("GatewayIPsEnv = %q", e.Value)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected MESH_IN_AGENT_GATEWAY_IPS env")
+	}
+	empty := InitContainerSpec()
+	for _, e := range empty.Env {
+		if e.Name == GatewayIPsEnv {
+			t.Fatal("empty InitContainerSpec must omit GatewayIPsEnv")
+		}
+	}
+}

--- a/framework/app-service/pkg/gateway/meshinagent/eligible.go
+++ b/framework/app-service/pkg/gateway/meshinagent/eligible.go
@@ -20,6 +20,13 @@ const (
 	// DefaultGatewayHost is the Shared HTTP data-plane Service (namespace os-gateway).
 	DefaultGatewayHost = "app-gateway-data.os-gateway.svc"
 
+	// GatewayIPsEnv carries comma/space-separated gateway data-plane ClusterIPs
+	// injected by admission (preferred over in-pod DNS for iptables -d).
+	GatewayIPsEnv = "MESH_IN_AGENT_GATEWAY_IPS"
+
+	// GatewayDataServiceName is the ClusterIP Service for Shared HTTP/HTTPS data plane.
+	GatewayDataServiceName = "app-gateway-data"
+
 	// FailClosedEnv tells the agent to reject traffic when no valid JWT is present.
 	FailClosedEnv = "MESH_IN_AGENT_FAIL_CLOSED"
 

--- a/framework/app-service/pkg/gateway/meshinagent/eligible.go
+++ b/framework/app-service/pkg/gateway/meshinagent/eligible.go
@@ -38,24 +38,12 @@ func ApplicationDeclaresSharedAccess(app *appv1alpha1.Application) bool {
 }
 
 // ShouldInject reports whether the mesh-in agent may be considered for a pod.
-// Shared apps inject only with decide=true or named callee refs; needsSharedAccess
-// alone is not enough. Ordinary apps may still inject via Decide when there are
-// no named callees. Entrance vs outbound gating uses AllowOutboundMeshIn.
+// Injection follows only persisted decide / named callee facts (DeclaresSharedCaller).
+// Live Decide eligibility is no longer evaluated here; the controller persists
+// decide via ApplyDecide. isSharedApp is retained for admission call sites.
 func ShouldInject(app *appv1alpha1.Application, isSharedApp bool) bool {
-	if app == nil {
-		return false
-	}
-	if isSharedApp {
-		return DeclaresSharedCaller(app.Spec.Settings)
-	}
-	if DeclaresSharedCaller(app.Spec.Settings) {
-		return true
-	}
-	name := strings.TrimSpace(app.Spec.Name)
-	if name == "" {
-		name = app.Name
-	}
-	return Decide(name, app.Spec.Settings, DefaultRules(), false).Inject
+	_ = isSharedApp
+	return ApplicationDeclaresSharedAccess(app)
 }
 
 // AllowOutboundMeshIn reports whether a pod that already passed ShouldInject

--- a/framework/app-service/pkg/gateway/meshinagent/eligible_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/eligible_test.go
@@ -76,8 +76,9 @@ func TestShouldInjectMeshInAgent(t *testing.T) {
 			Settings: map[string]string{SettingNeedsSharedAccess: "true"},
 		},
 	}
-	if !ShouldInject(needsAccessOnly, false) {
-		t.Fatal("ordinary app with needsSharedAccess and no named callees must inject")
+	// Live Decide eligibility removed: needsSharedAccess alone is not persisted decide.
+	if ShouldInject(needsAccessOnly, false) {
+		t.Fatal("ordinary app with needsSharedAccess alone must not inject without decide")
 	}
 	consumer := &appv1alpha1.Application{
 		Spec: appv1alpha1.ApplicationSpec{
@@ -105,6 +106,22 @@ func TestShouldInjectMeshInAgent(t *testing.T) {
 	}
 	if !ShouldInject(sharedDecide, true) {
 		t.Fatal("shared app with decide=true must inject")
+	}
+	ordinaryDecide := &appv1alpha1.Application{
+		Spec: appv1alpha1.ApplicationSpec{
+			Settings: map[string]string{AnnotDecide: "true", AnnotDecideSource: DecideSourceEligibility},
+		},
+	}
+	if !ShouldInject(ordinaryDecide, false) {
+		t.Fatal("ordinary app with persisted decide=true must inject")
+	}
+	sharedPureCallee := &appv1alpha1.Application{
+		Spec: appv1alpha1.ApplicationSpec{
+			Settings: map[string]string{AnnotDecide: "false"},
+		},
+	}
+	if ShouldInject(sharedPureCallee, true) {
+		t.Fatal("shared pure callee with decide=false must not inject")
 	}
 	if ShouldInject(nil, false) {
 		t.Fatal("nil app must not inject")

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -197,8 +197,8 @@ func TestJWTSecretVolumeUsesCallerJWT(t *testing.T) {
 	if v.Secret.SecretName != callerjwt.AppJWTSecretName {
 		t.Fatalf("secretName = %q, want %q", v.Secret.SecretName, callerjwt.AppJWTSecretName)
 	}
-	if v.Secret.Optional == nil || *v.Secret.Optional {
-		t.Fatal("caller-jwt mount must be required (fail closed)")
+	if v.Secret.Optional == nil || !*v.Secret.Optional {
+		t.Fatal("caller-jwt mount must be optional (Pod start); fail-closed via njs authDeny")
 	}
 }
 

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -172,12 +172,13 @@ func TestInitContainerSpec(t *testing.T) {
 	script := strings.Join(c.Command, " ")
 	for _, want := range []string{
 		"iptables", "-I OUTPUT", "--dport 80", "REDIRECT", "16080", "os-gateway",
-		"--dport 443", "16443",
+		"--dport 443", "16443", `-d "$ip"`,
 		`NGINX_UID="1651"`,
 		`LINKERD_UID="2102"`,
 		`ENVOY_UID="1555"`,
 		"! --uid-owner $NGINX_UID",
 		"! --uid-owner $LINKERD_UID",
+		"exit 0",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("init script missing %q in %#v", want, c.Command)
@@ -186,6 +187,9 @@ func TestInitContainerSpec(t *testing.T) {
 	if strings.Contains(script, `--uid-owner "$NGINX_UID" -j RETURN`) ||
 		strings.Contains(script, `--uid-owner $NGINX_UID -j RETURN`) {
 		t.Fatal("must not install blanket uid RETURN (blocks Linkerd mTLS)")
+	}
+	if strings.Contains(script, "*:443") {
+		t.Fatal("must not advertise blanket *:443 redirect")
 	}
 }
 

--- a/framework/app-service/pkg/webhook/resolve_shared_flags_test.go
+++ b/framework/app-service/pkg/webhook/resolve_shared_flags_test.go
@@ -1,0 +1,116 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResolveSharedFlags(t *testing.T) {
+	mgr := &v1alpha1.ApplicationManager{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine"},
+		Spec:       v1alpha1.ApplicationManagerSpec{AppName: "engine"},
+	}
+	mgrLabeled := mgr.DeepCopy()
+	mgrLabeled.Labels = map[string]string{constants.AppSharedLabel: constants.AppSharedTrue}
+
+	cases := []struct {
+		name            string
+		ns              *corev1.Namespace
+		mgr             *v1alpha1.ApplicationManager
+		wantShared      bool
+		wantSharedApp   bool
+	}{
+		{
+			name: "v3 shared ns: app-shared without applications name label",
+			ns: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: "engine-shared",
+				Labels: map[string]string{
+					constants.AppSharedLabel: constants.AppSharedTrue,
+				},
+			}},
+			mgr:           mgr,
+			wantShared:    false,
+			wantSharedApp: true,
+		},
+		{
+			name: "v2 shared ns: ns-shared + name label",
+			ns: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: "engine-shared",
+				Labels: map[string]string{
+					"bytetrade.io/ns-shared":       "true",
+					constants.ApplicationNameLabel: "engine",
+				},
+			}},
+			mgr:           mgr,
+			wantShared:    true,
+			wantSharedApp: true,
+		},
+		{
+			name: "manager app-shared label alone",
+			ns: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name:   "engine-shared",
+				Labels: map[string]string{},
+			}},
+			mgr:           mgrLabeled,
+			wantShared:    false,
+			wantSharedApp: true,
+		},
+		{
+			name: "ordinary ns",
+			ns: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: "user-app",
+				Labels: map[string]string{
+					constants.ApplicationNameLabel: "chat",
+				},
+			}},
+			mgr: &v1alpha1.ApplicationManager{
+				Spec: v1alpha1.ApplicationManagerSpec{AppName: "chat"},
+			},
+			wantShared:    false,
+			wantSharedApp: false,
+		},
+		{
+			name:          "nil inputs",
+			ns:            nil,
+			mgr:           nil,
+			wantShared:    false,
+			wantSharedApp: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotShared, gotApp := resolveSharedFlags(tc.ns, tc.mgr)
+			if gotShared != tc.wantShared || gotApp != tc.wantSharedApp {
+				t.Fatalf("resolveSharedFlags() = (%v,%v), want (%v,%v)",
+					gotShared, gotApp, tc.wantShared, tc.wantSharedApp)
+			}
+		})
+	}
+}
+
+// TestLegacyIsSharedIndependentOfSharedApp documents AC-8: mesh-in uses isSharedApp
+// while ws/upload/oes/mesh-out/appkey keep reading legacy isShared. For a v3 shared
+// NS the two flags diverge; callers must not swap them.
+func TestLegacyIsSharedIndependentOfSharedApp(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "vllm-shared",
+		Labels: map[string]string{
+			constants.AppSharedLabel: constants.AppSharedTrue,
+			// no applications.app.bytetrade.io/name → legacy isShared stays false
+		},
+	}}
+	mgr := &v1alpha1.ApplicationManager{
+		Spec: v1alpha1.ApplicationManagerSpec{AppName: "vllm"},
+	}
+	isShared, isSharedApp := resolveSharedFlags(ns, mgr)
+	if isShared {
+		t.Fatal("legacy isShared must stay false for v3 shared without name label")
+	}
+	if !isSharedApp {
+		t.Fatal("isSharedApp must be true from app-shared label")
+	}
+}

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -270,7 +270,8 @@ func (wh *Webhook) CreatePatch(
 				meshinagent.CertsVolumeForViewer(viewer),
 				meshinagent.SharedHostsVolume(),
 			)
-			pod.Spec.InitContainers = append(pod.Spec.InitContainers, meshinagent.InitContainerSpec())
+			gatewayIPs := wh.lookupMeshInGatewayIPs(ctx)
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, meshinagent.InitContainerSpecWithGatewayIPs(gatewayIPs))
 			pod.Spec.Containers = append(pod.Spec.Containers, meshinagent.ContainerSpec())
 			// ARCH S6: mesh-in and linkerd-proxy share the same admission predicate.
 			if mesh.ShouldInjectLinkerdProxy(injectMeshInAgent) {
@@ -572,6 +573,30 @@ func (wh *Webhook) shouldInjectMeshInAgent(ctx context.Context, appConfig *appcf
 	}
 	declaresSharedCaller = meshinagent.DeclaresSharedCaller(app.Spec.Settings)
 	return meshinagent.ShouldInject(app, isSharedApp), declaresSharedCaller, nil
+}
+
+// lookupMeshInGatewayIPs returns the app-gateway-data ClusterIP for iptables -d.
+// Empty means init falls back to the os-gateway Service DNS name.
+func (wh *Webhook) lookupMeshInGatewayIPs(ctx context.Context) string {
+	if wh == nil || wh.kubeClient == nil {
+		return ""
+	}
+	ns := security.AppGatewayNamespace
+	svc, err := wh.kubeClient.CoreV1().Services(ns).Get(ctx, meshinagent.GatewayDataServiceName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Warningf("mesh-in: get %s/%s: %v", ns, meshinagent.GatewayDataServiceName, err)
+		}
+		klog.Warningf("mesh-in: gateway ClusterIP unavailable; iptables init will fall back to DNS")
+		return ""
+	}
+	ip := strings.TrimSpace(svc.Spec.ClusterIP)
+	if ip == "" || ip == corev1.ClusterIPNone {
+		klog.Warningf("mesh-in: %s/%s has no ClusterIP; iptables init will fall back to DNS", ns, meshinagent.GatewayDataServiceName)
+		return ""
+	}
+	klog.V(4).Infof("mesh-in: gateway ClusterIP %s from %s/%s", ip, ns, meshinagent.GatewayDataServiceName)
+	return ip
 }
 
 // isSharedEntranceWorkload reports whether the pod is a Shared entrance (callee

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -86,10 +86,10 @@ func New(config *rest.Config) (*Webhook, error) {
 }
 
 // GetAppConfig get app config by namespace.
-func (wh *Webhook) GetAppConfig(namespace string) (appMgr *v1alpha1.ApplicationManager, appConfig *appcfg.ApplicationConfig, isShared bool, err error) {
+func (wh *Webhook) GetAppConfig(namespace string) (appMgr *v1alpha1.ApplicationManager, appConfig *appcfg.ApplicationConfig, isShared, isSharedApp bool, err error) {
 	list, err := wh.dynamicClient.AppV1alpha1().ApplicationManagers().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	sorted := list.Items
 	sort.Slice(sorted, func(i, j int) bool {
@@ -99,7 +99,7 @@ func (wh *Webhook) GetAppConfig(namespace string) (appMgr *v1alpha1.ApplicationM
 	ns, err := wh.kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 	if err != nil {
 		klog.Error("failed to get namespace, namespace=", namespace, " err=", err)
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 
 	refAppName := ns.Labels[constants.ApplicationNameLabel]
@@ -115,12 +115,34 @@ func (wh *Webhook) GetAppConfig(namespace string) (appMgr *v1alpha1.ApplicationM
 				(a.Spec.Type == v1alpha1.App || a.Spec.Type == v1alpha1.Middleware):
 			err = json.Unmarshal([]byte(a.Spec.Config), &appconfig)
 			if err != nil {
-				return nil, nil, false, err
+				return nil, nil, false, false, err
 			}
-			return &a, &appconfig, (sharedNamespace == "true" && a.Spec.AppName == refAppName), nil
+			// isShared keeps the legacy heuristic (ws/upload/oes/mesh-out/appkey).
+			// isSharedApp is the union source for mesh-in only (v2 heuristic + v3 labels).
+			isShared, isSharedApp = resolveSharedFlags(ns, &a)
+			return &a, &appconfig, isShared, isSharedApp, nil
 		}
 	}
-	return nil, nil, false, api.ErrApplicationManagerNotFound
+	return nil, nil, false, false, api.ErrApplicationManagerNotFound
+}
+
+// resolveSharedFlags returns legacy isShared (admission sidecars other than mesh-in)
+// and isSharedApp (mesh-in only). Union: ApplicationManager / Namespace app-shared
+// labels or the v2 ns-shared + name-label heuristic.
+func resolveSharedFlags(ns *corev1.Namespace, mgr *v1alpha1.ApplicationManager) (isShared, isSharedApp bool) {
+	if ns == nil || mgr == nil {
+		return false, false
+	}
+	refAppName := ""
+	if ns.Labels != nil {
+		refAppName = ns.Labels[constants.ApplicationNameLabel]
+	}
+	sharedNamespace := ""
+	if ns.Labels != nil {
+		sharedNamespace = ns.Labels["bytetrade.io/ns-shared"]
+	}
+	legacyShared := sharedNamespace == "true" && mgr.Spec.AppName == refAppName
+	return legacyShared, appcfg.IsShared(mgr) || appcfg.IsShared(ns) || legacyShared
 }
 
 // GetAdmissionRequestBody returns admission request body.
@@ -420,7 +442,8 @@ func (wh *Webhook) MustInject(ctx context.Context, pod *corev1.Pod, namespace st
 		return
 	}
 
-	appMgr, appConfig, isShared, err = wh.GetAppConfig(namespace)
+	var isSharedApp bool
+	appMgr, appConfig, isShared, isSharedApp, err = wh.GetAppConfig(namespace)
 	if err != nil {
 		if errors.Is(err, api.ErrApplicationManagerNotFound) {
 			err = nil
@@ -511,7 +534,7 @@ func (wh *Webhook) MustInject(ctx context.Context, pod *corev1.Pod, namespace st
 	}
 
 	var declaresSharedCaller bool
-	injectMeshInAgent, declaresSharedCaller, err = wh.shouldInjectMeshInAgent(ctx, appConfig, namespace, isShared)
+	injectMeshInAgent, declaresSharedCaller, err = wh.shouldInjectMeshInAgent(ctx, appConfig, namespace, isSharedApp)
 	if err != nil {
 		return false, false, false, false, false, nil, perms, nil, nil, err
 	}
@@ -532,7 +555,7 @@ func applyOutboundMeshInGate(injectMeshInAgent, isEntrancePod, declaresSharedCal
 	return true
 }
 
-func (wh *Webhook) shouldInjectMeshInAgent(ctx context.Context, appConfig *appcfg.ApplicationConfig, ns string, isShared bool) (inject bool, declaresSharedCaller bool, err error) {
+func (wh *Webhook) shouldInjectMeshInAgent(ctx context.Context, appConfig *appcfg.ApplicationConfig, ns string, isSharedApp bool) (inject bool, declaresSharedCaller bool, err error) {
 	if appConfig == nil {
 		return false, false, nil
 	}
@@ -548,7 +571,7 @@ func (wh *Webhook) shouldInjectMeshInAgent(ctx context.Context, appConfig *appcf
 		return false, false, err
 	}
 	declaresSharedCaller = meshinagent.DeclaresSharedCaller(app.Spec.Settings)
-	return meshinagent.ShouldInject(app, isShared), declaresSharedCaller, nil
+	return meshinagent.ShouldInject(app, isSharedApp), declaresSharedCaller, nil
 }
 
 // isSharedEntranceWorkload reports whether the pod is a Shared entrance (callee
@@ -917,7 +940,7 @@ func (wh *Webhook) getAppKeySecret(namespace string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	_, appConfig, isShared, err := wh.GetAppConfig(namespace)
+	_, appConfig, isShared, _, err := wh.GetAppConfig(namespace)
 	if err != nil {
 		klog.Errorf("Failed to get app config err=%v", err)
 		return "", "", err

--- a/framework/app-service/pkg/webhook/webhook_mesh_in_gateway_ips_test.go
+++ b/framework/app-service/pkg/webhook/webhook_mesh_in_gateway_ips_test.go
@@ -1,0 +1,49 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/gateway/meshinagent"
+	"github.com/beclab/Olares/framework/app-service/pkg/security"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestLookupMeshInGatewayIPsUsesOsGateway(t *testing.T) {
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: meshinagent.GatewayDataServiceName, Namespace: security.AppGatewayNamespace},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.233.5.10"},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: meshinagent.GatewayDataServiceName, Namespace: "app-gateway"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.233.9.9"},
+		},
+	)}
+	got := wh.lookupMeshInGatewayIPs(context.Background())
+	if got != "10.233.5.10" {
+		t.Fatalf("got %q, want os-gateway ClusterIP", got)
+	}
+}
+
+func TestLookupMeshInGatewayIPsIgnoresLegacyNamespace(t *testing.T) {
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: meshinagent.GatewayDataServiceName, Namespace: "app-gateway"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.233.9.9"},
+		},
+	)}
+	got := wh.lookupMeshInGatewayIPs(context.Background())
+	if got != "" {
+		t.Fatalf("got %q, want empty when os-gateway Service is absent", got)
+	}
+}
+
+func TestLookupMeshInGatewayIPsEmptyWhenMissing(t *testing.T) {
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset()}
+	if got := wh.lookupMeshInGatewayIPs(context.Background()); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Issue caller-jwt for all Shared apps (`app-shared` label).
- Limit mesh-in 443 redirect to gateway IP; log empty SNI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes outbound traffic redirection, Shared JWT issuance, and mesh-in injection gates across admission and gateway paths—misconfiguration could break Shared calls or widen JWT exposure if appid validation fails in production.
> 
> **Overview**
> Bumps **app-service** to `0.6.12` and tightens Shared gateway / mesh-in behavior.
> 
> **Caller JWT:** Every Shared app (`app-shared`) now gets a caller-jwt Secret—`shared-caller-decide`, mesh-inject opt-out, and pure callees no longer skip issuance. Missing `spec.appid` on Shared apps fails reconcile with logging and `olares_caller_jwt_issue_fail_total`. The JWT volume mount is **optional** so pods still start; allowlisted hosts stay fail-closed via njs `authDeny`.
> 
> **Admission / shared detection:** `GetAppConfig` returns legacy `isShared` (ws/upload/oes/mesh-out/appkey) and **`isSharedApp`** (v2 + v3 labels) used only for mesh-in. Mesh-in inject eligibility follows persisted decide / named callees only—not live `Decide` on `needsSharedAccess` alone.
> 
> **Mesh-in iptables & HTTPS:** Init installs OUTPUT REDIRECT for gateway **:80 and :443** only when `-d` is pinned to `app-gateway-data` ClusterIP(s) from `os-gateway` (env snapshot at admit, else DNS with retries). Blanket `*:443` redirect is removed; unresolved gateway **exits 0** so workloads are not blocked. njs `decideOffload` logs when hijacked 443 has no SNI (original destination lost under REDIRECT).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64cd0e1b183e027bc9be312d6626e50c927b0328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->