### PR TITLE
feat(market): serve stored chart packages from GET /apps/{id}/package

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -133,7 +133,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.82
+        image: beclab/market-backend:v0.6.83
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
serve stored chart packages from GET /apps/{id}/package, ticket bug fixs

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/398
https://github.com/beclab/market/pull/397


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest logic changes; risk depends on the backend release in v0.6.83 rather than this repo diff.
> 
> **Overview**
> **Bumps the appstore backend container image** in the market cluster deployment from `beclab/market-backend:v0.6.82` to `v0.6.83`.
> 
> This is a rollout-only change in `market_deploy.yaml`; no env, volume, or routing config is modified here. The new image is intended to ship market backend fixes (including serving stored chart packages from `GET /apps/{id}/package`, per the linked market PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0897495fb87caca1e47df2f54c5badf953f6a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->