### PR TITLE
chore(cli): add upgrader for mainline version 1.12.7

### DIFF
--- a/cli/pkg/upgrade/1_12_7.go
+++ b/cli/pkg/upgrade/1_12_7.go
@@ -1,0 +1,50 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/certs"
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/version"
+)
+
+var version_1_12_7 = semver.MustParse("1.12.7")
+
+type upgrader_1_12_7 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7) Version() *semver.Version {
+	cliVersion, err := semver.NewVersion(version.VERSION)
+	if err != nil {
+		return version_1_12_7
+	}
+	if samePatchLevelVersion(version_1_12_7, cliVersion) && getReleaseLineOfVersion(cliVersion) == mainLine {
+		return cliVersion
+	}
+	return version_1_12_7
+}
+
+func (u upgrader_1_12_7) AddedBreakingChange() bool {
+	if u.Version().Equal(version_1_12_7) {
+		return true
+	}
+	return false
+}
+
+func (u upgrader_1_12_7) PrepareForUpgrade() []task.Interface {
+	tasks := make([]task.Interface, 0)
+	tasks = append(tasks, migrateContainerdConfigV3()...)
+	tasks = append(tasks, &task.LocalTask{
+		Name:    "CleanupK3sCertsRenewService",
+		Prepare: new(common.OnlyK3s),
+		Action:  new(certs.UninstallAutoRenewCerts),
+	})
+
+	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+	return tasks
+}
+
+func init() {
+	registerMainUpgrader(upgrader_1_12_7{})
+}


### PR DESCRIPTION
* **Background**
Add upgrader for 1.12.7, excluding the upgrade tasks in 1.12.7 daily line that's already merged into 1.12.6

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade-time changes restart containerd and remove K3s cert renewal automation, which can briefly disrupt workloads and cert lifecycle on K3s clusters if mis-timed.
> 
> **Overview**
> Registers a **mainline 1.12.7** upgrade hook that marks the release as a breaking change and wires two pre-upgrade steps before the shared upgrade task chain.
> 
> On upgrade to 1.12.7, clusters run **containerd config v3 migration** (regenerate config and restart containerd), then on **K3s-only** nodes remove the **auto-renew certs** systemd service via `UninstallAutoRenewCerts`. Everything else defers to the existing `upgraderBase` prepare tasks—aligned with keeping 1.12.7 daily-line work that already landed in 1.12.6 out of this mainline upgrader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73999a019010e60d7e280db3f22c771018f493c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->