### PR TITLE
feat(app-service): fail fast on unrecoverable pods during install/upgrade/resume and add mount error check

### DIFF
--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -17,6 +17,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/errcode"
 	"github.com/beclab/Olares/framework/app-service/pkg/helm"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
+	"github.com/beclab/Olares/framework/app-service/pkg/podhealth"
 	"github.com/beclab/Olares/framework/app-service/pkg/tapr"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
@@ -629,11 +630,11 @@ func (h *HelmOps) WaitForStartUp() (bool, error) {
 		return true, nil
 	}
 	timer := time.NewTicker(1 * time.Second)
-	// unrecoverableSince records when an unrecoverable pod condition was first
-	// observed while the app is still not started. Once it persists past
-	// unrecoverableGrace, startup fails fast instead of polling until the outer
-	// installing TTL expires (which left CrashLoopBackOff apps stuck ~30m).
-	var unrecoverableSince time.Time
+	// health fast-fails startup once a pod hits a condition that will not
+	// self-heal and it persists past that signal's grace, instead of polling
+	// until the outer installing TTL expires (which left CrashLoopBackOff apps
+	// stuck ~30m).
+	var health podhealth.GraceTracker
 	for {
 		select {
 		case <-timer.C:
@@ -651,16 +652,15 @@ func (h *HelmOps) WaitForStartUp() (bool, error) {
 				return false, err
 			}
 
-			if reason, ok := h.hasUnrecoverablePod(h.ctx); ok {
-				if unrecoverableSince.IsZero() {
-					unrecoverableSince = time.Now()
-					klog.Warningf("app %s has unrecoverable pod (%s); will fail startup if it persists for %s",
-						h.app.AppName, reason, unrecoverableGrace)
-				} else if time.Since(unrecoverableSince) > unrecoverableGrace {
-					return false, fmt.Errorf("app %s failed to start up: %s", h.app.AppName, reason)
+			if in, ok := h.podHealthInput(); ok {
+				sig, fatal, started := health.Observe(podhealth.Run(in))
+				if fatal {
+					return false, fmt.Errorf("app %s failed to start up: %s", h.app.AppName, sig.Message)
 				}
-			} else {
-				unrecoverableSince = time.Time{}
+				if started {
+					klog.Warningf("app %s pod-health signal (%s: %s); will fail startup if it persists for %s",
+						h.app.AppName, sig.Reason, sig.Message, sig.Grace)
+				}
 			}
 
 		case <-h.ctx.Done():
@@ -768,8 +768,6 @@ func (h *HelmOps) checkIfStartup(pods []corev1.Pod, isServerSide bool) (bool, er
 	if len(pods) == 0 {
 		return false, errors.New("no pod found")
 	}
-	startedPods := 0
-	totalPods := len(pods)
 	for _, pod := range pods {
 		creationTime := pod.GetCreationTimestamp()
 		pendingDuration := time.Since(creationTime.Time)
@@ -790,27 +788,8 @@ func (h *HelmOps) checkIfStartup(pods []corev1.Pod, isServerSide bool) (bool, er
 			}
 			return false, errcode.ErrPodPending
 		}
-		totalContainers := len(pod.Spec.Containers)
-		startedContainers := 0
-		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
-			container := pod.Status.ContainerStatuses[i]
-			if *container.Started {
-				startedContainers++
-				continue
-			}
-			// job-created pods with completed status are also treated as started
-			if container.State.Terminated != nil && container.State.Terminated.Reason == "Completed" {
-				startedContainers++
-			}
-		}
-		if startedContainers == totalContainers {
-			startedPods++
-		}
 	}
-	if totalPods == startedPods {
-		return true, nil
-	}
-	return false, nil
+	return podhealth.AllPodsStarted(pods), nil
 }
 
 func (h *HelmOps) getPendingKind(pod *corev1.Pod) (string, error) {
@@ -1018,11 +997,14 @@ func (h *HelmOps) WaitForLaunch() (bool, error) {
 			entranceCount++
 		}
 	}
-	// unrecoverableSince records when an unrecoverable pod condition was first
-	// observed while the entrances are still unreachable. Once it persists past
-	// unrecoverableGrace, the launch fails fast instead of polling until the
-	// outer initializing TTL (60m) expires.
-	var unrecoverableSince time.Time
+	// health fast-fails the launch on the same conditions WaitForStartUp guards
+	// against. Passing WaitForStartUp only proves the containers reported
+	// Started once; a pod that afterwards falls into CrashLoopBackOff (or is
+	// replaced by one that cannot pull its image) never opens its entrance, and
+	// without this the wait would spin until the 60m initializing TTL. Middleware
+	// installs skip WaitForStartUp entirely, so this is their only pod-health
+	// gate.
+	var health podhealth.GraceTracker
 	for {
 		select {
 		case <-timer.C:
@@ -1041,16 +1023,15 @@ func (h *HelmOps) WaitForLaunch() (bool, error) {
 				return true, nil
 			}
 
-			if reason, ok := h.hasUnrecoverablePod(h.ctx); ok {
-				if unrecoverableSince.IsZero() {
-					unrecoverableSince = time.Now()
-					klog.Warningf("app %s has unrecoverable pod (%s); will fail launch if it persists for %s",
-						h.app.AppName, reason, unrecoverableGrace)
-				} else if time.Since(unrecoverableSince) > unrecoverableGrace {
-					return false, fmt.Errorf("app %s failed to launch: %s", h.app.AppName, reason)
+			if in, ok := h.podHealthInput(); ok {
+				sig, fatal, started := health.Observe(podhealth.Run(in))
+				if fatal {
+					return false, fmt.Errorf("app %s failed to launch: %s", h.app.AppName, sig.Message)
 				}
-			} else {
-				unrecoverableSince = time.Time{}
+				if started {
+					klog.Warningf("app %s pod-health signal (%s: %s); will fail launch if it persists for %s",
+						h.app.AppName, sig.Reason, sig.Message, sig.Grace)
+				}
 			}
 
 		case <-h.ctx.Done():
@@ -1060,69 +1041,29 @@ func (h *HelmOps) WaitForLaunch() (bool, error) {
 	}
 }
 
-const (
-	// unrecoverableGrace is how long an unrecoverable pod condition must
-	// persist (while entrances remain unreachable) before WaitForLaunch
-	// gives up. It tolerates transient crashes during normal startup.
-	unrecoverableGrace = 5 * time.Minute
-	// crashLoopRestartThreshold is the minimum container restart count for a
-	// CrashLoopBackOff pod to be treated as unrecoverable. CrashLoopBackOff
-	// backoff caps at 300s, so >=5 restarts means several minutes of failing.
-	crashLoopRestartThreshold = 5
-)
-
-// hasUnrecoverablePod inspects pods in the app namespace and reports whether
-// any is in a state that will not heal on its own. It returns a human-readable
-// reason and true when such a pod is found.
-//
-// Two tiers are considered:
-//   - hard errors that never self-heal: ImagePullBackOff, ErrImagePull,
-//     InvalidImageName, CreateContainerConfigError, and Unschedulable pods.
-//   - CrashLoopBackOff with RestartCount >= crashLoopRestartThreshold, which
-//     covers a dependency that keeps crashing (e.g. due to a permission error)
-//     while avoiding false positives on slow-starting apps.
-func (h *HelmOps) hasUnrecoverablePod(ctx context.Context) (string, bool) {
-	pods, err := h.client.KubeClient.Kubernetes().CoreV1().Pods(h.app.Namespace).List(ctx, metav1.ListOptions{})
+// podHealthInput lists the pods in the app namespace and returns a
+// podhealth.Input wired with a clientset-backed event fetcher for the
+// mount-failure checker. ok is false (and the caller skips this tick's health
+// check) when listing fails, so a transient API error neither trips a false
+// positive nor resets an in-flight grace window.
+func (h *HelmOps) podHealthInput() (podhealth.Input, bool) {
+	pods, err := h.client.KubeClient.Kubernetes().CoreV1().Pods(h.app.Namespace).List(h.ctx, metav1.ListOptions{})
 	if err != nil {
-		klog.Warningf("list pods in namespace %s failed, skip unrecoverable check: %v", h.app.Namespace, err)
-		return "", false
+		klog.Warningf("list pods in namespace %s failed, skip pod-health check: %v", h.app.Namespace, err)
+		return podhealth.Input{}, false
 	}
-
-	hardErrorReasons := map[string]bool{
-		"ImagePullBackOff":           true,
-		"ErrImagePull":               true,
-		"InvalidImageName":           true,
-		"CreateContainerConfigError": true,
-	}
-
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-
-		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse &&
-				cond.Reason == corev1.PodReasonUnschedulable {
-				return fmt.Sprintf("pod %s unschedulable: %s", pod.Name, cond.Message), true
+	return podhealth.Input{
+		Pods: pods.Items,
+		FetchEvents: func(pod corev1.Pod) ([]corev1.Event, error) {
+			fieldSelector := fields.OneTermEqualSelector("involvedObject.name", pod.Name).String()
+			events, err := h.client.KubeClient.Kubernetes().CoreV1().Events(pod.Namespace).
+				List(h.ctx, metav1.ListOptions{FieldSelector: fieldSelector})
+			if err != nil {
+				return nil, err
 			}
-		}
-
-		statuses := append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
-		statuses = append(statuses, pod.Status.ContainerStatuses...)
-		for _, cs := range statuses {
-			waiting := cs.State.Waiting
-			if waiting == nil {
-				continue
-			}
-			if hardErrorReasons[waiting.Reason] {
-				return fmt.Sprintf("pod %s container %s: %s (%s)", pod.Name, cs.Name, waiting.Reason, waiting.Message), true
-			}
-			if waiting.Reason == "CrashLoopBackOff" && cs.RestartCount >= crashLoopRestartThreshold {
-				return fmt.Sprintf("pod %s container %s: CrashLoopBackOff after %d restarts (%s)",
-					pod.Name, cs.Name, cs.RestartCount, waiting.Message), true
-			}
-		}
-	}
-
-	return "", false
+			return events.Items, nil
+		},
+	}, true
 }
 
 func (h *HelmOps) App() *appcfg.ApplicationConfig {

--- a/framework/app-service/pkg/appstate/resuming_app.go
+++ b/framework/app-service/pkg/appstate/resuming_app.go
@@ -4,21 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/client-go/kubernetes"
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/appinstaller"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/podhealth"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
 	kbopv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// errUnrecoverablePod is returned by IsStartUp when a resumed app has a pod in
+// a state that will not self-heal, so poll surfaces a precise ResumeFailed
+// reason instead of the generic startup-timeout message.
+var errUnrecoverablePod = errors.New("resume aborted: unrecoverable pod")
 
 var _ OperationApp = &ResumingApp{}
 
@@ -171,9 +181,7 @@ func (p *resumingInProgressApp) WaitAsync(ctx context.Context) {
 		updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.Initializing, nil, appsv1.Initializing.String(), appsv1.Initializing.String())
 		if updateErr != nil {
 			klog.Errorf("update app manager %s to %s state failed %v", p.manager.Name, appsv1.Initializing.String(), updateErr)
-			return
 		}
-		return
 	})
 }
 
@@ -182,25 +190,63 @@ func (p *resumingInProgressApp) poll(ctx context.Context) error {
 	if p.manager.Spec.Type == appsv1.Middleware {
 		return nil
 	}
-	ok := p.IsStartUp(ctx)
-
-	if !ok {
-		isPending, err := p.stopRequested(ctx)
-		if err != nil {
-			return err
-		}
-		if isPending {
-			return errStopRequestedDueToPendingPod
-		}
-		return fmt.Errorf("wait for app %s startup failed", p.manager.Spec.AppName)
+	ok, unrecoverableErr := p.IsStartUp(ctx)
+	if ok {
+		return nil
 	}
 
-	return nil
+	// An unrecoverable pod is a definitive failure; surface its reason so
+	// WaitAsync records a precise ResumeFailed message rather than the generic
+	// startup-timeout one.
+	if unrecoverableErr != nil {
+		return unrecoverableErr
+	}
+
+	isPending, err := p.stopRequested(ctx)
+	if err != nil {
+		return err
+	}
+	if isPending {
+		return errStopRequestedDueToPendingPod
+	}
+	return fmt.Errorf("wait for app %s startup failed", p.manager.Spec.AppName)
 }
 
-func (p *resumingInProgressApp) IsStartUp(ctx context.Context) bool {
+// IsStartUp polls until the resumed app's pods have started, ctx is canceled,
+// or an unrecoverable pod condition persists past its grace window. It returns
+// (true, nil) on startup, (false, nil) on ctx cancel, and (false, err) with a
+// descriptive error when it aborts early on an unrecoverable pod.
+func (p *resumingInProgressApp) IsStartUp(ctx context.Context) (bool, error) {
 	timer := time.NewTicker(time.Second)
+	defer timer.Stop()
 	start := time.Now()
+
+	// Build a direct clientset for the (event-based) permanent mount-failure
+	// scan. Deliberately NOT the controller-runtime cache client: Events are
+	// high-churn and caching them would spin up an expensive informer.
+	kubeConfig, err := p.deps.KubeConfig()
+	if err != nil {
+		klog.Errorf("get kube config failed %v", err)
+		return false, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return false, err
+	}
+
+	// fetchEvents backs podhealth's mount-failure checker. A failing List only
+	// skips that tier for the tick; the container-status tiers still run off the
+	// cache client.
+	fetchEvents := func(pod corev1.Pod) ([]corev1.Event, error) {
+		fieldSelector := fields.OneTermEqualSelector("involvedObject.name", pod.Name).String()
+		events, err := kubeClient.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
+		if err != nil {
+			return nil, err
+		}
+		return events.Items, nil
+	}
+
+	var health podhealth.GraceTracker
 	for {
 		select {
 		case <-timer.C:
@@ -208,11 +254,26 @@ func (p *resumingInProgressApp) IsStartUp(ctx context.Context) bool {
 			klog.Infof("wait app %s pod to startup, time elapsed: %v", p.manager.Spec.AppName, time.Since(start))
 			if startedUp {
 				klog.Infof("app: %s,time: %v, appState: %v", p.manager.Spec.AppName, time.Now(), appsv1.Initializing)
-				return true
+				return true, nil
 			}
+
+			pods, err := listAppPods(p.manager, p.client)
+			if err != nil || len(pods) == 0 {
+				continue
+			}
+
+			sig, fatal, started := health.Observe(podhealth.Run(podhealth.Input{Pods: pods, FetchEvents: fetchEvents}))
+			if fatal {
+				return false, fmt.Errorf("%w: %s", errUnrecoverablePod, sig.Message)
+			}
+			if started {
+				klog.Warningf("resume %s pod-health signal (%s: %s); will fail if it persists for %s",
+					p.manager.Spec.AppName, sig.Reason, sig.Message, sig.Grace)
+			}
+
 		case <-ctx.Done():
 			klog.Infof("Waiting for app startup canceled appName=%s", p.manager.Spec.AppName)
-			return false
+			return false, nil
 		}
 	}
 }

--- a/framework/app-service/pkg/appstate/resuming_unrecoverable_test.go
+++ b/framework/app-service/pkg/appstate/resuming_unrecoverable_test.go
@@ -1,0 +1,92 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/podhealth"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+// unreachableKubeConfig yields a config that kubernetes.NewForConfig accepts
+// (non-empty Host) but whose every request fails immediately, so the
+// event-based mount tier is effectively disabled without hanging the test.
+func unreachableKubeConfig() *rest.Config {
+	return &rest.Config{Host: "https://127.0.0.1:1"}
+}
+
+func TestResume_IsStartUp_FastFailsOnUnrecoverablePod(t *testing.T) {
+	// Shorten the grace so the poll loop trips on the first detection tick.
+	oldGrace := podhealth.HardErrorGrace
+	podhealth.HardErrorGrace = 0
+	defer func() { podhealth.HardErrorGrace = oldGrace }()
+
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	dep, pod := pendingWorkload("demo", "demo-ns")
+	// Make the pod's container unrecoverable (missing ConfigMap/Secret volume
+	// surfaces as CreateContainerConfigError on the container).
+	pod.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Waiting: &corev1.ContainerStateWaiting{Reason: "CreateContainerConfigError", Message: "configmap \"x\" not found"},
+	}
+	c := newFakeClient(t, dep, pod, am)
+	deps, tf := newTestDeps(c)
+	// Unreachable apiserver: the clientset builds, but the mount tier's event
+	// List fails fast so only the container-status tier is exercised.
+	tf.kubeConfig = unreachableKubeConfig()
+
+	rp := &ResumingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+	ip := &resumingInProgressApp{
+		ResumingApp:                       rp,
+		basePollableStatefulInProgressApp: &basePollableStatefulInProgressApp{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ok, err := ip.IsStartUp(ctx)
+	if ok {
+		t.Fatal("expected IsStartUp to report not started")
+	}
+	if err == nil || !errors.Is(err, errUnrecoverablePod) {
+		t.Fatalf("expected errUnrecoverablePod, got %v", err)
+	}
+}
+
+func TestResume_IsStartUp_ReturnsOnCancelWithoutError(t *testing.T) {
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	dep, pod := pendingWorkload("demo", "demo-ns") // healthy-but-not-started
+	c := newFakeClient(t, dep, pod, am)
+	deps, tf := newTestDeps(c)
+	tf.kubeConfig = unreachableKubeConfig()
+
+	rp := &ResumingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+	ip := &resumingInProgressApp{
+		ResumingApp:                       rp,
+		basePollableStatefulInProgressApp: &basePollableStatefulInProgressApp{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	ok, err := ip.IsStartUp(ctx)
+	if ok {
+		t.Fatal("expected not started")
+	}
+	if err != nil {
+		t.Fatalf("expected nil error on ctx cancel, got %v", err)
+	}
+}

--- a/framework/app-service/pkg/appstate/testutil_test.go
+++ b/framework/app-service/pkg/appstate/testutil_test.go
@@ -143,6 +143,12 @@ type testFakes struct {
 	kubeConfigErr error
 	newHelmOpsErr error
 
+	// kubeConfig overrides what the KubeConfig seam returns. Needed by tests
+	// whose code path builds a real clientset (kubernetes.NewForConfig rejects a
+	// config with an empty Host); point it at an unreachable host so the
+	// clientset is constructible but every request fails fast.
+	kubeConfig *rest.Config
+
 	// resolveRefs overrides ResolveImageRefs; nil means "return no refs".
 	resolveRefs func(ctx context.Context, am *appv1alpha1.ApplicationManager, cfg *appcfg.ApplicationConfig) ([]appv1alpha1.Ref, error)
 
@@ -167,6 +173,9 @@ func newTestDeps(c client.Client) (Deps, *testFakes) {
 		KubeConfig: func() (*rest.Config, error) {
 			if tf.kubeConfigErr != nil {
 				return nil, tf.kubeConfigErr
+			}
+			if tf.kubeConfig != nil {
+				return tf.kubeConfig, nil
 			}
 			return &rest.Config{}, nil
 		},

--- a/framework/app-service/pkg/appstate/utils.go
+++ b/framework/app-service/pkg/appstate/utils.go
@@ -6,15 +6,14 @@ import (
 	"fmt"
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/podhealth"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -195,52 +194,25 @@ func resumeV2AppAll(ctx context.Context, cli client.Client, am *appv1alpha1.Appl
 	return suspendOrResumeApp(ctx, cli, am, 1, true)
 }
 
-func isStartUp(am *appv1alpha1.ApplicationManager, cli client.Client) (bool, error) {
-	var labelSelector string
-	var deployment appsv1.Deployment
-
-	err := cli.Get(context.TODO(), types.NamespacedName{Name: am.Spec.AppName, Namespace: am.Spec.AppNamespace}, &deployment)
-
-	if err == nil {
-		labelSelector = metav1.FormatLabelSelector(deployment.Spec.Selector)
-	}
-
-	if apierrors.IsNotFound(err) {
-		var sts appsv1.StatefulSet
-		err = cli.Get(context.TODO(), types.NamespacedName{Name: am.Spec.AppName, Namespace: am.Spec.AppNamespace}, &sts)
-		if err != nil {
-			return false, err
-
-		}
-		labelSelector = metav1.FormatLabelSelector(sts.Spec.Selector)
-	}
+// listAppPods returns every pod in the app's namespace. Olares gives each app
+// its own namespace
+func listAppPods(am *appv1alpha1.ApplicationManager, cli client.Client) ([]corev1.Pod, error) {
 	var pods corev1.PodList
-	//pods, err := h.client.KubeClient.Kubernetes().CoreV1().Pods(h.app.Namespace).
-	//	List(h.ctx, metav1.ListOptions{LabelSelector: labelSelector})
-	selector, _ := labels.Parse(labelSelector)
-	err = cli.List(context.TODO(), &pods, &client.ListOptions{Namespace: am.Spec.AppNamespace, LabelSelector: selector})
-	if len(pods.Items) == 0 {
+	if err := cli.List(context.TODO(), &pods, client.InNamespace(am.Spec.AppNamespace)); err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+func isStartUp(am *appv1alpha1.ApplicationManager, cli client.Client) (bool, error) {
+	pods, err := listAppPods(am, cli)
+	if err != nil {
+		return false, err
+	}
+	if len(pods) == 0 {
 		return false, errors.New("no pod found..")
 	}
-	for _, pod := range pods.Items {
-		totalContainers := len(pod.Spec.Containers)
-		startedContainers := 0
-		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
-			container := pod.Status.ContainerStatuses[i]
-			if *container.Started == true {
-				startedContainers++
-				continue
-			}
-			// job-created pods with completed status are also treated as started
-			if container.State.Terminated != nil && container.State.Terminated.Reason == "Completed" {
-				startedContainers++
-			}
-		}
-		if startedContainers == totalContainers {
-			return true, nil
-		}
-	}
-	return false, nil
+	return podhealth.AllPodsStarted(pods), nil
 }
 
 func makeRecord(am *appv1alpha1.ApplicationManager, status appv1alpha1.ApplicationManagerState, message string) *appv1alpha1.OpRecord {

--- a/framework/app-service/pkg/podhealth/checkers.go
+++ b/framework/app-service/pkg/podhealth/checkers.go
@@ -1,0 +1,272 @@
+package podhealth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// DefaultCheckers is the canonical detection chain, ordered cheapest/most
+// actionable first. To add a new detection, implement Checker and append it
+// here (and, if it needs data beyond Pods, extend Input).
+func DefaultCheckers() []Checker {
+	return []Checker{
+		unschedulableChecker{},
+		containerWaitingChecker{},
+		crashLoopChecker{},
+		permanentMountChecker{},
+	}
+}
+
+// hardWaitingReasons maps a container waiting reason that never self-heals to
+// the Signal reason code we surface. These are terminal misconfigurations
+// (unpullable/bad image reference, unresolvable container config) that will not
+// recover without a spec change.
+var hardWaitingReasons = map[string]string{
+	"ImagePullBackOff":           ReasonImagePull,
+	"ErrImagePull":               ReasonImagePull,
+	"InvalidImageName":           ReasonImagePull,
+	"CreateContainerConfigError": ReasonContainerConfig,
+	"CreateContainerError":       ReasonContainerConfig,
+	"RunContainerError":          ReasonContainerConfig,
+}
+
+// unschedulableChecker flags pods the scheduler has rejected (PodScheduled
+// False / Unschedulable), e.g. no node satisfies the resource request or
+// affinity/taint constraints.
+type unschedulableChecker struct{}
+
+func (unschedulableChecker) Name() string { return "unschedulable" }
+
+func (unschedulableChecker) Check(in Input) (Signal, bool) {
+	for i := range in.Pods {
+		pod := &in.Pods[i]
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse &&
+				cond.Reason == corev1.PodReasonUnschedulable {
+				return Signal{
+					Reason:  ReasonUnschedulable,
+					Message: fmt.Sprintf("pod %s unschedulable: %s", pod.Name, cond.Message),
+					Grace:   HardErrorGrace,
+				}, true
+			}
+		}
+	}
+	return Signal{}, false
+}
+
+// containerWaitingChecker flags containers stuck in a hard waiting reason (see
+// hardWaitingReasons), covering both init and regular containers.
+type containerWaitingChecker struct{}
+
+func (containerWaitingChecker) Name() string { return "container-waiting" }
+
+func (containerWaitingChecker) Check(in Input) (Signal, bool) {
+	for i := range in.Pods {
+		pod := &in.Pods[i]
+		for _, cs := range allContainerStatuses(pod) {
+			waiting := cs.State.Waiting
+			if waiting == nil {
+				continue
+			}
+			if code, ok := hardWaitingReasons[waiting.Reason]; ok {
+				return Signal{
+					Reason:  code,
+					Message: fmt.Sprintf("pod %s container %s: %s (%s)", pod.Name, cs.Name, waiting.Reason, waiting.Message),
+					Grace:   HardErrorGrace,
+				}, true
+			}
+		}
+	}
+	return Signal{}, false
+}
+
+// crashLoopChecker flags containers in CrashLoopBackOff that have restarted at
+// least CrashLoopRestartThreshold times, which distinguishes a persistently
+// failing dependency from a slow first start.
+type crashLoopChecker struct{}
+
+func (crashLoopChecker) Name() string { return "crashloop" }
+
+func (crashLoopChecker) Check(in Input) (Signal, bool) {
+	for i := range in.Pods {
+		pod := &in.Pods[i]
+		for _, cs := range allContainerStatuses(pod) {
+			waiting := cs.State.Waiting
+			if waiting == nil {
+				continue
+			}
+			if waiting.Reason == "CrashLoopBackOff" && cs.RestartCount >= in.CrashLoopRestartThreshold {
+				return Signal{
+					Reason: ReasonCrashLoop,
+					Message: fmt.Sprintf("pod %s container %s: CrashLoopBackOff after %d restarts (%s)",
+						pod.Name, cs.Name, cs.RestartCount, waiting.Message),
+					Grace: HardErrorGrace,
+				}, true
+			}
+		}
+	}
+	return Signal{}, false
+}
+
+// permanentMountChecker flags a deterministic, non-self-healing FailedMount
+// (missing Secret/ConfigMap volume, bad subPath, hostPath type check). These
+// never surface as a container waiting reason, so they are invisible to the
+// pod-status checkers and must be read from events. It only scans pods that have
+// not started any container yet (see podBlockedBeforeStart) and is a no-op when
+// Input.FetchEvents is nil.
+type permanentMountChecker struct{}
+
+func (permanentMountChecker) Name() string { return "permanent-mount" }
+
+func (permanentMountChecker) Check(in Input) (Signal, bool) {
+	if in.FetchEvents == nil {
+		return Signal{}, false
+	}
+	var graced *Signal
+	for i := range in.Pods {
+		pod := in.Pods[i]
+		if !podBlockedBeforeStart(pod) {
+			continue
+		}
+		events, err := in.FetchEvents(pod)
+		if err != nil {
+			klog.Warningf("podhealth: fetch events for pod %s failed, skip mount-failure check: %v", pod.Name, err)
+			continue
+		}
+		klog.V(4).Infof("podhealth: scanning %d events of pod %s for mount failures", len(events), pod.Name)
+		reason, kind, ok := scanPermanentMountFailure(events, in.Now, in.MountEventRecency)
+		if !ok {
+			continue
+		}
+		klog.V(4).Infof("podhealth: pod %s permanent mount failure (kind=%d): %s", pod.Name, kind, reason)
+		// Immediate failures win outright (no create-race window); keep the
+		// first graced hit as a fallback in case no immediate one shows up.
+		if kind == mountImmediate {
+			return Signal{Reason: ReasonPermanentMount, Message: reason, Grace: 0}, true
+		}
+		if graced == nil {
+			sig := Signal{Reason: ReasonPermanentMount, Message: reason, Grace: MountFailureGrace}
+			graced = &sig
+		}
+	}
+	if graced != nil {
+		return *graced, true
+	}
+	return Signal{}, false
+}
+
+// allContainerStatuses returns init + regular container statuses so callers
+// treat a failing init container the same as a failing app container.
+func allContainerStatuses(pod *corev1.Pod) []corev1.ContainerStatus {
+	statuses := append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
+	return append(statuses, pod.Status.ContainerStatuses...)
+}
+
+// podBlockedBeforeStart reports whether the pod is still Pending with no
+// container having started, which is the only window in which a FailedMount can
+// be the reason it is stuck. It gates the (relatively expensive) per-pod event
+// scan to pods that could plausibly be hitting a mount failure.
+//
+// It deliberately does not key off a specific waiting reason: kubelet reports
+// "ContainerCreating" for a plain pod but "PodInitializing" for a pod with init
+// containers, and a pod whose volumes never mount stays in the latter forever
+// (volume manager waits for every pod volume before starting any container,
+// init included). Matching only ContainerCreating therefore missed every app
+// with an init container.
+//
+// A running or terminated container proves the volumes did mount, so those pods
+// are skipped.
+func podBlockedBeforeStart(pod corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodPending {
+		return false
+	}
+	for _, cs := range allContainerStatuses(&pod) {
+		if cs.State.Running != nil || cs.State.Terminated != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// mountKind classifies a permanent FailedMount by whether it can transiently
+// occur during normal startup (and thus warrants a grace window) or is
+// deterministic with no such race (and can fail immediately).
+type mountKind int
+
+const (
+	// mountNone means the message is not a recognized permanent failure (or is
+	// a transient one such as attach timeout / Multi-Attach).
+	mountNone mountKind = iota
+	// mountImmediate is a deterministic failure with no create-race window:
+	// hostPath type check failure or a missing subPath. These never self-heal,
+	// so they can fail without waiting.
+	mountImmediate
+	// mountGraced can transiently occur while helm is still creating the
+	// referenced Secret/ConfigMap concurrently with the workload, so it needs a
+	// short grace before being treated as permanent.
+	mountGraced
+)
+
+// classifyMountFailure classifies a FailedMount message. It intentionally
+// returns mountNone for transient failures such as attach timeouts ("timed out
+// waiting for the condition") or Multi-Attach errors, which routinely resolve
+// once an old pod terminates or the volume detaches.
+func classifyMountFailure(msg string) mountKind {
+	switch {
+	// hostPath type check, e.g. "/dev/ttyUSB0 is not a character device".
+	case strings.Contains(msg, "hostPath type check failed"):
+		return mountImmediate
+	// subPath does not exist on the volume.
+	case strings.Contains(msg, "failed to prepare subPath"):
+		return mountImmediate
+	case strings.Contains(msg, "subPath") && strings.Contains(msg, "no such file or directory"):
+		return mountImmediate
+	// Referenced Secret/ConfigMap used as a volume does not exist. This may be
+	// a create race with helm, so it is graced rather than immediate.
+	case (strings.Contains(msg, "secret \"") || strings.Contains(msg, "configmap \"")) &&
+		strings.Contains(msg, "not found"):
+		return mountGraced
+	}
+	return mountNone
+}
+
+// scanPermanentMountFailure scans a pod's events and reports whether it has a
+// recent, permanent FailedMount, returning a human-readable reason and its kind
+// (mountImmediate vs mountGraced). Events older than recency are ignored so an
+// already-recovered mount does not cause a false positive. When both kinds are
+// present the immediate one wins. Pure function over the event slice.
+func scanPermanentMountFailure(events []corev1.Event, now time.Time, recency time.Duration) (string, mountKind, bool) {
+	var gracedReason string
+	var gracedFound bool
+	for i := range events {
+		e := &events[i]
+		if e.Reason != "FailedMount" {
+			continue
+		}
+		ts := e.LastTimestamp.Time
+		if ts.IsZero() {
+			// series / newer events populate EventTime instead of LastTimestamp.
+			ts = e.EventTime.Time
+		}
+		if !ts.IsZero() && now.Sub(ts) > recency {
+			continue
+		}
+		switch classifyMountFailure(e.Message) {
+		case mountImmediate:
+			return fmt.Sprintf("pod %s FailedMount: %s", e.InvolvedObject.Name, e.Message), mountImmediate, true
+		case mountGraced:
+			if !gracedFound {
+				gracedReason = fmt.Sprintf("pod %s FailedMount: %s", e.InvolvedObject.Name, e.Message)
+				gracedFound = true
+			}
+		}
+	}
+	if gracedFound {
+		return gracedReason, mountGraced, true
+	}
+	return "", mountNone, false
+}

--- a/framework/app-service/pkg/podhealth/podhealth.go
+++ b/framework/app-service/pkg/podhealth/podhealth.go
@@ -1,0 +1,161 @@
+// Package podhealth detects pod conditions that will not heal on their own
+// during install / upgrade / resume startup waits, so those flows can fail
+// fast instead of polling until an outer TTL expires.
+//
+// It mirrors the chainable shape of pkg/compute/validation: each check is a
+// small Checker that inspects an Input and returns a structured Signal. Run
+// executes a chain and returns the first hit; adding a new detection later is
+// just a new Checker appended to DefaultCheckers. Callers that poll feed each
+// tick's Run result into a GraceTracker, which turns a momentary Signal into a
+// fatal one only after it has persisted past the Signal's grace window.
+package podhealth
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Reason codes surfaced on Signal.Reason. They are machine-readable and stable
+// so callers/logs can key on them without parsing Message.
+const (
+	ReasonUnschedulable   = "Unschedulable"
+	ReasonImagePull       = "ImagePullFailure"
+	ReasonContainerConfig = "ContainerConfigError"
+	ReasonCrashLoop       = "CrashLoopBackOff"
+	ReasonPermanentMount  = "PermanentMountFailure"
+)
+
+// Grace defaults. Exported as vars (not consts) so tests can shorten them.
+var (
+	// HardErrorGrace is how long a hard, self-non-healing pod condition
+	// (bad image, container config error, unschedulable, deep CrashLoopBackOff)
+	// must persist before it is treated as fatal. It tolerates transient
+	// crashes during normal startup.
+	HardErrorGrace = 5 * time.Minute
+
+	// MountFailureGrace is how long a permanent FailedMount signature must
+	// persist before it is fatal. Shorter than HardErrorGrace because these
+	// failures are deterministic; the grace only tolerates the brief window
+	// where helm is still creating the referenced Secret/ConfigMap
+	// concurrently with the workload.
+	MountFailureGrace = 3 * time.Minute
+)
+
+const (
+	// DefaultCrashLoopRestartThreshold is the minimum container restart count
+	// for a CrashLoopBackOff pod to be treated as unrecoverable. CrashLoopBackOff
+	// backoff caps at 300s, so >=5 restarts means several minutes of failing,
+	// which filters out transient crashes during normal startup.
+	DefaultCrashLoopRestartThreshold int32 = 5
+
+	// DefaultMountEventRecency bounds how old a FailedMount event may be to
+	// still count. It filters out stale events from an already-recovered mount
+	// so only currently-recurring failures are considered.
+	DefaultMountEventRecency = 90 * time.Second
+)
+
+// Signal is the structured outcome of a Checker. Reason is a stable code,
+// Message is human-readable detail, and Grace is how long the condition must
+// persist before it is fatal (0 means fail immediately). Checker is populated
+// by Run with the name of the checker that produced the signal.
+type Signal struct {
+	Reason  string
+	Message string
+	Grace   time.Duration
+	Checker string
+}
+
+// Input bundles everything the checkers inspect. Pods is required; the
+// event-based mount checker is skipped unless FetchEvents is supplied, which
+// lets each call site plug in its own (clientset) event source and keeps the
+// pod-only checkers I/O-free and easy to unit test.
+type Input struct {
+	Pods []corev1.Pod
+
+	// Now is the reference time for event-recency filtering; Run defaults it
+	// to time.Now() when zero.
+	Now time.Time
+
+	// CrashLoopRestartThreshold overrides DefaultCrashLoopRestartThreshold when
+	// non-zero.
+	CrashLoopRestartThreshold int32
+
+	// MountEventRecency overrides DefaultMountEventRecency when non-zero.
+	MountEventRecency time.Duration
+
+	// FetchEvents returns the events for a single pod. Optional: when nil the
+	// event-based mount checker is a no-op. The mount checker only calls it for
+	// pods stuck in ContainerCreating, so callers can back it with a plain
+	// clientset List without an informer.
+	FetchEvents func(pod corev1.Pod) ([]corev1.Event, error)
+}
+
+// Checker inspects an Input and reports whether it found an unrecoverable
+// condition. Name identifies it in logs and Signal.Checker.
+type Checker interface {
+	Name() string
+	Check(in Input) (Signal, bool)
+}
+
+// Run executes the checkers in order and returns the first hit. Passing no
+// checkers runs DefaultCheckers. Defaults for Now / thresholds are applied
+// once here so individual checkers stay simple.
+func Run(in Input, checkers ...Checker) (Signal, bool) {
+	if in.Now.IsZero() {
+		in.Now = time.Now()
+	}
+	if in.CrashLoopRestartThreshold == 0 {
+		in.CrashLoopRestartThreshold = DefaultCrashLoopRestartThreshold
+	}
+	if in.MountEventRecency == 0 {
+		in.MountEventRecency = DefaultMountEventRecency
+	}
+	if len(checkers) == 0 {
+		checkers = DefaultCheckers()
+	}
+	for _, c := range checkers {
+		if sig, ok := c.Check(in); ok {
+			sig.Checker = c.Name()
+			return sig, true
+		}
+	}
+	return Signal{}, false
+}
+
+// GraceTracker turns the per-tick Signal from Run into a fatal decision only
+// after the signal has persisted past its Grace (or is immediate). It is the
+// stateful companion to Run for callers that poll on a ticker. Not safe for
+// concurrent use; use one per poll loop.
+type GraceTracker struct {
+	since  time.Time
+	reason string
+}
+
+// Observe records a tick's Run result. It returns:
+//   - fatal=true when the signal is immediate (Grace<=0) or has persisted past
+//     its Grace, meaning the caller should abort;
+//   - started=true on the tick that opens a new grace window, so the caller can
+//     emit a single warning log rather than one per tick.
+//
+// A not-detected result resets the tracker so an intervening healthy tick
+// clears the grace window.
+func (g *GraceTracker) Observe(sig Signal, detected bool) (out Signal, fatal bool, started bool) {
+	if !detected {
+		g.since = time.Time{}
+		g.reason = ""
+		return Signal{}, false, false
+	}
+	if sig.Grace <= 0 {
+		return sig, true, false
+	}
+	if g.since.IsZero() || g.reason != sig.Reason {
+		g.since = time.Now()
+		g.reason = sig.Reason
+		return sig, false, true
+	}
+	if time.Since(g.since) > sig.Grace {
+		return sig, true, false
+	}
+	return sig, false, false
+}

--- a/framework/app-service/pkg/podhealth/podhealth_test.go
+++ b/framework/app-service/pkg/podhealth/podhealth_test.go
@@ -1,0 +1,340 @@
+package podhealth
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func waitingPod(name, container, reason string, restarts int32) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: container}}},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         container,
+				RestartCount: restarts,
+				State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}},
+			}},
+		},
+	}
+}
+
+func TestRun_PodStatusTiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		pods       []corev1.Pod
+		wantOK     bool
+		wantReason string
+	}{
+		{"empty", nil, false, ""},
+		{"image pull backoff", []corev1.Pod{waitingPod("p", "c", "ImagePullBackOff", 0)}, true, ReasonImagePull},
+		{"err image pull", []corev1.Pod{waitingPod("p", "c", "ErrImagePull", 0)}, true, ReasonImagePull},
+		{"invalid image", []corev1.Pod{waitingPod("p", "c", "InvalidImageName", 0)}, true, ReasonImagePull},
+		{"create container config error", []corev1.Pod{waitingPod("p", "c", "CreateContainerConfigError", 0)}, true, ReasonContainerConfig},
+		{"create container error", []corev1.Pod{waitingPod("p", "c", "CreateContainerError", 0)}, true, ReasonContainerConfig},
+		{"run container error", []corev1.Pod{waitingPod("p", "c", "RunContainerError", 0)}, true, ReasonContainerConfig},
+		{"crashloop below threshold", []corev1.Pod{waitingPod("p", "c", "CrashLoopBackOff", 4)}, false, ""},
+		{"crashloop at threshold", []corev1.Pod{waitingPod("p", "c", "CrashLoopBackOff", 5)}, true, ReasonCrashLoop},
+		{"container creating is not unrecoverable", []corev1.Pod{waitingPod("p", "c", "ContainerCreating", 0)}, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sig, ok := Run(Input{Pods: tt.pods})
+			if ok != tt.wantOK {
+				t.Fatalf("Run ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && sig.Reason != tt.wantReason {
+				t.Fatalf("Run reason = %q, want %q", sig.Reason, tt.wantReason)
+			}
+			if ok && sig.Grace != HardErrorGrace {
+				t.Fatalf("Run grace = %v, want %v", sig.Grace, HardErrorGrace)
+			}
+		})
+	}
+}
+
+func TestRun_Unschedulable(t *testing.T) {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:    corev1.PodScheduled,
+				Status:  corev1.ConditionFalse,
+				Reason:  corev1.PodReasonUnschedulable,
+				Message: "0/3 nodes available",
+			}},
+		},
+	}
+	sig, ok := Run(Input{Pods: []corev1.Pod{pod}})
+	if !ok || sig.Reason != ReasonUnschedulable {
+		t.Fatalf("expected unschedulable hit, got ok=%v reason=%q", ok, sig.Reason)
+	}
+}
+
+func TestRun_InitContainer(t *testing.T) {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "init",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+			}},
+		},
+	}
+	if _, ok := Run(Input{Pods: []corev1.Pod{pod}}); !ok {
+		t.Fatal("expected init container ImagePullBackOff to be a hit")
+	}
+}
+
+func TestRun_PermanentMount(t *testing.T) {
+	now := time.Now()
+	mkEvent := func(reason, msg string, age time.Duration) corev1.Event {
+		return corev1.Event{
+			InvolvedObject: corev1.ObjectReference{Name: "p"},
+			Reason:         reason,
+			Message:        msg,
+			LastTimestamp:  metav1.NewTime(now.Add(-age)),
+		}
+	}
+	// A pod that has not started any container, so the mount checker inspects
+	// its events.
+	stuckPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "c",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+			}},
+		},
+	}
+	run := func(events []corev1.Event) (Signal, bool) {
+		return Run(Input{
+			Pods:        []corev1.Pod{stuckPod},
+			Now:         now,
+			FetchEvents: func(corev1.Pod) ([]corev1.Event, error) { return events, nil },
+		})
+	}
+
+	t.Run("graced failure has mount grace", func(t *testing.T) {
+		sig, ok := run([]corev1.Event{mkEvent("FailedMount", `secret "s" not found`, 10*time.Second)})
+		if !ok || sig.Reason != ReasonPermanentMount || sig.Grace != MountFailureGrace {
+			t.Fatalf("expected graced mount, got ok=%v reason=%q grace=%v", ok, sig.Reason, sig.Grace)
+		}
+	})
+
+	t.Run("hostpath failure is immediate", func(t *testing.T) {
+		sig, ok := run([]corev1.Event{mkEvent("FailedMount", `hostPath type check failed: /dev/ttyUSB0 is not a character device`, 10*time.Second)})
+		if !ok || sig.Grace != 0 {
+			t.Fatalf("expected immediate mount (grace 0), got ok=%v grace=%v", ok, sig.Grace)
+		}
+	})
+
+	t.Run("stale event ignored", func(t *testing.T) {
+		if _, ok := run([]corev1.Event{mkEvent("FailedMount", `secret "s" not found`, 10*time.Minute)}); ok {
+			t.Fatal("expected stale FailedMount to be ignored")
+		}
+	})
+
+	t.Run("nil FetchEvents skips mount tier", func(t *testing.T) {
+		if _, ok := Run(Input{Pods: []corev1.Pod{stuckPod}, Now: now}); ok {
+			t.Fatal("expected no hit when FetchEvents is nil")
+		}
+	})
+
+	// Regression: a pod with init containers blocked on volume mounting reports
+	// every container as PodInitializing, never ContainerCreating. Gating the
+	// event scan on ContainerCreating missed this entirely.
+	t.Run("init-container pod stuck in PodInitializing is scanned", func(t *testing.T) {
+		initializing := func(name string) corev1.ContainerStatus {
+			return corev1.ContainerStatus{
+				Name:  name,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "PodInitializing"}},
+			}
+		}
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "homeassistant-557f6444f-fb4d6"},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Name: "check-auth"}},
+				Containers:     []corev1.Container{{Name: "homeassistant"}},
+			},
+			Status: corev1.PodStatus{
+				Phase:                 corev1.PodPending,
+				InitContainerStatuses: []corev1.ContainerStatus{initializing("check-auth")},
+				ContainerStatuses:     []corev1.ContainerStatus{initializing("homeassistant")},
+			},
+		}
+		events := []corev1.Event{mkEvent("FailedMount",
+			`MountVolume.SetUp failed for volume "usb-device" : hostPath type check failed: /dev/ttyUSB0 is not a character device`,
+			63*time.Second)}
+		sig, ok := Run(Input{
+			Pods:        []corev1.Pod{pod},
+			Now:         now,
+			FetchEvents: func(corev1.Pod) ([]corev1.Event, error) { return events, nil },
+		})
+		if !ok || sig.Reason != ReasonPermanentMount || sig.Grace != 0 {
+			t.Fatalf("expected immediate permanent-mount hit, got ok=%v reason=%q grace=%v", ok, sig.Reason, sig.Grace)
+		}
+	})
+
+	t.Run("pod with a running container is skipped", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "c",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}},
+			},
+		}
+		called := false
+		_, ok := Run(Input{
+			Pods: []corev1.Pod{pod},
+			Now:  now,
+			FetchEvents: func(corev1.Pod) ([]corev1.Event, error) {
+				called = true
+				return nil, nil
+			},
+		})
+		if ok || called {
+			t.Fatalf("expected running-container pod to be skipped, ok=%v fetched=%v", ok, called)
+		}
+	})
+}
+
+func TestClassifyMountFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want mountKind
+	}{
+		{"secret not found is graced", `MountVolume.SetUp failed for volume "cfg" : secret "my-secret" not found`, mountGraced},
+		{"configmap not found is graced", `MountVolume.SetUp failed for volume "cfg" : configmap "my-cm" not found`, mountGraced},
+		{"hostpath type check is immediate", `MountVolume.SetUp failed for volume "usb-device" : hostPath type check failed: /dev/ttyUSB0 is not a character device`, mountImmediate},
+		{"subpath prepare is immediate", `failed to prepare subPath for volumeMount "data" of container "app"`, mountImmediate},
+		{"subpath no such file is immediate", `MountVolume.SetUp failed for volume "data" : subPath "conf" not found: no such file or directory`, mountImmediate},
+		{"attach timeout is transient", `Unable to attach or mount volumes: unmounted volumes=[data], timed out waiting for the condition`, mountNone},
+		{"multi-attach is transient", `Multi-Attach error for volume "pvc-x" Volume is already exclusively attached to one node`, mountNone},
+		{"unrelated", `Successfully pulled image`, mountNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyMountFailure(tt.msg); got != tt.want {
+				t.Fatalf("classifyMountFailure(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanPermanentMountFailure(t *testing.T) {
+	now := time.Now()
+	mkEvent := func(reason, msg string, age time.Duration) corev1.Event {
+		return corev1.Event{
+			InvolvedObject: corev1.ObjectReference{Name: "p"},
+			Reason:         reason,
+			Message:        msg,
+			LastTimestamp:  metav1.NewTime(now.Add(-age)),
+		}
+	}
+
+	t.Run("recent graced failure hits as graced", func(t *testing.T) {
+		events := []corev1.Event{mkEvent("FailedMount", `secret "s" not found`, 10*time.Second)}
+		_, kind, ok := scanPermanentMountFailure(events, now, DefaultMountEventRecency)
+		if !ok || kind != mountGraced {
+			t.Fatalf("expected graced hit, got kind=%v ok=%v", kind, ok)
+		}
+	})
+
+	t.Run("immediate wins over graced", func(t *testing.T) {
+		events := []corev1.Event{
+			mkEvent("FailedMount", `secret "s" not found`, 5*time.Second),
+			mkEvent("FailedMount", `failed to prepare subPath for volumeMount "data"`, 5*time.Second),
+		}
+		_, kind, ok := scanPermanentMountFailure(events, now, DefaultMountEventRecency)
+		if !ok || kind != mountImmediate {
+			t.Fatalf("expected immediate to win, got kind=%v ok=%v", kind, ok)
+		}
+	})
+
+	t.Run("stale event ignored", func(t *testing.T) {
+		events := []corev1.Event{mkEvent("FailedMount", `secret "s" not found`, 10*time.Minute)}
+		if _, _, ok := scanPermanentMountFailure(events, now, DefaultMountEventRecency); ok {
+			t.Fatal("expected stale FailedMount to be ignored")
+		}
+	})
+
+	t.Run("transient reason ignored", func(t *testing.T) {
+		events := []corev1.Event{mkEvent("FailedMount", `timed out waiting for the condition`, 5*time.Second)}
+		if _, _, ok := scanPermanentMountFailure(events, now, DefaultMountEventRecency); ok {
+			t.Fatal("expected transient FailedMount to be ignored")
+		}
+	})
+
+	t.Run("non FailedMount reason ignored", func(t *testing.T) {
+		events := []corev1.Event{mkEvent("FailedScheduling", `secret "s" not found`, 5*time.Second)}
+		if _, _, ok := scanPermanentMountFailure(events, now, DefaultMountEventRecency); ok {
+			t.Fatal("expected non-FailedMount reason to be ignored")
+		}
+	})
+
+	t.Run("eventTime fallback when lastTimestamp zero", func(t *testing.T) {
+		e := corev1.Event{
+			InvolvedObject: corev1.ObjectReference{Name: "p"},
+			Reason:         "FailedMount",
+			Message:        `configmap "c" not found`,
+			EventTime:      metav1.NewMicroTime(now.Add(-5 * time.Second)),
+		}
+		if _, _, ok := scanPermanentMountFailure([]corev1.Event{e}, now, DefaultMountEventRecency); !ok {
+			t.Fatal("expected eventTime fallback to be honored")
+		}
+	})
+}
+
+func TestGraceTracker(t *testing.T) {
+	t.Run("immediate signal is fatal at once", func(t *testing.T) {
+		var g GraceTracker
+		_, fatal, started := g.Observe(Signal{Reason: ReasonPermanentMount, Grace: 0}, true)
+		if !fatal || started {
+			t.Fatalf("immediate: fatal=%v started=%v, want true/false", fatal, started)
+		}
+	})
+
+	t.Run("graced signal waits then fires", func(t *testing.T) {
+		var g GraceTracker
+		sig := Signal{Reason: ReasonImagePull, Grace: 10 * time.Millisecond}
+		if _, fatal, started := g.Observe(sig, true); fatal || !started {
+			t.Fatalf("first tick: fatal=%v started=%v, want false/true", fatal, started)
+		}
+		time.Sleep(20 * time.Millisecond)
+		if _, fatal, _ := g.Observe(sig, true); !fatal {
+			t.Fatal("expected fatal after grace elapsed")
+		}
+	})
+
+	t.Run("healthy tick resets the window", func(t *testing.T) {
+		var g GraceTracker
+		sig := Signal{Reason: ReasonImagePull, Grace: time.Hour}
+		g.Observe(sig, true)
+		if _, _, started := g.Observe(Signal{}, false); started {
+			t.Fatal("reset tick should not report started")
+		}
+		if _, _, started := g.Observe(sig, true); !started {
+			t.Fatal("expected a fresh window after reset")
+		}
+	})
+
+	t.Run("changed reason restarts the window", func(t *testing.T) {
+		var g GraceTracker
+		g.Observe(Signal{Reason: ReasonImagePull, Grace: time.Hour}, true)
+		_, fatal, started := g.Observe(Signal{Reason: ReasonCrashLoop, Grace: time.Hour}, true)
+		if fatal || !started {
+			t.Fatalf("reason change: fatal=%v started=%v, want false/true", fatal, started)
+		}
+	})
+}

--- a/framework/app-service/pkg/podhealth/readiness.go
+++ b/framework/app-service/pkg/podhealth/readiness.go
@@ -1,0 +1,43 @@
+package podhealth
+
+import corev1 "k8s.io/api/core/v1"
+
+// PodContainersStarted reports whether every regular container in the pod has
+// started (or has already completed). It mirrors kubelet's per-container
+// Started flag and additionally treats a container Terminated with reason
+// "Completed" as started, so job-style pods that run to completion count as up.
+//
+// It is the single source of truth for the "is this pod up?" predicate shared
+// by the install/upgrade wait (HelmOps.checkIfStartup, which requires every
+// pod to be up) and the resume wait (appstate.isStartUp, which needs any pod
+// to be up). The nil-check on Started guards pods whose kubelet has not yet
+// populated container statuses.
+func PodContainersStarted(pod corev1.Pod) bool {
+	total := len(pod.Spec.Containers)
+	started := 0
+	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+		cs := pod.Status.ContainerStatuses[i]
+		if cs.Started != nil && *cs.Started {
+			started++
+			continue
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "Completed" {
+			started++
+		}
+	}
+	return started == total
+}
+
+// AllPodsStarted reports whether every pod in the slice has all its containers
+// started (see PodContainersStarted). It is the shared "is the workload up?"
+// tally for both the install/upgrade wait (HelmOps.checkIfStartup) and the
+// resume wait (appstate.isStartUp). An empty slice returns true, so callers
+// that treat "no pods yet" as not-started must check len(pods) themselves.
+func AllPodsStarted(pods []corev1.Pod) bool {
+	for _, pod := range pods {
+		if !PodContainersStarted(pod) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
* **Background**

Add a chainable pkg/podhealth checker (container waiting, crashloop, unschedulable, permanent FailedMount) with GraceTracker so startup waits abort on hard failures instead of spinning until the outer TTL. Wire it into WaitForStartUp and resume IsStartUp; treat hostPath/subPath mount errors as immediate and Secret/ConfigMap races with a short grace. Share AllPodsStarted across install and resume, and list pods by app namespace.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install, launch, and resume failure timing and resume startup pod selection (namespace-wide vs workload labels), which can alter when operations fail or succeed; logic is well-tested but affects core app lifecycle paths.
> 
> **Overview**
> Adds **`pkg/podhealth`**, a chain of checkers (unschedulable, hard container waiting states, deep **CrashLoopBackOff**, and permanent **FailedMount** from pod events) plus **`GraceTracker`** so a bad condition must persist past a grace window before the wait aborts.
> 
> **Helm install/launch** replaces inline unrecoverable-pod logic in **`WaitForStartUp`** and **`WaitForLaunch`** with **`podhealth.Run`** via **`podHealthInput`** (namespace pod list + event fetcher). **`checkIfStartup`** now delegates “all containers up” to **`AllPodsStarted`**.
> 
> **Resume** uses the same health gate in **`IsStartUp`**, returns **`errUnrecoverablePod`** with a concrete message for **`ResumeFailed`**, and **`isStartUp`** lists pods in the app namespace instead of resolving deployment/StatefulSet selectors. Mount failures treat hostPath/subPath as **immediate**; missing Secret/ConfigMap volumes get a **shorter grace** to tolerate Helm create races; init-container pods stuck in **PodInitializing** are included in mount scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ffb814d19e498190d15a261d87c4342d745dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->