### PR TITLE
fix(build): ensure directory creation for replaced vendor files

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -16,6 +16,11 @@ if [[ "${REPO_PATH}" != "" && "$REPO_PATH" != "/" ]]; then
         file=$(awk -F "$path" '{print $1$2}' <<< "$l")  
         if [[ "$file" != ".gitkeep" ]]; then
             echo "replace [$file] with [$l]"
+            replace_path=$(dirname $file)
+            if [ ! -d $replace_path ]; then
+                echo "create replace dir [$replace_path]"
+                mkdir -p $replace_path
+            fi
             cp -f "$l" "$file"
         fi
     done


### PR DESCRIPTION
* **Background**
Ensure directory creation for replaced vendor files

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time shell change only; no runtime, security, or data-handling impact.
> 
> **Overview**
> Fixes the **vendor replace** step in `build/build.sh` so `cp` no longer fails when the destination path’s parent directory is missing.
> 
> Before copying each override from `vendor${REPO_PATH}` into the tree, the script now derives the target directory with `dirname`, runs **`mkdir -p`** when it does not exist, then performs the copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf3a8b2c9a1d926a57d3d6e5e283672ffdfef6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->