### PR TITLE
fix(cli): use target node architecture for chart images

### DIFF
--- a/cli/cmd/ctl/cluster/node/list.go
+++ b/cli/cmd/ctl/cluster/node/list.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"text/tabwriter"
@@ -30,8 +31,9 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 		Short: "list K8s nodes visible to the active profile",
 		Long: `List Kubernetes nodes visible to the active profile.
 
-Output (table mode): NAME, STATUS, ROLES, AGE, VERSION, INTERNAL-IP
-— same shape kubectl uses. STATUS = Ready /
+Output (table mode): NAME, STATUS, ROLES, AGE, VERSION, INTERNAL-IP,
+ARCHITECTURE
+— kubectl-style node columns with architecture included. STATUS = Ready /
 "Ready,SchedulingDisabled" / NotReady / Unknown derived from the
 Ready condition + spec.unschedulable. ROLES are read from
 node-role.kubernetes.io/* labels.
@@ -89,24 +91,25 @@ func runList(ctx context.Context, o *clusteropts.ClusterOptions, p *clusteropts.
 	if o.Quiet {
 		return nil
 	}
-	return renderListTable(items, o.NoHeaders, p, total)
+	return renderListTable(os.Stdout, items, o.NoHeaders, p, total)
 }
 
-func renderListTable(items []Node, noHeaders bool, p *clusteropts.PaginationOptions, totalItems int) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func renderListTable(out io.Writer, items []Node, noHeaders bool, p *clusteropts.PaginationOptions, totalItems int) error {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 	if !noHeaders {
-		fmt.Fprintln(w, "NAME\tSTATUS\tROLES\tAGE\tVERSION\tINTERNAL-IP")
+		fmt.Fprintln(w, "NAME\tSTATUS\tROLES\tAGE\tVERSION\tINTERNAL-IP\tARCHITECTURE")
 	}
 	now := time.Now()
 	for _, n := range items {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			n.Metadata.Name,
 			n.StatusLabel(),
 			n.Roles(),
 			n.Age(now),
 			clusteropts.DashIfEmpty(n.KubeletVersion()),
 			n.InternalIP(),
+			clusteropts.DashIfEmpty(n.Status.NodeInfo.Architecture),
 		)
 	}
 	w.Flush()

--- a/cli/cmd/ctl/cluster/node/list_test.go
+++ b/cli/cmd/ctl/cluster/node/list_test.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/internal/clusteropts"
+)
+
+func TestRenderListTableIncludesArchitecture(t *testing.T) {
+	items := []Node{{}, {}, {}}
+	items[0].Metadata.Name = "amd-node"
+	items[0].Status.NodeInfo.Architecture = "amd64"
+	items[1].Metadata.Name = "arm-node"
+	items[1].Status.NodeInfo.Architecture = "arm64"
+	items[2].Metadata.Name = "unknown-node"
+
+	var out bytes.Buffer
+	p := clusteropts.NewPaginationOptions()
+	if err := renderListTable(&out, items, false, p, len(items)); err != nil {
+		t.Fatalf("render node list: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"ARCHITECTURE",
+		"amd-node",
+		"amd64",
+		"arm-node",
+		"arm64",
+		"unknown-node",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("node list missing %q:\n%s", want, got)
+		}
+	}
+
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "unknown-node ") && !strings.HasSuffix(strings.TrimSpace(line), "-") {
+			t.Errorf("empty architecture should render as '-':\n%s", got)
+		}
+	}
+}

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -41,13 +41,13 @@ Porting an app is **not** a fixed `from-compose → lint → deploy` pipeline �
 
 ## Axis 1 — Packaging (the image)
 
-Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and logged in, then **build + push yourself** — only `docker login` stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). No Olares login needed. Build for **this node's arch** (single-arch); multi-arch is only for publishing.
+Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: first query the **target Olares node's architecture** with `olares-cli cluster node list`, then ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and logged in, and **build + push yourself** — only `docker login` stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). Querying the target needs an Olares profile login; Docker packaging itself does not. Build for the target node's arch (single-arch), never the development host's implicit/default arch; multi-arch is only for publishing.
 
 | Packaging state | Do this | Ready when |
 |---|---|---|
 | No Dockerfile (just source) | author a Dockerfile, then build+push | — |
 | Dockerfile, but no pullable image | build+push (Docker Hub or ghcr) | — |
-| A pullable image exists | check its arch; rebuild if it doesn't match this node (`olares-cli cluster node list`) | every workload has a pullable, arch-correct image |
+| A pullable image exists | check its arch; rebuild if it doesn't match the target Olares node (`olares-cli cluster node list`) | every workload has a pullable, arch-correct image |
 
 ## Axis 2 — Deployment (the chart)
 
@@ -73,7 +73,7 @@ For deploying to your own Olares, **metadata can stay a stub** as long as `lint`
 
 | Axis | Concern | Get this right | Loop back when | Reference |
 |---|---|---|---|---|
-| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for **this node** | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
+| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for the **target Olares node**; pass it explicitly through Buildx `--platform` rather than using the development host default | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
 | packaging+deployment | **Run identity** | final app process uid 1000; normally `spec.runAsUser: true`; for verified PUID/PGID root-init images leave it false/absent so the entrypoint can initialize then drop privileges; use initContainer `chown` only for root-owned volumes | EACCES on appData/appCache/userData; forced uid breaks a root-init entrypoint; admission denies an explicit root securityContext | [run-as-user.md](references/olares-chart-run-as-user.md) |
 | deployment | **Storage** | every compose volume → the right userspace area (Data/Cache/Home/Common/External), matching `permission`, leftover kompose PVCs deleted | a volume isn't persisting or lands in the wrong area | [manifest.md](references/olares-chart-manifest.md) §2 |
 | deployment | **Middleware & deps** | no bundled `postgres`/`redis`/`mongo`/…; wire to system middleware; SQLite→Postgres where supported; companion apps as `type: application` deps | a bundled db/queue remains, or a companion should be a dependency | [middleware.md](references/olares-chart-middleware.md) |

--- a/cli/skills/olares-chart/references/olares-chart-image.md
+++ b/cli/skills/olares-chart/references/olares-chart-image.md
@@ -5,7 +5,7 @@
 
 ## Arch strategy
 
-Deploying to your Olares only needs **this node's arch** (single-arch) — query it with `olares-cli cluster node list` (needs login); `spec.supportArch` is optional. Multi-arch (`linux/amd64,linux/arm64` + a matching `spec.supportArch: [amd64, arm64]`) is only required when **publishing to the public Market** — see the [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md) skill.
+Deploying to your Olares only needs the **target Olares node's arch** (single-arch) — query it with `olares-cli cluster node list` (needs login); `spec.supportArch` is optional. The development host may have a different architecture, so never derive the image platform from `uname`, `runtime.GOARCH`, or Docker's default platform. Multi-arch (`linux/amd64,linux/arm64` + a matching `spec.supportArch: [amd64, arm64]`) is only required when **publishing to the public Market** — see the [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md) skill.
 
 ## When you need it
 
@@ -32,14 +32,15 @@ A wrong-architecture image installs but never runs (`ImagePullBackOff` with `no 
 
 1. **Find the target node arch:**
    ```bash
-   olares-cli cluster node list          # the node row shows amd64 / arm64 (needs login)
+   olares-cli cluster node list          # ARCHITECTURE shows amd64 / arm64 (needs login)
    ```
+   If more than one architecture is listed, identify the node that will run the workload and confirm it with `olares-cli cluster node get <name>`. Do not silently choose the development host's architecture. If the target cannot be identified, stop and ask rather than building an image for a guessed platform.
 2. **Inspect a candidate image's platforms** before trusting it:
    ```bash
    docker manifest inspect <image-ref>   # look for the platform.architecture entries
    ```
    (No docker daemon? Query the registry manifest list over HTTP and read each `platform.architecture`.)
-3. **Build single platform matching the node** — `--platform linux/amd64` or `linux/arm64`. A single-arch image **must** equal the node arch. (Multi-arch is only for publishing — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
+3. **Build single platform matching the target node** — `--platform linux/amd64` or `linux/arm64`. Always pass `--platform` explicitly; a single-arch image **must** equal the target node arch. (Multi-arch is only for publishing — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
 
 ## GPU / CUDA images
 
@@ -49,37 +50,38 @@ Building a CUDA image (no GPU needed on the build box, custom-kernel arch flags,
 
 You drive this end to end — ask the registry, check login, build, push, verify. The **only** manual step is the developer typing a registry token into `docker login`, and only when they are not already authenticated. **Never invent/hardcode tokens or push under an account the developer didn't choose.**
 
-1. **Ask which registry the developer uses + the target `<user>/<repo>`** before anything else (don't assume one):
+1. **Resolve the target Olares node architecture before any build** using `olares-cli cluster node list`, following the multi-node rule above. Keep the resolved value as `<target-arch>`; do not substitute the development host architecture.
+
+2. **Ask which registry the developer uses + the target `<user>/<repo>`** (don't assume one):
    - **Docker Hub** — image ref `<dockerhub-user>/<repo>`
    - **GitHub Container Registry (ghcr)** — image ref `ghcr.io/<owner>/<repo>`
    > An Olares-local private registry is not supported here — the image must live on a registry the Olares node can pull from publicly.
 
-2. **Check docker is usable:**
+3. **Check docker is usable:**
    ```bash
    docker version          # must show a Server section; if it errors, the daemon isn't running
-   docker buildx version   # buildx is needed for --platform multi-arch
+   docker buildx version   # buildx is needed for the explicit --platform build
    ```
    If docker is missing or the daemon is down, point the developer to install / start it: Docker Desktop on macOS/Windows, or the engine on Linux — https://docs.docker.com/get-docker/ . Stop and wait until `docker version` shows a Server.
 
-3. **Check whether they're already logged in to that registry** — don't ask for a login they already have:
+4. **Check whether they're already logged in to that registry** — don't ask for a login they already have:
    ```bash
    docker login <registry>   # already authed? prints "Authenticating with existing credentials" / "Login Succeeded"
    ```
    Or read `~/.docker/config.json` `auths` for the registry key (Docker Hub → `https://index.docker.io/v1/`, ghcr → `ghcr.io`; a `credsStore`/`credHelpers` entry can be empty but present). A push that later fails with `unauthorized` / `denied` is the authoritative "not logged in / wrong account" signal.
-   - **Already logged in** → go straight to build + push (step 4).
+   - **Already logged in** → go straight to build + push (step 5).
    - **Not logged in** → ask the developer to run the right `docker login` (this is the one step you can't do — it needs their secret token), then continue:
      - Docker Hub: `docker login` with a Docker Hub **access token** (Account Settings → Security → New Access Token).
      - ghcr: `docker login ghcr.io -u <github-user>` with a **GitHub PAT** that has `write:packages`. After the first push, set the package **visibility to public** so Olares can pull it without auth.
 
-4. **Build for the node arch and push** — you run this, after confirming `<registry-ref>:<tag>` with the developer:
+5. **Build for the target node arch and push** — you run this, after confirming `<registry-ref>:<tag>` with the developer:
    ```bash
-   # this node (example: amd64):
-   docker buildx build --platform linux/amd64 -t <registry-ref>:<tag> --push <build-context>
+   docker buildx build --platform linux/<target-arch> -t <registry-ref>:<tag> --push <build-context>
    ```
    (Publishing to the public Market? Build multi-arch instead — `--platform linux/amd64,linux/arm64` — per [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
    `<build-context>` can be a local path (`.`) or a git URL (e.g. `https://github.com/org/repo.git#main`). Use the upstream Dockerfile or one you authored.
 
-5. **Verify the pushed image** before wiring it in:
+6. **Verify the pushed image** before wiring it in:
    ```bash
    docker manifest inspect <registry-ref>:<tag>   # confirm the expected platforms are present
    ```

--- a/cli/skills/olares-chart/references/olares-chart-workflow.md
+++ b/cli/skills/olares-chart/references/olares-chart-workflow.md
@@ -7,9 +7,11 @@
 
 ```
  Packaging (agent-driven; only if an image is missing / wrong-arch):
- P1. docker?    docker version && docker buildx version   # else guide install
- P2. registry   ask which registry + <user>/<repo>; check login — if not authed, the developer runs `docker login` (agent can't type their token)
- P3. build+push docker buildx build --platform linux/<node-arch> -t <ref>:<tag> --push <ctx>
+ P1. target     olares-cli cluster node list              # read the target node's ARCHITECTURE; never infer it from the development host
+                -> if nodes have different architectures, identify the scheduled target with `cluster node get <name>`; stop and ask if unknown
+ P2. docker?    docker version && docker buildx version   # else guide install
+ P3. registry   ask which registry + <user>/<repo>; check login — if not authed, the developer runs `docker login` (agent can't type their token)
+ P4. build+push docker buildx build --platform linux/<target-arch> -t <ref>:<tag> --push <ctx>
                 -> you run build+push, then wire <ref>:<tag> into every build-only `image:` in the compose
 
  Deployment authoring (no login):
@@ -25,7 +27,7 @@
  V3. upload     olares-cli market upload ./<app>-<ver>.tgz
  V4. run        olares-cli market install <app> -s upload --version <ver> --watch -o json
  V5. on failure diagnose via olares-doctor (symptom -> root cause), then loop back
- V6. decide     loop back: chart problem -> D2 ; image problem -> P3 ; uid/EACCES -> run identity (uid 1000) guidance ; not a chart problem -> break out, report & ask
+ V6. decide     loop back: chart problem -> D2 ; image problem -> P1/P4 ; uid/EACCES -> run identity (uid 1000) guidance ; not a chart problem -> break out, report & ask
  V7. cleanup    olares-cli market uninstall <app> --watch ; olares-cli market delete <app>
 ```
 


### PR DESCRIPTION
## Summary
- show node architecture in `cluster node list` table output
- make chart image packaging resolve the target Olares node architecture before building
- require an explicit Buildx `--platform` and document mixed-architecture node handling

## Verification
- `go test ./cmd/ctl/cluster/node`
- `go test ./cmd/ctl/cluster/...`
- `go vet ./cmd/ctl/cluster/...`
- `go build -o /tmp/olares-cli-target-arch-verify ./cmd`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI change is additive table column plus testable output refactor; skill doc updates only affect agent guidance, not runtime behavior.
> 
> **Overview**
> Adds an **ARCHITECTURE** column to `olares-cli cluster node list` table output (from `status.nodeInfo.architecture`, with `-` when empty) and refactors `renderListTable` to take an `io.Writer` so table rendering is unit-tested.
> 
> Updates **olares-chart** agent docs so image packaging resolves the **target Olares node** arch via `cluster node list` before any Buildx build—not the dev host’s default—and requires explicit `--platform linux/<target-arch>`. Mixed-arch clusters must pick the scheduled node (`cluster node get`) or stop and ask; workflow steps reorder packaging to **P1 target → P4 build+push**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea6e8a27fb4c2a7eb51379f188f78629e875bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->