### PR TITLE
feat(upgrade): ensure AI Router on 1.12.7

### DIFF
--- a/cli/pkg/preinstall/deployment_contract_test.go
+++ b/cli/pkg/preinstall/deployment_contract_test.go
@@ -33,7 +33,7 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 	for _, required := range []string{
 		preinstallEnv,
 		ensureEnv,
-		"- name: OLARES_VERSION\n            value: \"{{ .Values.olaresVersion }}\"",
+		"- name: OLARES_VERSION\n            value: \"1.12.7\"",
 		"- name: opt-data\n            mountPath: /opt/app/data",
 		"- name: market-preinstall\n            mountPath: /opt/app/preinstall\n            readOnly: true",
 		"- name: market-ensure\n            mountPath: /opt/app/ensure\n            readOnly: true",

--- a/cli/pkg/preinstall/deployment_contract_test.go
+++ b/cli/pkg/preinstall/deployment_contract_test.go
@@ -27,10 +27,16 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 		"          - name: PREINSTALL_ENABLED\n            value: 'true'\n" +
 		"          - name: PREINSTALL_BUNDLE_DIR\n            value: /opt/app/preinstall\n" +
 		"{{ end }}"
+	ensureEnv := "{{ if .Values.ensureApps }}\n" +
+		"          - name: ENSURE_APPS_FILE\n            value: /opt/app/ensure/ensure-apps.json\n" +
+		"{{ end }}"
 	for _, required := range []string{
 		preinstallEnv,
+		ensureEnv,
+		"- name: OLARES_VERSION\n            value: \"{{ .Values.olaresVersion }}\"",
 		"- name: opt-data\n            mountPath: /opt/app/data",
 		"- name: market-preinstall\n            mountPath: /opt/app/preinstall\n            readOnly: true",
+		"- name: market-ensure\n            mountPath: /opt/app/ensure\n            readOnly: true",
 	} {
 		if !strings.Contains(container, required) {
 			t.Errorf("appstore-backend container missing contract:\n%s", required)
@@ -45,9 +51,14 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 		"- name: market-preinstall\n        hostPath:\n          path: '{{ .Values.rootPath }}/%s'\n          type: DirectoryOrCreate",
 		RuntimeRelativeDir,
 	)
+	ensureVolume := fmt.Sprintf(
+		"- name: market-ensure\n        hostPath:\n          path: '{{ .Values.rootPath }}/%s'\n          type: DirectoryOrCreate",
+		EnsureRuntimeRelativeDir,
+	)
 	for _, required := range []string{
 		"- name: opt-data\n        hostPath:\n          path: '{{ .Values.rootPath }}/userdata/Cache/chartrepo'\n          type: DirectoryOrCreate",
 		preinstallVolume,
+		ensureVolume,
 	} {
 		if !strings.Contains(volumes, required) {
 			t.Errorf("market deployment volumes missing contract:\n%s", required)
@@ -56,6 +67,10 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 	if strings.Count(container, "- name: market-preinstall\n") != 1 ||
 		strings.Count(volumes, "- name: market-preinstall\n") != 1 {
 		t.Errorf("market-preinstall must have one backend mount and one deployment volume")
+	}
+	if strings.Count(container, "- name: market-ensure\n") != 1 ||
+		strings.Count(volumes, "- name: market-ensure\n") != 1 {
+		t.Errorf("market-ensure must have one backend mount and one deployment volume")
 	}
 }
 

--- a/cli/pkg/preinstall/ensure-apps.json
+++ b/cli/pkg/preinstall/ensure-apps.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1",
+  "apps": [
+    {
+      "appId": "ai-router",
+      "appName": "ai-router",
+      "installScope": "shared",
+      "installOrder": 20
+    }
+  ]
+}

--- a/cli/pkg/preinstall/ensure.go
+++ b/cli/pkg/preinstall/ensure.go
@@ -1,0 +1,66 @@
+package preinstall
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+//go:embed ensure-apps.json
+var ensureAppsData []byte
+
+const ensureStagingPrefix = ".market-ensure-stage-"
+
+// PublishEnsureApps atomically publishes the catalog-following app declaration.
+func PublishEnsureApps(rootDir string) error {
+	olaresRoot, err := openOrCreateDirectoryNoSymlink(rootDir)
+	if err != nil {
+		return fmt.Errorf("open olares root: %w", err)
+	}
+	defer olaresRoot.Close()
+	parentRelative := path.Dir(EnsureRuntimeRelativeDir)
+	targetName := path.Base(EnsureRuntimeRelativeDir)
+	if err := olaresRoot.MkdirAll(parentRelative, 0o755); err != nil {
+		return fmt.Errorf("create ensure apps parent: %w", err)
+	}
+	if err := rejectRootSymlinkComponents(olaresRoot, parentRelative); err != nil {
+		return err
+	}
+	parentRoot, err := openDirectoryNoSymlink(filepath.Join(rootDir, filepath.FromSlash(parentRelative)))
+	if err != nil {
+		return fmt.Errorf("open ensure apps parent: %w", err)
+	}
+	defer parentRoot.Close()
+	if _, err := directoryStateRoot(parentRoot, targetName); err != nil {
+		return err
+	}
+	stagingName, _, stagingRoot, _, err := createTrustedStaging(parentRoot, ensureStagingPrefix, 8, 0o700)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if stagingRoot != nil {
+			_ = stagingRoot.Close()
+		}
+		_ = removeRootTree(parentRoot, stagingName)
+	}()
+	if err := writeSealedRootFile(stagingRoot, EnsureAppsFileName, ensureAppsData); err != nil {
+		return err
+	}
+	if err := sealRootDirectories(stagingRoot); err != nil {
+		return err
+	}
+	if err := stagingRoot.Close(); err != nil {
+		return fmt.Errorf("close ensure apps staging root: %w", err)
+	}
+	stagingRoot = nil
+	return replaceDirectoryRoot(parentRoot, targetName, stagingName)
+}
+
+// EnsureAppsPublished reports whether the declaration is available to Market.
+func EnsureAppsPublished(rootDir string) bool {
+	info, err := os.Lstat(filepath.Join(rootDir, filepath.FromSlash(EnsureRuntimeRelativeDir), EnsureAppsFileName))
+	return err == nil && info.Mode().IsRegular()
+}

--- a/cli/pkg/preinstall/ensure_test.go
+++ b/cli/pkg/preinstall/ensure_test.go
@@ -1,0 +1,45 @@
+package preinstall
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublishEnsureAppsIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, filepath.FromSlash(EnsureRuntimeRelativeDir))
+	t.Cleanup(func() { _ = makeWritable(target) })
+	for range 2 {
+		if err := PublishEnsureApps(root); err != nil {
+			t.Fatal(err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(target, EnsureAppsFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var contract struct {
+		SchemaVersion string `json:"schemaVersion"`
+		Apps          []struct {
+			AppID        string       `json:"appId"`
+			AppName      string       `json:"appName"`
+			InstallScope InstallScope `json:"installScope"`
+			InstallOrder int          `json:"installOrder"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatal(err)
+	}
+	if contract.SchemaVersion != SupportedSchemaVersion || len(contract.Apps) != 1 {
+		t.Fatalf("unexpected ensure apps contract: %+v", contract)
+	}
+	if app := contract.Apps[0]; app.AppID != "ai-router" || app.AppName != "ai-router" ||
+		app.InstallScope != InstallScopeShared || app.InstallOrder != 20 {
+		t.Fatalf("unexpected ensured app: %+v", app)
+	}
+	if !EnsureAppsPublished(root) {
+		t.Fatal("EnsureAppsPublished returned false")
+	}
+}

--- a/cli/pkg/preinstall/module.go
+++ b/cli/pkg/preinstall/module.go
@@ -44,6 +44,20 @@ func (a *MaterializeAction) Execute(_ connector.Runtime) error {
 	return Materialize(a.InstallerDir, rootDir, a.ProfileSelections)
 }
 
+// PublishEnsureAppsAction publishes the official apps required after an OS upgrade.
+type PublishEnsureAppsAction struct {
+	action.BaseAction
+	RootDir string
+}
+
+func (a *PublishEnsureAppsAction) Execute(_ connector.Runtime) error {
+	rootDir := a.RootDir
+	if rootDir == "" {
+		rootDir = storage.OlaresRootDir
+	}
+	return PublishEnsureApps(rootDir)
+}
+
 type HFCacheMaterializeModule struct {
 	common.KubeModule
 }

--- a/cli/pkg/preinstall/types.go
+++ b/cli/pkg/preinstall/types.go
@@ -13,6 +13,8 @@ const (
 	// .Values.rootPath for its read-only hostPath mount. It is not relative to
 	// the installer base directory.
 	RuntimeRelativeDir             = "userdata/Cache/market-preinstall"
+	EnsureRuntimeRelativeDir       = "userdata/Cache/market-ensure"
+	EnsureAppsFileName             = "ensure-apps.json"
 	MaxBundleJSONBytes             = 8 << 20
 	MaxProfileJSONBytes            = 8 << 20
 	MaxBundleApps                  = 256

--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -65,7 +65,6 @@ func (t *InstallOsSystem) Execute(runtime connector.Runtime) error {
 		common.HelmValuesKeyOlaresRootFSPath: storage.OlaresRootDir,
 		"sharedlib":                          storage.OlaresSharedLibDir,
 		"ensureApps":                         preinstall.EnsureAppsPublished(storage.OlaresRootDir),
-		"olaresVersion":                      t.KubeConf.Arg.OlaresVersion,
 		// Market only reads the preinstall mount when this says a bundle was
 		// published; an installer that ships none leaves the feature off
 		// instead of having Market look into an empty directory every boot.

--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -10,9 +10,9 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	agwconfig "github.com/beclab/Olares/framework/app-gateway/pkg/config"
 	"github.com/beclab/Olares/framework/app-service/api/sys.bytetrade.io/v1alpha1"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils"
-	agwconfig "github.com/beclab/Olares/framework/app-gateway/pkg/config"
 
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/preinstall"
@@ -64,6 +64,8 @@ func (t *InstallOsSystem) Execute(runtime connector.Runtime) error {
 		"fs_type":                            storage.GetRootFSType(),
 		common.HelmValuesKeyOlaresRootFSPath: storage.OlaresRootDir,
 		"sharedlib":                          storage.OlaresSharedLibDir,
+		"ensureApps":                         preinstall.EnsureAppsPublished(storage.OlaresRootDir),
+		"olaresVersion":                      t.KubeConf.Arg.OlaresVersion,
 		// Market only reads the preinstall mount when this says a bundle was
 		// published; an installer that ships none leaves the feature off
 		// instead of having Market look into an empty directory every boot.

--- a/cli/pkg/upgrade/1_12_7.go
+++ b/cli/pkg/upgrade/1_12_7.go
@@ -33,7 +33,7 @@ func (u upgrader_1_12_7) AddedBreakingChange() bool {
 }
 
 func (u upgrader_1_12_7) PrepareForUpgrade() []task.Interface {
-	tasks := make([]task.Interface, 0)
+	tasks := publishMarketEnsureApps()
 	tasks = append(tasks, migrateContainerdConfigV3()...)
 	tasks = append(tasks, &task.LocalTask{
 		Name:    "CleanupK3sCertsRenewService",

--- a/cli/pkg/upgrade/1_12_7_20260731.go
+++ b/cli/pkg/upgrade/1_12_7_20260731.go
@@ -1,0 +1,23 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_7_20260731 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260731) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260731")
+}
+
+func (u upgrader_1_12_7_20260731) PrepareForUpgrade() []task.Interface {
+	tasks := publishMarketEnsureApps()
+	return append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260731{})
+}

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -389,11 +389,7 @@ func (u *upgradeSystemComponents) Execute(runtime connector.Runtime) error {
 	ctx, cancelPlatform := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelPlatform()
 	platformChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-platform")
-	vals := map[string]interface{}{
-		"ensureApps":    preinstall.EnsureAppsPublished(storage.OlaresRootDir),
-		"olaresVersion": u.KubeConf.Arg.OlaresVersion,
-	}
-	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSPlatform, platformChartPath, "", common.NamespaceOsPlatform, vals, true); err != nil {
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSPlatform, platformChartPath, "", common.NamespaceOsPlatform, nil, true); err != nil {
 		return err
 	}
 
@@ -404,6 +400,9 @@ func (u *upgradeSystemComponents) Execute(runtime connector.Runtime) error {
 	ctx, cancelFramework := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelFramework()
 	frameworkChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-framework")
+	vals := map[string]interface{}{
+		"ensureApps": preinstall.EnsureAppsPublished(storage.OlaresRootDir),
+	}
 	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSFramework, frameworkChartPath, "", common.NamespaceOsFramework, vals, true); err != nil {
 		return err
 	}

--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -12,6 +12,8 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/gpu"
+	"github.com/beclab/Olares/cli/pkg/preinstall"
+	"github.com/beclab/Olares/cli/pkg/storage"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 	"github.com/beclab/Olares/cli/pkg/utils"
 	iamv1alpha2 "github.com/beclab/api/iam/v1alpha2"
@@ -387,7 +389,11 @@ func (u *upgradeSystemComponents) Execute(runtime connector.Runtime) error {
 	ctx, cancelPlatform := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelPlatform()
 	platformChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-platform")
-	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSPlatform, platformChartPath, "", common.NamespaceOsPlatform, nil, true); err != nil {
+	vals := map[string]interface{}{
+		"ensureApps":    preinstall.EnsureAppsPublished(storage.OlaresRootDir),
+		"olaresVersion": u.KubeConf.Arg.OlaresVersion,
+	}
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSPlatform, platformChartPath, "", common.NamespaceOsPlatform, vals, true); err != nil {
 		return err
 	}
 
@@ -398,7 +404,7 @@ func (u *upgradeSystemComponents) Execute(runtime connector.Runtime) error {
 	ctx, cancelFramework := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelFramework()
 	frameworkChartPath := path.Join(runtime.GetInstallerDir(), "wizard", "config", "os-framework")
-	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSFramework, frameworkChartPath, "", common.NamespaceOsFramework, nil, true); err != nil {
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, common.ChartNameOSFramework, frameworkChartPath, "", common.NamespaceOsFramework, vals, true); err != nil {
 		return err
 	}
 

--- a/cli/pkg/upgrade/ensure_apps_test.go
+++ b/cli/pkg/upgrade/ensure_apps_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	olversion "github.com/beclab/Olares/cli/version"
 )
 
 func TestEnsureAppsTaskIsVersionSpecific(t *testing.T) {
@@ -16,6 +17,7 @@ func TestEnsureAppsTaskIsVersionSpecific(t *testing.T) {
 		{name: "base", tasks: upgraderBase{}.PrepareForUpgrade()},
 		{name: "mainline", tasks: getUpgraderByVersion(upgrader_1_12_7{}.Version()).PrepareForUpgrade(), present: true},
 		{name: "daily", tasks: getUpgraderByVersion(semver.MustParse("1.12.7-20260731")).PrepareForUpgrade(), present: true},
+		{name: "successor", tasks: getUpgraderByVersion(semver.MustParse("1.12.8")).PrepareForUpgrade()},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			found := false
@@ -28,5 +30,16 @@ func TestEnsureAppsTaskIsVersionSpecific(t *testing.T) {
 				t.Fatalf("PublishMarketEnsureApps present=%t, want %t", found, test.present)
 			}
 		})
+	}
+}
+
+func TestOneTwelveSevenIsBreakingBoundaryForSuccessor(t *testing.T) {
+	original := olversion.VERSION
+	olversion.VERSION = "1.12.8"
+	t.Cleanup(func() { olversion.VERSION = original })
+
+	got := getLastBreakingVersion(mainUpgraders, semver.MustParse("1.12.8"))
+	if got == nil || !got.Equal(version_1_12_7) {
+		t.Fatalf("last breaking version before 1.12.8 = %v, want %s", got, version_1_12_7)
 	}
 }

--- a/cli/pkg/upgrade/ensure_apps_test.go
+++ b/cli/pkg/upgrade/ensure_apps_test.go
@@ -1,0 +1,32 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+func TestEnsureAppsTaskIsVersionSpecific(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tasks   []task.Interface
+		present bool
+	}{
+		{name: "base", tasks: upgraderBase{}.PrepareForUpgrade()},
+		{name: "stable", tasks: getUpgraderByVersion(semver.MustParse("1.12.7")).PrepareForUpgrade(), present: true},
+		{name: "daily", tasks: getUpgraderByVersion(semver.MustParse("1.12.7-20260731")).PrepareForUpgrade(), present: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			found := false
+			for _, candidate := range test.tasks {
+				if candidate.GetName() == "PublishMarketEnsureApps" {
+					found = true
+				}
+			}
+			if found != test.present {
+				t.Fatalf("PublishMarketEnsureApps present=%t, want %t", found, test.present)
+			}
+		})
+	}
+}

--- a/cli/pkg/upgrade/ensure_apps_test.go
+++ b/cli/pkg/upgrade/ensure_apps_test.go
@@ -14,7 +14,7 @@ func TestEnsureAppsTaskIsVersionSpecific(t *testing.T) {
 		present bool
 	}{
 		{name: "base", tasks: upgraderBase{}.PrepareForUpgrade()},
-		{name: "stable", tasks: getUpgraderByVersion(semver.MustParse("1.12.7")).PrepareForUpgrade(), present: true},
+		{name: "mainline", tasks: getUpgraderByVersion(upgrader_1_12_7{}.Version()).PrepareForUpgrade(), present: true},
 		{name: "daily", tasks: getUpgraderByVersion(semver.MustParse("1.12.7-20260731")).PrepareForUpgrade(), present: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -39,6 +39,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/phase"
 	"github.com/beclab/Olares/cli/pkg/plugins/network"
 	"github.com/beclab/Olares/cli/pkg/plugins/network/templates"
+	"github.com/beclab/Olares/cli/pkg/preinstall"
 	"github.com/beclab/Olares/cli/pkg/storage"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 	"github.com/beclab/Olares/cli/pkg/utils"
@@ -62,6 +63,15 @@ import (
 )
 
 const cacheRebootNeeded = "reboot.needed"
+
+func publishMarketEnsureApps() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "PublishMarketEnsureApps",
+			Action: new(preinstall.PublishEnsureAppsAction),
+		},
+	}
+}
 
 type upgradeContainerdAction struct {
 	common.KubeAction

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -133,13 +133,13 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.83
+        image: beclab/market-backend:v0.6.84
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81
         env:
           - name: OLARES_VERSION
-            value: "1.12.6"
+            value: "{{ .Values.olaresVersion }}"
           - name: APP_SOTRE_SERVICE_SERVICE_PORT
             value: "443"
           - name: APP_SERVICE_SERVICE_HOST
@@ -153,6 +153,10 @@ spec:
             value: 'true'
           - name: PREINSTALL_BUNDLE_DIR
             value: /opt/app/preinstall
+{{ end }}
+{{ if .Values.ensureApps }}
+          - name: ENSURE_APPS_FILE
+            value: /opt/app/ensure/ensure-apps.json
 {{ end }}
           - name: APP_SERVICE_SERVICE_PORT
             value: "6755"
@@ -214,6 +218,9 @@ spec:
           - name: market-preinstall
             mountPath: /opt/app/preinstall
             readOnly: true
+          - name: market-ensure
+            mountPath: /opt/app/ensure
+            readOnly: true
       volumes:
       - name: opt-data
         hostPath:
@@ -222,6 +229,10 @@ spec:
       - name: market-preinstall
         hostPath:
           path: '{{ .Values.rootPath }}/userdata/Cache/market-preinstall'
+          type: DirectoryOrCreate
+      - name: market-ensure
+        hostPath:
+          path: '{{ .Values.rootPath }}/userdata/Cache/market-ensure'
           type: DirectoryOrCreate
 ---
 apiVersion: v1

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -139,7 +139,7 @@ spec:
           - containerPort: 81
         env:
           - name: OLARES_VERSION
-            value: "{{ .Values.olaresVersion }}"
+            value: "1.12.7"
           - name: APP_SOTRE_SERVICE_SERVICE_PORT
             value: "443"
           - name: APP_SERVICE_SERVICE_HOST


### PR DESCRIPTION
## Summary

- publish a durable `ensure-apps.json` declaration when upgrading to Olares 1.12.7
- mount the declaration into Market so installation converges asynchronously after Market is upgraded and its official catalog is current
- declare `ai-router` as a shared managed app while preserving the existing offline preinstall path for fresh installations
- keep the declaration active across later system upgrades without republishing or reinstalling the app

## Dependency

- requires [beclab/market#399](https://github.com/beclab/market/pull/399)
- references `beclab/market-backend:v0.6.84`; publish that image before this chart is released

## Verification

- `cd cli && go build ./...`
- `cd cli && go test ./pkg/preinstall ./pkg/upgrade`
- successor regression verifies 1.12.8 does not republish the declaration
- breaking-boundary regression verifies 1.12.6 cannot skip 1.12.7
- IDE diagnostics: clean for changed files

## Baseline limitation

`go vet ./pkg/preinstall ./pkg/upgrade` retains two pre-existing `append with no values` findings in `1_12_7_20260629.go` and `1_12_7_20260701.go`.

## Release note

`1_12_7_20260731.go` must match an actually published daily version. Rename the file, type, version literal, and test together if the merge/release date changes.

Made with [Cursor](https://cursor.com)