### PR TITLE
fix: scope --delete-data to the app's own data dir and report ClearData failures

### DIFF
--- a/cli/cmd/ctl/market/help_test.go
+++ b/cli/cmd/ctl/market/help_test.go
@@ -21,6 +21,24 @@ func TestMarketCloneHelpMatchesCloneContract(t *testing.T) {
 	}
 }
 
+func TestMarketUninstallHelpScopesDeleteData(t *testing.T) {
+	long := NewCmdMarketUninstall(&cmdutil.Factory{}).Long
+	// "persistent data" reads as "everything the app wrote", which sent at
+	// least one user hunting for a bug when drive/Home survived uninstall.
+	for _, unwanted := range []string{"the app's persistent data", "remove the app's persistent data"} {
+		if strings.Contains(long, unwanted) {
+			t.Errorf("uninstall help understates --delete-data's scope: %q", unwanted)
+		}
+	}
+	// Addressing must match the platform storage model: Home and Data live
+	// under drive/, the per-app cache is reached as cache/<node>.
+	for _, required := range []string{"drive/Data", "cache/<node>", "drive/Home", "permission.userData", "deleteData"} {
+		if !strings.Contains(long, required) {
+			t.Errorf("uninstall help must describe %q", required)
+		}
+	}
+}
+
 func TestMarketGetHelpDescribesComputedCloneability(t *testing.T) {
 	long := NewCmdMarketGet(&cmdutil.Factory{}).Long
 	for _, unwanted := range []string{"full upstream payload", "jq '.cloneable'"} {

--- a/cli/cmd/ctl/market/options.go
+++ b/cli/cmd/ctl/market/options.go
@@ -202,7 +202,8 @@ func (o *MarketOptions) addEntranceTitleFlag(cmd *cobra.Command) {
 }
 
 func (o *MarketOptions) addDeleteDataFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&o.DeleteData, "delete-data", false, "delete persistent data when uninstalling")
+	cmd.Flags().BoolVar(&o.DeleteData, "delete-data", false,
+		"also delete the app's private data dir (drive/Data/<app>) when uninstalling; the node-local cache (cache/<node>/<app>) is cleared either way. Paths under drive/Home granted via the manifest's permission.userData are NEVER deleted — they belong to the user, not the app; remove them yourself with `olares-cli files rm`")
 }
 
 func (o *MarketOptions) addTitleFlag(cmd *cobra.Command) {

--- a/cli/cmd/ctl/market/uninstall.go
+++ b/cli/cmd/ctl/market/uninstall.go
@@ -58,7 +58,21 @@ is ALWAYS cascaded — the backend forces all=true and the SPA disables
 the checkbox — so --cascade=false is overridden (a stderr note reports
 the force). The --cascade=false override only takes effect on 1.12.5.
 
-Use --delete-data to also remove the app's persistent data.
+--delete-data covers only the app's OWN data (the JSON payload field
+is "deleteData"). What happens to each storage area on uninstall:
+
+  - cache/<node>/<app> — node-local and regenerable, so it is always
+    cleared, with or without the flag.
+  - drive/Data/<app> — app-private state (db files, config); cleared
+    only when --delete-data is passed.
+  - drive/Home/... — NEVER deleted. The manifest's permission.userData
+    grants an app access to the user's own files; it does not make the
+    app their owner, and the same paths may be shared with other apps
+    holding that permission. Clean up leftovers yourself with
+    "olares-cli files rm --recursive <path>".
+
+An app declaring only permission.userData therefore owns no data at
+all, and --delete-data has nothing to remove for it.
 
 --watch blocks until the row reaches 'uninstalled' or disappears
 entirely (acceptInitialAbsent=true: if the user's per-user row is
@@ -159,7 +173,7 @@ func runUninstall(opts *MarketOptions, cmd *cobra.Command, appName string) error
 		opts.info("  --cascade: will uninstall all sub-charts")
 	}
 	if opts.DeleteData {
-		opts.info("  --delete-data: will delete persistent data")
+		opts.info("  --delete-data: will delete the app's data dir (drive/Data/<app>); drive/Home is not touched")
 	}
 
 	// 1.12.6 requires source in the uninstall body, and the only place we

--- a/cli/skills/olares-market/references/olares-market-lifecycle.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle.md
@@ -87,6 +87,14 @@ The JSON payload field is `all`. Behavior depends on the backend version:
 
 > **1.12.6 caveat — cascade-cleanup after the row is gone:** once a prior uninstall has cleared the per-user row, 1.12.6's uninstall body has no source to send, so the CLI reports an idempotent `nothing to uninstall`. `market uninstall` does **not** expose `--source`, so re-running it to tear down leftover shared sub-charts is not reachable from the CLI — clean those up from the Market SPA.
 
+### `--delete-data`
+
+The JSON payload field is `deleteData`. It gates **only** the app's private `drive/Data/<app>`; `cache/<node>/<app>` is cleared either way and `drive/Home` is never touched. The full per-area rule and the reason `Home` is exempt live in the platform [storage model](../../olares-shared/references/olares-platform.md#userspace-storage-model).
+
+> **"Persistent data" is narrower than it sounds.** An app whose manifest declares only `permission.userData` (paths under `Home`) owns no app-private data, so `--delete-data` finds nothing to remove and its files survive the uninstall. That is by design, not a backend bug — clean them up with `olares-cli files rm --recursive <path>`.
+
+On a **cascading uninstall of a v2 multi-chart app** the flag reaches only the user's own client chart. The shared sub-charts are torn down with their cache cleared but their `Data/<subChart>` left in place — `v2`'s uninstall path never consults `deleteData`. Remove those by hand if you need the storage back.
+
 ### Uninstalling an in-flight app (auto-orchestrated)
 
 app-service only accepts `uninstall` from a settled state (`running` / `stopped` / a terminal `*Failed`, including `installFailed`); while an operation is in flight it accepts only `cancel`. `market uninstall` handles this for you so **`uninstall` always means "fully remove"** regardless of state:

--- a/cli/skills/olares-shared/references/olares-platform.md
+++ b/cli/skills/olares-shared/references/olares-platform.md
@@ -21,8 +21,9 @@ Key facts:
 - **Owner is uid 1000.** All five are read/written as uid/gid 1000 (see next section).
 - **Version gates.** `appCommon` needs Olares ≥ 1.12.6; `externalData`/`sharedlib` needs `olaresManifest.version` ≥ 0.12.0.
 - **Drive's `extend` must be `Home` or `Data` exactly** — `home` is rejected with `invalid drive type`.
+- **Uninstall deletes by area, not by "everything the app wrote".** app-service scans the workload's `hostPath` volumes against exactly two prefixes: the `appcache_hostpath` annotation (`Cache/<app>` — **always** cleared, it is regenerable) and `<userspace_hostpath>/Data/` (`Data/<app>` — cleared **only** with `market uninstall --delete-data`). `Home` matches neither prefix and is **never** deleted: `permission.userData` grants an app access to the user's own files, it does not make the app their owner, and the same paths may be shared with other apps holding the permission. Consequence: an app declaring only `userData` owns no data at all, so `--delete-data` is a no-op for it and leftovers need a manual `files rm --recursive`.
 
-Used by: `files` (addressing) and `chart` (mounting).
+Used by: `files` (addressing), `chart` (mounting) and `market` (what uninstall deletes).
 
 ## Run identity: uid/gid 1000
 

--- a/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
@@ -69,10 +69,10 @@ func (h *HelmOps) UninstallAll() error {
 		return err
 	}
 	if deleteData {
-		h.ClearData(client, appDataDirs)
-		if err != nil {
+		// Non-fatal: the release is already gone, so a failed data wipe must
+		// not block namespace teardown.
+		if err := h.ClearData(client, appDataDirs); err != nil {
 			klog.Errorf("Failed to clear app data dirs %v err=%v", appDataDirs, err)
-			//return err
 		}
 	}
 


### PR DESCRIPTION
## What

Two related changes around `market uninstall --delete-data`: make the flag's scope explicit in the CLI and the skill docs, and fix a swallowed error in app-service's uninstall path.

## Why

A user uninstalled an app with `--delete-data` and found its files still sitting under `drive/Home`, which reads like a backend bug. It is not.

`TryToGetAppdataDirFromDeployment` matches the workload's `hostPath` volumes against exactly two prefixes: the `appcache_hostpath` annotation (always cleared) and `<userspace_hostpath>/Data/` (cleared only when the flag is set). `drive/Home` matches neither, so it is never deleted — correctly so, since `permission.userData` grants an app *access* to the user's own files rather than ownership of them, and other apps may hold the same grant. An app that declares only `permission.userData` therefore owns no data at all, and `--delete-data` has nothing to remove for it.

The help text said only "delete persistent data", which reads as "everything the app wrote". That is the whole gap.

## Changes

**`fix(app-service)`** — [`helm_ops_uninstall.go`](framework/app-service/pkg/appinstaller/helm_ops_uninstall.go):

```go
h.ClearData(client, appDataDirs)   // error return discarded
if err != nil {                    // reads the err left over from ClearCache
    klog.Errorf(...)               // unreachable: the block above returns on non-nil err
}
```

`ClearData` returns an `error` that was never assigned, and the check right after it reads the `err` from the preceding `ClearCache` call — provably `nil` there, because that block already returns on a non-nil value. The `klog.Errorf` was dead code and a failed data wipe was swallowed without a trace. The non-fatal semantics are intentional (the release is already gone, so a failed wipe must not block namespace teardown) and are kept; only the log is made to fire.

**`docs(market)`** — the flag usage, the uninstall long help and the runtime notice now name `drive/Data/<app>` and state that `drive/Home` is never touched. The per-area rule is recorded once in the platform storage model, with a `--delete-data` section in the market lifecycle reference pointing at it.

## Verification

- `go vet ./cmd/ctl/market/...` clean
- `go test ./cmd/ctl/market/...` passes, including a new `TestMarketUninstallHelpScopesDeleteData` written in the style of the existing help tests
- The new test was checked against the wording it replaces: both strings in its `unwanted` list match the previous help text, so a regression to vague wording fails the test rather than passing silently
- `go build ./...` in `cli`, `go build ./pkg/appinstaller/...` in `framework/app-service`

Not covered: the app-service change is a logging path and was not exercised against a live cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CLI/docs plus a logging fix on an already non-fatal uninstall path; no change to what storage is deleted.
> 
> **Overview**
> Replaces vague **"persistent data"** wording for `market uninstall --delete-data` with explicit per-area behavior: **`cache/<node>/<app>`** is always cleared, **`drive/Data/<app>`** only with the flag, and **`drive/Home`** (including `permission.userData` paths) is never removed. Updates the flag help, uninstall long help, the runtime `--delete-data` notice, the platform storage model, and the market lifecycle reference; adds **`TestMarketUninstallHelpScopesDeleteData`** to lock the help text.
> 
> In **app-service** `UninstallAll`, **`ClearData`** errors are now assigned and logged instead of checking the stale **`err`** from **`ClearCache`** (which made the data-wipe failure log unreachable). Data wipe stays non-fatal so namespace teardown still proceeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a98ec748764105bc49e01ad717f3db3e3314256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->