### PR TITLE
fix(download-server): keep torrents seeding, HuggingFace inspect fixes

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -135,7 +135,7 @@ spec:
 
       containers:
       - name: aria2
-        image: "beclab/aria2:v0.0.4"
+        image: "beclab/aria2:v1.0.0"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.7"
+        image: "beclab/download-server:v1.0.8"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
The aria2 daemon was ending seeding the instant a download finished, so tasks went downloading → completed and the seed-control (stop/resume) feature had no active-seeding window to act on.
an inconclusive inspection is reported as unknown rather than being mislabelled public.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes ship only via new images on a cluster-critical DaemonSet; rollout risk depends on image contents not visible in this diff.
> 
> **Overview**
> This PR **only updates container images** in the download `DaemonSet` manifest—no application source changes in the diff.
> 
> The **aria2** sidecar moves from `beclab/aria2:v0.0.4` to **`v1.0.0`**, intended so torrents **keep seeding** after download completes instead of jumping straight to completed, which restores a window for seed stop/resume controls.
> 
> The **download-server** container moves from `v1.0.7` to **`v1.0.8`**, carrying fixes so **inconclusive HuggingFace repository inspection** is reported as **unknown** rather than mislabeled public.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892beeb7d90211dcdcc6fe1f5c28c40690d7f915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->