### PR TITLE
fix(app-service): bypass Linkerd iptables for Overlay macvlan (nft-only)

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
@@ -9,16 +9,6 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: os-mesh
 ---
-# Source: linkerd-control-plane/templates/heartbeat-rbac.yaml
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-heartbeat
-  namespace: os-mesh
-  labels:
-    linkerd.io/control-plane-component: heartbeat
-    linkerd.io/control-plane-ns: os-mesh
----
 # Source: linkerd-control-plane/templates/identity-rbac.yaml
 kind: ServiceAccount
 apiVersion: v1
@@ -94,7 +84,7 @@ data:
       podAnnotations: {}
       readinessProbe:
         timeoutSeconds: 1
-    disableHeartBeat: false
+    disableHeartBeat: true
     disableIPv6: true
     egress:
       globalEgressNetworkNamespace: linkerd-egress
@@ -492,21 +482,6 @@ rules:
       - get
       - patch
 ---
-# Source: linkerd-control-plane/templates/heartbeat-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: linkerd-heartbeat
-  labels:
-    linkerd.io/control-plane-ns: os-mesh
-rules:
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list"]
-- apiGroups: ["linkerd.io"]
-  resources: ["serviceprofiles"]
-  verbs: ["list"]
----
 # Source: linkerd-control-plane/templates/identity-rbac.yaml
 ###
 ### Identity Controller Service RBAC
@@ -591,22 +566,6 @@ subjects:
     name: linkerd-destination
     namespace: os-mesh
 ---
-# Source: linkerd-control-plane/templates/heartbeat-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: linkerd-heartbeat
-  labels:
-    linkerd.io/control-plane-ns: os-mesh
-roleRef:
-  kind: ClusterRole
-  name: linkerd-heartbeat
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: linkerd-heartbeat
-  namespace: os-mesh
----
 # Source: linkerd-control-plane/templates/identity-rbac.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -678,23 +637,6 @@ rules:
       - list
       - watch
 ---
-# Source: linkerd-control-plane/templates/heartbeat-rbac.yaml
-###
-### Heartbeat RBAC
-###
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: linkerd-heartbeat
-  namespace: os-mesh
-  labels:
-    linkerd.io/control-plane-ns: os-mesh
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get"]
-  resourceNames: ["linkerd-config"]
----
 # Source: linkerd-control-plane/templates/destination-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -713,23 +655,6 @@ subjects:
   - kind: ServiceAccount
     name: linkerd-destination
     namespace: os-mesh
----
-# Source: linkerd-control-plane/templates/heartbeat-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: linkerd-heartbeat
-  namespace: os-mesh
-  labels:
-    linkerd.io/control-plane-ns: os-mesh
-roleRef:
-  kind: Role
-  name: linkerd-heartbeat
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: linkerd-heartbeat
-  namespace: os-mesh
 ---
 # Source: linkerd-control-plane/templates/destination.yaml
 ###
@@ -2036,89 +1961,3 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
----
-# Source: linkerd-control-plane/templates/heartbeat.yaml
-###
-### Heartbeat
-###
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: linkerd-heartbeat
-  namespace: os-mesh
-  labels:
-    app.kubernetes.io/name: heartbeat
-    app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: edge-26.5.1
-    linkerd.io/control-plane-component: heartbeat
-    linkerd.io/control-plane-ns: os-mesh
-  annotations:
-    linkerd.io/created-by: linkerd/helm edge-26.5.1
-spec:
-  concurrencyPolicy: Replace
-  schedule: "13 09 * * *"
-  successfulJobsHistoryLimit: 0
-  jobTemplate:
-    spec:
-      template:
-        metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
-            linkerd.io/workload-ns: linkerd
-          annotations:
-            linkerd.io/created-by: linkerd/helm edge-26.5.1
-        spec:
-          nodeSelector:
-            kubernetes.io/os: linux
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
-          automountServiceAccountToken: false
-          containers:
-          - name: heartbeat
-            image: cr.l5d.io/linkerd/controller:edge-26.5.1
-            imagePullPolicy: IfNotPresent
-            env:
-            - name: LINKERD_DISABLED
-              value: "the heartbeat controller does not use the proxy"
-            args:
-            - "heartbeat"
-            - "-controller-namespace=os-mesh"
-            - "-log-level=info"
-            - "-log-format=plain"
-            - "-prometheus-url=http://prometheus-k8s.kubesphere-monitoring-system.svc.cluster.local:9090"
-            securityContext:
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              runAsUser: 2103
-              allowPrivilegeEscalation: false
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              name: kube-api-access
-              readOnly: true
-          volumes:
-          - name: kube-api-access
-            projected:
-              defaultMode: 420
-              sources:
-              - serviceAccountToken:
-                  expirationSeconds: 3607
-                  path: token
-              - configMap:
-                  items:
-                  - key: ca.crt
-                    path: ca.crt
-                  name: kube-root-ca.crt
-              - downwardAPI:
-                  items:
-                  - fieldRef:
-                      apiVersion: v1
-                      fieldPath: metadata.namespace
-                    path: namespace

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.13
+        image: beclab/app-service:0.6.14
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass.go
@@ -10,8 +10,8 @@ const (
 	// the macvlan NIC out of any in-pod transparent proxy interception.
 	MacvlanBypassInitContainerName = "macvlan-bypass-iptables"
 
-	// macvlanBypassImage must ship an iptables binary; it is the same image the
-	// envoy sidecar iptables init uses.
+	// macvlanBypassImage must ship iptables-nft. The image's bare `iptables`
+	// resolves to legacy; this bypass intentionally never calls it.
 	macvlanBypassImage = "beclab/init:v1.2.3"
 
 	// macvlanIfaceEnv carries the macvlan NIC name into the bypass script.
@@ -26,12 +26,32 @@ const (
 // jump a data-plane proxy installed (linkerd-init appends its jump to
 // PREROUTING/OUTPUT, mesh-in inserts its own REDIRECT at the head of OUTPUT).
 //
+// requirement: use iptables-nft only. Linkerd and mesh-in write nf_tables; a
+// bare `iptables` call in beclab/init lands on legacy and leaves the nft hijack
+// untouched (empty bypass). Envoy's macvlan RETURN still lives in the envoy
+// iptables init on legacy (#3239) and is not this container's job.
+// behavior: write four head ACCEPT rules on nft, then fail closed unless each
+// of the four chain heads is the iface ACCEPT.
 // The container must therefore run as the last init that touches iptables; it
 // writes once and exits instead of polling to reclaim the chain head.
 func MacvlanBypassScript() string {
 	return `set -u
 IFACE="${MACVLAN_IFACE:-net1}"
-echo "macvlan-bypass: interface=$IFACE"
+# Prefer PATH override for tests; production image has /sbin/iptables-nft.
+IPTABLES_BIN="${IPTABLES_BIN:-iptables-nft}"
+echo "macvlan-bypass: interface=$IFACE bin=$IPTABLES_BIN"
+command -v "$IPTABLES_BIN" >/dev/null 2>&1 || {
+  echo "macvlan-bypass: $IPTABLES_BIN not found (need nf_tables variant)" >&2
+  exit 1
+}
+version=$("$IPTABLES_BIN" --version 2>/dev/null || true)
+case "$version" in
+  *nf_tables*) ;;
+  *)
+    echo "macvlan-bypass: $IPTABLES_BIN is not nf_tables (got: ${version:-unknown})" >&2
+    exit 1
+    ;;
+esac
 ip link show "$IFACE" >/dev/null 2>&1 \
   || echo "macvlan-bypass: $IFACE not attached yet; interface-matched rules apply once it appears" >&2
 
@@ -39,17 +59,30 @@ reinsert() {
   t="$1"
   c="$2"
   d="$3"
-  while iptables -t "$t" -C "$c" "$d" "$IFACE" -j ACCEPT 2>/dev/null; do
-    iptables -t "$t" -D "$c" "$d" "$IFACE" -j ACCEPT || {
+  while "$IPTABLES_BIN" -t "$t" -C "$c" "$d" "$IFACE" -j ACCEPT 2>/dev/null; do
+    "$IPTABLES_BIN" -t "$t" -D "$c" "$d" "$IFACE" -j ACCEPT || {
       echo "macvlan-bypass: failed to drop stale rule -t $t $c $d $IFACE" >&2
       exit 1
     }
   done
-  iptables -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT || {
+  "$IPTABLES_BIN" -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT || {
     echo "macvlan-bypass: failed to install -t $t $c $d $IFACE" >&2
     exit 1
   }
   echo "macvlan-bypass: installed -t $t -I $c 1 $d $IFACE -j ACCEPT"
+}
+
+verify_head() {
+  t="$1"
+  c="$2"
+  d="$3"
+  dump=$("$IPTABLES_BIN" -t "$t" -S "$c" 2>/dev/null || true)
+  first=$(printf '%s\n' "$dump" | awk '/^-A /{print; exit}')
+  want="-A $c $d $IFACE -j ACCEPT"
+  if [ "$first" != "$want" ]; then
+    echo "macvlan-bypass: $t/$c head is not iface ACCEPT (got: ${first:-empty})" >&2
+    exit 1
+  fi
 }
 
 reinsert nat PREROUTING -i
@@ -57,11 +90,11 @@ reinsert nat OUTPUT -o
 reinsert filter INPUT -i
 reinsert filter OUTPUT -o
 
-echo "macvlan-bypass: nat/filter head after install:"
-iptables -t nat -S PREROUTING 2>/dev/null || true
-iptables -t nat -S OUTPUT 2>/dev/null || true
-iptables -t filter -S INPUT 2>/dev/null || true
-iptables -t filter -S OUTPUT 2>/dev/null || true
+verify_head nat PREROUTING -i
+verify_head nat OUTPUT -o
+verify_head filter INPUT -i
+verify_head filter OUTPUT -o
+echo "macvlan-bypass: verified four iface ACCEPT heads on nft"
 `
 }
 

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass.go
@@ -1,0 +1,111 @@
+package sidecar
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// MacvlanBypassInitContainerName is the init container that keeps traffic on
+	// the macvlan NIC out of any in-pod transparent proxy interception.
+	MacvlanBypassInitContainerName = "macvlan-bypass-iptables"
+
+	// macvlanBypassImage must ship an iptables binary; it is the same image the
+	// envoy sidecar iptables init uses.
+	macvlanBypassImage = "beclab/init:v1.2.3"
+
+	// macvlanIfaceEnv carries the macvlan NIC name into the bypass script.
+	macvlanIfaceEnv = "MACVLAN_IFACE"
+)
+
+// MacvlanBypassScript renders the bypass shell (unit-tested).
+//
+// Rules match on the interface only, so every protocol and port on the macvlan
+// NIC is covered without tracking business port lists. Each rule is re-inserted
+// at position 1 of a built-in chain, which short-circuits the chain before any
+// jump a data-plane proxy installed (linkerd-init appends its jump to
+// PREROUTING/OUTPUT, mesh-in inserts its own REDIRECT at the head of OUTPUT).
+//
+// The container must therefore run as the last init that touches iptables; it
+// writes once and exits instead of polling to reclaim the chain head.
+func MacvlanBypassScript() string {
+	return `set -u
+IFACE="${MACVLAN_IFACE:-net1}"
+echo "macvlan-bypass: interface=$IFACE"
+ip link show "$IFACE" >/dev/null 2>&1 \
+  || echo "macvlan-bypass: $IFACE not attached yet; interface-matched rules apply once it appears" >&2
+
+reinsert() {
+  t="$1"
+  c="$2"
+  d="$3"
+  while iptables -t "$t" -C "$c" "$d" "$IFACE" -j ACCEPT 2>/dev/null; do
+    iptables -t "$t" -D "$c" "$d" "$IFACE" -j ACCEPT || {
+      echo "macvlan-bypass: failed to drop stale rule -t $t $c $d $IFACE" >&2
+      exit 1
+    }
+  done
+  iptables -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT || {
+    echo "macvlan-bypass: failed to install -t $t $c $d $IFACE" >&2
+    exit 1
+  }
+  echo "macvlan-bypass: installed -t $t -I $c 1 $d $IFACE -j ACCEPT"
+}
+
+reinsert nat PREROUTING -i
+reinsert nat OUTPUT -o
+reinsert filter INPUT -i
+reinsert filter OUTPUT -o
+
+echo "macvlan-bypass: nat/filter head after install:"
+iptables -t nat -S PREROUTING 2>/dev/null || true
+iptables -t nat -S OUTPUT 2>/dev/null || true
+iptables -t filter -S INPUT 2>/dev/null || true
+iptables -t filter -S OUTPUT 2>/dev/null || true
+`
+}
+
+// GetMacvlanBypassInitContainer returns the macvlan bypass init container spec.
+func GetMacvlanBypassInitContainer() corev1.Container {
+	return corev1.Container{
+		Name:            MacvlanBypassInitContainerName,
+		Image:           macvlanBypassImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                pointer.Int64Ptr(0),
+			RunAsNonRoot:             pointer.BoolPtr(false),
+			AllowPrivilegeEscalation: pointer.BoolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+			},
+		},
+		Command: []string{"/bin/sh", "-c", MacvlanBypassScript()},
+		Env: []corev1.EnvVar{
+			{Name: macvlanIfaceEnv, Value: defaultMacvlanIface},
+		},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+// EnsureMacvlanBypassLast moves the bypass init container to the end of the
+// init sequence, appending it when absent.
+//
+// Admission runs in several passes (macvlan webhook, sidecar webhook, then the
+// Linkerd injector), and each pass may append its own iptables init. Re-placing
+// the bypass on every pass is what keeps it behind mesh-in and linkerd-init
+// without depending on webhook ordering.
+func EnsureMacvlanBypassLast(pod *corev1.Pod) {
+	if pod == nil {
+		return
+	}
+	kept := make([]corev1.Container, 0, len(pod.Spec.InitContainers)+1)
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == MacvlanBypassInitContainerName {
+			continue
+		}
+		kept = append(kept, c)
+	}
+	pod.Spec.InitContainers = append(kept, GetMacvlanBypassInitContainer())
+}

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_script_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_script_test.go
@@ -10,8 +10,12 @@ import (
 
 // iptablesMock records rules per table/chain in files so the bypass script can
 // be executed end-to-end without a real netfilter stack: -A appends, -I
-// prepends, -C probes, -D removes, -S dumps.
+// prepends, -C probes, -D removes, -S dumps (iptables-save style with -A lines).
 const iptablesMock = `#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "iptables v1.8.8 (nf_tables)"
+  exit 0
+fi
 table=filter
 op=""
 chain=""
@@ -55,7 +59,13 @@ case "$op" in
     cat "$f" >> "$f.tmp"
     mv "$f.tmp" "$f"
     ;;
-  -S) cat "$f" ;;
+  -S)
+    printf -- '-P %s ACCEPT\n' "$chain"
+    while IFS= read -r line || [ -n "$line" ]; do
+      [ -z "$line" ] && continue
+      printf -- '-A %s %s\n' "$chain" "$line"
+    done < "$f"
+    ;;
   *) exit 2 ;;
 esac
 `
@@ -76,8 +86,8 @@ func newBypassScriptRun(t *testing.T) *bypassScriptRun {
 			t.Fatalf("mkdir %s: %v", d, err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(bin, "iptables"), []byte(iptablesMock), 0o755); err != nil {
-		t.Fatalf("write iptables mock: %v", err)
+	if err := os.WriteFile(filepath.Join(bin, "iptables-nft"), []byte(iptablesMock), 0o755); err != nil {
+		t.Fatalf("write iptables-nft mock: %v", err)
 	}
 	return &bypassScriptRun{t: t, state: state, bin: bin}
 }
@@ -135,6 +145,9 @@ func TestMacvlanBypassScriptWinsChainHeadOverProxyRules(t *testing.T) {
 	out, err := r.run()
 	if err != nil {
 		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "verified four iface ACCEPT heads on nft") {
+		t.Fatalf("self-check must confirm nft chain heads, output:\n%s", out)
 	}
 
 	for _, tc := range []struct{ table, chain, want string }{
@@ -196,5 +209,39 @@ func TestMacvlanBypassScriptFailsClosedWhenInsertFails(t *testing.T) {
 	}
 	if !strings.Contains(out, "failed to install") {
 		t.Fatalf("script must report the failing rule, output:\n%s", out)
+	}
+}
+
+func TestMacvlanBypassScriptFailsClosedWhenNftBinaryMissing(t *testing.T) {
+	r := newBypassScriptRun(t)
+
+	out, err := r.run("IPTABLES_BIN=iptables-nft-missing")
+	if err == nil {
+		t.Fatalf("script must fail when iptables-nft is missing, output:\n%s", out)
+	}
+	if !strings.Contains(out, "iptables-nft-missing not found") {
+		t.Fatalf("script must report missing nft binary, output:\n%s", out)
+	}
+}
+
+func TestMacvlanBypassScriptFailsClosedWhenNotNftVariant(t *testing.T) {
+	r := newBypassScriptRun(t)
+	legacy := `#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "iptables v1.8.8 (legacy)"
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(r.bin, "iptables-legacy-fake"), []byte(legacy), 0o755); err != nil {
+		t.Fatalf("write legacy fake: %v", err)
+	}
+
+	out, err := r.run("IPTABLES_BIN=iptables-legacy-fake")
+	if err == nil {
+		t.Fatalf("script must fail when binary is not nf_tables, output:\n%s", out)
+	}
+	if !strings.Contains(out, "is not nf_tables") {
+		t.Fatalf("script must reject non-nft variant, output:\n%s", out)
 	}
 }

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_script_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_script_test.go
@@ -1,0 +1,200 @@
+package sidecar
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// iptablesMock records rules per table/chain in files so the bypass script can
+// be executed end-to-end without a real netfilter stack: -A appends, -I
+// prepends, -C probes, -D removes, -S dumps.
+const iptablesMock = `#!/bin/sh
+table=filter
+op=""
+chain=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -t)
+      table="$2"
+      shift 2
+      ;;
+    -C|-D|-A|-S)
+      op="$1"
+      chain="$2"
+      shift 2
+      break
+      ;;
+    -I)
+      op="-I"
+      chain="$2"
+      shift 2
+      case "$1" in
+        [0-9]*) shift ;;
+      esac
+      break
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+f="${IPT_STATE}/${table}_${chain}"
+: > /dev/null
+touch "$f"
+rule="$*"
+case "$op" in
+  -C) grep -Fxq -- "$rule" "$f" ;;
+  -D) grep -vFx -- "$rule" "$f" > "$f.tmp"; mv "$f.tmp" "$f" ;;
+  -A) printf '%s\n' "$rule" >> "$f" ;;
+  -I)
+    if [ "${IPT_FAIL_INSERT:-0}" = "1" ]; then exit 1; fi
+    printf '%s\n' "$rule" > "$f.tmp"
+    cat "$f" >> "$f.tmp"
+    mv "$f.tmp" "$f"
+    ;;
+  -S) cat "$f" ;;
+  *) exit 2 ;;
+esac
+`
+
+type bypassScriptRun struct {
+	t     *testing.T
+	state string
+	bin   string
+}
+
+func newBypassScriptRun(t *testing.T) *bypassScriptRun {
+	t.Helper()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	state := filepath.Join(root, "state")
+	for _, d := range []string{bin, state} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(bin, "iptables"), []byte(iptablesMock), 0o755); err != nil {
+		t.Fatalf("write iptables mock: %v", err)
+	}
+	return &bypassScriptRun{t: t, state: state, bin: bin}
+}
+
+// seed installs a pre-existing rule, e.g. the jump linkerd-init appends.
+func (r *bypassScriptRun) seed(table, chain, rule string) {
+	r.t.Helper()
+	path := filepath.Join(r.state, table+"_"+chain)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		r.t.Fatalf("seed %s/%s: %v", table, chain, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(rule + "\n"); err != nil {
+		r.t.Fatalf("seed write %s/%s: %v", table, chain, err)
+	}
+}
+
+func (r *bypassScriptRun) run(extraEnv ...string) (string, error) {
+	r.t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", MacvlanBypassScript())
+	cmd.Env = append(os.Environ(),
+		"PATH="+r.bin+":"+os.Getenv("PATH"),
+		"IPT_STATE="+r.state,
+		"MACVLAN_IFACE=net1",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func (r *bypassScriptRun) rules(table, chain string) []string {
+	r.t.Helper()
+	raw, err := os.ReadFile(filepath.Join(r.state, table+"_"+chain))
+	if err != nil {
+		r.t.Fatalf("read %s/%s: %v", table, chain, err)
+	}
+	lines := make([]string, 0, 4)
+	for _, l := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if l != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
+}
+
+func TestMacvlanBypassScriptWinsChainHeadOverProxyRules(t *testing.T) {
+	r := newBypassScriptRun(t)
+	// linkerd-init appends its inbound jump, mesh-in inserts a REDIRECT head.
+	r.seed("nat", "PREROUTING", "-p tcp -j PROXY_INIT_REDIRECT")
+	r.seed("nat", "OUTPUT", "-p tcp -d 10.0.0.1 --dport 80 -j REDIRECT --to-ports 15001")
+	r.seed("filter", "INPUT", "-p tcp -j DROP")
+	r.seed("filter", "OUTPUT", "-p tcp -j DROP")
+
+	out, err := r.run()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+
+	for _, tc := range []struct{ table, chain, want string }{
+		{"nat", "PREROUTING", "-i net1 -j ACCEPT"},
+		{"nat", "OUTPUT", "-o net1 -j ACCEPT"},
+		{"filter", "INPUT", "-i net1 -j ACCEPT"},
+		{"filter", "OUTPUT", "-o net1 -j ACCEPT"},
+	} {
+		rules := r.rules(tc.table, tc.chain)
+		if rules[0] != tc.want {
+			t.Fatalf("%s/%s head = %q, want %q (all: %v)", tc.table, tc.chain, rules[0], tc.want, rules)
+		}
+		if len(rules) != 2 {
+			t.Fatalf("%s/%s must keep the pre-existing rule, got %v", tc.table, tc.chain, rules)
+		}
+	}
+}
+
+func TestMacvlanBypassScriptReinsertsStaleRuleAtHead(t *testing.T) {
+	r := newBypassScriptRun(t)
+	// A bypass rule left behind below a later -I 1 from another component.
+	r.seed("nat", "PREROUTING", "-p tcp -j PROXY_INIT_REDIRECT")
+	r.seed("nat", "PREROUTING", "-i net1 -j ACCEPT")
+
+	out, err := r.run()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+
+	rules := r.rules("nat", "PREROUTING")
+	if rules[0] != "-i net1 -j ACCEPT" {
+		t.Fatalf("stale rule not moved to head: %v", rules)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("stale duplicate not cleaned up: %v", rules)
+	}
+}
+
+func TestMacvlanBypassScriptIsIdempotentAcrossRuns(t *testing.T) {
+	r := newBypassScriptRun(t)
+
+	for i := 0; i < 3; i++ {
+		if out, err := r.run(); err != nil {
+			t.Fatalf("run %d failed: %v\n%s", i, err, out)
+		}
+	}
+
+	if rules := r.rules("filter", "INPUT"); len(rules) != 1 {
+		t.Fatalf("expected exactly one rule after repeated runs, got %v", rules)
+	}
+}
+
+func TestMacvlanBypassScriptFailsClosedWhenInsertFails(t *testing.T) {
+	r := newBypassScriptRun(t)
+
+	out, err := r.run("IPT_FAIL_INSERT=1")
+	if err == nil {
+		t.Fatalf("script must exit non-zero when a rule cannot be installed, output:\n%s", out)
+	}
+	if !strings.Contains(out, "failed to install") {
+		t.Fatalf("script must report the failing rule, output:\n%s", out)
+	}
+}

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_test.go
@@ -1,0 +1,154 @@
+package sidecar
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMacvlanBypassScriptInstallsFourHeadAcceptRules(t *testing.T) {
+	script := MacvlanBypassScript()
+
+	for _, want := range []string{
+		"reinsert nat PREROUTING -i",
+		"reinsert nat OUTPUT -o",
+		"reinsert filter INPUT -i",
+		"reinsert filter OUTPUT -o",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("bypass script missing %q in:\n%s", want, script)
+		}
+	}
+	if !strings.Contains(script, `iptables -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT`) {
+		t.Fatalf("bypass script must insert ACCEPT at chain head in:\n%s", script)
+	}
+	if !strings.Contains(script, `IFACE="${MACVLAN_IFACE:-net1}"`) {
+		t.Fatalf("bypass script must read the iface from env with net1 default in:\n%s", script)
+	}
+}
+
+func TestMacvlanBypassScriptStaysSingleShotAndNonDestructive(t *testing.T) {
+	script := MacvlanBypassScript()
+
+	for _, forbidden := range []string{
+		"NOTRACK",
+		"iptables -F",
+		"iptables -t nat -F",
+		"-P INPUT",
+		"-P OUTPUT",
+		"sleep",
+		"while true",
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("bypass script must not contain %q (no reclaim loop, no flush, no policy change) in:\n%s", forbidden, script)
+		}
+	}
+	if strings.Count(script, "exit 1") == 0 {
+		t.Fatalf("bypass script must fail closed when a rule cannot be installed in:\n%s", script)
+	}
+}
+
+func TestGetMacvlanBypassInitContainerSpec(t *testing.T) {
+	c := GetMacvlanBypassInitContainer()
+
+	if c.Name != MacvlanBypassInitContainerName {
+		t.Fatalf("unexpected container name %q", c.Name)
+	}
+	if strings.HasSuffix(c.Image, ":latest") || !strings.Contains(c.Image, ":") {
+		t.Fatalf("bypass image must be pinned to a tag other than latest, got %q", c.Image)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.Capabilities == nil {
+		t.Fatalf("bypass container needs a security context with capabilities")
+	}
+	hasNetAdmin := false
+	for _, add := range c.SecurityContext.Capabilities.Add {
+		if add == "NET_ADMIN" {
+			hasNetAdmin = true
+		}
+	}
+	if !hasNetAdmin {
+		t.Fatalf("bypass container needs NET_ADMIN to write iptables, got %v", c.SecurityContext.Capabilities.Add)
+	}
+	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Fatalf("bypass container must run as root to write iptables")
+	}
+	iface := ""
+	for _, e := range c.Env {
+		if e.Name == macvlanIfaceEnv {
+			iface = e.Value
+		}
+	}
+	if iface != defaultMacvlanIface {
+		t.Fatalf("expected %s=%s, got %q", macvlanIfaceEnv, defaultMacvlanIface, iface)
+	}
+}
+
+func TestEnsureMacvlanBypassLast(t *testing.T) {
+	tests := []struct {
+		name  string
+		inits []string
+		want  []string
+	}{
+		{
+			name:  "append to empty init list",
+			inits: nil,
+			want:  []string{MacvlanBypassInitContainerName},
+		},
+		{
+			name:  "append after linkerd and mesh-in iptables writers",
+			inits: []string{"linkerd-init", "macvlan-reply-via-eth0", "olares-mesh-in-agent-iptables"},
+			want:  []string{"linkerd-init", "macvlan-reply-via-eth0", "olares-mesh-in-agent-iptables", MacvlanBypassInitContainerName},
+		},
+		{
+			name:  "move an already injected bypass back to the tail",
+			inits: []string{"linkerd-init", MacvlanBypassInitContainerName, "olares-mesh-in-agent-iptables"},
+			want:  []string{"linkerd-init", "olares-mesh-in-agent-iptables", MacvlanBypassInitContainerName},
+		},
+		{
+			name:  "collapse duplicates",
+			inits: []string{MacvlanBypassInitContainerName, "linkerd-init", MacvlanBypassInitContainerName},
+			want:  []string{"linkerd-init", MacvlanBypassInitContainerName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			for _, n := range tt.inits {
+				pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{Name: n})
+			}
+
+			EnsureMacvlanBypassLast(pod)
+
+			got := make([]string, 0, len(pod.Spec.InitContainers))
+			for _, c := range pod.Spec.InitContainers {
+				got = append(got, c.Name)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("init order = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureMacvlanBypassLastIsIdempotent(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Spec.InitContainers = []corev1.Container{{Name: "linkerd-init"}}
+
+	EnsureMacvlanBypassLast(pod)
+	first := len(pod.Spec.InitContainers)
+	EnsureMacvlanBypassLast(pod)
+
+	if len(pod.Spec.InitContainers) != first {
+		t.Fatalf("repeated calls must not grow the init list: %d -> %d", first, len(pod.Spec.InitContainers))
+	}
+	last := pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1]
+	if last.Name != MacvlanBypassInitContainerName {
+		t.Fatalf("bypass must stay last, got %q", last.Name)
+	}
+}
+
+func TestEnsureMacvlanBypassLastNilPod(t *testing.T) {
+	EnsureMacvlanBypassLast(nil)
+}

--- a/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/macvlan_bypass_test.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestMacvlanBypassScriptInstallsFourHeadAcceptRules(t *testing.T) {
+func TestMacvlanBypassScriptInstallsFourHeadAcceptRulesOnNft(t *testing.T) {
 	script := MacvlanBypassScript()
 
 	for _, want := range []string{
@@ -20,11 +20,20 @@ func TestMacvlanBypassScriptInstallsFourHeadAcceptRules(t *testing.T) {
 			t.Fatalf("bypass script missing %q in:\n%s", want, script)
 		}
 	}
-	if !strings.Contains(script, `iptables -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT`) {
-		t.Fatalf("bypass script must insert ACCEPT at chain head in:\n%s", script)
+	if !strings.Contains(script, `"$IPTABLES_BIN" -t "$t" -I "$c" 1 "$d" "$IFACE" -j ACCEPT`) {
+		t.Fatalf("bypass script must insert ACCEPT at chain head via IPTABLES_BIN in:\n%s", script)
+	}
+	if !strings.Contains(script, `IPTABLES_BIN="${IPTABLES_BIN:-iptables-nft}"`) {
+		t.Fatalf("bypass script must default IPTABLES_BIN to iptables-nft in:\n%s", script)
 	}
 	if !strings.Contains(script, `IFACE="${MACVLAN_IFACE:-net1}"`) {
 		t.Fatalf("bypass script must read the iface from env with net1 default in:\n%s", script)
+	}
+	if strings.Count(script, "verify_head ") != 4 {
+		t.Fatalf("bypass script must self-check all four nft chain heads in:\n%s", script)
+	}
+	if strings.Contains(script, "iptables-legacy") {
+		t.Fatalf("bypass script must be nft-only and must not mention iptables-legacy in:\n%s", script)
 	}
 }
 
@@ -42,6 +51,15 @@ func TestMacvlanBypassScriptStaysSingleShotAndNonDestructive(t *testing.T) {
 	} {
 		if strings.Contains(script, forbidden) {
 			t.Fatalf("bypass script must not contain %q (no reclaim loop, no flush, no policy change) in:\n%s", forbidden, script)
+		}
+	}
+	// Bare `iptables` is alternatives-dependent (legacy in beclab/init); only iptables-nft.
+	for _, line := range strings.Split(script, "\n") {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "iptables ") || strings.Contains(trim, " iptables ") {
+			if !strings.Contains(trim, "iptables-nft") && !strings.Contains(trim, "IPTABLES_BIN") {
+				t.Fatalf("bypass script must not invoke bare iptables on line %q in:\n%s", trim, script)
+			}
 		}
 	}
 	if strings.Count(script, "exit 1") == 0 {

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -286,6 +286,18 @@ func (wh *Webhook) CreatePatch(
 		}
 	} // end of inject sidecar
 
+	// The macvlan bypass must stay behind every iptables writer in the init
+	// sequence (mesh-in agent iptables is appended above, linkerd-init comes
+	// from a later admission pass), so re-place it after the sidecar block.
+	injectMacvlanBypass, err := wh.ShouldInjectMacvlanInit(ctx, pod, req.Namespace)
+	if err != nil {
+		klog.Errorf("macvlan-bypass: failed to evaluate injection for pod=%s/%s err=%v", req.Namespace, pod.Name, err)
+		return nil, err
+	}
+	if injectMacvlanBypass {
+		sidecar.EnsureMacvlanBypassLast(pod)
+	}
+
 	if injectSharedPod != nil {
 		if *injectSharedPod {
 			if pod.Labels == nil {
@@ -1107,15 +1119,22 @@ func (wh *Webhook) CreateMacvlanInitPatch(req *admissionv1.AdmissionRequest, pod
 	}
 	pod.Annotations["k8s.v1.cni.cncf.io/networks"] = "kube-system/underlay-macvlan"
 
+	hasReplyInit := false
 	for _, c := range pod.Spec.InitContainers {
 		if c.Name == MacvlanInitContainerName {
 			klog.Infof("macvlan-init: container already present in pod=%s/%s, skip", pod.Namespace, pod.Name)
-			return makePatches(req, pod)
+			hasReplyInit = true
+			break
 		}
 	}
-	// Append after any existing init containers (e.g. sidecar wait-for /
-	// render-envoy-config) so we run after them but still before the main
-	// app containers.
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, GetMacvlanInitContainer())
+	if !hasReplyInit {
+		// Append after any existing init containers (e.g. sidecar wait-for /
+		// render-envoy-config) so we run after them but still before the main
+		// app containers.
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, GetMacvlanInitContainer())
+	}
+	// Keep the iptables bypass last: routing setup above only touches ip rules,
+	// while the bypass has to win the head of the nat/filter chains.
+	sidecar.EnsureMacvlanBypassLast(pod)
 	return makePatches(req, pod)
 }

--- a/framework/app-service/pkg/webhook/webhook_macvlan_bypass_test.go
+++ b/framework/app-service/pkg/webhook/webhook_macvlan_bypass_test.go
@@ -1,0 +1,119 @@
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/gateway/meshinagent"
+	"github.com/beclab/Olares/framework/app-service/pkg/sandbox/sidecar"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func macvlanBypassAdmissionRequest(t *testing.T, pod *corev1.Pod) *admissionv1.AdmissionRequest {
+	t.Helper()
+	raw, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("marshal pod: %v", err)
+	}
+	return &admissionv1.AdmissionRequest{
+		Namespace: pod.Namespace,
+		Object:    runtime.RawExtension{Raw: raw},
+	}
+}
+
+func initNames(pod *corev1.Pod) []string {
+	names := make([]string, 0, len(pod.Spec.InitContainers))
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+func indexOfInit(pod *corev1.Pod, name string) int {
+	for i, c := range pod.Spec.InitContainers {
+		if c.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestCreateMacvlanInitPatchPutsBypassAfterReplyInit(t *testing.T) {
+	wh := &Webhook{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "jellyfin-0", Namespace: "app-space"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "linkerd-init"}},
+			Containers:     []corev1.Container{{Name: "jellyfin"}},
+		},
+	}
+	req := macvlanBypassAdmissionRequest(t, pod)
+
+	if _, err := wh.CreateMacvlanInitPatch(req, pod); err != nil {
+		t.Fatalf("CreateMacvlanInitPatch: %v", err)
+	}
+
+	names := initNames(pod)
+	if last := names[len(names)-1]; last != sidecar.MacvlanBypassInitContainerName {
+		t.Fatalf("bypass must be the last init, got order %v", names)
+	}
+	if indexOfInit(pod, MacvlanInitContainerName) < 0 {
+		t.Fatalf("macvlan reply init missing, order %v", names)
+	}
+	if indexOfInit(pod, MacvlanInitContainerName) > indexOfInit(pod, sidecar.MacvlanBypassInitContainerName) {
+		t.Fatalf("bypass must run after the reply-route init, order %v", names)
+	}
+}
+
+func TestCreateMacvlanInitPatchIsIdempotent(t *testing.T) {
+	wh := &Webhook{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "jellyfin-0", Namespace: "app-space"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "jellyfin"}}},
+	}
+	req := macvlanBypassAdmissionRequest(t, pod)
+
+	if _, err := wh.CreateMacvlanInitPatch(req, pod); err != nil {
+		t.Fatalf("first patch: %v", err)
+	}
+	if _, err := wh.CreateMacvlanInitPatch(req, pod); err != nil {
+		t.Fatalf("second patch: %v", err)
+	}
+
+	names := initNames(pod)
+	if len(names) != 2 {
+		t.Fatalf("expected reply init + bypass only, got %v", names)
+	}
+	if names[1] != sidecar.MacvlanBypassInitContainerName {
+		t.Fatalf("bypass must stay last, got %v", names)
+	}
+}
+
+// The bypass only works when it writes iptables after every other writer in the
+// pod; mesh-in inserts its own REDIRECT at the head of nat OUTPUT.
+func TestMacvlanBypassRunsAfterMeshInIptablesInit(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "linkerd-init"},
+				{Name: MacvlanInitContainerName},
+			},
+		},
+	}
+	sidecar.EnsureMacvlanBypassLast(pod)
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, meshinagent.InitContainerSpec())
+
+	sidecar.EnsureMacvlanBypassLast(pod)
+
+	names := initNames(pod)
+	if indexOfInit(pod, meshinagent.InitContainerName) > indexOfInit(pod, sidecar.MacvlanBypassInitContainerName) {
+		t.Fatalf("bypass must run after mesh-in iptables init, order %v", names)
+	}
+	if names[len(names)-1] != sidecar.MacvlanBypassInitContainerName {
+		t.Fatalf("bypass must be last, order %v", names)
+	}
+}


### PR DESCRIPTION
## Summary

Overlay (`net1`) traffic was still redirected by Linkerd because the bypass wrote legacy iptables while Linkerd uses nft.

This change injects a final init that installs four head `ACCEPT` rules with `iptables-nft` only, verifies the chain heads, and pins `app-service` to `0.6.14`.

## Test plan

- [x] Unit tests pass
- [x] Bypass is last init; logs show nft verify
- [x] `iptables-nft` PREROUTING head is `-i net1 -j ACCEPT` before Linkerd redirect
- [x] LAN curl to `net1:8096` returns 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pod networking changes depend on init ordering and privileged `NET_ADMIN` iptables rules; mis-ordering or a failed bypass could break overlay reachability or leave mesh redirect in place, though behavior is fail-closed and heavily unit-tested.
> 
> **Overview**
> Fixes overlay (`net1`) LAN traffic being hijacked by Linkerd/mesh-in because prior bypass logic used legacy iptables while the mesh writes **nf_tables**.
> 
> **app-service** adds a `macvlan-bypass-iptables` init that uses **`iptables-nft` only** to insert four interface-scoped `ACCEPT` rules at the head of `nat`/`filter` `PREROUTING`, `OUTPUT`, and `INPUT` chains for `net1`, then verifies each chain head and fails closed on error. `EnsureMacvlanBypassLast` keeps this init **after** `linkerd-init`, mesh-in iptables, and the macvlan reply-route init across multiple admission passes; injection is wired from the sidecar webhook and macvlan init patch. Deploy image bumps to **`beclab/app-service:0.6.14`**.
> 
> **Linkerd control-plane manifest** sets `disableHeartBeat: true` and removes the heartbeat ServiceAccount, RBAC, and CronJob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8bdc010f5097377658d3f0fa7bf305f2645a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->