### PR TITLE
fix(cli): use controller-runtime client to patch node label

### DIFF
--- a/cli/pkg/clientset/client.go
+++ b/cli/pkg/clientset/client.go
@@ -4,16 +4,21 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Client interface {
 	Kubernetes() kubernetes.Interface
+	CtrlRuntime() ctrlclient.Client
 	Config() *rest.Config
 }
 
 type kubeClient struct {
 	// kubernetes client
 	k8s kubernetes.Interface
+
+	// controller-runtime client
+	ctrl ctrlclient.Client
 
 	// +optional
 	master string
@@ -35,8 +40,14 @@ func NewKubeClient() (Client, error) {
 		return nil, err
 	}
 
+	ctrlClient, err := ctrlclient.New(config, ctrlclient.Options{})
+	if err != nil {
+		return nil, err
+	}
+
 	client := kubeClient{
 		k8s:    k8sClient,
+		ctrl:   ctrlClient,
 		master: config.Host,
 		config: config,
 	}
@@ -46,6 +57,10 @@ func NewKubeClient() (Client, error) {
 
 func (k *kubeClient) Kubernetes() kubernetes.Interface {
 	return k.k8s
+}
+
+func (k *kubeClient) CtrlRuntime() ctrlclient.Client {
+	return k.ctrl
 }
 
 func (k *kubeClient) Config() *rest.Config {

--- a/cli/pkg/gpu/amdgpu/tasks.go
+++ b/cli/pkg/gpu/amdgpu/tasks.go
@@ -250,7 +250,7 @@ func (u *UpdateNodeAMDInfo) Execute(runtime connector.Runtime) error {
 	rocmVersion := rocmV.Original()
 
 	// Use the ROCm version as the driver label for the "amd" mode.
-	return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.AMDType, &rocmVersion, nil, nil)
+	return gpu.SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpu.AMDType, &rocmVersion, nil, nil)
 }
 
 // InstallAmdPlugin installs the AMD GPU device plugin DaemonSet.

--- a/cli/pkg/gpu/intelgpu/tasks.go
+++ b/cli/pkg/gpu/intelgpu/tasks.go
@@ -108,12 +108,12 @@ func (u *LabelIntelGPUs) Execute(runtime connector.Runtime) error {
 	}
 
 	if plan.labelIntel {
-		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelType, nil, nil, nil); err != nil {
+		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpu.IntelType, nil, nil, nil); err != nil {
 			return err
 		}
 	}
 	if plan.labelIntelGPU {
-		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.IntelGpuType, nil, nil, nil); err != nil {
+		if err := gpu.SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpu.IntelGpuType, nil, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/cli/pkg/gpu/mtgpu/tasks.go
+++ b/cli/pkg/gpu/mtgpu/tasks.go
@@ -31,7 +31,7 @@ func (u *UpdateNodeMThreadsGPUInfo) Execute(runtime connector.Runtime) error {
 	}
 
 	if runtime.GetSystemInfo().IsMThreadsM1000() {
-		return gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.MooreSocType, nil, nil, nil)
+		return gpu.SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpu.MooreSocType, nil, nil, nil)
 	}
 
 	return nil

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -29,13 +29,12 @@ import (
 	"github.com/pelletier/go-toml"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apixclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 )
 
 type CheckWslGPU struct {
@@ -385,7 +384,7 @@ func (u *UpdateNodeGPUInfo) Execute(runtime connector.Runtime) error {
 		gpuType = GB10ChipType
 	}
 
-	return SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpuType, &driverVersion, &st.CudaVersion, &supported)
+	return SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpuType, &driverVersion, &st.CudaVersion, &supported)
 }
 
 type RemoveNodeLabels struct {
@@ -398,24 +397,29 @@ func (u *RemoveNodeLabels) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 	}
 
-	return RemoveAllNodeGpuLabels(context.Background(), client.Kubernetes())
+	return RemoveAllNodeGpuLabels(context.Background(), client.CtrlRuntime())
 }
 
 // updateCurrentNodeLabels reads the node matching the local hostname, hands its
 // label map to mutate (which returns whether it changed anything) and persists
-// the result with conflict retries when needed.
-func updateCurrentNodeLabels(ctx context.Context, client kubernetes.Interface, mutate func(labels map[string]string) bool) error {
+// the result as a merge patch carrying only the labels that were touched.
+// Patching rather than updating the whole node avoids resourceVersion conflicts
+// with the kubelet and the controllers writing to the same object.
+func updateCurrentNodeLabels(ctx context.Context, client ctrlclient.Client, mutate func(labels map[string]string) bool) error {
 	nodeName, err := os.Hostname()
 	if err != nil {
 		logger.Error("get hostname error, ", err)
 		return err
 	}
 
-	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
+	var node corev1.Node
+	if err := client.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
 		logger.Error("get node error, ", err)
 		return err
 	}
+
+	// mutate edits the node's own label map, so snapshot it to diff against
+	patch := ctrlclient.MergeFrom(node.DeepCopy())
 
 	labels := node.GetLabels()
 	if labels == nil {
@@ -425,15 +429,11 @@ func updateCurrentNodeLabels(ctx context.Context, client kubernetes.Interface, m
 	if !mutate(labels) {
 		return nil
 	}
-
 	node.SetLabels(labels)
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		logger.Infof("updating node gpu labels for %s", nodeName)
-		_, err := client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-		return err
-	})
-	if err != nil {
-		logger.Error("update node error, ", err)
+
+	logger.Infof("patching node gpu labels for %s", nodeName)
+	if err := client.Patch(ctx, &node, patch); err != nil {
+		logger.Error("patch node error, ", err)
 		return err
 	}
 	return nil
@@ -447,7 +447,7 @@ func updateCurrentNodeLabels(ctx context.Context, client kubernetes.Interface, m
 // corresponding gpu.bytetrade.io/{driver,cuda,cuda-supported} labels (used by
 // the nvidia path); a nil pointer means "leave that label as-is". The legacy
 // gpu.bytetrade.io/type label is intentionally never written.
-func SetNodeGpuModeLabel(ctx context.Context, client kubernetes.Interface, mode string, driver, cuda, cudaSupported *string) error {
+func SetNodeGpuModeLabel(ctx context.Context, client ctrlclient.Client, mode string, driver, cuda, cudaSupported *string) error {
 	err := updateCurrentNodeLabels(ctx, client, func(labels map[string]string) bool {
 		update := false
 		if mode != "" && mode != CPUType {
@@ -493,7 +493,7 @@ func SetNodeGpuModeLabel(ctx context.Context, client kubernetes.Interface, mode 
 // current node: the driver / cuda / cuda-supported labels, all per-mode
 // existence labels (gpu.bytetrade.io/<mode>), and the legacy
 // gpu.bytetrade.io/type label.
-func RemoveAllNodeGpuLabels(ctx context.Context, client kubernetes.Interface) error {
+func RemoveAllNodeGpuLabels(ctx context.Context, client ctrlclient.Client) error {
 	return updateCurrentNodeLabels(ctx, client, func(labels map[string]string) bool {
 		update := false
 		del := func(key string) {

--- a/cli/pkg/terminus/hostname.go
+++ b/cli/pkg/terminus/hostname.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
@@ -395,6 +396,10 @@ func (a *RestoreLabelsFromRenamedNode) Execute(runtime connector.Runtime) error 
 		return fmt.Errorf("new node %q is not ready yet", a.NewNode)
 	}
 
+	// patch instead of update: the kubelet and the controllers keep writing to
+	// the freshly registered node, so a full update would race with them
+	patch := ctrlclient.MergeFrom(newNode.DeepCopy())
+
 	if newNode.Labels == nil {
 		newNode.Labels = map[string]string{}
 	}
@@ -435,8 +440,13 @@ func (a *RestoreLabelsFromRenamedNode) Execute(runtime connector.Runtime) error 
 		logger.Infof("no labels/annotations need restoring onto node %q", a.NewNode)
 		return nil
 	}
-	if _, err := kubeClient.CoreV1().Nodes().Update(ctx, newNode, metav1.UpdateOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to update node %q with restored labels", a.NewNode)
+
+	patchData, err := patch.Data(newNode)
+	if err != nil {
+		return errors.Wrapf(err, "failed to build metadata patch for node %q", a.NewNode)
+	}
+	if _, err := kubeClient.CoreV1().Nodes().Patch(ctx, a.NewNode, patch.Type(), patchData, metav1.PatchOptions{}); err != nil {
+		return errors.Wrapf(err, "failed to patch node %q with restored labels", a.NewNode)
 	}
 	return nil
 }

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -610,7 +610,7 @@ func (a *upgradeGPUDriverIfNeeded) Execute(runtime connector.Runtime) error {
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "kubeclient create error")
 		}
-		err = gpu.SetNodeGpuModeLabel(context.Background(), client.Kubernetes(), gpu.NvidiaCardType, &targetDriverVersionStr, ptr.To(common.CurrentVerifiedCudaVersion), ptr.To("true"))
+		err = gpu.SetNodeGpuModeLabel(context.Background(), client.CtrlRuntime(), gpu.NvidiaCardType, &targetDriverVersionStr, ptr.To(common.CurrentVerifiedCudaVersion), ptr.To("true"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* **Background**
A newly created node is prune to update conflict so we use controller-runtime to path it instead of updating to avoid conflict.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how node labels and annotations are written during GPU setup, upgrades, and hostname migration; patch semantics should match prior intent but any bug could leave nodes mis-labeled for scheduling.
> 
> **Overview**
> Node GPU labeling and related metadata writes no longer use a full **Node** `Update` with conflict retries. The shared kube client now exposes a **controller-runtime** client, and `SetNodeGpuModeLabel` / `RemoveAllNodeGpuLabels` persist label changes with a **merge patch** of only the labels that changed.
> 
> All GPU install/upgrade paths (NVIDIA, AMD, Intel, MThreads) and post-driver-upgrade labeling call through `client.CtrlRuntime()` instead of `client.Kubernetes()`. **Hostname-change** label/annotation restore onto the newly registered node uses the same patch approach instead of updating the whole node object.
> 
> This targets **resourceVersion conflicts** when the kubelet or other controllers update the same node concurrently—especially on **newly registered** nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337dc74a9c72484a686211751fe367af846accea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->