### PR TITLE
docs: update local model config section in NOFX

### DIFF
--- a/docs/use-cases/nofx.md
+++ b/docs/use-cases/nofx.md
@@ -6,9 +6,9 @@ head:
   - - meta
     - name: keywords
       content: Olares, NOFX, AI trading, autonomous agent, crypto, Hyperliquid, self-hosted
-app_version: "1.0.5"
-doc_version: "1.1"
-doc_updated: "2026-05-09"
+app_version: "1.0.12"
+doc_version: "1.2"
+doc_updated: "2026-08-03"
 ---
 
 # Set up an autonomous AI trading agent with NOFX
@@ -208,45 +208,31 @@ Yes, you can use a local model, but ensure it meets the following requirements:
 - It needs strong instruction-following capabilities, a sufficient context window, and fast inference speeds. Otherwise, the model might fail to output valid trading instructions.
 
 To configure a local model:
-1. On the **Config** page, click **+ MODELS_CONFIG**.
-2. Click **Other API Providers**, and then select **OpenAI**.
-3. In the **API Key** field, enter any text string.
-4. In the **Base URL** field, enter your local model endpoint URL. Ensure the URL ends with `/v1`.
+<!-- #region get-model-connection-details -->
+1. Open the model app from Launchpad. Its Model Console opens automatically.
+2. Wait until **Model** shows **READY** and **Engine** shows **RUNNING**.
 
-   Olares offers two ways to serve local models. For either way, get the shared entrance URL:
+   ![Qwen3.6-27B model console](/images/manual/use-cases/qwen3.6-27b-model-console1.png#bordered)
 
-   <Tabs>
-   <template #Ollama>
+3. Under **Model**, copy the **Model name** exactly as shown.
+4. Under **Engine**:
 
-   One app that hosts multiple models behind a single shared endpoint.
-
-   a. Open Settings, and then go to **Applications** > **Ollama**.
-
-   b. In **Shared entrances**, select **Ollama API** to view the shared endpoint URL.
-
-      ![Ollama shared entrance in Settings](/images/manual/use-cases/ollama-shared.png#bordered){width=80%}
-
-   c. Copy the shared endpoint. For example, `http://d54536a50.shared.olares.com`.
+   a. **Connection source**: Select **Apps in Olares**. 
    
-   d. Append `/v1` to this endpoint URL, that is `http://d54536a50.shared.olares.com/v1`.
-   </template>
-   <template #Single-model-apps>
-
-   Each app packages one specific model and exposes its own shared endpoint. Take **Qwen3.5 9B Q4_K_M (Ollama)** for example.
-
-   a. Open Settings, and then go to **Applications** > **Qwen3.5 9B Q4_K_M (Ollama)**.
+   b. **API format**: Select **OpenAI-Compatible**.
    
-   b. In **Shared entrances**, select **Qwen3.5 9B Q4_K_M** to view the endpoint URL.
+   c. Copy the provided **Base URL** exactly as shown.
 
-      ![Qwen3.5 9B shared entrance](/images/manual/use-cases/anythingllm-qwen359b-shared-entrance.png#bordered){width=80%}
+<!-- #endregion get-model-connection-details -->
+5. Open NOFX, and click **+ MODELS_CONFIG** on the **Config** page.
+6. Click **Other API Providers**, and then select **OpenAI**.
+7. Specify the following settings:
 
-   c. Copy the shared endpoint URL. For example, `http://bd5355000.shared.olares.com`.
-   
-   d. Append `/v1` to this endpoint URL, that is `http://bd5355000.shared.olares.com/v1`.
-   </template>
-   </Tabs>
+   - **API Key**: Enter any text string such as `local`.
+   - **Base URL**: Enter the **Base URL** copied from the Model Console. Ensure the URL ends with `/v1`.
+   - **Model Name (Optional)**: Enter the **Model name** copied from the Model Console.
 
-5. Click **Save Configuration**.
+8. Click **Save Configuration**.
 
 ### Model didn't output structured JSON decision
 

--- a/docs/zh/use-cases/nofx.md
+++ b/docs/zh/use-cases/nofx.md
@@ -215,16 +215,16 @@ NOFX 需要两个不同的钱包用于不同的目的：
 1. 从启动台打开模型应用。其模型控制台会自动打开。
 2. 等待**模型**显示**就绪**，且**引擎**显示**运行中**。
 
-   ![Qwen3.6-27B 模型控制台](/images/manual/use-cases/qwen3.6-27b-model-console1.png#bordered)
+   ![Qwen3.6-27B 模型控制台](/images/zh/manual/use-cases/qwen3.6-27b-model-console1.png#bordered)
 
 3. 在**模型**部分，按显示内容原样复制**模型名称**。
 4. 在**引擎**部分：
 
-   a. **连接来源**：选择 **Apps in Olares**。 
-   
+   a. **连接来源**：选择 **Olares 内应用**。
+
    b. **API 格式**：选择 **OpenAI-Compatible**。
-   
-   c. 按显示内容原样复制 **Base URL** 地址。
+
+   c.按显示内容原样复制 **Base URL** 地址。
 
 <!-- #endregion get-model-connection-details -->
 5. 打开 NOFX，然后点击 **Config** 页面上的 **+ MODELS_CONFIG**。

--- a/docs/zh/use-cases/nofx.md
+++ b/docs/zh/use-cases/nofx.md
@@ -211,45 +211,31 @@ NOFX 需要两个不同的钱包用于不同的目的：
 - 它需要强大的指令遵循能力、足够的上下文窗口和快速的推理速度。否则，模型可能无法输出有效的交易指令。
 
 要配置本地模型：
-1. 在 **配置** 页面上，点击 **+ 模型配置**。
-2. 点击 **其他 API 提供商**，然后选择 **OpenAI**。
-3. 在 **API 密钥** 字段中，输入任意文本字符串。
-4. 在 **基础地址** 字段中，输入你的本地模型端点 URL。确保 URL 以 `/v1` 结尾。
+<!-- #region get-model-connection-details -->
+1. 从启动台打开模型应用。其模型控制台会自动打开。
+2. 等待**模型**显示**就绪**，且**引擎**显示**运行中**。
 
-   Olares 提供两种提供本地模型的方式。对于任一方式，获取共享入口 URL：
+   ![Qwen3.6-27B 模型控制台](/images/manual/use-cases/qwen3.6-27b-model-console1.png#bordered)
 
-   <Tabs>
-   <template #Ollama>
+3. 在**模型**部分，按显示内容原样复制**模型名称**。
+4. 在**引擎**部分：
 
-   一个应用托管多个模型，位于单个共享端点后面。
+   a. **连接来源**：选择 **Apps in Olares**。 
+   
+   b. **API 格式**：选择 **OpenAI-Compatible**。
+   
+   c. 按显示内容原样复制 **Base URL** 地址。
 
-   a. 打开 **设置**，然后前往 **应用** > **Ollama**。
+<!-- #endregion get-model-connection-details -->
+5. 打开 NOFX，然后点击 **Config** 页面上的 **+ MODELS_CONFIG**。
+6. 点击 **Other API Providers**，然后选择 **OpenAI**。
+7. 指定以下设置：
 
-   b. 在 **共享入口** 中，选择 **Ollama API** 以查看共享端点 URL。
+   - **API Key**：输入任意文本字符串，例如 `local`。
+   - **Base URL**：输入从模型控制台复制的 **Base URL**。确保 URL 以 `/v1` 结尾。
+   - **Model Name (Optional)**：输入从模型控制台复制的 **Model name**。
 
-      ![设置中的 Ollama 共享入口](/images/manual/use-cases/ollama-shared.png#bordered){width=80%}
-
-   c. 复制共享端点。例如，`http://d54536a50.shared.olares.com`。
-
-   d. 在此端点 URL 后附加 `/v1`，即 `http://d54536a50.shared.olares.com/v1`。
-   </template>
-   <template #单模型应用>
-
-   每个应用打包一个特定模型并暴露其自己的共享端点。以 **Qwen3.5 9B Q4_K_M (Ollama)** 为例。
-
-   a. 打开 **设置**，然后前往 **应用** > **Qwen3.5 9B Q4_K_M (Ollama)**。
-
-   b. 在 **共享入口** 中，选择 **Qwen3.5 9B Q4_K_M** 以查看端点 URL。
-
-      ![Qwen3.5 9B 共享入口](/images/manual/use-cases/anythingllm-qwen359b-shared-entrance.png#bordered){width=80%}
-
-   c. 复制共享端点 URL。例如，`http://bd5355000.shared.olares.com`。
-
-   d. 在此端点 URL 后附加 `/v1`，即 `http://bd5355000.shared.olares.com/v1`。
-   </template>
-   </Tabs>
-
-5. 点击 **保存配置**。
+8. 点击 **Save Configuration**。
 
 ### 模型未输出结构化 JSON 决策
 


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to user-facing setup steps; no application or security logic is modified.
> 
> **Overview**
> **Updates the NOFX “local model” FAQ** in English and Chinese so it matches the current Olares **Model Console** flow instead of the old Settings → Ollama / per-app **Shared entrances** tabs.
> 
> Users are now told to launch the model app, wait for **READY** / **RUNNING**, copy **Model name** and **Base URL** (with **Apps in Olares** + **OpenAI-Compatible** on the engine), then enter those values in NOFX’s **MODELS_CONFIG** OpenAI provider fields—including optional **Model Name**. The shared steps are wrapped in a `get-model-connection-details` region (aligned with `ai-service-connections.md`), with a new Qwen console screenshot.
> 
> The English page metadata is bumped to **app_version 1.0.12**, **doc_version 1.2**, and **doc_updated 2026-08-03**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c407fd8c27d491000c43e33adef2de81abf22c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->