### PR TITLE
chore: bump hami core version

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.23"
+version: "v2.6.24"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.23
+      name: beclab/hami:v2.6.24
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Bump hami core version

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only pin change with no application code; rollout risk is limited to the usual GPU scheduler/device-plugin upgrade behavior on cluster deploy.
> 
> **Overview**
> Bumps the packaged **HAMI** (heterogeneous GPU virtualization) core image from **v2.6.23** to **v2.6.24**.
> 
> The Helm `version` in `infrastructure/gpu/.olares/config/gpu/hami/values.yaml` tags the scheduler extender and device-plugin/monitor containers (`beclab/hami`). The platform prebuilt manifest in `platform/hami/.olares/Olares.yaml` is updated to the same image so builds and deployments stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abbca6e5bf5dcd5fcbf8109b6d84aa39bc5726ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->