### PR TITLE
feat(daemon): skip sunshine mdns restart when overlay gateway is enabled

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -157,9 +157,31 @@ func main() {
 					FieldSelector: "metadata.name=steamheadless",
 				}); err == nil {
 					if len(deployments.Items) > 0 {
-						found = true
-						if err := sunshine.Restart(); err != nil {
-							klog.Error(err)
+						// check if the overlay gateway is enabled and the steamheadless
+						// is running with the overlay gateway enabled, if not restart the sunshine mdns proxy
+						var overlaygatewayEnabled bool
+
+						c, err := utils.FindBridgeConnection(mainCtx)
+						if err != nil {
+							klog.Error("find bridge connection error, ", err)
+						} else {
+							if c != nil && c.Active {
+								enabled, err := utils.GetApplicationSettings(mainCtx, "steamheadless", "enableOverlayGateway")
+								if err != nil {
+									klog.Error("get application settings error, ", err)
+								} else {
+									if enabled == "true" {
+										overlaygatewayEnabled = true
+									}
+								}
+							}
+						}
+
+						if !overlaygatewayEnabled {
+							found = true
+							if err := sunshine.Restart(); err != nil {
+								klog.Error(err)
+							}
 						}
 					}
 				}

--- a/daemon/pkg/utils/k8s.go
+++ b/daemon/pkg/utils/k8s.go
@@ -972,7 +972,7 @@ func GetOverlayGatewaySupportedApps(ctx context.Context, user string) ([]Overlay
 	return supportedApps, nil
 }
 
-func UpdateApplicationSettings(ctx context.Context, appName string, option string, value string) error {
+func UpdateApplicationSettings(ctx context.Context, appResourceName string, option string, value string) error {
 	clientset, err := GetAppClientSet()
 	if err != nil {
 		klog.Error("get app clientset error, ", err)
@@ -980,7 +980,7 @@ func UpdateApplicationSettings(ctx context.Context, appName string, option strin
 	}
 
 	retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		app, err := clientset.AppV1alpha1().Applications().Get(ctx, appName, metav1.GetOptions{})
+		app, err := clientset.AppV1alpha1().Applications().Get(ctx, appResourceName, metav1.GetOptions{})
 		if err != nil {
 			klog.Error("get application error, ", err)
 			return err
@@ -997,6 +997,33 @@ func UpdateApplicationSettings(ctx context.Context, appName string, option strin
 	})
 
 	return nil
+}
+
+func GetApplicationSettings(ctx context.Context, appName, option string) (string, error) {
+	clientset, err := GetAppClientSet()
+	if err != nil {
+		klog.Error("get app clientset error, ", err)
+		return "", err
+	}
+
+	apps, err := clientset.AppV1alpha1().Applications().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Error("get application error, ", err)
+		return "", err
+	}
+
+	for _, app := range apps.Items {
+		if app.Spec.Name != appName {
+			continue
+		}
+		value, ok := app.Spec.Settings[option]
+		if !ok {
+			return "", errors.New("option not found")
+		}
+		return value, nil
+	}
+
+	return "", errors.New("app not found")
 }
 
 func RestartOverlayGatewaySupportedApps(ctx context.Context, apps []OverlayGatewaySupportedApp) error {


### PR DESCRIPTION
## Summary
- Skip restarting the sunshine mDNS proxy when steamheadless is already running with the overlay gateway bridge active.
- Add `GetApplicationSettings` to read app settings, and clarify the `UpdateApplicationSettings` resource-name parameter.

## Test plan
- [ ] With overlay gateway disabled / bridge inactive, confirm sunshine mDNS proxy still restarts when steamheadless is present.
- [ ] With overlay gateway bridge active and `steamheadless` `enableOverlayGateway=true`, confirm sunshine mDNS proxy is not restarted.
- [ ] With bridge active but setting missing/false, confirm restart still occurs.
- [ ] Confirm `FindBridgeConnection` returning nil does not panic WatchStatus.


Made with [Cursor](https://cursor.com)