### PR TITLE
market: add icon_url and per-user entrances to /llm-providers

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -133,7 +133,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.84
+        image: beclab/market-backend:v0.6.85
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
feat(llm-providers): add icon_url and per-user entrances to /llm-providers

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/402


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on the market deployment; behavior changes depend on the v0.6.85 image contents but the manifest change itself is low risk.
> 
> **Overview**
> Bumps the **appstore-backend** container image in the market cluster deployment from `beclab/market-backend:v0.6.84` to **`v0.6.85`**, rolling out the newer market backend build (aligned with v1.12.7 / related market changes such as `/llm-providers` updates in the upstream market repo).
> 
> No other manifest fields, env vars, or RBAC change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2968c8d4c25592fbae108b8e6a131b74508226b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->