### PR TITLE
feat(app-service): default Shared callers and client appid headers

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.14
+        image: beclab/app-service:0.6.15
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/gateway/callerjwt/issuer.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer.go
@@ -26,6 +26,7 @@ const (
 	ClaimEntrance       = "olares.entrance"
 	ClaimViewer         = "olares.viewer"
 	ClaimAppid          = "olares.caller.appid"
+	ClaimClientAppid    = "olares.caller.clientAppid"
 	// CallerJWTHeaderName is the platform caller-jwt transport header (bare JWT,
 	// no Bearer prefix). Distinct from Authorization so app credentials pass through.
 	CallerJWTHeaderName = "X-Olares-Caller-Jwt"
@@ -40,8 +41,9 @@ const (
 )
 
 // IssueRequest carries workload identity for a caller JWT.
-// Ordinary callers set Viewer (user); Shared callers set Appid and leave Viewer empty.
-// Viewer and Appid must not both be set.
+// Shared callers set Appid only. Ordinary callers set Viewer and ClientAppid.
+// Appid (Shared) and ClientAppid (ordinary) must not both be set; Viewer must
+// not accompany Appid.
 type IssueRequest struct {
 	Namespace          string
 	ServiceAccountName string
@@ -49,16 +51,18 @@ type IssueRequest struct {
 	Entrance           string
 	Viewer             string
 	Appid              string
+	ClientAppid        string
 	TTL                time.Duration
 }
 
 // Claims is the caller JWT claim schema published to Envoy Gateway.
 type Claims struct {
 	jwt.RegisteredClaims
-	AppRef   string `json:"olares.caller.appRef"`
-	Entrance string `json:"olares.entrance,omitempty"`
-	Viewer   string `json:"olares.viewer,omitempty"`
-	Appid    string `json:"olares.caller.appid,omitempty"`
+	AppRef      string `json:"olares.caller.appRef"`
+	Entrance    string `json:"olares.entrance,omitempty"`
+	Viewer      string `json:"olares.viewer,omitempty"`
+	Appid       string `json:"olares.caller.appid,omitempty"`
+	ClientAppid string `json:"olares.caller.clientAppid,omitempty"`
 }
 
 // KeyPair holds one RS256 signing key and its JWKS key ID.
@@ -107,8 +111,12 @@ func (i *Issuer) Issue(req IssueRequest) (string, error) {
 	}
 	viewer := strings.TrimSpace(req.Viewer)
 	appid := strings.TrimSpace(req.Appid)
+	clientAppid := strings.TrimSpace(req.ClientAppid)
+	if appid != "" && clientAppid != "" {
+		return "", errors.New("callerjwt: shared appid and clientAppid claims are mutually exclusive")
+	}
 	if viewer != "" && appid != "" {
-		return "", errors.New("callerjwt: viewer and appid identity claims are mutually exclusive")
+		return "", errors.New("callerjwt: viewer and shared appid identity claims are mutually exclusive")
 	}
 	ttl := req.TTL
 	if ttl <= 0 {
@@ -137,6 +145,9 @@ func (i *Issuer) Issue(req IssueRequest) (string, error) {
 	}
 	if appid != "" {
 		claims.Appid = appid
+	}
+	if clientAppid != "" {
+		claims.ClientAppid = clientAppid
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	token.Header["kid"] = i.keys.Active.KID

--- a/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
@@ -45,6 +45,7 @@ func TestIssueCallerJWTClaimsAndVerify(t *testing.T) {
 		AppRef:             "demo",
 		Entrance:           "web",
 		Viewer:             "alice",
+		ClientAppid:        "6bf98da2",
 		TTL:                30 * time.Minute,
 	})
 	if err != nil {
@@ -75,7 +76,10 @@ func TestIssueCallerJWTClaimsAndVerify(t *testing.T) {
 		t.Fatalf("viewer = %q", claims.Viewer)
 	}
 	if claims.Appid != "" {
-		t.Fatalf("ordinary caller must omit appid, got %q", claims.Appid)
+		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid)
+	}
+	if claims.ClientAppid != "6bf98da2" {
+		t.Fatalf("clientAppid = %q", claims.ClientAppid)
 	}
 	if claims.ExpiresAt == nil || claims.ExpiresAt.Time.Before(time.Now()) {
 		t.Fatalf("exp missing or in the past")
@@ -99,7 +103,28 @@ func TestIssueRejectsViewerAndAppidTogether(t *testing.T) {
 		Appid:              "deadbeef",
 	})
 	if err == nil {
-		t.Fatal("expected error when viewer and appid are both set")
+		t.Fatal("expected error when viewer and shared appid are both set")
+	}
+}
+
+func TestIssueRejectsAppidAndClientAppidTogether(t *testing.T) {
+	ring, err := NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+	_, err = issuer.Issue(IssueRequest{
+		Namespace:          "ns",
+		ServiceAccountName: "sa",
+		AppRef:             "demo",
+		Appid:              "deadbeef",
+		ClientAppid:        "6bf98da2",
+	})
+	if err == nil {
+		t.Fatal("expected error when shared appid and clientAppid are both set")
 	}
 }
 
@@ -130,6 +155,9 @@ func TestIssueSharedCallerAppidOmitsViewer(t *testing.T) {
 	}
 	if claims.Viewer != "" {
 		t.Fatalf("shared caller must omit viewer, got %q", claims.Viewer)
+	}
+	if claims.ClientAppid != "" {
+		t.Fatalf("shared caller must omit clientAppid, got %q", claims.ClientAppid)
 	}
 }
 
@@ -249,6 +277,7 @@ func TestIssuerReconcilerCreatesJWTSecretForCaller(t *testing.T) {
 		},
 		Spec: appv1alpha1.ApplicationSpec{
 			Name:      "demo",
+			Appid:     "6bf98da2",
 			Namespace: "user-space-alice-demo",
 			Owner:     "alice",
 			Settings: map[string]string{
@@ -285,6 +314,12 @@ func TestIssuerReconcilerCreatesJWTSecretForCaller(t *testing.T) {
 	if claims.Viewer != "alice" {
 		t.Fatalf("viewer = %q", claims.Viewer)
 	}
+	if claims.ClientAppid != "6bf98da2" {
+		t.Fatalf("clientAppid = %q", claims.ClientAppid)
+	}
+	if claims.Appid != "" {
+		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid)
+	}
 }
 
 func TestIssuerReconcilerCreatesJWTSecretWhenDecideTrue(t *testing.T) {
@@ -305,6 +340,7 @@ func TestIssuerReconcilerCreatesJWTSecretWhenDecideTrue(t *testing.T) {
 		},
 		Spec: appv1alpha1.ApplicationSpec{
 			Name:      "litellm",
+			Appid:     "6aead52a",
 			Namespace: "litellm-alice",
 			Owner:     "alice",
 			Settings: map[string]string{
@@ -355,6 +391,7 @@ func TestIssuerReconcileRequeuesForJWTRefresh(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "user-space-alice"},
 		Spec: appv1alpha1.ApplicationSpec{
 			Name:      "demo",
+			Appid:     "6bf98da2",
 			Namespace: "user-space-alice-demo",
 			Owner:     "alice",
 			Settings: map[string]string{
@@ -382,6 +419,7 @@ func TestIssueRequestFromApplicationOmitsCalleeAsEntrance(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "user-space-alice"},
 		Spec: appv1alpha1.ApplicationSpec{
 			Name:      "demo",
+			Appid:     "6bf98da2",
 			Namespace: "user-space-alice-demo",
 			Owner:     "alice",
 			Settings: map[string]string{
@@ -399,6 +437,9 @@ func TestIssueRequestFromApplicationOmitsCalleeAsEntrance(t *testing.T) {
 	}
 	if req.Appid != "" {
 		t.Fatalf("ordinary caller Appid = %q, want empty", req.Appid)
+	}
+	if req.ClientAppid != "6bf98da2" {
+		t.Fatalf("ClientAppid = %q", req.ClientAppid)
 	}
 	if req.Namespace != "user-space-alice-demo" {
 		t.Fatalf("Namespace = %q", req.Namespace)
@@ -428,6 +469,37 @@ func TestIssueRequestFromSharedApplicationUsesAppid(t *testing.T) {
 	}
 	if req.Viewer != "" {
 		t.Fatalf("Viewer = %q, want empty for shared caller", req.Viewer)
+	}
+	if req.ClientAppid != "" {
+		t.Fatalf("ClientAppid = %q, want empty for shared caller", req.ClientAppid)
+	}
+}
+
+func TestIssuerReconcilerOrdinaryMissingAppidErrors(t *testing.T) {
+	scheme := testScheme(t)
+	ring, err := NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "user-space-alice"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:      "demo",
+			Namespace: "user-space-alice-demo",
+			Owner:     "alice",
+			Settings: map[string]string{
+				settingSharedCallerDecide: "true",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r := &IssuerReconciler{Client: c, Scheme: scheme, issuer: issuer}
+	if err := r.reconcileApplication(context.Background(), app); err == nil {
+		t.Fatal("expected error when ordinary caller has empty spec.appid")
 	}
 }
 

--- a/framework/app-service/pkg/gateway/callerjwt/reconcile.go
+++ b/framework/app-service/pkg/gateway/callerjwt/reconcile.go
@@ -92,6 +92,12 @@ func (r *IssuerReconciler) reconcileApplication(ctx context.Context, app *appv1a
 		RecordIssueFail(app.Spec.Namespace)
 		return err
 	}
+	if !appcfg.IsShared(app) && strings.TrimSpace(req.ClientAppid) == "" {
+		err := fmt.Errorf("callerjwt: ordinary caller requires spec.appid")
+		klog.Errorf("caller_jwt_issue_fail app=%s ns=%s err=%v", app.Spec.Name, app.Spec.Namespace, err)
+		RecordIssueFail(app.Spec.Namespace)
+		return err
+	}
 	token, err := r.issuer.Issue(req)
 	if err != nil {
 		klog.Warningf("caller_jwt_issue_fail app=%s ns=%s err=%v", app.Spec.Name, app.Spec.Namespace, err)
@@ -299,6 +305,7 @@ func issueRequestFromApplication(app *appv1alpha1.Application) IssueRequest {
 		return req
 	}
 	req.Viewer = strings.TrimSpace(app.Spec.Owner)
+	req.ClientAppid = strings.TrimSpace(app.Spec.Appid)
 	return req
 }
 

--- a/framework/app-service/pkg/gateway/meshinagent/decide.go
+++ b/framework/app-service/pkg/gateway/meshinagent/decide.go
@@ -12,13 +12,14 @@ const (
 	AnnotDecideRuleID       = "gateway.olares.io/shared-caller-rule-id"
 	SettingOptOutMesh       = "mesh-inject"
 	SettingAppRef           = "appRef"
-	DecideSourceExplicit    = "explicit"
-	DecideSourceRule        = "rule"
-	DecideSourceEligibility = "eligibility"
-	DecideSourceNone        = "none"
+	DecideSourceExplicit       = "explicit"
+	DecideSourceRule           = "rule"
+	DecideSourceEligibility    = "eligibility"
+	DecideSourceSharedDefault  = "shared-default"
+	DecideSourceNone           = "none"
 
-	// RuleAllowSharedLLMGateway auto-Decides Shared AI Router apps as callers
-	// with empty edges (OPEN-01). Pure Shared callees (e.g. ollama*) do not match.
+	// RuleAllowSharedLLMGateway keeps name-based Shared AI Router Decide for
+	// compatibility. All Shared apps also default to caller via shared-default.
 	RuleAllowSharedLLMGateway = "R-ALLOW-shared-llmgateway"
 )
 
@@ -155,8 +156,8 @@ func isOptOut(settings map[string]string) bool {
 
 // Decide chooses mesh-in for a caller: deny and opt-out win, then named callees,
 // then allow rules. Ordinary apps may fall through to eligibility (empty edges).
-// Shared apps never use eligibility — only explicit callees, allow rules, or a
-// preserved settings decide=true (ApplyDecide explicit path).
+// Shared apps default to Inject=true with source shared-default (OPEN-01 empty
+// edges) when no explicit callees or allow rule matched.
 func Decide(appName string, settings map[string]string, rules RuleSet, sharedApp bool) DecideResult {
 	if rules == nil {
 		rules = DefaultRules()
@@ -185,6 +186,8 @@ func Decide(appName string, settings map[string]string, rules RuleSet, sharedApp
 		return res
 	}
 	if sharedApp {
+		res.Inject = true
+		res.Source = DecideSourceSharedDefault
 		return res
 	}
 	res.Inject = true
@@ -208,7 +211,8 @@ func DeclaresSharedCaller(settings map[string]string) bool {
 
 // ApplyDecide mutates settings with decide facts and sets Changed vs previous annotate.
 // When source is already explicit and decide=true (vendor settings patch), preserve
-// those keys so rules cannot clear the opt-in. sharedApp disables eligibility.
+// those keys so rules cannot clear the opt-in. Shared apps without explicit/rule
+// facts receive source=shared-default.
 func ApplyDecide(appName string, settings map[string]string, rules RuleSet, sharedApp bool) DecideResult {
 	if settings == nil {
 		return DecideResult{}

--- a/framework/app-service/pkg/gateway/meshinagent/decide_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/decide_test.go
@@ -25,10 +25,20 @@ func TestDecideEligibilityWithoutCallees(t *testing.T) {
 	}
 }
 
-func TestDecideSharedNoEligibility(t *testing.T) {
+func TestDecideSharedDefaultCaller(t *testing.T) {
 	r := Decide("ollamallmbase", map[string]string{SettingNeedsSharedAccess: "true"}, DefaultRules(), true)
+	if !r.Inject || r.Source != DecideSourceSharedDefault {
+		t.Fatalf("Shared app must default to caller: %+v", r)
+	}
+	if len(r.Callees) != 0 {
+		t.Fatalf("shared-default edges must be empty: %+v", r)
+	}
+}
+
+func TestDecideSharedOptOutBlocksDefault(t *testing.T) {
+	r := Decide("ollamallmbase", map[string]string{SettingOptOutMesh: "disabled"}, DefaultRules(), true)
 	if r.Inject {
-		t.Fatalf("Shared pure callee must not get eligibility decide: %+v", r)
+		t.Fatalf("opt-out must block shared-default: %+v", r)
 	}
 }
 
@@ -138,11 +148,22 @@ func TestApplyDecideSharedPlatformRule(t *testing.T) {
 	}
 }
 
-func TestApplyDecideSharedPureCallee(t *testing.T) {
+func TestApplyDecideSharedDefaultCaller(t *testing.T) {
 	s := map[string]string{SettingNeedsSharedAccess: "true"}
 	r := ApplyDecide("ollamallmbase", s, DefaultRules(), true)
-	if r.Inject || s[AnnotDecide] != "false" {
-		t.Fatalf("pure Shared callee must not decide: %+v settings=%v", r, s)
+	if !r.Inject || r.Source != DecideSourceSharedDefault || s[AnnotDecide] != "true" {
+		t.Fatalf("Shared must default decide: %+v settings=%v", r, s)
+	}
+	if s[AnnotDecideSource] != DecideSourceSharedDefault || s[AnnotDecideEdges] != "" {
+		t.Fatalf("shared-default settings: %v", s)
+	}
+}
+
+func TestApplyDecideSharedRenameStillCaller(t *testing.T) {
+	s := map[string]string{}
+	r := ApplyDecide("router", s, DefaultRules(), true)
+	if !r.Inject || r.Source != DecideSourceSharedDefault {
+		t.Fatalf("renamed Shared must still decide: %+v", r)
 	}
 }
 

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy.go
@@ -28,6 +28,8 @@ const (
 	CallerJWTViewerHeader        = "X-BFL-USER"
 	CallerJWTAppidClaim          = "olares.caller.appid"
 	CallerJWTAppidHeader         = "X-Shared-Appid"
+	CallerJWTClientAppidClaim    = "olares.caller.clientAppid"
+	CallerJWTClientAppidHeader   = "X-Caller-Appid"
 	CallerJWTJWKSServiceName     = "caller-jwt-jwks"
 	CallerJWTJWKSServiceNamespace = "os-framework"
 	CallerJWTJWKSServicePort     = int32(443)
@@ -46,9 +48,10 @@ func securityPolicyName(srr *srrv1alpha1.SharedRouteRegistry) string {
 }
 
 // desiredSharedRouteSecurityPolicy builds JWT authn for a Shared HTTPRoute.
-// After verification, the gateway copies olares.viewer → X-BFL-USER for ordinary
-// callers and olares.caller.appid → X-Shared-Appid for Shared callers. A header
-// is written only when that claim exists in the token; missing Bearer is rejected.
+// After verification, the gateway copies olares.viewer → X-BFL-USER,
+// olares.caller.appid → X-Shared-Appid (Shared callers), and
+// olares.caller.clientAppid → X-Caller-Appid (ordinary callers). A header is
+// written only when that claim exists in the token; missing JWT is rejected.
 func desiredSharedRouteSecurityPolicy(srr *srrv1alpha1.SharedRouteRegistry) *unstructured.Unstructured {
 	routeName := httpRouteName(srr)
 	return &unstructured.Unstructured{Object: map[string]any{
@@ -89,6 +92,10 @@ func desiredSharedRouteSecurityPolicy(srr *srrv1alpha1.SharedRouteRegistry) *uns
 							map[string]any{
 								"claim":  CallerJWTAppidClaim,
 								"header": CallerJWTAppidHeader,
+							},
+							map[string]any{
+								"claim":  CallerJWTClientAppidClaim,
+								"header": CallerJWTClientAppidHeader,
 							},
 						},
 						"remoteJWKS": map[string]any{

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
@@ -75,7 +75,7 @@ func TestDesiredSharedRouteSecurityPolicyJWTAuthn(t *testing.T) {
 	}
 
 	claimToHeaders, ok := provider["claimToHeaders"].([]any)
-	if !ok || len(claimToHeaders) != 2 {
+	if !ok || len(claimToHeaders) != 3 {
 		t.Fatalf("claimToHeaders = %#v", provider["claimToHeaders"])
 	}
 	claimMap := claimToHeaders[0].(map[string]any)
@@ -93,7 +93,14 @@ func TestDesiredSharedRouteSecurityPolicyJWTAuthn(t *testing.T) {
 	if appidMap["header"] != "X-Shared-Appid" {
 		t.Fatalf("shared appid header must remain X-Shared-Appid, got %#v", appidMap["header"])
 	}
-	// Both mappings stay configured; a given token carries only one identity claim.
+	clientMap := claimToHeaders[2].(map[string]any)
+	if clientMap["claim"] != CallerJWTClientAppidClaim || clientMap["header"] != CallerJWTClientAppidHeader {
+		t.Fatalf("claimToHeaders[2] = %#v", clientMap)
+	}
+	if clientMap["header"] != "X-Caller-Appid" {
+		t.Fatalf("ordinary client appid header must remain X-Caller-Appid, got %#v", clientMap["header"])
+	}
+	// Three mappings stay configured; a given token carries the claims for its caller type.
 
 	extractFrom, ok := provider["extractFrom"].(map[string]any)
 	if !ok {


### PR DESCRIPTION
Summary
Shared apps default to callers (shared-default); opt-out/deny unchanged.
Ordinary callers get clientAppid → X-Caller-Appid; Shared stay on appid → X-Shared-Appid.
Pin beclab/app-service:0.6.15.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway auth identity headers and mesh injection defaults for all Shared apps, which can alter who gets caller JWTs and mesh behavior in production; ordinary apps without spec.appid will fail JWT issuance.
> 
> **Overview**
> **Shared apps** now default to mesh-in caller mode with source `shared-default` and empty callee edges (OPEN-01), including apps that previously behaved as “pure callees” unless they opt out via `mesh-inject`. Explicit callees, allow rules (e.g. `llmgateway*`), and deny/opt-out behavior are unchanged.
> 
> **Ordinary callers** get a new JWT claim `olares.caller.clientAppid` populated from `spec.appid` (distinct from Shared `olares.caller.appid`). Issuance rejects mixing shared appid with clientAppid or viewer with shared appid, and the issuer reconciler fails if an ordinary app lacks `spec.appid`.
> 
> **Envoy Gateway** `SecurityPolicy` adds claim-to-header mapping `olares.caller.clientAppid` → `X-Caller-Appid` alongside existing viewer and shared-appid headers. Deploy pins **`beclab/app-service:0.6.15`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7389728708b35792811d29ec05434c58c56931fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->