### PR TITLE
fix(oac): spec.supportArch cannot be empty

### DIFF
--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -312,6 +312,8 @@ func validateAppSpec(configVersion, apiVersion string, templateOnly bool, s AppS
 		validation.Field(&s.RequiredGPU, optionalGPUQuantity),
 		validation.Field(&s.LimitedGPU, optionalLimitedGPUQuantity),
 		validation.Field(&s.SupportArch,
+			validation.Required.Error("spec.supportArch is required"),
+			validation.Length(1, 0).Error("spec.supportArch must contain at least one item"),
 			validation.Each(validation.By(validateSupportArchEntry)),
 			validation.By(uniqueSupportArches),
 		),

--- a/framework/oac/internal/manifest/validate_test.go
+++ b/framework/oac/internal/manifest/validate_test.go
@@ -35,6 +35,7 @@ func newValidConfig() *AppConfiguration {
 			RequiredMemory: "128Mi",
 			LimitedMemory:  "256Mi",
 			RequiredDisk:   "1Gi",
+			SupportArch:    []string{"amd64"},
 		},
 		Options: Options{
 			Dependencies: []Dependency{{
@@ -1056,16 +1057,24 @@ func TestSpec_SupportArch_AcceptsKnownArches(t *testing.T) {
 	}
 }
 
-func TestSpec_SupportArch_EmptyIsAccepted(t *testing.T) {
+func TestSpec_SupportArch_RejectsEmpty(t *testing.T) {
 	c := newValidConfig()
 	c.Spec.SupportArch = nil
-	if err := ValidateAppConfiguration(c); err != nil {
-		t.Fatalf("empty supportArch must remain valid (no enum gate): %v", err)
+	err := ValidateAppConfiguration(c)
+	if err == nil {
+		t.Fatal("nil supportArch must be rejected")
+	}
+	if !strings.Contains(err.Error(), "spec.supportArch is required") {
+		t.Fatalf("error should mention required, got: %v", err)
 	}
 
 	c.Spec.SupportArch = []string{}
-	if err := ValidateAppConfiguration(c); err != nil {
-		t.Fatalf("zero-length supportArch slice must remain valid: %v", err)
+	err = ValidateAppConfiguration(c)
+	if err == nil {
+		t.Fatal("zero-length supportArch slice must be rejected")
+	}
+	if !strings.Contains(err.Error(), "spec.supportArch") {
+		t.Fatalf("error should mention spec.supportArch, got: %v", err)
 	}
 }
 


### PR DESCRIPTION


* **Background**
spec.supportArch cannot be empty
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for manifests that omitted `supportArch`; limited to OAC structural validation, not runtime install paths.
> 
> **Overview**
> **`spec.supportArch` is now mandatory** on app manifests: validation rejects a missing field (`nil`) and an empty slice, with messages `spec.supportArch is required` and at least one entry required.
> 
> Existing per-entry rules (`amd64` / `arm64`, uniqueness) are unchanged; only the prior allowance for omitting or leaving the list empty is removed, matching installer expectations that compare against declared architectures.
> 
> Tests were updated so the default valid fixture includes `amd64`, and `TestSpec_SupportArch_RejectsEmpty` asserts both nil and `[]` fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9258ce3cd94833d697a5cd715b25d41c90483cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->