### PR TITLE
fix(app-service): inject arch nodeSelector for single-arch apps

### DIFF
--- a/framework/app-service/pkg/apiserver/filters.go
+++ b/framework/app-service/pkg/apiserver/filters.go
@@ -97,6 +97,7 @@ func (h *Handler) authenticate(req *restful.Request, resp *restful.Response, cha
 		"/app-service/v1/terminus/version",
 		"/app-service/v1/app-label/inject",
 		"/app-service/v1/macvlan-init/inject",
+		"/app-service/v1/podarch/inject",
 		"/app-service/v1/apps/image-info",
 		"/app-service/v1/all/apps",
 		"/app-service/v1/apps/oamvalues",

--- a/framework/app-service/pkg/apiserver/handler.go
+++ b/framework/app-service/pkg/apiserver/handler.go
@@ -148,6 +148,10 @@ func (b *handlerBuilder) Build() (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = wh.CreateOrUpdatePodArchNodeSelectorMutatingWebhook()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Handler{
 		kubeHost:           b.ksHost,

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -108,10 +108,10 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest,
 	}
 	var (
 		injectPolicy, injectWs, injectUpload, injectMeshInAgent, injectMeshOutAgent bool
-		injectSharedPod                                                            *bool
-		appMgr                                                                     *v1alpha1.ApplicationManager
-		appCfg                                                                     *appcfg_mod.ApplicationConfig
-		perms                                                                      []appcfg.ProviderPermission
+		injectSharedPod                                                             *bool
+		appMgr                                                                      *v1alpha1.ApplicationManager
+		appCfg                                                                      *appcfg_mod.ApplicationConfig
+		perms                                                                       []appcfg.ProviderPermission
 	)
 	if injectPolicy, injectWs, injectUpload, injectMeshInAgent, injectMeshOutAgent, injectSharedPod, perms, appCfg, appMgr, err = h.sidecarWebhook.MustInject(ctx, &pod, req.Namespace); err != nil {
 		return h.sidecarWebhook.AdmissionError(req.UID, err)
@@ -258,7 +258,6 @@ func (h *Handler) validate(ctx context.Context, req *admissionv1.AdmissionReques
 	klog.Infof("Done validate with UID=%s in protected namespace, that's APPROVE", object.GetUID())
 	return resp
 }
-
 
 // tlsReplicaMountValidate is the validating admission entrypoint that blocks
 // tls-replica private-key bypass mounts. Decode/unmarshal failures fail closed.
@@ -1029,6 +1028,90 @@ func (h *Handler) runAsUserInject(ctx context.Context, pod *corev1.Pod, namespac
 	}
 
 	return pod, nil
+}
+
+func (h *Handler) podArchInject(req *restful.Request, resp *restful.Response) {
+	klog.Infof("Received mutating webhook[pod-arch inject] request: Method=%v, URL=%v", req.Request.Method, req.Request.URL)
+	admissionRequestBody, ok := h.sidecarWebhook.GetAdmissionRequestBody(req, resp)
+	if !ok {
+		return
+	}
+	var admissionReq, admissionResp admissionv1.AdmissionReview
+	proxyUUID := uuid.New()
+	if _, _, err := webhook.Deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
+		klog.Errorf("Failed to decode admission request body err=%v", err)
+		admissionResp.Response = h.sidecarWebhook.AdmissionError("", err)
+	} else {
+		admissionResp.Response = h.podArchMutate(req.Request.Context(), admissionReq.Request, proxyUUID)
+	}
+	admissionResp.TypeMeta = admissionReq.TypeMeta
+	admissionResp.Kind = admissionReq.Kind
+
+	requestForNamespace := "unknown"
+	if admissionReq.Request != nil {
+		requestForNamespace = admissionReq.Request.Namespace
+	}
+	err := resp.WriteAsJson(&admissionResp)
+	if err != nil {
+		klog.Errorf("Failed to write response[pod-arch inject] admin review in namespace=%s err=%v", requestForNamespace, err)
+		return
+	}
+	klog.Infof("Done[pod-arch inject] with uuid=%s in namespace=%s", proxyUUID, requestForNamespace)
+}
+
+// podArchMutate injects a kubernetes.io/arch nodeSelector into the pod when its
+// owning app's OlaresManifest declares exactly one spec.supportArch. Apps that
+// declare zero or multiple architectures are left untouched, as are pods whose
+// namespace has no resolvable app config or that already pin an arch selector.
+func (h *Handler) podArchMutate(ctx context.Context, req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) *admissionv1.AdmissionResponse {
+	if req == nil {
+		klog.Error("Failed to get admission request err=admission request is nil")
+		return h.sidecarWebhook.AdmissionError("", errNilAdmissionRequest)
+	}
+	resp := &admissionv1.AdmissionResponse{
+		Allowed: true,
+		UID:     req.UID,
+	}
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		klog.Errorf("Failed to unmarshal request object raw to pod with uuid=%s namespace=%s", proxyUUID, req.Namespace)
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+
+	_, appCfg, _, _, _ := h.sidecarWebhook.GetAppConfig(req.Namespace)
+	if appCfg == nil {
+		return resp
+	}
+	// len==0: covers apps installed before the SupportArch field existed, whose
+	// ApplicationManager.Spec.Config has no supportArch — leave them
+	// unpinned for backward compatibility. len==2: dual-arch (amd64+arm64),
+	// no single node arch to select.
+	if len(appCfg.SupportArch) == 0 || len(appCfg.SupportArch) == 2 {
+		return resp
+	}
+
+	arch := appCfg.SupportArch[0]
+	if _, ok := pod.Spec.NodeSelector[constants.ArchLabelKey]; ok {
+		// Respect an explicit arch nodeSelector already set by the chart.
+		return resp
+	}
+	if pod.Spec.NodeSelector == nil {
+		pod.Spec.NodeSelector = make(map[string]string)
+	}
+	pod.Spec.NodeSelector[constants.ArchLabelKey] = arch
+
+	current, err := json.Marshal(&pod)
+	if err != nil {
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	admissionResp := admission.PatchResponseFromRaw(req.Object.Raw, current)
+	patchBytes, err := json.Marshal(admissionResp.Patches)
+	if err != nil {
+		return h.sidecarWebhook.AdmissionError(req.UID, err)
+	}
+	h.sidecarWebhook.PatchAdmissionResponse(resp, patchBytes)
+	klog.Infof("Injected arch nodeSelector=%s for pod uuid=%s namespace=%s", arch, proxyUUID, req.Namespace)
+	return resp
 }
 
 func (h *Handler) appLabelInject(req *restful.Request, resp *restful.Response) {

--- a/framework/app-service/pkg/apiserver/webservice.go
+++ b/framework/app-service/pkg/apiserver/webservice.go
@@ -340,6 +340,13 @@ func addServiceToContainer(c *restful.Container, handler *Handler) error {
 		Returns(http.StatusOK, "Success to inject", nil)).
 		Consumes(restful.MIME_JSON)
 
+	ws.Route(ws.POST("/podarch/inject").
+		To(handler.podArchInject).
+		Doc("mutating webhook to inject kubernetes.io/arch nodeSelector for single-arch apps").
+		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
+		Returns(http.StatusOK, "Success to inject", nil)).
+		Consumes(restful.MIME_JSON)
+
 	ws.Route(ws.POST("/provider-registry/validate").
 		To(handler.providerRegistryValidate).
 		Doc("validating webhook for validate app install namespace").

--- a/framework/app-service/pkg/appcfg/application.go
+++ b/framework/app-service/pkg/appcfg/application.go
@@ -109,6 +109,11 @@ type ApplicationConfig struct {
 	SharedEntrances      []Entrance
 	SelectedGpuType      string
 	Accelerator          []ResourceMode
+	// SupportArch mirrors spec.supportArch in OlaresManifest.yaml. When it
+	// declares exactly one architecture (amd64 or arm64) the pod-arch
+	// mutating webhook pins the app's pods to matching nodes via a
+	// kubernetes.io/arch nodeSelector.
+	SupportArch []string
 	// NeedsSharedAccess signals that the app needs cross-namespace access to
 	// a shared app's services (e.g. for service-mesh sidecar injection).
 	// Force-set to true for SHARED apps in toApplicationConfig regardless of

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -1119,6 +1119,7 @@ func toApplicationConfig(opt *ConfigOptions, chart string, cfg *appcfg.AppConfig
 		SharedEntrances:      cfg.SharedEntrances,
 		SelectedGpuType:      opt.SelectedGpu,
 		Accelerator:          cfg.Spec.Accelerator,
+		SupportArch:          cfg.Spec.SupportArch,
 		NeedsSharedAccess:    cfg.Options.NeedsSharedAccess,
 		LLMGatewaySupported:  cfg.Options.LLMGatewaySupported,
 		OverlayGateway:       cfg.OverlayGateway,

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -39,6 +39,9 @@ const (
 	macvlanInitWebhookName         = "macvlan-init-webhook"
 	mutatingWebhookMacvlanInitName = "macvlan-init-inject-webhook.bytetrade.io"
 
+	podArchWebhookName         = "pod-arch-nodeselector-webhook"
+	mutatingWebhookPodArchName = "pod-arch-nodeselector-inject-webhook.bytetrade.io"
+
 	applicationManagerMutatingWebhookName   = "applicationmanager-mutating-webhook"
 	applicationManagerValidatingWebhookName = "applicationmanager-validating-webhook"
 	argoResourceValidatingWebhookName       = "argo-resource-validating-webhook"
@@ -1221,5 +1224,113 @@ func (wh *Webhook) CreateOrUpdateMacvlanInitMutatingWebhook() error {
 		}
 	}
 	klog.Infof("Finished creating MutatingWebhookConfiguration %s", macvlanInitWebhookName)
+	return nil
+}
+
+// CreateOrUpdatePodArchNodeSelectorMutatingWebhook creates or updates the pod
+// architecture nodeSelector mutating webhook. It fires for pods on Create and,
+// when the owning app's OlaresManifest declares exactly one spec.supportArch,
+// injects a kubernetes.io/arch nodeSelector so the pod lands on a matching
+// node. FailurePolicy is Ignore so a transient webhook outage never blocks pod
+// creation, because the arch nodeSelector is an additive scheduling hint.
+func (wh *Webhook) CreateOrUpdatePodArchNodeSelectorMutatingWebhook() error {
+	webhookPath := "/app-service/v1/podarch/inject"
+	port, err := strconv.Atoi(strings.Split(constants.WebhookServerListenAddress, ":")[1])
+	if err != nil {
+		return err
+	}
+	webhookPort := int32(port)
+	failurePolicy := admissionregv1.Ignore
+	matchPolicy := admissionregv1.Exact
+	webhookTimeout := int32(30)
+
+	mwhLabels := map[string]string{"velero.io/exclude-from-backup": "true"}
+	caBundle, err := ioutil.ReadFile(defaultCaPath)
+	if err != nil {
+		return err
+	}
+	mwh := admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podArchWebhookName,
+			Labels: mwhLabels,
+		},
+		Webhooks: []admissionregv1.MutatingWebhook{
+			{
+				Name: mutatingWebhookPodArchName,
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &admissionregv1.ServiceReference{
+						Namespace: webhookServiceNamespace,
+						Name:      webhookServiceName,
+						Path:      &webhookPath,
+						Port:      &webhookPort,
+					},
+				},
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.UnderLayerNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSNetworkNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.GPUSystemNamespaces,
+						},
+					},
+				},
+				Rules: []admissionregv1.RuleWithOperations{
+					{
+						Operations: []admissionregv1.OperationType{admissionregv1.Create},
+						Rule: admissionregv1.Rule{
+							APIGroups:   []string{"*"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				TimeoutSeconds:          &webhookTimeout,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+	if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), &mwh, metav1.CreateOptions{}); err != nil {
+		// Webhook already exists, update the webhook in this scenario
+		if apierrors.IsAlreadyExists(err) {
+			existing, err := wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), mwh.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("Failed to get MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+				return err
+			}
+			mwh.ObjectMeta.ResourceVersion = existing.ObjectMeta.ResourceVersion
+			if _, err = wh.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.Background(), &mwh, metav1.UpdateOptions{}); err != nil {
+				if !apierrors.IsConflict(err) {
+					klog.Errorf("Failed to update MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+					return err
+				}
+			}
+		} else {
+			klog.Errorf("Failed to create MutatingWebhookConfiguration name=%s err=%v", mwh.Name, err)
+			return err
+		}
+	}
+	klog.Infof("Finished creating MutatingWebhookConfiguration %s", podArchWebhookName)
 	return nil
 }


### PR DESCRIPTION
* **Background**
Add a mutating webhook that pins an app's pods to a matching node architecture when its OlaresManifest declares exactly one spec.supportArch. On pod Create the webhook resolves the owning app config by namespace and, for a single declared arch (amd64/arm64), injects a kubernetes.io/arch nodeSelector; apps declaring zero (including pre-existing installs without the field) or both arches are left untouched, and an explicit chart-set arch selector is preserved.

- appcfg: carry SupportArch through ApplicationConfig so it round-trips via ApplicationManager.Spec.Config and is readable by the webhook
- webhook: register pod-arch-nodeselector-webhook (pods/Create, failurePolicy=Ignore) and add the podArchInject handler + route
- apiserver: whitelist /podarch/inject in the auth filter so admission requests are not rejected with 401

Effective for newly installed/upgraded apps only; existing installs repopulate SupportArch on reinstall or upgrade.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod scheduling constraints cluster-wide for affected apps via admission; `failurePolicy=Ignore` limits blast radius if the webhook is down, but wrong arch pinning could still strand workloads on heterogeneous clusters.
> 
> **Overview**
> Adds a **pod-arch mutating admission webhook** so single-architecture apps schedule onto matching nodes. On pod **Create**, the handler resolves app config from the pod namespace; when `spec.supportArch` in the OlaresManifest maps to **exactly one** arch in `ApplicationConfig.SupportArch`, it patches in a `kubernetes.io/arch` **nodeSelector**. Apps with **no** arch list (legacy installs), **both** amd64 and arm64, missing config, or an arch selector already set by the chart are left unchanged.
> 
> **Config plumbing:** `SupportArch` is added on `ApplicationConfig` and filled from the manifest in `toApplicationConfig`, so the webhook can read it via `ApplicationManager.Spec.Config` like other app settings.
> 
> **Wiring:** Registers `pod-arch-nodeselector-webhook` (`failurePolicy=Ignore`), exposes `POST /app-service/v1/podarch/inject`, whitelists that path in the auth filter, and registers the webhook at handler build time. Behavior applies to **new** installs/upgrades that persist `SupportArch`, not existing clusters until reinstall/upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41a85a2e7cb4fcb986b5e73fbeeeb846f6620cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->