### PR TITLE
cli/search: add gdrive, dropbox and knowledge subcommands

### DIFF
--- a/cli/cmd/ctl/search/cloud.go
+++ b/cli/cmd/ctl/search/cloud.go
@@ -1,0 +1,187 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/whoami"
+)
+
+// cloudProvider describes a third-party cloud drive that search3 indexes
+// under its own app partition (google_drive / dropbox). The CLI surfaces
+// each as its own subcommand, mirroring TermiPass Desktop's independent
+// search sources.
+type cloudProvider struct {
+	// use is the cobra Use name (e.g. "gdrive", "dropbox").
+	use string
+	// aliases are additional cobra aliases.
+	aliases []string
+	// title is the human label used in help and empty-result hints.
+	title string
+	// app is the search3 /api/search/init "app" field.
+	app string
+	// accountType is the /api/account/<type> segment used to probe whether
+	// any integration account is bound (e.g. "google", "dropbox").
+	accountType string
+	// verb is the full CLI verb rendered in the version-gate error.
+	verb string
+	// reason is the parenthetical in the version-gate error.
+	reason string
+}
+
+var (
+	googleDriveProvider = cloudProvider{
+		use:         "gdrive",
+		aliases:     []string{"google-drive", "google"},
+		title:       "Google Drive",
+		app:         appGoogleDrive,
+		accountType: "google",
+		verb:        "search gdrive",
+		reason:      "search3 app=google_drive index",
+	}
+	dropboxProvider = cloudProvider{
+		use:         "dropbox",
+		aliases:     nil,
+		title:       "Dropbox",
+		app:         appDropbox,
+		accountType: "dropbox",
+		verb:        "search dropbox",
+		reason:      "search3 app=dropbox index",
+	}
+)
+
+type cloudOptions struct {
+	pagingOptions
+	searchType string
+}
+
+func newGDriveCommand(f *cmdutil.Factory) *cobra.Command {
+	return newCloudCommand(f, googleDriveProvider)
+}
+
+func newDropboxCommand(f *cmdutil.Factory) *cobra.Command {
+	return newCloudCommand(f, dropboxProvider)
+}
+
+func newCloudCommand(f *cmdutil.Factory, p cloudProvider) *cobra.Command {
+	o := &cloudOptions{}
+	cmd := &cobra.Command{
+		Use:     p.use + " <keyword>",
+		Aliases: p.aliases,
+		Short:   "Search " + p.title + " files (Olares >= 1.12.7)",
+		Long: fmt.Sprintf(`Search the per-user search3 index for %s files.
+
+Requires Olares >= %s. Uses the same session-based protocol as
+`+"`search drive`"+` (/api/search/init + /more + /cancel), with app=%s.
+
+Result locations are files-backend front-end paths (e.g. %s/<account>/...),
+so they can be passed directly to `+"`olares-cli files ls`"+` / cat.
+
+If no integration account is bound, the empty result prints a hint to
+complete OAuth binding in LarePass → Settings → Integration.
+
+Examples:
+  olares-cli search %s report
+  olares-cli search %s invoice --limit 50
+  olares-cli search %s "design doc" --offset 20 -o json
+`, p.title, searchSessionAppMinOlaresVersion, p.app, p.accountType, p.use, p.use, p.use),
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			keyword, err := parseKeyword(args)
+			if err != nil {
+				return err
+			}
+			return runCloudSearch(c.Context(), f, keyword, p, o)
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.Flags().StringVarP(&o.searchType, "type", "t", searchTypeAggregate,
+		"search mode: aggregate, file_name")
+	registerPagingFlags(cmd, &o.pagingOptions)
+	return cmd
+}
+
+func runCloudSearch(ctx context.Context, f *cmdutil.Factory, keyword string, p cloudProvider, o *cloudOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := requireSessionAppBackendVersion(ctx, f, p.verb, p.reason); err != nil {
+		return err
+	}
+	searchType, err := parseSearchType(o.searchType)
+	if err != nil {
+		return err
+	}
+	format, err := o.validate()
+	if err != nil {
+		return err
+	}
+
+	items, err := runSessionSearch(ctx, f, keyword, p.app, searchType, &o.pagingOptions)
+	if err != nil {
+		return err
+	}
+
+	if len(items) == 0 && format == FormatTable {
+		return printCloudEmpty(ctx, f, p, os.Stdout)
+	}
+	return printSearchResults(format, items)
+}
+
+// accountMini is the slim IntegrationAccountMiniData shape returned by
+// GET /api/account/<type>. Only Available matters for the empty-result hint.
+type accountMini struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Available bool   `json:"available"`
+}
+
+// printCloudEmpty renders the empty-result message for a cloud search.
+// Best-effort: if we can confirm no available integration account is bound,
+// print a binding hint; any probe failure falls back to plain "no results".
+func printCloudEmpty(ctx context.Context, f *cmdutil.Factory, p cloudProvider, w io.Writer) error {
+	msg := cloudEmptyMessage(p, nil, true)
+	if doer, err := newDoer(ctx, f); err == nil {
+		accounts, probeErr := fetchIntegrationAccounts(ctx, doer, p.accountType)
+		msg = cloudEmptyMessage(p, accounts, probeErr != nil)
+	}
+	_, err := fmt.Fprintln(w, msg)
+	return err
+}
+
+// cloudEmptyMessage picks the empty-result copy. probeFailed=true means the
+// account list could not be fetched, so we stay silent about bindings.
+// Pure helper so tests can drive every branch without an HTTP client.
+func cloudEmptyMessage(p cloudProvider, accounts []accountMini, probeFailed bool) string {
+	if probeFailed {
+		return "no results"
+	}
+	if hasAvailableAccount(accounts) {
+		return "no results"
+	}
+	return fmt.Sprintf(
+		"no results — no available %s integration account; bind one in LarePass → Settings → Integration (check with `olares-cli settings integration accounts list-by-type %s`)",
+		p.title, p.accountType)
+}
+
+func hasAvailableAccount(accounts []accountMini) bool {
+	for _, a := range accounts {
+		if a.Available {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchIntegrationAccounts(ctx context.Context, doer *whoami.HTTPClient, accountType string) ([]accountMini, error) {
+	var rows []accountMini
+	if err := doEnvelope(ctx, doer, "GET", "/api/account/"+accountType, nil, &rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/cli/cmd/ctl/search/cloud_test.go
+++ b/cli/cmd/ctl/search/cloud_test.go
@@ -1,0 +1,104 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCloudProviderMapping(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		p           cloudProvider
+		wantApp     string
+		wantAccount string
+		wantUse     string
+	}{
+		{"google drive", googleDriveProvider, appGoogleDrive, "google", "gdrive"},
+		{"dropbox", dropboxProvider, appDropbox, "dropbox", "dropbox"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.p.app != tc.wantApp {
+				t.Fatalf("app = %q, want %q", tc.p.app, tc.wantApp)
+			}
+			if tc.p.accountType != tc.wantAccount {
+				t.Fatalf("accountType = %q, want %q", tc.p.accountType, tc.wantAccount)
+			}
+			if tc.p.use != tc.wantUse {
+				t.Fatalf("use = %q, want %q", tc.p.use, tc.wantUse)
+			}
+		})
+	}
+}
+
+func TestCloudEmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	p := dropboxProvider
+
+	t.Run("probe failed falls back to no results", func(t *testing.T) {
+		t.Parallel()
+		got := cloudEmptyMessage(p, nil, true)
+		if got != "no results" {
+			t.Fatalf("got %q, want %q", got, "no results")
+		}
+	})
+
+	t.Run("available account stays no results", func(t *testing.T) {
+		t.Parallel()
+		got := cloudEmptyMessage(p, []accountMini{{Name: "me", Available: true}}, false)
+		if got != "no results" {
+			t.Fatalf("got %q, want %q", got, "no results")
+		}
+	})
+
+	t.Run("no available account prints LarePass binding hint", func(t *testing.T) {
+		t.Parallel()
+		got := cloudEmptyMessage(p, []accountMini{{Name: "stale", Available: false}}, false)
+		if !strings.Contains(got, "LarePass → Settings → Integration") {
+			t.Fatalf("expected LarePass binding hint, got %q", got)
+		}
+		if !strings.Contains(got, "list-by-type dropbox") {
+			t.Fatalf("expected list-by-type hint, got %q", got)
+		}
+		if !strings.Contains(got, "Dropbox") {
+			t.Fatalf("expected provider title, got %q", got)
+		}
+	})
+
+	t.Run("empty account list prints binding hint", func(t *testing.T) {
+		t.Parallel()
+		got := cloudEmptyMessage(p, nil, false)
+		if !strings.Contains(got, "LarePass → Settings → Integration") {
+			t.Fatalf("expected LarePass binding hint, got %q", got)
+		}
+	})
+}
+
+func TestHasAvailableAccount(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []accountMini
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", []accountMini{}, false},
+		{"all unavailable", []accountMini{{Available: false}, {Available: false}}, false},
+		{"one available", []accountMini{{Available: false}, {Available: true}}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasAvailableAccount(tc.in); got != tc.want {
+				t.Fatalf("hasAvailableAccount = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/ctl/search/common.go
+++ b/cli/cmd/ctl/search/common.go
@@ -24,9 +24,16 @@ const (
 	appDropbox     = "dropbox"
 	appKnowledge   = "knowledge"
 
-	// searchSessionAppMinOlaresVersion is the first Olares line whose
-	// search3 accepts app=google_drive|dropbox|knowledge. Mirrors
-	// TermiPass's seachOSVersionLargeThan12_7 gate.
+	// searchSessionAppMinOlaresVersion is the first Olares line on which
+	// search3 serves app=google_drive|dropbox|knowledge.
+	//
+	// For google_drive and dropbox this mirrors TermiPass's
+	// seachOSVersionLargeThan12_7 gate directly. knowledge has no such
+	// gate in the SPA -- it offers the Wise source whenever Wise is
+	// installed -- but it lands on the same floor anyway, because only
+	// the new Wise feeds search3's knowledge partition and it can only be
+	// installed on Olares >= 1.12.7. Supporting the older Wise is
+	// explicitly out of scope for the CLI.
 	searchSessionAppMinOlaresVersion = "1.12.7"
 
 	searchTypeAggregate = "aggregate"

--- a/cli/cmd/ctl/search/common.go
+++ b/cli/cmd/ctl/search/common.go
@@ -19,7 +19,15 @@ import (
 )
 
 const (
-	appFilesV2 = "files_v2"
+	appFilesV2     = "files_v2"
+	appGoogleDrive = "google_drive"
+	appDropbox     = "dropbox"
+	appKnowledge   = "knowledge"
+
+	// searchSessionAppMinOlaresVersion is the first Olares line whose
+	// search3 accepts app=google_drive|dropbox|knowledge. Mirrors
+	// TermiPass's seachOSVersionLargeThan12_7 gate.
+	searchSessionAppMinOlaresVersion = "1.12.7"
 
 	searchTypeAggregate = "aggregate"
 	searchTypeFileName  = "file_name"

--- a/cli/cmd/ctl/search/drive.go
+++ b/cli/cmd/ctl/search/drive.go
@@ -2,9 +2,7 @@ package search
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
@@ -63,52 +61,7 @@ func runDriveSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *
 		return err
 	}
 
-	doer, err := newDoer(ctx, f)
-	if err != nil {
-		return err
-	}
-
-	reqid := uuid.NewString()
-	defer func() {
-		_ = doEnvelope(ctx, doer, "POST", "/api/search/cancel",
-			map[string]interface{}{"reqid": reqid}, nil)
-	}()
-
-	// init runs the search, caches the full (server-capped) result set, and
-	// returns only the first initPageSize hits. It ignores offset/limit, so we
-	// don't send them.
-	initBody := map[string]interface{}{
-		"reqid":   reqid,
-		"keyword": keyword,
-		"type":    searchType,
-		"app":     appFilesV2,
-	}
-	var initRows []json.RawMessage
-	if err := doEnvelope(ctx, doer, "POST", "/api/search/init", initBody, &initRows); err != nil {
-		return err
-	}
-
-	// Honor --offset/--limit client-side. If the requested window already lies
-	// within what init returned -- or init returned a short final page (fewer
-	// than initPageSize hits means the cache holds no more) -- serve it
-	// directly. Otherwise page the exact window via /search/more, whose limit
-	// must stay within the backend's 1-100 range; a past-the-end offset comes
-	// back as codeNoMoreResults, which we treat as an empty result set.
-	var window []json.RawMessage
-	if needsMorePage(o.offset, o.limit, len(initRows)) {
-		moreBody := map[string]interface{}{
-			"reqid":  reqid,
-			"offset": o.offset,
-			"limit":  clampMoreLimit(o.limit),
-		}
-		if err := doEnvelopeAllowing(ctx, doer, "POST", "/api/search/more", moreBody, &window, codeNoMoreResults); err != nil {
-			return err
-		}
-	} else {
-		window = paginateRaw(initRows, o.offset, o.limit)
-	}
-
-	items, err := decodeResultRows(window)
+	items, err := runSessionSearch(ctx, f, keyword, appFilesV2, searchType, &o.pagingOptions)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/ctl/search/knowledge.go
+++ b/cli/cmd/ctl/search/knowledge.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+type knowledgeOptions struct {
+	pagingOptions
+}
+
+func newKnowledgeCommand(f *cmdutil.Factory) *cobra.Command {
+	o := &knowledgeOptions{}
+	cmd := &cobra.Command{
+		Use:     "knowledge <keyword>",
+		Aliases: []string{"wise"},
+		Short:   "Search Wise / Knowledge content (Olares >= 1.12.7)",
+		Long: fmt.Sprintf(`Search Wise (Knowledge) content via the search3 index.
+
+Requires Olares >= %s. Uses the same session-based protocol as
+`+"`search drive`"+` (/api/search/init + /more + /cancel), with app=knowledge.
+
+Search mode is fixed to aggregate (full-content); there is no --type flag.
+Result locations are typically http(s) URLs into the Wise app.
+
+Examples:
+  olares-cli search knowledge report
+  olares-cli search wise invoice --limit 50
+  olares-cli search knowledge "design doc" --offset 20 -o json
+`, searchSessionAppMinOlaresVersion),
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			keyword, err := parseKeyword(args)
+			if err != nil {
+				return err
+			}
+			return runKnowledgeSearch(c.Context(), f, keyword, o)
+		},
+	}
+	cmd.SilenceUsage = true
+	registerPagingFlags(cmd, &o.pagingOptions)
+	return cmd
+}
+
+func runKnowledgeSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *knowledgeOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := requireSessionAppBackendVersion(ctx, f, "search knowledge", "search3 app=knowledge index"); err != nil {
+		return err
+	}
+	format, err := o.validate()
+	if err != nil {
+		return err
+	}
+
+	items, err := runSessionSearch(ctx, f, keyword, appKnowledge, searchTypeAggregate, &o.pagingOptions)
+	if err != nil {
+		return err
+	}
+	return printSearchResults(format, items)
+}

--- a/cli/cmd/ctl/search/root.go
+++ b/cli/cmd/ctl/search/root.go
@@ -8,22 +8,29 @@ import (
 
 // NewSearchCommand returns the top-level `search` command group. Each data
 // source is a subcommand so flags are scoped to what the backend supports
-// (e.g. sync has no --type).
+// (e.g. sync has no --type; knowledge has no --type; gdrive/dropbox/knowledge
+// require Olares >= 1.12.7).
 func NewSearchCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search",
-		Short: "Search Drive files, Sync libraries, or installed applications",
+		Short: "Search Drive, Sync, cloud drives, Wise, or installed applications",
 		Long: `Run the same searches the Olares Desktop global search dialog uses.
 
 Subcommands:
-  drive   Full-content search of user Drive files (search3 index)
-  sync    Search Seafile/Sync libraries
-  app     Search installed applications by title
+  drive       Full-content search of user Drive files (search3 index)
+  sync        Search Seafile/Sync libraries
+  gdrive      Search Google Drive files (Olares >= 1.12.7; aliases: google-drive, google)
+  dropbox     Search Dropbox files (Olares >= 1.12.7)
+  knowledge   Search Wise / Knowledge content (Olares >= 1.12.7; alias: wise)
+  app         Search installed applications by title
 
 Examples:
   olares-cli search drive report
   olares-cli search drive "design doc" --type file_name
   olares-cli search sync notes --offset 20 -o json
+  olares-cli search gdrive invoice --limit 50
+  olares-cli search dropbox report -o json
+  olares-cli search knowledge design
   olares-cli search app wise
 `,
 	}
@@ -32,6 +39,9 @@ Examples:
 
 	cmd.AddCommand(newDriveCommand(f))
 	cmd.AddCommand(newSyncCommand(f))
+	cmd.AddCommand(newGDriveCommand(f))
+	cmd.AddCommand(newDropboxCommand(f))
+	cmd.AddCommand(newKnowledgeCommand(f))
 	cmd.AddCommand(newAppCommand(f))
 	return cmd
 }

--- a/cli/cmd/ctl/search/session.go
+++ b/cli/cmd/ctl/search/session.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// runSessionSearch runs a search3 session-based search for the given app
+// partition (files_v2 / google_drive / dropbox / knowledge). It bootstraps
+// /api/search/init, pages via /api/search/more when the requested window
+// extends past the first page, and best-effort cancels the session on exit.
+func runSessionSearch(ctx context.Context, f *cmdutil.Factory, keyword, app, searchType string, o *pagingOptions) ([]resultItem, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	doer, err := newDoer(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	reqid := uuid.NewString()
+	defer func() {
+		_ = doEnvelope(ctx, doer, "POST", "/api/search/cancel",
+			map[string]interface{}{"reqid": reqid}, nil)
+	}()
+
+	// init runs the search, caches the full (server-capped) result set, and
+	// returns only the first initPageSize hits. It ignores offset/limit, so we
+	// don't send them.
+	initBody := map[string]interface{}{
+		"reqid":   reqid,
+		"keyword": keyword,
+		"type":    searchType,
+		"app":     app,
+	}
+	var initRows []json.RawMessage
+	if err := doEnvelope(ctx, doer, "POST", "/api/search/init", initBody, &initRows); err != nil {
+		return nil, err
+	}
+
+	// Honor --offset/--limit client-side. If the requested window already lies
+	// within what init returned -- or init returned a short final page (fewer
+	// than initPageSize hits means the cache holds no more) -- serve it
+	// directly. Otherwise page the exact window via /search/more, whose limit
+	// must stay within the backend's 1-100 range; a past-the-end offset comes
+	// back as codeNoMoreResults, which we treat as an empty result set.
+	var window []json.RawMessage
+	if needsMorePage(o.offset, o.limit, len(initRows)) {
+		moreBody := map[string]interface{}{
+			"reqid":  reqid,
+			"offset": o.offset,
+			"limit":  clampMoreLimit(o.limit),
+		}
+		if err := doEnvelopeAllowing(ctx, doer, "POST", "/api/search/more", moreBody, &window, codeNoMoreResults); err != nil {
+			return nil, err
+		}
+	} else {
+		window = paginateRaw(initRows, o.offset, o.limit)
+	}
+
+	return decodeResultRows(window)
+}
+
+// requireSessionAppBackendVersion is the fail-closed preflight for the
+// search3 app partitions that only exist on Olares >= 1.12.7 (google_drive,
+// dropbox, knowledge). Older backends would return an opaque empty set or
+// an unexpected error code; reject up front with an actionable upgrade
+// message instead. The version is cached per profile at login, so in the
+// common case this adds no network round-trip.
+func requireSessionAppBackendVersion(ctx context.Context, f *cmdutil.Factory, verb, reason string) error {
+	return cmdutil.RequireMinVersion(ctx, f, cmdutil.MinVersionGate{
+		Verb:       verb,
+		MinVersion: searchSessionAppMinOlaresVersion,
+		Reason:     reason,
+		Fallback:   "upgrade the Olares system, or use `olares-cli search drive` for local Drive files",
+	})
+}

--- a/cli/cmd/ctl/search/session_test.go
+++ b/cli/cmd/ctl/search/session_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"testing"
+)
+
+// TestSessionAppConstants pins the search3 app partition strings that the
+// new gdrive / dropbox / knowledge subcommands send as the "app" field on
+// /api/search/init. These must stay aligned with TermiPass ServiceType.
+func TestSessionAppConstants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"files_v2", appFilesV2, "files_v2"},
+		{"google_drive", appGoogleDrive, "google_drive"},
+		{"dropbox", appDropbox, "dropbox"},
+		{"knowledge", appKnowledge, "knowledge"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.got != tc.want {
+				t.Fatalf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSearchSessionAppMinVersion(t *testing.T) {
+	t.Parallel()
+	if searchSessionAppMinOlaresVersion != "1.12.7" {
+		t.Fatalf("searchSessionAppMinOlaresVersion = %q, want 1.12.7", searchSessionAppMinOlaresVersion)
+	}
+}

--- a/cli/cmd/ctl/search/version_gate_test.go
+++ b/cli/cmd/ctl/search/version_gate_test.go
@@ -1,0 +1,73 @@
+package search
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// TestRequireSessionAppBackendVersion pins the 1.12.7 fail-closed gate for
+// search gdrive / dropbox / knowledge. The gate reuses
+// cmdutil.RequireMinVersion, whose version resolution short-circuits on the
+// version override viper key (FlagOlaresVersion) BEFORE any profile /
+// network access — so a zero-value Factory plus a viper override is enough
+// to drive every branch without a fake backend. A fresh Factory per
+// scenario avoids the per-Factory memoization (backendVersionOnce) leaking
+// a version across cases.
+func TestRequireSessionAppBackendVersion(t *testing.T) {
+	prev := viper.GetString(cmdutil.FlagOlaresVersion)
+	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, prev) })
+
+	verbs := []struct {
+		verb   string
+		reason string
+	}{
+		{"search gdrive", "search3 app=google_drive index"},
+		{"search dropbox", "search3 app=dropbox index"},
+		{"search knowledge", "search3 app=knowledge index"},
+	}
+
+	for _, v := range verbs {
+		v := v
+
+		t.Run(v.verb+" on 1.12.6 backend is rejected", func(t *testing.T) {
+			viper.Set(cmdutil.FlagOlaresVersion, "1.12.6")
+			err := requireSessionAppBackendVersion(context.Background(), &cmdutil.Factory{}, v.verb, v.reason)
+			if err == nil {
+				t.Fatalf("%s on 1.12.6 must be rejected", v.verb)
+			}
+			if !strings.Contains(err.Error(), searchSessionAppMinOlaresVersion) {
+				t.Fatalf("error should name the %s minimum, got %q", searchSessionAppMinOlaresVersion, err.Error())
+			}
+			if !strings.Contains(err.Error(), v.verb) {
+				t.Fatalf("error should name the verb %q, got %q", v.verb, err.Error())
+			}
+		})
+
+		t.Run(v.verb+" on 1.12.7 backend is allowed", func(t *testing.T) {
+			viper.Set(cmdutil.FlagOlaresVersion, "1.12.7")
+			if err := requireSessionAppBackendVersion(context.Background(), &cmdutil.Factory{}, v.verb, v.reason); err != nil {
+				t.Fatalf("%s on 1.12.7 must be allowed, got: %v", v.verb, err)
+			}
+		})
+
+		t.Run(v.verb+" on a newer 1.12.7 daily build is allowed", func(t *testing.T) {
+			viper.Set(cmdutil.FlagOlaresVersion, "1.12.7-20260604")
+			if err := requireSessionAppBackendVersion(context.Background(), &cmdutil.Factory{}, v.verb, v.reason); err != nil {
+				t.Fatalf("%s on a 1.12.7 daily build must be allowed, got: %v", v.verb, err)
+			}
+		})
+
+		t.Run(v.verb+" on undetectable version is fail-closed", func(t *testing.T) {
+			viper.Set(cmdutil.FlagOlaresVersion, "not-a-version")
+			err := requireSessionAppBackendVersion(context.Background(), &cmdutil.Factory{}, v.verb, v.reason)
+			if err == nil {
+				t.Fatalf("%s with undetectable version must be rejected", v.verb)
+			}
+		})
+	}
+}

--- a/cli/skills/olares-search/SKILL.md
+++ b/cli/skills/olares-search/SKILL.md
@@ -55,7 +55,7 @@ Multiple words are joined into one keyword (quote multi-word phrases to be expli
 - The only difference between these sources is the `app` field sent on `/init`: `files_v2`, `google_drive`, `dropbox`, or `knowledge`.
 - `drive` / `gdrive` / `dropbox` expose `--type aggregate` (default, full-content) and `--type file_name` (filename only). `knowledge` is fixed to `aggregate` (no `--type` flag).
 - `--limit` (default 20) caps results; `--offset` pages. `/init` always returns the first 20 hits and ignores offset/limit, so the CLI honors them itself: when the requested window fits inside those 20 hits (or the search returned fewer), it is sliced client-side with no extra call; only a window past the first 20 triggers `/more` (limit clamped to the backend's 1-100). A single search resolves at most ~50 hits server-side, so `--limit` is effectively capped around 50, and an `--offset` past the end prints "no results" rather than erroring.
-- `gdrive` / `dropbox` / `knowledge` are **fail-closed version-gated** to Olares >= 1.12.7 (same line TermiPass exposes those Desktop search sources). On an older or undetectable backend the CLI rejects up front with an upgrade message instead of hitting an opaque empty/error response.
+- `gdrive` / `dropbox` / `knowledge` are **fail-closed version-gated** to Olares >= 1.12.7 — the line on which Desktop exposes the two cloud sources, and on which the new Wise (the only one indexed under `app=knowledge`) can be installed. On an older or undetectable backend the CLI rejects up front with an upgrade message instead of hitting an opaque empty/error response.
 
 ### sync
 

--- a/cli/skills/olares-search/SKILL.md
+++ b/cli/skills/olares-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: olares-search
-version: 1.2.1
-description: "Olares Search via olares-cli search — query the Desktop global index for Drive/Sync filenames and content or installed app titles, with paging and JSON output. Use for full-text search, Text Search, global search, finding a file by content, or finding an app by title; not for configuring indexed directories or rebuilding the index (olares-settings)."
+version: 1.3.0
+description: "Olares search via olares-cli search — the Desktop global search over Drive files, Sync (Seafile) libraries, Google Drive, Dropbox, Wise/Knowledge, and installed applications, with paging and JSON output. Use for Olares search, full-text search, find a file by content, Text Search, global search, search apps, search google drive, search dropbox, search wise."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
   openclaw:
@@ -20,35 +20,42 @@ metadata:
 
 - Find content by keyword across the user's data: "where is the file that mentions X", "search my drive for invoice", full-text / Text Search, Desktop global search.
 - Find installed applications by title: "open wise", "search for firefox app".
-- Subcommands: `drive` (user Drive files), `sync` (Seafile / Sync libraries), `app` (installed applications).
-- Keywords: Olares search, full-text search, find by content, Text Search, global search, search drive, search sync, search app.
+- Search Google Drive / Dropbox / Wise content (Olares >= 1.12.7).
+- Subcommands: `drive` (user Drive files), `sync` (Seafile / Sync libraries), `gdrive` (Google Drive), `dropbox`, `knowledge` / `wise` (Wise content), `app` (installed applications).
+- Keywords: Olares search, full-text search, find by content, Text Search, global search, search drive, search sync, search google drive, search dropbox, search wise, search app.
 
 > Anything outside this scope -> see the **Skill suite map** in [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) (already loaded as the suite prerequisite).
 
-> **Mental model:** `search drive` / `search sync` answers *"which file CONTAINS this text"* by querying the pre-built per-user index. `search app` answers *"which installed app matches this name"*. It is not lifecycle inventory (`market list --mine` / `market status`) or resource ranking (`dashboard applications`). To LIST or READ a known path, use [`olares-files`](../olares-files/SKILL.md) (`files ls` / `files cat` / `files download`).
+> **Mental model:** `search drive` / `search sync` / `search gdrive` / `search dropbox` / `search knowledge` answer *"which file CONTAINS this text"* by querying the pre-built per-user index. `search app` answers *"which installed app matches this name"*. It is not lifecycle inventory (`market list --mine` / `market status`) or resource ranking (`dashboard applications`). To LIST or READ a known path, use [`olares-files`](../olares-files/SKILL.md) (`files ls` / `files cat` / `files download`).
 
 ## What it is
 
-`olares-cli search` is the CLI mirror of the Olares Desktop global search dialog (reached via the Dock search icon / Shift+Space). It is a **command group** with three subcommands:
+`olares-cli search` is the CLI mirror of the Olares Desktop global search dialog (reached via the Dock search icon / Shift+Space). It is a **command group** with these subcommands:
 
-| Subcommand | Backend | Purpose |
-|---|---|---|
-| `search drive <keyword>` | search3 index (`/api/search/init` + `/more`) | Full-content / filename search of Drive files |
-| `search sync <keyword>` | `/api/search/sync` | Search Seafile/Sync libraries |
-| `search app <keyword>` | `/server/myApps` (local filter) | Search installed applications by entrance title |
+| Subcommand | Backend | Min Olares | Purpose |
+|---|---|---|---|
+| `search drive <keyword>` | search3 index (`/api/search/init` + `/more`, `app=files_v2`) | any | Full-content / filename search of Drive files |
+| `search sync <keyword>` | `/api/search/sync` | any | Search Seafile/Sync libraries |
+| `search gdrive <keyword>` | search3 (`app=google_drive`); aliases: `google-drive`, `google` | >= 1.12.7 | Search Google Drive files |
+| `search dropbox <keyword>` | search3 (`app=dropbox`) | >= 1.12.7 | Search Dropbox files |
+| `search knowledge <keyword>` | search3 (`app=knowledge`); alias: `wise` | >= 1.12.7 | Search Wise / Knowledge content |
+| `search app <keyword>` | `/server/myApps` (local filter) | any | Search installed applications by entrance title |
 
 Multiple words are joined into one keyword (quote multi-word phrases to be explicit).
 
-- `drive` / `sync` results show a title, a location (resource URI / path / repo), and a content snippet with the match. `--output json` emits the raw upstream rows verbatim.
+- `drive` / `sync` / `gdrive` / `dropbox` / `knowledge` results show a title, a location (resource URI / path / repo), and a content snippet with the match. `--output json` emits the raw upstream rows verbatim.
+- Cloud-drive locations (`google/<account>/...`, `dropbox/<account>/...`) are files-backend front-end paths — pass them directly to `olares-cli files ls` / `files cat`.
 - `app` results show title, app id, entrance name, state, and URL. `--output json` emits structured app rows.
 
 ## Search model
 
-### drive
+### drive / gdrive / dropbox / knowledge (session-based)
 
 - Session-based: bootstraps `/api/search/init`, pages deeper with `/api/search/more` (same `reqid`), best-effort cleanup via `/api/search/cancel`.
-- `--type aggregate` (default) is full-content search; `--type file_name` matches on filename only.
+- The only difference between these sources is the `app` field sent on `/init`: `files_v2`, `google_drive`, `dropbox`, or `knowledge`.
+- `drive` / `gdrive` / `dropbox` expose `--type aggregate` (default, full-content) and `--type file_name` (filename only). `knowledge` is fixed to `aggregate` (no `--type` flag).
 - `--limit` (default 20) caps results; `--offset` pages. `/init` always returns the first 20 hits and ignores offset/limit, so the CLI honors them itself: when the requested window fits inside those 20 hits (or the search returned fewer), it is sliced client-side with no extra call; only a window past the first 20 triggers `/more` (limit clamped to the backend's 1-100). A single search resolves at most ~50 hits server-side, so `--limit` is effectively capped around 50, and an `--offset` past the end prints "no results" rather than erroring.
+- `gdrive` / `dropbox` / `knowledge` are **fail-closed version-gated** to Olares >= 1.12.7 (same line TermiPass exposes those Desktop search sources). On an older or undetectable backend the CLI rejects up front with an upgrade message instead of hitting an opaque empty/error response.
 
 ### sync
 
@@ -61,9 +68,11 @@ Multiple words are joined into one keyword (quote multi-word phrases to be expli
 - Returns all matches in one response (**no `--limit` / `--offset`**).
 - Skips uninstalled/failed apps and invisible entrances (same rules as the Desktop SPA). For a `running` app the row shows the per-entrance state.
 
-### Indexing (drive / sync only)
+### Indexing (drive / sync / cloud / knowledge)
 
 Indexing is asynchronous on the server: a just-created/just-uploaded file may not be searchable until the index catches up. A miss is "not indexed yet", not necessarily "absent" — confirm a known path with `files ls`, check progress with `olares-cli settings search status`, and force a full reindex with `olares-cli settings search rebuild` (both in the [`olares-settings`](../olares-settings/SKILL.md) skill).
+
+Google Drive / Dropbox indexing is driven by the provider-side crawl after an integration account is bound; it does **not** follow the local Drive `/Documents/` full-content directory rules below. Wise / Knowledge indexing is owned by the Wise app.
 
 ## Index coverage (drive only)
 
@@ -87,6 +96,14 @@ olares-cli search drive "design doc" --type file_name --limit 50
 # Search Sync (Seafile) libraries, paged, JSON for scripting.
 olares-cli search sync notes --offset 20 -o json
 
+# Google Drive / Dropbox (Olares >= 1.12.7). Locations are files paths.
+olares-cli search gdrive invoice --limit 50
+olares-cli search dropbox report -o json
+
+# Wise / Knowledge (Olares >= 1.12.7).
+olares-cli search knowledge design
+olares-cli search wise invoice
+
 # Search installed applications.
 olares-cli search app wise
 olares-cli search app firefox -o json
@@ -97,8 +114,10 @@ olares-cli search app firefox -o json
 | Symptom | Cause | Fix |
 |---|---|---|
 | `a non-empty search keyword is required` | No keyword given | Pass `<keyword>` (quote phrases) |
-| `unsupported --type "<x>" (allowed: aggregate, file_name)` | Unknown search mode on drive | Use `aggregate` or `file_name` (drive only) |
+| `unsupported --type "<x>" (allowed: aggregate, file_name)` | Unknown search mode on drive/gdrive/dropbox | Use `aggregate` or `file_name` |
 | `--limit must be a positive integer` / `--offset must not be negative` | Bad paging values | Use `--limit > 0`, `--offset >= 0` |
-| `no results` but the file exists | Index hasn't caught up, or content not indexed | Check `settings search status` for progress/failures; verify the path with `files ls`. If it's a content miss, confirm the dir is in `settings search dirs`, then `settings search rebuild` |
+| `` `search gdrive` requires Olares >= 1.12.7 ... `` (same for dropbox / knowledge) | Backend below 1.12.7, or version undetectable | Upgrade Olares, or use `search drive` for local Drive; refresh profile (`profile whoami` / re-login) if version is unknown |
+| `no results — no available <provider> integration account; bind one in LarePass → Settings → Integration ...` | Cloud search with no bound OAuth account | Bind Google Drive / Dropbox in LarePass → Settings → Integration; verify with `olares-cli settings integration accounts list-by-type google\|dropbox` |
+| `no results` but the file exists | Index hasn't caught up, or content not indexed | Check `settings search status` for progress/failures; verify the path with `files ls`. If it's a content miss on Drive, confirm the dir is in `settings search dirs`, then `settings search rebuild` |
 | `no results` for app search | No installed app matches the keyword | Try a shorter keyword; confirm the app is installed and visible |
 | `server rejected the access token` / token invalidated | Auth | See [`../olares-shared/SKILL.md`](../olares-shared/SKILL.md) recovery table |


### PR DESCRIPTION
## Summary

Brings `olares-cli search` in line with the TermiPass Desktop global search dialog, which offers Google Drive, Dropbox and Wise as first-class search sources that the CLI had no equivalent for.

All three run over the **same search3 session protocol** the existing `search drive` already uses (`/api/search/init` → `/api/search/more` → `/api/search/cancel`); the only difference is the `app` field on `/init`. That flow was inlined in `drive.go` with `app=files_v2` hardcoded, so it is extracted into `runSessionSearch(app, searchType)` and each source becomes its own subcommand — matching how the Desktop dialog lists them independently, and keeping flags scoped to what each backend actually supports.

| Subcommand | `app` sent to `/init` | Notes |
|---|---|---|
| `search gdrive` (aliases `google-drive`, `google`) | `google_drive` | `--type aggregate\|file_name` |
| `search dropbox` | `dropbox` | `--type aggregate\|file_name` |
| `search knowledge` (alias `wise`) | `knowledge` | fixed to `aggregate`, no `--type` |

`search drive` / `sync` / `app` are untouched behaviorally.

### Version gate

The three new subcommands are **fail-closed gated to Olares >= 1.12.7** via `cmdutil.RequireMinVersion`, the same line on which TermiPass exposes these sources (`seachOSVersionLargeThan12_7`). Older backends don't know these `app` values and would answer with an opaque empty set rather than an error, so the CLI rejects up front with an actionable upgrade message. The version comes from the profile cache, so there is no extra round-trip in the common case, and dated builds such as `1.12.7-20260604` count as satisfying the floor.

### Cloud drive ergonomics

Cloud results carry `resource_uri` values shaped like `google/<account>/...` and `dropbox/<account>/...`, which are already valid files-backend front-end paths (`knownFileTypes` in `cli/cmd/ctl/files/path.go` covers `google` and `dropbox`). They are printed verbatim, so a hit can be pasted straight into `olares-cli files ls` / `files cat` — no need for the `/Drive/google/...` UI-path translation the SPA performs.

When a cloud search returns nothing, the CLI makes a best-effort probe of `GET /api/account/<google|dropbox>`. If no available integration account is bound, the empty result explains that and points at LarePass → Settings → Integration instead of printing a bare `no results`. Any probe failure silently falls back to the plain message, so the hint never affects the exit code.

## Changes

- `cli/cmd/ctl/search/session.go` (new) — shared `runSessionSearch` + `requireSessionAppBackendVersion`
- `cli/cmd/ctl/search/cloud.go` (new) — `gdrive` / `dropbox` behind one provider-driven constructor, plus the integration-account hint
- `cli/cmd/ctl/search/knowledge.go` (new) — `knowledge` / `wise`
- `cli/cmd/ctl/search/drive.go` — reduced to a thin wrapper over the shared session layer
- `cli/cmd/ctl/search/{common,root}.go` — `app` constants, version floor, subcommand listing and help
- `cli/skills/olares-search/SKILL.md` — bumped to 1.3.0; documents the new sources, the version floor, provider-side indexing (distinct from the local `/Documents/` full-text rules) and two new error-matrix rows
- Tests: `cloud_test.go`, `version_gate_test.go`, `session_test.go`

## Test plan

- [x] `go test ./cmd/ctl/search/...` passes
- [x] Version gate covered for all three verbs: 1.12.6 rejected, 1.12.7 allowed, `1.12.7-20260604` daily build allowed, unparseable version fail-closed
- [x] Empty-result hint covered for all three branches: available account, no available account, probe failure
- [x] `--help` output verified for the group and each new subcommand
- [x] Built against a live 1.12.7 profile; `search dropbox` clears the gate and reaches `/api/search/init`
- [ ] Re-run against a live profile with Google Drive / Dropbox accounts bound to confirm `/more` paging and `--type file_name` behavior on the provider-backed partitions

Made with [Cursor](https://cursor.com)