### PR TITLE
fix(app-service,daemon): unify caller appid header, overlay disable panic, and linkerd admin probes

### DIFF
--- a/daemon/cmd/terminusd/main.go
+++ b/daemon/cmd/terminusd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/beclab/Olares/daemon/cmd/terminusd/version"
 	"github.com/beclab/Olares/daemon/internel/apiserver"
+	"github.com/beclab/Olares/daemon/internel/apiserver/handlers"
 	"github.com/beclab/Olares/daemon/internel/ble"
 	"github.com/beclab/Olares/daemon/internel/mdns"
 	"github.com/beclab/Olares/daemon/internel/watcher"
@@ -57,6 +58,11 @@ func main() {
 	}
 
 	commands.Init()
+
+	// Clear leftover overlay op locks from a previous crash so status does not
+	// report a permanent activating/deactivating state. Do not reconcile app
+	// settings or cni-dhcp here.
+	handlers.ClearOverlayGatewayOpLocks()
 
 	mainCtx, cancel := context.WithCancel(context.Background())
 

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_disable.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_disable.go
@@ -26,12 +26,12 @@ func (h *Handlers) DisableOverlayGateway(ctx *fiber.Ctx, cmd commands.Interface)
 	}
 
 	// check if the lock file exists
-	if _, err := os.Stat(OverlayGatewayDisableLockFile); err == nil {
+	if inFlight, _ := consumeOverlayGatewayOpLock(OverlayGatewayDisableLockFile); inFlight {
 		s.Status = OverlayGatewayDeactivating
 		return h.OkJSON(ctx, "success", s)
 	}
 
-	if _, err := os.Stat(OverlayGatewayEnableLockFile); err == nil {
+	if inFlight, _ := consumeOverlayGatewayOpLock(OverlayGatewayEnableLockFile); inFlight {
 		s.Status = OverlayGatewayActivating
 		return h.OkJSON(ctx, "success", s)
 	}

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_enable.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_enable.go
@@ -26,12 +26,12 @@ func (h *Handlers) EnableOverlayGateway(ctx *fiber.Ctx, cmd commands.Interface) 
 	}
 
 	// check if the lock file exists
-	if _, err := os.Stat(OverlayGatewayEnableLockFile); err == nil {
+	if inFlight, _ := consumeOverlayGatewayOpLock(OverlayGatewayEnableLockFile); inFlight {
 		s.Status = OverlayGatewayActivating
 		return h.OkJSON(ctx, "success", s)
 	}
 
-	if _, err := os.Stat(OverlayGatewayDisableLockFile); err == nil {
+	if inFlight, _ := consumeOverlayGatewayOpLock(OverlayGatewayDisableLockFile); inFlight {
 		s.Status = OverlayGatewayDeactivating
 		return h.OkJSON(ctx, "success", s)
 	}

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_oplock.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_oplock.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"os"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// OverlayGatewayOpLockTTL is longer than the enable/disable operation timer (60s)
+// so a live in-flight lock is not treated as stale mid-operation.
+const OverlayGatewayOpLockTTL = 90 * time.Second
+
+const overlayGatewayOpLockStaleMsg = "overlay gateway operation lock expired"
+
+// ClearOverlayGatewayOpLocks removes enable/disable in-flight lock files left
+// behind after a crash. Does not touch application settings or cni-dhcp.
+func ClearOverlayGatewayOpLocks() {
+	clearOverlayGatewayOpLocks(OverlayGatewayEnableLockFile, OverlayGatewayDisableLockFile)
+}
+
+func clearOverlayGatewayOpLocks(paths ...string) {
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("overlay gateway: clear op lock %s failed: %v", path, err)
+		}
+	}
+}
+
+// consumeOverlayGatewayOpLock reports whether an in-flight op lock is present.
+// Locks older than OverlayGatewayOpLockTTL are removed and reported via staleMsg
+// so callers can surface an English machine message without treating them as
+// still in progress.
+func consumeOverlayGatewayOpLock(path string) (inFlight bool, staleMsg string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			klog.Errorf("overlay gateway: stat op lock %s failed: %v", path, err)
+		}
+		return false, ""
+	}
+	if time.Since(info.ModTime()) > OverlayGatewayOpLockTTL {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("overlay gateway: remove stale op lock %s failed: %v", path, err)
+		} else {
+			klog.Warningf("overlay gateway: removed stale op lock %s", path)
+		}
+		return false, overlayGatewayOpLockStaleMsg
+	}
+	return true, ""
+}

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_oplock_test.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_oplock_test.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestClearOverlayGatewayOpLocks(t *testing.T) {
+	dir := t.TempDir()
+	enable := filepath.Join(dir, "enable.lock")
+	disable := filepath.Join(dir, "disable.lock")
+
+	if err := os.WriteFile(enable, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(disable, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clearOverlayGatewayOpLocks(enable, disable)
+
+	if _, err := os.Stat(enable); !os.IsNotExist(err) {
+		t.Fatalf("enable lock still present: %v", err)
+	}
+	if _, err := os.Stat(disable); !os.IsNotExist(err) {
+		t.Fatalf("disable lock still present: %v", err)
+	}
+
+	// Idempotent when missing.
+	clearOverlayGatewayOpLocks(enable, disable)
+}
+
+func TestConsumeOverlayGatewayOpLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "op.lock")
+
+	inFlight, stale := consumeOverlayGatewayOpLock(path)
+	if inFlight || stale != "" {
+		t.Fatalf("absent lock: inFlight=%v stale=%q", inFlight, stale)
+	}
+
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inFlight, stale = consumeOverlayGatewayOpLock(path)
+	if !inFlight || stale != "" {
+		t.Fatalf("fresh lock: inFlight=%v stale=%q", inFlight, stale)
+	}
+
+	past := time.Now().Add(-OverlayGatewayOpLockTTL - time.Second)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatal(err)
+	}
+	inFlight, stale = consumeOverlayGatewayOpLock(path)
+	if inFlight {
+		t.Fatal("stale lock still reported in-flight")
+	}
+	if stale != overlayGatewayOpLockStaleMsg {
+		t.Fatalf("stale msg=%q", stale)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale lock not removed: %v", err)
+	}
+}

--- a/daemon/internel/apiserver/handlers/handler_overlay_gateway_status.go
+++ b/daemon/internel/apiserver/handlers/handler_overlay_gateway_status.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/beclab/Olares/daemon/pkg/utils"
@@ -66,13 +65,17 @@ func (h *Handlers) GetOverlayGatewayStatus(ctx *fiber.Ctx) error {
 		s.ErrorMessage = disableOverlayGatewayError
 	}
 
-	if _, err := os.Stat(OverlayGatewayEnableLockFile); err == nil {
+	if inFlight, stale := consumeOverlayGatewayOpLock(OverlayGatewayEnableLockFile); inFlight {
 		s.Status = OverlayGatewayActivating
 		return h.OkJSON(ctx, "success", s)
+	} else if stale != "" {
+		s.ErrorMessage = stale
 	}
-	if _, err := os.Stat(OverlayGatewayDisableLockFile); err == nil {
+	if inFlight, stale := consumeOverlayGatewayOpLock(OverlayGatewayDisableLockFile); inFlight {
 		s.Status = OverlayGatewayDeactivating
 		return h.OkJSON(ctx, "success", s)
+	} else if stale != "" {
+		s.ErrorMessage = stale
 	}
 
 	if s.Status == OverlayGatewayOn {

--- a/daemon/internel/watcher/system/watchers.go
+++ b/daemon/internel/watcher/system/watchers.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"sync"
 
 	"github.com/beclab/Olares/daemon/internel/watcher"
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
@@ -92,6 +93,7 @@ func (w *autoRepair) Watch(ctx context.Context) {
 
 type bridgeConnectionWatcher struct {
 	watcher.Watcher
+	mu     sync.Mutex
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -105,17 +107,37 @@ func (w *bridgeConnectionWatcher) Watch(ctx context.Context) {
 		klog.Error("find bridge connection error, ", err)
 	} else if c == nil {
 		// bridge connection is removed, stop watching
+		w.mu.Lock()
 		if w.cancel != nil {
 			w.cancel()
 			w.cancel = nil
 			w.ctx = nil
 		}
-	} else if w.ctx == nil {
+		w.mu.Unlock()
+	} else {
+		w.mu.Lock()
+		if w.ctx != nil {
+			w.mu.Unlock()
+			return
+		}
 		// bridge connection is back, start watching
 		w.ctx, w.cancel = context.WithCancel(context.Background())
+		watchCtx := w.ctx
+		w.mu.Unlock()
+
 		klog.Info("start watching network carrier changes for bridge connection")
 		go func() {
-			err := utils.ListenNetworkCarrierChanges(w.ctx, func() {
+			defer func() {
+				if r := recover(); r != nil {
+					klog.Errorf("bridge carrier watch panic recovered: %v", r)
+				}
+				w.mu.Lock()
+				w.cancel = nil
+				w.ctx = nil
+				w.mu.Unlock()
+			}()
+
+			err := utils.ListenNetworkCarrierChanges(watchCtx, func() {
 				// disable the overlay gateway supported apps' option for all users
 				apps, err := utils.GetOverlayGatewaySupportedApps(ctx, "")
 				if err != nil {

--- a/daemon/pkg/utils/network_carrier_test.go
+++ b/daemon/pkg/utils/network_carrier_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+// +build linux
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestHandleCarrierLinkUpdateClosedChannel(t *testing.T) {
+	ctx := context.Background()
+	called := false
+	stop := handleCarrierLinkUpdate(ctx, netlink.LinkUpdate{}, false, func() {
+		called = true
+	})
+	if !stop {
+		t.Fatal("closed channel should stop watcher")
+	}
+	if called {
+		t.Fatal("downCallback must not run on closed channel")
+	}
+}
+
+func TestHandleCarrierLinkUpdateNilLink(t *testing.T) {
+	ctx := context.Background()
+	// Zero-value LinkUpdate has nil Link — must not panic via Attrs().
+	stop := handleCarrierLinkUpdate(ctx, netlink.LinkUpdate{}, true, func() {
+		t.Fatal("downCallback must not run for nil Link")
+	})
+	if stop {
+		t.Fatal("nil Link should continue, not stop")
+	}
+}
+
+func TestHandleCarrierLinkUpdateCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stop := handleCarrierLinkUpdate(ctx, netlink.LinkUpdate{}, true, func() {
+		t.Fatal("downCallback must not run when ctx cancelled")
+	})
+	if !stop {
+		t.Fatal("cancelled context should stop watcher")
+	}
+}

--- a/daemon/pkg/utils/network_linux.go
+++ b/daemon/pkg/utils/network_linux.go
@@ -1157,19 +1157,39 @@ func ListenNetworkCarrierChanges(ctx context.Context, downCallback func()) error
 
 	for {
 		select {
-		case update := <-updates:
-			if update.Attrs().Name == bridgeConnectionName {
-				isLowerUp := (update.Flags & 0x10000) != 0
-				isUp := (update.Flags & 1) != 0
-
-				if !isLowerUp || !isUp {
-					klog.Infof("network change detected: %s, state: %s", update.Attrs().Name, update.Link.Attrs().OperState.String())
-					downCallback()
-				}
+		case update, ok := <-updates:
+			if handleCarrierLinkUpdate(ctx, update, ok, downCallback) {
+				klog.Info("stop listening network changes")
+				return nil
 			}
 		case <-ctx.Done():
 			klog.Info("stop listening network changes")
 			return nil
 		}
 	}
+}
+
+// handleCarrierLinkUpdate processes one LinkUpdate. Returns true when the
+// watcher should stop (channel closed or context cancelled). A closed channel
+// yields a zero-value LinkUpdate whose Link is nil; callers must not call
+// Attrs() on it.
+func handleCarrierLinkUpdate(ctx context.Context, update netlink.LinkUpdate, ok bool, downCallback func()) (stop bool) {
+	if !ok || ctx.Err() != nil {
+		return true
+	}
+	if update.Link == nil {
+		return false
+	}
+	attrs := update.Attrs()
+	if attrs == nil || attrs.Name != bridgeConnectionName {
+		return false
+	}
+
+	isLowerUp := (update.Flags & 0x10000) != 0
+	isUp := (update.Flags & 1) != 0
+	if !isLowerUp || !isUp {
+		klog.Infof("network change detected: %s, state: %s", attrs.Name, attrs.OperState.String())
+		downCallback()
+	}
+	return false
 }

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -142,6 +142,17 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest,
 	}
 
 	if nothingToInject {
+		// Still harden linkerd admin probes when proxy was injected by an earlier webhook.
+		patchBytes, patched, err := h.sidecarWebhook.PatchLinkerdAdminProbesOnly(ctx, req, &pod)
+		if err != nil {
+			klog.Errorf("Failed to harden linkerd probes uuid=%s namespace=%s err=%v", proxyUUID, req.Namespace, err)
+			return h.sidecarWebhook.AdmissionError(req.UID, err)
+		}
+		if patched {
+			h.sidecarWebhook.PatchAdmissionResponse(resp, patchBytes)
+			klog.Infof("Hardened linkerd-proxy probes for pod uuid=%s namespace=%s (nothing else to inject)", proxyUUID, req.Namespace)
+			return resp
+		}
 		klog.Infof("Skipping sidecar injection for pod with uuid=%s namespace=%s", proxyUUID, req.Namespace)
 		return resp
 	}

--- a/framework/app-service/pkg/gateway/callerjwt/issuer.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer.go
@@ -22,11 +22,13 @@ const (
 	// JWKSURI is the HTTPS URL EG remoteJWKS uses (hostname must match TLS SAN).
 	JWKSURI             = "https://" + IssuerHost + JWKSPath
 	Audience            = "app-gateway-data"
-	ClaimAppRef         = "olares.caller.appRef"
-	ClaimEntrance       = "olares.entrance"
-	ClaimViewer         = "olares.viewer"
-	ClaimAppid          = "olares.caller.appid"
-	ClaimClientAppid    = "olares.caller.clientAppid"
+	// Claim* constants are Envoy jwt_authn claim_to_headers paths (dot =
+	// nested JSON), not flat JWT object keys.
+	ClaimAppRef      = "olares.caller.appRef"
+	ClaimEntrance    = "olares.entrance"
+	ClaimViewer      = "olares.viewer"
+	ClaimAppid       = "olares.caller.appid"
+	ClaimClientAppid = "olares.caller.clientAppid"
 	// CallerJWTHeaderName is the platform caller-jwt transport header (bare JWT,
 	// no Bearer prefix). Distinct from Authorization so app credentials pass through.
 	CallerJWTHeaderName = "X-Olares-Caller-Jwt"
@@ -56,13 +58,67 @@ type IssueRequest struct {
 }
 
 // Claims is the caller JWT claim schema published to Envoy Gateway.
+// Identity fields are nested under "olares" so Envoy claim_to_headers paths
+// resolve (dots are JSON path separators):
+// olares.viewer → X-BFL-USER, olares.caller.appid → X-Shared-Appid,
+// olares.caller.clientAppid → X-Caller-Appid.
 type Claims struct {
 	jwt.RegisteredClaims
-	AppRef      string `json:"olares.caller.appRef"`
-	Entrance    string `json:"olares.entrance,omitempty"`
-	Viewer      string `json:"olares.viewer,omitempty"`
-	Appid       string `json:"olares.caller.appid,omitempty"`
-	ClientAppid string `json:"olares.caller.clientAppid,omitempty"`
+	Olares OlaresClaims `json:"olares"`
+}
+
+// OlaresClaims holds platform identity claims under the "olares" JSON object.
+type OlaresClaims struct {
+	Caller   CallerClaims `json:"caller"`
+	Viewer   string       `json:"viewer,omitempty"`
+	Entrance string       `json:"entrance,omitempty"`
+}
+
+// CallerClaims holds caller application identity under "olares.caller".
+type CallerClaims struct {
+	AppRef      string `json:"appRef,omitempty"`
+	Appid       string `json:"appid,omitempty"`
+	ClientAppid string `json:"clientAppid,omitempty"`
+}
+
+// AppRef returns olares.caller.appRef.
+func (c *Claims) AppRef() string {
+	if c == nil {
+		return ""
+	}
+	return c.Olares.Caller.AppRef
+}
+
+// Entrance returns olares.entrance.
+func (c *Claims) Entrance() string {
+	if c == nil {
+		return ""
+	}
+	return c.Olares.Entrance
+}
+
+// Viewer returns olares.viewer.
+func (c *Claims) Viewer() string {
+	if c == nil {
+		return ""
+	}
+	return c.Olares.Viewer
+}
+
+// Appid returns olares.caller.appid (Shared callers).
+func (c *Claims) Appid() string {
+	if c == nil {
+		return ""
+	}
+	return c.Olares.Caller.Appid
+}
+
+// ClientAppid returns olares.caller.clientAppid (ordinary callers).
+func (c *Claims) ClientAppid() string {
+	if c == nil {
+		return ""
+	}
+	return c.Olares.Caller.ClientAppid
 }
 
 // KeyPair holds one RS256 signing key and its JWKS key ID.
@@ -135,19 +191,21 @@ func (i *Issuer) Issue(req IssueRequest) (string, error) {
 			NotBefore: jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 		},
-		AppRef: appRef,
+		Olares: OlaresClaims{
+			Caller: CallerClaims{AppRef: appRef},
+		},
 	}
 	if v := strings.TrimSpace(req.Entrance); v != "" {
-		claims.Entrance = v
+		claims.Olares.Entrance = v
 	}
 	if viewer != "" {
-		claims.Viewer = viewer
+		claims.Olares.Viewer = viewer
 	}
 	if appid != "" {
-		claims.Appid = appid
+		claims.Olares.Caller.Appid = appid
 	}
 	if clientAppid != "" {
-		claims.ClientAppid = clientAppid
+		claims.Olares.Caller.ClientAppid = clientAppid
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	token.Header["kid"] = i.keys.Active.KID

--- a/framework/app-service/pkg/gateway/callerjwt/issuer.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer.go
@@ -60,8 +60,8 @@ type IssueRequest struct {
 // Claims is the caller JWT claim schema published to Envoy Gateway.
 // Identity fields are nested under "olares" so Envoy claim_to_headers paths
 // resolve (dots are JSON path separators):
-// olares.viewer → X-BFL-USER, olares.caller.appid → X-Shared-Appid,
-// olares.caller.clientAppid → X-Caller-Appid.
+// olares.viewer → X-BFL-USER; olares.caller.appid and
+// olares.caller.clientAppid both map to X-Caller-Appid (mutually exclusive).
 type Claims struct {
 	jwt.RegisteredClaims
 	Olares OlaresClaims `json:"olares"`

--- a/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
+++ b/framework/app-service/pkg/gateway/callerjwt/issuer_test.go
@@ -2,9 +2,11 @@ package callerjwt
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,20 +68,20 @@ func TestIssueCallerJWTClaimsAndVerify(t *testing.T) {
 	if !audienceContains(claims.Audience, Audience) {
 		t.Fatalf("aud = %v, want %q", claims.Audience, Audience)
 	}
-	if claims.AppRef != "demo" {
-		t.Fatalf("appRef = %q", claims.AppRef)
+	if claims.AppRef() != "demo" {
+		t.Fatalf("appRef = %q", claims.AppRef())
 	}
-	if claims.Entrance != "web" {
-		t.Fatalf("entrance = %q", claims.Entrance)
+	if claims.Entrance() != "web" {
+		t.Fatalf("entrance = %q", claims.Entrance())
 	}
-	if claims.Viewer != "alice" {
-		t.Fatalf("viewer = %q", claims.Viewer)
+	if claims.Viewer() != "alice" {
+		t.Fatalf("viewer = %q", claims.Viewer())
 	}
-	if claims.Appid != "" {
-		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid)
+	if claims.Appid() != "" {
+		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid())
 	}
-	if claims.ClientAppid != "6bf98da2" {
-		t.Fatalf("clientAppid = %q", claims.ClientAppid)
+	if claims.ClientAppid() != "6bf98da2" {
+		t.Fatalf("clientAppid = %q", claims.ClientAppid())
 	}
 	if claims.ExpiresAt == nil || claims.ExpiresAt.Time.Before(time.Now()) {
 		t.Fatalf("exp missing or in the past")
@@ -150,14 +152,133 @@ func TestIssueSharedCallerAppidOmitsViewer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseClaims: %v", err)
 	}
-	if claims.Appid != "a1b2c3d4" {
-		t.Fatalf("appid = %q", claims.Appid)
+	if claims.Appid() != "a1b2c3d4" {
+		t.Fatalf("appid = %q", claims.Appid())
 	}
-	if claims.Viewer != "" {
-		t.Fatalf("shared caller must omit viewer, got %q", claims.Viewer)
+	if claims.Viewer() != "" {
+		t.Fatalf("shared caller must omit viewer, got %q", claims.Viewer())
 	}
-	if claims.ClientAppid != "" {
-		t.Fatalf("shared caller must omit clientAppid, got %q", claims.ClientAppid)
+	if claims.ClientAppid() != "" {
+		t.Fatalf("shared caller must omit clientAppid, got %q", claims.ClientAppid())
+	}
+}
+
+func TestIssuePayloadNestedForEnvoyClaimPaths(t *testing.T) {
+	ring, err := NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+
+	sharedToken, err := issuer.Issue(IssueRequest{
+		Namespace:          "router-shared",
+		ServiceAccountName: "router",
+		AppRef:             "router",
+		Appid:              "f3395cd5",
+	})
+	if err != nil {
+		t.Fatalf("Issue shared: %v", err)
+	}
+	assertEnvoyClaimPath(t, sharedToken, ClaimAppid, "f3395cd5")
+	assertEnvoyClaimPathMissing(t, sharedToken, ClaimViewer)
+	assertEnvoyClaimPathMissing(t, sharedToken, ClaimClientAppid)
+	assertNoFlatDottedIdentityKeys(t, sharedToken)
+
+	ordinaryToken, err := issuer.Issue(IssueRequest{
+		Namespace:          "user-space-alice-demo",
+		ServiceAccountName: "demo",
+		AppRef:             "demo",
+		Entrance:           "web",
+		Viewer:             "alice",
+		ClientAppid:        "6bf98da2",
+	})
+	if err != nil {
+		t.Fatalf("Issue ordinary: %v", err)
+	}
+	// All three post-authn identity headers' claim paths must resolve for the
+	// claims that token type carries (viewer + clientAppid; not shared appid).
+	assertEnvoyClaimPath(t, ordinaryToken, ClaimViewer, "alice")
+	assertEnvoyClaimPath(t, ordinaryToken, ClaimClientAppid, "6bf98da2")
+	assertEnvoyClaimPathMissing(t, ordinaryToken, ClaimAppid)
+	assertEnvoyClaimPath(t, ordinaryToken, ClaimEntrance, "web")
+	assertEnvoyClaimPath(t, ordinaryToken, ClaimAppRef, "demo")
+	assertNoFlatDottedIdentityKeys(t, ordinaryToken)
+}
+
+func decodeJWTPayload(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		t.Fatalf("token parts = %d", len(parts))
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload
+}
+
+func assertNoFlatDottedIdentityKeys(t *testing.T, token string) {
+	t.Helper()
+	payload := decodeJWTPayload(t, token)
+	for _, k := range []string{
+		ClaimAppid, ClaimClientAppid, ClaimViewer, ClaimAppRef, ClaimEntrance,
+	} {
+		if _, ok := payload[k]; ok {
+			t.Fatalf("payload must not use flat key %q", k)
+		}
+	}
+}
+
+func assertEnvoyClaimPath(t *testing.T, token, claimPath, want string) {
+	t.Helper()
+	payload := decodeJWTPayload(t, token)
+	cur := any(payload)
+	for _, part := range strings.Split(claimPath, ".") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("claim path %q: not an object before %q", claimPath, part)
+		}
+		next, ok := obj[part]
+		if !ok {
+			t.Fatalf("claim path %q: missing %q in %#v", claimPath, part, obj)
+		}
+		cur = next
+	}
+	got, ok := cur.(string)
+	if !ok {
+		t.Fatalf("claim path %q: got %#v, want string %q", claimPath, cur, want)
+	}
+	if got != want {
+		t.Fatalf("claim path %q = %q, want %q", claimPath, got, want)
+	}
+}
+
+func assertEnvoyClaimPathMissing(t *testing.T, token, claimPath string) {
+	t.Helper()
+	payload := decodeJWTPayload(t, token)
+	cur := any(payload)
+	parts := strings.Split(claimPath, ".")
+	for i, part := range parts {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return
+		}
+		next, ok := obj[part]
+		if !ok {
+			return
+		}
+		if i == len(parts)-1 {
+			t.Fatalf("claim path %q must be absent for this token type, got %#v", claimPath, next)
+		}
+		cur = next
 	}
 }
 
@@ -308,17 +429,17 @@ func TestIssuerReconcilerCreatesJWTSecretForCaller(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseClaims: %v", err)
 	}
-	if claims.AppRef != "demo" {
-		t.Fatalf("appRef = %q", claims.AppRef)
+	if claims.AppRef() != "demo" {
+		t.Fatalf("appRef = %q", claims.AppRef())
 	}
-	if claims.Viewer != "alice" {
-		t.Fatalf("viewer = %q", claims.Viewer)
+	if claims.Viewer() != "alice" {
+		t.Fatalf("viewer = %q", claims.Viewer())
 	}
-	if claims.ClientAppid != "6bf98da2" {
-		t.Fatalf("clientAppid = %q", claims.ClientAppid)
+	if claims.ClientAppid() != "6bf98da2" {
+		t.Fatalf("clientAppid = %q", claims.ClientAppid())
 	}
-	if claims.Appid != "" {
-		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid)
+	if claims.Appid() != "" {
+		t.Fatalf("ordinary caller must omit shared appid, got %q", claims.Appid())
 	}
 }
 

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy.go
@@ -20,16 +20,17 @@ const (
 	SecurityPolicySuffix         = "-jwt-authn"
 	CallerJWTIssuer              = callerjwt.IssuerURL
 	CallerJWTAudience            = "app-gateway-data"
-	CallerJWTProviderName        = "caller-jwt"
-	CallerJWTViewerClaim         = "olares.viewer"
+	CallerJWTProviderName = "caller-jwt"
+	// Claim paths must match callerjwt nested JSON (Envoy treats '.' as path sep).
+	CallerJWTViewerClaim       = callerjwt.ClaimViewer
+	CallerJWTAppidClaim        = callerjwt.ClaimAppid
+	CallerJWTClientAppidClaim  = callerjwt.ClaimClientAppid
 	// CallerJWTViewerHeader is filled from the verified JWT viewer claim after
 	// gateway authn. Client-supplied X-BFL-USER is overwritten and must not be
 	// trusted as identity on its own.
-	CallerJWTViewerHeader        = "X-BFL-USER"
-	CallerJWTAppidClaim          = "olares.caller.appid"
-	CallerJWTAppidHeader         = "X-Shared-Appid"
-	CallerJWTClientAppidClaim    = "olares.caller.clientAppid"
-	CallerJWTClientAppidHeader   = "X-Caller-Appid"
+	CallerJWTViewerHeader         = "X-BFL-USER"
+	CallerJWTAppidHeader          = "X-Shared-Appid"
+	CallerJWTClientAppidHeader    = "X-Caller-Appid"
 	CallerJWTJWKSServiceName     = "caller-jwt-jwks"
 	CallerJWTJWKSServiceNamespace = "os-framework"
 	CallerJWTJWKSServicePort     = int32(443)

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy.go
@@ -28,9 +28,13 @@ const (
 	// CallerJWTViewerHeader is filled from the verified JWT viewer claim after
 	// gateway authn. Client-supplied X-BFL-USER is overwritten and must not be
 	// trusted as identity on its own.
-	CallerJWTViewerHeader         = "X-BFL-USER"
-	CallerJWTAppidHeader          = "X-Shared-Appid"
-	CallerJWTClientAppidHeader    = "X-Caller-Appid"
+	CallerJWTViewerHeader = "X-BFL-USER"
+	// CallerJWTAppidHeader and CallerJWTClientAppidHeader both map to
+	// X-Caller-Appid: Shared tokens carry olares.caller.appid, ordinary
+	// callers carry olares.caller.clientAppid; the claims stay mutually
+	// exclusive so only one value is written per request.
+	CallerJWTAppidHeader       = "X-Caller-Appid"
+	CallerJWTClientAppidHeader = "X-Caller-Appid"
 	CallerJWTJWKSServiceName     = "caller-jwt-jwks"
 	CallerJWTJWKSServiceNamespace = "os-framework"
 	CallerJWTJWKSServicePort     = int32(443)
@@ -49,9 +53,9 @@ func securityPolicyName(srr *srrv1alpha1.SharedRouteRegistry) string {
 }
 
 // desiredSharedRouteSecurityPolicy builds JWT authn for a Shared HTTPRoute.
-// After verification, the gateway copies olares.viewer → X-BFL-USER,
-// olares.caller.appid → X-Shared-Appid (Shared callers), and
-// olares.caller.clientAppid → X-Caller-Appid (ordinary callers). A header is
+// After verification, the gateway copies olares.viewer → X-BFL-USER and
+// either olares.caller.appid or olares.caller.clientAppid → X-Caller-Appid
+// (Shared vs ordinary callers; claims are mutually exclusive). A header is
 // written only when that claim exists in the token; missing JWT is rejected.
 func desiredSharedRouteSecurityPolicy(srr *srrv1alpha1.SharedRouteRegistry) *unstructured.Unstructured {
 	routeName := httpRouteName(srr)

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
@@ -2,6 +2,9 @@ package routecontrol
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,6 +104,11 @@ func TestDesiredSharedRouteSecurityPolicyJWTAuthn(t *testing.T) {
 		t.Fatalf("ordinary client appid header must remain X-Caller-Appid, got %#v", clientMap["header"])
 	}
 	// Three mappings stay configured; a given token carries the claims for its caller type.
+	if CallerJWTViewerClaim != callerjwt.ClaimViewer ||
+		CallerJWTAppidClaim != callerjwt.ClaimAppid ||
+		CallerJWTClientAppidClaim != callerjwt.ClaimClientAppid {
+		t.Fatalf("SecurityPolicy claim paths must alias callerjwt nested claim constants")
+	}
 
 	extractFrom, ok := provider["extractFrom"].(map[string]any)
 	if !ok {
@@ -133,6 +141,92 @@ func TestDesiredSharedRouteSecurityPolicyJWTAuthn(t *testing.T) {
 	if backend["name"] != CallerJWTJWKSServiceName || backend["namespace"] != CallerJWTJWKSServiceNamespace {
 		t.Fatalf("backendRef = %#v", backend)
 	}
+}
+
+func TestIssuedJWTSatisfiesClaimToHeaderPaths(t *testing.T) {
+	ring, err := callerjwt.NewKeyRingForTest(false)
+	if err != nil {
+		t.Fatalf("NewKeyRingForTest: %v", err)
+	}
+	issuer, err := callerjwt.NewIssuer(ring)
+	if err != nil {
+		t.Fatalf("NewIssuer: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		req    callerjwt.IssueRequest
+		header string
+		claim  string
+		want   string
+	}{
+		{
+			name:   "X-Shared-Appid",
+			req:    callerjwt.IssueRequest{Namespace: "router-shared", ServiceAccountName: "router", AppRef: "router", Appid: "f3395cd5"},
+			header: CallerJWTAppidHeader,
+			claim:  CallerJWTAppidClaim,
+			want:   "f3395cd5",
+		},
+		{
+			name:   "X-BFL-USER",
+			req:    callerjwt.IssueRequest{Namespace: "ns", ServiceAccountName: "sa", AppRef: "demo", Viewer: "alice", ClientAppid: "6bf98da2"},
+			header: CallerJWTViewerHeader,
+			claim:  CallerJWTViewerClaim,
+			want:   "alice",
+		},
+		{
+			name:   "X-Caller-Appid",
+			req:    callerjwt.IssueRequest{Namespace: "ns", ServiceAccountName: "sa", AppRef: "demo", Viewer: "alice", ClientAppid: "6bf98da2"},
+			header: CallerJWTClientAppidHeader,
+			claim:  CallerJWTClientAppidClaim,
+			want:   "6bf98da2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token, err := issuer.Issue(tc.req)
+			if err != nil {
+				t.Fatalf("Issue: %v", err)
+			}
+			got := walkJWTClaimPath(t, token, tc.claim)
+			if got != tc.want {
+				t.Fatalf("header %s claim %s = %q, want %q", tc.header, tc.claim, got, tc.want)
+			}
+		})
+	}
+}
+
+func walkJWTClaimPath(t *testing.T, token, claimPath string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		t.Fatalf("token parts = %d", len(parts))
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cur := any(payload)
+	for _, part := range strings.Split(claimPath, ".") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("path %q: not object before %q", claimPath, part)
+		}
+		next, ok := obj[part]
+		if !ok {
+			t.Fatalf("path %q: missing %q", claimPath, part)
+		}
+		cur = next
+	}
+	got, ok := cur.(string)
+	if !ok {
+		t.Fatalf("path %q: got %#v", claimPath, cur)
+	}
+	return got
 }
 
 func TestReconcileSharedRouteGatewayModeCreatesSecurityPolicy(t *testing.T) {

--- a/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/security_policy_test.go
@@ -93,15 +93,18 @@ func TestDesiredSharedRouteSecurityPolicyJWTAuthn(t *testing.T) {
 	if appidMap["claim"] != CallerJWTAppidClaim || appidMap["header"] != CallerJWTAppidHeader {
 		t.Fatalf("claimToHeaders[1] = %#v", appidMap)
 	}
-	if appidMap["header"] != "X-Shared-Appid" {
-		t.Fatalf("shared appid header must remain X-Shared-Appid, got %#v", appidMap["header"])
+	if appidMap["header"] != "X-Caller-Appid" {
+		t.Fatalf("shared appid claim must map to X-Caller-Appid, got %#v", appidMap["header"])
 	}
 	clientMap := claimToHeaders[2].(map[string]any)
 	if clientMap["claim"] != CallerJWTClientAppidClaim || clientMap["header"] != CallerJWTClientAppidHeader {
 		t.Fatalf("claimToHeaders[2] = %#v", clientMap)
 	}
 	if clientMap["header"] != "X-Caller-Appid" {
-		t.Fatalf("ordinary client appid header must remain X-Caller-Appid, got %#v", clientMap["header"])
+		t.Fatalf("ordinary client appid claim must map to X-Caller-Appid, got %#v", clientMap["header"])
+	}
+	if CallerJWTAppidHeader != CallerJWTClientAppidHeader {
+		t.Fatalf("shared and ordinary appid headers must be unified, got %q vs %q", CallerJWTAppidHeader, CallerJWTClientAppidHeader)
 	}
 	// Three mappings stay configured; a given token carries the claims for its caller type.
 	if CallerJWTViewerClaim != callerjwt.ClaimViewer ||
@@ -161,7 +164,7 @@ func TestIssuedJWTSatisfiesClaimToHeaderPaths(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "X-Shared-Appid",
+			name:   "X-Caller-Appid-from-shared-appid",
 			req:    callerjwt.IssueRequest{Namespace: "router-shared", ServiceAccountName: "router", AppRef: "router", Appid: "f3395cd5"},
 			header: CallerJWTAppidHeader,
 			claim:  CallerJWTAppidClaim,
@@ -175,7 +178,7 @@ func TestIssuedJWTSatisfiesClaimToHeaderPaths(t *testing.T) {
 			want:   "alice",
 		},
 		{
-			name:   "X-Caller-Appid",
+			name:   "X-Caller-Appid-from-clientAppid",
 			req:    callerjwt.IssueRequest{Namespace: "ns", ServiceAccountName: "sa", AppRef: "demo", Viewer: "alice", ClientAppid: "6bf98da2"},
 			header: CallerJWTClientAppidHeader,
 			claim:  CallerJWTClientAppidClaim,

--- a/framework/app-service/pkg/mesh/proxy_probe.go
+++ b/framework/app-service/pkg/mesh/proxy_probe.go
@@ -1,0 +1,99 @@
+package mesh
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+)
+
+const (
+	// LinkerdProxyContainerName is the upstream injected proxy container name.
+	LinkerdProxyContainerName = "linkerd-proxy"
+	// LinkerdAwaitBinary is shipped in the proxy image (also used by postStart).
+	LinkerdAwaitBinary = "/usr/lib/linkerd/linkerd-await"
+	// LinkerdAdminPortName is the injected admin port name.
+	LinkerdAdminPortName = "linkerd-admin"
+)
+
+// HardenLinkerdProxyAdminProbes converts linkerd-proxy HTTP probes against the
+// admin port (4191) into in-container exec probes using linkerd-await.
+//
+// kubelet httpGet to PodIP:4191 traverses eth0 and can be DNATed by workloads
+// that rewrite pod iptables (e.g. dockurr). Exec runs in the proxy netns and
+// reaches 127.0.0.1:4191 without that path. Returns whether any probe changed.
+func HardenLinkerdProxyAdminProbes(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	changed := false
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.Name != LinkerdProxyContainerName {
+			continue
+		}
+		if hardenLinkerdAdminProbe(&c.LivenessProbe) {
+			changed = true
+		}
+		if hardenLinkerdAdminProbe(&c.ReadinessProbe) {
+			changed = true
+		}
+		if hardenLinkerdAdminProbe(&c.StartupProbe) {
+			changed = true
+		}
+	}
+	if changed {
+		klog.Infof("mesh-probe: hardened linkerd-proxy admin probes to exec await ns=%s pod=%s",
+			pod.Namespace, pod.Name)
+	}
+	return changed
+}
+
+func hardenLinkerdAdminProbe(probe **corev1.Probe) bool {
+	if probe == nil || *probe == nil {
+		return false
+	}
+	p := *probe
+	if isLinkerdAwaitExec(p) {
+		return false
+	}
+	if p.HTTPGet == nil || !isLinkerdAdminPort(p.HTTPGet.Port) {
+		return false
+	}
+
+	timeout := p.TimeoutSeconds
+	if timeout < 2 {
+		timeout = 2
+	}
+	p.HTTPGet = nil
+	p.TCPSocket = nil
+	p.GRPC = nil
+	p.Exec = &corev1.ExecAction{
+		Command: []string{
+			LinkerdAwaitBinary,
+			"--timeout=1s",
+			"--port=4191",
+		},
+	}
+	p.TimeoutSeconds = timeout
+	return true
+}
+
+func isLinkerdAwaitExec(p *corev1.Probe) bool {
+	if p == nil || p.Exec == nil || len(p.Exec.Command) == 0 {
+		return false
+	}
+	return p.Exec.Command[0] == LinkerdAwaitBinary
+}
+
+func isLinkerdAdminPort(port intstr.IntOrString) bool {
+	switch port.Type {
+	case intstr.Int:
+		return port.IntVal == int32(constants.LinkerdAdminPort)
+	case intstr.String:
+		return port.StrVal == LinkerdAdminPortName || port.StrVal == "4191"
+	default:
+		return false
+	}
+}

--- a/framework/app-service/pkg/mesh/proxy_probe_test.go
+++ b/framework/app-service/pkg/mesh/proxy_probe_test.go
@@ -1,0 +1,107 @@
+package mesh
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+)
+
+func TestHardenLinkerdProxyAdminProbesConvertsHTTPGet(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app"},
+				{
+					Name: LinkerdProxyContainerName,
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/live",
+								Port: intstr.FromInt(constants.LinkerdAdminPort),
+							},
+						},
+						InitialDelaySeconds: 10,
+						TimeoutSeconds:      1,
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/ready",
+								Port: intstr.FromString(LinkerdAdminPortName),
+							},
+						},
+						InitialDelaySeconds: 2,
+						TimeoutSeconds:      1,
+					},
+				},
+			},
+		},
+	}
+	if !HardenLinkerdProxyAdminProbes(pod) {
+		t.Fatal("expected probes to change")
+	}
+	c := pod.Spec.Containers[1]
+	if c.LivenessProbe.HTTPGet != nil || c.LivenessProbe.Exec == nil {
+		t.Fatalf("liveness not converted: %#v", c.LivenessProbe)
+	}
+	if c.ReadinessProbe.HTTPGet != nil || c.ReadinessProbe.Exec == nil {
+		t.Fatalf("readiness not converted: %#v", c.ReadinessProbe)
+	}
+	want := []string{LinkerdAwaitBinary, "--timeout=1s", "--port=4191"}
+	for i, s := range want {
+		if c.LivenessProbe.Exec.Command[i] != s {
+			t.Fatalf("liveness cmd[%d]=%q want %q", i, c.LivenessProbe.Exec.Command[i], s)
+		}
+	}
+	if c.LivenessProbe.TimeoutSeconds < 2 {
+		t.Fatalf("liveness TimeoutSeconds=%d want >=2", c.LivenessProbe.TimeoutSeconds)
+	}
+	if c.LivenessProbe.InitialDelaySeconds != 10 {
+		t.Fatalf("liveness InitialDelaySeconds changed: %d", c.LivenessProbe.InitialDelaySeconds)
+	}
+	// idempotent
+	if HardenLinkerdProxyAdminProbes(pod) {
+		t.Fatal("second harden should be no-op")
+	}
+}
+
+func TestHardenLinkerdProxyAdminProbesSkipsNonAdmin(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: LinkerdProxyContainerName,
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromInt(8080),
+						},
+					},
+				},
+			}},
+		},
+	}
+	if HardenLinkerdProxyAdminProbes(pod) {
+		t.Fatal("non-admin probe must not change")
+	}
+	if pod.Spec.Containers[0].LivenessProbe.HTTPGet == nil {
+		t.Fatal("httpGet cleared unexpectedly")
+	}
+}
+
+func TestHardenLinkerdProxyAdminProbesNoProxy(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app"}},
+		},
+	}
+	if HardenLinkerdProxyAdminProbes(pod) {
+		t.Fatal("no linkerd-proxy: expect false")
+	}
+	if HardenLinkerdProxyAdminProbes(nil) {
+		t.Fatal("nil pod: expect false")
+	}
+}

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -187,6 +187,11 @@ func (wh *Webhook) CreatePatch(
 	if isInjected {
 		// TODO: force mutate
 		klog.Infof("Pod is injected with uuid=%s namespace=%s", prevUUID, req.Namespace)
+		mesh.HardenLinkerdProxyAdminProbes(pod)
+		if err := wh.patchProbeHeaders(ctx, pod); err != nil {
+			klog.Errorf("Failed to patch probe headers for already-injected pod=%s/%s err=%v", pod.Namespace, pod.Name, err)
+			return nil, err
+		}
 		return makePatches(req, pod)
 	}
 
@@ -316,12 +321,37 @@ func (wh *Webhook) CreatePatch(
 	}
 	pod.Annotations[UUIDAnnotation] = proxyUUID.String()
 
+	// Avoid kubelet httpGet to PodIP:4191 (stolen by in-pod DNAT on virt workloads).
+	mesh.HardenLinkerdProxyAdminProbes(pod)
+
 	// add header to probes
 	if err := wh.patchProbeHeaders(ctx, pod); err != nil {
 		klog.Errorf("Failed to patch probe headers for pod=%s/%s err=%v", pod.Namespace, pod.Name, err)
 		return nil, err
 	}
 	return makePatches(req, pod)
+}
+
+// PatchLinkerdAdminProbesOnly hardens linkerd-proxy admin probes when no other
+// sidecar work is required. Returns patched=false when nothing changed.
+func (wh *Webhook) PatchLinkerdAdminProbesOnly(
+	ctx context.Context,
+	req *admissionv1.AdmissionRequest,
+	pod *corev1.Pod,
+) (patchBytes []byte, patched bool, err error) {
+	if !mesh.HardenLinkerdProxyAdminProbes(pod) {
+		return nil, false, nil
+	}
+	if err := wh.patchProbeHeaders(ctx, pod); err != nil {
+		klog.Errorf("Failed to patch probe headers after linkerd harden pod=%s/%s err=%v", pod.Namespace, pod.Name, err)
+		return nil, false, err
+	}
+	patchBytes, err = makePatches(req, pod)
+	if err != nil {
+		klog.Errorf("Failed to build patch after linkerd harden pod=%s/%s err=%v", pod.Namespace, pod.Name, err)
+		return nil, false, err
+	}
+	return patchBytes, true, nil
 }
 
 func (wh *Webhook) shouldInjectEnvoySidecar(ctx context.Context, injectPolicy bool, appConfig *appcfg.ApplicationConfig, pod *corev1.Pod) bool {


### PR DESCRIPTION
- Nest caller JWT identity claims and map both Shared/ordinary appid claims to `X-Caller-Appid`.
- Harden olaresd overlay disable path: guard netlink carrier updates, recover watcher panics, and clear stale OpLocks on start/TTL.
- Convert linkerd-proxy admin liveness/readiness probes from kubelet `httpGet PodIP:4191` to in-container `linkerd-await` exec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes JWT claim shape and gateway identity headers (auth-critical), plus overlay networking and pod probe behavior; misconfiguration could break shared-route auth or pod readiness.
> 
> **Overview**
> Fixes **gateway caller identity**, **overlay gateway** reliability, and **linkerd-proxy** health checks across daemon and app-service.
> 
> **Caller JWT & Envoy Gateway:** Identity claims are issued under a nested `olares` JSON object (e.g. `olares.viewer`, `olares.caller.appid`) so Envoy `claim_to_headers` dot paths resolve correctly instead of flat dotted keys. Shared-route **SecurityPolicy** now maps both `olares.caller.appid` and `olares.caller.clientAppid` to **`X-Caller-Appid`** (replacing shared traffic’s former `X-Shared-Appid` header). Tests assert issued tokens match the configured claim paths.
> 
> **olaresd overlay gateway:** Startup clears stale enable/disable **op lock** files; locks older than **90s** are removed on read and surfaced as an expired-lock error so UI is not stuck in activating/deactivating after crashes. **Netlink** carrier watching no longer panics on closed subscriptions or nil links; the bridge carrier goroutine is mutex-guarded with panic recovery.
> 
> **Admission webhook:** **linkerd-proxy** admin HTTP probes on port 4191 are rewritten to in-container **`linkerd-await` exec** probes (including pods that skip other sidecar injection), avoiding kubelet `httpGet` to PodIP when in-pod DNAT steals 4191.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b525530b813112fb14c624874b7441b776080df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->