### PR TITLE
docs: update joincluster.sh source for cluster setup

### DIFF
--- a/docs/one/connect-two-olares-one.md
+++ b/docs/one/connect-two-olares-one.md
@@ -98,17 +98,23 @@ The worker must be in one of these states:
     :::info
     By default, all Olares One units have the hostname `olares`. Kubernetes requires unique hostnames for every node in a cluster. Before joining it to the cluster, you must ensure it has a unique hostname.
     :::
-3. Download `joincluster.sh`:
+3. Set the Olares version, then download the matching `joincluster.sh`:
+
+    :::info About `VERSION`
+    `VERSION` selects which release of `joincluster.sh` to download. This guide uses `1.12.6`.
+    :::
 
     ::: code-group
     ```bash [curl]
     # This command is for users who have curl installed.
-    curl -fsSL https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh -o joincluster.sh
+    export VERSION=1.12.6
+    curl -fsSL "https://github.com/beclab/Olares/releases/download/${VERSION}/joincluster.sh" -o joincluster.sh
     ```
 
     ```bash [wget]
     # This command is for users who have wget installed.
-    wget https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh
+    export VERSION=1.12.6
+    wget "https://github.com/beclab/Olares/releases/download/${VERSION}/joincluster.sh"
     ```
     :::
 4. Run the script with the master node details:

--- a/docs/zh/one/connect-two-olares-one.md
+++ b/docs/zh/one/connect-two-olares-one.md
@@ -103,17 +103,23 @@ sudo olares-cli uninstall
     :::info
     默认情况下，所有 Olares One 设备的主机名都是 `olares`。Kubernetes 要求集群中每个节点的主机名唯一。在将工作节点加入集群之前，必须确保它具有唯一的主机名。
     :::
-3. 下载 `joincluster.sh`：
+3. 设置 Olares 版本，然后下载匹配的 `joincluster.sh`：
+
+    :::info 关于 `VERSION`
+    `VERSION` 用于选择要下载的 `joincluster.sh` 版本。本指南使用 `1.12.6`。
+    :::
 
     ::: code-group
     ```bash [curl]
     # 此命令适用于已安装 curl 的用户。
-    curl -fsSL https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh -o joincluster.sh
+    export VERSION=1.12.6
+    curl -fsSL "https://github.com/beclab/Olares/releases/download/${VERSION}/joincluster.sh" -o joincluster.sh
     ```
 
     ```bash [wget]
     # 此命令适用于已安装 wget 的用户。
-    wget https://raw.githubusercontent.com/beclab/Olares/refs/heads/main/build/base-package/joincluster.sh
+    export VERSION=1.12.6
+    wget "https://github.com/beclab/Olares/releases/download/${VERSION}/joincluster.sh"
     ```
     :::
 4. 使用主节点信息运行脚本：


### PR DESCRIPTION
* **Background**

* **Target Version for Merge**

* **Related Issues**

* **PRs Involving Sub-Systems** 

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to install commands; no application or infrastructure code is modified.
> 
> **Overview**
> The **Olares One** two-node cluster guides (English and Chinese) no longer tell users to pull `joincluster.sh` from the `main` branch on GitHub. Step 2 now has users set **`VERSION=1.12.6`** and download the script from **`https://github.com/beclab/Olares/releases/download/${VERSION}/joincluster.sh`** via both **curl** and **wget**, with a short info callout explaining that `VERSION` picks the script release (example **1.12.6**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53fa5095c801f344b1421b2dc7c9c85c9270ad27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->