### PR TITLE
fix(app-service): materialize shared-hosts under the caller viewer and upload forward max 100m

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.17
+        image: beclab/app-service:0.6.18
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.16
+        image: beclab/app-service:0.6.17
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -87,10 +87,12 @@ const (
 	MeshInCertCacheValid            = "1m"
 	MeshInProxyReadTimeout          = "600s"
 	MeshInProxySendTimeout          = "600s"
-	// MeshInMaxBodySize lifts nginx's built-in 1m request-body cap. mesh-in is a
-	// transparent identity-injection hop, so body-size policy belongs to the
-	// destination app; "0" means no limit at this hop.
-	MeshInMaxBodySize               = "0"
+	// MeshInMaxBodySize lifts nginx's built-in 1m request-body cap for Shared
+	// east-west relays (e.g. audio embeddings). 100m covers typical API uploads
+	// while still bounding abuse at this hop; destination apps may set a lower
+	// limit. With proxy_request_buffering off, this does not require buffering
+	// the full body in the 64Mi sidecar.
+	MeshInMaxBodySize               = "100m"
 	LabelTLSReplica                 = "gateway.olares.io/tls-replica"
 	DefaultEnvoyLogLevel                  = "debug"
 	EnvoyImageVersion                     = "beclab/envoy:v1.25.11.1"

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -87,6 +87,10 @@ const (
 	MeshInCertCacheValid            = "1m"
 	MeshInProxyReadTimeout          = "600s"
 	MeshInProxySendTimeout          = "600s"
+	// MeshInMaxBodySize lifts nginx's built-in 1m request-body cap. mesh-in is a
+	// transparent identity-injection hop, so body-size policy belongs to the
+	// destination app; "0" means no limit at this hop.
+	MeshInMaxBodySize               = "0"
 	LabelTLSReplica                 = "gateway.olares.io/tls-replica"
 	DefaultEnvoyLogLevel                  = "debug"
 	EnvoyImageVersion                     = "beclab/envoy:v1.25.11.1"

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
@@ -130,8 +130,8 @@ func RenderNginxConf(in NginxConfInput) string {
 	b.WriteString("  access_log off;\n")
 	// nginx -c replaces the image's main config, so nothing seeds a body limit
 	// and the built-in 1m default would reject every upload above it with 413.
-	// Set it once at http level so both the plain and TLS-offload servers, and
-	// any location added later, inherit it.
+	// Set MeshInMaxBodySize once at http level so both the plain and TLS-offload
+	// servers, and any location added later, inherit it.
 	b.WriteString(fmt.Sprintf("  client_max_body_size %s;\n", constants.MeshInMaxBodySize))
 	b.WriteString("  js_import main from /tmp/mesh-in/bearer.js;\n")
 	b.WriteString(fmt.Sprintf("  # jwt path: %s\n", in.JWTTokenPath))

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
@@ -101,6 +101,10 @@ func RenderNginxConf(in NginxConfInput) string {
 		}
 		lb.WriteString("      proxy_http_version 1.1;\n")
 		lb.WriteString("      proxy_buffering off;\n")
+		// Stream the request body instead of spooling it to disk first: the
+		// sidecar runs under a 64Mi memory limit and buffering a large upload
+		// adds a full write-then-read round trip before the gateway sees it.
+		lb.WriteString("      proxy_request_buffering off;\n")
 		lb.WriteString(fmt.Sprintf("      proxy_read_timeout %s;\n", constants.MeshInProxyReadTimeout))
 		lb.WriteString(fmt.Sprintf("      proxy_send_timeout %s;\n", constants.MeshInProxySendTimeout))
 		lb.WriteString("      proxy_set_header Host $host;\n")
@@ -124,6 +128,11 @@ func RenderNginxConf(in NginxConfInput) string {
 	b.WriteString(failClosedNote + "\n")
 	b.WriteString("http {\n")
 	b.WriteString("  access_log off;\n")
+	// nginx -c replaces the image's main config, so nothing seeds a body limit
+	// and the built-in 1m default would reject every upload above it with 413.
+	// Set it once at http level so both the plain and TLS-offload servers, and
+	// any location added later, inherit it.
+	b.WriteString(fmt.Sprintf("  client_max_body_size %s;\n", constants.MeshInMaxBodySize))
 	b.WriteString("  js_import main from /tmp/mesh-in/bearer.js;\n")
 	b.WriteString(fmt.Sprintf("  # jwt path: %s\n", in.JWTTokenPath))
 	b.WriteString(fmt.Sprintf("  # certs: %s\n", in.CertDir))

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -19,6 +19,8 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 		"decideOffload",
 		"ssl_certificate_cache",
 		"proxy_buffering off",
+		"proxy_request_buffering off",
+		"client_max_body_size " + constants.MeshInMaxBodySize,
 		"proxy_read_timeout 600s",
 		"return 421",
 		JWTSecretMountPath + "/token",
@@ -61,6 +63,51 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 	}
 	if strings.Count(got, "proxy_pass http://app-gateway-data.os-gateway.svc:80") < 2 {
 		t.Fatal("expected HTTP and HTTPS terminate servers both proxy to gateway:80")
+	}
+}
+
+// TestRenderNginxConfDoesNotCapRequestBody guards the 413 regression: nginx -c
+// replaces the image's main config, so without an explicit directive the
+// built-in 1m client_max_body_size applied and every relayed upload above 1 MiB
+// was rejected with "413 Request Entity Too Large" on both the plain and the
+// TLS-offload listener.
+func TestRenderNginxConfDoesNotCapRequestBody(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		enableHTTPS bool
+		wantProxies int
+	}{
+		{name: "http and https", enableHTTPS: true, wantProxies: 2},
+		{name: "http only", enableHTTPS: false, wantProxies: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RenderNginxConf(NginxConfInput{FailClosed: true, EnableHTTPS: tc.enableHTTPS})
+
+			limit := "client_max_body_size " + constants.MeshInMaxBodySize + ";"
+			if n := strings.Count(got, limit); n != 1 {
+				t.Fatalf("client_max_body_size occurrences = %d, want 1 at http level:\n%s", n, got)
+			}
+			// http level, not per server: it must precede the first server block
+			// so both listeners and any later location inherit it.
+			if at, firstServer := strings.Index(got, limit), strings.Index(got, "  server {"); at < 0 || firstServer < 0 || at > firstServer {
+				t.Fatalf("client_max_body_size must sit in http {} before the first server block:\n%s", got)
+			}
+			if n := strings.Count(got, "proxy_request_buffering off;"); n != tc.wantProxies {
+				t.Fatalf("proxy_request_buffering off occurrences = %d, want %d (one per proxy location)", n, tc.wantProxies)
+			}
+			// Unbuffered upload requires HTTP/1.1 upstream; keep them paired.
+			if n := strings.Count(got, "proxy_http_version 1.1;"); n != tc.wantProxies {
+				t.Fatalf("proxy_http_version 1.1 occurrences = %d, want %d", n, tc.wantProxies)
+			}
+		})
+	}
+}
+
+func TestMeshInMaxBodySizeIsUnlimited(t *testing.T) {
+	// "0" disables the cap. Any other value silently reintroduces a hop-local
+	// limit that the destination app cannot see or override.
+	if constants.MeshInMaxBodySize != "0" {
+		t.Fatalf("MeshInMaxBodySize = %q, want \"0\" (no limit at the mesh-in hop)", constants.MeshInMaxBodySize)
 	}
 }
 

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -66,12 +66,12 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 	}
 }
 
-// TestRenderNginxConfDoesNotCapRequestBody guards the 413 regression: nginx -c
+// TestRenderNginxConfLiftsDefaultBodyCap guards the 413 regression: nginx -c
 // replaces the image's main config, so without an explicit directive the
 // built-in 1m client_max_body_size applied and every relayed upload above 1 MiB
 // was rejected with "413 Request Entity Too Large" on both the plain and the
 // TLS-offload listener.
-func TestRenderNginxConfDoesNotCapRequestBody(t *testing.T) {
+func TestRenderNginxConfLiftsDefaultBodyCap(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		enableHTTPS bool
@@ -103,11 +103,11 @@ func TestRenderNginxConfDoesNotCapRequestBody(t *testing.T) {
 	}
 }
 
-func TestMeshInMaxBodySizeIsUnlimited(t *testing.T) {
-	// "0" disables the cap. Any other value silently reintroduces a hop-local
-	// limit that the destination app cannot see or override.
-	if constants.MeshInMaxBodySize != "0" {
-		t.Fatalf("MeshInMaxBodySize = %q, want \"0\" (no limit at the mesh-in hop)", constants.MeshInMaxBodySize)
+func TestMeshInMaxBodySizeIsAPIUploadBound(t *testing.T) {
+	// Keep above nginx's 1m default and below multi-GB fileserver caps; 100m
+	// is the hop-local ceiling for Shared east-west relays.
+	if constants.MeshInMaxBodySize != "100m" {
+		t.Fatalf("MeshInMaxBodySize = %q, want \"100m\"", constants.MeshInMaxBodySize)
 	}
 }
 

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/cluster"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
-	"github.com/beclab/Olares/framework/app-service/pkg/gateway"
 	"github.com/beclab/Olares/framework/app-service/pkg/gateway/meshinagent"
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 	"github.com/beclab/Olares/framework/app-service/pkg/security"
@@ -91,6 +90,7 @@ func (r *MeshInSharedHostsReconciler) Reconcile(ctx context.Context, req reconci
 		}
 	}
 	sharedHostsTargetCount.WithLabelValues(hashCallerNS(req.Namespace)).Set(float64(len(nsTargets)))
+	noteEmptySharedHostsTargets(req.Namespace, nsTargets)
 	return reconcile.Result{}, r.ReconcileNamespace(ctx, req.Namespace, nsTargets)
 }
 
@@ -238,9 +238,7 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 	if err := c.List(ctx, &nsList, client.MatchingLabels{security.NamespaceInClusterCallerLabel: "true"}); err != nil {
 		return nil, err
 	}
-	ownerIdx := gateway.BuildClusterAppOwnerIndex(appList.Items)
-	nsOwnerIdx := buildNamespaceOwnerIndex(appList.Items)
-	srrByOwner := groupSRRByOwner(srrList.Items, nsOwnerIdx)
+	srrIdx := buildSharedGatewaySRRIndex(srrList.Items, appList.Items)
 	appsByNS := map[string][]appv1alpha1.Application{}
 	for i := range appList.Items {
 		app := appList.Items[i]
@@ -256,9 +254,14 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 	type key struct{ ns, viewer string }
 	authByKey := map[key]map[string]struct{}{}
 	tlsByKey := map[key]map[string]struct{}{}
-	addViewerHosts := func(callerNS, viewer string) {
+	// addViewerHosts materializes srrs under viewer. The SRR set (what may be
+	// called) and the viewer (whose URL segment the caller uses) are separate
+	// inputs on purpose: the viewer is always the caller's own owner, never the
+	// installer of the shared app being called.
+	addViewerHosts := func(callerNS, viewer string, srrs []srrv1alpha1.SharedRouteRegistry) {
 		viewer = strings.ToLower(strings.TrimSpace(viewer))
 		if viewer == "" {
+			sharedHostsDropTotal.WithLabelValues(rDropOwnerUnresolved).Inc()
 			return
 		}
 		k := key{ns: callerNS, viewer: viewer}
@@ -268,7 +271,7 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 		if tlsByKey[k] == nil {
 			tlsByKey[k] = map[string]struct{}{}
 		}
-		auth, tlsHosts := enumerateHostsForViewer(viewer, srrByOwner[viewer], platformDomain)
+		auth, tlsHosts := enumerateHostsForViewer(viewer, srrs, platformDomain)
 		for _, h := range auth {
 			authByKey[k][h] = struct{}{}
 		}
@@ -281,24 +284,23 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 		for _, app := range appsByNS[callerNS] {
 			refs := callerSharedAppRefs(&app)
 			if len(refs) == 0 {
-				// No named callee refs: still project viewer hosts when the app is a caller.
+				// Eligibility caller: no named callee, so the whole shared
+				// gateway menu is offered under the caller's own viewer.
 				if !meshinagent.DeclaresSharedCaller(app.Spec.Settings) {
 					continue
 				}
-				addViewerHosts(callerNS, app.Spec.Owner)
+				addViewerHosts(callerNS, app.Spec.Owner, srrIdx.all)
 				continue
 			}
 			if len(refs) > 1 {
 				sharedHostsDropTotal.WithLabelValues(rDropMultiRef).Inc()
 			}
-			owners := gateway.SplitClusterAppRefs(gateway.ResolveClusterAppOwner(ownerIdx, refs[0]))
-			if len(owners) == 0 {
-				sharedHostsDropTotal.WithLabelValues(rDropOwnerUnresolved).Inc()
+			srrs := srrIdx.byAppRef[refs[0]]
+			if len(srrs) == 0 {
+				sharedHostsDropTotal.WithLabelValues(rDropRefUnresolved).Inc()
 				continue
 			}
-			for _, owner := range owners {
-				addViewerHosts(callerNS, owner)
-			}
+			addViewerHosts(callerNS, app.Spec.Owner, srrs)
 		}
 	}
 	out := make([]SharedHostsTarget, 0, len(authByKey))

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
@@ -50,6 +50,9 @@ const (
 	rDropInvalidChars    = "invalid_chars"
 	rDropEmptyPatterns   = "empty_patterns"
 	rDropSharedAuthOnly  = "shared_auth_only"
+	// rDropRefUnresolved means a caller named a shared dep that publishes no
+	// gateway SRR, so there is nothing to materialize for it.
+	rDropRefUnresolved = "shared_ref_unresolved"
 	// GC reason label values.
 	rGCNSOptOut  = "ns_opt_out"
 	rGCNSDeleted = "ns_deleted"
@@ -64,6 +67,9 @@ const (
 	// platformDomainWarnInterval throttles the unavailability warning: the
 	// condition fans out over every opt-in namespace on each retry.
 	platformDomainWarnInterval = time.Minute
+	// emptyAllowlistWarnInterval throttles the empty-allowlist warning per
+	// caller namespace; reconciles fan out on every SRR or Application event.
+	emptyAllowlistWarnInterval = time.Minute
 )
 
 var (
@@ -95,12 +101,19 @@ var (
 		Name: "olares_mesh_in_shared_hosts_platform_domain_ready",
 		Help: "1 when the platform domain resolves for host materialization, 0 while it is unavailable.",
 	})
+	sharedHostsEmptyAllowlistTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "olares_mesh_in_shared_hosts_empty_allowlist_total",
+		Help: "Count of reconciles where a declared caller viewer resolved zero auth hosts.",
+	}, []string{"caller_ns"})
 
 	sharedHostsHashStateMu sync.Mutex
 	sharedHostsHashState   = map[string]meshInHashSnapshot{}
 
 	platformDomainWarnMu   sync.Mutex
 	platformDomainWarnedAt time.Time
+
+	emptyAllowlistWarnMu   sync.Mutex
+	emptyAllowlistWarnedAt = map[string]time.Time{}
 )
 
 // warnPlatformDomainUnavailable logs at default verbosity, throttled to one line
@@ -117,6 +130,34 @@ func warnPlatformDomainUnavailable(callerNS string) {
 		sharedHostsPlatformDomainRequeue, hashCallerNS(callerNS))
 }
 
+// noteEmptySharedHostsTargets reports caller viewers that opted in but resolved
+// no auth host. mesh-in then falls back to passthrough without injecting the
+// platform JWT and the callee answers "Jwt is missing", which used to be silent
+// on the control plane side. Returns how many targets were reported.
+func noteEmptySharedHostsTargets(callerNS string, targets []SharedHostsTarget) int {
+	empty := 0
+	for _, t := range targets {
+		if len(t.Hosts) > 0 {
+			continue
+		}
+		empty++
+		sharedHostsEmptyAllowlistTotal.WithLabelValues(hashCallerNS(callerNS)).Inc()
+		warnEmptySharedHostsAllowlist(callerNS, t.Viewer)
+	}
+	return empty
+}
+
+func warnEmptySharedHostsAllowlist(callerNS, viewer string) {
+	emptyAllowlistWarnMu.Lock()
+	defer emptyAllowlistWarnMu.Unlock()
+	if at, ok := emptyAllowlistWarnedAt[callerNS]; ok && time.Since(at) < emptyAllowlistWarnInterval {
+		return
+	}
+	emptyAllowlistWarnedAt[callerNS] = time.Now()
+	klog.Warningf("shared_hosts: caller declared shared access but allowlist is empty ns=%s viewer=%s",
+		hashCallerNS(callerNS), viewer)
+}
+
 type meshInHashSnapshot struct {
 	hash string
 	at   time.Time
@@ -126,7 +167,7 @@ func init() {
 	prometheus.MustRegister(
 		sharedHostsReconcileTotal, sharedHostsDropTotal, sharedHostsGCTotal,
 		sharedHostsTargetCount, sharedHostsCount, sharedHostsContentHashAgeSeconds,
-		sharedHostsPlatformDomainReady,
+		sharedHostsPlatformDomainReady, sharedHostsEmptyAllowlistTotal,
 	)
 }
 
@@ -388,42 +429,52 @@ func countSharedHostsRows(targets []SharedHostsTarget) int {
 	return len(all)
 }
 
-func buildNamespaceOwnerIndex(apps []appv1alpha1.Application) map[string]string {
-	idx := map[string]string{}
+// sharedGatewaySRRIndex is the routable menu offered to in-cluster callers: the
+// gateway-mode SRRs published by shared server Applications. It is deliberately
+// keyed by callee, never by the installer of the shared app -- the installer is
+// only one of the users allowed to call it, so indexing by owner left every
+// other user with an empty allowlist (DEFECT-SH-N6-OWNER-01).
+type sharedGatewaySRRIndex struct {
+	// all backs eligibility callers, which declare no named callee and may
+	// reach any installed shared app.
+	all []srrv1alpha1.SharedRouteRegistry
+	// byAppRef narrows the menu for callers with named shared deps. The key is
+	// Application spec.name, matching gateway.BuildClusterAppOwnerIndex refs.
+	byAppRef map[string][]srrv1alpha1.SharedRouteRegistry
+}
+
+func buildSharedGatewaySRRIndex(srrs []srrv1alpha1.SharedRouteRegistry, apps []appv1alpha1.Application) sharedGatewaySRRIndex {
+	refsByNS := map[string][]string{}
 	for i := range apps {
 		app := apps[i]
 		if !appcfg.IsSharedServerApp(&app) {
 			continue
 		}
 		ns := strings.TrimSpace(app.Spec.Namespace)
-		owner := strings.ToLower(strings.TrimSpace(app.Spec.Owner))
-		if ns == "" || owner == "" {
+		name := strings.TrimSpace(app.Spec.Name)
+		if ns == "" || name == "" {
 			continue
 		}
-		idx[ns] = owner
+		refsByNS[ns] = append(refsByNS[ns], name)
 	}
-	return idx
-}
-func groupSRRByOwner(srrs []srrv1alpha1.SharedRouteRegistry, nsOwnerIdx map[string]string) map[string][]srrv1alpha1.SharedRouteRegistry {
-	out := map[string][]srrv1alpha1.SharedRouteRegistry{}
+	idx := sharedGatewaySRRIndex{byAppRef: map[string][]srrv1alpha1.SharedRouteRegistry{}}
 	for i := range srrs {
 		srr := srrs[i]
 		if srr.Spec.RouteMode != srrv1alpha1.RouteModeGateway && srr.Spec.RouteMode != "" {
 			continue
 		}
-		viewer := ""
-		if v, ok := viewerFromUserSpaceNS(srr.Namespace); ok {
-			viewer = v
-		} else if owner, ok := nsOwnerIdx[srr.Namespace]; ok {
-			viewer = owner
-		}
-		viewer = strings.ToLower(strings.TrimSpace(viewer))
-		if viewer == "" {
+		// A gateway SRR outside a shared server namespace is a private per-user
+		// route; keeping it out bounds the allowlist to shared traffic.
+		refs, ok := refsByNS[strings.TrimSpace(srr.Namespace)]
+		if !ok {
 			continue
 		}
-		out[viewer] = append(out[viewer], srr)
+		idx.all = append(idx.all, srr)
+		for _, ref := range refs {
+			idx.byAppRef[ref] = append(idx.byAppRef[ref], srr)
+		}
 	}
-	return out
+	return idx
 }
 
 func hashCallerNS(ns string) string {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
@@ -192,38 +192,152 @@ func TestCallerSharedAppRefsFromDecideEdges(t *testing.T) {
 	}
 }
 
-func TestBuildSharedHostsDemandEligibilityWithoutRefs(t *testing.T) {
+// sharedHostsScheme registers the types BuildSharedHostsDemand lists.
+func sharedHostsScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = appv1alpha1.AddToScheme(scheme)
 	_ = srrv1alpha1.AddToScheme(scheme)
+	return scheme
+}
 
-	callerNS := &corev1.Namespace{
+func callerNamespace(ns string) *corev1.Namespace {
+	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "chat-alice",
+			Name:   ns,
 			Labels: map[string]string{security.NamespaceInClusterCallerLabel: "true"},
 		},
 	}
-	app := &appv1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{Name: "chat-alice-chat"},
+}
+
+// sharedServerApp is an installed shared app. owner is the installer, which is
+// deliberately not the caller viewer in these tests.
+func sharedServerApp(name, ns, owner string) *appv1alpha1.Application {
+	return &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   ns + "-" + name,
+			Labels: map[string]string{constants.AppSharedLabel: constants.AppSharedTrue},
+		},
+		Spec: appv1alpha1.ApplicationSpec{Name: name, Namespace: ns, Owner: owner},
+	}
+}
+
+func callerApp(name, ns, owner string, settings map[string]string) *appv1alpha1.Application {
+	return &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: ns + "-" + name},
 		Spec: appv1alpha1.ApplicationSpec{
-			Name:      "chat",
-			Namespace: "chat-alice",
-			Owner:     "alice",
-			Settings: map[string]string{
-				"gateway.olares.io/shared-caller-decide":        "true",
-				"gateway.olares.io/shared-caller-decide-source": "eligibility",
-			},
+			Name:      name,
+			Namespace: ns,
+			Owner:     owner,
+			Settings:  settings,
 		},
 	}
-	srr := &srrv1alpha1.SharedRouteRegistry{
-		ObjectMeta: metav1.ObjectMeta{Name: "shared-demo", Namespace: "user-space-alice"},
+}
+
+func eligibilityCallerApp(name, ns, owner string) *appv1alpha1.Application {
+	return callerApp(name, ns, owner, map[string]string{
+		"gateway.olares.io/shared-caller-decide":        "true",
+		"gateway.olares.io/shared-caller-decide-source": "eligibility",
+	})
+}
+
+func gatewaySRR(name, ns, pattern string) *srrv1alpha1.SharedRouteRegistry {
+	return &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Spec: srrv1alpha1.SharedRouteRegistrySpec{
 			RouteMode:    srrv1alpha1.RouteModeGateway,
-			HostPatterns: []string{"abcd1234.*.olares.com"},
+			HostPatterns: []string{pattern},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(callerNS, app, srr).Build()
+}
+
+func demandFor(t *testing.T, got []SharedHostsTarget, ns, viewer string) SharedHostsTarget {
+	t.Helper()
+	for _, target := range got {
+		if target.CallerNamespace == ns && target.Viewer == viewer {
+			return target
+		}
+	}
+	t.Fatalf("no demand for ns=%s viewer=%s: %+v", ns, viewer, got)
+	return SharedHostsTarget{}
+}
+
+// TestBuildSharedHostsDemandEligibilityWithoutRefs pins AC-1/AC-2: the host is
+// materialized under the caller's own owner even though the shared app was
+// installed by someone else, and one caller's demand does not depend on the
+// other's (DEFECT-SH-N6-OWNER-01).
+func TestBuildSharedHostsDemandEligibilityWithoutRefs(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(
+		callerNamespace("chat-alice"),
+		callerNamespace("chat-bob"),
+		eligibilityCallerApp("chat", "chat-alice", "alice"),
+		eligibilityCallerApp("chat", "chat-bob", "bob"),
+		sharedServerApp("ollama", "ollama-shared", "admin"),
+		gatewaySRR("shared-ollama", "ollama-shared", "abcd1234.*.olares.com"),
+	).Build()
+
+	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("demand len=%d want 2: %+v", len(got), got)
+	}
+	alice := demandFor(t, got, "chat-alice", "alice")
+	if len(alice.Hosts) != 1 || alice.Hosts[0] != "abcd1234.alice.olares.com" {
+		t.Fatalf("alice hosts=%v", alice.Hosts)
+	}
+	bob := demandFor(t, got, "chat-bob", "bob")
+	if len(bob.Hosts) != 1 || bob.Hosts[0] != "abcd1234.bob.olares.com" {
+		t.Fatalf("bob hosts=%v", bob.Hosts)
+	}
+}
+
+// TestBuildSharedHostsDemandCoversEverySharedApp pins AC-3: an eligibility
+// caller may reach any installed shared app, so every shared gateway SRR is
+// materialized, not only those of the app its owner installed.
+func TestBuildSharedHostsDemandCoversEverySharedApp(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(
+		callerNamespace("chat-alice"),
+		eligibilityCallerApp("chat", "chat-alice", "alice"),
+		sharedServerApp("ollama", "ollama-shared", "admin"),
+		gatewaySRR("shared-ollama", "ollama-shared", "abcd1234.*.olares.com"),
+		sharedServerApp("whisper", "whisper-shared", "bob"),
+		gatewaySRR("shared-whisper", "whisper-shared", "deadbeef.*.olares.com"),
+	).Build()
+
+	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice := demandFor(t, got, "chat-alice", "alice")
+	want := []string{"abcd1234.alice.olares.com", "deadbeef.alice.olares.com"}
+	if len(alice.Hosts) != len(want) {
+		t.Fatalf("hosts=%v want %v", alice.Hosts, want)
+	}
+	for i, h := range want {
+		if alice.Hosts[i] != h {
+			t.Fatalf("hosts=%v want %v", alice.Hosts, want)
+		}
+	}
+}
+
+// TestBuildSharedHostsDemandNamedDepsUseCallerViewer pins AC-4: a caller with
+// named shared deps gets only that callee's routes, still materialized under
+// its own viewer rather than the callee installer's.
+func TestBuildSharedHostsDemandNamedDepsUseCallerViewer(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(
+		callerNamespace("litellm-alice"),
+		callerApp("litellm", "litellm-alice", "alice", map[string]string{
+			"gateway.olares.io/shared-caller-decide": "true",
+			"clusterAppRef":                          "ollama",
+		}),
+		sharedServerApp("ollama", "ollama-shared", "admin"),
+		gatewaySRR("shared-ollama", "ollama-shared", "abcd1234.*.olares.com"),
+		sharedServerApp("whisper", "whisper-shared", "admin"),
+		gatewaySRR("shared-whisper", "whisper-shared", "deadbeef.*.olares.com"),
+	).Build()
+
 	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
 	if err != nil {
 		t.Fatal(err)
@@ -231,11 +345,62 @@ func TestBuildSharedHostsDemandEligibilityWithoutRefs(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("demand len=%d want 1: %+v", len(got), got)
 	}
-	if got[0].CallerNamespace != "chat-alice" || got[0].Viewer != "alice" {
-		t.Fatalf("got %+v", got[0])
+	target := demandFor(t, got, "litellm-alice", "alice")
+	if len(target.Hosts) != 1 || target.Hosts[0] != "abcd1234.alice.olares.com" {
+		t.Fatalf("hosts=%v want only the named callee under the caller viewer", target.Hosts)
 	}
-	if len(got[0].Hosts) != 1 || got[0].Hosts[0] != "abcd1234.alice.olares.com" {
-		t.Fatalf("hosts=%v", got[0].Hosts)
+}
+
+func TestBuildSharedHostsDemandDropsUnresolvedRef(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(
+		callerNamespace("litellm-alice"),
+		callerApp("litellm", "litellm-alice", "alice", map[string]string{
+			"gateway.olares.io/shared-caller-decide": "true",
+			"clusterAppRef":                          "gone",
+		}),
+		sharedServerApp("ollama", "ollama-shared", "admin"),
+		gatewaySRR("shared-ollama", "ollama-shared", "abcd1234.*.olares.com"),
+	).Build()
+
+	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("demand=%+v want none for an unresolved dep", got)
+	}
+}
+
+// TestBuildSharedHostsDemandSkipsNonSharedSRR pins AC-5: gateway SRRs outside a
+// shared server namespace are private per-user routes and must stay out of the
+// eligibility allowlist.
+func TestBuildSharedHostsDemandSkipsNonSharedSRR(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(
+		callerNamespace("chat-alice"),
+		eligibilityCallerApp("chat", "chat-alice", "alice"),
+		callerApp("private", "private-bob", "bob", nil),
+		gatewaySRR("private-route", "private-bob", "cafebabe.*.olares.com"),
+	).Build()
+
+	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := demandFor(t, got, "chat-alice", "alice")
+	if len(target.Hosts) != 0 {
+		t.Fatalf("hosts=%v want none: non-shared SRR leaked into the allowlist", target.Hosts)
+	}
+}
+
+// TestNoteEmptySharedHostsTargets pins AC-6: an opted-in caller that resolves no
+// host is reported instead of silently falling back to passthrough.
+func TestNoteEmptySharedHostsTargets(t *testing.T) {
+	got := noteEmptySharedHostsTargets("chat-alice", []SharedHostsTarget{
+		{CallerNamespace: "chat-alice", Viewer: "alice"},
+		{CallerNamespace: "chat-alice", Viewer: "bob", Hosts: []string{"abcd1234.bob.olares.com"}},
+	})
+	if got != 1 {
+		t.Fatalf("empty targets reported = %d want 1", got)
 	}
 }
 
@@ -245,41 +410,19 @@ func sharedHostsRequest(ns string) reconcile.Request {
 	}}
 }
 
-// sharedHostsCallerFixture builds an opted-in caller NS whose viewer resolves a
-// single logical SRR pattern to abcd1234.alice.olares.com.
+// sharedHostsCallerFixture builds an opted-in caller NS owned by alice plus a
+// shared app installed by admin, so the single logical SRR pattern resolves to
+// abcd1234.alice.olares.com.
 func sharedHostsCallerFixture(extra ...client.Object) client.Client {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appv1alpha1.AddToScheme(scheme)
-	_ = srrv1alpha1.AddToScheme(scheme)
-
 	objs := []client.Object{
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "chat-alice",
-				Labels: map[string]string{security.NamespaceInClusterCallerLabel: "true"},
-			},
-		},
-		&appv1alpha1.Application{
-			ObjectMeta: metav1.ObjectMeta{Name: "chat-alice-chat"},
-			Spec: appv1alpha1.ApplicationSpec{
-				Name:      "chat",
-				Namespace: "chat-alice",
-				Owner:     "alice",
-				Settings: map[string]string{
-					"gateway.olares.io/shared-caller-decide": "true",
-				},
-			},
-		},
-		&srrv1alpha1.SharedRouteRegistry{
-			ObjectMeta: metav1.ObjectMeta{Name: "shared-demo", Namespace: "user-space-alice"},
-			Spec: srrv1alpha1.SharedRouteRegistrySpec{
-				RouteMode:    srrv1alpha1.RouteModeGateway,
-				HostPatterns: []string{"abcd1234.*.olares.com"},
-			},
-		},
+		callerNamespace("chat-alice"),
+		callerApp("chat", "chat-alice", "alice", map[string]string{
+			"gateway.olares.io/shared-caller-decide": "true",
+		}),
+		sharedServerApp("ollama", "ollama-shared", "admin"),
+		gatewaySRR("shared-ollama", "ollama-shared", "abcd1234.*.olares.com"),
 	}
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(append(objs, extra...)...).Build()
+	return fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(append(objs, extra...)...).Build()
 }
 
 func TestMeshInSharedHostsKeepsAllowlistWhenPlatformDomainUnavailable(t *testing.T) {


### PR DESCRIPTION
## Summary
Any user can call Shared apps via their own viewer URL
(`<hash>.<user>.domain`). The shared-hosts allowlist is now built for the
caller, not the Shared installer, so mesh-in injects the platform JWT for
non-installer users as well.
set body size with 100m for Shared east-west forword uploads 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes shared east-west gateway allowlist and JWT injection semantics (auth-critical); incorrect indexing could deny access or widen routes until reconciled.
> 
> **Overview**
> Fixes **shared mesh-in allowlists** so hosts are built for the **caller's viewer** (`app.Spec.Owner`), not the shared app's installer. Gateway SRRs are indexed by **shared server app ref** (`buildSharedGatewaySRRIndex`) instead of grouping by installer owner, so non-installer users get auth hosts under their own URL segment and mesh-in can inject the platform JWT. Eligibility callers without named deps see **all** shared gateway routes; named `clusterAppRef` callers see only that callee's routes.
> 
> Adds **visibility** when a declared caller resolves zero auth hosts (throttled warnings + `olares_mesh_in_shared_hosts_empty_allowlist_total`) and a **`shared_ref_unresolved`** drop reason when a named dep has no gateway SRR.
> 
> **Mesh-in nginx** now sets **`client_max_body_size` 100m** at the `http` level (fixes 413 on uploads above 1 MiB) and **`proxy_request_buffering off`** on proxy locations so large bodies stream within the sidecar memory limit.
> 
> Bumps **`beclab/app-service` to 0.6.18** in deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37b029d5b1b18d623a40afd10bd28a769f6826d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->