### PR TITLE
refactor(app-service): unify compute device selection across preflight, install and resume

### DIFF
--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -13,13 +13,27 @@ import (
 
 var errBindingUnavailable = errors.New("compute binding unavailable")
 
+// listAvailableForLaunch classifies every node and device in the cluster
+// against the app's selected requirement. It is the shared first step of both
+// placement flows: resume hands the result to the user and waits for a manual
+// pick, while install feeds the very same result to pickLaunchSelection and
+// picks automatically. Neither flow can therefore place an app on a device the
+// other wouldn't offer.
 func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnapshot) *AvailabilityResult {
+	return listAvailableForLaunchWithOptions(req, nodes, pressure, allocationOptions{checkPressure: true})
+}
+
+// listAvailableForLaunchWithOptions is listAvailableForLaunch with the fit
+// checks parameterized, so preflight can build the same view against a
+// simulated cluster (its own added-resources budget, and a first pass that
+// ignores node pressure entirely).
+func listAvailableForLaunchWithOptions(req Requirement, nodes []Node, pressure PressureSnapshot, opts allocationOptions) *AvailabilityResult {
 	result := &AvailabilityResult{
 		Requirement: req,
 		Scope:       availabilityScope(req),
 		Nodes:       make([]NodeOption, 0, len(nodes)),
 	}
-	classified := classifyLaunchNodes(req, nodes, pressure)
+	classified := classifyLaunchNodes(req, nodes, pressure, opts)
 	for _, node := range classified {
 		if node.Status == NodeStatusNotMatch {
 			continue
@@ -36,7 +50,7 @@ func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnap
 	return result
 }
 
-func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot) []NodeOption {
+func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot, opts allocationOptions) []NodeOption {
 	out := make([]NodeOption, 0, len(nodes))
 	for _, node := range nodes {
 		if !node.SupportsMode(req.Mode) {
@@ -50,17 +64,17 @@ func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapsho
 		view := node.viewForMode(req.Mode)
 		var option NodeOption
 		if req.Mode == utils.NvidiaCardType {
-			option = classifyNvidiaNode(req, view, pressure)
+			option = classifyNvidiaNode(req, view, pressure, opts)
 		} else {
-			option = classifyNonNvidiaNode(req, view, pressure)
+			option = classifyNonNvidiaNode(req, view, pressure, opts)
 		}
 		out = append(out, option)
 	}
 	return out
 }
 
-func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
-	summary := summarizeNvidiaNode(req, node, pressure)
+func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) NodeOption {
+	summary := summarizeNvidiaNode(req, node, pressure, opts)
 	option := NodeOption{
 		NodeName: node.NodeName,
 		GPUType:  req.Mode,
@@ -74,28 +88,58 @@ func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) N
 	return option
 }
 
-func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
+// classifyNonNvidiaNode classifies every device a node exposes for a non-nvidia
+// mode. Most such modes are unified memory and model the whole node as a single
+// device, but nvidia-gb10 and discrete Intel GPUs can expose several cards on
+// one node, so the node's status is taken from its best card the way
+// classifyNvidiaNode does — listing only the first one would hide the rest from
+// both the resume picker and install's auto-pick.
+func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) NodeOption {
 	option := NodeOption{NodeName: node.NodeName, GPUType: req.Mode}
 	if len(node.Devices) == 0 {
 		option.Status = NodeStatusNotAvailable
 		return option
 	}
-	devOpt := makeDeviceOption(req, node, node.Devices[0], pressure)
-	option.Devices = []DeviceOption{devOpt}
-	switch {
-	case devOpt.Health != deviceHealthYes:
+	option.Devices = make([]DeviceOption, 0, len(node.Devices))
+	var healthy bool
+	var maxCapacity, maxAvailable int64
+	for _, device := range node.Devices {
+		devOpt := makeDeviceOption(req, node, device, pressure, opts)
+		option.Devices = append(option.Devices, devOpt)
+		if devOpt.Health != deviceHealthYes {
+			continue
+		}
+		healthy = true
+		if devOpt.Capacity > maxCapacity {
+			maxCapacity = devOpt.Capacity
+		}
+		if devOpt.Available > maxAvailable {
+			maxAvailable = devOpt.Available
+		}
+	}
+	if !healthy {
 		option.Status = NodeStatusNotAvailable
-	case devOpt.Capacity < req.RequiredMemory:
-		option.Status = NodeStatusNotEnough
-	case devOpt.Available >= req.RequiredMemory && !pressure.WouldPressure(node, AddedResources{
-		CPU:    req.RequiredCPU,
-		Memory: req.RequiredMemory,
-	}):
-		option.Status = NodeStatusAvailable
-	default:
+		return option
+	}
+	option.Status = nodeStatusFromCapacity(req.RequiredMemory, maxCapacity, maxAvailable)
+	if option.Status == NodeStatusAvailable && nodeWouldPressure(req, node, pressure, opts) {
 		option.Status = NodeStatusNotAvailable
 	}
 	return option
+}
+
+// nodeWouldPressure reports whether hosting the app would push the node past
+// its pressure threshold. Unlike the per-device fit checks it deliberately
+// leaves disk out: node status has always been a cpu/memory judgement.
+func nodeWouldPressure(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) bool {
+	if !opts.checkPressure {
+		return false
+	}
+	added := AddedResources{CPU: req.RequiredCPU, Memory: req.RequiredMemory}
+	if opts.pressureAdded != nil {
+		added = *opts.pressureAdded
+	}
+	return pressure.WouldPressure(node, added)
 }
 
 type nvidiaNodeSummary struct {
@@ -106,10 +150,10 @@ type nvidiaNodeSummary struct {
 	maxAvailable   int64
 }
 
-func summarizeNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) nvidiaNodeSummary {
+func summarizeNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) nvidiaNodeSummary {
 	summary := nvidiaNodeSummary{devices: make([]DeviceOption, 0, len(node.Devices))}
 	for _, device := range node.Devices {
-		devOpt := makeDeviceOption(req, node, device, pressure)
+		devOpt := makeDeviceOption(req, node, device, pressure, opts)
 		summary.devices = append(summary.devices, devOpt)
 		if devOpt.Health != deviceHealthYes {
 			continue
@@ -136,7 +180,7 @@ func nodeStatusFromCapacity(required, capacity, available int64) string {
 	return NodeStatusNotAvailable
 }
 
-func makeDeviceOption(req Requirement, node Node, device Device, pressure PressureSnapshot) DeviceOption {
+func makeDeviceOption(req Requirement, node Node, device Device, pressure PressureSnapshot, opts allocationOptions) DeviceOption {
 	req.RequiredDisk = 0
 	available := deviceAvailableMemory(device)
 	option := DeviceOption{
@@ -153,13 +197,46 @@ func makeDeviceOption(req Requirement, node Node, device Device, pressure Pressu
 		option.Health = deviceHealthYes
 	}
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
-		fits, _ := deviceFitsLevel(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes, 0)
+		fits, _ := deviceFitsLevelWithPressure(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes, 0, opts)
 		if fits {
 			option.FitLevel = level
 			break
 		}
 	}
 	return option
+}
+
+// asNodeDevice re-materializes the (node, device) pair a DeviceOption was
+// derived from, so the auto-picker can run the fit checks straight against the
+// availability view rather than against a second copy of the node snapshot.
+// That is what keeps install's automatic pick and resume's manual pick anchored
+// to the same candidate set: both are choosing among the very devices this view
+// exposes, judged by the very fit level it reports.
+//
+// The conversion goes this direction, rather than deviceFitsLevelWithPressure
+// simply taking a DeviceOption, because that function is also what builds the
+// view: makeDeviceOption calls it to compute FitLevel, at which point only the
+// raw Node and Device exist and the DeviceOption does not yet. The fit logic
+// therefore has to stay Device-shaped, and the view side adapts.
+//
+// The round trip is exact for everything the fit checks read — Health, plus
+// SupportType/Memory/Bindings, which are what deviceAvailableMemory and
+// timeSliceAddedMemory consume, plus the node name that pressure lookups are
+// keyed by. Recomputing deviceAvailableMemory on the result therefore
+// reproduces DeviceOption.Available. The identity fields (ID, Mode, CardModel)
+// are along for the ride so the value is a well-formed Device; no fit check
+// reads them.
+func (o DeviceOption) asNodeDevice(mode string) (Node, Device) {
+	return Node{NodeName: o.NodeName}, Device{
+		ID:          o.DeviceID,
+		NodeName:    o.NodeName,
+		Mode:        mode,
+		CardModel:   o.CardModel,
+		Memory:      o.Capacity,
+		Health:      o.Health,
+		SupportType: o.SupportType,
+		Bindings:    o.Bindings,
+	}
 }
 
 func availabilityScope(req Requirement) string {
@@ -284,21 +361,12 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 	var unavailable *BindingApplyResult
 	if _, err := mutateAllocations(ctx, c, func(nodes []Node, existing []Allocation) ([]Allocation, *Allocation, error) {
 		attachBindings(nodes, withoutAppAllocations(existing, appConfig.AppName, appConfig.OwnerName))
-		resolved, resolveErr := resolveSelection(selections, nodes)
-		if resolveErr != nil {
-			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error()))
-			return nil, nil, errBindingUnavailable
-		}
-		validation := validateResolvedBindingSelection(req, resolved, pressure)
+		bound, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 		if !validation.OK {
 			unavailable = unavailableBindingApplyResult(req, nodes, pressure, validation)
 			return nil, nil, errBindingUnavailable
 		}
-		allocations = allocationsFromResolvedSelection(appConfig, req, resolved)
-		if len(allocations) == 0 {
-			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding"))
-			return nil, nil, errBindingUnavailable
-		}
+		allocations = bound
 		next := replaceAppAllocations(existing, allocations)
 		return next, &allocations[0], nil
 	}); err != nil {
@@ -307,15 +375,8 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		}
 		return nil, err
 	}
-	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
-		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, allocations); err != nil {
 		return nil, err
-	}
-	for _, allocation := range allocations {
-		if err := createHAMIBinding(ctx, c, allocation); err != nil {
-			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
-			return nil, err
-		}
 	}
 	return &BindingApplyResult{
 		Status:      BindingApplyStatusApplied,
@@ -323,6 +384,45 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		TargetApp:   appConfig.AppName,
 		TargetOwner: appConfig.OwnerName,
 	}, nil
+}
+
+// bindAllocations turns a compute binding selection — the user's manual pick on
+// resume, or install's automatic pick out of the same availability view — into
+// the app's allocation rows. Both flows converge here so a placement install
+// makes on its own is held to exactly the same rules as one a user submits.
+// The returned validation result is always non-nil; the allocations are only
+// meaningful when it reports OK.
+func bindAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, selections []BindingSelection, nodes []Node, pressure PressureSnapshot) ([]Allocation, *BindingValidationResult) {
+	resolved, err := resolveSelection(selections, nodes)
+	if err != nil {
+		return nil, invalidBinding(err.Error())
+	}
+	validation := validateResolvedBindingSelection(req, resolved, pressure)
+	if !validation.OK {
+		return nil, validation
+	}
+	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
+	if len(allocations) == 0 {
+		return nil, invalidBinding("empty-compute-binding")
+	}
+	return allocations, validation
+}
+
+// syncHAMIBindings replaces the app's HAMI GPUBindings with the ones its new
+// allocations call for. A failure at this point leaves the allocation rows
+// pointing at bindings that were never created, so it releases them.
+func syncHAMIBindings(ctx context.Context, c client.Client, appName, owner string, allocations []Allocation) error {
+	if err := deleteHAMIBindingsForApp(ctx, c, appName, owner); err != nil {
+		_ = DeleteAllocationsForApp(ctx, c, appName, owner)
+		return err
+	}
+	for _, allocation := range allocations {
+		if err := createHAMIBinding(ctx, c, allocation); err != nil {
+			_ = DeleteAllocationsForApp(ctx, c, appName, owner)
+			return err
+		}
+	}
+	return nil
 }
 
 // ValidateBindingForResume mirrors ApplyBindingSelection's feasibility
@@ -372,17 +472,9 @@ func ValidateBindingForResume(ctx context.Context, c client.Client, appConfig *a
 			TargetOwner:  appConfig.OwnerName,
 		}, nil
 	}
-	resolved, resolveErr := resolveSelection(selections, nodes)
-	if resolveErr != nil {
-		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error())), nil
-	}
-	validation := validateResolvedBindingSelection(req, resolved, pressure)
+	allocations, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 	if !validation.OK {
 		return unavailableBindingApplyResult(req, nodes, pressure, validation), nil
-	}
-	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
-	if len(allocations) == 0 {
-		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding")), nil
 	}
 	// Even when the selection is valid we still hand back the full list of
 	// available options so the frontend can render the current selection in
@@ -590,6 +682,13 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 			amount = deviceAvailableMemory(item.device)
 		case len(resolved) > 1:
 			amount = minInt64(deviceAvailableMemory(item.device), remaining)
+		}
+		if amount <= 0 {
+			// The app declares no concrete demand for this mode, so the
+			// selection's own amount is all we have to go on. Without this the
+			// allocation would be dropped and the whole binding rejected as
+			// empty.
+			amount = item.memory
 		}
 		if amount <= 0 {
 			continue

--- a/framework/app-service/pkg/compute/launch_selection_test.go
+++ b/framework/app-service/pkg/compute/launch_selection_test.go
@@ -1,0 +1,179 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+// TestAutoPickOnlyChoosesDevicesTheResumeViewOffers pins the property that ties
+// the two placement flows together: install and resume start from the same
+// availability view, so a card install assigns itself must be one the resume
+// picker would have let a user click. The cluster below mixes every reason a
+// card is unusable — already taken exclusively, unhealthy, too little VRAM left
+// — so a picker running against the raw node list instead of the view would
+// have plenty of chances to reach past what the view exposes.
+func TestAutoPickOnlyChoosesDevicesTheResumeViewOffers(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice", SelectedGpuType: utils.NvidiaCardType}
+	req := Requirement{
+		Mode:           utils.NvidiaCardType,
+		RequiredGPU:    8 * gi,
+		LimitedGPU:     8 * gi,
+		RequiredMemory: gi,
+		LimitedMemory:  gi,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "a-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive,
+				Bindings: []Allocation{{AppName: "other", Owner: "bob"}}},
+			Device{ID: "a-gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+		),
+		nvidiaNode("nvidia-b",
+			Device{ID: "b-gpu0", Memory: 16 * gi, Health: deviceHealthNo, SupportType: SupportTypeExclusive},
+			Device{ID: "b-gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+		),
+		nvidiaNode("nvidia-c",
+			Device{ID: "c-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice,
+				Bindings: []Allocation{{AppName: "other", Owner: "bob", Memory: 12 * gi}}},
+		),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
+	}
+
+	offered := map[string]bool{}
+	for _, node := range listAvailableForLaunch(req, nodes, PressureSnapshot{}).Nodes {
+		for _, device := range node.Devices {
+			if device.Operable {
+				offered[node.NodeName+"/"+device.DeviceID] = true
+			}
+		}
+	}
+	if len(offered) != 2 {
+		t.Fatalf("expected the two free exclusive cards to be selectable, got %#v", offered)
+	}
+
+	// The picker breaks ties at random, so repeat enough to see every card it
+	// is willing to choose.
+	chosen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+		if !ok {
+			t.Fatalf("expected a placement on one of the free exclusive cards")
+		}
+		for _, allocation := range picked {
+			key := allocation.NodeName + "/" + allocation.DeviceID
+			if !offered[key] {
+				t.Fatalf("install picked %s, which the resume view does not offer as selectable", key)
+			}
+			chosen[key] = true
+		}
+	}
+	if len(chosen) != len(offered) {
+		t.Fatalf("expected the picker to spread across every offered card, got %#v", chosen)
+	}
+}
+
+// TestAutoPickPassesManualBindingValidation covers the other half of the
+// unification: AllocateForInstall now runs its own pick through the validation
+// a user-submitted binding goes through, so the picker must never produce a
+// selection that validation would turn away.
+func TestAutoPickPassesManualBindingValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		req   Requirement
+		nodes []Node
+	}{
+		{
+			name: "single exclusive card",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi, RequiredMemory: gi, LimitedMemory: gi},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive})},
+		},
+		{
+			name: "memory slice card",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi, RequiredMemory: gi, LimitedMemory: gi},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice})},
+		},
+		{
+			name: "multi card on one node",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 24 * gi, LimitedGPU: 24 * gi, SupportMultiCards: true},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+				Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+			)},
+		},
+		{
+			name: "multi card across nodes",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 24 * gi, LimitedGPU: 24 * gi, SupportMultiCards: true, SupportMultiNodes: true},
+			nodes: []Node{
+				nvidiaNode("nvidia-a", Device{ID: "a-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice}),
+				nvidiaNode("nvidia-b", Device{ID: "b-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice}),
+			},
+		},
+		{
+			name:  "gb10 chip",
+			req:   Requirement{Mode: utils.GB10ChipType, RequiredMemory: 24 * gi, LimitedMemory: 48 * gi},
+			nodes: []Node{computeNode("spark-ab12", utils.GB10ChipType, 96*gi, SupportTypeMemorySlice)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			availability := listAvailableForLaunch(tc.req, tc.nodes, PressureSnapshot{})
+			selections, ok := pickLaunchSelection(tc.req, availability, PressureSnapshot{}, allocationOptions{checkPressure: true})
+			if !ok {
+				t.Fatalf("expected the auto-picker to find a placement")
+			}
+			if result := ValidateBindingSelection(tc.req, selections, tc.nodes, PressureSnapshot{}); !result.OK {
+				t.Fatalf("install's own pick %#v was rejected by the manual binding validation: %#v", selections, result)
+			}
+		})
+	}
+}
+
+// TestNonNvidiaNodeExposesEveryDevice covers nvidia-gb10 chips and discrete
+// Intel GPUs, the non-nvidia modes that can put several cards on one node. The
+// availability view used to report only the node's first card, which hid the
+// rest from the resume picker; now that install picks from the same view, that
+// would also have made a busy first card look like a full node.
+func TestNonNvidiaNodeExposesEveryDevice(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "ollama", OwnerName: "alice", SelectedGpuType: utils.GB10ChipType}
+	req := Requirement{Mode: utils.GB10ChipType, RequiredMemory: 24 * gi, LimitedMemory: 24 * gi}
+	nodes := []Node{multiDeviceNode("spark-ab12", utils.GB10ChipType, SupportTypeMemorySlice,
+		Device{ID: "spark-0", Memory: 96 * gi, Bindings: []Allocation{{AppName: "other", Owner: "bob", Memory: 90 * gi}}},
+		Device{ID: "spark-1", Memory: 96 * gi},
+	)}
+
+	result := listAvailableForLaunch(req, nodes, PressureSnapshot{})
+	if len(result.Nodes) != 1 || len(result.Nodes[0].Devices) != 2 {
+		t.Fatalf("expected both cards to be listed for manual selection, got %#v", result.Nodes)
+	}
+
+	picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+	if !ok || len(picked) != 1 {
+		t.Fatalf("expected a single placement on the free card, got ok=%v picked=%#v", ok, picked)
+	}
+	if picked[0].DeviceID != "spark-1" || picked[0].Memory != 24*gi {
+		t.Fatalf("expected a 24Gi slice of the free second card, got %#v", picked[0])
+	}
+}
+
+func multiDeviceNode(name, mode, supportType string, devices ...Device) Node {
+	node := Node{
+		NodeName:       name,
+		GPUTypes:       []string{mode},
+		memoryCapacity: 128 * gi,
+		Devices:        devices,
+	}
+	for i := range node.Devices {
+		node.Devices[i].NodeName = name
+		node.Devices[i].Mode = mode
+		if node.Devices[i].Health == "" {
+			node.Devices[i].Health = deviceHealthYes
+		}
+		if node.Devices[i].SupportType == "" {
+			node.Devices[i].SupportType = supportType
+		}
+	}
+	return node
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -74,9 +74,19 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	var pickedAllocations []Allocation
 	allocation, err := mutateAllocations(ctx, c, func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
 		attachBindings(nodes, withoutAppAllocations(allocations, appConfig.AppName, appConfig.OwnerName))
-		picked, ok := PickAllocations(appConfig, req, nodes, pressure)
+		// Same first step as resume: classify every node and device against
+		// the app's requirement. Where resume hands that view to the user,
+		// install picks from it here and then runs the pick through resume's
+		// own validation so an automatic placement can't bypass a rule a
+		// manual one has to satisfy.
+		availability := listAvailableForLaunch(req, nodes, pressure)
+		selections, ok := pickLaunchSelection(req, availability, pressure, allocationOptions{checkPressure: true})
 		if !ok {
 			return nil, nil, fmt.Errorf("no available compute resource for type %s", req.Mode)
+		}
+		picked, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
+		if !validation.OK {
+			return nil, nil, fmt.Errorf("no available compute resource for type %s: %s", req.Mode, validation.Code)
 		}
 		pickedAllocations = picked
 		next := replaceAppAllocations(allocations, picked)
@@ -85,15 +95,8 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	if err != nil {
 		return nil, err
 	}
-	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
-		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, pickedAllocations); err != nil {
 		return nil, err
-	}
-	for _, item := range pickedAllocations {
-		if err := createHAMIBinding(ctx, c, item); err != nil {
-			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
-			return nil, err
-		}
 	}
 	return allocation, nil
 }
@@ -154,6 +157,19 @@ func EvaluateInstallMode(req Requirement, nodes []Node) ModePlanResult {
 	return ModePlanResult{ComputeType: req.Mode, Status: StatusInsufficientResources, Reason: "insufficient_resources"}
 }
 
+// matchingNodes returns the nodes that support `mode`, each projected onto that
+// single mode (Devices filtered to the mode) so the device-centric helpers only
+// ever see the relevant devices of a multi-mode node.
+func matchingNodes(mode string, nodes []Node) []Node {
+	out := make([]Node, 0)
+	for _, node := range nodes {
+		if node.SupportsMode(mode) {
+			out = append(out, node.viewForMode(mode))
+		}
+	}
+	return out
+}
+
 func PickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
 	return pickAllocations(appConfig, req, nodes, pressure, allocationOptions{checkPressure: true})
 }
@@ -164,31 +180,45 @@ type allocationOptions struct {
 	pressureAdded *AddedResources
 }
 
+// pickAllocations places an app automatically: it builds the availability view
+// resume would show the user, picks a binding out of it, and turns that binding
+// into allocation rows through the same resolve/build path resume uses for a
+// manually submitted one.
 func pickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
-	if req.Mode == utils.CPUType {
+	availability := listAvailableForLaunchWithOptions(req, nodes, pressure, pressureOptions)
+	selections, ok := pickLaunchSelection(req, availability, pressure, pressureOptions)
+	if !ok {
 		return nil, false
 	}
-	matching := matchingNodes(req.Mode, nodes)
-	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, true)
+	resolved, err := resolveSelection(selections, nodes)
+	if err != nil {
+		return nil, false
 	}
-	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, false)
+	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
+	if len(allocations) == 0 {
+		return nil, false
 	}
-	return pickSingleAllocation(appConfig, req, matching, pressure, pressureOptions)
+	return allocations, true
 }
 
-// matchingNodes returns the nodes that support `mode`, each projected onto that
-// single mode (Devices filtered to the mode) so the device-centric scheduling
-// helpers only ever see the relevant devices of a multi-mode node.
-func matchingNodes(mode string, nodes []Node) []Node {
-	out := make([]Node, 0)
-	for _, node := range nodes {
-		if node.SupportsMode(mode) {
-			out = append(out, node.viewForMode(mode))
-		}
+// pickLaunchSelection auto-picks a compute binding out of the availability view
+// that resume hands to the user for a manual pick. Install runs this instead of
+// prompting, so both flows choose among exactly the same devices, ranked the
+// same way: the best fit level first (an app that fits its limit is placed
+// before one that only fits its request), then whole cards before shared ones,
+// then at random among the remaining ties to spread load across the cluster.
+func pickLaunchSelection(req Requirement, availability *AvailabilityResult, pressure PressureSnapshot, opts allocationOptions) ([]BindingSelection, bool) {
+	if availability == nil || req.Mode == utils.CPUType {
+		return nil, false
 	}
-	return out
+	switch availability.Scope {
+	case AvailabilityScopeCrossNode:
+		return pickAggregateSelection(req, availability.Nodes, pressure, opts, true)
+	case AvailabilityScopeSingleNode:
+		return pickAggregateSelection(req, availability.Nodes, pressure, opts, false)
+	default:
+		return pickSingleSelection(req, availability.Nodes, pressure, opts)
+	}
 }
 
 func evaluateCPUInstallMode(req Requirement, nodes []Node) ModePlanResult {
@@ -239,82 +269,87 @@ func installCapacityFits(req Requirement, nodes []Node) bool {
 		}
 		return false
 	}
+	// Non-nvidia modes are scheduled one device at a time, but a node can still
+	// expose several of them (nvidia-gb10 cards, discrete Intel GPUs), so every
+	// device gets a look rather than just the first.
 	for _, node := range nodes {
-		if len(node.Devices) > 0 && node.Devices[0].Memory >= req.RequiredMemory {
-			return true
+		for _, device := range node.Devices {
+			if device.Memory >= req.RequiredMemory {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
+// pickSingleSelection places the app on one device, which is the unit of
+// scheduling for every mode except multi-card nvidia.
+func pickSingleSelection(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions) ([]BindingSelection, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		for _, supportType := range supportTypeOrder(req.Mode) {
-			candidates := make([]Allocation, 0)
+			candidates := make([]BindingSelection, 0)
 			for _, node := range nodes {
-				for _, device := range node.Devices {
-					if supportType != "" && device.SupportType != supportType {
+				for _, option := range node.Devices {
+					if option.SupportType != supportType || !option.Operable {
 						continue
 					}
-					fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, false, 0, pressureOptions)
-					if fits {
-						assigned := requiredTargetForMode(req)
-						if assigned == 0 {
-							assigned = amount
-						}
-						candidates = append(candidates, buildAllocation(appConfig, req, node, device, assigned))
+					if fits, _ := deviceOptionFits(req, option, pressure, level, false, 0, opts); !fits {
+						continue
 					}
+					candidates = append(candidates, selectDevice(option, requiredTargetForMode(req)))
 				}
 			}
 			if len(candidates) > 0 {
-				if pressureOptions.deterministic {
-					return []Allocation{candidates[0]}, true
+				if opts.deterministic {
+					return []BindingSelection{candidates[0]}, true
 				}
-				return []Allocation{candidates[rand.Intn(len(candidates))]}, true
+				return []BindingSelection{candidates[rand.Intn(len(candidates))]}, true
 			}
 		}
 	}
 	return nil, false
 }
 
-func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, crossNode bool) ([]Allocation, bool) {
+// pickAggregateSelection places a multi-card nvidia app across several cards,
+// either within a single node or — when the app declares multi-node support —
+// across the whole cluster.
+func pickAggregateSelection(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions, crossNode bool) ([]BindingSelection, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		target := targetGPU(req, level)
 		if target <= 0 {
 			continue
 		}
 		if crossNode {
-			picked, ok := collectDevicesForTarget(appConfig, req, nodes, pressure, pressureOptions, level, target, req.RequiredGPU)
-			if ok {
-				return picked, ok
+			if picked, ok := collectDevicesForTarget(req, nodes, pressure, opts, level, target, req.RequiredGPU); ok {
+				return picked, true
 			}
 			continue
 		}
 		for _, node := range nodes {
-			picked, ok := collectDevicesForTarget(appConfig, req, []Node{node}, pressure, pressureOptions, level, target, req.RequiredGPU)
-			if ok {
-				return picked, ok
+			if picked, ok := collectDevicesForTarget(req, []NodeOption{node}, pressure, opts, level, target, req.RequiredGPU); ok {
+				return picked, true
 			}
 		}
 	}
 	return nil, false
 }
 
-func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, level string, target, allocationTarget int64) ([]Allocation, bool) {
+func collectDevicesForTarget(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions, level string, target, allocationTarget int64) ([]BindingSelection, bool) {
 	fitRemaining := target
 	allocationRemaining := allocationTarget
-	var out []Allocation
+	var out []BindingSelection
 	timeSliceMemoryByNode := make(map[string]int64)
 	for _, supportType := range supportTypeOrder(req.Mode) {
 		for _, node := range nodes {
-			for _, device := range node.Devices {
-				if supportType != "" && device.SupportType != supportType {
+			for _, option := range node.Devices {
+				if option.SupportType != supportType || !option.Operable {
 					continue
 				}
-				fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, true, timeSliceMemoryByNode[node.NodeName], pressureOptions)
+				fits, amount := deviceOptionFits(req, option, pressure, level, true, timeSliceMemoryByNode[node.NodeName], opts)
 				if !fits || amount <= 0 {
 					continue
 				}
+				_, device := option.asNodeDevice(req.Mode)
 				nextMemory, ok := checkedAdd(timeSliceMemoryByNode[node.NodeName], timeSliceAddedMemory(device))
 				if !ok {
 					continue
@@ -322,7 +357,7 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 				timeSliceMemoryByNode[node.NodeName] = nextMemory
 				if allocationRemaining > 0 {
 					assigned := minInt64(amount, allocationRemaining)
-					out = append(out, buildAllocation(appConfig, req, node, device, assigned))
+					out = append(out, selectDevice(option, assigned))
 					allocationRemaining -= assigned
 				}
 				fitRemaining -= amount
@@ -335,8 +370,21 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 	return nil, false
 }
 
-func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64) (bool, int64) {
-	return deviceFitsLevelWithPressure(req, node, device, pressure, level, allowPartial, priorTimeSliceMemory, allocationOptions{checkPressure: true})
+// selectDevice records a picked device as the same BindingSelection the resume
+// frontend submits. `assigned` only reaches the allocation for memory-slice
+// cards, where the binding carves out an explicit slice; whole-card placements
+// ignore it. A non-positive amount means the app declared no concrete demand
+// for this mode, so it takes whatever the card has free.
+func selectDevice(option DeviceOption, assigned int64) BindingSelection {
+	if assigned <= 0 {
+		assigned = option.Available
+	}
+	return BindingSelection{NodeName: option.NodeName, DeviceID: option.DeviceID, Memory: assigned}
+}
+
+func deviceOptionFits(req Requirement, option DeviceOption, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64, opts allocationOptions) (bool, int64) {
+	node, device := option.asNodeDevice(req.Mode)
+	return deviceFitsLevelWithPressure(req, node, device, pressure, level, allowPartial, priorTimeSliceMemory, opts)
 }
 
 func deviceFitsLevelWithPressure(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64, pressureOptions allocationOptions) (bool, int64) {

--- a/framework/app-service/pkg/compute/scheduler_test.go
+++ b/framework/app-service/pkg/compute/scheduler_test.go
@@ -34,13 +34,14 @@ func TestDeviceFitsLevelTimeSliceMemoryForZeroRequirement(t *testing.T) {
 		RequiredMemory: 5 * gib,
 	}
 
-	fits, _ := deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	opts := allocationOptions{checkPressure: true}
+	fits, _ := deviceFitsLevelWithPressure(req, node, device, pressure, FitLevelRequired, false, 0, opts)
 	if !fits {
 		t.Fatal("zero GPU requirement should preserve the legacy fit decision without time-slice host memory")
 	}
 
 	req.RequiredGPU = gib
-	fits, _ = deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	fits, _ = deviceFitsLevelWithPressure(req, node, device, pressure, FitLevelRequired, false, 0, opts)
 	if fits {
 		t.Fatal("positive GPU requirement must include time-slice host memory")
 	}


### PR DESCRIPTION
## Summary

Install, resume and preflight each decided which accelerator device an app should land on through their own code path. Resume classified every node and device into an availability view and handed it to the user to pick from; install ran a separate node-level scheduler over the raw node snapshot; preflight reused install's scheduler with its own options. Three traversals of the same data meant the three could disagree about which devices were usable.

They now share one pipeline:

1. **Build the availability view.** `listAvailableForLaunch` classifies every node and device against the app's selected requirement, and is the single source of candidates for all three flows. Preflight parameterizes the fit checks via `listAvailableForLaunchWithOptions` so it can simulate against its own pressure budget, but builds the same structure.
2. **Choose from that view.** Resume returns it to the user for a manual pick. Install and preflight call the new `pickLaunchSelection`, which auto-picks from the same classified devices and emits the same `BindingSelection` shape the resume frontend submits.
3. **Apply the selection.** A user's manual pick and install's automatic one converge on `bindAllocations`, which resolves the selection, runs the binding validation and materializes the allocation rows. Install previously constructed allocations directly and skipped that validation.

The old node-level scheduler (`pickSingleAllocation` / `pickAggregateAllocations`) is gone. Its replacements read the view's `DeviceOption`s directly, which turns "install can only place an app where resume would let a user place it" into a structural property rather than two implementations happening to agree.

Ranking behaviour is unchanged: best fit level first, whole cards before shared ones, random among ties, with per-node time-slice accounting for multi-card placements.

## Drive-by fixes

Unifying surfaced two spots where the availability view was less capable than the scheduler it now feeds:

- `classifyNonNvidiaNode` only reported a node's *first* device, so nvidia-gb10 and multi-discrete-Intel-GPU nodes hid their remaining cards from the resume picker — and would have hidden them from install too. It now classifies every device and derives node status from the best card, mirroring the nvidia path.
- `installCapacityFits` had the same truncation for non-nvidia modes.

The first is an additive API change: compute-resource payloads will list more devices for those node types.

## Test plan

- [ ] `go test ./pkg/compute/...`
- [ ] New `launch_selection_test.go` pins the invariants: the auto-pick only ever chooses devices the resume view marks selectable, its selections survive the manual-binding validation, and multi-device non-nvidia nodes expose every card.

Made with [Cursor](https://cursor.com)