### PR TITLE
docs(cli): make app porting checks actionable

### DIFF
--- a/cli/cmd/ctl/settings/apps/domain.go
+++ b/cli/cmd/ctl/settings/apps/domain.go
@@ -524,7 +524,8 @@ This call does NOT resolve DNS. It sets cname_target_status to "set"
 and cname_status to "pending", then returns; verification of both the
 CNAME and the certificate happens asynchronously afterwards. Running
 it before the record exists is accepted silently and simply leaves the
-entrance pending until the upstream check fails.
+entrance pending while the asynchronous checker retries; any later
+failure is visible only through "domain get".
 
 So run it AFTER you've pointed the DNS CNAME at cname_target (see
 "domain get"), then poll "domain get" until cname_status reads

--- a/cli/cmd/ctl/settings/apps/domain.go
+++ b/cli/cmd/ctl/settings/apps/domain.go
@@ -246,8 +246,10 @@ domain is complete as soon as it is set.
                        cert-invalid | timeout | error -- the result
                        of the upstream's asynchronous check
 
-Both statuses read unset right after "domain set"; "domain finish"
-moves them to set / pending. Unrecognized values are printed as-is.
+Adding or changing the third-party domain resets both statuses to
+unset; "domain finish" moves them to set / pending. Updating an
+unchanged domain may preserve its existing state. Unrecognized values
+are printed as-is.
 
 cert / key are NEVER printed in the default table view; pass
 --output json to retrieve them too.
@@ -513,7 +515,7 @@ func certKeyMark(s string) string {
 func newDomainFinishCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "finish <app> <entrance>",
-		Short: "confirm a third-party CNAME is live (Settings UI's \"Finish\" button)",
+		Short: "record a third-party CNAME and start verification (Settings UI's \"Finish\" button)",
 		Long: `Record that the third-party domain's CNAME has been created, and ask
 the upstream to start verifying it. This is the same action triggered
 by the Settings UI's "Finish" button on the Custom Domain dialog.

--- a/cli/cmd/ctl/settings/apps/domain.go
+++ b/cli/cmd/ctl/settings/apps/domain.go
@@ -103,15 +103,20 @@ Set semantics: unspecified flags survive (read-modify-write). Use
 --clear-third-level / --clear-third-party to explicitly drop a
 domain dimension.
 
-Setting a third-party domain requires --cert-file AND --key-file
-(unless you're using --clear-third-party). The cert/key files are
-read verbatim and POSTed as multi-line strings; whatever PEM the
-upstream accepts will round-trip.
+The two kinds are separate pipelines. A third-level domain (the
+"custom route ID" in the UI) is done as soon as it is set: no DNS
+record, no finish, no cname_* state. A third-party domain needs a
+certificate, a CNAME record, a finish and then polling.
 
-After setting a third-party domain you typically need to point the
-DNS CNAME at the upstream's cname_target value (visible via
-"domain get") and then run "domain finish" to ask the upstream to
-verify and activate the cert.
+Setting a third-party domain requires --cert-file AND --key-file
+(unless you're using --clear-third-party), and the entrance's auth
+level must be "public" -- the upstream rejects a private entrance.
+The cert/key files are read verbatim and POSTed as multi-line
+strings, so they must be readable here, and the key must be RSA.
+
+After setting a third-party domain, point the DNS CNAME at the
+upstream's cname_target value (visible via "domain get"), then run
+"domain finish" and poll "domain get" until cname_status is active.
 `,
 	}
 	cmd.SilenceUsage = true
@@ -229,11 +234,23 @@ func newDomainGetCommand(f *cmdutil.Factory) *cobra.Command {
 		Long: `Show the current third-level / third-party / CNAME state for an
 entrance.
 
-The output includes cname_status (None / Default / ThirdLevel /
-ThirdParty), cname_target (the value users should CNAME their
-custom domain at), and cname_target_status (whether the upstream
-has detected the CNAME yet). cert / key are NEVER printed in the
-default table view; pass --output json to retrieve them too.
+Only a third-party domain uses the cname_* fields; a third-level
+domain is complete as soon as it is set.
+
+  cname_target         the value to CNAME the custom domain at --
+                       the Olares zone, not the app's current URL
+  cname_target_status  unset | set -- whether "domain finish" has
+                       been submitted for this domain. It does NOT
+                       mean the upstream has detected the CNAME
+  cname_status         unset | pending | active | cert-not-found |
+                       cert-invalid | timeout | error -- the result
+                       of the upstream's asynchronous check
+
+Both statuses read unset right after "domain set"; "domain finish"
+moves them to set / pending. Unrecognized values are printed as-is.
+
+cert / key are NEVER printed in the default table view; pass
+--output json to retrieve them too.
 
 Examples:
   olares-cli settings apps domain get files file
@@ -328,10 +345,11 @@ flags survive untouched (RMW); pass --clear-third-level or
 
 Setting a third-party domain requires --cert-file AND --key-file. The
 files are read verbatim — pass the same PEM the upstream's UI would
-accept (typically the full chain for the cert).
+accept: the full chain for the cert, and an RSA private key. It also
+requires the entrance's auth level to be "public".
 
 Examples:
-  # Add a sub.example.com CNAME-style third-level domain
+  # Serve the entrance at sub.<zone> as well (no DNS work needed)
   olares-cli settings apps domain set files file --third-level sub
 
   # Switch to a fully custom third-party domain with cert/key
@@ -496,15 +514,19 @@ func newDomainFinishCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "finish <app> <entrance>",
 		Short: "confirm a third-party CNAME is live (Settings UI's \"Finish\" button)",
-		Long: `Ask the upstream to re-check the third-party domain CNAME and finish
-the domain setup. This is the same action triggered by the Settings
-UI's "Finish" button on the Custom Domain dialog.
+		Long: `Record that the third-party domain's CNAME has been created, and ask
+the upstream to start verifying it. This is the same action triggered
+by the Settings UI's "Finish" button on the Custom Domain dialog.
 
-Run this AFTER you've pointed the DNS CNAME at cname_target (see
-"domain get") and given DNS time to propagate. The upstream will
-re-resolve the CNAME and, if it now resolves to cname_target,
-activate the third-party cert and flip cname_target_status to
-"completed".
+This call does NOT resolve DNS. It sets cname_target_status to "set"
+and cname_status to "pending", then returns; verification of both the
+CNAME and the certificate happens asynchronously afterwards. Running
+it before the record exists is accepted silently and simply leaves the
+entrance pending until the upstream check fails.
+
+So run it AFTER you've pointed the DNS CNAME at cname_target (see
+"domain get"), then poll "domain get" until cname_status reads
+"active".
 
 Examples:
   olares-cli settings apps domain finish files file

--- a/cli/skills/olares-chart/SKILL.md
+++ b/cli/skills/olares-chart/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: olares-chart
-version: 4.14.0
+version: 4.15.0
 description: "Olares app packaging and chart authoring via olares-cli chart — port a repo, docker-compose, or generic Helm chart; build/push the image; author, lint, package, and deploy an OlaresManifest; wire storage, middleware, entrances, env, and GPU; edit the chart after diagnosis. Runtime failure diagnosis is olares-doctor; public Market submission is olares-publish."
-compatibility: Requires olares-cli on PATH; chart authoring is local-only, deploy needs login
+compatibility: Requires olares-cli on PATH; chart authoring is local-only, building an image for a specific Olares and deploying both need login
 metadata:
   openclaw:
     requires:
@@ -18,7 +18,7 @@ metadata:
 
 > **Canonical manifest combination:** new ports use `OlaresManifest.yaml apiVersion: v3` + `olaresManifest.version: 0.12.0` + an `olares` `type: system` dependency at `>=1.12.6-0`; current `from-compose` emits all three. Never downgrade these to satisfy `lint`—check for an old CLI or skill. `Chart.yaml apiVersion: v2` is a separate Helm field and remains `v2`.
 
-> **Platform model (read once, no login needed for authoring).** Porting decisions rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). Packaging an image and authoring/validating the chart need no login; only **deploy to your Olares** (`market upload` + `install`) does.
+> **Platform model (read once, no login needed for authoring).** Porting decisions rely on the Olares storage model, uid-1000 run identity, app/namespace & networking, system middleware, and version model — all defined once in [`../olares-shared/references/olares-platform.md`](../olares-shared/references/olares-platform.md). Authoring and validating the chart (`from-compose` / `lint` / `package`) need no login. **Login is needed earlier than the deploy step, though:** as soon as the app is meant to run on a specific Olares, its image must be built for that node's architecture — so the target has to be resolved *before* the first `docker build`. See Axis 1.
 
 ## When to use
 
@@ -41,7 +41,9 @@ Porting an app is **not** a fixed `from-compose → lint → deploy` pipeline �
 
 ## Axis 1 — Packaging (the image)
 
-Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: first query the **target Olares node's architecture** with `olares-cli cluster node list`, then ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and logged in, and **build + push yourself** — only `docker login` stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). Querying the target needs an Olares profile login; Docker packaging itself does not. Build for the target node's arch (single-arch), never the development host's implicit/default arch; multi-arch is only for publishing.
+Olares **pulls images from a registry and never builds from source**, so every workload must reference a publicly pullable, node-arch-correct image. Image work is **agent-driven**: resolve the **target Olares node's architecture** with `olares-cli cluster node list`, then ask which registry the developer uses (Docker Hub / ghcr), check docker is usable and logged in, and **build + push yourself** — only `docker login` stays manual, and only when not already authenticated ([references/olares-chart-image.md](references/olares-chart-image.md)). Build for the target node's arch (single-arch), never the development host's implicit/default arch; multi-arch is only for publishing.
+
+> **The target architecture is a build input, and resolving it cannot be deferred.** `spec.supportArch` and the platform checks around it describe what the chart *claims*; what a built image *is* is a separate fact that no platform-side check inspects. So a wrong guess survives everything you can run locally — build succeeds, push succeeds, `lint` passes — and first shows up as `exec format error` inside the cluster. Docker on Apple Silicon defaults to arm64, which is what an unresolved target silently becomes. Either log in and query the node, or have the developer state the architecture; with **neither, ask instead of building on a guess.** Authoring a chart nobody is deploying yet is the one case that needs no target.
 
 | Packaging state | Do this | Ready when |
 |---|---|---|
@@ -73,7 +75,7 @@ For deploying to your own Olares, **metadata can stay a stub** as long as `lint`
 
 | Axis | Concern | Get this right | Loop back when | Reference |
 |---|---|---|---|---|
-| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for the **target Olares node**; pass it explicitly through Buildx `--platform` rather than using the development host default | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
+| packaging | **Image** | pullable, pinned to a version tag (never `:latest`), arch-correct for the **target Olares node**; pass it explicitly through Buildx `--platform` rather than using the development host default, then clear the **image-readiness gate** (assert the built arch, prove an anonymous pull) before wiring it into the chart | `ImagePullBackOff` / wrong arch, or a deploy constraint forces a rebuild | [image.md](references/olares-chart-image.md) |
 | packaging+deployment | **Run identity** | final app process uid 1000; normally `spec.runAsUser: true`; for verified PUID/PGID root-init images leave it false/absent so the entrypoint can initialize then drop privileges; use initContainer `chown` only for root-owned volumes | EACCES on appData/appCache/userData; forced uid breaks a root-init entrypoint; admission denies an explicit root securityContext | [run-as-user.md](references/olares-chart-run-as-user.md) |
 | deployment | **Storage** | every compose volume → the right userspace area (Data/Cache/Home/Common/External), matching `permission`, leftover kompose PVCs deleted | a volume isn't persisting or lands in the wrong area | [manifest.md](references/olares-chart-manifest.md) §2 |
 | deployment | **Middleware & deps** | no bundled `postgres`/`redis`/`mongo`/…; wire to system middleware; SQLite→Postgres where supported; companion apps as `type: application` deps | a bundled db/queue remains, or a companion should be a dependency | [middleware.md](references/olares-chart-middleware.md) |
@@ -90,6 +92,7 @@ For deploying to your own Olares, **metadata can stay a stub** as long as `lint`
 | deployment | **Metadata** | stub OK for local deploy (`Utilities`, default icon) while `lint` passes; full `metadata.*` + listing images only when publishing | `lint` flags missing metadata, or you want a public listing | [manifest.md](references/olares-chart-manifest.md) §1 |
 | deployment | **Validate-local** | `olares-cli chart lint ./<app>` passes, then `chart package` | a refinement changed the manifest/templates | [lint.md](references/olares-chart-lint.md) |
 | deploy | **Deploy** | `market upload` + `market install`, then diagnose from logs — automatic after `lint` passes (login required) | proving the chart actually runs on the developer's Olares | [deploy.md](references/olares-chart-deploy.md) |
+| deploy | **Custom URL** | only once the app is `running`: a memorable route ID (one command, no DNS), or the developer's own FQDN (auth level `public` + RSA PEM cert + a CNAME only they can add, then activate and poll) | the developer wants a nicer URL, or their own domain | [custom-domain.md](references/olares-chart-custom-domain.md) |
 
 > **Deploy** leans on sibling skills: [`olares-shared`](../olares-shared/SKILL.md) (login check), [`olares-market`](../olares-market/SKILL.md) (upload / install / cleanup), [`olares-cluster`](../olares-cluster/SKILL.md) (logs), and [`olares-doctor`](../olares-doctor/SKILL.md) (runtime root-cause diagnosis when a deploy fails or the app won't start). **After `lint` passes, drive the deploy loop automatically without asking** (proceed unless olares-shared's auth-readiness gate says stop); **never log in on the developer's behalf without asking.** One way to sequence the whole assembly (and the file tree `from-compose` emits) lives in [references/olares-chart-workflow.md](references/olares-chart-workflow.md) — a reference, not a required order.
 

--- a/cli/skills/olares-chart/references/olares-chart-custom-domain.md
+++ b/cli/skills/olares-chart/references/olares-chart-custom-domain.md
@@ -64,7 +64,7 @@ olares-cli settings apps domain get <app> <entrance>
 | Record field | Value | Common mistake |
 |---|---|---|
 | Type | `CNAME` | — |
-| Name / Host | only the **subdomain label** of the custom domain — `media` for `media.example.com` | pasting the whole FQDN, or `@` |
+| Name / Host | the record name **relative to the DNS zone** — `media` for `media.n1.monster` when the managed zone is `n1.monster`; `foo.bar` when it is `example.com` | using `@`, or copying a full FQDN into a provider that expects a relative name |
 | Value / Target | `cname_target` **exactly as printed** | using the app's current Olares URL, the `<appid>` host, or the FQDN being set up |
 
 Never derive the target from the app's access URL. It is not the same string, and the resulting record resolves to something that will never activate.
@@ -94,7 +94,7 @@ olares-cli settings apps domain get <app> <entrance>
 ## Hard constraints
 
 - **Auth level must be `public`.** A custom domain cannot carry Olares authentication, so the platform declines to combine the two: BFL rejects the write outright while the entrance is `private` (`custom domain can not be set when auth level is private`). Treat `public` as the requirement rather than probing what else the backend happens to tolerate — `internal` is not reachable from the internet, which is the entire point of the exercise.
-- **The certificate and its private key must be RSA, PEM, and readable by you.** `--cert-file` / `--key-file` are read verbatim from disk, so a cert sitting in a root-only directory (`/etc/letsencrypt/live/...` is the usual one) has to be copied somewhere readable first — and copied, not moved, or renewal breaks. The cert is normally the full chain.
+- **The certificate and its private key must be RSA, PEM, and readable by you.** `--cert-file` / `--key-file` are read verbatim from disk, so files in a root-only directory (`/etc/letsencrypt/live/...` is the usual one) have to be copied into a private temporary directory first — and copied, not moved, or renewal breaks. Keep the private-key copy mode `0600` and delete it after `domain set` returns. The cert is normally the full chain.
 - **Certbot defaults to ECDSA and must be told otherwise.** `--key-type rsa` at issue time. A default certbot key arrives as an ECDSA key inside a `-----BEGIN PRIVATE KEY-----` (PKCS#8) block, and the platform's validator assumes PKCS#8 means RSA; the result is a failure with nothing useful to read, not a clean rejection. This is worth stating to the developer before they issue, because re-issuing later is another round of DNS work.
 - **`domain set` is read-modify-write.** Passing only `--third-level` leaves an existing third-party domain in place, and vice versa. Dropping one dimension needs `--clear-third-level` / `--clear-third-party`.
 - **The domain must be fully qualified.** `example.com` and `media.example.com` are fine; a bare label or a trailing-dot form is rejected before anything is stored.
@@ -133,5 +133,5 @@ Two facts about issuing are worth passing on, because both cost a DNS round trip
 | `custom domain can not be set when auth level is private` | Pipeline B started before the auth level was changed | `auth-level set --level public`, then retry |
 | `--third-party requires both --cert-file and --key-file` | Domain passed without its cert pair | Supply both, or `--clear-third-party` to drop the domain |
 | `app not set custom domain` from `finish` | `finish` ran on an entrance with no third-party domain — often a typo'd entrance, or `set` silently targeted a different one | `domain get` the entrance and confirm `third_party_domain` before finishing |
-| Cert file unreadable | The PEM lives in a root-only directory | Copy it somewhere readable; do not move it |
+| Cert file unreadable | The PEM lives in a root-only directory | Copy it into a private temporary directory; preserve `0600` on the key, delete the copy after use, and do not move the renewal source |
 | `cname_status` stuck at `pending` | The record is missing, still propagating, or points somewhere other than `cname_target` | Re-read `cname_target` and compare it against what the panel actually holds |

--- a/cli/skills/olares-chart/references/olares-chart-custom-domain.md
+++ b/cli/skills/olares-chart/references/olares-chart-custom-domain.md
@@ -1,0 +1,137 @@
+# Custom URL: route ID or your own domain (post-deploy)
+
+> **Prerequisite:** read the parent [`../SKILL.md`](../SKILL.md) first. This is the last step of a port — the app is already installed and `running`, and the developer wants a URL they can say out loud.
+> **Verb mechanics** (flags, RMW merge, wire fields) live in [`olares-settings-apps.md`](../../olares-settings/references/olares-settings-apps.md#domain-set--rmw-semantics--certkey-handling). This file owns the **process**: which of the two pipelines applies, which stage the entrance is in, and what to ask the developer for next.
+
+Both pipelines run against a **live app** through `olares-cli settings apps domain`, so they need login and an entrance name. Never guess the entrance:
+
+```bash
+olares-cli settings apps entrances list <app>     # ENTRANCE / STATE / AUTH LEVEL / DOMAIN
+```
+
+## Two pipelines, not one flow
+
+The two options share a verb and nothing else. A custom **route ID** stays inside the Olares zone, so the platform owns DNS and TLS and the change is effectively instant. A **third-party domain** is the developer's own FQDN: they own DNS, they supply the certificate, and part of the work happens in a control panel this CLI cannot reach.
+
+```mermaid
+flowchart TD
+  start["entrances list"] --> choose{"which kind?"}
+  choose -->|"custom route ID"| A1["domain set --third-level"]
+  A1 --> Adone["done: no DNS, no finish"]
+  choose -->|"own FQDN"| B0["auth level must be public"]
+  B0 --> B2["domain set --third-party + cert + key"]
+  B2 --> B3["developer adds the CNAME"]
+  B3 --> B4["domain finish"]
+  B4 --> B5["poll until cname_status=active"]
+```
+
+## Pipeline A — custom route ID
+
+The user manual calls this the **custom route ID**; the CLI flag and the wire field call the same thing `--third-level` / `third_level_domain`. Say both names once, or the developer will look for a feature that does not exist.
+
+```bash
+olares-cli settings apps domain set <app> <entrance> --third-level <prefix>
+```
+
+The old URL keeps working; the new one is `https://<prefix>.<zone>`. There is no CNAME and no `finish` in this pipeline — an agent that waits for `cname_status` here waits forever.
+
+- `auth`, `desktop` and `wizard` are reserved. So is any prefix already taken in that user's zone: two entrances sharing one prefix is a collision the write itself does not reject. Audit with [`doctor thirdleveldomain`](../../olares-doctor/references/olares-doctor-thirdleveldomain.md), which reports `duplicate` and `reserved` findings across the zone.
+
+## Pipeline B — the developer's own domain
+
+### Stage detection: read before you write
+
+`domain get` is the whole state machine. Read it first and act on **one** stage only. Handing over every command at once is how a session ends up stalled at a CNAME nobody added, or re-running `set` against a domain that was already activating.
+
+```bash
+olares-cli settings apps domain get <app> <entrance>
+```
+
+| What `domain get` shows | Stage | The only next step |
+|---|---|---|
+| `third_party_domain` empty | not started | Read `AUTH LEVEL` from `entrances list`. Not `public` → set it first (below) |
+| `third_party_domain` set, `cname_target_status` empty or `unset` | waiting on the developer's DNS | Give them the CNAME **verbatim** (below) and stop. Do not run `finish` yet |
+| `cname_target_status=set`, `cname_status=pending` | activating | Poll `domain get`. Nothing to change |
+| `cname_status=active` | done | Confirm over HTTPS and stop |
+| `cname_status=cert-not-found` / `cert-invalid` | the certificate, not DNS | Re-check the PEM pair (below), then `domain set` again |
+| `cname_status=timeout` / `error`, or `pending` for far too long | the CNAME never resolved to the target | Re-read `cname_target`, have them fix the record, then `finish` again |
+| anything else | unknown to this skill | Show the value as-is. Never fold an unrecognized status into "probably fine" |
+
+### The CNAME is where this goes wrong
+
+`cname_target` is the **Olares zone** (e.g. `laresprime.olares.com`), and it is issued by the server. Pass it through untouched, and split the record for the developer explicitly, because a DNS panel asks for two fields and both are easy to fill in wrong:
+
+| Record field | Value | Common mistake |
+|---|---|---|
+| Type | `CNAME` | — |
+| Name / Host | only the **subdomain label** of the custom domain — `media` for `media.example.com` | pasting the whole FQDN, or `@` |
+| Value / Target | `cname_target` **exactly as printed** | using the app's current Olares URL, the `<appid>` host, or the FQDN being set up |
+
+Never derive the target from the app's access URL. It is not the same string, and the resulting record resolves to something that will never activate.
+
+### Sequence
+
+```bash
+# 1. Auth level must be public (see the constraint below).
+olares-cli settings apps auth-level set <app> <entrance> --level public
+
+# 2. Register the domain together with its cert pair.
+olares-cli settings apps domain set <app> <entrance> \
+  --third-party <fqdn> --cert-file <cert.pem> --key-file <key.pem>
+
+# 3. Read the target, hand the developer the record, and wait for them.
+olares-cli settings apps domain get <app> <entrance>
+
+# 4. Only once they confirm the record exists:
+olares-cli settings apps domain finish <app> <entrance>
+
+# 5. Poll. Propagation is minutes to hours, set by their registrar.
+olares-cli settings apps domain get <app> <entrance>
+```
+
+**`finish` does not check DNS.** It flips `cname_target_status` to `set` and `cname_status` to `pending`, and asks the platform to start verifying — that is all. Running it before the record exists is not an error and produces no warning; it just leaves the entrance in `pending` until the platform's own check eventually fails. So gate it on the developer confirming the record, not on a guess about propagation.
+
+## Hard constraints
+
+- **Auth level must be `public`.** A custom domain cannot carry Olares authentication, so the platform declines to combine the two: BFL rejects the write outright while the entrance is `private` (`custom domain can not be set when auth level is private`). Treat `public` as the requirement rather than probing what else the backend happens to tolerate — `internal` is not reachable from the internet, which is the entire point of the exercise.
+- **The certificate and its private key must be RSA, PEM, and readable by you.** `--cert-file` / `--key-file` are read verbatim from disk, so a cert sitting in a root-only directory (`/etc/letsencrypt/live/...` is the usual one) has to be copied somewhere readable first — and copied, not moved, or renewal breaks. The cert is normally the full chain.
+- **Certbot defaults to ECDSA and must be told otherwise.** `--key-type rsa` at issue time. A default certbot key arrives as an ECDSA key inside a `-----BEGIN PRIVATE KEY-----` (PKCS#8) block, and the platform's validator assumes PKCS#8 means RSA; the result is a failure with nothing useful to read, not a clean rejection. This is worth stating to the developer before they issue, because re-issuing later is another round of DNS work.
+- **`domain set` is read-modify-write.** Passing only `--third-level` leaves an existing third-party domain in place, and vice versa. Dropping one dimension needs `--clear-third-level` / `--clear-third-party`.
+- **The domain must be fully qualified.** `example.com` and `media.example.com` are fine; a bare label or a trailing-dot form is rejected before anything is stored.
+- **One entrance at a time.** Domain setup is per-entrance, and an app with several entrances needs the whole pipeline repeated per entrance that should get its own hostname.
+
+## Auth level persistence: know the version boundary
+
+On the **1.12.7** line, a runtime auth-level change is stored in an override slot — per-user `Spec.UserSettings[caller]` for shared apps, the app-global `Spec.Settings["authLevel"]` otherwise — specifically so it survives the reconciler reprojecting chart values over `Spec.Entrances`. The custom domain configuration itself is stored the same way. Two consequences:
+
+- The chart's `entrances[].authLevel` is the **install-time default**, nothing more. Do **not** edit the chart and redeploy to make a `public` entrance "stick"; that is a rebuild-and-reinstall for something the override already handles.
+- **On 1.12.6 and older** there is no override slot, so a reconcile or an upgrade can put the chart's value back and quietly return the entrance to `private` — taking the custom domain's requirement with it. On those versions, re-read the auth level after any upgrade instead of assuming it held.
+
+Either way, **read state back rather than assuming a side effect**: after changing the auth level, re-run `entrances list` and check the app's state, and only call `market resume` if the app actually reads as `stopped`. An unconditional resume is a no-op at best and a surprise restart at worst.
+
+## Tools you may need but must not install
+
+If the developer already has a valid certificate, none of this applies — take the files and move on.
+
+When a certificate has to be issued and they choose certbot, check for it and stop if it is missing:
+
+```bash
+command -v certbot
+```
+
+Missing → say so, name what it is for, and let them install it. Do not install it for them and do not turn this reference into an installation guide for four operating systems.
+
+Two facts about issuing are worth passing on, because both cost a DNS round trip to discover:
+
+- A DNS-01 challenge needs a **TXT** record, which is a different record from the **CNAME** that puts the domain into service. Two records, two purposes, and the TXT one can be removed afterwards.
+- Ask for RSA explicitly (`--key-type rsa`), per the constraint above.
+
+## Common errors
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `custom domain can not be set when auth level is private` | Pipeline B started before the auth level was changed | `auth-level set --level public`, then retry |
+| `--third-party requires both --cert-file and --key-file` | Domain passed without its cert pair | Supply both, or `--clear-third-party` to drop the domain |
+| `app not set custom domain` from `finish` | `finish` ran on an entrance with no third-party domain — often a typo'd entrance, or `set` silently targeted a different one | `domain get` the entrance and confirm `third_party_domain` before finishing |
+| Cert file unreadable | The PEM lives in a root-only directory | Copy it somewhere readable; do not move it |
+| `cname_status` stuck at `pending` | The record is missing, still propagating, or points somewhere other than `cname_target` | Re-read `cname_target` and compare it against what the panel actually holds |

--- a/cli/skills/olares-chart/references/olares-chart-custom-domain.md
+++ b/cli/skills/olares-chart/references/olares-chart-custom-domain.md
@@ -54,7 +54,7 @@ olares-cli settings apps domain get <app> <entrance>
 | `cname_target_status=set`, `cname_status=pending` | activating | Poll `domain get`. Nothing to change |
 | `cname_status=active` | done | Confirm over HTTPS and stop |
 | `cname_status=cert-not-found` / `cert-invalid` | the certificate, not DNS | Re-check the PEM pair (below), then `domain set` again |
-| `cname_status=timeout` / `error`, or `pending` for far too long | the CNAME never resolved to the target | Re-read `cname_target`, have them fix the record, then `finish` again |
+| `cname_status=timeout` / `error`, or `pending` for far too long | verification stalled or failed | Compare the live record with `cname_target`; fix and `finish` again if it differs. If it already matches, treat a persistent error as platform-side |
 | anything else | unknown to this skill | Show the value as-is. Never fold an unrecognized status into "probably fine" |
 
 ### The CNAME is where this goes wrong
@@ -89,13 +89,13 @@ olares-cli settings apps domain finish <app> <entrance>
 olares-cli settings apps domain get <app> <entrance>
 ```
 
-**`finish` does not check DNS.** It flips `cname_target_status` to `set` and `cname_status` to `pending`, and asks the platform to start verifying — that is all. Running it before the record exists is not an error and produces no warning; it just leaves the entrance in `pending` until the platform's own check eventually fails. So gate it on the developer confirming the record, not on a guess about propagation.
+**`finish` does not check DNS.** It flips `cname_target_status` to `set` and `cname_status` to `pending`, and asks the platform to start verifying — that is all. Running it before the record exists is not an error and produces no warning; it leaves the entrance pending while the asynchronous checker retries, and any later failure appears only in `domain get`. So gate it on the developer confirming the record, not on a guess about propagation.
 
 ## Hard constraints
 
 - **Auth level must be `public`.** A custom domain cannot carry Olares authentication, so the platform declines to combine the two: BFL rejects the write outright while the entrance is `private` (`custom domain can not be set when auth level is private`). Treat `public` as the requirement rather than probing what else the backend happens to tolerate — `internal` is not reachable from the internet, which is the entire point of the exercise.
 - **The certificate and its private key must be RSA, PEM, and readable by you.** `--cert-file` / `--key-file` are read verbatim from disk, so files in a root-only directory (`/etc/letsencrypt/live/...` is the usual one) have to be copied into a private temporary directory first — and copied, not moved, or renewal breaks. Keep the private-key copy mode `0600` and delete it after `domain set` returns. The cert is normally the full chain.
-- **Certbot defaults to ECDSA and must be told otherwise.** `--key-type rsa` at issue time. A default certbot key arrives as an ECDSA key inside a `-----BEGIN PRIVATE KEY-----` (PKCS#8) block, and the platform's validator assumes PKCS#8 means RSA; the result is a failure with nothing useful to read, not a clean rejection. This is worth stating to the developer before they issue, because re-issuing later is another round of DNS work.
+- **Certbot defaults to ECDSA and must be told otherwise.** `--key-type rsa` at issue time. A default certbot key arrives as an ECDSA key inside a `-----BEGIN PRIVATE KEY-----` (PKCS#8) block, and the platform's validator assumes PKCS#8 means RSA; the result is a failure with nothing useful to read, not a clean rejection. State this before issuance so the developer does not have to repeat the certificate challenge.
 - **`domain set` is read-modify-write.** Passing only `--third-level` leaves an existing third-party domain in place, and vice versa. Dropping one dimension needs `--clear-third-level` / `--clear-third-party`.
 - **The domain must be fully qualified.** `example.com` and `media.example.com` are fine; a bare label or a trailing-dot form is rejected before anything is stored.
 - **One entrance at a time.** Domain setup is per-entrance, and an app with several entrances needs the whole pipeline repeated per entrance that should get its own hostname.

--- a/cli/skills/olares-chart/references/olares-chart-image.md
+++ b/cli/skills/olares-chart/references/olares-chart-image.md
@@ -54,9 +54,9 @@ flowchart TD
 | 3 | `docker image inspect <ref>:<tag> --format '{{.Architecture}}'` | the output **equals** the target arch |
 | 4 | Start the container (when that proves something — see below) | the process does not exit immediately; an HTTP service answers on its declared port |
 | 5 | `docker buildx build ... --push` (or `docker push <ref>:<tag>`) | the push reports success for that exact tag |
-| 6 | Pull anonymously, with an empty `DOCKER_CONFIG` | the registry serves the manifest **and** the right architecture to a caller holding no credentials |
+| 6 | Inspect anonymously, with an empty `DOCKER_CONFIG` | the registry serves that tag to a caller holding no credentials |
 
-Step 3 is what turns "remember to pass `--platform`" into something that can fail. Step 6 is what turns "the push printed no error" into evidence: Olares nodes pull anonymously, and a logged-in shell cannot tell a public repository from a private one.
+Step 3 is what turns "remember to pass `--platform`" into something that can fail. Step 6 is what turns "the push printed no error" into evidence: Olares nodes pull anonymously, and a logged-in shell cannot tell a public repository from a private one. The remote manifest for a single-platform image does not always carry a `platform` field, so architecture is asserted locally in step 3; step 6 proves anonymous registry access.
 
 Do not wire an image into the chart until step 6 passes.
 
@@ -76,11 +76,15 @@ A mismatch means `--platform` was wrong or missing: rebuild, and do not push. (P
 For an ordinary long-running service, a container that exits at once is a defect visible in seconds — a missing entrypoint dependency, an unwritable runtime path ([run-as-user.md](olares-chart-run-as-user.md)), a wrong `CMD`:
 
 ```bash
-docker run --rm -d --name <app>-smoke -p <host>:<container> <ref>:<tag>
-sleep 5 && docker ps --filter name=<app>-smoke     # still up?
+docker run -d --name <app>-smoke -p <host>:<container> <ref>:<tag>
+sleep 5
+running=$(docker inspect --format '{{.State.Running}}' <app>-smoke)
 docker logs <app>-smoke                            # then curl the declared port for an HTTP service
 docker rm -f <app>-smoke
+test "$running" = true                             # assert only after preserving logs and cleanup
 ```
+
+Do not add `--rm`: if startup fails, automatic removal deletes the container before `docker logs` can explain why. Remove it explicitly after inspecting the result.
 
 Emulating a foreign architecture makes this slow and sometimes impossible. If the container cannot run on this host at all, say so and move on rather than skipping in silence.
 
@@ -89,10 +93,14 @@ Emulating a foreign architecture makes this slow and sometimes impossible. If th
 ### Step 6: verify the pull the node will actually make
 
 ```bash
-DOCKER_CONFIG=$(mktemp -d) docker manifest inspect <ref>:<tag>
+(
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  DOCKER_CONFIG="$tmp" docker manifest inspect <ref>:<tag>
+)
 ```
 
-Run it against a throwaway config dir. **Never `docker logout`** to simulate an anonymous client — that destroys credentials the developer then has to retype. `denied` / `unauthorized` here means the repository is private (ghcr defaults to private on first push: set the package visibility to public) or that the tag was never pushed. Check the `platform.architecture` entry against the target arch while you are here.
+Run it against a throwaway config dir. **Never `docker logout`** to simulate an anonymous client — that destroys credentials the developer then has to retype. `denied` / `unauthorized` here means the repository is private (ghcr defaults to private on first push: set the package visibility to public) or that the tag was never pushed. A manifest list may show `platform.architecture`; a single-image manifest may not, so absence of that field is not a failure.
 
 ## Resolving the target architecture
 
@@ -149,10 +157,10 @@ You drive this end to end — ask the registry, check login, build, push, verify
    docker buildx build --platform linux/<target-arch> --load -t <registry-ref>:<tag> <build-context>
    docker image inspect <registry-ref>:<tag> --format '{{.Architecture}}'      # == <target-arch>
    # start smoke where meaningful, then:
-   docker buildx build --platform linux/<target-arch> --push -t <registry-ref>:<tag> <build-context>
-   DOCKER_CONFIG=$(mktemp -d) docker manifest inspect <registry-ref>:<tag>     # anonymous pull
+   docker push <registry-ref>:<tag>                                           # push the image just inspected
+   # run the anonymous manifest check from step 6
    ```
-   The second build reuses the buildx cache, so it publishes the layers you just asserted rather than rebuilding them. `<build-context>` can be a local path (`.`) or a git URL (e.g. `https://github.com/org/repo.git#main`); use the upstream Dockerfile or one you authored. (Publishing to the public Market? Build multi-arch instead — `--platform linux/amd64,linux/arm64` — per [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
+   `<build-context>` can be a local path (`.`) or a git URL (e.g. `https://github.com/org/repo.git#main`); use the upstream Dockerfile or one you authored. (Publishing to the public Market? Build multi-arch instead — `--platform linux/amd64,linux/arm64` — per [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
 
 ## Handoff: wire the image into the compose
 

--- a/cli/skills/olares-chart/references/olares-chart-image.md
+++ b/cli/skills/olares-chart/references/olares-chart-image.md
@@ -5,7 +5,9 @@
 
 ## Arch strategy
 
-Deploying to your Olares only needs the **target Olares node's arch** (single-arch) — query it with `olares-cli cluster node list` (needs login); `spec.supportArch` is optional. The development host may have a different architecture, so never derive the image platform from `uname`, `runtime.GOARCH`, or Docker's default platform. Multi-arch (`linux/amd64,linux/arm64` + a matching `spec.supportArch: [amd64, arm64]`) is only required when **publishing to the public Market** — see the [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md) skill.
+Deploying to your Olares only needs the **target Olares node's arch** (single-arch) — query it with `olares-cli cluster node list` (needs login). The development host may have a different architecture, so never derive the image platform from `uname`, `runtime.GOARCH`, or Docker's default platform. Multi-arch (`linux/amd64,linux/arm64` + a matching `spec.supportArch: [amd64, arm64]`) is only required when **publishing to the public Market** — see the [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md) skill.
+
+Declare that same architecture in `spec.supportArch`: it is **required and must be non-empty** (`lint` rejects a missing or empty list), and declaring exactly one arch additionally makes app-service pin the app's pods to matching nodes through a `kubernetes.io/arch` nodeSelector. Be clear about what that buys you, though. `spec.supportArch` is a **declaration about the chart**; no platform-side check opens the image to see which architecture was actually built. A chart that declares `amd64` around an arm64 image is consistent to every one of those checks, and still crashes.
 
 ## When you need it
 
@@ -26,21 +28,89 @@ flowchart TD
 - **Repo has no Dockerfile:** read the code to infer the runtime (language, start command, listening port, required env, data directories), **author a Dockerfile**, then build+push.
 - **Repo has a Dockerfile but no official (or no target-arch) image:** build+push from the Dockerfile.
 
-## Image architecture must match the target
+## The image-readiness gate
 
-A wrong-architecture image installs but never runs (`ImagePullBackOff` with `no match for platform`, or the container `exec format error`-crashes):
+Everything below applies to an image **you** build. Four of its properties stay invisible until the cluster rejects it: the architecture actually built, whether it can be pulled **without credentials**, whether the process even starts, and whether the node is still serving older layers under a tag you reused. Reading these rules is not the same as applying them — run the gate and look at its output, because each step is an assertion that can fail here, in seconds, instead of a deploy cycle later.
 
-1. **Find the target node arch:**
-   ```bash
-   olares-cli cluster node list          # ARCHITECTURE shows amd64 / arm64 (needs login)
-   ```
-   If more than one architecture is listed, identify the node that will run the workload and confirm it with `olares-cli cluster node get <name>`. Do not silently choose the development host's architecture. If the target cannot be identified, stop and ask rather than building an image for a guessed platform.
-2. **Inspect a candidate image's platforms** before trusting it:
-   ```bash
-   docker manifest inspect <image-ref>   # look for the platform.architecture entries
-   ```
-   (No docker daemon? Query the registry manifest list over HTTP and read each `platform.architecture`.)
-3. **Build single platform matching the target node** — `--platform linux/amd64` or `linux/arm64`. Always pass `--platform` explicitly; a single-arch image **must** equal the target node arch. (Multi-arch is only for publishing — see [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
+```mermaid
+flowchart TD
+  target["resolve target-arch"] --> build["build with --load"]
+  build --> archChk{"built arch == target-arch?"}
+  archChk -->|no| rebuild["rebuild with --platform"]
+  rebuild --> build
+  archChk -->|yes| smoke{"can it start here?"}
+  smoke -->|yes| run["run it: process stays up"]
+  smoke -->|"no: GPU / cluster deps / job"| note["record why, leave it to the deploy loop"]
+  run --> push["push"]
+  note --> push
+  push --> anon["anonymous pull check"]
+  anon --> ready["image ready: wire it into the chart"]
+```
+
+| # | Step | The assertion |
+|---|---|---|
+| 1 | Resolve the target arch (`olares-cli cluster node list`) | a value exists, and it came from the target rather than from `uname` |
+| 2 | `docker buildx build --platform linux/<target-arch> --load -t <ref>:<tag> <ctx>` | the build carries an explicit platform |
+| 3 | `docker image inspect <ref>:<tag> --format '{{.Architecture}}'` | the output **equals** the target arch |
+| 4 | Start the container (when that proves something — see below) | the process does not exit immediately; an HTTP service answers on its declared port |
+| 5 | `docker buildx build ... --push` (or `docker push <ref>:<tag>`) | the push reports success for that exact tag |
+| 6 | Pull anonymously, with an empty `DOCKER_CONFIG` | the registry serves the manifest **and** the right architecture to a caller holding no credentials |
+
+Step 3 is what turns "remember to pass `--platform`" into something that can fail. Step 6 is what turns "the push printed no error" into evidence: Olares nodes pull anonymously, and a logged-in shell cannot tell a public repository from a private one.
+
+Do not wire an image into the chart until step 6 passes.
+
+### Steps 2-3: build locally first, then assert the architecture
+
+`--push` on its own leaves nothing behind to inspect, so load the image and assert before publishing it:
+
+```bash
+docker buildx build --platform linux/<target-arch> --load -t <ref>:<tag> <build-context>
+docker image inspect <ref>:<tag> --format '{{.Architecture}}'   # must print <target-arch>
+```
+
+A mismatch means `--platform` was wrong or missing: rebuild, and do not push. (Publishing to the public Market builds multi-arch and cannot use `--load` — that path is [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
+
+### Step 4: start it, when starting it proves something
+
+For an ordinary long-running service, a container that exits at once is a defect visible in seconds — a missing entrypoint dependency, an unwritable runtime path ([run-as-user.md](olares-chart-run-as-user.md)), a wrong `CMD`:
+
+```bash
+docker run --rm -d --name <app>-smoke -p <host>:<container> <ref>:<tag>
+sleep 5 && docker ps --filter name=<app>-smoke     # still up?
+docker logs <app>-smoke                            # then curl the declared port for an HTTP service
+docker rm -f <app>-smoke
+```
+
+Emulating a foreign architecture makes this slow and sometimes impossible. If the container cannot run on this host at all, say so and move on rather than skipping in silence.
+
+**Skip the port probe — and say why — when the workload cannot answer one here:** GPU / accelerator images, images bound to host devices, anything that needs cluster middleware (Postgres, Redis, an `.Values.olaresEnv` value) to finish booting, and job or one-shot containers that are *supposed* to exit. A fabricated check on those fails for reasons that mean nothing; the deploy loop is their real test, and the run log should say that this was a choice.
+
+### Step 6: verify the pull the node will actually make
+
+```bash
+DOCKER_CONFIG=$(mktemp -d) docker manifest inspect <ref>:<tag>
+```
+
+Run it against a throwaway config dir. **Never `docker logout`** to simulate an anonymous client — that destroys credentials the developer then has to retype. `denied` / `unauthorized` here means the repository is private (ghcr defaults to private on first push: set the package visibility to public) or that the tag was never pushed. Check the `platform.architecture` entry against the target arch while you are here.
+
+## Resolving the target architecture
+
+A wrong-architecture image installs but never runs (`ImagePullBackOff` with `no match for platform`, or the container `exec format error`-crashes). Gate step 1 is where that value comes from:
+
+```bash
+olares-cli cluster node list          # ARCHITECTURE shows amd64 / arm64 (needs login)
+```
+
+If more than one architecture is listed, identify the node that will run the workload and confirm it with `olares-cli cluster node get <name>` — a single-arch app is pinned to matching nodes, so on a mixed cluster the choice also decides where it can run. Never fall back to the development host's architecture. If the target cannot be identified, stop and ask rather than building for a guessed platform.
+
+**For an image you did not build** — an upstream or third-party ref — read its platforms before trusting it:
+
+```bash
+docker manifest inspect <image-ref>   # look for the platform.architecture entries
+```
+
+(No docker daemon? Query the registry manifest list over HTTP and read each `platform.architecture`.) An upstream image that already covers the target arch needs no gate run; one that doesn't sends you back to building your own.
 
 ## GPU / CUDA images
 
@@ -50,7 +120,7 @@ Building a CUDA image (no GPU needed on the build box, custom-kernel arch flags,
 
 You drive this end to end — ask the registry, check login, build, push, verify. The **only** manual step is the developer typing a registry token into `docker login`, and only when they are not already authenticated. **Never invent/hardcode tokens or push under an account the developer didn't choose.**
 
-1. **Resolve the target Olares node architecture before any build** using `olares-cli cluster node list`, following the multi-node rule above. Keep the resolved value as `<target-arch>`; do not substitute the development host architecture.
+1. **Resolve `<target-arch>` before any build** using `olares-cli cluster node list`, following the multi-node rule above (gate step 1). Never substitute the development host architecture.
 
 2. **Ask which registry the developer uses + the target `<user>/<repo>`** (don't assume one):
    - **Docker Hub** — image ref `<dockerhub-user>/<repo>`
@@ -74,21 +144,19 @@ You drive this end to end — ask the registry, check login, build, push, verify
      - Docker Hub: `docker login` with a Docker Hub **access token** (Account Settings → Security → New Access Token).
      - ghcr: `docker login ghcr.io -u <github-user>` with a **GitHub PAT** that has `write:packages`. After the first push, set the package **visibility to public** so Olares can pull it without auth.
 
-5. **Build for the target node arch and push** — you run this, after confirming `<registry-ref>:<tag>` with the developer:
+5. **Build, assert, start, push, verify** — gate steps 2-6, after confirming `<registry-ref>:<tag>` with the developer:
    ```bash
-   docker buildx build --platform linux/<target-arch> -t <registry-ref>:<tag> --push <build-context>
+   docker buildx build --platform linux/<target-arch> --load -t <registry-ref>:<tag> <build-context>
+   docker image inspect <registry-ref>:<tag> --format '{{.Architecture}}'      # == <target-arch>
+   # start smoke where meaningful, then:
+   docker buildx build --platform linux/<target-arch> --push -t <registry-ref>:<tag> <build-context>
+   DOCKER_CONFIG=$(mktemp -d) docker manifest inspect <registry-ref>:<tag>     # anonymous pull
    ```
-   (Publishing to the public Market? Build multi-arch instead — `--platform linux/amd64,linux/arm64` — per [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
-   `<build-context>` can be a local path (`.`) or a git URL (e.g. `https://github.com/org/repo.git#main`). Use the upstream Dockerfile or one you authored.
-
-6. **Verify the pushed image** before wiring it in:
-   ```bash
-   docker manifest inspect <registry-ref>:<tag>   # confirm the expected platforms are present
-   ```
+   The second build reuses the buildx cache, so it publishes the layers you just asserted rather than rebuilding them. `<build-context>` can be a local path (`.`) or a git URL (e.g. `https://github.com/org/repo.git#main`); use the upstream Dockerfile or one you authored. (Publishing to the public Market? Build multi-arch instead — `--platform linux/amd64,linux/arm64` — per [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
 
 ## Handoff: wire the image into the compose
 
-In the compose (the compose-input capability), replace every `build:` block (and any local-only `image:` tag like `image: app`) with the pushed `<registry-ref>:<tag>`. Now every service is pullable and arch-correct, so proceed to scaffold:
+Once the gate has passed for every service, replace each `build:` block in the compose (and any local-only `image:` tag like `image: app`) with the pushed `<registry-ref>:<tag>`. Every service is now proven pullable and arch-correct, so proceed to scaffold:
 
 ```bash
 olares-cli chart from-compose --name <app> -f docker-compose.yml
@@ -108,6 +176,7 @@ When using a **third-party** image, inspect `docker inspect <ref> --format '{{.C
 ## Hard rules
 
 - **Every service must reference a publicly pullable image** for the node arch — no `build:`, no local-only tags, no private registry (until Olares-local registry support lands).
-- **Deploy to your Olares:** arch must match the node. Verify with `docker manifest inspect`. (Multi-arch + `spec.supportArch` is only for publishing — [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md).)
+- **Deploy to your Olares:** the image's built architecture must equal the node's. Assert it (gate step 3) rather than inferring it from the chart's `spec.supportArch`, which is a declaration and not a fact about the image. (Multi-arch is only for publishing — [`../../olares-publish/SKILL.md`](../../olares-publish/SKILL.md); `spec.supportArch` itself is required either way.)
 - **Never bake registry credentials into the chart** (no `imagePullSecrets` with inline tokens, no secrets in `values.yaml`). Public images only.
-- **Pin every image to a specific version tag** — **never `:latest`** or an untagged image (implicit `latest`). `latest` drifts, so installs become non-reproducible and rollbacks/caching unreliable. Bump the tag when you rebuild. (`lint` does not enforce this — it's on you.)
+- **Pin every image to a specific version tag** — **never `:latest`** or an untagged image (implicit `latest`). `latest` drifts, so installs become non-reproducible and rollbacks/caching unreliable. (`lint` does not enforce this — it's on you.)
+- **Bump the tag on every rebuild, and know why:** a node that already pulled `<ref>:<tag>` keeps serving the cached layers, so pushing new bytes under a tag the node has seen changes nothing on that node. A fix that "did not take effect" after a rebuild is usually this, not the fix. A new tag is also the only way to tell a reused-tag cache hit apart from a chart that was never redeployed.

--- a/cli/skills/olares-chart/references/olares-chart-image.md
+++ b/cli/skills/olares-chart/references/olares-chart-image.md
@@ -30,7 +30,7 @@ flowchart TD
 
 ## The image-readiness gate
 
-Everything below applies to an image **you** build. Four of its properties stay invisible until the cluster rejects it: the architecture actually built, whether it can be pulled **without credentials**, whether the process even starts, and whether the node is still serving older layers under a tag you reused. Reading these rules is not the same as applying them — run the gate and look at its output, because each step is an assertion that can fail here, in seconds, instead of a deploy cycle later.
+Everything below applies to an image **you** build. Three of its properties stay invisible until the cluster rejects it: the architecture actually built, whether it can be pulled **without credentials**, and whether the process even starts. A fourth failure mode — a node continuing to serve cached layers under a reused tag — cannot be detected from the build host, so the hard rule is simpler: every rebuild gets a new tag. Reading these rules is not the same as applying them — run the gate and look at its output, because each step is an assertion that can fail here, in seconds, instead of a deploy cycle later.
 
 ```mermaid
 flowchart TD

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -19,6 +19,8 @@ RUN chown -R 1000:1000 /var/lib/myapp
 USER 1000
 ```
 
+`chown` the **runtime** paths too, not just the data ones: pid files, sockets, lock files and scratch dirs under `/run`, `/var/run` or `/tmp` are written before the app does anything useful, and a base image whose default config puts them in a root-owned directory (nginx, php-fpm, supervisor) fails at startup under `USER 1000`. Either relocate the path in the image's config or make it writable here — a path baked into the image cannot be fixed from the chart.
+
 Verify before pushing:
 
 ```bash
@@ -151,6 +153,7 @@ Omitting `spec.runAsUser` is equivalent for webhook injection. Do not set Pod/co
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | CrashLoop, `Permission denied` writing data dir | uid ≠ 1000 or dir owned by root | A or B above |
+| Container exits at once; the log names a **pid / socket / lock / temp file** it cannot open, under `/run`, `/var/run`, `/var/lib/<app>` or similar | A non-root process is writing a **runtime path the image left owned by root**. This is not about volumes — the path is inside the image, so no chart-side mount or `chown` reaches it | Fix it in the **Dockerfile**, where you are still root: point the path at somewhere the process owns (e.g. nginx `pid /tmp/nginx.pid;`), or `chown 1000:1000` / `chmod` it before `USER 1000`. Rebuild and bump the tag |
 | Install OK but config/data not persisted | Writes go to container-local path, or EACCES silently ignored | Check mount paths + run identity |
 | Admission denied: untrusted image + root | Chart explicitly sets a root-equivalent Pod/container securityContext | Remove the explicit root context; use A, B, or the verified PUID/PGID pattern C |
 | OPA OK but app still can't write | Final process uid is not 1000, or volume pre-dates chown | Use A + B for ordinary images; for pattern C verify `PUID`/`PGID` and the post-init process identity |

--- a/cli/skills/olares-chart/references/olares-chart-run-as-user.md
+++ b/cli/skills/olares-chart/references/olares-chart-run-as-user.md
@@ -19,7 +19,7 @@ RUN chown -R 1000:1000 /var/lib/myapp
 USER 1000
 ```
 
-`chown` the **runtime** paths too, not just the data ones: pid files, sockets, lock files and scratch dirs under `/run`, `/var/run` or `/tmp` are written before the app does anything useful, and a base image whose default config puts them in a root-owned directory (nginx, php-fpm, supervisor) fails at startup under `USER 1000`. Either relocate the path in the image's config or make it writable here — a path baked into the image cannot be fixed from the chart.
+`chown` the **runtime** paths too, not just the data ones: pid files, sockets, lock files and scratch dirs under `/run`, `/var/run` or `/tmp` are written before the app does anything useful, and a base image whose default config puts them in a root-owned directory (nginx, php-fpm, supervisor) fails at startup under `USER 1000`. For an image you build, relocate the path in its config or make it writable here. A third-party image can instead point a configurable runtime path at `/tmp`, or mount a writable `emptyDir` there and prepare its ownership with the trusted init-container pattern below.
 
 Verify before pushing:
 
@@ -153,7 +153,7 @@ Omitting `spec.runAsUser` is equivalent for webhook injection. Do not set Pod/co
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | CrashLoop, `Permission denied` writing data dir | uid ≠ 1000 or dir owned by root | A or B above |
-| Container exits at once; the log names a **pid / socket / lock / temp file** it cannot open, under `/run`, `/var/run`, `/var/lib/<app>` or similar | A non-root process is writing a **runtime path the image left owned by root**. This is not about volumes — the path is inside the image, so no chart-side mount or `chown` reaches it | Fix it in the **Dockerfile**, where you are still root: point the path at somewhere the process owns (e.g. nginx `pid /tmp/nginx.pid;`), or `chown 1000:1000` / `chmod` it before `USER 1000`. Rebuild and bump the tag |
+| Container exits at once; the log names a **pid / socket / lock / temp file** it cannot open, under `/run`, `/var/run`, `/var/lib/<app>` or similar | A non-root process is writing a **runtime path the image left owned by root** | Self-built image: relocate or `chown` the path in the Dockerfile before `USER 1000`, then rebuild and bump the tag. Third-party image: configure a writable path, or overlay it with an `emptyDir` whose ownership is prepared by B |
 | Install OK but config/data not persisted | Writes go to container-local path, or EACCES silently ignored | Check mount paths + run identity |
 | Admission denied: untrusted image + root | Chart explicitly sets a root-equivalent Pod/container securityContext | Remove the explicit root context; use A, B, or the verified PUID/PGID pattern C |
 | OPA OK but app still can't write | Final process uid is not 1000, or volume pre-dates chown | Use A + B for ordinary images; for pattern C verify `PUID`/`PGID` and the post-init process identity |

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-settings
-version: 4.4.3
+version: 4.5.0
 description: "Olares Settings via olares-cli settings — mirror the Settings SPA: users, apps, VPN, network, backup, integrations, GPU/compute, search-index directories/rebuild, and me/whoami. Use for system or post-install app configuration; not for querying file contents with olares-search."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:

--- a/cli/skills/olares-settings/references/olares-settings-apps.md
+++ b/cli/skills/olares-settings/references/olares-settings-apps.md
@@ -19,7 +19,7 @@ The **post-install** surface for an Olares app. Inspect the app, list its entran
 | `domain get <app> <entrance>` | normal | VERIFIED | Per-entrance custom-domain setup |
 | `domain list <app>` | normal | VERIFIED | Every entrance's domain setup |
 | `domain set <app> <entrance> [flags]` | normal | UNVERIFIED | RMW update |
-| `domain finish <app> <entrance>` | normal | UNVERIFIED | Confirm third-party CNAME after DNS propagates |
+| `domain finish <app> <entrance>` | normal | UNVERIFIED | Record that the CNAME exists and start asynchronous verification |
 | `policy get <app> <entrance>` | normal | VERIFIED | Per-entrance auth policy |
 | `policy list <app>` | normal | VERIFIED | Every entrance's policy |
 | `policy set <app> <entrance> [flags]` | normal | UNVERIFIED | RMW update |
@@ -70,7 +70,7 @@ olares-cli settings apps domain set firefox www --clear-third-level
 
 ## `domain get` — reading the third-party stage
 
-Both status fields start empty / `unset` after `domain set`. `finish` is what moves `cname_target_status` to `set` and `cname_status` to `pending`; everything after that is the platform's own asynchronous check writing back.
+Adding or changing the third-party domain resets both status fields to empty / `unset`. `finish` moves `cname_target_status` to `set` and `cname_status` to `pending`; everything after that is the platform's own asynchronous check writing back. An RMW update that keeps the same third-party domain can preserve its existing state.
 
 | `cname_target_status` | `cname_status` | Means |
 |---|---|---|
@@ -80,7 +80,7 @@ Both status fields start empty / `unset` after `domain set`. `finish` is what mo
 | `set` | `cert-not-found` / `cert-invalid` | The certificate side failed, not DNS |
 | any | `timeout` / `error` | The CNAME did not resolve to `cname_target`, or the upstream check failed |
 
-`cname_target` is the user's Olares **zone** (e.g. `laresprime.olares.com`) — it is the CNAME's *value*, while its *name* is only the custom domain's own subdomain label. Print it verbatim; it cannot be derived from the app's current URL. Values outside this table are possible (the field is a plain string on the wire): show them as-is rather than guessing.
+`cname_target` is the user's Olares **zone** (e.g. `laresprime.olares.com`) and is the CNAME's *value*. Its *name* is the custom domain relative to the DNS zone managed at that provider (`media` for `media.n1.monster` in zone `n1.monster`, or `foo.bar` in zone `example.com`). Print the target verbatim; it cannot be derived from the app's current URL. Values outside this table are possible (the field is a plain string on the wire): show them as-is rather than guessing.
 
 ## `policy set` — replace sub-policies
 

--- a/cli/skills/olares-settings/references/olares-settings-apps.md
+++ b/cli/skills/olares-settings/references/olares-settings-apps.md
@@ -42,11 +42,9 @@ olares-cli settings apps policy get firefox www
 # 3. RMW update (unspecified flags survive).
 olares-cli settings apps domain set firefox www --third-level my-firefox
 olares-cli settings apps policy set firefox www --default-policy two_factor
-# 4. Third-party domains: confirm CNAME after DNS propagation.
-olares-cli settings apps domain set firefox www --third-party firefox.example.com \
-  --cert-file /path/to/cert.pem --key-file /path/to/key.pem
-olares-cli settings apps domain finish firefox www
 ```
+
+> **The two domain kinds are two different pipelines, not two steps of one.** `--third-level` is complete on its own — no DNS record, no `finish`, and no `cname_*` field ever becomes relevant. Only `--third-party` involves a certificate, a CNAME the user adds at their registrar, `finish`, and then polling. End-to-end procedure, including which stage an entrance is in and what to ask the user for: [`olares-chart-custom-domain.md`](../../olares-chart/references/olares-chart-custom-domain.md).
 
 ## `domain set` — RMW semantics + cert/key handling
 
@@ -66,8 +64,23 @@ olares-cli settings apps domain set firefox www --clear-third-level
 ```
 
 - **Unspecified flags survive** — RMW under the hood. Pass `--clear-*` to drop a dimension.
-- **Third-party domains REQUIRE both `--cert-file` AND `--key-file`** (unless `--clear-third-party`). The PEM bytes are POSTed verbatim as multi-line strings.
-- After `domain set --third-party`, run `domain finish` once the CNAME propagates. Without `finish`, the SPA shows "pending" status.
+- **Third-party domains REQUIRE both `--cert-file` AND `--key-file`** (unless `--clear-third-party`). The PEM bytes are POSTed verbatim as multi-line strings, so the files must be readable by the CLI's own user, and the key must be RSA.
+- **A third-party domain also requires the entrance's auth level to be `public`** — BFL rejects the write with `custom domain can not be set when auth level is private`. Change it with `auth-level set` first.
+- After `domain set --third-party`, the user adds a CNAME pointing at `cname_target`, and **then** `domain finish` records that they have done so. `finish` does not resolve DNS itself.
+
+## `domain get` — reading the third-party stage
+
+Both status fields start empty / `unset` after `domain set`. `finish` is what moves `cname_target_status` to `set` and `cname_status` to `pending`; everything after that is the platform's own asynchronous check writing back.
+
+| `cname_target_status` | `cname_status` | Means |
+|---|---|---|
+| empty or `unset` | empty or `unset` | Domain registered; **`finish` has not run**. Waiting on the user's DNS record |
+| `set` | `pending` | Activation submitted; the platform is verifying the CNAME and the certificate |
+| `set` | `active` | Live. The custom domain serves the entrance |
+| `set` | `cert-not-found` / `cert-invalid` | The certificate side failed, not DNS |
+| any | `timeout` / `error` | The CNAME did not resolve to `cname_target`, or the upstream check failed |
+
+`cname_target` is the user's Olares **zone** (e.g. `laresprime.olares.com`) — it is the CNAME's *value*, while its *name* is only the custom domain's own subdomain label. Print it verbatim; it cannot be derived from the app's current URL. Values outside this table are possible (the field is a plain string on the wire): show them as-is rather than guessing.
 
 ## `policy set` — replace sub-policies
 
@@ -132,7 +145,7 @@ olares-cli settings apps list --all            # also include uninstalled / pend
 
 - **Always run `entrances list <app>` before any per-entrance edit.** Don't assume entrance names; the user-facing names (e.g. `www`) often differ from the chart-defined service names.
 - **For `policy set`**, surface `policy get` output to the user BEFORE applying — the sub-policy replacement semantics are easy to misuse.
-- **For `domain set --third-party`**, remind the user to set up the CNAME at their DNS provider AND run `domain finish` once it propagates.
+- **For `domain set --third-party`**, run `domain get` first and act on that one stage only (table above). Hand the user the CNAME name/value split verbatim, wait for them to confirm the record exists, then `finish` — a full command list given up front reliably ends with `finish` run against a record nobody added yet.
 - **For UNVERIFIED verbs** (`env set`, `domain set/finish`, `policy set`, `auth-level set`), the result is provisional (not yet smoke-tested against a live instance) — confirm the outcome after running.
 
 ## Common errors
@@ -141,5 +154,7 @@ olares-cli settings apps list --all            # also include uninstalled / pend
 |---|---|---|
 | `entrance '<name>' not found on app '<app>'` | Typo / chart vs user-facing name mismatch | `apps entrances list <app>` to enumerate |
 | `--cert-file and --key-file are required when --third-party is set` | Third-party domain without cert | Provide both, or use `--clear-third-party` |
+| `custom domain can not be set when auth level is private` | Third-party domain on a `private` entrance | `auth-level set <app> <entrance> --level public`, then retry |
+| `app not set custom domain` from `domain finish` | `finish` ran on an entrance with no third-party domain — usually the wrong entrance | `domain get` that entrance and check `third_party_domain` first |
 | `--default-policy: invalid value 'X' (allowed: system, one_factor, two_factor, public)` | Typo | Use one of the four valid values |
 | `auth-level get is not supported (no upstream endpoint); use 'apps entrances list <app>' to read the AUTH LEVEL column` | Tried to GET auth-level | Read from `entrances list` |


### PR DESCRIPTION
## Summary
- turn target architecture handling into an image-readiness gate that verifies the built platform, startup behavior where meaningful, and anonymous registry access
- document custom route IDs and third-party domains as separate staged workflows, including DNS ownership, certificate constraints, and the Olares 1.12.7 auth-level persistence boundary
- align `settings apps domain` help and settings skill status descriptions with the BFL state machine

## Test plan
- [x] `cd cli && go test ./cmd/ctl/settings/apps/...`
- [x] `cd cli && go build ./...`
- [x] `cd cli && go vet ./cmd/ctl/settings/apps/...`
- [x] `cd cli/skills && ./publish.sh --dry-run olares-chart olares-settings`
- [x] `git diff --check origin/main...HEAD`

Made with [Cursor](https://cursor.com)