### PR TITLE
fix(app-service): skip *Failed state writes when ops are canceled

### DIFF
--- a/framework/app-service/pkg/appstate/applying_env_app.go
+++ b/framework/app-service/pkg/appstate/applying_env_app.go
@@ -64,6 +64,20 @@ func (a *ApplyingEnvApp) Exec(ctx context.Context) (StatefulInProgressApp, error
 
 				err := a.exec(c)
 				if err != nil {
+					// A cancel (POST /cancel, the TTL watchdog or a force uninstall)
+					// cancels opCtx, which is what aborts the helm env upgrade and
+					// the startup wait, so err here is the cancellation itself rather
+					// than an applyEnv failure. The initiator already wrote the
+					// terminal target state (ApplyingEnvCanceling for cancel,
+					// Uninstalling for force uninstall) and owns the transition;
+					// ApplyingEnvCanceling -> ApplyEnvFailed is not a declared
+					// transition, so this write would only be rejected by the guard.
+					// Bail out quietly and let the initiator drive the state.
+					if c.Err() != nil {
+						klog.Infof("applyEnv of app %s canceled; leaving terminal state to the initiator", a.manager.Spec.AppName)
+						return
+					}
+
 					a.finally = func() {
 						klog.Info("ApplyEnv operation failed, update app status to ApplyEnvFailed, ", a.manager.Name)
 						opRecord := makeRecord(a.manager, appsv1.ApplyEnvFailed,

--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -120,6 +120,21 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				// timeout so operators can investigate, and InstallFailedApp.Exec
 				// will keep retrying the same helper on subsequent reconciles.
 				toInstallFailed := func(msg string) {
+					// A cancel (DELETE /apps/{name}/install) or a force uninstall
+					// cancels opCtx, which is what aborts validation / helm install
+					// / scale-up, so msg here describes the cancellation rather than
+					// an install failure. The initiator already wrote the terminal
+					// target state (InstallingCanceling for cancel, Uninstalling for
+					// force uninstall) and owns both the teardown and the following
+					// transition; InstallingCanceling -> InstallFailed is not a
+					// declared transition, so the write below would only be rejected
+					// by the guard while the cleanup duplicates the cancel path's.
+					// Bail out quietly and let the initiator drive the state.
+					if c.Err() != nil {
+						klog.Infof("install of app %s canceled; leaving cleanup and terminal state to the initiator", p.manager.Spec.AppName)
+						return
+					}
+
 					cleanupErr := cleanupAfterInstallFailure(context.TODO(), p.client, p.manager)
 					finalMsg := msg
 					if cleanupErr != nil {
@@ -185,6 +200,15 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				err = ops.Install()
 				if err != nil {
 					klog.Errorf("install app %s failed %v", p.manager.Spec.AppName, err)
+					// Same reasoning as in toInstallFailed, applied before the
+					// pending-pod branches below: those write Stopping directly,
+					// which InstallingCanceling does not allow either, and the
+					// cancel path already releases the compute allocation as part
+					// of its uninstall.
+					if c.Err() != nil {
+						klog.Infof("install of app %s canceled during helm install; leaving cleanup and terminal state to the initiator", p.manager.Spec.AppName)
+						return
+					}
 					// Release compute allocation up-front so the pending-pod paths
 					// (ErrServerSidePodPending / ErrPodPending → Stopping) don't leak
 					// the GPU/compute reservation. The generic InstallFailed branch

--- a/framework/app-service/pkg/appstate/operation_cancel_race_test.go
+++ b/framework/app-service/pkg/appstate/operation_cancel_race_test.go
@@ -1,0 +1,152 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute/validation"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	"k8s.io/client-go/rest"
+)
+
+// The three tests below pin the cancel guards added to InstallingApp,
+// UpgradingApp and ApplyingEnvApp, mirroring InitializingApp: when the
+// operation context is canceled (a *Canceling app's Cleanup, or a force
+// uninstall) the in-flight goroutine must NOT publish its own terminal state,
+// because the initiator already owns the transition and *Canceling -> *Failed
+// is not a declared edge in StateTransitions.
+//
+// Each test blocks the operation goroutine on a seam, cancels the operation via
+// Cleanup (what cancelOperation does in production), releases the seam with an
+// error and then asserts that the ApplicationManager was left in the operating
+// state for the initiator to move on.
+
+// blockingKubeConfig returns a KubeConfig seam that reports it was reached, then
+// blocks until release is closed and finally fails. Every operation goroutine
+// calls it first, so it is a reliable place to freeze one mid-flight.
+func blockingKubeConfig(started chan<- struct{}, release <-chan struct{}) func() (*rest.Config, error) {
+	return func() (*rest.Config, error) {
+		close(started)
+		<-release
+		return nil, errors.New("operation aborted")
+	}
+}
+
+func TestUpgrade_CanceledExecSkipsUpgradeFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("upgrade-race", appv1alpha1.App, appv1alpha1.Upgrading, appv1alpha1.UpgradeOp,
+		configJSON(t, "upgrade-race", false))
+	c := newFakeClient(t, am)
+	deps, _ := newTestDeps(c)
+
+	started, release := make(chan struct{}), make(chan struct{})
+	deps.KubeConfig = blockingKubeConfig(started, release)
+
+	p := &UpgradingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+		downloadTTL: time.Hour,
+		imageClient: &fakeImageManager{},
+	}
+
+	in, err := p.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	// Finally blocks until the goroutine either publishes a transition or closes
+	// finallyCh on its way out, so it doubles as a barrier: no sleep needed.
+	p.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.Upgrading {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.Upgrading)
+	}
+}
+
+func TestApplyEnv_CanceledExecSkipsApplyEnvFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("applyenv-race", appv1alpha1.App, appv1alpha1.ApplyingEnv, appv1alpha1.ApplyEnvOp,
+		configJSON(t, "applyenv-race", false))
+	c := newFakeClient(t, am)
+	deps, _ := newTestDeps(c)
+
+	started, release := make(chan struct{}), make(chan struct{})
+	deps.KubeConfig = blockingKubeConfig(started, release)
+
+	a := &ApplyingEnvApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+
+	in, err := a.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	// No finallyCh barrier here, so give the goroutine room to reach its guard
+	// before running the hook it would have installed without the fix.
+	time.Sleep(200 * time.Millisecond)
+	in.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.ApplyingEnv {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.ApplyingEnv)
+	}
+}
+
+func TestInstall_CanceledExecSkipsInstallFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("install-race", appv1alpha1.App, appv1alpha1.Installing, appv1alpha1.InstallOp,
+		configJSON(t, "install-race", false))
+	c := newFakeClient(t, am)
+	deps, tf := newTestDeps(c)
+
+	// Freeze inside validation: it is the first step of the install goroutine
+	// and its failure funnels straight into toInstallFailed.
+	started, release := make(chan struct{}), make(chan struct{})
+	tf.validation = func(ctx context.Context, in validation.Input) (validation.Decision, error) {
+		close(started)
+		<-release
+		return validation.Decision{}, errors.New("validation aborted")
+	}
+
+	p := &InstallingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+
+	in, err := p.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	time.Sleep(200 * time.Millisecond)
+	in.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.Installing {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.Installing)
+	}
+}

--- a/framework/app-service/pkg/appstate/resuming_app.go
+++ b/framework/app-service/pkg/appstate/resuming_app.go
@@ -169,6 +169,15 @@ func (p *resumingInProgressApp) WaitAsync(ctx context.Context) {
 				klog.Infof("app %s stop requested while resuming, skip setting ResumeFailed", p.manager.Spec.AppName)
 				return
 			}
+			// A canceled poll means another path (Resuming -> ResumingCanceling
+			// via Cancel, which stops the polling) already owns the next
+			// transition, so ResumeFailed must not be written here: the
+			// transition guard would reject it anyway
+			// (ResumingCanceling -> ResumeFailed is not declared).
+			if errors.Is(err, context.Canceled) {
+				klog.Infof("app %s resume canceled while waiting for startup, skip setting ResumeFailed", p.manager.Spec.AppName)
+				return
+			}
 			opRecord := makeRecord(p.manager, appsv1.ResumeFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
 			updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.ResumeFailed, opRecord, err.Error(), appsv1.ResumeFailed.String())
 			if updateErr != nil {
@@ -202,13 +211,26 @@ func (p *resumingInProgressApp) poll(ctx context.Context) error {
 		return unrecoverableErr
 	}
 
-	isPending, err := p.stopRequested(ctx)
+	// Reaching here means IsStartUp returned (false, nil), which only happens
+	// when the poll context was canceled. Use a detached context for the
+	// annotation lookup so the canceled poll context doesn't turn the check
+	// into a spurious error (and clobber the real reason we stopped polling).
+	isPending, err := p.stopRequested(context.WithoutCancel(ctx))
 	if err != nil {
 		return err
 	}
 	if isPending {
 		return errStopRequestedDueToPendingPod
 	}
+
+	// The operation was canceled or superseded (e.g. cancel-by-timeout moved
+	// the app to ResumingCanceling and stopped polling). Surface the context
+	// error so WaitAsync skips the ResumeFailed write, the same way
+	// downloadingInProgressApp.WaitAsync skips DownloadFailed.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return fmt.Errorf("wait for app %s startup failed", p.manager.Spec.AppName)
 }
 

--- a/framework/app-service/pkg/appstate/resuming_cancel_race_test.go
+++ b/framework/app-service/pkg/appstate/resuming_cancel_race_test.go
@@ -1,0 +1,69 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+)
+
+// newResumingInProgress wires a resumingInProgressApp against the fake client
+// with an unreachable kube config (the event tier fails fast, matching the
+// other resume tests).
+func newResumingInProgress(t *testing.T, am *appv1alpha1.ApplicationManager) *resumingInProgressApp {
+	t.Helper()
+	dep, pod := pendingWorkload(am.Spec.AppName, am.Spec.AppNamespace)
+	c := newFakeClient(t, dep, pod, am)
+	deps, tf := newTestDeps(c)
+	tf.kubeConfig = unreachableKubeConfig()
+
+	rp := &ResumingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+	return &resumingInProgressApp{
+		ResumingApp:                       rp,
+		basePollableStatefulInProgressApp: &basePollableStatefulInProgressApp{},
+	}
+}
+
+// TestResume_Poll_CanceledReturnsContextCanceled pins the fix for the
+// ResumingCanceling -> ResumeFailed race: when the poll context is canceled
+// (cancel-by-timeout moves the app to ResumingCanceling and stops polling),
+// poll must report the context error so WaitAsync skips the ResumeFailed write
+// that the transition guard would otherwise reject.
+func TestResume_Poll_CanceledReturnsContextCanceled(t *testing.T) {
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	ip := newResumingInProgress(t, am)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate Cleanup -> stopPolling cancelling the poll context
+
+	err := ip.poll(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestResume_Poll_StopRequestedSurvivesCanceledCtx verifies the detached-context
+// annotation read: even when the poll context is canceled, a pending-pod stop
+// request is still detected (errStopRequestedDueToPendingPod) rather than being
+// masked by the cancellation.
+func TestResume_Poll_StopRequestedSurvivesCanceledCtx(t *testing.T) {
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	am.Annotations = map[string]string{api.AppStopByControllerDuePendingPod: "true"}
+	ip := newResumingInProgress(t, am)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ip.poll(ctx)
+	if !errors.Is(err, errStopRequestedDueToPendingPod) {
+		t.Fatalf("expected errStopRequestedDueToPendingPod, got %v", err)
+	}
+}

--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -103,6 +103,22 @@ func (p *UpgradingApp) Exec(ctx context.Context) (StatefulInProgressApp, error) 
 						execErr = fmt.Errorf("panic: %v", r)
 					}
 					if execErr != nil {
+						// A cancel (POST /cancel, the TTL watchdog or a force
+						// uninstall) cancels opCtx, which is what aborts the image
+						// download / helm upgrade / startup wait, so execErr here is
+						// the cancellation itself rather than an upgrade failure. The
+						// initiator already wrote the terminal target state
+						// (UpgradingCanceling for cancel, Uninstalling for force
+						// uninstall) and UpgradingCancelingApp owns the transition to
+						// Stopping; UpgradingCanceling -> UpgradeFailed is not a
+						// declared transition, so this write would only be rejected
+						// by the guard. Bail out quietly (Finally() tolerates the
+						// closed channel) and let the initiator drive the state.
+						if c.Err() != nil {
+							klog.Infof("upgrade of app %s canceled; leaving terminal state to the initiator", p.manager.Spec.AppName)
+							return
+						}
+
 						reason := appsv1.UpgradeFailed.String()
 						if errors.Is(execErr, errcode.ErrPodPending) || errors.Is(execErr, errcode.ErrServerSidePodPending) {
 							reason = constants.AppUnschedulable

--- a/framework/app-service/pkg/security/namespace.go
+++ b/framework/app-service/pkg/security/namespace.go
@@ -37,6 +37,12 @@ var (
 	OSProtectedNamespaces = []string{
 		"os-protected",
 	}
+	OSMeshNamespaces = []string{
+		"os-mesh",
+	}
+	OSGatewayNamespaces = []string{
+		"os-gateway",
+	}
 )
 
 // IsUserInternalNamespaces returns true if namespace is user level namespace for a user application, false otherwise.

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -116,6 +116,16 @@ func (wh *Webhook) CreateOrUpdateSandboxMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.OSProtectedNamespaces,
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -421,6 +431,16 @@ func (wh *Webhook) CreateOrUpdateGpuLimitMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   []string{"user-space"},
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
 					},
 				},
 				ObjectSelector: &metav1.LabelSelector{
@@ -708,6 +728,16 @@ func (wh *Webhook) CreateOrUpdateRunAsUserMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -808,6 +838,16 @@ func (wh *Webhook) CreateOrUpdateAppLabelMutatingWebhook() error {
 							Key:      "kubernetes.io/metadata.name",
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
 						},
 					},
 				},
@@ -1289,6 +1329,16 @@ func (wh *Webhook) CreateOrUpdatePodArchNodeSelectorMutatingWebhook() error {
 							Key:      "kubernetes.io/metadata.name",
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
 						},
 					},
 				},


### PR DESCRIPTION
* **Background**
Cancel/force-uninstall already owns the terminal transition; writing InstallFailed/UpgradeFailed/ApplyEnvFailed/ResumeFailed races the guard and can leave cleanup inconsistent. Also exclude os-mesh/os-gateway from some mutating webhooks.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ApplicationManager state transitions and admission webhook scope; incorrect guards could leave apps stuck or skip real failures, but changes are narrow defensive checks plus namespace exclusions for system tiers.
> 
> **Overview**
> Fixes **cancel/force-uninstall races** where in-flight install, upgrade, apply-env, and resume work could still publish `*Failed` (or run install-failure cleanup) after the operation context was canceled. Those paths now **bail out when `c.Err()` / `context.Canceled`** so the cancel or uninstall initiator keeps owning the terminal transition (`*Canceling` → …), matching the pattern already used for initializing.
> 
> For **resume**, polling now returns **`context.Canceled`** when the poll context is stopped, **`WaitAsync` skips `ResumeFailed`** in that case, and pending-pod stop detection uses a **detached context** so cancellation does not mask a real stop request.
> 
> Adds **race tests** for install, upgrade, apply-env, and resume cancel behavior.
> 
> Separately, **`os-mesh` and `os-gateway`** are added to protected namespace lists and **excluded from several mutating admission webhooks** (sandbox, GPU limit, run-as-user, app-label, pod-arch) so mesh/gateway workloads are not mutated like user apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d323f924b139acafdb2b2d15c8f0beacd0c09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->