### PR TITLE
fix: files client_max_body_size down to 100M

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -609,7 +609,7 @@ data:
 
       sendfile        on;
       keepalive_timeout  2700;
-      client_max_body_size 4000M;
+      client_max_body_size 100M;
 
       client_body_buffer_size 64m;
       proxy_buffers 32 256k;
@@ -643,7 +643,7 @@ data:
       gzip_http_version 1.1;
       gzip_comp_level 6;
       gzip_types *;
-      client_max_body_size 2000M;
+      client_max_body_size 100M;
       root /app;
 
       # normal routes
@@ -666,7 +666,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
 
           client_body_timeout 600s;
-          client_max_body_size 2000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -683,7 +683,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
 
           client_body_timeout 1800s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 2700s;
           proxy_read_timeout 1800s;
@@ -700,7 +700,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
 
           client_body_timeout 1800s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 2700s;
           proxy_read_timeout 1800s;
@@ -716,7 +716,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
           add_header Accept-Ranges bytes;
           client_body_timeout 1800s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 2700s;
           proxy_read_timeout 1800s;
@@ -732,7 +732,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
           add_header Accept-Ranges bytes;
           client_body_timeout 1800s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 2700s;
           proxy_read_timeout 1800s;
@@ -748,7 +748,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
           add_header Accept-Ranges bytes;
           client_body_timeout 1800s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 2700s;
           proxy_read_timeout 1800s;
@@ -765,7 +765,7 @@ data:
           proxy_set_header X-Forwarded-Host $host;
 
           client_body_timeout 60s;
-          client_max_body_size 2000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 75s;
           proxy_read_timeout 60s;
@@ -784,7 +784,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -803,7 +803,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -849,7 +849,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -868,7 +868,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 4000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -887,7 +887,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 2000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -906,7 +906,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 2000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;
@@ -925,7 +925,7 @@ data:
           add_header Accept-Ranges bytes;
 
           client_body_timeout 600s;
-          client_max_body_size 2000M;
+          client_max_body_size 100M;
           proxy_request_buffering off;
           keepalive_timeout 750s;
           proxy_read_timeout 600s;


### PR DESCRIPTION
Background
- fix: files client_max_body_size down to 100M

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- none

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightening upload limits can break large file uploads and Seafile/API raw flows that relied on multi-gigabyte nginx allowances; no auth changes, but user-visible regression risk is real.
> 
> **Overview**
> Lowers the **files** service nginx upload ceiling by standardizing **`client_max_body_size`** to **100M** everywhere it was previously **2000M** or **4000M** (global `http`/`server` defaults and per-`location` overrides for API, raw upload, Seafile, and related proxy routes).
> 
> This is a behavioral change: HTTP requests with bodies larger than 100MB will be rejected at nginx (typically **413**) before they reach the filebrowser backend. The **`/upload`** block is unchanged in this diff and still has no explicit `client_max_body_size`; inherited limits now apply. **`UPLOAD_LIMITED_SIZE`** on the files container is unchanged (~110GB), so the effective cap for traffic through this nginx front door becomes **100M**, not the app env limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b4c6e355f8adb3cb499ed6e98c5acf093d05ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->