### PR TITLE
olares: bump system-frontend to v1.11.23

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -301,7 +301,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.20
+          image: beclab/system-frontend:v1.11.23
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Bump the bundled system application image to its latest release:
- `beclab/system-frontend` (TermiPass): `v1.11.20` -> `v1.11.23`

This update pulls in the latest fixes and improvements from the TermiPass sub-system.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
- https://github.com/beclab/TermiPass/pull/1331

* **Other information**:
Image reference is updated in `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml` for the `olares-app-init` container.

Made with [Cursor](https://cursor.com)