### PR TITLE
fix(app-service): stop image pull on IM delete and reuse downloading IM

### DIFF
--- a/framework/app-service/controllers/image_controller.go
+++ b/framework/app-service/controllers/image_controller.go
@@ -64,6 +64,15 @@ func (r *ImageManagerController) SetupWithManager(mgr ctrl.Manager) error {
 				return r.preEnqueueCheckForUpdate(e.ObjectOld, e.ObjectNew)
 			},
 			DeleteFunc: func(e event.TypedDeleteEvent[*appv1alpha1.ImageManager]) bool {
+				// Only cancel in-flight pulls. Terminal IMs have nothing
+				// running; calling cancel would only log a no-op error.
+				if e.Object != nil && !isTerminalState(e.Object.Status.State) {
+					go func() {
+						if err := r.cancel(e.Object); err != nil {
+							klog.Infof("cancel im=%s on delete: %v", e.Object.Name, err)
+						}
+					}()
+				}
 				return false
 			},
 		},

--- a/framework/app-service/pkg/images/client.go
+++ b/framework/app-service/pkg/images/client.go
@@ -63,6 +63,13 @@ func (imc *ImageManagerClient) Create(ctx context.Context, am *appv1alpha1.Appli
 	var im appv1alpha1.ImageManager
 	err = imc.Get(ctx, types.NamespacedName{Name: am.Name}, &im)
 	if err == nil {
+		// Reuse an in-flight IM (e.g. app-service restarted while download
+		// was still running). Delete+recreate would cancel the pull and
+		// lose progress for no benefit.
+		if im.Status.State == appv1alpha1.Downloading.String() {
+			klog.Infof("imagemanager name=%s already downloading, skip recreate", im.Name)
+			return nil
+		}
 		err = imc.Delete(ctx, &im)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err


### PR DESCRIPTION


* **Background**
Cancel in-flight downloads when an ImageManager is deleted, and skip delete+recreate when Create finds an IM already in downloading so restarts do not wipe pull progress.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
