### PR TITLE
fix(app-service): validate upgrade resource headroom on delta

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -446,18 +446,18 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	// Reject upgrades whose new chart's declared resource requirements
-	// exceed the cluster's total schedulable capacity, before we acquire
-	// any env-batch lease or kick off helm. Mirrors the install handler's
-	// cluster-capacity gate (handler_installer_install.go) but uses the
-	// upgrade-specific chain — UpgradabilityValidators currently only
-	// runs clusterCapacityValidator (see that function for why the other
-	// install-time checks are intentionally skipped on upgrade).
+	// Reject upgrades the cluster can't accommodate before we acquire any
+	// env-batch lease or kick off helm. UpgradabilityValidators runs
+	// cluster-capacity against the new chart's absolute requirements, plus
+	// cluster-pressure / k8s-request against the non-negative delta
+	// (new − old) so the running deployment is not double-counted (see
+	// that function for details). 
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
-		Client:    h.ctrlClient,
-		AppConfig: appCfg,
-		Op:        appv1alpha1.UpgradeOp,
-		Token:     token,
+		Client:        h.ctrlClient,
+		AppConfig:     appCfg,
+		PrevAppConfig: &prevCfg,
+		Op:            appv1alpha1.UpgradeOp,
+		Token:         token,
 	}, validation.UpgradabilityValidators()...)
 	if err != nil {
 		api.HandleError(resp, req, err)

--- a/framework/app-service/pkg/compute/upgrade_resources.go
+++ b/framework/app-service/pkg/compute/upgrade_resources.go
@@ -1,0 +1,57 @@
+package compute
+
+import (
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// UpgradeResourceDelta returns the non-negative per-dimension increase
+// from prev to next app declared requirements. Negative deltas (resource
+// reductions) are clamped to zero: upgrade pressure/quota checks only
+// ask whether the cluster can absorb additional demand; releasing
+// resources does not need a headroom check.
+//
+// Units match AddedResourcesFromAppConfig: CPU in milli-cores, Memory
+// and Disk in bytes.
+func UpgradeResourceDelta(prev, next *appcfg.ApplicationConfig) AddedResources {
+	old := AddedResourcesFromAppConfig(prev)
+	neu := AddedResourcesFromAppConfig(next)
+	return AddedResources{
+		CPU:    maxInt64(0, neu.CPU-old.CPU),
+		Memory: maxInt64(0, neu.Memory-old.Memory),
+		Disk:   maxInt64(0, neu.Disk-old.Disk),
+	}
+}
+
+// AppConfigWithRequirement returns a shallow copy of base whose
+// Requirement CPU/Memory/Disk are set from added (nil for zero dims so
+// resourceStateFromConfig skips them). Accelerator is cleared so any
+// SelectedRequirement lookup cannot override the injected delta.
+// OwnerName and other identity fields are preserved for user-quota
+// lookups.
+func AppConfigWithRequirement(base *appcfg.ApplicationConfig, added AddedResources) *appcfg.ApplicationConfig {
+	if base == nil {
+		return nil
+	}
+	cfg := *base
+	cfg.Accelerator = nil
+	cfg.Requirement = appcfg.AppRequirement{}
+	if added.CPU > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(added.CPU, resource.DecimalSI)
+	}
+	if added.Memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(added.Memory, resource.BinarySI)
+	}
+	if added.Disk > 0 {
+		cfg.Requirement.Disk = resource.NewQuantity(added.Disk, resource.BinarySI)
+	}
+	return &cfg
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/framework/app-service/pkg/compute/upgrade_resources_test.go
+++ b/framework/app-service/pkg/compute/upgrade_resources_test.go
@@ -1,0 +1,125 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func legacyConfig(cpuMilli, memory, disk int64) *appcfg.ApplicationConfig {
+	cfg := &appcfg.ApplicationConfig{AppName: "app", OwnerName: "alice"}
+	if cpuMilli > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(cpuMilli, resource.DecimalSI)
+	}
+	if memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(memory, resource.BinarySI)
+	}
+	if disk > 0 {
+		cfg.Requirement.Disk = resource.NewQuantity(disk, resource.BinarySI)
+	}
+	return cfg
+}
+
+func TestUpgradeResourceDelta(t *testing.T) {
+	cases := []struct {
+		name string
+		prev *appcfg.ApplicationConfig
+		next *appcfg.ApplicationConfig
+		want AddedResources
+	}{
+		{
+			name: "increase all dims",
+			prev: legacyConfig(1000, 1<<30, 2<<30),
+			next: legacyConfig(2500, 3<<30, 5<<30),
+			want: AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 3 << 30},
+		},
+		{
+			name: "unchanged",
+			prev: legacyConfig(1000, 1<<30, 2<<30),
+			next: legacyConfig(1000, 1<<30, 2<<30),
+			want: AddedResources{},
+		},
+		{
+			name: "decrease clamps to zero",
+			prev: legacyConfig(2500, 3<<30, 5<<30),
+			next: legacyConfig(1000, 1<<30, 2<<30),
+			want: AddedResources{},
+		},
+		{
+			name: "missing prev dims treat as zero",
+			prev: &appcfg.ApplicationConfig{AppName: "app"},
+			next: legacyConfig(1500, 2<<30, 4<<30),
+			want: AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 4 << 30},
+		},
+		{
+			name: "nil prev",
+			prev: nil,
+			next: legacyConfig(500, 1<<20, 1<<20),
+			want: AddedResources{CPU: 500, Memory: 1 << 20, Disk: 1 << 20},
+		},
+		{
+			name: "nil next",
+			prev: legacyConfig(500, 1<<20, 1<<20),
+			next: nil,
+			want: AddedResources{},
+		},
+		{
+			name: "partial increase",
+			prev: legacyConfig(1000, 2<<30, 4<<30),
+			next: legacyConfig(1000, 3<<30, 2<<30),
+			want: AddedResources{Memory: 1 << 30},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UpgradeResourceDelta(tc.prev, tc.next); got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppConfigWithRequirement(t *testing.T) {
+	if got := AppConfigWithRequirement(nil, AddedResources{CPU: 1}); got != nil {
+		t.Fatalf("nil base: got %+v, want nil", got)
+	}
+
+	base := &appcfg.ApplicationConfig{
+		AppName:         "app",
+		OwnerName:       "alice",
+		SelectedGpuType: "nvidia",
+		Accelerator: []appcfg.ResourceMode{{
+			Mode: "nvidia",
+			ResourceRequirement: appcfg.ResourceRequirement{
+				RequiredCPU:    "4",
+				RequiredMemory: "8Gi",
+			},
+		}},
+	}
+	base.Requirement.CPU = resource.NewMilliQuantity(4000, resource.DecimalSI)
+
+	got := AppConfigWithRequirement(base, AddedResources{CPU: 500, Memory: 1 << 30})
+	if got == nil {
+		t.Fatal("got nil")
+	}
+	if got.OwnerName != "alice" || got.AppName != "app" {
+		t.Errorf("identity fields not preserved: %+v", got)
+	}
+	if got.Accelerator != nil {
+		t.Errorf("Accelerator should be cleared, got %+v", got.Accelerator)
+	}
+	if got.Requirement.CPU == nil || got.Requirement.CPU.MilliValue() != 500 {
+		t.Errorf("CPU=%v, want 500m", got.Requirement.CPU)
+	}
+	if got.Requirement.Memory == nil || got.Requirement.Memory.Value() != 1<<30 {
+		t.Errorf("Memory=%v, want 1Gi", got.Requirement.Memory)
+	}
+	if got.Requirement.Disk != nil {
+		t.Errorf("Disk should be nil for zero delta, got %v", got.Requirement.Disk)
+	}
+	if base.Accelerator == nil || base.Requirement.CPU.MilliValue() != 4000 {
+		t.Error("base was mutated")
+	}
+}

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // fakeValidator is the only Validator the run-level tests use so the
@@ -276,13 +277,17 @@ func TestChainShapes(t *testing.T) {
 	}
 	assertChainNames(t, "InstallabilityValidators", InstallabilityValidators(), wantInstall)
 
-	// UpgradabilityValidators is intentionally just cluster-capacity:
-	// upgrade reuses the existing allocation (compute-mode), the
-	// running deployment is already counted against the owner's quota
-	// (user-quota), and helm upgrade goes through kube-scheduler for
-	// the rest. See UpgradabilityValidators in validators.go.
+	// UpgradabilityValidators gates cluster-capacity on the new chart's
+	// absolute requirements, then cluster-pressure / k8s-request on the
+	// non-negative delta (new − old). user-quota, compute-mode,
+	// node-pressure and compute-allocation stay excluded: install/resume
+	// remain the quota gates, upgrade reuses the existing allocation,
+	// and helm upgrade goes through kube-scheduler. See
+	// UpgradabilityValidators in validators.go.
 	wantUpgrade := []string{
 		"cluster-capacity",
+		"cluster-pressure",
+		"k8s-request",
 	}
 	assertChainNames(t, "UpgradabilityValidators", UpgradabilityValidators(), wantUpgrade)
 
@@ -324,19 +329,18 @@ func assertChainNames(t *testing.T, label string, chain []Validator, want []stri
 // here would silently include or exclude the wrong validator for a
 // given lifecycle stage.
 //
-// UpgradeOp is opted into ONLY by cluster-capacity (so the upgrade
-// handler can reject a new chart whose declared requirements exceed
-// the cluster's total schedulable capacity before any helm work
-// happens). Every other validator in this package is intentionally
-// false for UpgradeOp.
+// UpgradeOp is opted into by cluster-capacity (absolute new
+// requirements) and by cluster-pressure / k8s-request (which run
+// against the delta new − old on upgrade). user-quota, compute-mode,
+// node-pressure and compute-allocation stay false for UpgradeOp.
 //
 // The remaining semantic mapping (matching the comments inside
 // validators.go):
 //
-//   - cluster-pressure, k8s-request, node-pressure :
-//     install + resume.
-//   - user-quota         : install + resume (quota is a running total
-//     that grows on either transition).
+//   - cluster-pressure, k8s-request : install + resume + upgrade.
+//   - node-pressure                 : install + resume.
+//   - user-quota         : install + resume only (upgrade does not
+//     re-check owner quota).
 //   - cluster-capacity   : install + upgrade — resume reuses the
 //     placement chosen at install; the cluster's
 //     total schedulable capacity hasn't shrunk in
@@ -372,16 +376,20 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
+			// cluster-pressure runs on upgrade too, but against the
+			// resource delta (new − old) rather than absolute new.
 			name: "cluster-pressure",
 			v:    clusterPressureValidator{},
 			want: map[Op]bool{
 				v1alpha1.InstallOp: true,
-				v1alpha1.UpgradeOp: false,
+				v1alpha1.UpgradeOp: true,
 				v1alpha1.ResumeOp:  true,
 				v1alpha1.StopOp:    false,
 			},
 		},
 		{
+			// user-quota is install + resume only; upgrade does not
+			// re-check owner quota (see UpgradabilityValidators).
 			name: "user-quota",
 			v:    userQuotaValidator{},
 			want: map[Op]bool{
@@ -392,11 +400,13 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
+			// k8s-request runs on upgrade too, but against the resource
+			// delta so already-scheduled requests are not double-counted.
 			name: "k8s-request",
 			v:    k8sRequestValidator{},
 			want: map[Op]bool{
 				v1alpha1.InstallOp: true,
-				v1alpha1.UpgradeOp: false,
+				v1alpha1.UpgradeOp: true,
 				v1alpha1.ResumeOp:  true,
 				v1alpha1.StopOp:    false,
 			},
@@ -446,5 +456,106 @@ func TestAppliesToMatrix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func upgradeConfig(name string, cpuMilli, memory int64) *appcfg.ApplicationConfig {
+	cfg := &appcfg.ApplicationConfig{AppName: name, OwnerName: "alice"}
+	if cpuMilli > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(cpuMilli, resource.DecimalSI)
+	}
+	if memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(memory, resource.BinarySI)
+	}
+	return cfg
+}
+
+// TestUpgradeDeltaFeedsPressureChecks verifies the delta-aware upgrade
+// validators receive the non-negative delta (new − old) on UpgradeOp,
+// not the new chart's absolute requirements.
+func TestUpgradeDeltaFeedsPressureChecks(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+	})
+
+	var gotCPU int64 = -1
+	capture := func(cfg *appcfg.ApplicationConfig) {
+		if cfg != nil && cfg.Requirement.CPU != nil {
+			gotCPU = cfg.Requirement.CPU.MilliValue()
+		}
+	}
+	checkAppRequirement = func(_ string, cfg *appcfg.ApplicationConfig, _ v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		capture(cfg)
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(cfg *appcfg.ApplicationConfig, _ v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		capture(cfg)
+		return "", "", nil
+	}
+
+	// new needs 3000m, old needs 1000m -> delta 2000m.
+	in := Input{
+		AppConfig:     upgradeConfig("app", 3000, 4<<30),
+		PrevAppConfig: upgradeConfig("app", 1000, 2<<30),
+		Op:            v1alpha1.UpgradeOp,
+	}
+
+	for _, v := range []Validator{clusterPressureValidator{}, k8sRequestValidator{}} {
+		gotCPU = -1
+		decision, err := v.Validate(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%s validate: %v", v.Name(), err)
+		}
+		if !decision.OK {
+			t.Fatalf("%s decision=%#v, want OK", v.Name(), decision)
+		}
+		if gotCPU != 2000 {
+			t.Fatalf("%s received CPU=%dm, want delta 2000m", v.Name(), gotCPU)
+		}
+	}
+}
+
+// TestUpgradeZeroDeltaShortCircuits verifies the delta-aware upgrade
+// validators pass without touching any backend when the new version
+// keeps or lowers its requests.
+func TestUpgradeZeroDeltaShortCircuits(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+	})
+
+	var calls int
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(*appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+
+	// new <= old on every dimension -> delta zero.
+	in := Input{
+		AppConfig:     upgradeConfig("app", 1000, 2<<30),
+		PrevAppConfig: upgradeConfig("app", 2000, 3<<30),
+		Op:            v1alpha1.UpgradeOp,
+	}
+
+	for _, v := range []Validator{clusterPressureValidator{}, k8sRequestValidator{}} {
+		decision, err := v.Validate(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%s validate: %v", v.Name(), err)
+		}
+		if !decision.OK {
+			t.Fatalf("%s decision=%#v, want OK", v.Name(), decision)
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("expected zero backend calls for zero delta, got %d", calls)
 	}
 }

--- a/framework/app-service/pkg/compute/validation/validator.go
+++ b/framework/app-service/pkg/compute/validation/validator.go
@@ -2,9 +2,11 @@
 // upgrade and resume. Legacy installs run InstallRuntimePressureValidators
 // before helm; two-phase installs (workloadReplicas) run the same chain
 // after helm at replicas=0 and before Scale(-1). The upgrade handler
-// runs UpgradabilityValidators at HTTP submit time, which currently only
-// gates on cluster-capacity (see that function for the rationale on why
-// the other install-time checks are intentionally skipped on upgrade).
+// runs UpgradabilityValidators at HTTP submit time: cluster-capacity
+// against the new chart's absolute requirements, plus cluster-pressure /
+// k8s-request against the non-negative delta (new − old) so the running
+// deployment is not double-counted (see that function). User-quota is
+// not part of the upgrade chain (install/resume remain the quota gates).
 //
 // Each individual check (cluster pressure, per-user quota, k8s request
 // availability, per-node pressure, GPU compute plan) is wrapped in a
@@ -28,13 +30,20 @@ import (
 type Op = v1alpha1.OpType
 
 // Input bundles everything a Validator might need. Token is optional and
-// only the cluster-pressure validator currently uses it; the others
-// ignore unset fields.
+// only the cluster-pressure / cluster-capacity validators currently use
+// it; the others ignore unset fields.
+//
+// PrevAppConfig is required for UpgradeOp when running cluster-pressure /
+// k8s-request: those validators check only the non-negative resource
+// delta (new − old) against live headroom so the running deployment is
+// not double-counted. Cluster-capacity still uses AppConfig (the new
+// chart) absolutely, and install/resume ignore PrevAppConfig.
 type Input struct {
-	Client    client.Client
-	AppConfig *appcfg.ApplicationConfig
-	Op        Op
-	Token     string
+	Client        client.Client
+	AppConfig     *appcfg.ApplicationConfig
+	PrevAppConfig *appcfg.ApplicationConfig
+	Op            Op
+	Token         string
 }
 
 // Decision is the structured outcome of a single validator (or the chain

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -68,9 +69,10 @@ func (clusterCapacityValidator) Name() string { return NameClusterCapacity }
 // Upgrade is included so we reject an upgrade whose new chart declares
 // resource requirements the cluster can never satisfy (e.g. the new
 // version raised CPU/memory/disk past the cluster's total schedulable
-// capacity) at HTTP submit time, before any helm work happens. None
-// of the other validators in this file apply to UpgradeOp — runtime
-// pressure / per-user quota are handled separately on the upgrade path.
+// capacity) at HTTP submit time, before any helm work happens. This
+// validator uses the new chart's ABSOLUTE requirements on upgrade;
+// cluster-pressure / k8s-request handle the headroom side against the
+// delta (new − old) — see UpgradabilityValidators.
 func (clusterCapacityValidator) AppliesTo(op Op) bool {
 	switch op {
 	case v1alpha1.InstallOp, v1alpha1.UpgradeOp:
@@ -150,22 +152,28 @@ func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decisio
 // checks aggregate cluster headroom (disk/memory/CPU) against the app's
 // declared requirements. Requires a kubesphere token because the
 // underlying call hits the kubesphere monitoring API.
+//
+// On UpgradeOp the check uses the non-negative resource delta
+// (new − old) so the running deployment already counted in cluster
+// usage is not double-counted.
 type clusterPressureValidator struct{}
 
 func (clusterPressureValidator) Name() string { return NameClusterPressure }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (clusterPressureValidator) AppliesTo(op Op) bool {
 	switch op {
-	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
+	case v1alpha1.InstallOp, v1alpha1.ResumeOp, v1alpha1.UpgradeOp:
 		return true
 	}
 	return false
 }
 
 func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkAppRequirement(in.Token, in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkAppRequirement(in.Token, cfg, in.Op)
 	if err != nil {
 		// CheckAppRequirement returns an empty resource/reason only when
 		// the check itself couldn't be evaluated (e.g. the kubesphere
@@ -189,12 +197,11 @@ func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decisio
 
 // userQuotaValidator wraps apputils.CheckUserResRequirement which
 // checks the owner's per-user memory / CPU quota via prometheus.
+
 type userQuotaValidator struct{}
 
 func (userQuotaValidator) Name() string { return NameUserQuota }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (userQuotaValidator) AppliesTo(op Op) bool {
 	switch op {
 	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
@@ -204,7 +211,11 @@ func (userQuotaValidator) AppliesTo(op Op) bool {
 }
 
 func (userQuotaValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkUserResRequirement(ctx, in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkUserResRequirement(ctx, cfg, in.Op)
 	if err != nil {
 		// Empty resource/reason means the prometheus user-metrics call
 		// failed, not that the user is over quota. Treat it as a fatal
@@ -227,22 +238,28 @@ func (userQuotaValidator) Validate(ctx context.Context, in Input) (Decision, err
 // the cluster has room for the app's CPU/memory request. Runs as part
 // of RuntimePressureValidators in installing_app after helm install and
 // before Scale(-1).
+//
+// On UpgradeOp the check uses the non-negative resource delta
+// (new − old) so already-scheduled requests of the running deployment
+// are not double-counted. Rolling-update surge is left to kube-scheduler.
 type k8sRequestValidator struct{}
 
 func (k8sRequestValidator) Name() string { return NameK8sRequest }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (k8sRequestValidator) AppliesTo(op Op) bool {
 	switch op {
-	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
+	case v1alpha1.InstallOp, v1alpha1.ResumeOp, v1alpha1.UpgradeOp:
 		return true
 	}
 	return false
 }
 
 func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkAppK8sRequestResource(in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkAppK8sRequestResource(cfg, in.Op)
 	if err != nil {
 		// Empty resource/reason means the node/allocatable lookup failed
 		// (or appConfig was nil), not that the cluster lacks room. Surface
@@ -259,6 +276,22 @@ func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, er
 		}, nil
 	}
 	return ok(), nil
+}
+
+// requirementConfigForOp returns the ApplicationConfig whose declared
+// Requirement should be checked. For install/resume that is AppConfig
+// as-is. For upgrade it is a shallow copy with Requirement set to
+// max(0, new−old); skip is true when the delta is zero on every
+// dimension (caller should treat as OK without hitting metrics).
+func requirementConfigForOp(in Input) (cfg *appcfg.ApplicationConfig, skip bool) {
+	if in.Op != v1alpha1.UpgradeOp {
+		return in.AppConfig, false
+	}
+	delta := compute.UpgradeResourceDelta(in.PrevAppConfig, in.AppConfig)
+	if delta.CPU <= 0 && delta.Memory <= 0 && delta.Disk <= 0 {
+		return nil, true
+	}
+	return compute.AppConfigWithRequirement(in.AppConfig, delta), false
 }
 
 // computeModeValidator wraps compute.AppInstallable which validates
@@ -430,35 +463,43 @@ func InstallabilityValidators() []Validator {
 	}
 }
 
-// UpgradabilityValidators returns the structural feasibility chain
-// applied at HTTP submit time by the upgrade handler. The upgrade flow
-// only needs to ask "is the cluster big enough to host the NEW chart's
-// declared requirements at all?", because:
+// UpgradabilityValidators returns the feasibility chain applied at HTTP
+// submit time by the upgrade handler. It answers two questions:
 //
+//   - cluster-capacity: "is the cluster physically big enough to host
+//     the NEW chart's declared requirements at all?" — evaluated
+//     against the new chart's ABSOLUTE requirements (Total, not
+//     Total−Usage), since a running old version does not shrink the
+//     cluster's total schedulable size.
+//   - cluster-pressure / k8s-request: "can live headroom absorb the
+//     resource INCREASE this upgrade introduces?" — each runs against
+//     the non-negative delta (new − old) computed from
+//     Input.PrevAppConfig, so the running deployment already reflected
+//     in cluster usage / scheduled requests is not double-counted.
+//     When the delta is zero on every dimension (the common case where
+//     a new version keeps or lowers its requests) these validators
+//     short-circuit to OK without any metrics round trip.
+//
+// Intentionally excluded:
+//
+//   - user-quota: install/resume remain the per-user quota gates;
+//     upgrade does not re-check owner quota.
 //   - compute-mode: the existing app already has an allocation, the
 //     upgrade reuses prevCfg.SelectedGpuType. Re-running the planner
 //     would either no-op or spuriously fail on a transiently-degraded
 //     node.
-//   - user-quota: the running deployment is already counted against
-//     the owner's quota, so re-checking on upgrade would double-count
-//     for templates whose new version raises requests only marginally.
-//   - runtime-pressure / k8s-request / node-pressure: the upgrade goes
-//     through helm upgrade which schedules its own replacement pods;
-//     kubelet/kube-scheduler are the authoritative gate there.
+//   - node-pressure / compute-allocation: rolling-update surge and pod
+//     placement go through helm upgrade + kube-scheduler, which are the
+//     authoritative gate there.
 //
-// So the chain is intentionally just clusterCapacityValidator. We keep
-// it as a separate exported chain (rather than letting callers pass a
-// single validator inline) so that:
-//
-//   - The "what validates on upgrade?" answer lives in one place that
-//     matches the InstallabilityValidators / RuntimePressureValidators
-//     pattern.
-//   - The clusterCapacityValidator type stays unexported.
-//   - Adding another upgrade-time gate later only touches this file
-//     and TestChainShapes, not every upgrade call site.
+// The delta-aware validators REQUIRE Input.PrevAppConfig to be set for
+// UpgradeOp; the upgrade handler is the only caller of this chain and
+// always supplies it.
 func UpgradabilityValidators() []Validator {
 	return []Validator{
 		clusterCapacityValidator{},
+		clusterPressureValidator{},
+		k8sRequestValidator{},
 	}
 }
 


### PR DESCRIPTION
* **Background**
Expand UpgradabilityValidators beyond absolute cluster-capacity: run cluster-pressure and k8s-request against max(0, new−old) with PrevAppConfig so the running deployment is not double-counted, and skip those checks when the delta is zero.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-helm upgrade gating and depends on KubeSphere/Prometheus metrics; mis-delta logic could block valid upgrades or allow overstressed clusters, but behavior is covered by new unit tests.
> 
> **Overview**
> **App upgrades** now run **cluster-pressure** and **k8s-request** at HTTP submit time (in addition to **cluster-capacity** on the new chart’s absolute requirements), so upgrades that only increase requests are checked against **live headroom** without treating the already-running version as extra demand.
> 
> The upgrade handler passes **`PrevAppConfig`** into `validation.Run`. New helpers **`UpgradeResourceDelta`** and **`AppConfigWithRequirement`** compute `max(0, new − old)` per CPU/memory/disk and feed that synthetic requirement into the pressure validators; when the delta is zero everywhere, those checks **skip** metrics calls. **User-quota**, **compute-mode**, and **node-pressure** stay off the upgrade chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d2490d4c9d3da849af133a749f73568e600a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->