### PR TITLE
fix: wise backup svc replace

### DIFF
--- a/framework/backup-server/pkg/handlers/handler_app.go
+++ b/framework/backup-server/pkg/handlers/handler_app.go
@@ -26,7 +26,7 @@ const (
 )
 
 var appNameMap = map[string]string{
-	"wise": "knowledge",
+	"wisev3": "knowledge",
 }
 
 type AppHandler struct {

--- a/framework/backup-server/pkg/handlers/handler_app.go
+++ b/framework/backup-server/pkg/handlers/handler_app.go
@@ -13,9 +13,9 @@ import (
 	"olares.com/backup-server/pkg/util/log"
 )
 
-const (
-	BackupAppHost = "rss-svc.knowledge-shared:3010"
-)
+const defaultBackupWiseHost = "rss-svc.knowledgev3-shared:3010"
+
+var BackupAppHost = util.GetEnvOrDefault("BACKUP_WISE_HOST", defaultBackupWiseHost)
 
 const (
 	BackupAppStartPath   = "{app}/backup/start"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
fix: wise backup svc replace

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured host or app name would break Wise backup/restore flows; change is small and env-overridable for rollout.
> 
> **Overview**
> **Wise (knowledge) app backup/restore** now targets the **knowledgev3** RSS service instead of the legacy knowledge-shared endpoint.
> 
> The default upstream host changes from `rss-svc.knowledge-shared:3010` to `rss-svc.knowledgev3-shared:3010`, and **`BackupAppHost`** can be overridden with the **`BACKUP_WISE_HOST`** environment variable. The internal app key in **`appNameMap`** is updated from **`wise`** to **`wisev3`** so backup URLs still resolve to the `knowledge` path segment on the Wise side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645b86ad5e4d58600ea5ffec4fc5d1d598d9ddf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->