### PR TITLE
backup: wise backup svc replace

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.67" }}
+{{ $backupVersion := "0.3.68" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/pkg/handlers/handler_app.go
+++ b/framework/backup-server/pkg/handlers/handler_app.go
@@ -26,7 +26,7 @@ const (
 )
 
 var appNameMap = map[string]string{
-	"wise": "knowledge",
+	"wisev3": "knowledge",
 }
 
 type AppHandler struct {

--- a/framework/backup-server/pkg/handlers/handler_app.go
+++ b/framework/backup-server/pkg/handlers/handler_app.go
@@ -13,9 +13,9 @@ import (
 	"olares.com/backup-server/pkg/util/log"
 )
 
-const (
-	BackupAppHost = "rss-svc.knowledge-shared:3010"
-)
+const defaultBackupWiseHost = "rss-svc.knowledgev3-shared:3010"
+
+var BackupAppHost = util.GetEnvOrDefault("BACKUP_WISE_HOST", defaultBackupWiseHost)
 
 const (
 	BackupAppStartPath   = "{app}/backup/start"


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
backup: wise backup svc replace

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/Olares/pull/3866


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default in-cluster target and app id for Wise backups; a mismatch with the platform app name or service DNS would break backup/restore until env or config is aligned.
> 
> **Overview**
> **Wise (Knowledge) backup integration** is retargeted from the legacy `knowledge-shared` RSS service to **`rss-svc.knowledgev3-shared:3010`**. The backup HTTP host is still overridable via **`BACKUP_WISE_HOST`**, with that v3 address as the new default.
> 
> The app handler maps the Olares app id **`wisev3`** (replacing **`wise`**) to the **`knowledge`** URL segment used on backup/restore API paths.
> 
> Cluster deploy bumps the **`beclab/backup-server`** image tag from **0.3.67** to **0.3.68** so clusters pick up this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a435ad19a947c3e6ef4f6f8f9954da31c82489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->