### PR TITLE
market: reject uploaded charts unsupported by cluster nodes

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.87
+        image: beclab/market-backend:v0.6.88
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.86
+        image: beclab/market-backend:v0.6.87
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
market: reject uploaded charts unsupported by cluster nodes

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/405


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in deployment config; behavior change is scoped to upload validation in the market backend.
> 
> **Overview**
> Bumps the **appstore-backend** container image from `beclab/market-backend:v0.6.86` to **`v0.6.88`** in the market cluster deployment manifest.
> 
> That release carries the market change to **reject chart uploads** when the chart is not supported by the cluster’s nodes (see related market PR). No other deployment env, RBAC, or service settings change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d96b744041b83666a3a3549e24aad428f1d7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->