### PR TITLE
fix(oac): reject reserved system app names on metadata.name

### DIFF
--- a/framework/oac/internal/manifest/validate.go
+++ b/framework/oac/internal/manifest/validate.go
@@ -150,7 +150,7 @@ func validateAppMetaData(v interface{}) error {
 			validation.Required.Error("metadata.version is required"),
 			isSemver.Error("metadata.version must be a valid semantic version (e.g. 1.2.3)"),
 		),
-		validation.Field(&m.AppID,
+		validation.Field(&m.Name,
 			validation.By(validateMetadataAppID),
 		),
 	)
@@ -164,14 +164,14 @@ func validateAppMetaData(v interface{}) error {
 func validateMetadataAppID(v interface{}) error {
 	s, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("metadata.appid: unexpected type %T", v)
+		return fmt.Errorf("metadata.name: unexpected type %T", v)
 	}
 	if s == "" {
 		return nil
 	}
 	if IsReservedSystemAppID(s) {
 		return fmt.Errorf(
-			"metadata.appid %q collides with a reserved system app id; choose a different value (the loader normalizes appid to md5(metadata.name)[:8] anyway, so leaving the field empty is also fine)",
+			"%q collides with a reserved system app; choose a different value",
 			s,
 		)
 	}


### PR DESCRIPTION


* **Background**
fix(oac): reject reserved system app names on metadata.name

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation wiring change in manifest lint only; no runtime install or auth paths modified in this diff.
> 
> **Overview**
> Manifest validation now applies the reserved built-in system app check to **`metadata.name`** instead of **`metadata.appid`**, using the existing `validateMetadataAppID` helper (still backed by `IsReservedSystemAppID`).
> 
> Collision errors are shortened and type-mismatch messages refer to **`metadata.name`**. Empty names remain allowed at this step because required/length rules run separately on the same field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b88f3cc4218885dcdcbb1cf4f5965d98b716c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->