### PR TITLE
fix(app-service): validate upgrade resource headroom on delta

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.19
+        image: beclab/app-service:0.6.21
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.18
+        image: beclab/app-service:0.6.19
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755
@@ -418,7 +418,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
         - name: image-service
-          image: beclab/image-service:0.6.9
+          image: beclab/image-service:0.6.19
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0

--- a/framework/app-service/controllers/image_controller.go
+++ b/framework/app-service/controllers/image_controller.go
@@ -64,6 +64,15 @@ func (r *ImageManagerController) SetupWithManager(mgr ctrl.Manager) error {
 				return r.preEnqueueCheckForUpdate(e.ObjectOld, e.ObjectNew)
 			},
 			DeleteFunc: func(e event.TypedDeleteEvent[*appv1alpha1.ImageManager]) bool {
+				// Only cancel in-flight pulls. Terminal IMs have nothing
+				// running; calling cancel would only log a no-op error.
+				if e.Object != nil && !isTerminalState(e.Object.Status.State) {
+					go func() {
+						if err := r.cancel(e.Object); err != nil {
+							klog.Infof("cancel im=%s on delete: %v", e.Object.Name, err)
+						}
+					}()
+				}
 				return false
 			},
 		},

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260804143153-7a64d00df3e3
+	github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421
 	github.com/beclab/api v0.0.24
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,8 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260804143153-7a64d00df3e3 h1:8GGNH/ciRtGwePzDthdlge6Uol+V6dfBV1J5DAfdCfQ=
-github.com/beclab/Olares/framework/oac v0.0.0-20260804143153-7a64d00df3e3/go.mod h1:5hm6YNfFzaiiSOsCvCapYiJhtGQeNxd1oXnp4+2LNBw=
+github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421 h1:+nDNYQHujaVK0FIWdLKLZmmXhEmWkGWpp4r3/uTowvg=
+github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421/go.mod h1:5hm6YNfFzaiiSOsCvCapYiJhtGQeNxd1oXnp4+2LNBw=
 github.com/beclab/api v0.0.24 h1:Ob01wkENbiBWis/O32Sn7xLQc8sAtCVmP6zksrMAlaQ=
 github.com/beclab/api v0.0.24/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -446,18 +446,18 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	// Reject upgrades whose new chart's declared resource requirements
-	// exceed the cluster's total schedulable capacity, before we acquire
-	// any env-batch lease or kick off helm. Mirrors the install handler's
-	// cluster-capacity gate (handler_installer_install.go) but uses the
-	// upgrade-specific chain — UpgradabilityValidators currently only
-	// runs clusterCapacityValidator (see that function for why the other
-	// install-time checks are intentionally skipped on upgrade).
+	// Reject upgrades the cluster can't accommodate before we acquire any
+	// env-batch lease or kick off helm. UpgradabilityValidators runs
+	// cluster-capacity against the new chart's absolute requirements, plus
+	// cluster-pressure / k8s-request against the non-negative delta
+	// (new − old) so the running deployment is not double-counted (see
+	// that function for details). 
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
-		Client:    h.ctrlClient,
-		AppConfig: appCfg,
-		Op:        appv1alpha1.UpgradeOp,
-		Token:     token,
+		Client:        h.ctrlClient,
+		AppConfig:     appCfg,
+		PrevAppConfig: &prevCfg,
+		Op:            appv1alpha1.UpgradeOp,
+		Token:         token,
 	}, validation.UpgradabilityValidators()...)
 	if err != nil {
 		api.HandleError(resp, req, err)

--- a/framework/app-service/pkg/appstate/applying_env_app.go
+++ b/framework/app-service/pkg/appstate/applying_env_app.go
@@ -64,6 +64,20 @@ func (a *ApplyingEnvApp) Exec(ctx context.Context) (StatefulInProgressApp, error
 
 				err := a.exec(c)
 				if err != nil {
+					// A cancel (POST /cancel, the TTL watchdog or a force uninstall)
+					// cancels opCtx, which is what aborts the helm env upgrade and
+					// the startup wait, so err here is the cancellation itself rather
+					// than an applyEnv failure. The initiator already wrote the
+					// terminal target state (ApplyingEnvCanceling for cancel,
+					// Uninstalling for force uninstall) and owns the transition;
+					// ApplyingEnvCanceling -> ApplyEnvFailed is not a declared
+					// transition, so this write would only be rejected by the guard.
+					// Bail out quietly and let the initiator drive the state.
+					if c.Err() != nil {
+						klog.Infof("applyEnv of app %s canceled; leaving terminal state to the initiator", a.manager.Spec.AppName)
+						return
+					}
+
 					a.finally = func() {
 						klog.Info("ApplyEnv operation failed, update app status to ApplyEnvFailed, ", a.manager.Name)
 						opRecord := makeRecord(a.manager, appsv1.ApplyEnvFailed,

--- a/framework/app-service/pkg/appstate/installing_app.go
+++ b/framework/app-service/pkg/appstate/installing_app.go
@@ -120,6 +120,21 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				// timeout so operators can investigate, and InstallFailedApp.Exec
 				// will keep retrying the same helper on subsequent reconciles.
 				toInstallFailed := func(msg string) {
+					// A cancel (DELETE /apps/{name}/install) or a force uninstall
+					// cancels opCtx, which is what aborts validation / helm install
+					// / scale-up, so msg here describes the cancellation rather than
+					// an install failure. The initiator already wrote the terminal
+					// target state (InstallingCanceling for cancel, Uninstalling for
+					// force uninstall) and owns both the teardown and the following
+					// transition; InstallingCanceling -> InstallFailed is not a
+					// declared transition, so the write below would only be rejected
+					// by the guard while the cleanup duplicates the cancel path's.
+					// Bail out quietly and let the initiator drive the state.
+					if c.Err() != nil {
+						klog.Infof("install of app %s canceled; leaving cleanup and terminal state to the initiator", p.manager.Spec.AppName)
+						return
+					}
+
 					cleanupErr := cleanupAfterInstallFailure(context.TODO(), p.client, p.manager)
 					finalMsg := msg
 					if cleanupErr != nil {
@@ -185,6 +200,15 @@ func (p *InstallingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 				err = ops.Install()
 				if err != nil {
 					klog.Errorf("install app %s failed %v", p.manager.Spec.AppName, err)
+					// Same reasoning as in toInstallFailed, applied before the
+					// pending-pod branches below: those write Stopping directly,
+					// which InstallingCanceling does not allow either, and the
+					// cancel path already releases the compute allocation as part
+					// of its uninstall.
+					if c.Err() != nil {
+						klog.Infof("install of app %s canceled during helm install; leaving cleanup and terminal state to the initiator", p.manager.Spec.AppName)
+						return
+					}
 					// Release compute allocation up-front so the pending-pod paths
 					// (ErrServerSidePodPending / ErrPodPending → Stopping) don't leak
 					// the GPU/compute reservation. The generic InstallFailed branch

--- a/framework/app-service/pkg/appstate/operation_cancel_race_test.go
+++ b/framework/app-service/pkg/appstate/operation_cancel_race_test.go
@@ -1,0 +1,152 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/compute/validation"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+
+	"k8s.io/client-go/rest"
+)
+
+// The three tests below pin the cancel guards added to InstallingApp,
+// UpgradingApp and ApplyingEnvApp, mirroring InitializingApp: when the
+// operation context is canceled (a *Canceling app's Cleanup, or a force
+// uninstall) the in-flight goroutine must NOT publish its own terminal state,
+// because the initiator already owns the transition and *Canceling -> *Failed
+// is not a declared edge in StateTransitions.
+//
+// Each test blocks the operation goroutine on a seam, cancels the operation via
+// Cleanup (what cancelOperation does in production), releases the seam with an
+// error and then asserts that the ApplicationManager was left in the operating
+// state for the initiator to move on.
+
+// blockingKubeConfig returns a KubeConfig seam that reports it was reached, then
+// blocks until release is closed and finally fails. Every operation goroutine
+// calls it first, so it is a reliable place to freeze one mid-flight.
+func blockingKubeConfig(started chan<- struct{}, release <-chan struct{}) func() (*rest.Config, error) {
+	return func() (*rest.Config, error) {
+		close(started)
+		<-release
+		return nil, errors.New("operation aborted")
+	}
+}
+
+func TestUpgrade_CanceledExecSkipsUpgradeFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("upgrade-race", appv1alpha1.App, appv1alpha1.Upgrading, appv1alpha1.UpgradeOp,
+		configJSON(t, "upgrade-race", false))
+	c := newFakeClient(t, am)
+	deps, _ := newTestDeps(c)
+
+	started, release := make(chan struct{}), make(chan struct{})
+	deps.KubeConfig = blockingKubeConfig(started, release)
+
+	p := &UpgradingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+		downloadTTL: time.Hour,
+		imageClient: &fakeImageManager{},
+	}
+
+	in, err := p.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	// Finally blocks until the goroutine either publishes a transition or closes
+	// finallyCh on its way out, so it doubles as a barrier: no sleep needed.
+	p.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.Upgrading {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.Upgrading)
+	}
+}
+
+func TestApplyEnv_CanceledExecSkipsApplyEnvFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("applyenv-race", appv1alpha1.App, appv1alpha1.ApplyingEnv, appv1alpha1.ApplyEnvOp,
+		configJSON(t, "applyenv-race", false))
+	c := newFakeClient(t, am)
+	deps, _ := newTestDeps(c)
+
+	started, release := make(chan struct{}), make(chan struct{})
+	deps.KubeConfig = blockingKubeConfig(started, release)
+
+	a := &ApplyingEnvApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+
+	in, err := a.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	// No finallyCh barrier here, so give the goroutine room to reach its guard
+	// before running the hook it would have installed without the fix.
+	time.Sleep(200 * time.Millisecond)
+	in.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.ApplyingEnv {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.ApplyingEnv)
+	}
+}
+
+func TestInstall_CanceledExecSkipsInstallFailed(t *testing.T) {
+	isolateKubeconfig(t)
+
+	am := buildAM("install-race", appv1alpha1.App, appv1alpha1.Installing, appv1alpha1.InstallOp,
+		configJSON(t, "install-race", false))
+	c := newFakeClient(t, am)
+	deps, tf := newTestDeps(c)
+
+	// Freeze inside validation: it is the first step of the install goroutine
+	// and its failure funnels straight into toInstallFailed.
+	started, release := make(chan struct{}), make(chan struct{})
+	tf.validation = func(ctx context.Context, in validation.Input) (validation.Decision, error) {
+		close(started)
+		<-release
+		return validation.Decision{}, errors.New("validation aborted")
+	}
+
+	p := &InstallingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+
+	in, err := p.Exec(context.TODO())
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	<-started
+	in.Cleanup(context.TODO())
+	close(release)
+
+	time.Sleep(200 * time.Millisecond)
+	in.Finally()
+
+	if got := getAM(t, c, am.Name).Status.State; got != appv1alpha1.Installing {
+		t.Fatalf("state = %q, want %q left for the cancel handler", got, appv1alpha1.Installing)
+	}
+}

--- a/framework/app-service/pkg/appstate/resuming_app.go
+++ b/framework/app-service/pkg/appstate/resuming_app.go
@@ -169,6 +169,15 @@ func (p *resumingInProgressApp) WaitAsync(ctx context.Context) {
 				klog.Infof("app %s stop requested while resuming, skip setting ResumeFailed", p.manager.Spec.AppName)
 				return
 			}
+			// A canceled poll means another path (Resuming -> ResumingCanceling
+			// via Cancel, which stops the polling) already owns the next
+			// transition, so ResumeFailed must not be written here: the
+			// transition guard would reject it anyway
+			// (ResumingCanceling -> ResumeFailed is not declared).
+			if errors.Is(err, context.Canceled) {
+				klog.Infof("app %s resume canceled while waiting for startup, skip setting ResumeFailed", p.manager.Spec.AppName)
+				return
+			}
 			opRecord := makeRecord(p.manager, appsv1.ResumeFailed, fmt.Sprintf(constants.OperationFailedTpl, p.manager.Spec.OpType, err.Error()))
 			updateErr := p.updateStatus(context.TODO(), p.manager, appsv1.ResumeFailed, opRecord, err.Error(), appsv1.ResumeFailed.String())
 			if updateErr != nil {
@@ -202,13 +211,26 @@ func (p *resumingInProgressApp) poll(ctx context.Context) error {
 		return unrecoverableErr
 	}
 
-	isPending, err := p.stopRequested(ctx)
+	// Reaching here means IsStartUp returned (false, nil), which only happens
+	// when the poll context was canceled. Use a detached context for the
+	// annotation lookup so the canceled poll context doesn't turn the check
+	// into a spurious error (and clobber the real reason we stopped polling).
+	isPending, err := p.stopRequested(context.WithoutCancel(ctx))
 	if err != nil {
 		return err
 	}
 	if isPending {
 		return errStopRequestedDueToPendingPod
 	}
+
+	// The operation was canceled or superseded (e.g. cancel-by-timeout moved
+	// the app to ResumingCanceling and stopped polling). Surface the context
+	// error so WaitAsync skips the ResumeFailed write, the same way
+	// downloadingInProgressApp.WaitAsync skips DownloadFailed.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return fmt.Errorf("wait for app %s startup failed", p.manager.Spec.AppName)
 }
 

--- a/framework/app-service/pkg/appstate/resuming_cancel_race_test.go
+++ b/framework/app-service/pkg/appstate/resuming_cancel_race_test.go
@@ -1,0 +1,69 @@
+package appstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+)
+
+// newResumingInProgress wires a resumingInProgressApp against the fake client
+// with an unreachable kube config (the event tier fails fast, matching the
+// other resume tests).
+func newResumingInProgress(t *testing.T, am *appv1alpha1.ApplicationManager) *resumingInProgressApp {
+	t.Helper()
+	dep, pod := pendingWorkload(am.Spec.AppName, am.Spec.AppNamespace)
+	c := newFakeClient(t, dep, pod, am)
+	deps, tf := newTestDeps(c)
+	tf.kubeConfig = unreachableKubeConfig()
+
+	rp := &ResumingApp{
+		baseOperationApp: &baseOperationApp{
+			ttl:             time.Hour,
+			baseStatefulApp: &baseStatefulApp{manager: am, client: c, deps: deps},
+		},
+	}
+	return &resumingInProgressApp{
+		ResumingApp:                       rp,
+		basePollableStatefulInProgressApp: &basePollableStatefulInProgressApp{},
+	}
+}
+
+// TestResume_Poll_CanceledReturnsContextCanceled pins the fix for the
+// ResumingCanceling -> ResumeFailed race: when the poll context is canceled
+// (cancel-by-timeout moves the app to ResumingCanceling and stops polling),
+// poll must report the context error so WaitAsync skips the ResumeFailed write
+// that the transition guard would otherwise reject.
+func TestResume_Poll_CanceledReturnsContextCanceled(t *testing.T) {
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	ip := newResumingInProgress(t, am)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate Cleanup -> stopPolling cancelling the poll context
+
+	err := ip.poll(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestResume_Poll_StopRequestedSurvivesCanceledCtx verifies the detached-context
+// annotation read: even when the poll context is canceled, a pending-pod stop
+// request is still detected (errStopRequestedDueToPendingPod) rather than being
+// masked by the cancellation.
+func TestResume_Poll_StopRequestedSurvivesCanceledCtx(t *testing.T) {
+	am := buildAM("demo", appv1alpha1.App, appv1alpha1.Resuming, appv1alpha1.ResumeOp, "")
+	am.Annotations = map[string]string{api.AppStopByControllerDuePendingPod: "true"}
+	ip := newResumingInProgress(t, am)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ip.poll(ctx)
+	if !errors.Is(err, errStopRequestedDueToPendingPod) {
+		t.Fatalf("expected errStopRequestedDueToPendingPod, got %v", err)
+	}
+}

--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -103,6 +103,22 @@ func (p *UpgradingApp) Exec(ctx context.Context) (StatefulInProgressApp, error) 
 						execErr = fmt.Errorf("panic: %v", r)
 					}
 					if execErr != nil {
+						// A cancel (POST /cancel, the TTL watchdog or a force
+						// uninstall) cancels opCtx, which is what aborts the image
+						// download / helm upgrade / startup wait, so execErr here is
+						// the cancellation itself rather than an upgrade failure. The
+						// initiator already wrote the terminal target state
+						// (UpgradingCanceling for cancel, Uninstalling for force
+						// uninstall) and UpgradingCancelingApp owns the transition to
+						// Stopping; UpgradingCanceling -> UpgradeFailed is not a
+						// declared transition, so this write would only be rejected
+						// by the guard. Bail out quietly (Finally() tolerates the
+						// closed channel) and let the initiator drive the state.
+						if c.Err() != nil {
+							klog.Infof("upgrade of app %s canceled; leaving terminal state to the initiator", p.manager.Spec.AppName)
+							return
+						}
+
 						reason := appsv1.UpgradeFailed.String()
 						if errors.Is(execErr, errcode.ErrPodPending) || errors.Is(execErr, errcode.ErrServerSidePodPending) {
 							reason = constants.AppUnschedulable

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -13,13 +13,27 @@ import (
 
 var errBindingUnavailable = errors.New("compute binding unavailable")
 
+// listAvailableForLaunch classifies every node and device in the cluster
+// against the app's selected requirement. It is the shared first step of both
+// placement flows: resume hands the result to the user and waits for a manual
+// pick, while install feeds the very same result to pickLaunchSelection and
+// picks automatically. Neither flow can therefore place an app on a device the
+// other wouldn't offer.
 func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnapshot) *AvailabilityResult {
+	return listAvailableForLaunchWithOptions(req, nodes, pressure, allocationOptions{checkPressure: true})
+}
+
+// listAvailableForLaunchWithOptions is listAvailableForLaunch with the fit
+// checks parameterized, so preflight can build the same view against a
+// simulated cluster (its own added-resources budget, and a first pass that
+// ignores node pressure entirely).
+func listAvailableForLaunchWithOptions(req Requirement, nodes []Node, pressure PressureSnapshot, opts allocationOptions) *AvailabilityResult {
 	result := &AvailabilityResult{
 		Requirement: req,
 		Scope:       availabilityScope(req),
 		Nodes:       make([]NodeOption, 0, len(nodes)),
 	}
-	classified := classifyLaunchNodes(req, nodes, pressure)
+	classified := classifyLaunchNodes(req, nodes, pressure, opts)
 	for _, node := range classified {
 		if node.Status == NodeStatusNotMatch {
 			continue
@@ -36,7 +50,7 @@ func listAvailableForLaunch(req Requirement, nodes []Node, pressure PressureSnap
 	return result
 }
 
-func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot) []NodeOption {
+func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot, opts allocationOptions) []NodeOption {
 	out := make([]NodeOption, 0, len(nodes))
 	for _, node := range nodes {
 		if !node.SupportsMode(req.Mode) {
@@ -50,17 +64,17 @@ func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapsho
 		view := node.viewForMode(req.Mode)
 		var option NodeOption
 		if req.Mode == utils.NvidiaCardType {
-			option = classifyNvidiaNode(req, view, pressure)
+			option = classifyNvidiaNode(req, view, pressure, opts)
 		} else {
-			option = classifyNonNvidiaNode(req, view, pressure)
+			option = classifyNonNvidiaNode(req, view, pressure, opts)
 		}
 		out = append(out, option)
 	}
 	return out
 }
 
-func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
-	summary := summarizeNvidiaNode(req, node, pressure)
+func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) NodeOption {
+	summary := summarizeNvidiaNode(req, node, pressure, opts)
 	option := NodeOption{
 		NodeName: node.NodeName,
 		GPUType:  req.Mode,
@@ -74,28 +88,58 @@ func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) N
 	return option
 }
 
-func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) NodeOption {
+// classifyNonNvidiaNode classifies every device a node exposes for a non-nvidia
+// mode. Most such modes are unified memory and model the whole node as a single
+// device, but nvidia-gb10 and discrete Intel GPUs can expose several cards on
+// one node, so the node's status is taken from its best card the way
+// classifyNvidiaNode does — listing only the first one would hide the rest from
+// both the resume picker and install's auto-pick.
+func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) NodeOption {
 	option := NodeOption{NodeName: node.NodeName, GPUType: req.Mode}
 	if len(node.Devices) == 0 {
 		option.Status = NodeStatusNotAvailable
 		return option
 	}
-	devOpt := makeDeviceOption(req, node, node.Devices[0], pressure)
-	option.Devices = []DeviceOption{devOpt}
-	switch {
-	case devOpt.Health != deviceHealthYes:
+	option.Devices = make([]DeviceOption, 0, len(node.Devices))
+	var healthy bool
+	var maxCapacity, maxAvailable int64
+	for _, device := range node.Devices {
+		devOpt := makeDeviceOption(req, node, device, pressure, opts)
+		option.Devices = append(option.Devices, devOpt)
+		if devOpt.Health != deviceHealthYes {
+			continue
+		}
+		healthy = true
+		if devOpt.Capacity > maxCapacity {
+			maxCapacity = devOpt.Capacity
+		}
+		if devOpt.Available > maxAvailable {
+			maxAvailable = devOpt.Available
+		}
+	}
+	if !healthy {
 		option.Status = NodeStatusNotAvailable
-	case devOpt.Capacity < req.RequiredMemory:
-		option.Status = NodeStatusNotEnough
-	case devOpt.Available >= req.RequiredMemory && !pressure.WouldPressure(node, AddedResources{
-		CPU:    req.RequiredCPU,
-		Memory: req.RequiredMemory,
-	}):
-		option.Status = NodeStatusAvailable
-	default:
+		return option
+	}
+	option.Status = nodeStatusFromCapacity(req.RequiredMemory, maxCapacity, maxAvailable)
+	if option.Status == NodeStatusAvailable && nodeWouldPressure(req, node, pressure, opts) {
 		option.Status = NodeStatusNotAvailable
 	}
 	return option
+}
+
+// nodeWouldPressure reports whether hosting the app would push the node past
+// its pressure threshold. Unlike the per-device fit checks it deliberately
+// leaves disk out: node status has always been a cpu/memory judgement.
+func nodeWouldPressure(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) bool {
+	if !opts.checkPressure {
+		return false
+	}
+	added := AddedResources{CPU: req.RequiredCPU, Memory: req.RequiredMemory}
+	if opts.pressureAdded != nil {
+		added = *opts.pressureAdded
+	}
+	return pressure.WouldPressure(node, added)
 }
 
 type nvidiaNodeSummary struct {
@@ -106,10 +150,10 @@ type nvidiaNodeSummary struct {
 	maxAvailable   int64
 }
 
-func summarizeNvidiaNode(req Requirement, node Node, pressure PressureSnapshot) nvidiaNodeSummary {
+func summarizeNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) nvidiaNodeSummary {
 	summary := nvidiaNodeSummary{devices: make([]DeviceOption, 0, len(node.Devices))}
 	for _, device := range node.Devices {
-		devOpt := makeDeviceOption(req, node, device, pressure)
+		devOpt := makeDeviceOption(req, node, device, pressure, opts)
 		summary.devices = append(summary.devices, devOpt)
 		if devOpt.Health != deviceHealthYes {
 			continue
@@ -136,7 +180,7 @@ func nodeStatusFromCapacity(required, capacity, available int64) string {
 	return NodeStatusNotAvailable
 }
 
-func makeDeviceOption(req Requirement, node Node, device Device, pressure PressureSnapshot) DeviceOption {
+func makeDeviceOption(req Requirement, node Node, device Device, pressure PressureSnapshot, opts allocationOptions) DeviceOption {
 	req.RequiredDisk = 0
 	available := deviceAvailableMemory(device)
 	option := DeviceOption{
@@ -153,13 +197,46 @@ func makeDeviceOption(req Requirement, node Node, device Device, pressure Pressu
 		option.Health = deviceHealthYes
 	}
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
-		fits, _ := deviceFitsLevel(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes, 0)
+		fits, _ := deviceFitsLevelWithPressure(req, node, device, pressure, level, req.SupportMultiCards || req.SupportMultiNodes, 0, opts)
 		if fits {
 			option.FitLevel = level
 			break
 		}
 	}
 	return option
+}
+
+// asNodeDevice re-materializes the (node, device) pair a DeviceOption was
+// derived from, so the auto-picker can run the fit checks straight against the
+// availability view rather than against a second copy of the node snapshot.
+// That is what keeps install's automatic pick and resume's manual pick anchored
+// to the same candidate set: both are choosing among the very devices this view
+// exposes, judged by the very fit level it reports.
+//
+// The conversion goes this direction, rather than deviceFitsLevelWithPressure
+// simply taking a DeviceOption, because that function is also what builds the
+// view: makeDeviceOption calls it to compute FitLevel, at which point only the
+// raw Node and Device exist and the DeviceOption does not yet. The fit logic
+// therefore has to stay Device-shaped, and the view side adapts.
+//
+// The round trip is exact for everything the fit checks read — Health, plus
+// SupportType/Memory/Bindings, which are what deviceAvailableMemory and
+// timeSliceAddedMemory consume, plus the node name that pressure lookups are
+// keyed by. Recomputing deviceAvailableMemory on the result therefore
+// reproduces DeviceOption.Available. The identity fields (ID, Mode, CardModel)
+// are along for the ride so the value is a well-formed Device; no fit check
+// reads them.
+func (o DeviceOption) asNodeDevice(mode string) (Node, Device) {
+	return Node{NodeName: o.NodeName}, Device{
+		ID:          o.DeviceID,
+		NodeName:    o.NodeName,
+		Mode:        mode,
+		CardModel:   o.CardModel,
+		Memory:      o.Capacity,
+		Health:      o.Health,
+		SupportType: o.SupportType,
+		Bindings:    o.Bindings,
+	}
 }
 
 func availabilityScope(req Requirement) string {
@@ -284,21 +361,12 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 	var unavailable *BindingApplyResult
 	if _, err := mutateAllocations(ctx, c, func(nodes []Node, existing []Allocation) ([]Allocation, *Allocation, error) {
 		attachBindings(nodes, withoutAppAllocations(existing, appConfig.AppName, appConfig.OwnerName))
-		resolved, resolveErr := resolveSelection(selections, nodes)
-		if resolveErr != nil {
-			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error()))
-			return nil, nil, errBindingUnavailable
-		}
-		validation := validateResolvedBindingSelection(req, resolved, pressure)
+		bound, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 		if !validation.OK {
 			unavailable = unavailableBindingApplyResult(req, nodes, pressure, validation)
 			return nil, nil, errBindingUnavailable
 		}
-		allocations = allocationsFromResolvedSelection(appConfig, req, resolved)
-		if len(allocations) == 0 {
-			unavailable = unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding"))
-			return nil, nil, errBindingUnavailable
-		}
+		allocations = bound
 		next := replaceAppAllocations(existing, allocations)
 		return next, &allocations[0], nil
 	}); err != nil {
@@ -307,15 +375,8 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		}
 		return nil, err
 	}
-	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
-		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, allocations); err != nil {
 		return nil, err
-	}
-	for _, allocation := range allocations {
-		if err := createHAMIBinding(ctx, c, allocation); err != nil {
-			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
-			return nil, err
-		}
 	}
 	return &BindingApplyResult{
 		Status:      BindingApplyStatusApplied,
@@ -323,6 +384,45 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		TargetApp:   appConfig.AppName,
 		TargetOwner: appConfig.OwnerName,
 	}, nil
+}
+
+// bindAllocations turns a compute binding selection — the user's manual pick on
+// resume, or install's automatic pick out of the same availability view — into
+// the app's allocation rows. Both flows converge here so a placement install
+// makes on its own is held to exactly the same rules as one a user submits.
+// The returned validation result is always non-nil; the allocations are only
+// meaningful when it reports OK.
+func bindAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, selections []BindingSelection, nodes []Node, pressure PressureSnapshot) ([]Allocation, *BindingValidationResult) {
+	resolved, err := resolveSelection(selections, nodes)
+	if err != nil {
+		return nil, invalidBinding(err.Error())
+	}
+	validation := validateResolvedBindingSelection(req, resolved, pressure)
+	if !validation.OK {
+		return nil, validation
+	}
+	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
+	if len(allocations) == 0 {
+		return nil, invalidBinding("empty-compute-binding")
+	}
+	return allocations, validation
+}
+
+// syncHAMIBindings replaces the app's HAMI GPUBindings with the ones its new
+// allocations call for. A failure at this point leaves the allocation rows
+// pointing at bindings that were never created, so it releases them.
+func syncHAMIBindings(ctx context.Context, c client.Client, appName, owner string, allocations []Allocation) error {
+	if err := deleteHAMIBindingsForApp(ctx, c, appName, owner); err != nil {
+		_ = DeleteAllocationsForApp(ctx, c, appName, owner)
+		return err
+	}
+	for _, allocation := range allocations {
+		if err := createHAMIBinding(ctx, c, allocation); err != nil {
+			_ = DeleteAllocationsForApp(ctx, c, appName, owner)
+			return err
+		}
+	}
+	return nil
 }
 
 // ValidateBindingForResume mirrors ApplyBindingSelection's feasibility
@@ -372,17 +472,9 @@ func ValidateBindingForResume(ctx context.Context, c client.Client, appConfig *a
 			TargetOwner:  appConfig.OwnerName,
 		}, nil
 	}
-	resolved, resolveErr := resolveSelection(selections, nodes)
-	if resolveErr != nil {
-		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding(resolveErr.Error())), nil
-	}
-	validation := validateResolvedBindingSelection(req, resolved, pressure)
+	allocations, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 	if !validation.OK {
 		return unavailableBindingApplyResult(req, nodes, pressure, validation), nil
-	}
-	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
-	if len(allocations) == 0 {
-		return unavailableBindingApplyResult(req, nodes, pressure, invalidBinding("empty-compute-binding")), nil
 	}
 	// Even when the selection is valid we still hand back the full list of
 	// available options so the frontend can render the current selection in
@@ -590,6 +682,13 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 			amount = deviceAvailableMemory(item.device)
 		case len(resolved) > 1:
 			amount = minInt64(deviceAvailableMemory(item.device), remaining)
+		}
+		if amount <= 0 {
+			// The app declares no concrete demand for this mode, so the
+			// selection's own amount is all we have to go on. Without this the
+			// allocation would be dropped and the whole binding rejected as
+			// empty.
+			amount = item.memory
 		}
 		if amount <= 0 {
 			continue

--- a/framework/app-service/pkg/compute/launch_selection_test.go
+++ b/framework/app-service/pkg/compute/launch_selection_test.go
@@ -1,0 +1,179 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+// TestAutoPickOnlyChoosesDevicesTheResumeViewOffers pins the property that ties
+// the two placement flows together: install and resume start from the same
+// availability view, so a card install assigns itself must be one the resume
+// picker would have let a user click. The cluster below mixes every reason a
+// card is unusable — already taken exclusively, unhealthy, too little VRAM left
+// — so a picker running against the raw node list instead of the view would
+// have plenty of chances to reach past what the view exposes.
+func TestAutoPickOnlyChoosesDevicesTheResumeViewOffers(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "llm", OwnerName: "alice", SelectedGpuType: utils.NvidiaCardType}
+	req := Requirement{
+		Mode:           utils.NvidiaCardType,
+		RequiredGPU:    8 * gi,
+		LimitedGPU:     8 * gi,
+		RequiredMemory: gi,
+		LimitedMemory:  gi,
+	}
+	nodes := []Node{
+		nvidiaNode("nvidia-a",
+			Device{ID: "a-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive,
+				Bindings: []Allocation{{AppName: "other", Owner: "bob"}}},
+			Device{ID: "a-gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+		),
+		nvidiaNode("nvidia-b",
+			Device{ID: "b-gpu0", Memory: 16 * gi, Health: deviceHealthNo, SupportType: SupportTypeExclusive},
+			Device{ID: "b-gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+		),
+		nvidiaNode("nvidia-c",
+			Device{ID: "c-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice,
+				Bindings: []Allocation{{AppName: "other", Owner: "bob", Memory: 12 * gi}}},
+		),
+		computeNode("cpu-a", utils.CPUType, 64*gi, SupportTypeMemorySlice),
+	}
+
+	offered := map[string]bool{}
+	for _, node := range listAvailableForLaunch(req, nodes, PressureSnapshot{}).Nodes {
+		for _, device := range node.Devices {
+			if device.Operable {
+				offered[node.NodeName+"/"+device.DeviceID] = true
+			}
+		}
+	}
+	if len(offered) != 2 {
+		t.Fatalf("expected the two free exclusive cards to be selectable, got %#v", offered)
+	}
+
+	// The picker breaks ties at random, so repeat enough to see every card it
+	// is willing to choose.
+	chosen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+		if !ok {
+			t.Fatalf("expected a placement on one of the free exclusive cards")
+		}
+		for _, allocation := range picked {
+			key := allocation.NodeName + "/" + allocation.DeviceID
+			if !offered[key] {
+				t.Fatalf("install picked %s, which the resume view does not offer as selectable", key)
+			}
+			chosen[key] = true
+		}
+	}
+	if len(chosen) != len(offered) {
+		t.Fatalf("expected the picker to spread across every offered card, got %#v", chosen)
+	}
+}
+
+// TestAutoPickPassesManualBindingValidation covers the other half of the
+// unification: AllocateForInstall now runs its own pick through the validation
+// a user-submitted binding goes through, so the picker must never produce a
+// selection that validation would turn away.
+func TestAutoPickPassesManualBindingValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		req   Requirement
+		nodes []Node
+	}{
+		{
+			name: "single exclusive card",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi, RequiredMemory: gi, LimitedMemory: gi},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive})},
+		},
+		{
+			name: "memory slice card",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi, RequiredMemory: gi, LimitedMemory: gi},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice})},
+		},
+		{
+			name: "multi card on one node",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 24 * gi, LimitedGPU: 24 * gi, SupportMultiCards: true},
+			nodes: []Node{nvidiaNode("nvidia-a",
+				Device{ID: "gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+				Device{ID: "gpu1", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeExclusive},
+			)},
+		},
+		{
+			name: "multi card across nodes",
+			req:  Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 24 * gi, LimitedGPU: 24 * gi, SupportMultiCards: true, SupportMultiNodes: true},
+			nodes: []Node{
+				nvidiaNode("nvidia-a", Device{ID: "a-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice}),
+				nvidiaNode("nvidia-b", Device{ID: "b-gpu0", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeMemorySlice}),
+			},
+		},
+		{
+			name:  "gb10 chip",
+			req:   Requirement{Mode: utils.GB10ChipType, RequiredMemory: 24 * gi, LimitedMemory: 48 * gi},
+			nodes: []Node{computeNode("spark-ab12", utils.GB10ChipType, 96*gi, SupportTypeMemorySlice)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			availability := listAvailableForLaunch(tc.req, tc.nodes, PressureSnapshot{})
+			selections, ok := pickLaunchSelection(tc.req, availability, PressureSnapshot{}, allocationOptions{checkPressure: true})
+			if !ok {
+				t.Fatalf("expected the auto-picker to find a placement")
+			}
+			if result := ValidateBindingSelection(tc.req, selections, tc.nodes, PressureSnapshot{}); !result.OK {
+				t.Fatalf("install's own pick %#v was rejected by the manual binding validation: %#v", selections, result)
+			}
+		})
+	}
+}
+
+// TestNonNvidiaNodeExposesEveryDevice covers nvidia-gb10 chips and discrete
+// Intel GPUs, the non-nvidia modes that can put several cards on one node. The
+// availability view used to report only the node's first card, which hid the
+// rest from the resume picker; now that install picks from the same view, that
+// would also have made a busy first card look like a full node.
+func TestNonNvidiaNodeExposesEveryDevice(t *testing.T) {
+	app := &appcfg.ApplicationConfig{AppName: "ollama", OwnerName: "alice", SelectedGpuType: utils.GB10ChipType}
+	req := Requirement{Mode: utils.GB10ChipType, RequiredMemory: 24 * gi, LimitedMemory: 24 * gi}
+	nodes := []Node{multiDeviceNode("spark-ab12", utils.GB10ChipType, SupportTypeMemorySlice,
+		Device{ID: "spark-0", Memory: 96 * gi, Bindings: []Allocation{{AppName: "other", Owner: "bob", Memory: 90 * gi}}},
+		Device{ID: "spark-1", Memory: 96 * gi},
+	)}
+
+	result := listAvailableForLaunch(req, nodes, PressureSnapshot{})
+	if len(result.Nodes) != 1 || len(result.Nodes[0].Devices) != 2 {
+		t.Fatalf("expected both cards to be listed for manual selection, got %#v", result.Nodes)
+	}
+
+	picked, ok := PickAllocations(app, req, nodes, PressureSnapshot{})
+	if !ok || len(picked) != 1 {
+		t.Fatalf("expected a single placement on the free card, got ok=%v picked=%#v", ok, picked)
+	}
+	if picked[0].DeviceID != "spark-1" || picked[0].Memory != 24*gi {
+		t.Fatalf("expected a 24Gi slice of the free second card, got %#v", picked[0])
+	}
+}
+
+func multiDeviceNode(name, mode, supportType string, devices ...Device) Node {
+	node := Node{
+		NodeName:       name,
+		GPUTypes:       []string{mode},
+		memoryCapacity: 128 * gi,
+		Devices:        devices,
+	}
+	for i := range node.Devices {
+		node.Devices[i].NodeName = name
+		node.Devices[i].Mode = mode
+		if node.Devices[i].Health == "" {
+			node.Devices[i].Health = deviceHealthYes
+		}
+		if node.Devices[i].SupportType == "" {
+			node.Devices[i].SupportType = supportType
+		}
+	}
+	return node
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -74,9 +74,19 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	var pickedAllocations []Allocation
 	allocation, err := mutateAllocations(ctx, c, func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error) {
 		attachBindings(nodes, withoutAppAllocations(allocations, appConfig.AppName, appConfig.OwnerName))
-		picked, ok := PickAllocations(appConfig, req, nodes, pressure)
+		// Same first step as resume: classify every node and device against
+		// the app's requirement. Where resume hands that view to the user,
+		// install picks from it here and then runs the pick through resume's
+		// own validation so an automatic placement can't bypass a rule a
+		// manual one has to satisfy.
+		availability := listAvailableForLaunch(req, nodes, pressure)
+		selections, ok := pickLaunchSelection(req, availability, pressure, allocationOptions{checkPressure: true})
 		if !ok {
 			return nil, nil, fmt.Errorf("no available compute resource for type %s", req.Mode)
+		}
+		picked, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
+		if !validation.OK {
+			return nil, nil, fmt.Errorf("no available compute resource for type %s: %s", req.Mode, validation.Code)
 		}
 		pickedAllocations = picked
 		next := replaceAppAllocations(allocations, picked)
@@ -85,15 +95,8 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	if err != nil {
 		return nil, err
 	}
-	if err := deleteHAMIBindingsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName); err != nil {
-		_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
+	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, pickedAllocations); err != nil {
 		return nil, err
-	}
-	for _, item := range pickedAllocations {
-		if err := createHAMIBinding(ctx, c, item); err != nil {
-			_ = DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
-			return nil, err
-		}
 	}
 	return allocation, nil
 }
@@ -154,6 +157,19 @@ func EvaluateInstallMode(req Requirement, nodes []Node) ModePlanResult {
 	return ModePlanResult{ComputeType: req.Mode, Status: StatusInsufficientResources, Reason: "insufficient_resources"}
 }
 
+// matchingNodes returns the nodes that support `mode`, each projected onto that
+// single mode (Devices filtered to the mode) so the device-centric helpers only
+// ever see the relevant devices of a multi-mode node.
+func matchingNodes(mode string, nodes []Node) []Node {
+	out := make([]Node, 0)
+	for _, node := range nodes {
+		if node.SupportsMode(mode) {
+			out = append(out, node.viewForMode(mode))
+		}
+	}
+	return out
+}
+
 func PickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot) ([]Allocation, bool) {
 	return pickAllocations(appConfig, req, nodes, pressure, allocationOptions{checkPressure: true})
 }
@@ -164,31 +180,45 @@ type allocationOptions struct {
 	pressureAdded *AddedResources
 }
 
+// pickAllocations places an app automatically: it builds the availability view
+// resume would show the user, picks a binding out of it, and turns that binding
+// into allocation rows through the same resolve/build path resume uses for a
+// manually submitted one.
 func pickAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
-	if req.Mode == utils.CPUType {
+	availability := listAvailableForLaunchWithOptions(req, nodes, pressure, pressureOptions)
+	selections, ok := pickLaunchSelection(req, availability, pressure, pressureOptions)
+	if !ok {
 		return nil, false
 	}
-	matching := matchingNodes(req.Mode, nodes)
-	if req.Mode == utils.NvidiaCardType && req.SupportMultiNodes {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, true)
+	resolved, err := resolveSelection(selections, nodes)
+	if err != nil {
+		return nil, false
 	}
-	if req.Mode == utils.NvidiaCardType && req.SupportMultiCards {
-		return pickAggregateAllocations(appConfig, req, matching, pressure, pressureOptions, false)
+	allocations := allocationsFromResolvedSelection(appConfig, req, resolved)
+	if len(allocations) == 0 {
+		return nil, false
 	}
-	return pickSingleAllocation(appConfig, req, matching, pressure, pressureOptions)
+	return allocations, true
 }
 
-// matchingNodes returns the nodes that support `mode`, each projected onto that
-// single mode (Devices filtered to the mode) so the device-centric scheduling
-// helpers only ever see the relevant devices of a multi-mode node.
-func matchingNodes(mode string, nodes []Node) []Node {
-	out := make([]Node, 0)
-	for _, node := range nodes {
-		if node.SupportsMode(mode) {
-			out = append(out, node.viewForMode(mode))
-		}
+// pickLaunchSelection auto-picks a compute binding out of the availability view
+// that resume hands to the user for a manual pick. Install runs this instead of
+// prompting, so both flows choose among exactly the same devices, ranked the
+// same way: the best fit level first (an app that fits its limit is placed
+// before one that only fits its request), then whole cards before shared ones,
+// then at random among the remaining ties to spread load across the cluster.
+func pickLaunchSelection(req Requirement, availability *AvailabilityResult, pressure PressureSnapshot, opts allocationOptions) ([]BindingSelection, bool) {
+	if availability == nil || req.Mode == utils.CPUType {
+		return nil, false
 	}
-	return out
+	switch availability.Scope {
+	case AvailabilityScopeCrossNode:
+		return pickAggregateSelection(req, availability.Nodes, pressure, opts, true)
+	case AvailabilityScopeSingleNode:
+		return pickAggregateSelection(req, availability.Nodes, pressure, opts, false)
+	default:
+		return pickSingleSelection(req, availability.Nodes, pressure, opts)
+	}
 }
 
 func evaluateCPUInstallMode(req Requirement, nodes []Node) ModePlanResult {
@@ -239,82 +269,87 @@ func installCapacityFits(req Requirement, nodes []Node) bool {
 		}
 		return false
 	}
+	// Non-nvidia modes are scheduled one device at a time, but a node can still
+	// expose several of them (nvidia-gb10 cards, discrete Intel GPUs), so every
+	// device gets a look rather than just the first.
 	for _, node := range nodes {
-		if len(node.Devices) > 0 && node.Devices[0].Memory >= req.RequiredMemory {
-			return true
+		for _, device := range node.Devices {
+			if device.Memory >= req.RequiredMemory {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func pickSingleAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions) ([]Allocation, bool) {
+// pickSingleSelection places the app on one device, which is the unit of
+// scheduling for every mode except multi-card nvidia.
+func pickSingleSelection(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions) ([]BindingSelection, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		for _, supportType := range supportTypeOrder(req.Mode) {
-			candidates := make([]Allocation, 0)
+			candidates := make([]BindingSelection, 0)
 			for _, node := range nodes {
-				for _, device := range node.Devices {
-					if supportType != "" && device.SupportType != supportType {
+				for _, option := range node.Devices {
+					if option.SupportType != supportType || !option.Operable {
 						continue
 					}
-					fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, false, 0, pressureOptions)
-					if fits {
-						assigned := requiredTargetForMode(req)
-						if assigned == 0 {
-							assigned = amount
-						}
-						candidates = append(candidates, buildAllocation(appConfig, req, node, device, assigned))
+					if fits, _ := deviceOptionFits(req, option, pressure, level, false, 0, opts); !fits {
+						continue
 					}
+					candidates = append(candidates, selectDevice(option, requiredTargetForMode(req)))
 				}
 			}
 			if len(candidates) > 0 {
-				if pressureOptions.deterministic {
-					return []Allocation{candidates[0]}, true
+				if opts.deterministic {
+					return []BindingSelection{candidates[0]}, true
 				}
-				return []Allocation{candidates[rand.Intn(len(candidates))]}, true
+				return []BindingSelection{candidates[rand.Intn(len(candidates))]}, true
 			}
 		}
 	}
 	return nil, false
 }
 
-func pickAggregateAllocations(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, crossNode bool) ([]Allocation, bool) {
+// pickAggregateSelection places a multi-card nvidia app across several cards,
+// either within a single node or — when the app declares multi-node support —
+// across the whole cluster.
+func pickAggregateSelection(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions, crossNode bool) ([]BindingSelection, bool) {
 	for _, level := range []string{FitLevelLimit, FitLevelRequired} {
 		target := targetGPU(req, level)
 		if target <= 0 {
 			continue
 		}
 		if crossNode {
-			picked, ok := collectDevicesForTarget(appConfig, req, nodes, pressure, pressureOptions, level, target, req.RequiredGPU)
-			if ok {
-				return picked, ok
+			if picked, ok := collectDevicesForTarget(req, nodes, pressure, opts, level, target, req.RequiredGPU); ok {
+				return picked, true
 			}
 			continue
 		}
 		for _, node := range nodes {
-			picked, ok := collectDevicesForTarget(appConfig, req, []Node{node}, pressure, pressureOptions, level, target, req.RequiredGPU)
-			if ok {
-				return picked, ok
+			if picked, ok := collectDevicesForTarget(req, []NodeOption{node}, pressure, opts, level, target, req.RequiredGPU); ok {
+				return picked, true
 			}
 		}
 	}
 	return nil, false
 }
 
-func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requirement, nodes []Node, pressure PressureSnapshot, pressureOptions allocationOptions, level string, target, allocationTarget int64) ([]Allocation, bool) {
+func collectDevicesForTarget(req Requirement, nodes []NodeOption, pressure PressureSnapshot, opts allocationOptions, level string, target, allocationTarget int64) ([]BindingSelection, bool) {
 	fitRemaining := target
 	allocationRemaining := allocationTarget
-	var out []Allocation
+	var out []BindingSelection
 	timeSliceMemoryByNode := make(map[string]int64)
 	for _, supportType := range supportTypeOrder(req.Mode) {
 		for _, node := range nodes {
-			for _, device := range node.Devices {
-				if supportType != "" && device.SupportType != supportType {
+			for _, option := range node.Devices {
+				if option.SupportType != supportType || !option.Operable {
 					continue
 				}
-				fits, amount := deviceFitsLevelWithPressure(req, node, device, pressure, level, true, timeSliceMemoryByNode[node.NodeName], pressureOptions)
+				fits, amount := deviceOptionFits(req, option, pressure, level, true, timeSliceMemoryByNode[node.NodeName], opts)
 				if !fits || amount <= 0 {
 					continue
 				}
+				_, device := option.asNodeDevice(req.Mode)
 				nextMemory, ok := checkedAdd(timeSliceMemoryByNode[node.NodeName], timeSliceAddedMemory(device))
 				if !ok {
 					continue
@@ -322,7 +357,7 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 				timeSliceMemoryByNode[node.NodeName] = nextMemory
 				if allocationRemaining > 0 {
 					assigned := minInt64(amount, allocationRemaining)
-					out = append(out, buildAllocation(appConfig, req, node, device, assigned))
+					out = append(out, selectDevice(option, assigned))
 					allocationRemaining -= assigned
 				}
 				fitRemaining -= amount
@@ -335,8 +370,21 @@ func collectDevicesForTarget(appConfig *appcfg.ApplicationConfig, req Requiremen
 	return nil, false
 }
 
-func deviceFitsLevel(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64) (bool, int64) {
-	return deviceFitsLevelWithPressure(req, node, device, pressure, level, allowPartial, priorTimeSliceMemory, allocationOptions{checkPressure: true})
+// selectDevice records a picked device as the same BindingSelection the resume
+// frontend submits. `assigned` only reaches the allocation for memory-slice
+// cards, where the binding carves out an explicit slice; whole-card placements
+// ignore it. A non-positive amount means the app declared no concrete demand
+// for this mode, so it takes whatever the card has free.
+func selectDevice(option DeviceOption, assigned int64) BindingSelection {
+	if assigned <= 0 {
+		assigned = option.Available
+	}
+	return BindingSelection{NodeName: option.NodeName, DeviceID: option.DeviceID, Memory: assigned}
+}
+
+func deviceOptionFits(req Requirement, option DeviceOption, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64, opts allocationOptions) (bool, int64) {
+	node, device := option.asNodeDevice(req.Mode)
+	return deviceFitsLevelWithPressure(req, node, device, pressure, level, allowPartial, priorTimeSliceMemory, opts)
 }
 
 func deviceFitsLevelWithPressure(req Requirement, node Node, device Device, pressure PressureSnapshot, level string, allowPartial bool, priorTimeSliceMemory int64, pressureOptions allocationOptions) (bool, int64) {

--- a/framework/app-service/pkg/compute/scheduler_test.go
+++ b/framework/app-service/pkg/compute/scheduler_test.go
@@ -34,13 +34,14 @@ func TestDeviceFitsLevelTimeSliceMemoryForZeroRequirement(t *testing.T) {
 		RequiredMemory: 5 * gib,
 	}
 
-	fits, _ := deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	opts := allocationOptions{checkPressure: true}
+	fits, _ := deviceFitsLevelWithPressure(req, node, device, pressure, FitLevelRequired, false, 0, opts)
 	if !fits {
 		t.Fatal("zero GPU requirement should preserve the legacy fit decision without time-slice host memory")
 	}
 
 	req.RequiredGPU = gib
-	fits, _ = deviceFitsLevel(req, node, device, pressure, FitLevelRequired, false, 0)
+	fits, _ = deviceFitsLevelWithPressure(req, node, device, pressure, FitLevelRequired, false, 0, opts)
 	if fits {
 		t.Fatal("positive GPU requirement must include time-slice host memory")
 	}

--- a/framework/app-service/pkg/compute/upgrade_resources.go
+++ b/framework/app-service/pkg/compute/upgrade_resources.go
@@ -1,0 +1,57 @@
+package compute
+
+import (
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// UpgradeResourceDelta returns the non-negative per-dimension increase
+// from prev to next app declared requirements. Negative deltas (resource
+// reductions) are clamped to zero: upgrade pressure/quota checks only
+// ask whether the cluster can absorb additional demand; releasing
+// resources does not need a headroom check.
+//
+// Units match AddedResourcesFromAppConfig: CPU in milli-cores, Memory
+// and Disk in bytes.
+func UpgradeResourceDelta(prev, next *appcfg.ApplicationConfig) AddedResources {
+	old := AddedResourcesFromAppConfig(prev)
+	neu := AddedResourcesFromAppConfig(next)
+	return AddedResources{
+		CPU:    maxInt64(0, neu.CPU-old.CPU),
+		Memory: maxInt64(0, neu.Memory-old.Memory),
+		Disk:   maxInt64(0, neu.Disk-old.Disk),
+	}
+}
+
+// AppConfigWithRequirement returns a shallow copy of base whose
+// Requirement CPU/Memory/Disk are set from added (nil for zero dims so
+// resourceStateFromConfig skips them). Accelerator is cleared so any
+// SelectedRequirement lookup cannot override the injected delta.
+// OwnerName and other identity fields are preserved for user-quota
+// lookups.
+func AppConfigWithRequirement(base *appcfg.ApplicationConfig, added AddedResources) *appcfg.ApplicationConfig {
+	if base == nil {
+		return nil
+	}
+	cfg := *base
+	cfg.Accelerator = nil
+	cfg.Requirement = appcfg.AppRequirement{}
+	if added.CPU > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(added.CPU, resource.DecimalSI)
+	}
+	if added.Memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(added.Memory, resource.BinarySI)
+	}
+	if added.Disk > 0 {
+		cfg.Requirement.Disk = resource.NewQuantity(added.Disk, resource.BinarySI)
+	}
+	return &cfg
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/framework/app-service/pkg/compute/upgrade_resources_test.go
+++ b/framework/app-service/pkg/compute/upgrade_resources_test.go
@@ -1,0 +1,125 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func legacyConfig(cpuMilli, memory, disk int64) *appcfg.ApplicationConfig {
+	cfg := &appcfg.ApplicationConfig{AppName: "app", OwnerName: "alice"}
+	if cpuMilli > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(cpuMilli, resource.DecimalSI)
+	}
+	if memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(memory, resource.BinarySI)
+	}
+	if disk > 0 {
+		cfg.Requirement.Disk = resource.NewQuantity(disk, resource.BinarySI)
+	}
+	return cfg
+}
+
+func TestUpgradeResourceDelta(t *testing.T) {
+	cases := []struct {
+		name string
+		prev *appcfg.ApplicationConfig
+		next *appcfg.ApplicationConfig
+		want AddedResources
+	}{
+		{
+			name: "increase all dims",
+			prev: legacyConfig(1000, 1<<30, 2<<30),
+			next: legacyConfig(2500, 3<<30, 5<<30),
+			want: AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 3 << 30},
+		},
+		{
+			name: "unchanged",
+			prev: legacyConfig(1000, 1<<30, 2<<30),
+			next: legacyConfig(1000, 1<<30, 2<<30),
+			want: AddedResources{},
+		},
+		{
+			name: "decrease clamps to zero",
+			prev: legacyConfig(2500, 3<<30, 5<<30),
+			next: legacyConfig(1000, 1<<30, 2<<30),
+			want: AddedResources{},
+		},
+		{
+			name: "missing prev dims treat as zero",
+			prev: &appcfg.ApplicationConfig{AppName: "app"},
+			next: legacyConfig(1500, 2<<30, 4<<30),
+			want: AddedResources{CPU: 1500, Memory: 2 << 30, Disk: 4 << 30},
+		},
+		{
+			name: "nil prev",
+			prev: nil,
+			next: legacyConfig(500, 1<<20, 1<<20),
+			want: AddedResources{CPU: 500, Memory: 1 << 20, Disk: 1 << 20},
+		},
+		{
+			name: "nil next",
+			prev: legacyConfig(500, 1<<20, 1<<20),
+			next: nil,
+			want: AddedResources{},
+		},
+		{
+			name: "partial increase",
+			prev: legacyConfig(1000, 2<<30, 4<<30),
+			next: legacyConfig(1000, 3<<30, 2<<30),
+			want: AddedResources{Memory: 1 << 30},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UpgradeResourceDelta(tc.prev, tc.next); got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppConfigWithRequirement(t *testing.T) {
+	if got := AppConfigWithRequirement(nil, AddedResources{CPU: 1}); got != nil {
+		t.Fatalf("nil base: got %+v, want nil", got)
+	}
+
+	base := &appcfg.ApplicationConfig{
+		AppName:         "app",
+		OwnerName:       "alice",
+		SelectedGpuType: "nvidia",
+		Accelerator: []appcfg.ResourceMode{{
+			Mode: "nvidia",
+			ResourceRequirement: appcfg.ResourceRequirement{
+				RequiredCPU:    "4",
+				RequiredMemory: "8Gi",
+			},
+		}},
+	}
+	base.Requirement.CPU = resource.NewMilliQuantity(4000, resource.DecimalSI)
+
+	got := AppConfigWithRequirement(base, AddedResources{CPU: 500, Memory: 1 << 30})
+	if got == nil {
+		t.Fatal("got nil")
+	}
+	if got.OwnerName != "alice" || got.AppName != "app" {
+		t.Errorf("identity fields not preserved: %+v", got)
+	}
+	if got.Accelerator != nil {
+		t.Errorf("Accelerator should be cleared, got %+v", got.Accelerator)
+	}
+	if got.Requirement.CPU == nil || got.Requirement.CPU.MilliValue() != 500 {
+		t.Errorf("CPU=%v, want 500m", got.Requirement.CPU)
+	}
+	if got.Requirement.Memory == nil || got.Requirement.Memory.Value() != 1<<30 {
+		t.Errorf("Memory=%v, want 1Gi", got.Requirement.Memory)
+	}
+	if got.Requirement.Disk != nil {
+		t.Errorf("Disk should be nil for zero delta, got %v", got.Requirement.Disk)
+	}
+	if base.Accelerator == nil || base.Requirement.CPU.MilliValue() != 4000 {
+		t.Error("base was mutated")
+	}
+}

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // fakeValidator is the only Validator the run-level tests use so the
@@ -276,13 +277,17 @@ func TestChainShapes(t *testing.T) {
 	}
 	assertChainNames(t, "InstallabilityValidators", InstallabilityValidators(), wantInstall)
 
-	// UpgradabilityValidators is intentionally just cluster-capacity:
-	// upgrade reuses the existing allocation (compute-mode), the
-	// running deployment is already counted against the owner's quota
-	// (user-quota), and helm upgrade goes through kube-scheduler for
-	// the rest. See UpgradabilityValidators in validators.go.
+	// UpgradabilityValidators gates cluster-capacity on the new chart's
+	// absolute requirements, then cluster-pressure / k8s-request on the
+	// non-negative delta (new − old). user-quota, compute-mode,
+	// node-pressure and compute-allocation stay excluded: install/resume
+	// remain the quota gates, upgrade reuses the existing allocation,
+	// and helm upgrade goes through kube-scheduler. See
+	// UpgradabilityValidators in validators.go.
 	wantUpgrade := []string{
 		"cluster-capacity",
+		"cluster-pressure",
+		"k8s-request",
 	}
 	assertChainNames(t, "UpgradabilityValidators", UpgradabilityValidators(), wantUpgrade)
 
@@ -324,19 +329,18 @@ func assertChainNames(t *testing.T, label string, chain []Validator, want []stri
 // here would silently include or exclude the wrong validator for a
 // given lifecycle stage.
 //
-// UpgradeOp is opted into ONLY by cluster-capacity (so the upgrade
-// handler can reject a new chart whose declared requirements exceed
-// the cluster's total schedulable capacity before any helm work
-// happens). Every other validator in this package is intentionally
-// false for UpgradeOp.
+// UpgradeOp is opted into by cluster-capacity (absolute new
+// requirements) and by cluster-pressure / k8s-request (which run
+// against the delta new − old on upgrade). user-quota, compute-mode,
+// node-pressure and compute-allocation stay false for UpgradeOp.
 //
 // The remaining semantic mapping (matching the comments inside
 // validators.go):
 //
-//   - cluster-pressure, k8s-request, node-pressure :
-//     install + resume.
-//   - user-quota         : install + resume (quota is a running total
-//     that grows on either transition).
+//   - cluster-pressure, k8s-request : install + resume + upgrade.
+//   - node-pressure                 : install + resume.
+//   - user-quota         : install + resume only (upgrade does not
+//     re-check owner quota).
 //   - cluster-capacity   : install + upgrade — resume reuses the
 //     placement chosen at install; the cluster's
 //     total schedulable capacity hasn't shrunk in
@@ -372,16 +376,20 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
+			// cluster-pressure runs on upgrade too, but against the
+			// resource delta (new − old) rather than absolute new.
 			name: "cluster-pressure",
 			v:    clusterPressureValidator{},
 			want: map[Op]bool{
 				v1alpha1.InstallOp: true,
-				v1alpha1.UpgradeOp: false,
+				v1alpha1.UpgradeOp: true,
 				v1alpha1.ResumeOp:  true,
 				v1alpha1.StopOp:    false,
 			},
 		},
 		{
+			// user-quota is install + resume only; upgrade does not
+			// re-check owner quota (see UpgradabilityValidators).
 			name: "user-quota",
 			v:    userQuotaValidator{},
 			want: map[Op]bool{
@@ -392,11 +400,13 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
+			// k8s-request runs on upgrade too, but against the resource
+			// delta so already-scheduled requests are not double-counted.
 			name: "k8s-request",
 			v:    k8sRequestValidator{},
 			want: map[Op]bool{
 				v1alpha1.InstallOp: true,
-				v1alpha1.UpgradeOp: false,
+				v1alpha1.UpgradeOp: true,
 				v1alpha1.ResumeOp:  true,
 				v1alpha1.StopOp:    false,
 			},
@@ -446,5 +456,106 @@ func TestAppliesToMatrix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func upgradeConfig(name string, cpuMilli, memory int64) *appcfg.ApplicationConfig {
+	cfg := &appcfg.ApplicationConfig{AppName: name, OwnerName: "alice"}
+	if cpuMilli > 0 {
+		cfg.Requirement.CPU = resource.NewMilliQuantity(cpuMilli, resource.DecimalSI)
+	}
+	if memory > 0 {
+		cfg.Requirement.Memory = resource.NewQuantity(memory, resource.BinarySI)
+	}
+	return cfg
+}
+
+// TestUpgradeDeltaFeedsPressureChecks verifies the delta-aware upgrade
+// validators receive the non-negative delta (new − old) on UpgradeOp,
+// not the new chart's absolute requirements.
+func TestUpgradeDeltaFeedsPressureChecks(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+	})
+
+	var gotCPU int64 = -1
+	capture := func(cfg *appcfg.ApplicationConfig) {
+		if cfg != nil && cfg.Requirement.CPU != nil {
+			gotCPU = cfg.Requirement.CPU.MilliValue()
+		}
+	}
+	checkAppRequirement = func(_ string, cfg *appcfg.ApplicationConfig, _ v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		capture(cfg)
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(cfg *appcfg.ApplicationConfig, _ v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		capture(cfg)
+		return "", "", nil
+	}
+
+	// new needs 3000m, old needs 1000m -> delta 2000m.
+	in := Input{
+		AppConfig:     upgradeConfig("app", 3000, 4<<30),
+		PrevAppConfig: upgradeConfig("app", 1000, 2<<30),
+		Op:            v1alpha1.UpgradeOp,
+	}
+
+	for _, v := range []Validator{clusterPressureValidator{}, k8sRequestValidator{}} {
+		gotCPU = -1
+		decision, err := v.Validate(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%s validate: %v", v.Name(), err)
+		}
+		if !decision.OK {
+			t.Fatalf("%s decision=%#v, want OK", v.Name(), decision)
+		}
+		if gotCPU != 2000 {
+			t.Fatalf("%s received CPU=%dm, want delta 2000m", v.Name(), gotCPU)
+		}
+	}
+}
+
+// TestUpgradeZeroDeltaShortCircuits verifies the delta-aware upgrade
+// validators pass without touching any backend when the new version
+// keeps or lowers its requests.
+func TestUpgradeZeroDeltaShortCircuits(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+	})
+
+	var calls int
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(*appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+
+	// new <= old on every dimension -> delta zero.
+	in := Input{
+		AppConfig:     upgradeConfig("app", 1000, 2<<30),
+		PrevAppConfig: upgradeConfig("app", 2000, 3<<30),
+		Op:            v1alpha1.UpgradeOp,
+	}
+
+	for _, v := range []Validator{clusterPressureValidator{}, k8sRequestValidator{}} {
+		decision, err := v.Validate(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%s validate: %v", v.Name(), err)
+		}
+		if !decision.OK {
+			t.Fatalf("%s decision=%#v, want OK", v.Name(), decision)
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("expected zero backend calls for zero delta, got %d", calls)
 	}
 }

--- a/framework/app-service/pkg/compute/validation/validator.go
+++ b/framework/app-service/pkg/compute/validation/validator.go
@@ -2,9 +2,11 @@
 // upgrade and resume. Legacy installs run InstallRuntimePressureValidators
 // before helm; two-phase installs (workloadReplicas) run the same chain
 // after helm at replicas=0 and before Scale(-1). The upgrade handler
-// runs UpgradabilityValidators at HTTP submit time, which currently only
-// gates on cluster-capacity (see that function for the rationale on why
-// the other install-time checks are intentionally skipped on upgrade).
+// runs UpgradabilityValidators at HTTP submit time: cluster-capacity
+// against the new chart's absolute requirements, plus cluster-pressure /
+// k8s-request against the non-negative delta (new − old) so the running
+// deployment is not double-counted (see that function). User-quota is
+// not part of the upgrade chain (install/resume remain the quota gates).
 //
 // Each individual check (cluster pressure, per-user quota, k8s request
 // availability, per-node pressure, GPU compute plan) is wrapped in a
@@ -28,13 +30,20 @@ import (
 type Op = v1alpha1.OpType
 
 // Input bundles everything a Validator might need. Token is optional and
-// only the cluster-pressure validator currently uses it; the others
-// ignore unset fields.
+// only the cluster-pressure / cluster-capacity validators currently use
+// it; the others ignore unset fields.
+//
+// PrevAppConfig is required for UpgradeOp when running cluster-pressure /
+// k8s-request: those validators check only the non-negative resource
+// delta (new − old) against live headroom so the running deployment is
+// not double-counted. Cluster-capacity still uses AppConfig (the new
+// chart) absolutely, and install/resume ignore PrevAppConfig.
 type Input struct {
-	Client    client.Client
-	AppConfig *appcfg.ApplicationConfig
-	Op        Op
-	Token     string
+	Client        client.Client
+	AppConfig     *appcfg.ApplicationConfig
+	PrevAppConfig *appcfg.ApplicationConfig
+	Op            Op
+	Token         string
 }
 
 // Decision is the structured outcome of a single validator (or the chain

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -68,9 +69,10 @@ func (clusterCapacityValidator) Name() string { return NameClusterCapacity }
 // Upgrade is included so we reject an upgrade whose new chart declares
 // resource requirements the cluster can never satisfy (e.g. the new
 // version raised CPU/memory/disk past the cluster's total schedulable
-// capacity) at HTTP submit time, before any helm work happens. None
-// of the other validators in this file apply to UpgradeOp — runtime
-// pressure / per-user quota are handled separately on the upgrade path.
+// capacity) at HTTP submit time, before any helm work happens. This
+// validator uses the new chart's ABSOLUTE requirements on upgrade;
+// cluster-pressure / k8s-request handle the headroom side against the
+// delta (new − old) — see UpgradabilityValidators.
 func (clusterCapacityValidator) AppliesTo(op Op) bool {
 	switch op {
 	case v1alpha1.InstallOp, v1alpha1.UpgradeOp:
@@ -150,22 +152,28 @@ func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decisio
 // checks aggregate cluster headroom (disk/memory/CPU) against the app's
 // declared requirements. Requires a kubesphere token because the
 // underlying call hits the kubesphere monitoring API.
+//
+// On UpgradeOp the check uses the non-negative resource delta
+// (new − old) so the running deployment already counted in cluster
+// usage is not double-counted.
 type clusterPressureValidator struct{}
 
 func (clusterPressureValidator) Name() string { return NameClusterPressure }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (clusterPressureValidator) AppliesTo(op Op) bool {
 	switch op {
-	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
+	case v1alpha1.InstallOp, v1alpha1.ResumeOp, v1alpha1.UpgradeOp:
 		return true
 	}
 	return false
 }
 
 func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkAppRequirement(in.Token, in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkAppRequirement(in.Token, cfg, in.Op)
 	if err != nil {
 		// CheckAppRequirement returns an empty resource/reason only when
 		// the check itself couldn't be evaluated (e.g. the kubesphere
@@ -189,12 +197,11 @@ func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decisio
 
 // userQuotaValidator wraps apputils.CheckUserResRequirement which
 // checks the owner's per-user memory / CPU quota via prometheus.
+
 type userQuotaValidator struct{}
 
 func (userQuotaValidator) Name() string { return NameUserQuota }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (userQuotaValidator) AppliesTo(op Op) bool {
 	switch op {
 	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
@@ -204,7 +211,11 @@ func (userQuotaValidator) AppliesTo(op Op) bool {
 }
 
 func (userQuotaValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkUserResRequirement(ctx, in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkUserResRequirement(ctx, cfg, in.Op)
 	if err != nil {
 		// Empty resource/reason means the prometheus user-metrics call
 		// failed, not that the user is over quota. Treat it as a fatal
@@ -227,22 +238,28 @@ func (userQuotaValidator) Validate(ctx context.Context, in Input) (Decision, err
 // the cluster has room for the app's CPU/memory request. Runs as part
 // of RuntimePressureValidators in installing_app after helm install and
 // before Scale(-1).
+//
+// On UpgradeOp the check uses the non-negative resource delta
+// (new − old) so already-scheduled requests of the running deployment
+// are not double-counted. Rolling-update surge is left to kube-scheduler.
 type k8sRequestValidator struct{}
 
 func (k8sRequestValidator) Name() string { return NameK8sRequest }
 
-// Applies to install and resume only. UpgradeOp is excluded (upgrade
-// does not run validation).
 func (k8sRequestValidator) AppliesTo(op Op) bool {
 	switch op {
-	case v1alpha1.InstallOp, v1alpha1.ResumeOp:
+	case v1alpha1.InstallOp, v1alpha1.ResumeOp, v1alpha1.UpgradeOp:
 		return true
 	}
 	return false
 }
 
 func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, error) {
-	resource, reason, err := checkAppK8sRequestResource(in.AppConfig, in.Op)
+	cfg, skip := requirementConfigForOp(in)
+	if skip {
+		return ok(), nil
+	}
+	resource, reason, err := checkAppK8sRequestResource(cfg, in.Op)
 	if err != nil {
 		// Empty resource/reason means the node/allocatable lookup failed
 		// (or appConfig was nil), not that the cluster lacks room. Surface
@@ -259,6 +276,22 @@ func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, er
 		}, nil
 	}
 	return ok(), nil
+}
+
+// requirementConfigForOp returns the ApplicationConfig whose declared
+// Requirement should be checked. For install/resume that is AppConfig
+// as-is. For upgrade it is a shallow copy with Requirement set to
+// max(0, new−old); skip is true when the delta is zero on every
+// dimension (caller should treat as OK without hitting metrics).
+func requirementConfigForOp(in Input) (cfg *appcfg.ApplicationConfig, skip bool) {
+	if in.Op != v1alpha1.UpgradeOp {
+		return in.AppConfig, false
+	}
+	delta := compute.UpgradeResourceDelta(in.PrevAppConfig, in.AppConfig)
+	if delta.CPU <= 0 && delta.Memory <= 0 && delta.Disk <= 0 {
+		return nil, true
+	}
+	return compute.AppConfigWithRequirement(in.AppConfig, delta), false
 }
 
 // computeModeValidator wraps compute.AppInstallable which validates
@@ -430,35 +463,43 @@ func InstallabilityValidators() []Validator {
 	}
 }
 
-// UpgradabilityValidators returns the structural feasibility chain
-// applied at HTTP submit time by the upgrade handler. The upgrade flow
-// only needs to ask "is the cluster big enough to host the NEW chart's
-// declared requirements at all?", because:
+// UpgradabilityValidators returns the feasibility chain applied at HTTP
+// submit time by the upgrade handler. It answers two questions:
 //
+//   - cluster-capacity: "is the cluster physically big enough to host
+//     the NEW chart's declared requirements at all?" — evaluated
+//     against the new chart's ABSOLUTE requirements (Total, not
+//     Total−Usage), since a running old version does not shrink the
+//     cluster's total schedulable size.
+//   - cluster-pressure / k8s-request: "can live headroom absorb the
+//     resource INCREASE this upgrade introduces?" — each runs against
+//     the non-negative delta (new − old) computed from
+//     Input.PrevAppConfig, so the running deployment already reflected
+//     in cluster usage / scheduled requests is not double-counted.
+//     When the delta is zero on every dimension (the common case where
+//     a new version keeps or lowers its requests) these validators
+//     short-circuit to OK without any metrics round trip.
+//
+// Intentionally excluded:
+//
+//   - user-quota: install/resume remain the per-user quota gates;
+//     upgrade does not re-check owner quota.
 //   - compute-mode: the existing app already has an allocation, the
 //     upgrade reuses prevCfg.SelectedGpuType. Re-running the planner
 //     would either no-op or spuriously fail on a transiently-degraded
 //     node.
-//   - user-quota: the running deployment is already counted against
-//     the owner's quota, so re-checking on upgrade would double-count
-//     for templates whose new version raises requests only marginally.
-//   - runtime-pressure / k8s-request / node-pressure: the upgrade goes
-//     through helm upgrade which schedules its own replacement pods;
-//     kubelet/kube-scheduler are the authoritative gate there.
+//   - node-pressure / compute-allocation: rolling-update surge and pod
+//     placement go through helm upgrade + kube-scheduler, which are the
+//     authoritative gate there.
 //
-// So the chain is intentionally just clusterCapacityValidator. We keep
-// it as a separate exported chain (rather than letting callers pass a
-// single validator inline) so that:
-//
-//   - The "what validates on upgrade?" answer lives in one place that
-//     matches the InstallabilityValidators / RuntimePressureValidators
-//     pattern.
-//   - The clusterCapacityValidator type stays unexported.
-//   - Adding another upgrade-time gate later only touches this file
-//     and TestChainShapes, not every upgrade call site.
+// The delta-aware validators REQUIRE Input.PrevAppConfig to be set for
+// UpgradeOp; the upgrade handler is the only caller of this chain and
+// always supplies it.
 func UpgradabilityValidators() []Validator {
 	return []Validator{
 		clusterCapacityValidator{},
+		clusterPressureValidator{},
+		k8sRequestValidator{},
 	}
 }
 

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
@@ -2,8 +2,6 @@ package meshinagent
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 )
 
 // BearerJS is the njs module for JWT reads, auth/tls host allowlists, and stream
@@ -14,18 +12,13 @@ func BearerJS() string {
 		HostsMountPath+"/"+SharedHostsFileName,
 		HostsMountPath+"/"+TLSHostsFileName,
 		HTTPSTerminatePort,
-		"olares.com",
 		CertsMountPath,
 		PlaceholderCertDir,
 	)
 }
 
 // BearerJSWith builds the njs module with explicit paths (tests / render).
-func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile string, terminatePort int, platformDomain, certDir, placeholderDir string) string {
-	escapedDomain := regexp.QuoteMeta(strings.ToLower(strings.TrimSpace(platformDomain)))
-	if escapedDomain == "" {
-		escapedDomain = "olares\\.com"
-	}
+func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile string, terminatePort int, certDir, placeholderDir string) string {
 	if certDir == "" {
 		certDir = CertsMountPath
 	}
@@ -39,7 +32,6 @@ const AUTH_HOSTS_FILE = '%s';
 const TLS_HOSTS_FILE = '%s';
 const TERMINATE = '127.0.0.1:%d';
 const CACHE_TTL_MS = 5000;
-const PLATFORM_SUFFIX = '.%s';
 const REAL_CERT = '%s/tls.crt';
 const REAL_KEY = '%s/tls.key';
 const PH_CERT = '%s/tls.crt';
@@ -64,10 +56,6 @@ function normalizeHost(v) {
 function passthrough(host) {
   if (!host) { return 'invalid.local:443'; }
   return host + ':443';
-}
-
-function isPlatformHost(host) {
-  return host.length > PLATFORM_SUFFIX.length && host.endsWith(PLATFORM_SUFFIX);
 }
 
 function parseHosts(content) {
@@ -182,17 +170,18 @@ function authDeny(r) {
 function decideOffload(s) {
   // Empty SNI means the connection was redirected by IP (no hostname). Under
   // REDIRECT the original destination is unrecoverable — log and fail closed.
+  // Offload is allowlist-only (tls-hosts): no hard-coded platform suffix, so
+  // any zone the control plane materialized (e.g. .olares.cn) can terminate.
   const host = normalizeHost(s.variables.ssl_preread_server_name);
   if (!host) {
     s.error('mesh-in: no SNI on hijacked 443; original destination unrecoverable under REDIRECT, connection dropped');
     return passthrough(host);
   }
-  if (!isPlatformHost(host)) { return passthrough(host); }
   const hosts = reloadTLSHosts();
   if (hosts[host]) { return TERMINATE; }
   return passthrough(host);
 }
 
 export default {readJWT, checkHost, callerJwt, authDeny, decideOffload, tlsMode, pickCert, pickKey};
-`, jwtPath, authHostsFile, tlsHostsFile, terminatePort, escapedDomain, certDir, certDir, placeholderDir, placeholderDir)
+`, jwtPath, authHostsFile, tlsHostsFile, terminatePort, certDir, certDir, placeholderDir, placeholderDir)
 }

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
@@ -27,14 +27,34 @@ func TestBearerJSNoSNILogsError(t *testing.T) {
 	}
 }
 
-func TestBearerJSDecideOffloadKeepsPlatformPath(t *testing.T) {
+// TestBearerJSDecideOffloadUsesTLSHostsOnly pins DEFECT-SH-MESHIN-TLS-01: HTTPS
+// offload must not gate on a hard-coded platform suffix (e.g. .olares.com), so
+// zones like .olares.cn terminate when listed in tls-hosts.
+func TestBearerJSDecideOffloadUsesTLSHostsOnly(t *testing.T) {
 	js := BearerJS()
+	for _, ban := range []string{
+		"isPlatformHost",
+		"PLATFORM_SUFFIX",
+	} {
+		if strings.Contains(js, ban) {
+			t.Fatalf("bearer.js must not contain %q after tls-hosts-only offload", ban)
+		}
+	}
+	idx := strings.Index(js, "function decideOffload")
+	if idx < 0 {
+		t.Fatal("missing decideOffload")
+	}
+	fn := js[idx:]
+	end := strings.Index(fn, "\nexport default")
+	if end > 0 {
+		fn = fn[:end]
+	}
 	for _, want := range []string{
-		"isPlatformHost(host)",
 		"reloadTLSHosts()",
 		"return TERMINATE",
+		"return passthrough(host)",
 	} {
-		if !strings.Contains(js, want) {
+		if !strings.Contains(fn, want) {
 			t.Fatalf("decideOffload missing %q", want)
 		}
 	}

--- a/framework/app-service/pkg/images/client.go
+++ b/framework/app-service/pkg/images/client.go
@@ -63,6 +63,13 @@ func (imc *ImageManagerClient) Create(ctx context.Context, am *appv1alpha1.Appli
 	var im appv1alpha1.ImageManager
 	err = imc.Get(ctx, types.NamespacedName{Name: am.Name}, &im)
 	if err == nil {
+		// Reuse an in-flight IM (e.g. app-service restarted while download
+		// was still running). Delete+recreate would cancel the pull and
+		// lose progress for no benefit.
+		if im.Status.State == appv1alpha1.Downloading.String() {
+			klog.Infof("imagemanager name=%s already downloading, skip recreate", im.Name)
+			return nil
+		}
 		err = imc.Delete(ctx, &im)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err

--- a/framework/app-service/pkg/security/namespace.go
+++ b/framework/app-service/pkg/security/namespace.go
@@ -37,6 +37,12 @@ var (
 	OSProtectedNamespaces = []string{
 		"os-protected",
 	}
+	OSMeshNamespaces = []string{
+		"os-mesh",
+	}
+	OSGatewayNamespaces = []string{
+		"os-gateway",
+	}
 )
 
 // IsUserInternalNamespaces returns true if namespace is user level namespace for a user application, false otherwise.

--- a/framework/app-service/pkg/webhook/setup.go
+++ b/framework/app-service/pkg/webhook/setup.go
@@ -116,6 +116,16 @@ func (wh *Webhook) CreateOrUpdateSandboxMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.OSProtectedNamespaces,
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -421,6 +431,16 @@ func (wh *Webhook) CreateOrUpdateGpuLimitMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   []string{"user-space"},
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
 					},
 				},
 				ObjectSelector: &metav1.LabelSelector{
@@ -708,6 +728,16 @@ func (wh *Webhook) CreateOrUpdateRunAsUserMutatingWebhook() error {
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
 						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
+						},
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -808,6 +838,16 @@ func (wh *Webhook) CreateOrUpdateAppLabelMutatingWebhook() error {
 							Key:      "kubernetes.io/metadata.name",
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
 						},
 					},
 				},
@@ -1289,6 +1329,16 @@ func (wh *Webhook) CreateOrUpdatePodArchNodeSelectorMutatingWebhook() error {
 							Key:      "kubernetes.io/metadata.name",
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values:   security.GPUSystemNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSGatewayNamespaces,
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   security.OSMeshNamespaces,
 						},
 					},
 				},


### PR DESCRIPTION


* **Background**
fix(app-service): validate upgrade resource headroom on delta
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch upgrade admission, GPU scheduling, and application state transitions—user-visible failure modes—but are heavily tested and mostly add guards rather than new APIs.
> 
> **Overview**
> **Upgrade validation** now rejects upgrades before helm using `PrevAppConfig`: **cluster-capacity** still compares the new chart’s absolute requirements, while **cluster-pressure** and **k8s-request** run only on the non-negative **new − old** delta (zero delta short-circuits). The upgrade HTTP handler passes `PrevAppConfig` into `validation.Run`.
> 
> **Compute placement** routes install auto-pick through the same **availability view** and **binding validation** as manual resume: `pickLaunchSelection` / `bindAllocations` / `syncHAMIBindings`, multi-card **non-Nvidia** nodes list every device, and allocation building can fall back to selection memory when app demand is unset.
> 
> **Operation cancel races** add `c.Err()` / `context.Canceled` guards so in-flight **install**, **upgrade**, **apply-env**, and **resume** goroutines do not write `*Failed` when cancel or force-uninstall already owns the terminal transition; tests lock this behavior.
> 
> Smaller fixes: **ImageManager** delete cancels in-flight pulls; **image client** skips delete/recreate when status is already **Downloading**; mesh **decideOffload** is **tls-hosts allowlist only** (no hard-coded platform suffix); admission webhooks exclude **`os-mesh`** / **`os-gateway`**; deploy bumps **`app-service:0.6.21`**, **`image-service:0.6.19`**, and **`oac`** module pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67356cb67e5fc42401191bbb946b90891381deca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->