### PR TITLE
fix(app-service): decide HTTPS offload by tls-hosts only

### DIFF
--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
@@ -2,8 +2,6 @@ package meshinagent
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 )
 
 // BearerJS is the njs module for JWT reads, auth/tls host allowlists, and stream
@@ -14,18 +12,13 @@ func BearerJS() string {
 		HostsMountPath+"/"+SharedHostsFileName,
 		HostsMountPath+"/"+TLSHostsFileName,
 		HTTPSTerminatePort,
-		"olares.com",
 		CertsMountPath,
 		PlaceholderCertDir,
 	)
 }
 
 // BearerJSWith builds the njs module with explicit paths (tests / render).
-func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile string, terminatePort int, platformDomain, certDir, placeholderDir string) string {
-	escapedDomain := regexp.QuoteMeta(strings.ToLower(strings.TrimSpace(platformDomain)))
-	if escapedDomain == "" {
-		escapedDomain = "olares\\.com"
-	}
+func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile string, terminatePort int, certDir, placeholderDir string) string {
 	if certDir == "" {
 		certDir = CertsMountPath
 	}
@@ -39,7 +32,6 @@ const AUTH_HOSTS_FILE = '%s';
 const TLS_HOSTS_FILE = '%s';
 const TERMINATE = '127.0.0.1:%d';
 const CACHE_TTL_MS = 5000;
-const PLATFORM_SUFFIX = '.%s';
 const REAL_CERT = '%s/tls.crt';
 const REAL_KEY = '%s/tls.key';
 const PH_CERT = '%s/tls.crt';
@@ -64,10 +56,6 @@ function normalizeHost(v) {
 function passthrough(host) {
   if (!host) { return 'invalid.local:443'; }
   return host + ':443';
-}
-
-function isPlatformHost(host) {
-  return host.length > PLATFORM_SUFFIX.length && host.endsWith(PLATFORM_SUFFIX);
 }
 
 function parseHosts(content) {
@@ -182,17 +170,18 @@ function authDeny(r) {
 function decideOffload(s) {
   // Empty SNI means the connection was redirected by IP (no hostname). Under
   // REDIRECT the original destination is unrecoverable — log and fail closed.
+  // Offload is allowlist-only (tls-hosts): no hard-coded platform suffix, so
+  // any zone the control plane materialized (e.g. .olares.cn) can terminate.
   const host = normalizeHost(s.variables.ssl_preread_server_name);
   if (!host) {
     s.error('mesh-in: no SNI on hijacked 443; original destination unrecoverable under REDIRECT, connection dropped');
     return passthrough(host);
   }
-  if (!isPlatformHost(host)) { return passthrough(host); }
   const hosts = reloadTLSHosts();
   if (hosts[host]) { return TERMINATE; }
   return passthrough(host);
 }
 
 export default {readJWT, checkHost, callerJwt, authDeny, decideOffload, tlsMode, pickCert, pickKey};
-`, jwtPath, authHostsFile, tlsHostsFile, terminatePort, escapedDomain, certDir, certDir, placeholderDir, placeholderDir)
+`, jwtPath, authHostsFile, tlsHostsFile, terminatePort, certDir, certDir, placeholderDir, placeholderDir)
 }

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
@@ -27,14 +27,34 @@ func TestBearerJSNoSNILogsError(t *testing.T) {
 	}
 }
 
-func TestBearerJSDecideOffloadKeepsPlatformPath(t *testing.T) {
+// TestBearerJSDecideOffloadUsesTLSHostsOnly pins DEFECT-SH-MESHIN-TLS-01: HTTPS
+// offload must not gate on a hard-coded platform suffix (e.g. .olares.com), so
+// zones like .olares.cn terminate when listed in tls-hosts.
+func TestBearerJSDecideOffloadUsesTLSHostsOnly(t *testing.T) {
 	js := BearerJS()
+	for _, ban := range []string{
+		"isPlatformHost",
+		"PLATFORM_SUFFIX",
+	} {
+		if strings.Contains(js, ban) {
+			t.Fatalf("bearer.js must not contain %q after tls-hosts-only offload", ban)
+		}
+	}
+	idx := strings.Index(js, "function decideOffload")
+	if idx < 0 {
+		t.Fatal("missing decideOffload")
+	}
+	fn := js[idx:]
+	end := strings.Index(fn, "\nexport default")
+	if end > 0 {
+		fn = fn[:end]
+	}
 	for _, want := range []string{
-		"isPlatformHost(host)",
 		"reloadTLSHosts()",
 		"return TERMINATE",
+		"return passthrough(host)",
 	} {
-		if !strings.Contains(js, want) {
+		if !strings.Contains(fn, want) {
 			t.Fatalf("decideOffload missing %q", want)
 		}
 	}


### PR DESCRIPTION
- Decide HTTPS offload by `tls-hosts` only; drop the hard-coded `.olares.com` gate.
- Fixes Shared viewer HTTPS on non-`.com` zones (e.g. `.olares.cn`) that hit `Jwt is missing`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS routing on hijacked 443 for all non-allowlisted hosts (broader passthrough) while fixing termination for alternate platform zones; behavior is security-sensitive at the gateway edge.
> 
> **Overview**
> **HTTPS offload on mesh-in no longer requires a `.olares.com` SNI suffix.** Stream `decideOffload` now terminates only when the hostname appears in the control-plane **`tls-hosts`** file; everything else still passthroughs to `host:443`.
> 
> The embedded njs module drops `PLATFORM_SUFFIX`, `isPlatformHost`, and the `platformDomain` argument on `BearerJSWith`. Tests were renamed and tightened to forbid those symbols and assert `decideOffload` still uses `reloadTLSHosts()` / `TERMINATE` / `passthrough(host)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2a779f361672bb45c851f2f35c0d4903b72859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->