### PR TITLE
feat(search3): upgrade search3monitor log clean

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -310,7 +310,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.7
+        image: beclab/search3monitor:v0.3.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081


### PR DESCRIPTION
Title: search3monitr: change log clean strategy
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
Monitor file logs could grow without a real size limit (we saw ~470G on disk). Cleanup only deleted old *calendar-day* files and never capped how large a single day's log could get.

This PR adds two safety rails to `DualWriter` in `common_tool.rs`:

1. **Directory budget** (`LOG_DIR_MAX_BYTES`) — default **16 GiB**. When managed `LOG/` files exceed the budget, prune oldest files first and never delete the file currently being written.
2. **Per-file rotation** (`LOG_MAX_FILE_BYTES`) — default **256 MiB**. When the active file would go over the limit, open the next segment (`YYYYMMDD.log`, then `YYYYMMDD.1.log`, …) using an in-memory byte counter (no directory scan on every write). After each size rotate, re-run the directory budget check.

Both env vars accept **plain decimal bytes only** (no `10G` / `256M` suffixes). Set either to `0` to turn that control off. Docs updated in `docs/configuration.md`.


* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/206

<!-- CURSOR_SUMMARY -->
---

