### PR TITLE
fix(ci): use explicit goreleaser version tag to avoid conflict

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -143,6 +143,7 @@ jobs:
           version: v1.18.2
           args: release --clean
         env:
+          GORELEASER_CURRENT_TAG: ${{ needs.resolve-versions.outputs.npm_version }}
           OLARES_RELEASE_ID: ${{ inputs.release-id }}
           BINARY_VERSION: ${{ needs.resolve-versions.outputs.binary_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-daemon.yaml
+++ b/.github/workflows/release-daemon.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0
         env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.version }}
           OLARES_RELEASE_ID: ${{ inputs.release-id }}
         with:
           distribution: goreleaser

--- a/.github/workflows/release-mdns-agent.yaml
+++ b/.github/workflows/release-mdns-agent.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0
+        env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.version }}
         with:
           distribution: goreleaser
           version: v1.18.2


### PR DESCRIPTION
* **Background**
The `actions/checkout` checks out the `ref` as a prefix, so when tags exist with the same prefix as a PR opened from a branch name, the tags may be picked up by goreleaser, overriding the actual tag we want, we set the tag explicitly in the goreleaser step to avoid conflict.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that pins GoReleaser’s tag selection; no runtime application code is modified.
> 
> **Overview**
> Sets **`GORELEASER_CURRENT_TAG`** on the GoReleaser step in the CLI, daemon, and mdns-agent release workflows so builds use the workflow’s intended version instead of whatever git tag GoReleaser would pick from the checkout.
> 
> CLI releases pass **`needs.resolve-versions.outputs.npm_version`**; daemon and mdns-agent pass **`inputs.version`**. The mdns-agent workflow also wires this through a new **`env`** block on the GoReleaser action step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe76deee4fd954763b4d9b44bf910f8becb2c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->