### PR TITLE
fix(l4): gate all app routes behind per-user Authelia ext_auth

### DIFF
--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -190,6 +190,33 @@
       }
     },
     {
+      "name": "authelia_backend_bob",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_bob",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-bob.svc.cluster.local",
+                      "portValue": 9091
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
       "name": "nonapp_auth_bob",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -258,33 +285,6 @@
                     "socketAddress": {
                       "address": "wizard.user-space-bob.svc.cluster.local",
                       "portValue": 80
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
-      "name": "authelia_backend_bob",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_bob",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-bob.svc.cluster.local",
-                      "portValue": 9091
                     }
                   }
                 }
@@ -1557,6 +1557,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -2294,6 +2300,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -55,6 +55,33 @@
       }
     },
     {
+      "name": "authelia_backend_alice",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_alice",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
+                      "portValue": 9091
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
       "name": "nonapp_auth_alice",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -123,33 +150,6 @@
                     "socketAddress": {
                       "address": "wizard.user-space-alice.svc.cluster.local",
                       "portValue": 80
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
-      "name": "authelia_backend_alice",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_alice",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
-                      "portValue": 9091
                     }
                   }
                 }
@@ -755,6 +755,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -1069,6 +1075,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -55,6 +55,33 @@
       }
     },
     {
+      "name": "authelia_backend_alice",
+      "type": "STRICT_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "authelia_backend_alice",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
+                      "portValue": 9091
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "commonHttpProtocolOptions": {
+        "idleTimeout": "10s"
+      }
+    },
+    {
       "name": "nonapp_auth_alice",
       "type": "STRICT_DNS",
       "connectTimeout": "5s",
@@ -123,33 +150,6 @@
                     "socketAddress": {
                       "address": "wizard.user-space-alice.svc.cluster.local",
                       "portValue": 80
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "commonHttpProtocolOptions": {
-        "idleTimeout": "10s"
-      }
-    },
-    {
-      "name": "authelia_backend_alice",
-      "type": "STRICT_DNS",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "authelia_backend_alice",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "authelia-backend.user-system-alice.svc.cluster.local",
-                      "portValue": 9091
                     }
                   }
                 }
@@ -738,6 +738,12 @@
                   }
                 ]
               },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
+              },
               "requestHeadersToAdd": [
                 {
                   "header": {
@@ -1052,6 +1058,12 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
+              },
+              "typedPerFilterConfig": {
+                "envoy.filters.http.ext_authz": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                  "checkSettings": {}
+                }
               },
               "requestHeadersToAdd": [
                 {

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -602,11 +602,9 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			WebSocketUpgrade: true,
 		}
 
-		// Shared (v3) apps are cluster-wide and open to all users, so the
-		// whole app is gated behind the viewing user's Authelia instance.
-		if app.IsShared {
-			defaultRoute.ExtAuth = buildSharedAppExtAuthConfig(user)
-		}
+		// The whole app is gated behind the viewing user's Authelia instance,
+		// regardless of whether it is shared cluster-wide.
+		defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		routes = append(routes, defaultRoute)
 
@@ -617,11 +615,11 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 	return vhosts
 }
 
-// buildSharedAppExtAuthConfig returns the Authelia ext_auth config used to gate
-// shared (v3) apps behind the viewing user's per-user Authelia instance. It is
+// buildAppExtAuthConfig returns the Authelia ext_auth config used to gate
+// app routes behind the viewing user's per-user Authelia instance. It is
 // intentionally independent from the fileserver ext_auth wiring so the two can
 // evolve separately.
-func buildSharedAppExtAuthConfig(user *message.UserInfo) *ir.ExtAuthConfigIR {
+func buildAppExtAuthConfig(user *message.UserInfo) *ir.ExtAuthConfigIR {
 	return &ir.ExtAuthConfigIR{
 		Cluster:    fmt.Sprintf("%s_%s", autheliaClusterPrefix, user.Name),
 		PathPrefix: autheliaPathPrefix,
@@ -808,11 +806,9 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			WebSocketUpgrade: true,
 		}
 
-		// Shared (v3) apps stay gated behind Authelia even when reached via a
-		// custom domain, so the auth requirement can't be bypassed.
-		if app.IsShared {
-			customRoute.ExtAuth = buildSharedAppExtAuthConfig(user)
-		}
+		// Apps stay gated behind Authelia even when reached via a custom
+		// domain, so the auth requirement can't be bypassed.
+		customRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		vhost := &ir.VirtualHostIR{
 			Name:     fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -622,7 +622,8 @@ func TestBuildCustomDomainVirtualHosts_SharedApp_ExtAuth(t *testing.T) {
 	assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
 }
 
-// v1/v2 (non-shared) apps continue to reach their upstream cluster directly.
+// v1/v2 (non-shared) apps reach their upstream cluster and are gated behind
+// the viewing user's Authelia instance just like shared apps.
 func TestBuildAppVirtualHosts_NonSharedApp(t *testing.T) {
 	tr := &Translator{cfg: &Config{}}
 	user := &message.UserInfo{Name: "alice", Language: "en"}
@@ -641,8 +642,12 @@ func TestBuildAppVirtualHosts_NonSharedApp(t *testing.T) {
 	vhosts := tr.buildAppVirtualHosts(user, app, "alice.example.com", false, clusterSet)
 	require.Len(t, vhosts, 1)
 	require.Len(t, vhosts[0].Routes, 1)
-	assert.Nil(t, vhosts[0].Routes[0].DirectResponse)
-	assert.Nil(t, vhosts[0].Routes[0].ExtAuth, "non-shared apps must not be gated behind ext_auth")
+	r := vhosts[0].Routes[0]
+	assert.Nil(t, r.DirectResponse)
+	require.NotNil(t, r.ExtAuth, "non-shared apps must also be gated behind Authelia ext_auth")
+	assert.Equal(t, "authelia_backend_alice", r.ExtAuth.Cluster)
+	assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
+	assert.False(t, r.ExtAuth.Disabled)
 	assert.NotEmpty(t, clusterSet)
 }
 


### PR DESCRIPTION
* **Background**
fix(l4): gate all app routes behind per-user Authelia ext_auth
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes edge authentication for all user apps; misconfiguration or Authelia outages could block previously open v1/v2 traffic or alter access in security-sensitive paths.
> 
> **Overview**
> **All app HTTP routes** (standard hostnames and custom domains) are now protected by Envoy **ext_authz** against the **viewing user’s Authelia backend**, not only shared (v3) apps.
> 
> The l4-bfl-proxy translator always sets per-route `ExtAuth` via `buildAppExtAuthConfig` (replacing the shared-only `buildSharedAppExtAuthConfig` / `app.IsShared` branch). Generated Envoy config gains route-level `typedPerFilterConfig` with `ext_authz` `checkSettings` on app routes. Unit and e2e golden JSON were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fa841be739c3ac9ba77dbb07e4a85031cac6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->