### PR TITLE
fix(cli): Improve logging output and add upload progress indication

### DIFF
--- a/cli/cmd/ctl/os/logs_upload.go
+++ b/cli/cmd/ctl/os/logs_upload.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // logUploadOptions holds inputs for `olares-cli logs upload`. The pairing code
@@ -225,7 +226,7 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	if method == "" {
 		method = http.MethodPut
 	}
-	body := &progressReader{r: f, total: size, label: "Uploading"}
+	body, finish := uploadBody(f, size)
 	req, err := http.NewRequest(method, presign.UploadURL, body)
 	if err != nil {
 		return fmt.Errorf("build upload request: %v", err)
@@ -243,7 +244,7 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	}
 
 	resp, err := client.Do(req)
-	fmt.Fprint(os.Stderr, "\n")
+	finish()
 	if err != nil {
 		return fmt.Errorf("upload archive: %v", err)
 	}
@@ -255,14 +256,30 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	return nil
 }
 
-// progressReader wraps an io.Reader and prints a single-line stderr progress
-// update (percent + bytes) without pulling in a TUI dependency.
+// uploadBody wraps the archive with a live stderr progress line when stderr is
+// a terminal. Redirected stderr (scripts, CI, log capture) gets a single plain
+// status line instead, so no carriage returns end up in captured output. The
+// returned func must be called once the request finishes, to settle the line
+// before anything else is written.
+func uploadBody(f io.Reader, size int64) (io.Reader, func()) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		fmt.Fprintln(os.Stderr, "uploading log archive...")
+		return f, func() {}
+	}
+	p := &progressReader{r: f, total: size, label: "Uploading", last: -1}
+	return p, p.finish
+}
+
+// progressReader wraps an io.Reader and redraws a single-line stderr progress
+// update (percent + bytes) without pulling in a TUI dependency. Only used when
+// stderr is a terminal; see uploadBody.
 type progressReader struct {
 	r     io.Reader
 	total int64
 	read  int64
 	label string
 	last  int
+	drawn bool
 }
 
 func (p *progressReader) Read(b []byte) (int, error) {
@@ -279,17 +296,33 @@ func (p *progressReader) Read(b []byte) (int, error) {
 		// Throttle redraws to whole-percent steps (plus the final byte).
 		if percent != p.last || p.read == p.total || err == io.EOF {
 			p.last = percent
-			fmt.Fprintf(
-				os.Stderr,
-				"\r%s… %d%% (%s/%s)",
-				p.label,
-				percent,
-				humanBytes(p.read),
-				humanBytes(p.total),
-			)
+			p.draw(percent)
 		}
 	}
 	return n, err
+}
+
+func (p *progressReader) draw(percent int) {
+	p.drawn = true
+	// \033[K erases to end of line so a shorter update can't leave residue
+	// from the previous, longer one.
+	fmt.Fprintf(
+		os.Stderr,
+		"\r\033[K%s… %d%% (%s/%s)",
+		p.label,
+		percent,
+		humanBytes(p.read),
+		humanBytes(p.total),
+	)
+}
+
+// finish closes out the progress line so later output starts clean. It is a
+// no-op when nothing was drawn, e.g. an empty archive or a request that failed
+// before the body was read.
+func (p *progressReader) finish() {
+	if p.drawn {
+		fmt.Fprintln(os.Stderr)
+	}
 }
 
 func humanBytes(n int64) string {

--- a/cli/cmd/ctl/os/logs_upload.go
+++ b/cli/cmd/ctl/os/logs_upload.go
@@ -147,24 +147,23 @@ func runLogsUpload(options *logUploadOptions) error {
 	}
 	client := &http.Client{Timeout: timeout}
 
-	fmt.Println("requesting upload URL...")
+	fmt.Fprintln(os.Stderr, "requesting upload URL...")
 	presign, err := requestPresign(client, endpoint, options, filepath.Base(archivePath), info.Size())
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("uploading log archive...")
 	if err := putArchive(client, presign, archivePath, info.Size()); err != nil {
 		return err
 	}
 
-	fmt.Println("creating ticket...")
+	fmt.Fprintln(os.Stderr, "creating ticket...")
 	ticket, err := createTicket(client, endpoint, options, presign.AttachmentID)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("logs uploaded, ticket created: %s (%s)\n", ticket.TicketNumber, ticket.TicketID)
+	fmt.Fprintf(os.Stderr, "logs uploaded, ticket created: %s (%s)\n", ticket.TicketNumber, ticket.TicketID)
 	return nil
 }
 
@@ -183,9 +182,11 @@ func collectForUpload() (string, func(), error) {
 		OutputDir:        tempDir,
 		IgnoreKubeErrors: true,
 	}
+	fmt.Fprintln(os.Stderr, "collecting logs...")
 	if err := collectLogs(options); err != nil {
 		return "", cleanup, err
 	}
+	fmt.Fprintln(os.Stderr, "collection complete")
 
 	matches, err := filepath.Glob(filepath.Join(tempDir, "olares-logs-*.tar.gz"))
 	if err != nil || len(matches) == 0 {
@@ -224,7 +225,8 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	if method == "" {
 		method = http.MethodPut
 	}
-	req, err := http.NewRequest(method, presign.UploadURL, f)
+	body := &progressReader{r: f, total: size, label: "Uploading"}
+	req, err := http.NewRequest(method, presign.UploadURL, body)
 	if err != nil {
 		return fmt.Errorf("build upload request: %v", err)
 	}
@@ -241,6 +243,7 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	}
 
 	resp, err := client.Do(req)
+	fmt.Fprint(os.Stderr, "\n")
 	if err != nil {
 		return fmt.Errorf("upload archive: %v", err)
 	}
@@ -250,6 +253,56 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 		return fmt.Errorf("upload archive: storage returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
+}
+
+// progressReader wraps an io.Reader and prints a single-line stderr progress
+// update (percent + bytes) without pulling in a TUI dependency.
+type progressReader struct {
+	r     io.Reader
+	total int64
+	read  int64
+	label string
+	last  int
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.read += int64(n)
+		percent := 100
+		if p.total > 0 {
+			percent = int((p.read * 100) / p.total)
+			if percent > 100 {
+				percent = 100
+			}
+		}
+		// Throttle redraws to whole-percent steps (plus the final byte).
+		if percent != p.last || p.read == p.total || err == io.EOF {
+			p.last = percent
+			fmt.Fprintf(
+				os.Stderr,
+				"\r%s… %d%% (%s/%s)",
+				p.label,
+				percent,
+				humanBytes(p.read),
+				humanBytes(p.total),
+			)
+		}
+	}
+	return n, err
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 func createTicket(client *http.Client, endpoint string, options *logUploadOptions, attachmentID string) (*ticketResponse, error) {

--- a/cli/cmd/ctl/os/logs_upload_test.go
+++ b/cli/cmd/ctl/os/logs_upload_test.go
@@ -1,0 +1,86 @@
+package os
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStderr swaps os.Stderr for a pipe (never a TTY) and returns whatever
+// fn wrote to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
+func TestUploadBodyNonTTYEmitsNoCarriageReturns(t *testing.T) {
+	payload := strings.Repeat("x", 512*1024)
+	var body io.Reader
+
+	out := captureStderr(t, func() {
+		reader, finish := uploadBody(strings.NewReader(payload), int64(len(payload)))
+		body = reader
+		got, err := io.ReadAll(reader)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if len(got) != len(payload) {
+			t.Errorf("body length = %d, want %d", len(got), len(payload))
+		}
+		finish()
+	})
+
+	if strings.Contains(out, "\r") {
+		t.Errorf("non-TTY stderr contains carriage returns: %q", out)
+	}
+	if strings.Contains(out, "\033[") {
+		t.Errorf("non-TTY stderr contains ANSI escapes: %q", out)
+	}
+	if out != "uploading log archive...\n" {
+		t.Errorf("non-TTY stderr = %q, want single plain status line", out)
+	}
+	if _, wrapped := body.(*progressReader); wrapped {
+		t.Error("non-TTY stderr should not wrap the body in a progressReader")
+	}
+}
+
+func TestProgressReaderDrawClearsLine(t *testing.T) {
+	p := &progressReader{r: strings.NewReader(""), total: 1000, read: 1000, label: "Uploading", last: -1}
+	out := captureStderr(t, func() { p.draw(100) })
+
+	if !strings.HasPrefix(out, "\r\033[K") {
+		t.Errorf("draw output = %q, want it to start with \\r\\033[K to clear the line", out)
+	}
+}
+
+func TestProgressReaderFinishNoOpWhenNothingDrawn(t *testing.T) {
+	p := &progressReader{r: strings.NewReader(""), total: 0, label: "Uploading", last: -1}
+	if out := captureStderr(t, p.finish); out != "" {
+		t.Errorf("finish with nothing drawn wrote %q, want no output", out)
+	}
+
+	captureStderr(t, func() { p.draw(0) })
+	out := captureStderr(t, p.finish)
+	if out != "\n" {
+		t.Errorf("finish after a draw wrote %q, want a single newline", out)
+	}
+}


### PR DESCRIPTION
* **Background**
  - Changed standard output to standard error for log messages to enhance visibility.
  - Introduced a progress reader to display upload progress in real-time.
  - Added log messages for log collection status to provide better feedback during the upload process.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and stderr routing; upload and ticket API behavior are unchanged.
> 
> **Overview**
> **`olares-cli logs upload`** now writes all user-facing status (presign, upload, ticket creation, success, and auto-collect steps) to **stderr** instead of stdout, so stdout stays clean for piping or scripting.
> 
> When stderr is an **interactive terminal**, the presigned PUT body is wrapped in a **`progressReader`** that redraws a single line with percent and human-readable byte counts (`uploadBody` / `humanBytes`), using `\r` and ANSI clear-to-EOL. **Non-TTY** stderr (pipes, CI) gets one plain `uploading log archive...` line with no carriage returns or escape codes. **`putArchive`** calls the returned **`finish`** callback after the HTTP request so the progress line is closed before later messages.
> 
> Adds **`logs_upload_test.go`** to lock in non-TTY upload messaging and progress draw/finish behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede61712731ebbc751cc6bd48b8c88f0b5084257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->