### PR TITLE
fix(download-server): batch lifecycle endpoints, aria2 repeat-download rename prompt

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.8"
+        image: "beclab/download-server:v1.0.9"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
add batch lifecycle endpoints.
adds a HEAD/range-based inspector to fetch the actual filename for HTTP(S) direct links, enabling pre-submit duplicate detection in the new task dialog.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no manifest, RBAC, or env changes; risk is limited to whatever is in the v1.0.9 application image.
> 
> **Overview**
> **Rolls out `beclab/download-server:v1.0.9`** on the cluster `download` DaemonSet by updating the `download-server` container image tag in `download_deploy.yaml` (aria2 and all env/volume settings are unchanged).
> 
> This deploy change is the packaging step for the release described in the PR (batch task lifecycle APIs, HTTP(S) filename inspection for duplicate detection, and aria2 repeat-download rename handling)—those behaviors live in the new image, not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa571ddf4a3304dc2ad8ce769b7fa6f5abec80b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->