### PR TITLE
fix(daemon): filter SR-IOV VF GPUs from GetGpuInfo

### DIFF
--- a/daemon/pkg/utils/gpu_info.go
+++ b/daemon/pkg/utils/gpu_info.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jaypipes/ghw"
@@ -25,4 +27,28 @@ func collectGpuInfos(cards []*ghw.GraphicsCard) []string {
 		}
 	}
 	return append(nvidia, others...)
+}
+
+// filterSriovVirtualFunctions removes cards that sysfs identifies as SR-IOV
+// virtual functions. Cards are retained when their VF status cannot be
+// confirmed.
+func filterSriovVirtualFunctions(cards []*ghw.GraphicsCard, sysfsDevices string) []*ghw.GraphicsCard {
+	filtered := make([]*ghw.GraphicsCard, 0, len(cards))
+	for _, card := range cards {
+		address := ""
+		if card != nil {
+			address = card.Address
+			if address == "" && card.DeviceInfo != nil {
+				address = card.DeviceInfo.Address
+			}
+		}
+		if address != "" {
+			physfn := filepath.Join(sysfsDevices, address, "physfn")
+			if _, err := os.Lstat(physfn); err == nil {
+				continue
+			}
+		}
+		filtered = append(filtered, card)
+	}
+	return filtered
 }

--- a/daemon/pkg/utils/gpu_info_test.go
+++ b/daemon/pkg/utils/gpu_info_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -52,6 +54,43 @@ func TestCollectGpuInfos_Empty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("collectGpuInfos(nil) = %#v, want empty slice", got)
+	}
+}
+
+func TestFilterSriovVirtualFunctions_RemovesVF(t *testing.T) {
+	sysfsDevices := t.TempDir()
+	vfAddress := "0000:00:02.1"
+	vfPath := filepath.Join(sysfsDevices, vfAddress)
+	if err := os.Mkdir(vfPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../0000:00:02.0", filepath.Join(vfPath, "physfn")); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := gpuCard("Intel Corporation", "Arrow Lake-S Graphics")
+	pf.Address = "0000:00:02.0"
+	vf := gpuCard("Intel Corporation", "Arrow Lake-S Graphics")
+	vf.Address = vfAddress
+
+	got := filterSriovVirtualFunctions([]*ghw.GraphicsCard{pf, vf}, sysfsDevices)
+	want := []*ghw.GraphicsCard{pf}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterSriovVirtualFunctions() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFilterSriovVirtualFunctions_KeepsUnconfirmedCards(t *testing.T) {
+	sysfsDevices := t.TempDir()
+	pf := gpuCard("Intel Corporation", "Arrow Lake-S Graphics")
+	pf.Address = "0000:00:02.0"
+	unknown := gpuCard("NVIDIA Corporation", "GeForce RTX 4070")
+	unknown.Address = ""
+
+	got := filterSriovVirtualFunctions([]*ghw.GraphicsCard{pf, unknown}, sysfsDevices)
+	want := []*ghw.GraphicsCard{pf, unknown}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterSriovVirtualFunctions() = %#v, want %#v", got, want)
 	}
 }
 

--- a/daemon/pkg/utils/gpu_linux.go
+++ b/daemon/pkg/utils/gpu_linux.go
@@ -47,7 +47,8 @@ func GetGpuInfo() ([]string, error) {
 	}
 	gpuLastScan = time.Now()
 
-	result := collectGpuInfos(gpu.GraphicsCards)
+	cards := filterSriovVirtualFunctions(gpu.GraphicsCards, "/sys/bus/pci/devices")
+	result := collectGpuInfos(cards)
 	gpuInfoValue = result
 	if len(result) > 0 {
 		gpuInfoCached = true


### PR DESCRIPTION
* **Background**
fix(daemon): filter SR-IOV VF GPUs from GetGpuInfo
Skip cards with a sysfs physfn so PF-only GPU lists are reported, while keeping unconfirmed devices.

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to daemon GPU enumeration on Linux with fail-open behavior when VF status is unknown; no auth or data-path impact.
> 
> **Overview**
> **Linux GPU discovery** now drops SR-IOV virtual functions before building the reported GPU list, so nodes with split PF/VF devices no longer show duplicate “same” GPUs in cluster state.
> 
> A new `filterSriovVirtualFunctions` helper treats a PCI device as a VF when `/sys/bus/pci/devices/<address>/physfn` exists; cards without a usable address or without that sysfs entry are **kept** so reporting stays conservative. `GetGpuInfo` on Linux runs ghw results through this filter, then through the existing `collectGpuInfos` ordering. Unit tests cover VF removal and the unconfirmed-address path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f11e18bb32f883932a2123d79e3249aef94e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->