### PR TITLE
fix(l4): gate all app routes behind per-user Authelia ext_auth

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -157,7 +157,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.40"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.41"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.40
+          value: v0.3.41
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.40
+      name: beclab/l4-bfl-proxy:v0.3.41
 # must have blank new line            


### PR DESCRIPTION
* **Background**
fix(l4): gate all app routes behind per-user Authelia ext_auth
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the L4 edge proxy image used for user app routing and authentication integration; a bad rollout could break app access even though this diff is only a version pin.
> 
> **Overview**
> Bumps the pinned **`beclab/l4-bfl-proxy`** image from **`v0.3.40`** to **`v0.3.41`** so clusters pick up the L4 proxy build that matches the Authelia **ext_auth** app-route gating fix described in the PR title.
> 
> The version is updated in the Olares upgrade pipeline (`UpgradeL4BFLProxy`), the BFL launcher env **`L4_PROXY_IMAGE_VERSION`**, and **`framework/l4-bfl-proxy/.olares/Olares.yaml`** prebuilt container reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de78ba5b481c9cb13d79db2aea7a6b6119ea8912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->