### PR TITLE
fix(tapr): treat a missing user workspace as empty, not as a server error

### DIFF
--- a/platform/tapr/pkg/vault/infisical/controllers/secret.go
+++ b/platform/tapr/pkg/vault/infisical/controllers/secret.go
@@ -115,6 +115,13 @@ func (s *secretController) RetrieveSecret(c *fiber.Ctx) error {
 
 	workspaceId, err := s.Clientset().GetWorkspace(token.(string), orgId, userWorkspace)
 	if err != nil {
+		if s.Clientset().IsNotFound(err) {
+			return c.JSON(fiber.Map{
+				"code":    http.StatusNotFound,
+				"message": "secret not found",
+			})
+		}
+
 		return c.JSON(fiber.Map{
 			"code":    http.StatusInternalServerError,
 			"message": "get user workspace error, " + err.Error(),
@@ -176,8 +183,18 @@ func (s *secretController) ListSecret(c *fiber.Ctx) error {
 
 	userWorkspace := UserWorkspaceName(reqWorkspaceName, userName)
 
+	resData := []*Secret{}
+
 	workspaceId, err := s.Clientset().GetWorkspace(token.(string), orgId, userWorkspace)
 	if err != nil {
+		if s.Clientset().IsNotFound(err) {
+			return c.JSON(fiber.Map{
+				"code":    StatusOK,
+				"message": "",
+				"data":    resData,
+			})
+		}
+
 		return c.JSON(fiber.Map{
 			"code":    http.StatusInternalServerError,
 			"message": "get user workspace error, " + err.Error(),
@@ -192,7 +209,6 @@ func (s *secretController) ListSecret(c *fiber.Ctx) error {
 		})
 	}
 
-	var resData []*Secret
 	list, err := s.Clientset().ListSecretInWorkspace(token.(string), workspaceId, projectKey,
 		secret.Environment)
 	if err != nil {
@@ -247,6 +263,13 @@ func (s *secretController) DeleteSecret(c *fiber.Ctx) error {
 
 	workspaceId, err := s.Clientset().GetWorkspace(token.(string), orgId, userWorkspace)
 	if err != nil {
+		if s.Clientset().IsNotFound(err) {
+			return c.JSON(fiber.Map{
+				"code":    StatusOK,
+				"message": "delete secret succeed",
+			})
+		}
+
 		return c.JSON(fiber.Map{
 			"code":    http.StatusInternalServerError,
 			"message": "get user workspace error, " + err.Error(),
@@ -308,6 +331,13 @@ func (s *secretController) UpdateSecret(c *fiber.Ctx) error {
 
 	workspaceId, err := s.Clientset().GetWorkspace(token.(string), orgId, userWorkspace)
 	if err != nil {
+		if s.Clientset().IsNotFound(err) {
+			return c.JSON(fiber.Map{
+				"code":    http.StatusNotFound,
+				"message": "secret not found",
+			})
+		}
+
 		return c.JSON(fiber.Map{
 			"code":    http.StatusInternalServerError,
 			"message": "get user workspace error, " + err.Error(),

--- a/platform/tapr/pkg/vault/infisical/controllers/workspace.go
+++ b/platform/tapr/pkg/vault/infisical/controllers/workspace.go
@@ -164,6 +164,15 @@ func (w *workspaceClient) DeleteWorkspace(token, workspaceId string) error {
 
 }
 
+// IsNotFound reports whether err means the workspace simply is not there yet,
+// as opposed to a failure to find out.
+//
+// A user's workspace is created lazily, on their first secret write, so every
+// user who has never written one reads back as not-found. That is the ordinary
+// state of a fresh account, not a fault: read paths should answer with an empty
+// result and write paths should create the workspace, which is what
+// CreateSecret does. Reporting it as a server error instead pushes every
+// consumer into matching on the message text to recover.
 func (w *workspaceClient) IsNotFound(err error) bool {
 	return strings.HasPrefix(err.Error(), "not found")
 }

--- a/platform/tapr/pkg/vault/infisical/controllers/workspace_notfound_test.go
+++ b/platform/tapr/pkg/vault/infisical/controllers/workspace_notfound_test.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestIsNotFoundRecognisesTheWorkspaceLookupMisses pins the seam the secret
+// read paths rely on to tell "this user has no workspace yet" apart from "the
+// lookup failed". IsNotFound matches on message text, so GetWorkspace's two
+// miss messages are restated here on purpose: rewording either one without
+// updating this test would silently turn a fresh account back into a 500, and
+// push consumers into matching the new prose themselves.
+func TestIsNotFoundRecognisesTheWorkspaceLookupMisses(t *testing.T) {
+	w := &workspaceClient{}
+
+	notFound := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "org has no workspaces at all, which is every account before its first secret write",
+			err:  errors.New("not found the workspaces of user org"),
+		},
+		{
+			name: "org has workspaces but not this one",
+			err:  fmt.Errorf("not found the workspace: %s", "settings-alice"),
+		},
+	}
+	for _, tc := range notFound {
+		t.Run(tc.name, func(t *testing.T) {
+			if !w.IsNotFound(tc.err) {
+				t.Errorf("IsNotFound(%q) = false, want true", tc.err)
+			}
+		})
+	}
+
+	realFailures := []struct {
+		name string
+		err  error
+	}{
+		{"transport failure", errors.New("Get \"http://infisical/api/v2\": dial tcp: connection refused")},
+		{"upstream rejected the token", errors.New("{\"statusCode\":401,\"message\":\"Unauthorized\"}")},
+		{"decode failure", errors.New("invalid character '<' looking for beginning of value")},
+	}
+	for _, tc := range realFailures {
+		t.Run(tc.name, func(t *testing.T) {
+			if w.IsNotFound(tc.err) {
+				t.Errorf("IsNotFound(%q) = true, want false: a lookup that failed must not read as an empty workspace", tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A user's Infisical workspace is created lazily, on their first secret write. Every account that has never written one therefore reads back as not-found — the ordinary state of a fresh account, not a fault.

`CreateSecret` already knew this and used `IsNotFound` to create the workspace instead of failing. The four **read** paths did not: they answered any `GetWorkspace` error with a 500 carrying

```
get user workspace error, not found the workspaces of user org
```

This PR gives each read path an answer on its own terms:

| Path | Was | Now |
|---|---|---|
| `ListSecret` | 500 | `200` with an empty list |
| `RetrieveSecret` | 500 | `404` |
| `UpdateSecret` | 500 | `404` |
| `DeleteSecret` | 500 | `200` — a secret in a workspace that does not exist is already gone |

Genuine lookup failures still surface as 500. `admin.go` and `user.go` were already consulting `IsNotFound` and are unchanged.

`ListSecret`'s response is also initialised to an empty slice, so "workspace with no secrets" and "no workspace" serialise identically instead of one of them emitting `null`.

## Why it matters beyond this repo

Turning a normal state into an error forced every consumer to recognise it by its prose.

- `user-service` does exactly that, string-matching the sentence in `secret.service.ts` to recover an empty list.
- `integration-provider-svc` does not. So cloud-drive account lookup fails for any user with no bound account, which breaks `olares-cli search gdrive` and `search dropbox` end to end — the user is shown an internal service URL and `integration list failed`, with nothing actionable.
- `search3` logs `get user accounts failed` at ERROR every five seconds, per user, indefinitely.

Observed on a live 1.12.7 instance while validating an unrelated change.

The matching `user-service` cleanup is a separate PR and **must not merge before this ships** — it removes the workaround that is currently the only thing keeping that path working.

## Tests

`workspace_notfound_test.go` is new and hermetic. `IsNotFound` decides by prefix-matching a message, and the two messages it has to recognise are built inline inside `GetWorkspace`, which needs a live Infisical to reach — so nothing kept the predicate and its inputs agreeing. The test restates both misses and three genuine failures; restating the literals is the point, since rewording one would silently turn every fresh account back into a server error, and the symptom appears three services downstream.

The package's existing tests are excluded from this by construction: they dial a hardcoded dev Infisical with a token that expired in 2023. This one needs no network.

## Verification

- `gofmt` clean
- `go build ./...` passes
- `go vet ./pkg/vault/...` passes
- `go test ./pkg/vault/infisical/controllers/ -run TestIsNotFound` passes

Made with [Cursor](https://cursor.com)