### PR TITLE
fix: fix fsnotify-proxy missing send event

### DIFF
--- a/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
+++ b/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
@@ -26,7 +26,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
         - name: proxy
-          image: beclab/fsnotify-proxy:0.1.11
+          image: beclab/fsnotify-proxy:0.1.12
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5079

--- a/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
+++ b/platform/fs-lib/.olares/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
@@ -64,7 +64,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: proxy
-        image: beclab/fsnotify-proxy:0.1.11
+        image: beclab/fsnotify-proxy:0.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5079


### PR DESCRIPTION
Title: fsnotify-proxy: fix missing send envent to search3(or client)
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**

Pipeline: file change → daemon → Redis → proxy → search3.

The proxy debounces WRITEs: many writes to the same file in a short window are coalesced, then sent to search3 after ~1s of quiet time.

The old implementation was flawed:

First WRITE for a path → record timestamp + start a 1s timer
Later WRITEs → only refresh the timestamp, assuming the timer is still alive
If the timer was gone but the map entry remained → forever refresh, never translate / send
In production this looked like: Redis subscribed present, but no translate / send (e.g. ok7.txt).
CHMOD on the same connection could still work — pointing to a WRITE debounce stall, not “no client connected”.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/beclab/fs-lib/pull/7
<!-- CURSOR_SUMMARY -->
---

