### PR TITLE
feat: ingore .tmp .temp file

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.7
+        image: beclab/search3:v0.3.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -310,7 +310,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.8
+        image: beclab/search3monitor:v0.3.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081
@@ -354,6 +354,10 @@ spec:
           value: os.users
         - name: NATS_SUBJECT_SYSTEM_GROUPS
           value: os.groups
+        - name: LOG_MAX_FILE_BYTES
+          value: "16777216"
+        - name: LOG_DIR_MAX_BYTES
+          value: "1073741824"
         volumeMounts:
           - name: fb-data
             mountPath: /appdata

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.7
+        image: beclab/search3validation:v0.3.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3monitr: ignore .tmp file, .temp file
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
Monitor was still logging and debouncing file events for paths that are already in the exclude list (for example *.tmp / *.temp from atomic writes). Exclude only kicked in later inside the Task, so noisy Producer Created File / JuiceFS Producer Data Content lines kept filling the log.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/207

<!-- CURSOR_SUMMARY -->
---

