### PR TITLE
cli: [POC/DONTMERGE] dev verbs for testing local builds on a running Olares

### DIFF
--- a/.github/workflows/skills-ci.yml
+++ b/.github/workflows/skills-ci.yml
@@ -58,4 +58,4 @@ jobs:
         run: |
           go build -o /tmp/olares-cli ./cmd
           go test ./cmd/ctl -run '^TestSkillCommandPathsExist$|^TestEveryCommandTheSkillsDocumentResolves$'
-          go test ./cmd/ctl/... ./pkg/clusterclient ./pkg/clusterctx ./pkg/credential ./pkg/dashboard ./pkg/whoami
+          go test ./cmd/ctl/... ./pkg/clusterclient ./pkg/clusterctx ./pkg/credential ./pkg/dashboard ./pkg/whoami ./pkg/devdeploy

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ go.work
 .dist
 .manifest
 .dependencies
+# olares-cli built by the Makefile's dev-* targets
+.build
 install-wizard-*.tar.gz
 olares-cli-*.tar.gz
 !ks-console-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,130 @@
+# Olares developer targets.
+#
+# These wrap `olares-cli dev` for work on components in this repo: build a
+# component's image locally, side-load it onto your Olares, point the
+# workload at it, and put everything back afterwards.
+#
+# They are for testing your own builds against your own instance. Release
+# artifacts are built by `olares-cli release` and the
+# .github/workflows/module_*_publish_*.yaml workflows; nothing here
+# publishes anything.
+#
+# Usage:
+#   make dev-list
+#   make dev-deploy C=app-service
+#   make dev-revert C=app-service
+#
+# Requirements: Go 1.25+, docker (or podman), and either the CLI running
+# on the Olares node itself or `olares-cli dev node set` configured for
+# SSH access to it.
+
+SHELL := /usr/bin/env bash -o pipefail
+.SHELLFLAGS := -ec
+
+REPO_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CLI_BIN   := $(REPO_ROOT)/.build/olares-cli
+
+# TAG is the tag given to the locally built image. It must differ from any
+# released tag: `dev push` side-loads into the node's containerd, and
+# reusing a released tag would shadow the real image for every workload
+# that references it, including ones you did not mean to touch.
+TAG ?= dev
+
+# TRANSPORT is passed through to `dev push`; auto picks local when the CLI
+# runs on the node, else ssh.
+TRANSPORT ?= auto
+
+# Extra flags forwarded to `docker build` (e.g. PLATFORM=linux/arm64 is
+# spelled DOCKER_BUILD_FLAGS="--platform linux/arm64").
+DOCKER_BUILD_FLAGS ?=
+
+# cli/ is deliberately not a member of the repo's go.work: it depends on a
+# *published* framework/app-service module whose api/ packages do not exist
+# in this tree, so a workspace build fails to resolve them. GOWORK=off is
+# the supported way to build it from inside a checkout that has a go.work.
+GO_ENV := GOWORK=off
+
+.PHONY: help
+help:
+	@echo "Olares dev targets:"
+	@echo "  make dev-list                  list components that can be dev-built"
+	@echo "  make dev-show     C=<name>     show a component's build coordinates"
+	@echo "  make dev-build    C=<name>     docker build the component as <image>:$(TAG)"
+	@echo "  make dev-push     C=<name>     side-load <image>:$(TAG) onto the node"
+	@echo "  make dev-deploy   C=<name>     build + push + repoint the workloads, then wait"
+	@echo "  make dev-status                list workloads currently running a dev image"
+	@echo "  make dev-revert   C=<name>     restore the workloads that reference the component"
+	@echo "  make dev-validate              check the component map against the tree"
+	@echo ""
+	@echo "Variables: TAG=$(TAG) TRANSPORT=$(TRANSPORT) DOCKER_BUILD_FLAGS=\"$(DOCKER_BUILD_FLAGS)\""
+
+# The dev targets shell out to a locally built CLI rather than whatever is
+# on PATH: the verbs they use may not exist yet in the host-bundled copy,
+# which only changes when the OS itself is upgraded.
+$(CLI_BIN): $(shell find $(REPO_ROOT)/cli -name '*.go' -newer $(REPO_ROOT)/cli/go.mod 2>/dev/null | head -1) $(REPO_ROOT)/cli/go.mod
+	@mkdir -p $(dir $@)
+	@echo "+++ building olares-cli"
+	@cd $(REPO_ROOT)/cli && $(GO_ENV) go build -o $@ ./cmd
+
+.PHONY: cli
+cli: $(CLI_BIN)
+
+# require-component fails early with the list of valid names rather than
+# letting docker build fail on an empty context path.
+define require-component
+	@if [ -z "$(C)" ]; then \
+		echo "error: set C=<component>, e.g. make $@ C=app-service"; \
+		echo; \
+		$(CLI_BIN) dev components list --repo $(REPO_ROOT); \
+		exit 1; \
+	fi
+endef
+
+.PHONY: dev-list
+dev-list: $(CLI_BIN)
+	@$(CLI_BIN) dev components list --repo $(REPO_ROOT)
+
+.PHONY: dev-validate
+dev-validate: $(CLI_BIN)
+	@$(CLI_BIN) dev components validate --repo $(REPO_ROOT)
+
+.PHONY: dev-show
+dev-show: $(CLI_BIN)
+	$(require-component)
+	@$(CLI_BIN) dev components get $(C) --repo $(REPO_ROOT)
+
+.PHONY: dev-build
+dev-build: $(CLI_BIN)
+	$(require-component)
+	@eval "$$($(CLI_BIN) dev components get $(C) --format shell --repo $(REPO_ROOT))"; \
+	echo "+++ docker build $$IMAGE:$(TAG) (-f $$DOCKERFILE $$CONTEXT)"; \
+	docker build $(DOCKER_BUILD_FLAGS) -t "$$IMAGE:$(TAG)" -f "$(REPO_ROOT)/$$DOCKERFILE" "$(REPO_ROOT)/$$CONTEXT"
+
+.PHONY: dev-push
+dev-push: $(CLI_BIN)
+	$(require-component)
+	@eval "$$($(CLI_BIN) dev components get $(C) --format shell --repo $(REPO_ROOT))"; \
+	$(CLI_BIN) dev push "$$IMAGE:$(TAG)" --transport $(TRANSPORT)
+
+# dev-deploy resolves targets by the image the charts reference, so it
+# repoints whatever is actually running that component without being told
+# where it lives. --replaces takes the bare repository: the image scan
+# normalizes tags, so this matches whichever released tag is deployed.
+.PHONY: dev-deploy
+dev-deploy: dev-build dev-push
+	@eval "$$($(CLI_BIN) dev components get $(C) --format shell --repo $(REPO_ROOT))"; \
+	$(CLI_BIN) dev deploy "$$IMAGE:$(TAG)" --replaces "$$IMAGE" --watch
+
+.PHONY: dev-status
+dev-status: $(CLI_BIN)
+	@$(CLI_BIN) dev status
+
+.PHONY: dev-revert
+dev-revert: $(CLI_BIN)
+	$(require-component)
+	@eval "$$($(CLI_BIN) dev components get $(C) --format shell --repo $(REPO_ROOT))"; \
+	$(CLI_BIN) dev revert --image "$$IMAGE:$(TAG)" --watch
+
+.PHONY: clean-cli
+clean-cli:
+	rm -rf $(REPO_ROOT)/.build

--- a/build/dev-components.yaml
+++ b/build/dev-components.yaml
@@ -1,0 +1,159 @@
+# Component -> image build map, used by the root Makefile's dev-* targets
+# to turn a component name into "which Dockerfile, which context, which
+# image tag" so you can type `make dev-deploy C=app-service` instead of
+# remembering three paths.
+#
+# This mirrors the .github/workflows/module_*_publish_*.yaml files, which
+# remain the source of truth for what actually gets published. Each entry
+# names the workflow it was derived from, and `make dev-validate` checks
+# that every context and dockerfile still exists on disk — so a moved
+# Dockerfile fails loudly here instead of silently building the wrong
+# thing.
+#
+# Fields:
+#   image       repository the released chart references (no tag)
+#   context     docker build context, relative to the repo root
+#   dockerfile  path to the Dockerfile, relative to the repo root
+#   workflow    the publish workflow this entry mirrors
+#
+# The dev tag is not recorded here: `make dev-build` derives it as
+# <image>:dev unless you pass TAG=.
+
+components:
+  app-service:
+    image: beclab/app-service
+    context: framework/app-service
+    dockerfile: framework/app-service/Dockerfile
+    workflow: module_appservice_publish_docker.yaml
+
+  image-service:
+    image: beclab/image-service
+    context: framework/app-service
+    dockerfile: framework/app-service/Dockerfile.image
+    workflow: module_appservice_publish_imageservice.yaml
+
+  mesh-in-agent:
+    image: beclab/mesh-in-agent
+    context: framework/app-service/build/mesh-in-agent
+    dockerfile: framework/app-service/build/mesh-in-agent/Dockerfile
+    workflow: module_appservice_publish_mesh_in_agent.yaml
+
+  mesh-out-agent:
+    image: beclab/mesh-out-agent
+    context: framework/app-service/build/mesh-out-agent
+    dockerfile: framework/app-service/build/mesh-out-agent/Dockerfile
+    workflow: module_appservice_publish_mesh_out_agent.yaml
+
+  linkerd-pki-guardian:
+    image: beclab/linkerd-pki-guardian
+    context: framework/app-gateway
+    dockerfile: framework/app-gateway/cmd/linkerd-pki-guardian/Dockerfile
+    workflow: module_appgateway_publish_pki_guardian.yaml
+
+  backup-server:
+    image: beclab/backup-server
+    context: framework/backup-server
+    dockerfile: framework/backup-server/Dockerfile
+    workflow: module_backup_publish_docker.yaml
+
+  sidecar-backup-sync:
+    image: beclab/sidecar-backup-sync
+    context: framework/backup-server
+    dockerfile: framework/backup-server/Dockerfile.sidecar
+    workflow: module_backup_publish_sidecar.yaml
+
+  bfl:
+    image: beclab/bfl
+    context: framework/bfl
+    dockerfile: framework/bfl/Dockerfile.api
+    workflow: module_bfl_publish_docker.yaml
+
+  frpc:
+    image: beclab/frpc
+    context: framework/bfl
+    dockerfile: framework/bfl/Dockerfile.frpc
+    workflow: module_bfl_publish_frpc.yaml
+
+  integration-server:
+    image: beclab/integration-server
+    context: framework/integration
+    dockerfile: framework/integration/Dockerfile
+    workflow: module_integration_publish_docker.yaml
+
+  kube-state-metrics:
+    image: beclab/kube-state-metrics
+    context: framework/kube-state-metrics
+    dockerfile: framework/kube-state-metrics/Dockerfile
+    workflow: module_kubemetrics_publish_docker.yaml
+
+  ks-apiserver:
+    image: beclab/ks-apiserver
+    context: infrastructure/kubesphere
+    dockerfile: infrastructure/kubesphere/build/ks-apiserver/Dockerfile
+    workflow: module_kubesphere_publish_docker.yaml
+
+  l4-bfl-proxy:
+    image: beclab/l4-bfl-proxy
+    context: framework/l4-bfl-proxy
+    dockerfile: framework/l4-bfl-proxy/Dockerfile
+    workflow: module_l4_publish_docker.yaml
+
+  osnode-init:
+    image: beclab/osnode-init
+    context: framework/osnode-init
+    dockerfile: framework/osnode-init/Dockerfile
+    workflow: module_nodeinit_publish_docker.yaml
+
+  system-server:
+    image: beclab/system-server
+    context: framework/system-server
+    dockerfile: framework/system-server/Dockerfile
+    workflow: module_systemserver_publish_docker.yaml
+
+  provider-proxy:
+    image: beclab/provider-proxy
+    context: framework/system-server
+    dockerfile: framework/system-server/Dockerfile.provider
+    workflow: module_systemserver_publish_proxy.yaml
+
+  citus:
+    image: beclab/citus
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/citus/Dockerfile
+    workflow: module_tapr_publish_citus.yaml
+
+  images-uploader:
+    image: beclab/images-uploader
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/uploader/Dockerfile
+    workflow: module_tapr_publish_image.yaml
+
+  middleware-operator:
+    image: beclab/middleware-operator
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/middleware/Dockerfile
+    workflow: module_tapr_publish_middleware.yaml
+
+  s3rver:
+    image: beclab/s3rver
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/middleware/Dockerfile.s3rver
+    workflow: module_tapr_publish_s3rver.yaml
+
+  sys-event:
+    image: beclab/sys-event
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/sys-event/Dockerfile
+    workflow: module_tapr_publish_sysevent.yaml
+
+  secret-vault:
+    image: beclab/secret-vault
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/vault/Dockerfile
+    workflow: module_tapr_publish_vault.yaml
+
+  ws-gateway:
+    image: beclab/ws-gateway
+    context: platform/tapr
+    dockerfile: platform/tapr/docker/ws-gateway/Dockerfile
+    workflow: module_tapr_publish_wsgateway.yaml

--- a/cli/cmd/ctl/cluster/node/api.go
+++ b/cli/cmd/ctl/cluster/node/api.go
@@ -1,0 +1,64 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/internal/clusteropts"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// Architectures returns the distinct CPU architectures reported by the
+// cluster's nodes (status.nodeInfo.architecture — "amd64", "arm64", …).
+//
+// Exported as a Factory-based facade for the same reason as
+// workload/api.go: clusteropts is internal to the cluster tree, so
+// cmd/ctl/dev cannot build an options bag itself. `dev push` uses this
+// to refuse an image built for the wrong architecture *before* paying
+// for the transfer — a wrong-arch image imports cleanly and then fails
+// at runtime as an opaque CrashLoopBackOff ("exec format error" buried
+// in the container log), which is a genuinely expensive thing to debug.
+func Architectures(ctx context.Context, f *cmdutil.Factory) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	o := clusteropts.NewClusterOptions(f)
+	o.Quiet = true
+	client, err := o.Prepare()
+	if err != nil {
+		return nil, err
+	}
+	p := clusteropts.NewPaginationOptions()
+	p.All = true
+
+	items, _, err := clusteropts.FetchAllKubeSphere[Node](ctx, client, p, func(page int) string {
+		q := url.Values{}
+		p.AppendQueryForPage(q, page)
+		path := "/kapis/resources.kubesphere.io/v1alpha3/nodes"
+		if encoded := q.Encode(); encoded != "" {
+			path += "?" + encoded
+		}
+		return path
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+	for _, n := range items {
+		arch := n.Status.NodeInfo.Architecture
+		if arch == "" {
+			continue
+		}
+		if _, dup := seen[arch]; dup {
+			continue
+		}
+		seen[arch] = struct{}{}
+		out = append(out, arch)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cli/cmd/ctl/cluster/workload/api.go
+++ b/cli/cmd/ctl/cluster/workload/api.go
@@ -1,0 +1,340 @@
+package workload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/internal/clusteropts"
+	"github.com/beclab/Olares/cli/pkg/clusterclient"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// This file is the workload package's Factory-based facade.
+//
+// clusteropts lives under cmd/ctl/cluster/internal/, so Go's internal
+// rule makes it unreachable from cmd/ctl/dev. Rather than hoisting
+// clusteropts out of internal/ — which would widen a deliberately
+// narrow surface for every future caller — the dev tree talks to
+// workloads through these functions, which take a *cmdutil.Factory and
+// build the options bag themselves. Everything they expose is a type
+// this package owns.
+
+// OutputMode is the caller-settable slice of ClusterOptions that
+// matters to non-cobra callers. Table rendering is the default; JSON
+// and Quiet mirror the -o json / -q flags.
+type OutputMode struct {
+	JSON  bool
+	Quiet bool
+}
+
+func (m OutputMode) options(f *cmdutil.Factory) *clusteropts.ClusterOptions {
+	o := clusteropts.NewClusterOptions(f)
+	if m.JSON {
+		o.Output = "json"
+	}
+	o.Quiet = m.Quiet
+	return o
+}
+
+// SetImage is the Factory-based entry point to the set-image code path.
+// `dev deploy` uses it so that repointing a workload is byte-for-byte
+// the same operation whether it was reached through
+// `cluster workload set-image` or through the dev loop.
+func SetImage(ctx context.Context, f *cmdutil.Factory, m OutputMode, p SetImageParams) (SetImageResult, error) {
+	return RunSetImage(ctx, m.options(f), p)
+}
+
+// FindImageRefsFor is FindImageRefs with the options bag built here.
+func FindImageRefsFor(ctx context.Context, f *cmdutil.Factory, m OutputMode, namespace, image string) ([]ImageRef, error) {
+	return FindImageRefs(ctx, m.options(f), namespace, image)
+}
+
+// DevOverride is one workload carrying a `set-image` override, as
+// reported by `dev status`.
+type DevOverride struct {
+	Namespace  string `json:"namespace"`
+	Kind       string `json:"kind"`
+	KindPlural string `json:"-"`
+	Name       string `json:"name"`
+	Container  string `json:"container"`
+	// Current is the image the workload runs now (the dev build).
+	Current string `json:"current"`
+	// Previous is what it ran before the override, i.e. what `dev
+	// revert` will restore.
+	Previous string `json:"previous"`
+	// Missing is true when the annotation names a container that is no
+	// longer in the pod template — a leftover from a chart upgrade that
+	// renamed or dropped it. Revert skips these and says so.
+	Missing bool `json:"missing,omitempty"`
+}
+
+// ListDevOverrides scans every workload visible to the profile for the
+// previous-images annotation.
+//
+// This is the answer to "what on this cluster is currently running a
+// dev build?" — the first thing to check when a workload misbehaves
+// after a dev session, and the reason a side-loaded image that a node
+// prune has since collected is diagnosable at all.
+func ListDevOverrides(ctx context.Context, f *cmdutil.Factory, m OutputMode, namespace string) ([]DevOverride, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	o := m.options(f)
+	p := clusteropts.NewPaginationOptions()
+	p.All = true
+
+	collected, _, err := fetchWorkloads(ctx, o, p, namespace, KindAll, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []DevOverride
+	for _, result := range collected {
+		for _, w := range result.Items {
+			previous, err := DecodePreviousImages(w.Metadata.Annotations)
+			if err != nil {
+				// One malformed annotation must not blind the whole
+				// scan — report it in place and keep going.
+				out = append(out, DevOverride{
+					Namespace: w.Metadata.Namespace,
+					Kind:      nonEmpty(w.Kind, SingularKind(result.Kind)),
+					Name:      w.Metadata.Name,
+					Previous:  fmt.Sprintf("<malformed: %v>", err),
+					Missing:   true,
+				})
+				continue
+			}
+			if len(previous) == 0 {
+				continue
+			}
+			live := map[string]WorkloadContainer{}
+			if w.Spec.Template != nil {
+				for _, c := range w.Spec.Template.Spec.Containers {
+					live[c.Name] = c
+				}
+				for _, c := range w.Spec.Template.Spec.InitContainers {
+					live[c.Name] = c
+				}
+			}
+			for name, state := range previous {
+				entry := DevOverride{
+					Namespace:  w.Metadata.Namespace,
+					Kind:       nonEmpty(w.Kind, SingularKind(result.Kind)),
+					KindPlural: result.Kind,
+					Name:       w.Metadata.Name,
+					Container:  name,
+					Previous:   state.Image,
+				}
+				if c, ok := live[name]; ok {
+					entry.Current = c.Image
+				} else {
+					entry.Missing = true
+				}
+				out = append(out, entry)
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.Container < b.Container
+	})
+	return out, nil
+}
+
+// RevertResult reports one restored container.
+type RevertResult struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Container string `json:"container"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+	Skipped   string `json:"skipped,omitempty"`
+}
+
+// RevertParams selects what to restore.
+type RevertParams struct {
+	Namespace  string
+	Name       string
+	KindPlural string
+	// Container restricts the revert to one container; empty reverts
+	// every container recorded in the annotation.
+	Container string
+	Watch     bool
+	Interval  time.Duration
+	Timeout   time.Duration
+}
+
+// RevertImages restores the images recorded in the previous-images
+// annotation and clears the entries it consumed.
+//
+// Restoring the pull policy matters as much as the image: set-image
+// forces IfNotPresent so a side-loaded build is usable, and leaving
+// that behind would silently pin the workload to whatever happens to
+// be cached on the node, defeating the next legitimate chart upgrade.
+// An entry whose original policy was unset is restored by sending
+// null, which strategic merge patch treats as "delete this field" so
+// the API server reapplies its default.
+func RevertImages(ctx context.Context, f *cmdutil.Factory, m OutputMode, p RevertParams) ([]RevertResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	o := m.options(f)
+	client, err := o.Prepare()
+	if err != nil {
+		return nil, err
+	}
+
+	path := buildGetPath(p.Namespace, p.KindPlural, p.Name)
+	var w Workload
+	if err := clusterclient.GetK8sObject(ctx, client, path, &w); err != nil {
+		return nil, fmt.Errorf("get %s %s/%s: %w", SingularKind(p.KindPlural), p.Namespace, p.Name, err)
+	}
+	previous, err := DecodePreviousImages(w.Metadata.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if len(previous) == 0 {
+		return nil, fmt.Errorf("%s %s/%s carries no %s annotation — nothing to revert",
+			SingularKind(p.KindPlural), p.Namespace, p.Name, PreviousImagesAnnotation)
+	}
+	if p.Container != "" {
+		state, ok := previous[p.Container]
+		if !ok {
+			return nil, fmt.Errorf("%s %s/%s has no recorded original for container %q (recorded: %s)",
+				SingularKind(p.KindPlural), p.Namespace, p.Name, p.Container,
+				strings.Join(sortedKeys(previous), ", "))
+		}
+		previous = map[string]PreviousContainerState{p.Container: state}
+	}
+
+	live := map[string]string{} // container name -> list key
+	if w.Spec.Template != nil {
+		for _, c := range w.Spec.Template.Spec.Containers {
+			live[c.Name] = "containers"
+		}
+		for _, c := range w.Spec.Template.Spec.InitContainers {
+			live[c.Name] = "initContainers"
+		}
+	}
+
+	entries := map[string][]interface{}{}
+	var results []RevertResult
+	remaining, err := DecodePreviousImages(w.Metadata.Annotations)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range sortedKeys(previous) {
+		state := previous[name]
+		listKey, present := live[name]
+		if !present {
+			// The container is gone (renamed or removed by a chart
+			// upgrade). Patching it back would ADD a container to the
+			// pod template, which is worse than leaving it alone.
+			results = append(results, RevertResult{
+				Namespace: p.Namespace, Kind: SingularKind(p.KindPlural), Name: p.Name,
+				Container: name, To: state.Image,
+				Skipped: "container is no longer in the pod template",
+			})
+			delete(remaining, name)
+			continue
+		}
+		entry := map[string]interface{}{
+			"name":  name,
+			"image": state.Image,
+		}
+		if state.ImagePullPolicy != "" {
+			entry["imagePullPolicy"] = state.ImagePullPolicy
+		} else {
+			entry["imagePullPolicy"] = nil
+		}
+		entries[listKey] = append(entries[listKey], entry)
+		results = append(results, RevertResult{
+			Namespace: p.Namespace, Kind: SingularKind(p.KindPlural), Name: p.Name,
+			Container: name, From: currentImage(w, name), To: state.Image,
+		})
+		delete(remaining, name)
+	}
+
+	if len(entries) == 0 {
+		return results, nil
+	}
+
+	spec := map[string]interface{}{}
+	for listKey, list := range entries {
+		spec[listKey] = list
+	}
+	// An emptied map is written as a deleted annotation (null) rather
+	// than "{}" so a fully reverted workload looks untouched.
+	var annotationValue interface{}
+	if len(remaining) == 0 {
+		annotationValue = nil
+	} else {
+		encoded, merr := json.Marshal(remaining)
+		if merr != nil {
+			return nil, fmt.Errorf("encode %s annotation: %w", PreviousImagesAnnotation, merr)
+		}
+		annotationValue = string(encoded)
+	}
+
+	body := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				PreviousImagesAnnotation: annotationValue,
+			},
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": spec,
+			},
+		},
+	}
+	if err := clusterclient.Patch[Workload](ctx, client, path,
+		"application/strategic-merge-patch+json", body, nil); err != nil {
+		return nil, fmt.Errorf("revert %s %s/%s: %w", SingularKind(p.KindPlural), p.Namespace, p.Name, err)
+	}
+
+	if p.Watch {
+		if err := runRolloutStatus(ctx, o, p.Namespace, p.Name, p.KindPlural, true, p.Interval, p.Timeout); err != nil {
+			return results, err
+		}
+	}
+	return results, nil
+}
+
+func currentImage(w Workload, container string) string {
+	if w.Spec.Template == nil {
+		return ""
+	}
+	for _, c := range w.Spec.Template.Spec.Containers {
+		if c.Name == container {
+			return c.Image
+		}
+	}
+	for _, c := range w.Spec.Template.Spec.InitContainers {
+		if c.Name == container {
+			return c.Image
+		}
+	}
+	return ""
+}
+
+func sortedKeys(m map[string]PreviousContainerState) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/cmd/ctl/cluster/workload/batch_images.go
+++ b/cli/cmd/ctl/cluster/workload/batch_images.go
@@ -53,7 +53,7 @@ func fetchBatchImageRefs(
 	p *clusteropts.PaginationOptions,
 	namespace, labelSelector string,
 	kinds []string,
-) ([]workloadImageRef, []workloadImageScan, error) {
+) ([]ImageRef, []workloadImageScan, error) {
 	if len(kinds) == 0 {
 		return nil, nil, nil
 	}
@@ -62,7 +62,7 @@ func fetchBatchImageRefs(
 		return nil, nil, err
 	}
 	var (
-		refs []workloadImageRef
+		refs []ImageRef
 		scan []workloadImageScan
 	)
 	for _, kind := range kinds {
@@ -83,14 +83,14 @@ func fetchBatchImageRefs(
 	return refs, scan, nil
 }
 
-func collectBatchImageRefs(kindPlural string, items []batchWorkload) []workloadImageRef {
-	var refs []workloadImageRef
+func collectBatchImageRefs(kindPlural string, items []batchWorkload) []ImageRef {
+	var refs []ImageRef
 	for _, b := range items {
 		tmpl := b.podTemplate()
 		if tmpl == nil {
 			continue
 		}
-		base := workloadImageRef{
+		base := ImageRef{
 			Namespace: b.Metadata.Namespace,
 			Kind:      nonEmpty(b.Kind, SingularKind(kindPlural)),
 			Workload:  b.Metadata.Name,

--- a/cli/cmd/ctl/cluster/workload/doctor_images.go
+++ b/cli/cmd/ctl/cluster/workload/doctor_images.go
@@ -83,8 +83,8 @@ Two caveats before you prune:
 // top level of the JSON object.
 type imageUsage struct {
 	containerdimages.Image
-	Refs   int                `json:"refs"`
-	UsedBy []workloadImageRef `json:"used_by,omitempty"`
+	Refs   int        `json:"refs"`
+	UsedBy []ImageRef `json:"used_by,omitempty"`
 }
 
 func runDoctorImages(ctx context.Context, f *cmdutil.Factory, o *clusteropts.ClusterOptions, namespace, labelSelector, registry string, unusedOnly bool) error {
@@ -175,7 +175,7 @@ func sortBySizeDesc(usage []imageUsage) {
 // computeImageUsage joins local images with workload references, counting
 // distinct references per image (digest- and tag-aware) and skipping
 // runtime-pinned pause images. Output is deterministically sorted.
-func computeImageUsage(images []containerdimages.Image, refs []workloadImageRef) []imageUsage {
+func computeImageUsage(images []containerdimages.Image, refs []ImageRef) []imageUsage {
 	keyToRefs := map[string][]int{}
 	for i, ref := range refs {
 		for _, key := range imageMatchKeys(ref.Image) {

--- a/cli/cmd/ctl/cluster/workload/doctor_images_test.go
+++ b/cli/cmd/ctl/cluster/workload/doctor_images_test.go
@@ -20,7 +20,7 @@ func TestComputeImageUsageCountsReferences(t *testing.T) {
 		{ID: "sha256:used", RepoTags: []string{"docker.io/example/api:v1", "registry.local/example/api:v1"}},
 		{ID: "sha256:orphan", RepoTags: []string{"docker.io/example/old:v1"}},
 	}
-	refs := []workloadImageRef{
+	refs := []ImageRef{
 		{Workload: "api", Image: "docker.io/example/api:v1"},
 		{Workload: "api-canary", Image: "docker.io/example/api:v1"},
 	}
@@ -47,7 +47,7 @@ func TestComputeImageUsageNormalizesDockerHubShorthand(t *testing.T) {
 	local := []containerdimages.Image{
 		{ID: "sha256:nginx", RepoTags: []string{"docker.io/library/nginx:latest"}},
 	}
-	refs := []workloadImageRef{{Image: "nginx"}}
+	refs := []ImageRef{{Image: "nginx"}}
 
 	usage := computeImageUsage(local, refs)
 
@@ -84,7 +84,7 @@ func TestComputeImageUsageMatchesDigestPinnedReference(t *testing.T) {
 	}
 	// Workload pins by digest against a mirror host so the tag will not
 	// line up — only the digest can prove the image is used.
-	refs := []workloadImageRef{{Image: "registry.local/example/api@" + digest}}
+	refs := []ImageRef{{Image: "registry.local/example/api@" + digest}}
 
 	usage := computeImageUsage(local, refs)
 

--- a/cli/cmd/ctl/cluster/workload/images.go
+++ b/cli/cmd/ctl/cluster/workload/images.go
@@ -81,13 +81,65 @@ func resolveImageScanKinds(kindRaw string) (primary string, batch []string, err 
 	return plural, nil, nil
 }
 
-type workloadImageRef struct {
+// ImageRef is one (workload, container, image) tuple. Exported because
+// pkg/devdeploy resolves `dev deploy` targets through FindImageRefs and
+// needs to name the result type.
+type ImageRef struct {
 	Namespace     string `json:"namespace,omitempty"`
 	Kind          string `json:"kind"`
 	Workload      string `json:"workload"`
 	ContainerType string `json:"containerType"`
 	Container     string `json:"container"`
 	Image         string `json:"image"`
+}
+
+// KindPlural maps the ref's rendered kind ("StatefulSet") back to the
+// path segment the mutating verbs need ("statefulsets"). Returns an
+// error for the batch kinds (Job / CronJob), which the images scan can
+// report on but set-image cannot patch — their pod templates are
+// immutable once created.
+func (r ImageRef) KindPlural() (string, error) {
+	switch strings.ToLower(r.Kind) {
+	case "job", "jobs", "cronjob", "cronjobs":
+		return "", fmt.Errorf("%s %s/%s cannot be repointed: pod templates of %s objects are immutable",
+			r.Kind, r.Namespace, r.Workload, r.Kind)
+	}
+	return NormalizeKind(r.Kind)
+}
+
+// FindImageRefs answers "which workloads reference this image?" for
+// callers outside the cobra layer. It is the same forced-full-scan the
+// `images <IMAGE>` verb runs — a paged subset would miss references on
+// later pages and wrongly report an image as unreferenced, which for
+// `dev deploy` would mean silently repointing only some of the
+// workloads that need it.
+//
+// namespace "" scans every namespace visible to the active profile.
+func FindImageRefs(ctx context.Context, o *clusteropts.ClusterOptions, namespace, image string) ([]ImageRef, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if strings.TrimSpace(image) == "" {
+		return nil, fmt.Errorf("image is required")
+	}
+	p := clusteropts.NewPaginationOptions()
+	p.All = true
+
+	collected, _, err := fetchWorkloads(ctx, o, p, namespace, KindAll, "", true)
+	if err != nil {
+		return nil, err
+	}
+	refs := collectWorkloadImageRefs(collected)
+
+	batchRefs, _, err := fetchBatchImageRefs(ctx, o, p, namespace, "", batchKinds)
+	if err != nil {
+		return nil, err
+	}
+	refs = append(refs, batchRefs...)
+
+	refs = filterRefsByImage(refs, image)
+	sortImageRefs(refs)
+	return refs, nil
 }
 
 type workloadImageScan struct {
@@ -116,7 +168,7 @@ func runImages(ctx context.Context, o *clusteropts.ClusterOptions, p *clusteropt
 	}
 
 	var (
-		refs []workloadImageRef
+		refs []ImageRef
 		scan []workloadImageScan
 	)
 	if primary != "" {
@@ -141,7 +193,7 @@ func runImages(ctx context.Context, o *clusteropts.ClusterOptions, p *clusteropt
 	sortImageRefs(refs)
 	if o.IsJSON() {
 		return o.PrintJSON(struct {
-			Refs  []workloadImageRef  `json:"refs"`
+			Refs  []ImageRef          `json:"refs"`
 			Scan  []workloadImageScan `json:"scan"`
 			Page  int                 `json:"page"`
 			Limit int                 `json:"limit"`
@@ -154,14 +206,14 @@ func runImages(ctx context.Context, o *clusteropts.ClusterOptions, p *clusteropt
 	return renderImagesTable(refs, scan, o.NoHeaders, imageQuery)
 }
 
-func collectWorkloadImageRefs(results []workloadKindResult) []workloadImageRef {
-	var refs []workloadImageRef
+func collectWorkloadImageRefs(results []workloadKindResult) []ImageRef {
+	var refs []ImageRef
 	for _, result := range results {
 		for _, w := range result.Items {
 			if w.Spec.Template == nil {
 				continue
 			}
-			base := workloadImageRef{
+			base := ImageRef{
 				Namespace: w.Metadata.Namespace,
 				Kind:      nonEmpty(w.Kind, SingularKind(result.Kind)),
 				Workload:  w.Metadata.Name,
@@ -195,12 +247,12 @@ func collectWorkloadImageRefs(results []workloadKindResult) []workloadImageRef {
 // query, tag- and digest-normalized via imageMatchKeys (so "nginx"
 // matches "docker.io/library/nginx:latest", and a digest pin matches
 // by digest).
-func filterRefsByImage(refs []workloadImageRef, query string) []workloadImageRef {
+func filterRefsByImage(refs []ImageRef, query string) []ImageRef {
 	want := map[string]struct{}{}
 	for _, key := range imageMatchKeys(query) {
 		want[key] = struct{}{}
 	}
-	var out []workloadImageRef
+	var out []ImageRef
 	for _, ref := range refs {
 		for _, key := range imageMatchKeys(ref.Image) {
 			if _, ok := want[key]; ok {
@@ -214,7 +266,7 @@ func filterRefsByImage(refs []workloadImageRef, query string) []workloadImageRef
 
 // sortImageRefs orders refs deterministically so JSON and table output
 // is stable across runs regardless of per-kind fetch / pagination order.
-func sortImageRefs(refs []workloadImageRef) {
+func sortImageRefs(refs []ImageRef) {
 	sort.SliceStable(refs, func(i, j int) bool {
 		a, b := refs[i], refs[j]
 		if a.Namespace != b.Namespace {
@@ -249,7 +301,7 @@ func summarizeImageScan(results []workloadKindResult, p *clusteropts.PaginationO
 	return out
 }
 
-func renderImagesTable(refs []workloadImageRef, scan []workloadImageScan, noHeaders bool, imageQuery string) error {
+func renderImagesTable(refs []ImageRef, scan []workloadImageScan, noHeaders bool, imageQuery string) error {
 	if len(refs) == 0 {
 		if imageQuery != "" {
 			fmt.Fprintf(os.Stdout, "no workloads reference %q\n", imageQuery)

--- a/cli/cmd/ctl/cluster/workload/images_test.go
+++ b/cli/cmd/ctl/cluster/workload/images_test.go
@@ -105,7 +105,7 @@ func TestResolveImageScanKinds(t *testing.T) {
 }
 
 func TestFilterRefsByImageNormalizesAndMatches(t *testing.T) {
-	refs := []workloadImageRef{
+	refs := []ImageRef{
 		{Workload: "web", Image: "docker.io/library/nginx:latest"},
 		{Workload: "cache", Image: "docker.io/library/redis:7"},
 		{Workload: "edge", Image: "nginx"},

--- a/cli/cmd/ctl/cluster/workload/root.go
+++ b/cli/cmd/ctl/cluster/workload/root.go
@@ -67,6 +67,7 @@ active profile can see. Pass -n / --namespace to scope explicitly.
 	cmd.AddCommand(NewYAMLCommand(f))
 	cmd.AddCommand(NewRolloutStatusCommand(f))
 	cmd.AddCommand(NewScaleCommand(f))
+	cmd.AddCommand(NewSetImageCommand(f))
 	cmd.AddCommand(NewRestartCommand(f))
 	cmd.AddCommand(NewStopCommand(f))
 	cmd.AddCommand(NewStartCommand(f))

--- a/cli/cmd/ctl/cluster/workload/set_image.go
+++ b/cli/cmd/ctl/cluster/workload/set_image.go
@@ -1,0 +1,392 @@
+package workload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/internal/clusteropts"
+	"github.com/beclab/Olares/cli/pkg/clusterclient"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// PreviousImagesAnnotation records what a container's image and pull
+// policy were before `set-image` overrode them, so `dev revert` can put
+// them back exactly.
+//
+// It is ONE annotation holding a JSON object keyed by container name
+// rather than one annotation per container. A per-container key
+// ("previous-image.<container>") would blow the 63-character limit on
+// the annotation name segment for long container names, and a partial
+// write would leave a half-reverted workload. Container names are
+// unique across containers and initContainers within a pod spec (K8s
+// validation enforces it), so the container name alone is a safe key.
+const PreviousImagesAnnotation = "dev.olares.io/previous-images"
+
+// PreviousContainerState is one entry in the PreviousImagesAnnotation
+// map. ImagePullPolicy is empty when the container did not set one
+// explicitly — restoring that means dropping the field, which is what
+// the revert patch does by sending null.
+type PreviousContainerState struct {
+	Image           string `json:"image"`
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+}
+
+// DefaultDevPullPolicy is what set-image applies unless told otherwise.
+// A side-loaded image (imported straight into the node's containerd by
+// `dev push`) exists in no registry, so leaving the policy at Always
+// guarantees ErrImagePull on the next kubelet sync.
+const DefaultDevPullPolicy = "IfNotPresent"
+
+// SetImageResult is the `-o json` shape. Mirrors scaleResult's
+// philosophy: a stable synthesized summary rather than the (verbose)
+// post-patch object.
+type SetImageResult struct {
+	Operation     string `json:"operation"`
+	Kind          string `json:"kind"`
+	Namespace     string `json:"namespace"`
+	Name          string `json:"name"`
+	Container     string `json:"container"`
+	ContainerType string `json:"containerType"`
+	PreviousImage string `json:"previousImage"`
+	Image         string `json:"image"`
+	PullPolicy    string `json:"pullPolicy,omitempty"`
+}
+
+// NewSetImageCommand: `olares-cli cluster workload set-image
+// <ns/name | name> --kind X --image REF [-c CONTAINER] [-n NS]
+// [--pull-policy P] [--watch] [--yes]`.
+//
+// Unlike `scale`, this cannot use application/merge-patch+json:
+// merge-patch replaces whole arrays, so patching one container's image
+// would delete every other container in the pod template. Strategic
+// merge patch understands the containers list's patchMergeKey ("name")
+// and merges by it, which is what the SPA and kubectl both rely on.
+func NewSetImageCommand(f *cmdutil.Factory) *cobra.Command {
+	o := clusteropts.NewClusterOptions(f)
+	var (
+		namespace  string
+		kindRaw    string
+		container  string
+		image      string
+		pullPolicy string
+		watch      bool
+		interval   time.Duration
+		timeout    time.Duration
+		assumeYes  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "set-image <ns/name | name>",
+		Short: "point a container at a different image (records the old one for revert)",
+		Long: `Replace the image of one container in a Deployment / StatefulSet /
+DaemonSet pod template.
+
+PATCHes ` + "`/apis/apps/v1/namespaces/<ns>/<kind>/<name>`" + ` with
+` + "`application/strategic-merge-patch+json`" + `. Strategic merge is
+required here (not the merge-patch ` + "`scale`" + ` uses): the containers
+list has patchMergeKey "name", so the server merges the entry by name
+instead of replacing the whole array and dropping sibling containers.
+
+--container may be omitted when the pod template has exactly one
+container; otherwise it is required. initContainers are addressed by
+the same flag — the verb finds the container by name across both lists.
+
+The replaced image and pull policy are stashed in the
+` + "`" + PreviousImagesAnnotation + "`" + ` annotation so
+` + "`olares-cli dev revert`" + ` can restore them exactly.
+
+--pull-policy defaults to ` + DefaultDevPullPolicy + ` because the main
+consumer is a locally built image side-loaded into the node's
+containerd, which no registry can serve. Pass --pull-policy="" to leave
+the existing policy untouched.
+
+Examples:
+  olares-cli cluster workload set-image os-framework/app-service \
+      --kind sts --image beclab/app-service:dev -w
+  olares-cli cluster workload set-image myapp -n user-space-alice \
+      --kind deploy -c web --image ghcr.io/me/web:pr-42
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			plural, err := NormalizeKind(kindRaw)
+			if err != nil {
+				return err
+			}
+			if plural == KindAll {
+				return fmt.Errorf("--kind must be one of: deployment, statefulset, daemonset (not %q)", kindRaw)
+			}
+			if strings.TrimSpace(image) == "" {
+				return fmt.Errorf("--image is required")
+			}
+			ns, name, err := clusteropts.SplitNsName(namespace, args[0])
+			if err != nil {
+				return err
+			}
+			// Same contract as scale: watch-only knobs are dead
+			// without --watch, so reject rather than silently ignore.
+			if c.Flags().Changed("interval") && !watch {
+				return fmt.Errorf("--interval requires --watch")
+			}
+			if c.Flags().Changed("timeout") && !watch {
+				return fmt.Errorf("--timeout requires --watch")
+			}
+			_, err = RunSetImage(c.Context(), o, SetImageParams{
+				Namespace:  ns,
+				Name:       name,
+				KindPlural: plural,
+				Container:  container,
+				Image:      image,
+				PullPolicy: pullPolicy,
+				Watch:      watch,
+				Interval:   interval,
+				Timeout:    timeout,
+				AssumeYes:  assumeYes,
+			})
+			return err
+		},
+	}
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace (required when the positional argument is a bare name)")
+	cmd.Flags().StringVar(&kindRaw, "kind", "", "workload kind: deployment | statefulset | daemonset (REQUIRED)")
+	cmd.Flags().StringVarP(&container, "container", "c", "", "container name (optional when the pod template has exactly one container)")
+	cmd.Flags().StringVar(&image, "image", "", "new image reference (REQUIRED)")
+	cmd.Flags().StringVar(&pullPolicy, "pull-policy", DefaultDevPullPolicy, `imagePullPolicy to set alongside the image; "" leaves it untouched`)
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "after patching, wait for the rollout to converge")
+	cmd.Flags().DurationVar(&interval, "interval", 2*time.Second, "polling interval for --watch")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "give up after this duration when --watch is set; 0 = no timeout")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the confirmation prompt")
+	o.AddDetailOutputFlags(cmd)
+	return cmd
+}
+
+// SetImageParams is the input to RunSetImage. Exported because
+// pkg/devdeploy drives the same code path — `dev deploy` must not
+// re-implement the patch, so that the verb behaves identically whether
+// it is invoked directly or as one step of the dev loop.
+type SetImageParams struct {
+	Namespace  string
+	Name       string
+	KindPlural string
+	Container  string
+	Image      string
+	PullPolicy string
+	Watch      bool
+	Interval   time.Duration
+	Timeout    time.Duration
+	AssumeYes  bool
+	// SkipConfirm bypasses the prompt entirely (not just pre-answering
+	// it). `dev deploy` confirms once for the whole resolved target
+	// set, so re-prompting per workload would be noise.
+	SkipConfirm bool
+}
+
+// RunSetImage performs the GET → validate → PATCH → (optional) wait
+// sequence and returns what it did. The returned result is populated
+// even when Watch is set and the wait later fails, so callers can
+// report the patch that did land.
+func RunSetImage(ctx context.Context, o *clusteropts.ClusterOptions, p SetImageParams) (SetImageResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var zero SetImageResult
+	client, err := o.Prepare()
+	if err != nil {
+		return zero, err
+	}
+
+	path := buildGetPath(p.Namespace, p.KindPlural, p.Name)
+	var w Workload
+	if err := clusterclient.GetK8sObject(ctx, client, path, &w); err != nil {
+		return zero, fmt.Errorf("get %s %s/%s: %w", SingularKind(p.KindPlural), p.Namespace, p.Name, err)
+	}
+
+	current, containerType, err := resolveTargetContainer(w, p.Container)
+	if err != nil {
+		return zero, fmt.Errorf("%s %s/%s: %w", SingularKind(p.KindPlural), p.Namespace, p.Name, err)
+	}
+
+	if current.Image == p.Image && (p.PullPolicy == "" || current.ImagePullPolicy == p.PullPolicy) {
+		// No-op. Report it rather than issuing a PATCH that would bump
+		// the generation and trigger a pointless rollout.
+		result := SetImageResult{
+			Operation: "set-image (no-op)", Kind: SingularKind(p.KindPlural),
+			Namespace: p.Namespace, Name: p.Name,
+			Container: current.Name, ContainerType: containerType,
+			PreviousImage: current.Image, Image: p.Image, PullPolicy: p.PullPolicy,
+		}
+		if o.IsJSON() {
+			return result, o.PrintJSON(result)
+		}
+		if !o.Quiet {
+			fmt.Fprintf(os.Stdout, "%s %s/%s container %q already runs %s — nothing to do\n",
+				SingularKind(p.KindPlural), p.Namespace, p.Name, current.Name, p.Image)
+		}
+		return result, nil
+	}
+
+	if !p.SkipConfirm {
+		if err := clusteropts.ConfirmDestructive(os.Stderr, os.Stdin,
+			fmt.Sprintf("Repoint %s %s/%s container %q from %s to %s? Pods will be recreated",
+				SingularKind(p.KindPlural), p.Namespace, p.Name, current.Name, current.Image, p.Image),
+			p.AssumeYes); err != nil {
+			return zero, err
+		}
+	}
+
+	body, err := buildSetImagePatch(w, current, containerType, p.Image, p.PullPolicy)
+	if err != nil {
+		return zero, err
+	}
+	if err := clusterclient.Patch[Workload](ctx, client, path,
+		"application/strategic-merge-patch+json", body, nil); err != nil {
+		return zero, fmt.Errorf("set image on %s %s/%s container %q: %w",
+			SingularKind(p.KindPlural), p.Namespace, p.Name, current.Name, err)
+	}
+
+	result := SetImageResult{
+		Operation: "set-image", Kind: SingularKind(p.KindPlural),
+		Namespace: p.Namespace, Name: p.Name,
+		Container: current.Name, ContainerType: containerType,
+		PreviousImage: current.Image, Image: p.Image, PullPolicy: p.PullPolicy,
+	}
+
+	if !p.Watch {
+		if o.IsJSON() {
+			return result, o.PrintJSON(result)
+		}
+		if !o.Quiet {
+			fmt.Fprintf(os.Stdout, "%s %s/%s container %q: %s -> %s\n",
+				SingularKind(p.KindPlural), p.Namespace, p.Name, current.Name, current.Image, p.Image)
+		}
+		return result, nil
+	}
+
+	if !o.Quiet && !o.IsJSON() {
+		fmt.Fprintf(os.Stdout, "%s %s/%s container %q: %s -> %s; waiting for rollout to converge\n",
+			SingularKind(p.KindPlural), p.Namespace, p.Name, current.Name, current.Image, p.Image)
+	}
+	return result, runRolloutStatus(ctx, o, p.Namespace, p.Name, p.KindPlural, true, p.Interval, p.Timeout)
+}
+
+// resolveTargetContainer finds the container to patch. With an explicit
+// name it searches containers then initContainers (names are unique
+// across both). Without one it defaults to the sole container, and
+// refuses to guess when there is more than one.
+func resolveTargetContainer(w Workload, name string) (WorkloadContainer, string, error) {
+	if w.Spec.Template == nil {
+		return WorkloadContainer{}, "", fmt.Errorf("has no spec.template — not a workload with a pod template")
+	}
+	containers := w.Spec.Template.Spec.Containers
+	initContainers := w.Spec.Template.Spec.InitContainers
+
+	if name == "" {
+		switch len(containers) {
+		case 0:
+			return WorkloadContainer{}, "", fmt.Errorf("pod template has no containers")
+		case 1:
+			return containers[0], "container", nil
+		default:
+			return WorkloadContainer{}, "", fmt.Errorf(
+				"pod template has %d containers (%s) — pass -c/--container to pick one",
+				len(containers), strings.Join(containerNames(containers), ", "))
+		}
+	}
+	for _, c := range containers {
+		if c.Name == name {
+			return c, "container", nil
+		}
+	}
+	for _, c := range initContainers {
+		if c.Name == name {
+			return c, "initContainer", nil
+		}
+	}
+	known := append(containerNames(containers), containerNames(initContainers)...)
+	sort.Strings(known)
+	return WorkloadContainer{}, "", fmt.Errorf("no container named %q (have: %s)",
+		name, strings.Join(known, ", "))
+}
+
+func containerNames(cs []WorkloadContainer) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+// buildSetImagePatch assembles the strategic-merge body: the container
+// entry keyed by name, plus the updated previous-images annotation.
+//
+// The annotation is merged with whatever is already there so that
+// overriding a second container does not erase the first container's
+// recorded original. An existing entry is NOT overwritten — the first
+// override is the one that recorded the true pre-dev state, and
+// overwriting it on a second `set-image` would make revert restore a
+// dev image instead of the original.
+func buildSetImagePatch(w Workload, current WorkloadContainer, containerType, image, pullPolicy string) (map[string]interface{}, error) {
+	previous, err := DecodePreviousImages(w.Metadata.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if _, already := previous[current.Name]; !already {
+		previous[current.Name] = PreviousContainerState{
+			Image:           current.Image,
+			ImagePullPolicy: current.ImagePullPolicy,
+		}
+	}
+	encoded, err := json.Marshal(previous)
+	if err != nil {
+		return nil, fmt.Errorf("encode %s annotation: %w", PreviousImagesAnnotation, err)
+	}
+
+	entry := map[string]interface{}{
+		"name":  current.Name,
+		"image": image,
+	}
+	if pullPolicy != "" {
+		entry["imagePullPolicy"] = pullPolicy
+	}
+	listKey := "containers"
+	if containerType == "initContainer" {
+		listKey = "initContainers"
+	}
+
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				PreviousImagesAnnotation: string(encoded),
+			},
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					listKey: []interface{}{entry},
+				},
+			},
+		},
+	}, nil
+}
+
+// DecodePreviousImages reads the revert annotation off a workload's
+// metadata. A missing annotation yields an empty (non-nil) map; a
+// malformed one is an error rather than a silent reset, because
+// silently dropping it would strand the workload on a dev image with
+// no recorded way back.
+func DecodePreviousImages(annotations map[string]string) (map[string]PreviousContainerState, error) {
+	out := map[string]PreviousContainerState{}
+	raw, ok := annotations[PreviousImagesAnnotation]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return out, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("annotation %s is malformed (%w); fix or remove it before retrying",
+			PreviousImagesAnnotation, err)
+	}
+	return out, nil
+}

--- a/cli/cmd/ctl/cluster/workload/set_image_test.go
+++ b/cli/cmd/ctl/cluster/workload/set_image_test.go
@@ -1,0 +1,264 @@
+package workload
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func templateWith(containers, initContainers []WorkloadContainer, annotations map[string]string) Workload {
+	return Workload{
+		Metadata: WorkloadMetadata{Name: "app", Namespace: "os-framework", Annotations: annotations},
+		Spec: WorkloadSpec{
+			Template: &WorkloadTemplate{
+				Spec: WorkloadPodSpec{Containers: containers, InitContainers: initContainers},
+			},
+		},
+	}
+}
+
+func TestResolveTargetContainer(t *testing.T) {
+	one := []WorkloadContainer{{Name: "app", Image: "beclab/app-service:0.6.22"}}
+	two := append([]WorkloadContainer{}, one...)
+	two = append(two, WorkloadContainer{Name: "sidecar", Image: "envoy:v1"})
+	inits := []WorkloadContainer{{Name: "wait-db", Image: "busybox:1"}}
+
+	tests := []struct {
+		name       string
+		w          Workload
+		want       string
+		wantType   string
+		wantErr    bool
+		errSubstr  string
+		lookupName string
+	}{
+		{
+			name: "single container defaults without -c",
+			w:    templateWith(one, nil, nil),
+			want: "app", wantType: "container",
+		},
+		{
+			name:    "multiple containers refuse to guess",
+			w:       templateWith(two, nil, nil),
+			wantErr: true, errSubstr: "pass -c/--container",
+		},
+		{
+			name: "explicit name picks a sibling",
+			w:    templateWith(two, nil, nil), lookupName: "sidecar",
+			want: "sidecar", wantType: "container",
+		},
+		{
+			name: "initContainers are addressable by the same flag",
+			w:    templateWith(one, inits, nil), lookupName: "wait-db",
+			want: "wait-db", wantType: "initContainer",
+		},
+		{
+			name: "unknown name lists what exists",
+			w:    templateWith(one, inits, nil), lookupName: "nope",
+			wantErr: true, errSubstr: "have: app, wait-db",
+		},
+		{
+			name:    "no pod template is a clear error",
+			w:       Workload{Metadata: WorkloadMetadata{Name: "app"}},
+			wantErr: true, errSubstr: "no spec.template",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotType, err := resolveTargetContainer(tc.w, tc.lookupName)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got container %q", got.Name)
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("error %q does not mention %q", err, tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Name != tc.want {
+				t.Errorf("container = %q, want %q", got.Name, tc.want)
+			}
+			if gotType != tc.wantType {
+				t.Errorf("containerType = %q, want %q", gotType, tc.wantType)
+			}
+		})
+	}
+}
+
+// The patch has to address the containers list by merge key, not
+// replace it: a merge-patch-style whole-array write would delete every
+// sibling container in the pod template.
+func TestBuildSetImagePatchTargetsOneContainerByName(t *testing.T) {
+	w := templateWith([]WorkloadContainer{
+		{Name: "app", Image: "beclab/app-service:0.6.22", ImagePullPolicy: "Always"},
+		{Name: "sidecar", Image: "envoy:v1"},
+	}, nil, nil)
+
+	body, err := buildSetImagePatch(w, w.Spec.Template.Spec.Containers[0], "container", "beclab/app-service:dev", "IfNotPresent")
+	if err != nil {
+		t.Fatalf("buildSetImagePatch: %v", err)
+	}
+
+	spec := body["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	list, ok := spec["containers"].([]interface{})
+	if !ok {
+		t.Fatalf("patch has no containers list: %#v", spec)
+	}
+	if len(list) != 1 {
+		t.Fatalf("patch touches %d containers, want exactly 1 (the merge key does the rest)", len(list))
+	}
+	entry := list[0].(map[string]interface{})
+	if entry["name"] != "app" {
+		t.Errorf("patch entry name = %v, want app", entry["name"])
+	}
+	if entry["image"] != "beclab/app-service:dev" {
+		t.Errorf("patch entry image = %v", entry["image"])
+	}
+	if entry["imagePullPolicy"] != "IfNotPresent" {
+		t.Errorf("patch entry imagePullPolicy = %v", entry["imagePullPolicy"])
+	}
+	if _, present := spec["initContainers"]; present {
+		t.Error("patch touches initContainers when the target is a container")
+	}
+}
+
+func TestBuildSetImagePatchTargetsInitContainerList(t *testing.T) {
+	inits := []WorkloadContainer{{Name: "wait-db", Image: "busybox:1"}}
+	w := templateWith([]WorkloadContainer{{Name: "app", Image: "x:1"}}, inits, nil)
+
+	body, err := buildSetImagePatch(w, inits[0], "initContainer", "busybox:2", "")
+	if err != nil {
+		t.Fatalf("buildSetImagePatch: %v", err)
+	}
+	spec := body["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	if _, present := spec["containers"]; present {
+		t.Error("patch touches containers when the target is an initContainer")
+	}
+	list := spec["initContainers"].([]interface{})
+	entry := list[0].(map[string]interface{})
+	if _, present := entry["imagePullPolicy"]; present {
+		t.Error(`empty --pull-policy must leave the policy untouched, but the patch sets it`)
+	}
+}
+
+// The recorded original must survive a second override. Overwriting it
+// would make revert restore a dev image instead of the released one.
+func TestBuildSetImagePatchKeepsFirstRecordedOriginal(t *testing.T) {
+	existing, err := json.Marshal(map[string]PreviousContainerState{
+		"app": {Image: "beclab/app-service:0.6.22", ImagePullPolicy: "Always"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := templateWith(
+		[]WorkloadContainer{{Name: "app", Image: "beclab/app-service:dev", ImagePullPolicy: "IfNotPresent"}},
+		nil,
+		map[string]string{PreviousImagesAnnotation: string(existing)},
+	)
+
+	body, err := buildSetImagePatch(w, w.Spec.Template.Spec.Containers[0], "container", "beclab/app-service:dev2", "IfNotPresent")
+	if err != nil {
+		t.Fatalf("buildSetImagePatch: %v", err)
+	}
+	raw := body["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})[PreviousImagesAnnotation].(string)
+	got, err := DecodePreviousImages(map[string]string{PreviousImagesAnnotation: raw})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := map[string]PreviousContainerState{
+		"app": {Image: "beclab/app-service:0.6.22", ImagePullPolicy: "Always"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("recorded original = %#v, want %#v (the FIRST override is the true pre-dev state)", got, want)
+	}
+}
+
+// Overriding a second container must not erase the first one's record.
+func TestBuildSetImagePatchMergesAnnotationAcrossContainers(t *testing.T) {
+	existing, _ := json.Marshal(map[string]PreviousContainerState{
+		"app": {Image: "beclab/app-service:0.6.22"},
+	})
+	w := templateWith([]WorkloadContainer{
+		{Name: "app", Image: "beclab/app-service:dev"},
+		{Name: "sidecar", Image: "envoy:v1"},
+	}, nil, map[string]string{PreviousImagesAnnotation: string(existing)})
+
+	body, err := buildSetImagePatch(w, w.Spec.Template.Spec.Containers[1], "container", "envoy:dev", "IfNotPresent")
+	if err != nil {
+		t.Fatalf("buildSetImagePatch: %v", err)
+	}
+	raw := body["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})[PreviousImagesAnnotation].(string)
+	got, err := DecodePreviousImages(map[string]string{PreviousImagesAnnotation: raw})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 || got["app"].Image != "beclab/app-service:0.6.22" || got["sidecar"].Image != "envoy:v1" {
+		t.Errorf("annotation = %#v, want both containers recorded", got)
+	}
+}
+
+func TestDecodePreviousImages(t *testing.T) {
+	t.Run("missing annotation yields an empty non-nil map", func(t *testing.T) {
+		got, err := DecodePreviousImages(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || len(got) != 0 {
+			t.Errorf("got %#v, want an empty non-nil map", got)
+		}
+	})
+
+	// A malformed annotation must not be silently discarded: dropping it
+	// would strand the workload on a dev image with no recorded way back.
+	t.Run("malformed annotation is an error", func(t *testing.T) {
+		_, err := DecodePreviousImages(map[string]string{PreviousImagesAnnotation: "{not json"})
+		if err == nil {
+			t.Fatal("expected an error for a malformed annotation")
+		}
+		if !strings.Contains(err.Error(), "malformed") {
+			t.Errorf("error %q should say the annotation is malformed", err)
+		}
+	})
+}
+
+func TestImageRefKindPlural(t *testing.T) {
+	tests := []struct {
+		kind    string
+		want    string
+		wantErr bool
+	}{
+		{kind: "StatefulSet", want: "statefulsets"},
+		{kind: "Deployment", want: "deployments"},
+		{kind: "DaemonSet", want: "daemonsets"},
+		// Jobs reference images but their pod templates are immutable,
+		// so a fan-out must skip them with an explanation rather than
+		// PATCH and get a 422.
+		{kind: "Job", wantErr: true},
+		{kind: "CronJob", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.kind, func(t *testing.T) {
+			got, err := ImageRef{Kind: tc.kind, Namespace: "ns", Workload: "w"}.KindPlural()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %s", tc.kind)
+				}
+				if !strings.Contains(err.Error(), "immutable") {
+					t.Errorf("error %q should explain why", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("KindPlural() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/ctl/cluster/workload/types.go
+++ b/cli/cmd/ctl/cluster/workload/types.go
@@ -133,6 +133,12 @@ type WorkloadPodSpec struct {
 type WorkloadContainer struct {
 	Name  string `json:"name,omitempty"`
 	Image string `json:"image,omitempty"`
+	// ImagePullPolicy is carried so `set-image` can stash the
+	// pre-override value alongside the image and restore both on
+	// revert. Side-loaded dev images need IfNotPresent (there is no
+	// registry to pull them from), which means the verb has to mutate
+	// the policy too — and therefore has to remember it.
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 }
 
 type WorkloadStatus struct {

--- a/cli/cmd/ctl/dev/components.go
+++ b/cli/cmd/ctl/dev/components.go
@@ -1,0 +1,167 @@
+package dev
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/devdeploy"
+)
+
+// NewComponentsCommand: `olares-cli dev components [list|get|validate]`.
+//
+// This is the CLI half of the repo's `make dev-*` targets. Make cannot
+// parse YAML without pulling in yq, and the repo already depends on this
+// binary, so the map has exactly one parser and the Makefile stays a
+// thin wrapper.
+func NewComponentsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "components",
+		Short: "Inspect the component -> image build map (build/dev-components.yaml)",
+		Long: `Read ` + devdeploy.ComponentsFile + `, the map from a component name to
+its build context, Dockerfile, and released image repository.
+
+Only useful inside an Olares checkout: the map is a repo file, not
+something the CLI carries. The map mirrors the
+.github/workflows/module_*_publish_*.yaml files, which remain the source
+of truth for what actually gets published.
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], c.CommandPath())
+			}
+			return c.Help()
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newComponentsListCommand())
+	cmd.AddCommand(newComponentsGetCommand())
+	cmd.AddCommand(newComponentsValidateCommand())
+	return cmd
+}
+
+// loadComponents resolves the checkout and parses the map.
+func loadComponents(repoFlag string) (string, map[string]devdeploy.Component, error) {
+	start := repoFlag
+	if start == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", nil, err
+		}
+		start = cwd
+	}
+	root, err := devdeploy.FindRepoRoot(start)
+	if err != nil {
+		return "", nil, err
+	}
+	components, err := devdeploy.LoadComponents(root)
+	if err != nil {
+		return "", nil, err
+	}
+	return root, components, nil
+}
+
+func addRepoFlag(cmd *cobra.Command, repo *string) {
+	cmd.Flags().StringVar(repo, "repo", "",
+		"path inside the Olares checkout (default: current directory)")
+}
+
+func newComponentsListCommand() *cobra.Command {
+	var repo string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list every component that can be dev-built",
+		RunE: func(c *cobra.Command, args []string) error {
+			_, components, err := loadComponents(repo)
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			defer tw.Flush()
+			fmt.Fprintln(tw, "COMPONENT\tIMAGE\tDOCKERFILE")
+			for _, name := range devdeploy.ComponentNames(components) {
+				c := components[name]
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", name, c.Image, c.Dockerfile)
+			}
+			return nil
+		},
+	}
+	addRepoFlag(cmd, &repo)
+	return cmd
+}
+
+func newComponentsGetCommand() *cobra.Command {
+	var (
+		repo   string
+		format string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <component>",
+		Short: "print one component's build coordinates",
+		Long: `Print a component's image, context and Dockerfile.
+
+--format shell emits KEY=value lines meant to be eval'd from a Make
+recipe or shell script:
+
+  eval "$(olares-cli dev components get app-service --format shell)"
+  docker build -t "$IMAGE:dev" -f "$DOCKERFILE" "$CONTEXT"
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			_, components, err := loadComponents(repo)
+			if err != nil {
+				return err
+			}
+			comp, err := devdeploy.Lookup(components, args[0])
+			if err != nil {
+				return err
+			}
+			switch format {
+			case "shell":
+				fmt.Printf("COMPONENT=%s\n", comp.Name)
+				fmt.Printf("IMAGE=%s\n", comp.Image)
+				fmt.Printf("CONTEXT=%s\n", comp.Context)
+				fmt.Printf("DOCKERFILE=%s\n", comp.Dockerfile)
+				return nil
+			case "", "table":
+				tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				defer tw.Flush()
+				fmt.Fprintf(tw, "Component:\t%s\n", comp.Name)
+				fmt.Fprintf(tw, "Image:\t%s\n", comp.Image)
+				fmt.Fprintf(tw, "Context:\t%s\n", comp.Context)
+				fmt.Fprintf(tw, "Dockerfile:\t%s\n", comp.Dockerfile)
+				fmt.Fprintf(tw, "Workflow:\t%s\n", comp.Workflow)
+				return nil
+			default:
+				return fmt.Errorf("unknown --format %q (want table or shell)", format)
+			}
+		},
+	}
+	addRepoFlag(cmd, &repo)
+	cmd.Flags().StringVar(&format, "format", "table", "output format: table | shell")
+	return cmd
+}
+
+func newComponentsValidateCommand() *cobra.Command {
+	var repo string
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "check that every mapped context and Dockerfile still exists",
+		RunE: func(c *cobra.Command, args []string) error {
+			root, components, err := loadComponents(repo)
+			if err != nil {
+				return err
+			}
+			if err := devdeploy.Validate(root, components); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s: %d components, all paths resolve\n",
+				devdeploy.ComponentsFile, len(components))
+			return nil
+		},
+	}
+	addRepoFlag(cmd, &repo)
+	return cmd
+}

--- a/cli/cmd/ctl/dev/deploy.go
+++ b/cli/cmd/ctl/dev/deploy.go
@@ -1,0 +1,307 @@
+package dev
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/workload"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewDeployCommand: `olares-cli dev deploy <image> --replaces <image>
+// [--to ns/name] [--kind K] [-c CONTAINER] [-w] [--yes]`.
+func NewDeployCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		replaces   string
+		to         string
+		kindRaw    string
+		container  string
+		namespace  string
+		pullPolicy string
+		watch      bool
+		interval   time.Duration
+		timeout    time.Duration
+		assumeYes  bool
+		jsonOut    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "deploy <image>",
+		Short: "point workloads at a dev image (resolving targets by the image they replace)",
+		Long: `Repoint one or more workloads at <image>.
+
+Two ways to say which workloads:
+
+  --replaces <image>   find every workload currently referencing that
+                       image and repoint all of them. The lookup is the
+                       same full-cluster, tag- and digest-normalized scan
+                       ` + "`cluster workload images <IMAGE>`" + ` runs, so it
+                       cannot miss a reference on a later page.
+
+  --to <ns/name>       name one workload explicitly (needs --kind).
+
+--replaces is the normal path when working on this repo: you know the
+released tag baked into the chart, not where it is used.
+
+Every target is listed and confirmed once before anything is patched —
+an image referenced by several workloads repoints all of them, and that
+is worth seeing first.
+
+Patching goes through the same code path as
+` + "`cluster workload set-image`" + `, including the annotation that lets
+` + "`dev revert`" + ` restore the original image and pull policy.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			image := strings.TrimSpace(args[0])
+			if image == "" {
+				return fmt.Errorf("image is required")
+			}
+			if (replaces == "") == (to == "") {
+				return fmt.Errorf("pass exactly one of --replaces <image> or --to <ns/name>")
+			}
+			if c.Flags().Changed("interval") && !watch {
+				return fmt.Errorf("--interval requires --watch")
+			}
+			if c.Flags().Changed("timeout") && !watch {
+				return fmt.Errorf("--timeout requires --watch")
+			}
+			return runDeploy(c.Context(), f, deployParams{
+				Image:      image,
+				Replaces:   replaces,
+				To:         to,
+				KindRaw:    kindRaw,
+				Container:  container,
+				Namespace:  namespace,
+				PullPolicy: pullPolicy,
+				Watch:      watch,
+				Interval:   interval,
+				Timeout:    timeout,
+				AssumeYes:  assumeYes,
+				JSON:       jsonOut,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&replaces, "replaces", "", "repoint every workload currently referencing this image")
+	cmd.Flags().StringVar(&to, "to", "", "repoint one workload, as ns/name (requires --kind)")
+	cmd.Flags().StringVar(&kindRaw, "kind", "", "workload kind for --to: deployment | statefulset | daemonset")
+	cmd.Flags().StringVarP(&container, "container", "c", "", "container name (optional when the pod template has one container)")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "restrict the --replaces scan to one namespace")
+	cmd.Flags().StringVar(&pullPolicy, "pull-policy", workload.DefaultDevPullPolicy,
+		`imagePullPolicy to set alongside the image; "" leaves it untouched`)
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "wait for each rollout to converge")
+	cmd.Flags().DurationVar(&interval, "interval", 2*time.Second, "polling interval for --watch")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "give up after this duration when --watch is set; 0 = no timeout")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the confirmation prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the per-target results as JSON")
+	return cmd
+}
+
+type deployParams struct {
+	Image      string
+	Replaces   string
+	To         string
+	KindRaw    string
+	Container  string
+	Namespace  string
+	PullPolicy string
+	Watch      bool
+	Interval   time.Duration
+	Timeout    time.Duration
+	AssumeYes  bool
+	JSON       bool
+}
+
+// target is one resolved (workload, container) pair to patch.
+type target struct {
+	Namespace  string
+	Name       string
+	KindPlural string
+	Kind       string
+	Container  string
+	From       string
+}
+
+func runDeploy(ctx context.Context, f *cmdutil.Factory, p deployParams) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	mode := workload.OutputMode{JSON: p.JSON, Quiet: p.JSON}
+
+	targets, err := resolveTargets(ctx, f, mode, p)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("no workload references %s — nothing to repoint\n"+
+			"Check what is actually deployed with `olares-cli cluster workload images %s`",
+			p.Replaces, p.Replaces)
+	}
+
+	if !p.JSON {
+		printTargets(os.Stderr, targets, p.Image)
+	}
+	if err := confirmTargets(len(targets), p.AssumeYes, p.JSON); err != nil {
+		return err
+	}
+
+	results := make([]workload.SetImageResult, 0, len(targets))
+	var firstErr error
+	for _, t := range targets {
+		res, err := workload.SetImage(ctx, f, mode, workload.SetImageParams{
+			Namespace:   t.Namespace,
+			Name:        t.Name,
+			KindPlural:  t.KindPlural,
+			Container:   t.Container,
+			Image:       p.Image,
+			PullPolicy:  p.PullPolicy,
+			Watch:       p.Watch,
+			Interval:    p.Interval,
+			Timeout:     p.Timeout,
+			SkipConfirm: true,
+		})
+		if err != nil {
+			// Keep going: a partially applied fan-out is far easier to
+			// finish or unwind than one that stopped at an arbitrary
+			// point without saying which targets were done.
+			fmt.Fprintf(os.Stderr, "error: %s %s/%s: %v\n", t.Kind, t.Namespace, t.Name, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		results = append(results, res)
+	}
+
+	if p.JSON {
+		return printJSON(results)
+	}
+	return firstErr
+}
+
+func resolveTargets(ctx context.Context, f *cmdutil.Factory, mode workload.OutputMode, p deployParams) ([]target, error) {
+	if p.To != "" {
+		ns, name, err := splitNsName(p.Namespace, p.To)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(p.KindRaw) == "" {
+			return nil, fmt.Errorf("--kind is required with --to")
+		}
+		plural, err := workload.NormalizeKind(p.KindRaw)
+		if err != nil {
+			return nil, err
+		}
+		if plural == workload.KindAll {
+			return nil, fmt.Errorf("--kind must name one kind, not %q", p.KindRaw)
+		}
+		return []target{{
+			Namespace:  ns,
+			Name:       name,
+			KindPlural: plural,
+			Kind:       workload.SingularKind(plural),
+			Container:  p.Container,
+		}}, nil
+	}
+
+	refs, err := workload.FindImageRefsFor(ctx, f, mode, p.Namespace, p.Replaces)
+	if err != nil {
+		return nil, err
+	}
+	var out []target
+	for _, ref := range refs {
+		plural, err := ref.KindPlural()
+		if err != nil {
+			// Jobs / CronJobs can reference the image but cannot be
+			// repointed. Say so instead of dropping them silently.
+			fmt.Fprintf(os.Stderr, "skipping: %v\n", err)
+			continue
+		}
+		if p.Container != "" && ref.Container != p.Container {
+			continue
+		}
+		out = append(out, target{
+			Namespace:  ref.Namespace,
+			Name:       ref.Workload,
+			KindPlural: plural,
+			Kind:       ref.Kind,
+			Container:  ref.Container,
+			From:       ref.Image,
+		})
+	}
+	return out, nil
+}
+
+func printTargets(w *os.File, targets []target, image string) {
+	fmt.Fprintf(w, "About to repoint %d container(s) at %s:\n\n", len(targets), image)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAMESPACE\tKIND\tNAME\tCONTAINER\tCURRENT")
+	for _, t := range targets {
+		from := t.From
+		if from == "" {
+			from = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", t.Namespace, t.Kind, t.Name, dashIfEmpty(t.Container), from)
+	}
+	tw.Flush()
+	fmt.Fprintln(w)
+}
+
+// confirmTargets asks once for the whole fan-out.
+//
+// It does not reuse clusteropts.ConfirmDestructive because that lives
+// under the cluster tree's internal/ directory; the prompt contract
+// (default no, "y"/"yes" to proceed, --yes to skip) is kept identical
+// on purpose.
+func confirmTargets(count int, assumeYes, jsonMode bool) error {
+	if assumeYes {
+		return nil
+	}
+	if jsonMode {
+		return fmt.Errorf("--json requires --yes (there is nobody to answer the confirmation prompt)")
+	}
+	stat, err := os.Stdin.Stat()
+	if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
+		return fmt.Errorf("refusing to repoint %d container(s) without confirmation: "+
+			"stdin is not a terminal — pass --yes to proceed non-interactively", count)
+	}
+	fmt.Fprintf(os.Stderr, "Repoint these %d container(s)? Pods will be recreated [y/N]: ", count)
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("aborted")
+	}
+}
+
+func splitNsName(nsFlag, arg string) (string, string, error) {
+	if strings.Contains(arg, "/") {
+		parts := strings.SplitN(arg, "/", 2)
+		if parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("invalid target %q (want ns/name)", arg)
+		}
+		return parts[0], parts[1], nil
+	}
+	if strings.TrimSpace(nsFlag) == "" {
+		return "", "", fmt.Errorf("target %q is a bare name — pass -n/--namespace or use ns/name", arg)
+	}
+	return nsFlag, arg, nil
+}
+
+func dashIfEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cli/cmd/ctl/dev/node.go
+++ b/cli/cmd/ctl/dev/node.go
@@ -1,0 +1,173 @@
+package dev
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+)
+
+// NewNodeCommand assembles `olares-cli dev node` — where the ssh
+// transport's coordinates are stored, once, per profile.
+func NewNodeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "Configure how `dev push --transport ssh` reaches your Olares node",
+		Long: `Store the SSH coordinates of the Olares node for the active profile.
+
+The settings live in ~/.olares-cli/config.json next to the profile they
+belong to, so switching profiles switches nodes with them.
+
+There is deliberately no --password flag. A password would have to be
+written to that file or into the keychain, and the keychain is reserved
+for the tokens that gate access to the instance itself. Use a key or an
+SSH agent.
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], c.CommandPath())
+			}
+			return c.Help()
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newNodeSetCommand())
+	cmd.AddCommand(newNodeShowCommand())
+	cmd.AddCommand(newNodeClearCommand())
+	return cmd
+}
+
+func newNodeSetCommand() *cobra.Command {
+	var (
+		address    string
+		user       string
+		port       int
+		privateKey string
+	)
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "set the node address / user / key for the active profile",
+		Example: `  olares-cli dev node set --address 192.168.178.42 --user ronny
+  olares-cli dev node set --address olares.lan --user root --private-key ~/.ssh/id_ed25519`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if strings.TrimSpace(address) == "" {
+				return fmt.Errorf("--address is required")
+			}
+			if strings.TrimSpace(user) == "" {
+				return fmt.Errorf("--user is required")
+			}
+			cfg, err := cliconfig.LoadMultiProfileConfig()
+			if err != nil {
+				return err
+			}
+			current := cfg.Current()
+			if current == nil {
+				return fmt.Errorf("no profile selected; run `olares-cli profile login <olares-id>` first")
+			}
+			current.DevNode = &cliconfig.DevNodeConfig{
+				Address:        strings.TrimSpace(address),
+				Port:           port,
+				User:           strings.TrimSpace(user),
+				PrivateKeyPath: strings.TrimSpace(privateKey),
+			}
+			if err := cliconfig.SaveMultiProfileConfig(cfg); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "node for %s set to %s@%s:%d\n",
+				current.DisplayName(), current.DevNode.User, current.DevNode.Address, portOrDefault(current.DevNode.Port))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&address, "address", "", "node hostname or IP (REQUIRED)")
+	cmd.Flags().StringVar(&user, "user", "", "SSH user; must be able to reach containerd (root or a sudoer) (REQUIRED)")
+	cmd.Flags().IntVar(&port, "port", 22, "SSH port")
+	cmd.Flags().StringVar(&privateKey, "private-key", "", "path to an SSH private key; empty uses the agent (SSH_AUTH_SOCK)")
+	return cmd
+}
+
+func newNodeShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "print the node configured for the active profile",
+		RunE: func(c *cobra.Command, args []string) error {
+			cfg, err := cliconfig.LoadMultiProfileConfig()
+			if err != nil {
+				return err
+			}
+			current := cfg.Current()
+			if current == nil {
+				return fmt.Errorf("no profile selected; run `olares-cli profile login <olares-id>` first")
+			}
+			if current.DevNode == nil {
+				return fmt.Errorf("no node configured for %s; run `olares-cli dev node set --address <host> --user <user>`",
+					current.DisplayName())
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			defer tw.Flush()
+			fmt.Fprintf(tw, "Profile:\t%s\n", current.DisplayName())
+			fmt.Fprintf(tw, "Address:\t%s\n", current.DevNode.Address)
+			fmt.Fprintf(tw, "Port:\t%d\n", portOrDefault(current.DevNode.Port))
+			fmt.Fprintf(tw, "User:\t%s\n", current.DevNode.User)
+			key := current.DevNode.PrivateKeyPath
+			if key == "" {
+				key = "(ssh agent)"
+			}
+			fmt.Fprintf(tw, "Private key:\t%s\n", key)
+			return nil
+		},
+	}
+}
+
+func newNodeClearCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "forget the node configured for the active profile",
+		RunE: func(c *cobra.Command, args []string) error {
+			cfg, err := cliconfig.LoadMultiProfileConfig()
+			if err != nil {
+				return err
+			}
+			current := cfg.Current()
+			if current == nil {
+				return fmt.Errorf("no profile selected")
+			}
+			if current.DevNode == nil {
+				fmt.Fprintf(os.Stdout, "no node configured for %s — nothing to clear\n", current.DisplayName())
+				return nil
+			}
+			current.DevNode = nil
+			if err := cliconfig.SaveMultiProfileConfig(cfg); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "node cleared for %s\n", current.DisplayName())
+			return nil
+		},
+	}
+}
+
+// currentDevNode returns the active profile's node config, or nil when
+// none is set. A missing profile is not an error here: the transport
+// selector reports "no node configured" either way, and `dev push
+// --transport local` must keep working before anyone has logged in.
+func currentDevNode() *cliconfig.DevNodeConfig {
+	cfg, err := cliconfig.LoadMultiProfileConfig()
+	if err != nil {
+		return nil
+	}
+	current := cfg.Current()
+	if current == nil {
+		return nil
+	}
+	return current.DevNode
+}
+
+func portOrDefault(p int) int {
+	if p == 0 {
+		return 22
+	}
+	return p
+}

--- a/cli/cmd/ctl/dev/push.go
+++ b/cli/cmd/ctl/dev/push.go
@@ -1,0 +1,181 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/node"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/devdeploy"
+)
+
+// NewPushCommand: `olares-cli dev push <image> [--transport T]
+// [--image-tool docker|podman] [--skip-arch-check]`.
+func NewPushCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		transport     string
+		imageTool     string
+		skipArchCheck bool
+		quiet         bool
+	)
+	cmd := &cobra.Command{
+		Use:   "push <image>",
+		Short: "side-load a locally built image into the Olares node's containerd",
+		Long: `Move a locally built image into the image store the kubelet reads.
+
+The image is exported with ` + "`docker save`" + ` (or ` + "`podman save`" + `) and
+streamed into ` + "`ctr -n " + devdeploy.ContainerdNamespace + " images import -`" + ` on
+the node. Nothing is written to disk on either side, and no registry is
+involved.
+
+The containerd namespace is not configurable: an image imported
+anywhere other than ` + devdeploy.ContainerdNamespace + ` is invisible to
+the kubelet, which is the most common way a hand-rolled ctr import
+appears to succeed and then ImagePullBackOffs.
+
+Before transferring, the image's architecture is compared against the
+cluster's nodes and a mismatch is refused — a wrong-arch image imports
+perfectly and then fails at runtime with an "exec format error" buried
+in a container log. Pass --skip-arch-check to override (or when the
+check cannot reach the cluster).
+
+This only moves bytes. Point a workload at the image with
+` + "`olares-cli dev deploy`" + `.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			image := strings.TrimSpace(args[0])
+			if image == "" {
+				return fmt.Errorf("image is required")
+			}
+			return runPush(c.Context(), f, pushParams{
+				Image:         image,
+				Transport:     transport,
+				ImageTool:     imageTool,
+				SkipArchCheck: skipArchCheck,
+				Quiet:         quiet,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&transport, "transport", devdeploy.TransportAuto,
+		"how to move the image: auto | local | ssh | registry | api")
+	cmd.Flags().StringVar(&imageTool, "image-tool", "",
+		"local tool used to export the image: docker | podman (default: whichever is on PATH)")
+	cmd.Flags().BoolVar(&skipArchCheck, "skip-arch-check", false,
+		"do not compare the image's architecture against the cluster's nodes")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress progress output; exit code indicates success/failure")
+	return cmd
+}
+
+type pushParams struct {
+	Image         string
+	Transport     string
+	ImageTool     string
+	SkipArchCheck bool
+	Quiet         bool
+}
+
+func runPush(ctx context.Context, f *cmdutil.Factory, p pushParams) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	t, err := devdeploy.Select(p.Transport, devdeploy.Options{
+		Node:      currentDevNode(),
+		ImageTool: p.ImageTool,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !p.SkipArchCheck {
+		if err := checkArch(ctx, f, p.Image, p.ImageTool, p.Quiet); err != nil {
+			return err
+		}
+	}
+
+	// io.Writer, not *os.File: a typed nil pointer in an interface is
+	// not a nil interface, so keeping the static type as the interface
+	// is what makes the `progress == nil` checks inside the transports
+	// actually fire.
+	var progress io.Writer
+	if !p.Quiet {
+		progress = os.Stderr
+		fmt.Fprintf(progress, "transport: %s — %s\n", t.Name(), t.Describe())
+	}
+	if err := t.Import(ctx, p.Image, progress); err != nil {
+		return err
+	}
+
+	if !p.Quiet {
+		fmt.Fprintf(os.Stdout, "imported %s\n", p.Image)
+	}
+	return nil
+}
+
+// checkArch compares the local image's architecture with the cluster's.
+//
+// Failure to reach the cluster is a warning, not an error: the push
+// itself may well be the thing that fixes a broken cluster, and
+// refusing to move bytes because a read-only preflight could not run
+// would be the wrong trade.
+func checkArch(ctx context.Context, f *cmdutil.Factory, image, imageTool string, quiet bool) error {
+	imageArch, err := localImageArch(ctx, imageTool, image)
+	if err != nil {
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "warning: could not determine the image's architecture (%v); skipping the check\n", err)
+		}
+		return nil
+	}
+	nodeArches, err := node.Architectures(ctx, f)
+	if err != nil {
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "warning: could not read node architectures (%v); skipping the check\n", err)
+		}
+		return nil
+	}
+	if len(nodeArches) == 0 {
+		return nil
+	}
+	for _, arch := range nodeArches {
+		if arch == imageArch {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%s is built for %s but the cluster's nodes are %s\n"+
+			"Rebuild for the node's architecture (docker build --platform linux/%s ...) "+
+			"or pass --skip-arch-check if you know better",
+		image, imageArch, strings.Join(nodeArches, ", "), nodeArches[0])
+}
+
+// localImageArch reads the image's architecture from the local image
+// store. Both docker and podman accept this inspect format.
+func localImageArch(ctx context.Context, imageTool, image string) (string, error) {
+	tool := imageTool
+	if tool == "" {
+		for _, candidate := range []string{"docker", "podman"} {
+			if _, err := exec.LookPath(candidate); err == nil {
+				tool = candidate
+				break
+			}
+		}
+	}
+	if tool == "" {
+		return "", fmt.Errorf("neither docker nor podman on PATH")
+	}
+	out, err := exec.CommandContext(ctx, tool, "image", "inspect", "--format", "{{.Architecture}}", image).Output()
+	if err != nil {
+		return "", fmt.Errorf("%s image inspect %s: %w", tool, image, err)
+	}
+	arch := strings.TrimSpace(string(out))
+	if arch == "" {
+		return "", fmt.Errorf("%s reported an empty architecture for %s", tool, image)
+	}
+	return arch, nil
+}

--- a/cli/cmd/ctl/dev/revert.go
+++ b/cli/cmd/ctl/dev/revert.go
@@ -1,0 +1,195 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/workload"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewRevertCommand: `olares-cli dev revert <ns/name> --kind K
+// [-c CONTAINER] [-w]`.
+func NewRevertCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		namespace string
+		kindRaw   string
+		container string
+		image     string
+		watch     bool
+		interval  time.Duration
+		timeout   time.Duration
+		jsonOut   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "revert [<ns/name | name>]",
+		Short: "restore the images a workload ran before `dev deploy`",
+		Long: `Put a workload back the way ` + "`dev deploy`" + ` found it.
+
+Two ways to say which workloads, mirroring ` + "`dev deploy`" + `:
+
+  <ns/name> --kind K   revert one workload.
+  --image <ref>        revert every workload currently running that
+                       image — the counterpart of deploying by
+                       --replaces, so a component can be undone without
+                       remembering where it landed.
+
+Reads the ` + workload.PreviousImagesAnnotation + ` annotation and
+restores both the image and the imagePullPolicy recorded there, then
+clears the entries it consumed. Restoring the policy matters: set-image
+forces IfNotPresent so a side-loaded build is usable at all, and leaving
+that behind would pin the workload to whatever happens to be cached on
+the node and quietly defeat the next chart upgrade.
+
+Without -c every recorded container is restored. An entry whose
+container has since disappeared from the pod template is reported and
+skipped rather than re-added.
+
+Find what is currently overridden with ` + "`olares-cli dev status`" + `.
+`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			if (len(args) == 1) == (strings.TrimSpace(image) != "") {
+				return fmt.Errorf("pass exactly one of <ns/name> or --image <ref>")
+			}
+			if c.Flags().Changed("interval") && !watch {
+				return fmt.Errorf("--interval requires --watch")
+			}
+			if c.Flags().Changed("timeout") && !watch {
+				return fmt.Errorf("--timeout requires --watch")
+			}
+			mode := workload.OutputMode{JSON: jsonOut, Quiet: jsonOut}
+
+			var targets []workload.RevertParams
+			if len(args) == 1 {
+				ns, name, err := splitNsName(namespace, args[0])
+				if err != nil {
+					return err
+				}
+				if strings.TrimSpace(kindRaw) == "" {
+					return fmt.Errorf("--kind is required when naming a workload")
+				}
+				plural, err := workload.NormalizeKind(kindRaw)
+				if err != nil {
+					return err
+				}
+				if plural == workload.KindAll {
+					return fmt.Errorf("--kind must name one kind, not %q", kindRaw)
+				}
+				targets = append(targets, workload.RevertParams{
+					Namespace: ns, Name: name, KindPlural: plural, Container: container,
+					Watch: watch, Interval: interval, Timeout: timeout,
+				})
+			} else {
+				resolved, err := revertTargetsForImage(c.Context(), f, mode, namespace, image, container, watch, interval, timeout)
+				if err != nil {
+					return err
+				}
+				if len(resolved) == 0 {
+					return fmt.Errorf("no workload is running %s — nothing to revert\n"+
+						"List what is overridden with `olares-cli dev status`", image)
+				}
+				targets = resolved
+			}
+
+			var all []workload.RevertResult
+			var firstErr error
+			for _, t := range targets {
+				results, err := workload.RevertImages(c.Context(), f, mode, t)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "error: %s %s/%s: %v\n",
+						workload.SingularKind(t.KindPlural), t.Namespace, t.Name, err)
+					if firstErr == nil {
+						firstErr = err
+					}
+					continue
+				}
+				all = append(all, results...)
+			}
+
+			if jsonOut {
+				if err := printJSON(all); err != nil {
+					return err
+				}
+				return firstErr
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAMESPACE\tNAME\tCONTAINER\tFROM\tTO\tNOTE")
+			for _, r := range all {
+				note := r.Skipped
+				if note == "" {
+					note = "restored"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					r.Namespace, r.Name, r.Container, dashIfEmpty(r.From), dashIfEmpty(r.To), note)
+			}
+			tw.Flush()
+			return firstErr
+		},
+	}
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace (with a bare name), or the namespace to scan (with --image)")
+	cmd.Flags().StringVar(&kindRaw, "kind", "", "workload kind: deployment | statefulset | daemonset (required when naming a workload)")
+	cmd.Flags().StringVar(&image, "image", "", "revert every workload currently running this image")
+	cmd.Flags().StringVarP(&container, "container", "c", "", "restore only this container (default: every recorded container)")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "wait for the rollout to converge")
+	cmd.Flags().DurationVar(&interval, "interval", 2*time.Second, "polling interval for --watch")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "give up after this duration when --watch is set; 0 = no timeout")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the results as JSON")
+	return cmd
+}
+
+// revertTargetsForImage turns "--image beclab/app-service:dev" into one
+// RevertParams per workload running it.
+//
+// It resolves by the image the workloads run *now* (the dev tag), not by
+// what they will be restored to, because that is the thing the caller
+// knows: `make dev-revert C=app-service` knows it pushed
+// beclab/app-service:dev and has no idea which released tag the chart
+// pinned. Deduplication is by workload, since one workload with two
+// overridden containers is a single revert.
+func revertTargetsForImage(
+	ctx context.Context,
+	f *cmdutil.Factory,
+	mode workload.OutputMode,
+	namespace, image, container string,
+	watch bool,
+	interval, timeout time.Duration,
+) ([]workload.RevertParams, error) {
+	refs, err := workload.FindImageRefsFor(ctx, f, mode, namespace, image)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	var out []workload.RevertParams
+	for _, ref := range refs {
+		if container != "" && ref.Container != container {
+			continue
+		}
+		plural, err := ref.KindPlural()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping: %v\n", err)
+			continue
+		}
+		key := ref.Namespace + "/" + plural + "/" + ref.Workload
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, workload.RevertParams{
+			Namespace:  ref.Namespace,
+			Name:       ref.Workload,
+			KindPlural: plural,
+			Container:  container,
+			Watch:      watch,
+			Interval:   interval,
+			Timeout:    timeout,
+		})
+	}
+	return out, nil
+}

--- a/cli/cmd/ctl/dev/root.go
+++ b/cli/cmd/ctl/dev/root.go
@@ -1,0 +1,85 @@
+// Package dev implements `olares-cli dev ...` — the loop for testing a
+// locally built image on a running Olares.
+//
+// Registration note: this group is added to the root command
+// UNCONDITIONALLY, alongside `cluster` / `market` / `chart`, and not
+// inside root.go's `!remoteOnly` guard. The guard marks verbs that need
+// an Olares host filesystem; putting `dev` behind it would make the
+// whole group a host verb, and host verbs only reach users when the OS
+// itself is upgraded (the host binary is cut by the OS release with
+// publish-npm: false, then replaced by `olares-cli upgrade`). Outside
+// the guard, `dev` ships on the CLI's own npm cadence.
+//
+// The visible cost is that an `npx @olares/cli` user can see
+// `--transport local`, which can never work there. That is handled by
+// failing the transport with an explanatory message rather than by
+// hiding the group — a wrong-looking flag is cheaper than a verb that
+// is missing for months on the machines that most want it.
+package dev
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewDevCommand assembles `olares-cli dev`.
+func NewDevCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dev",
+		Short: "Test locally built images on a running Olares",
+		Long: `Push a locally built container image onto your Olares and point a
+workload at it, then put everything back when you're done.
+
+The loop:
+
+  olares-cli dev push  beclab/app-service:dev
+  olares-cli dev deploy beclab/app-service:dev --replaces beclab/app-service:0.6.22 -w
+  olares-cli dev status
+  olares-cli dev revert os-framework/app-service --kind sts
+
+push moves bytes; deploy repoints workloads. They are separate verbs
+because the failure modes are unrelated — a failed push is a transport
+or permission problem on the node, a failed deploy is an API or RBAC
+problem — and because one push often feeds several deploys.
+
+Transports (--transport, default auto):
+
+  local     import straight into this machine's containerd; only
+            works when the CLI runs on the Olares node itself
+  ssh       stream the image to the node over SSH (configure it once
+            with ` + "`olares-cli dev node set`" + `)
+  registry  not implemented yet
+  api       not implemented yet
+
+auto tries local, then ssh, and explains what it would take to make
+either work if neither is available.
+
+Repointing a workload always goes through the same authenticated
+ControlHub path as ` + "`cluster workload set-image`" + `, whether the CLI
+runs on the node or on your laptop. Only the image transport differs
+by location.
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], c.CommandPath())
+			}
+			return c.Help()
+		},
+	}
+	cmd.SilenceUsage = true
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		c.SilenceUsage = true
+	}
+
+	cmd.AddCommand(NewComponentsCommand())
+	cmd.AddCommand(NewNodeCommand())
+	cmd.AddCommand(NewPushCommand(f))
+	cmd.AddCommand(NewDeployCommand(f))
+	cmd.AddCommand(NewRevertCommand(f))
+	cmd.AddCommand(NewStatusCommand(f))
+
+	return cmd
+}

--- a/cli/cmd/ctl/dev/status.go
+++ b/cli/cmd/ctl/dev/status.go
@@ -1,0 +1,80 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/cluster/workload"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// NewStatusCommand: `olares-cli dev status [-n NS] [--json]`.
+func NewStatusCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		namespace string
+		jsonOut   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "list workloads currently running a dev image",
+		Long: `Report every workload carrying a ` + workload.PreviousImagesAnnotation + `
+annotation — i.e. everything ` + "`dev deploy`" + ` (or
+` + "`cluster workload set-image`" + `) has repointed and not yet reverted.
+
+This is the first thing to check when a workload misbehaves after a dev
+session. Side-loaded images are especially worth tracking: they exist
+only in the node's image store, so an image prune can delete one out
+from under a running workload, and with imagePullPolicy: IfNotPresent
+there is no registry to recover it from. The symptom is a pod that will
+not start with nothing obviously wrong in the chart; this command is
+what connects it back to a dev override.
+
+MISSING marks an annotation entry whose container is no longer in the
+pod template — usually a chart upgrade that renamed it. Those cannot be
+reverted automatically.
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			overrides, err := workload.ListDevOverrides(c.Context(), f,
+				workload.OutputMode{JSON: jsonOut, Quiet: jsonOut}, namespace)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return printJSON(overrides)
+			}
+			if len(overrides) == 0 {
+				fmt.Fprintln(os.Stdout, "no workloads are running a dev image")
+				return nil
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			defer tw.Flush()
+			fmt.Fprintln(tw, "NAMESPACE\tKIND\tNAME\tCONTAINER\tCURRENT\tORIGINAL")
+			for _, o := range overrides {
+				current := o.Current
+				if o.Missing {
+					current = "MISSING"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					o.Namespace, o.Kind, o.Name, dashIfEmpty(o.Container),
+					dashIfEmpty(current), dashIfEmpty(o.Previous))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "restrict the scan to one namespace")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the overrides as JSON")
+	return cmd
+}
+
+func printJSON(v interface{}) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+var _ = context.Background

--- a/cli/cmd/ctl/dev_registration_test.go
+++ b/cli/cmd/ctl/dev_registration_test.go
@@ -1,0 +1,79 @@
+package ctl
+
+import (
+	"testing"
+)
+
+// hasSubcommand reports whether the command tree resolves the given
+// path, e.g. []string{"dev", "push"}.
+func hasSubcommand(t *testing.T, path ...string) bool {
+	t.Helper()
+	cmd, _, err := NewDefaultCommand().Find(path)
+	if err != nil {
+		return false
+	}
+	// Find returns the deepest command it could resolve, so a path that
+	// stopped short resolves to an ancestor. Compare the leaf name.
+	return cmd.Name() == path[len(path)-1]
+}
+
+// The `dev` group must be registered in BOTH distributions.
+//
+// It is deliberately outside root.go's `!remoteOnly` guard: that guard
+// marks verbs needing an Olares host filesystem, and anything behind it
+// only reaches users when the OS itself is upgraded (the host binary is
+// cut by the OS release with publish-npm: false). Registering `dev`
+// unconditionally is what lets it ship on the CLI's own npm cadence, so
+// a regression that moves it behind the guard would silently delay
+// every future fix by an OS release.
+func TestDevGroupIsRegisteredInBothDistributions(t *testing.T) {
+	verbs := [][]string{
+		{"dev"},
+		{"dev", "push"},
+		{"dev", "deploy"},
+		{"dev", "revert"},
+		{"dev", "status"},
+		{"dev", "node"},
+		{"dev", "components"},
+	}
+
+	t.Run("host bundle", func(t *testing.T) {
+		t.Setenv("OLARES_CLI_REMOTE_ONLY", "")
+		for _, path := range verbs {
+			if !hasSubcommand(t, path...) {
+				t.Errorf("olares-cli %v is not registered on the host bundle", path)
+			}
+		}
+	})
+
+	t.Run("npm/npx build", func(t *testing.T) {
+		t.Setenv("OLARES_CLI_REMOTE_ONLY", "1")
+		for _, path := range verbs {
+			if !hasSubcommand(t, path...) {
+				t.Errorf("olares-cli %v is missing under OLARES_CLI_REMOTE_ONLY=1; "+
+					"`dev` must not be inside the !remoteOnly guard", path)
+			}
+		}
+	})
+}
+
+// Guard the other half of the contract: host verbs stay hidden in the
+// npm build. If this ever passes, the guard has been removed and npx
+// users get verbs that can only fail on a manifest they do not have.
+func TestHostVerbsStayHiddenUnderRemoteOnly(t *testing.T) {
+	t.Setenv("OLARES_CLI_REMOTE_ONLY", "1")
+	for _, name := range []string{"install", "uninstall", "node", "gpu", "disk", "wizard", "osinfo"} {
+		if hasSubcommand(t, name) {
+			t.Errorf("host verb %q is exposed under OLARES_CLI_REMOTE_ONLY=1", name)
+		}
+	}
+}
+
+// `cluster workload set-image` is the primitive `dev deploy` calls; it
+// lives in the always-registered cluster tree for the same reason.
+func TestSetImageIsRegistered(t *testing.T) {
+	t.Setenv("OLARES_CLI_REMOTE_ONLY", "1")
+	if !hasSubcommand(t, "cluster", "workload", "set-image") {
+		t.Error("olares-cli cluster workload set-image is not registered")
+	}
+}

--- a/cli/cmd/ctl/root.go
+++ b/cli/cmd/ctl/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beclab/Olares/cli/cmd/ctl/chart"
 	"github.com/beclab/Olares/cli/cmd/ctl/cluster"
 	"github.com/beclab/Olares/cli/cmd/ctl/dashboard"
+	"github.com/beclab/Olares/cli/cmd/ctl/dev"
 	"github.com/beclab/Olares/cli/cmd/ctl/disk"
 	"github.com/beclab/Olares/cli/cmd/ctl/doctor"
 	"github.com/beclab/Olares/cli/cmd/ctl/files"
@@ -108,6 +109,7 @@ func NewDefaultCommand() *cobra.Command {
 	// Always-on: developer utilities (chart, preinstall) + remote/agent verbs
 	// that go through control-hub.<terminus> via the active profile's token.
 	cmds.AddCommand(chart.NewChartCommand())
+	cmds.AddCommand(dev.NewDevCommand(factory))
 	cmds.AddCommand(preinstall.NewPreinstallCommand())
 	cmds.AddCommand(market.NewMarketCommand(factory))
 	cmds.AddCommand(profile.NewProfileCommand(factory))

--- a/cli/pkg/cliconfig/config.go
+++ b/cli/pkg/cliconfig/config.go
@@ -128,6 +128,39 @@ type ProfileConfig struct {
 	// successful /api/olares-info read that wrote BackendVersion. Surfaced
 	// for diagnostics ("last refreshed" hints); it does NOT drive any TTL.
 	BackendVersionRefreshedAt int64 `json:"backendVersionRefreshedAt,omitempty"`
+
+	// DevNode is the SSH coordinate of this profile's Olares node, used
+	// by `olares-cli dev push --transport ssh` to side-load a locally
+	// built image into the node's containerd. Optional: unset simply
+	// means the ssh transport is unavailable and `--transport auto`
+	// falls through to the next option.
+	//
+	// nil for every profile that has never run `dev node set`.
+	DevNode *DevNodeConfig `json:"devNode,omitempty"`
+}
+
+// DevNodeConfig is how to reach the Olares node over SSH.
+//
+// There is deliberately NO password field. A password would have to be
+// stored either in this world-readable JSON or in the keychain, and the
+// keychain is reserved for the auth tokens that actually gate access to
+// the instance. Key- or agent-based auth is the only supported mode;
+// `pkg/pipelines/join_credentials.go` already treats a key at the
+// conventional path as the default for exactly this reason.
+type DevNodeConfig struct {
+	// Address is the hostname or IP of the node.
+	Address string `json:"address"`
+
+	// Port defaults to 22 when zero.
+	Port int `json:"port,omitempty"`
+
+	// User is the SSH account. It must be able to reach containerd,
+	// which in practice means root or a sudoer.
+	User string `json:"user"`
+
+	// PrivateKeyPath points at the identity file. Empty means "let the
+	// SSH agent decide" (SSH_AUTH_SOCK).
+	PrivateKeyPath string `json:"privateKeyPath,omitempty"`
 }
 
 // ClusterContextCache is the per-profile snapshot of /capi/app/detail

--- a/cli/pkg/devdeploy/components.go
+++ b/cli/pkg/devdeploy/components.go
@@ -1,0 +1,144 @@
+package devdeploy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ComponentsFile is the repo-relative path of the component build map.
+const ComponentsFile = "build/dev-components.yaml"
+
+// Component is one entry of the map: everything needed to turn a
+// component name into a `docker build` and the image tag the released
+// charts reference.
+type Component struct {
+	// Name is the map key, filled in by LoadComponents.
+	Name string `yaml:"-"`
+	// Image is the repository (no tag) the charts reference, e.g.
+	// "beclab/app-service".
+	Image string `yaml:"image"`
+	// Context is the docker build context, relative to the repo root.
+	Context string `yaml:"context"`
+	// Dockerfile is relative to the repo root, not to Context — the two
+	// differ for most components here (Dockerfile.image, Dockerfile.api,
+	// docker/<name>/Dockerfile ...).
+	Dockerfile string `yaml:"dockerfile"`
+	// Workflow names the publish workflow this entry mirrors, so a
+	// reviewer can check the two against each other.
+	Workflow string `yaml:"workflow"`
+}
+
+type componentsDoc struct {
+	Components map[string]Component `yaml:"components"`
+}
+
+// LoadComponents parses the component map rooted at repoRoot.
+func LoadComponents(repoRoot string) (map[string]Component, error) {
+	path := filepath.Join(repoRoot, ComponentsFile)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc componentsDoc
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(doc.Components) == 0 {
+		return nil, fmt.Errorf("%s declares no components", path)
+	}
+	out := make(map[string]Component, len(doc.Components))
+	for name, c := range doc.Components {
+		c.Name = name
+		out[name] = c
+	}
+	return out, nil
+}
+
+// ComponentNames returns the map's keys in sorted order.
+func ComponentNames(components map[string]Component) []string {
+	out := make([]string, 0, len(components))
+	for name := range components {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Lookup resolves one component, with a "did you mean" style error that
+// lists what is actually available — the map is long enough that a bare
+// "unknown component" would send the reader back to the YAML.
+func Lookup(components map[string]Component, name string) (Component, error) {
+	c, ok := components[name]
+	if ok {
+		return c, nil
+	}
+	var near []string
+	for _, candidate := range ComponentNames(components) {
+		if strings.Contains(candidate, name) || strings.Contains(name, candidate) {
+			near = append(near, candidate)
+		}
+	}
+	if len(near) > 0 {
+		return Component{}, fmt.Errorf("unknown component %q; did you mean: %s", name, strings.Join(near, ", "))
+	}
+	return Component{}, fmt.Errorf("unknown component %q; known components: %s",
+		name, strings.Join(ComponentNames(components), ", "))
+}
+
+// Validate checks the map against the working tree: every context must
+// be a directory and every dockerfile a file.
+//
+// This is the guard that keeps the map honest. The publish workflows it
+// mirrors are only exercised on release, so a Dockerfile that moves in
+// a refactor can leave both the workflow and this map pointing at
+// nothing for months — as `framework/bfl/Dockerfile.ingress` already
+// does in module_bfl_publish_ingress.yaml, which is why that component
+// is deliberately absent here.
+func Validate(repoRoot string, components map[string]Component) error {
+	var problems []string
+	for _, name := range ComponentNames(components) {
+		c := components[name]
+		if strings.TrimSpace(c.Image) == "" {
+			problems = append(problems, fmt.Sprintf("%s: image is empty", name))
+		}
+		if strings.Contains(c.Image, ":") {
+			problems = append(problems, fmt.Sprintf("%s: image %q must not carry a tag", name, c.Image))
+		}
+		if fi, err := os.Stat(filepath.Join(repoRoot, c.Context)); err != nil || !fi.IsDir() {
+			problems = append(problems, fmt.Sprintf("%s: context %q is not a directory", name, c.Context))
+		}
+		if fi, err := os.Stat(filepath.Join(repoRoot, c.Dockerfile)); err != nil || fi.IsDir() {
+			problems = append(problems, fmt.Sprintf("%s: dockerfile %q is not a file", name, c.Dockerfile))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("%s is out of sync with the tree:\n  %s",
+			ComponentsFile, strings.Join(problems, "\n  "))
+	}
+	return nil
+}
+
+// FindRepoRoot walks up from start looking for the component map, so
+// the dev verbs work from anywhere inside a checkout.
+func FindRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ComponentsFile)); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("not inside an Olares checkout: no %s found in %s or any parent",
+				ComponentsFile, start)
+		}
+		dir = parent
+	}
+}

--- a/cli/pkg/devdeploy/components_test.go
+++ b/cli/pkg/devdeploy/components_test.go
@@ -1,0 +1,149 @@
+package devdeploy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot locates the checkout from the package directory. Tests run
+// with cwd set to the package dir, so this walks up the same way the
+// dev verbs do from wherever the user happens to be.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root, err := FindRepoRoot(cwd)
+	if err != nil {
+		t.Fatalf("FindRepoRoot: %v", err)
+	}
+	return root
+}
+
+// The map mirrors .github/workflows/module_*_publish_*.yaml, which only
+// run on release — so a Dockerfile that moves during a refactor can
+// leave both the workflow and this map pointing at nothing without
+// anyone noticing. This test is what turns that into a build failure.
+func TestComponentMapMatchesTheTree(t *testing.T) {
+	root := repoRoot(t)
+	components, err := LoadComponents(root)
+	if err != nil {
+		t.Fatalf("LoadComponents: %v", err)
+	}
+	if len(components) == 0 {
+		t.Fatal("component map is empty")
+	}
+	if err := Validate(root, components); err != nil {
+		t.Error(err)
+	}
+}
+
+// Every entry claims to mirror a publish workflow; if that workflow is
+// gone the entry has no upstream to be checked against.
+func TestComponentWorkflowsExist(t *testing.T) {
+	root := repoRoot(t)
+	components, err := LoadComponents(root)
+	if err != nil {
+		t.Fatalf("LoadComponents: %v", err)
+	}
+	for _, name := range ComponentNames(components) {
+		c := components[name]
+		if c.Workflow == "" {
+			t.Errorf("%s: no workflow recorded", name)
+			continue
+		}
+		path := filepath.Join(root, ".github", "workflows", c.Workflow)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s: workflow %s does not exist", name, c.Workflow)
+		}
+	}
+}
+
+func TestValidateRejectsBadEntries(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "framework/thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		component Component
+		wantMsg   string
+	}{
+		"missing dockerfile": {
+			component: Component{Image: "beclab/thing", Context: "framework/thing", Dockerfile: "framework/thing/Dockerfile"},
+			wantMsg:   "is not a file",
+		},
+		"missing context": {
+			component: Component{Image: "beclab/thing", Context: "framework/gone", Dockerfile: "framework/thing/Dockerfile"},
+			wantMsg:   "is not a directory",
+		},
+		// A tagged image would make `--replaces <image>` ambiguous: the
+		// Makefile appends its own tag, and "repo:tag:dev" is nonsense.
+		"image carrying a tag": {
+			component: Component{Image: "beclab/thing:1.2", Context: "framework/thing", Dockerfile: "framework/thing/Dockerfile"},
+			wantMsg:   "must not carry a tag",
+		},
+		"empty image": {
+			component: Component{Context: "framework/thing", Dockerfile: "framework/thing/Dockerfile"},
+			wantMsg:   "image is empty",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := Validate(root, map[string]Component{"thing": tc.component})
+			if err == nil {
+				t.Fatal("expected a validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error %q does not mention %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestLookupSuggestsNearMisses(t *testing.T) {
+	components := map[string]Component{
+		"app-service":   {Name: "app-service"},
+		"image-service": {Name: "image-service"},
+		"bfl":           {Name: "bfl"},
+	}
+
+	if _, err := Lookup(components, "app-service"); err != nil {
+		t.Fatalf("exact lookup failed: %v", err)
+	}
+
+	// A substring match is the common typo (dropping a prefix or
+	// suffix), so point at the candidates rather than dumping all 23.
+	_, err := Lookup(components, "service")
+	if err == nil {
+		t.Fatal("expected an error for an unknown component")
+	}
+	if !strings.Contains(err.Error(), "did you mean") {
+		t.Errorf("error %q should suggest near misses", err)
+	}
+	if !strings.Contains(err.Error(), "app-service") || !strings.Contains(err.Error(), "image-service") {
+		t.Errorf("error %q should list both near misses", err)
+	}
+
+	_, err = Lookup(components, "zzz")
+	if err == nil {
+		t.Fatal("expected an error for an unknown component")
+	}
+	if !strings.Contains(err.Error(), "known components") {
+		t.Errorf("error %q should list the known components when nothing is close", err)
+	}
+}
+
+func TestFindRepoRootFailsOutsideACheckout(t *testing.T) {
+	_, err := FindRepoRoot(t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error outside a checkout")
+	}
+	if !strings.Contains(err.Error(), ComponentsFile) {
+		t.Errorf("error %q should name the file it looked for", err)
+	}
+}

--- a/cli/pkg/devdeploy/local.go
+++ b/cli/pkg/devdeploy/local.go
@@ -1,0 +1,192 @@
+package devdeploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// containerdSockets are the socket paths probed to decide whether this
+// process is running on an Olares node, in the order Olares itself
+// prefers: k3s is the default KUBE_TYPE, so its socket is checked
+// first, and a host running both should be driven through k3s.
+//
+// k3sOwned marks a socket that only exists on a k3s node and is
+// therefore self-proving. The generic containerd paths are NOT: a
+// plain Docker install puts its own containerd at exactly
+// /run/containerd/containerd.sock (with /var/run symlinked to /run), so
+// finding a socket there says nothing about whether this machine runs
+// Kubernetes. Importing into that containerd would "succeed" and put
+// the image somewhere no kubelet will ever look.
+var containerdSockets = []struct {
+	path     string
+	ctr      []string
+	k3sOwned bool
+}{
+	{"/run/k3s/containerd/containerd.sock", []string{"k3s", "ctr"}, true},
+	{"/var/run/containerd/containerd.sock", []string{"ctr"}, false},
+	{"/run/containerd/containerd.sock", []string{"ctr"}, false},
+}
+
+// kubeletMarkers are paths that exist on a machine running a kubelet
+// and essentially nowhere else. One of them must be present before an
+// ambiguous containerd socket is accepted as "this is the node".
+var kubeletMarkers = []string{
+	"/etc/rancher/k3s",
+	"/var/lib/kubelet",
+	"/etc/kubernetes",
+}
+
+func hasKubeletMarker() bool {
+	for _, path := range kubeletMarkers {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// localTransport imports straight into this machine's containerd. This
+// is the LocalTask half of the install engine's local/remote split
+// (pkg/core/task/local_task.go): a plain child process, no SSH. The
+// engine's Dialer has no local shortcut — it would SSH to localhost —
+// so a host-mode push must not go through it.
+type localTransport struct {
+	tool   string   // docker | podman
+	ctr    []string // ["k3s","ctr"] or ["ctr"]
+	sock   string
+	sudo   bool
+	socket string
+}
+
+// newLocalTransport returns nil plus a human-readable reason when the
+// local transport cannot be used here.
+func newLocalTransport(opts Options) (Transport, string) {
+	if RemoteOnly() {
+		return nil, "this is the npm/npx build, which never runs on the Olares node itself"
+	}
+	var (
+		sock         string
+		ctr          []string
+		sawAmbiguous bool
+	)
+	for _, candidate := range containerdSockets {
+		fi, err := os.Stat(candidate.path)
+		if err != nil || fi.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+		// A socket is only useful if the matching ctr binary is
+		// actually installed; k3s ships its own.
+		if _, err := exec.LookPath(candidate.ctr[0]); err != nil {
+			continue
+		}
+		if !candidate.k3sOwned && !hasKubeletMarker() {
+			// Almost certainly a developer machine's Docker daemon.
+			sawAmbiguous = true
+			continue
+		}
+		sock, ctr = candidate.path, candidate.ctr
+		break
+	}
+	if sock == "" {
+		if sawAmbiguous {
+			return nil, "found a containerd socket but no kubelet on this machine — " +
+				"that containerd belongs to a local Docker/containerd install, not an Olares node"
+		}
+		return nil, "no containerd socket found (not an Olares node, or containerd is not running)"
+	}
+	tool, err := resolveImageTool(opts.ImageTool)
+	if err != nil {
+		return nil, err.Error()
+	}
+	return &localTransport{
+		tool:   tool,
+		ctr:    ctr,
+		sock:   sock,
+		socket: sock,
+		sudo:   os.Geteuid() != 0,
+	}, ""
+}
+
+func (t *localTransport) Name() string { return TransportLocal }
+
+func (t *localTransport) Describe() string {
+	prefix := ""
+	if t.sudo {
+		prefix = "sudo "
+	}
+	return fmt.Sprintf("%s save | %s%s -n %s images import - (socket %s)",
+		t.tool, prefix, strings.Join(t.ctr, " "), ContainerdNamespace, t.sock)
+}
+
+func (t *localTransport) Import(ctx context.Context, image string, progress io.Writer) error {
+	save := saveCommand(ctx, t.tool, image)
+	saveOut, err := save.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe %s save: %w", t.tool, err)
+	}
+	var saveErr strings.Builder
+	save.Stderr = &saveErr
+
+	args := importArgs(t.ctr)
+	name := args[0]
+	rest := args[1:]
+	if t.sudo {
+		// -E preserves the environment (notably CONTAINERD_ADDRESS if
+		// the operator set one); -n keeps sudo from silently blocking
+		// on a password prompt inside a pipeline, where the prompt
+		// would be invisible and look like a hang.
+		rest = append([]string{"-n", "-E", name}, rest...)
+		name = "sudo"
+	}
+	imp := exec.CommandContext(ctx, name, rest...)
+	imp.Stdin = saveOut
+	var impErr strings.Builder
+	imp.Stderr = &impErr
+	imp.Stdout = progress
+
+	progressf(progress, "importing %s into containerd (%s)\n", image, t.sock)
+
+	if err := save.Start(); err != nil {
+		return fmt.Errorf("start %s save %s: %w", t.tool, image, err)
+	}
+	if err := imp.Start(); err != nil {
+		_ = save.Process.Kill()
+		_ = save.Wait()
+		return fmt.Errorf("start ctr import: %w", err)
+	}
+
+	// Wait on the importer first: if it dies the writer gets EPIPE and
+	// unblocks. Waiting on the producer first would deadlock whenever
+	// the importer exits early (bad archive, permission denied).
+	impWaitErr := imp.Wait()
+	saveWaitErr := save.Wait()
+
+	// Report the producer's failure first even though it is reaped
+	// second. When `docker save` fails (typically "no such image") it
+	// closes the pipe having written nothing, and ctr then fails with
+	// "unrecognized image format" — a downstream symptom that says
+	// nothing about the actual mistake.
+	if saveWaitErr != nil {
+		msg := strings.TrimSpace(saveErr.String())
+		if msg == "" {
+			msg = saveWaitErr.Error()
+		}
+		return fmt.Errorf("%s save %s failed: %s", t.tool, image, msg)
+	}
+	if impWaitErr != nil {
+		msg := strings.TrimSpace(impErr.String())
+		if strings.Contains(msg, "permission denied") || strings.Contains(msg, "sudo:") {
+			return fmt.Errorf("ctr import failed with a permission error (%s); "+
+				"containerd's socket is root-owned — re-run as root or configure passwordless sudo", msg)
+		}
+		if msg == "" {
+			msg = impWaitErr.Error()
+		}
+		return fmt.Errorf("ctr import failed: %s", msg)
+	}
+	return nil
+}

--- a/cli/pkg/devdeploy/ssh.go
+++ b/cli/pkg/devdeploy/ssh.go
@@ -1,0 +1,174 @@
+package devdeploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+)
+
+// sshDialTimeout matches the masterSSHTimeout used by
+// pkg/pipelines/join_credentials.go so a wrong address fails at the
+// same speed everywhere in the CLI.
+const sshDialTimeout = 10 * time.Second
+
+// sshTransport streams the image over SSH into the node's containerd.
+//
+// It uses connector.Connection.PExec, whose stdin parameter lets the
+// local `docker save` pipe straight into the remote `ctr images import
+// -` with no temp file on either side. Scp-then-import would need
+// (image size) of free disk on the node and a cleanup path for the
+// half-written file when the transfer is interrupted.
+type sshTransport struct {
+	tool string
+	node cliconfig.DevNodeConfig
+}
+
+func newSSHTransport(opts Options) (Transport, string) {
+	if opts.Node == nil || strings.TrimSpace(opts.Node.Address) == "" {
+		return nil, "no node configured for this profile (run `olares-cli dev node set`)"
+	}
+	if strings.TrimSpace(opts.Node.User) == "" {
+		return nil, "the configured node has no SSH user (re-run `olares-cli dev node set --user <user>`)"
+	}
+	tool, err := resolveImageTool(opts.ImageTool)
+	if err != nil {
+		return nil, err.Error()
+	}
+	return &sshTransport{tool: tool, node: *opts.Node}, ""
+}
+
+func (t *sshTransport) Name() string { return TransportSSH }
+
+func (t *sshTransport) Describe() string {
+	port := t.node.Port
+	if port == 0 {
+		port = 22
+	}
+	return fmt.Sprintf("%s save | ssh %s@%s:%d 'ctr -n %s images import -'",
+		t.tool, t.node.User, t.node.Address, port, ContainerdNamespace)
+}
+
+// connect builds the standalone connection + host pair, mirroring
+// verifyMasterSSH in pkg/pipelines/join_credentials.go. Password auth is
+// intentionally unsupported (see cliconfig.DevNodeConfig).
+func (t *sshTransport) connect() (connector.Connection, connector.Host, error) {
+	host := connector.NewHost()
+	host.SetAddress(t.node.Address)
+	host.SetInternalAddress(t.node.Address)
+	host.SetPort(t.portOrDefault())
+	host.SetUser(t.node.User)
+	host.SetPrivateKeyPath(t.node.PrivateKeyPath)
+
+	cfg := connector.Cfg{
+		Username: t.node.User,
+		Address:  t.node.Address,
+		Port:     t.portOrDefault(),
+		KeyFile:  t.node.PrivateKeyPath,
+		Timeout:  sshDialTimeout,
+	}
+	// With no explicit key, fall back to the agent rather than failing
+	// validateOptions' "must specify at least one auth method" check.
+	if cfg.KeyFile == "" {
+		if os.Getenv("SSH_AUTH_SOCK") == "" {
+			return nil, nil, fmt.Errorf(
+				"no SSH key configured for the node and no agent running (SSH_AUTH_SOCK unset); " +
+					"re-run `olares-cli dev node set --private-key <path>`")
+		}
+		cfg.AgentSocket = "env:SSH_AUTH_SOCK"
+	}
+
+	conn, err := connector.NewConnection(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ssh to %s@%s: %w", t.node.User, t.node.Address, err)
+	}
+	return conn, host, nil
+}
+
+func (t *sshTransport) portOrDefault() int {
+	if t.node.Port == 0 {
+		return 22
+	}
+	return t.node.Port
+}
+
+func (t *sshTransport) Import(ctx context.Context, image string, progress io.Writer) error {
+	conn, host, err := t.connect()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	remoteCtr, err := t.probeCtr(conn, host)
+	if err != nil {
+		return err
+	}
+
+	save := saveCommand(ctx, t.tool, image)
+	saveOut, err := save.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe %s save: %w", t.tool, err)
+	}
+	var saveErr strings.Builder
+	save.Stderr = &saveErr
+	if err := save.Start(); err != nil {
+		return fmt.Errorf("start %s save %s: %w", t.tool, image, err)
+	}
+
+	cmd := strings.Join(importArgs(remoteCtr), " ")
+	cmd = host.SudoPrefixIfNecessary(cmd)
+	progressf(progress, "streaming %s to %s@%s (%s)\n", image, t.node.User, t.node.Address, cmd)
+
+	var remoteErr strings.Builder
+	code, execErr := conn.PExec(cmd, saveOut, progress, &remoteErr, host)
+
+	// Reap the producer regardless of how the remote side ended, so a
+	// failed import doesn't leave an orphaned `docker save`.
+	saveWaitErr := save.Wait()
+
+	// Local producer errors are reported first: a failed `docker save`
+	// (usually "no such image") closes the pipe having written nothing,
+	// and the remote ctr then fails with "unrecognized image format",
+	// which describes the symptom rather than the mistake.
+	if saveWaitErr != nil {
+		msg := strings.TrimSpace(saveErr.String())
+		if msg == "" {
+			msg = saveWaitErr.Error()
+		}
+		return fmt.Errorf("%s save %s failed: %s", t.tool, image, msg)
+	}
+	if execErr != nil {
+		return fmt.Errorf("remote import failed: %w (%s)", execErr, strings.TrimSpace(remoteErr.String()))
+	}
+	if code != 0 {
+		msg := strings.TrimSpace(remoteErr.String())
+		if msg == "" {
+			msg = fmt.Sprintf("exit status %d", code)
+		}
+		return fmt.Errorf("remote `%s` failed: %s", cmd, msg)
+	}
+	return nil
+}
+
+// probeCtr asks the node which ctr it has rather than assuming k3s.
+// KUBE_TYPE can be k8s, in which case there is no `k3s` binary and the
+// standalone `ctr` is the right entry point.
+func (t *sshTransport) probeCtr(conn connector.Connection, host connector.Host) ([]string, error) {
+	out, _, err := conn.Exec("command -v k3s >/dev/null 2>&1 && echo k3s || (command -v ctr >/dev/null 2>&1 && echo ctr || echo none)", host)
+	if err != nil {
+		return nil, fmt.Errorf("probe for ctr on %s: %w", t.node.Address, err)
+	}
+	switch strings.TrimSpace(out) {
+	case "k3s":
+		return []string{"k3s", "ctr"}, nil
+	case "ctr":
+		return []string{"ctr"}, nil
+	default:
+		return nil, fmt.Errorf("neither `k3s` nor `ctr` found on %s — is this an Olares node?", t.node.Address)
+	}
+}

--- a/cli/pkg/devdeploy/transport.go
+++ b/cli/pkg/devdeploy/transport.go
@@ -1,0 +1,166 @@
+// Package devdeploy implements the transports that move a locally built
+// container image into a running Olares node's image store, plus the
+// helpers `olares-cli dev` uses to pick between them.
+//
+// The package deliberately does NOT contain the workload-patching logic:
+// that lives in cmd/ctl/cluster/workload (RunSetImage) and is shared
+// verbatim, so `dev deploy` and `cluster workload set-image` cannot
+// drift. Transport is the only thing that varies with where the CLI is
+// running; the patch always goes through the same authenticated
+// ControlHub path regardless.
+package devdeploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+)
+
+// Transport names accepted by `dev push --transport`.
+const (
+	TransportAuto     = "auto"
+	TransportLocal    = "local"
+	TransportSSH      = "ssh"
+	TransportRegistry = "registry"
+	TransportAPI      = "api"
+)
+
+// ContainerdNamespace is the containerd namespace kubelet pulls from.
+// An image imported into any other namespace is invisible to the
+// kubelet, which is the single most common way a hand-rolled `ctr
+// images import` appears to succeed and then ImagePullBackOffs.
+const ContainerdNamespace = "k8s.io"
+
+// Transport moves an image into a node's image store.
+type Transport interface {
+	// Name is the --transport value that selects this transport.
+	Name() string
+	// Import streams the image into the node's containerd. progress is
+	// where human-readable step output goes; nil discards it.
+	Import(ctx context.Context, image string, progress io.Writer) error
+	// Describe is a one-line summary of what this transport will do,
+	// shown before a push so the user can see where the bytes go.
+	Describe() string
+}
+
+// Options carries everything the transports need. Zero values are
+// meaningful: a nil Node simply makes the ssh transport unavailable.
+type Options struct {
+	// Node is the SSH coordinate for TransportSSH.
+	Node *cliconfig.DevNodeConfig
+	// ImageTool overrides the local image tool ("docker" / "podman").
+	// Empty means auto-detect.
+	ImageTool string
+}
+
+// Select resolves a --transport value to a concrete Transport.
+//
+// For TransportAuto it walks the ladder local → ssh → registry, which
+// orders by iteration speed: importing straight into the local
+// containerd is the fastest, streaming over SSH costs a network hop,
+// and a registry round-trip costs two plus a public push.
+func Select(name string, opts Options) (Transport, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", TransportAuto:
+		return selectAuto(opts)
+	case TransportLocal:
+		t, why := newLocalTransport(opts)
+		if t == nil {
+			return nil, fmt.Errorf("--transport local is not usable here: %s", why)
+		}
+		return t, nil
+	case TransportSSH:
+		t, why := newSSHTransport(opts)
+		if t == nil {
+			return nil, fmt.Errorf("--transport ssh is not usable here: %s", why)
+		}
+		return t, nil
+	case TransportRegistry:
+		return nil, fmt.Errorf("--transport registry is not implemented yet; " +
+			"push the image to a registry the node can pull from and use " +
+			"`olares-cli cluster workload set-image` directly")
+	case TransportAPI:
+		return nil, fmt.Errorf("--transport api is not implemented yet; " +
+			"it needs a backend that can import an uploaded image, which no released Olares ships. " +
+			"Use --transport ssh (or local, on the node itself), or push to a registry the node " +
+			"can pull from and use `olares-cli cluster workload set-image` directly")
+	default:
+		return nil, fmt.Errorf("unknown transport %q (want one of: auto, local, ssh, registry, api)", name)
+	}
+}
+
+func selectAuto(opts Options) (Transport, error) {
+	local, localWhy := newLocalTransport(opts)
+	if local != nil {
+		return local, nil
+	}
+	ssh, sshWhy := newSSHTransport(opts)
+	if ssh != nil {
+		return ssh, nil
+	}
+	return nil, fmt.Errorf(
+		"no image transport is available\n"+
+			"  local: %s\n"+
+			"  ssh:   %s\n"+
+			"Configure a node with `olares-cli dev node set --address <host> --user <user>`, "+
+			"or push the image to a registry the node can pull from and use "+
+			"`olares-cli cluster workload set-image` directly.",
+		localWhy, sshWhy)
+}
+
+// RemoteOnly reports whether this process is the npm/npx distribution,
+// which the Node shim marks with OLARES_CLI_REMOTE_ONLY=1. The local
+// transport is meaningless there: the shim only ever runs on a machine
+// that is not the Olares node.
+func RemoteOnly() bool { return os.Getenv("OLARES_CLI_REMOTE_ONLY") == "1" }
+
+// imageToolCandidates is the probe order for the tool that can produce
+// a docker-archive stream from a local image.
+var imageToolCandidates = []string{"docker", "podman"}
+
+// resolveImageTool picks the local tool used for `<tool> save`.
+func resolveImageTool(override string) (string, error) {
+	if override != "" {
+		if _, err := exec.LookPath(override); err != nil {
+			return "", fmt.Errorf("image tool %q not found on PATH: %w", override, err)
+		}
+		return override, nil
+	}
+	for _, candidate := range imageToolCandidates {
+		if _, err := exec.LookPath(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("neither docker nor podman found on PATH; " +
+		"one of them is needed to export the image (override with --image-tool)",
+	)
+}
+
+// saveCommand builds the local `<tool> save <image>` whose stdout is a
+// docker-archive tar stream — the format `ctr images import` reads.
+func saveCommand(ctx context.Context, tool, image string) *exec.Cmd {
+	return exec.CommandContext(ctx, tool, "save", image)
+}
+
+// importArgs is the remote/local side: unpack the streamed archive into
+// the namespace the kubelet reads.
+//
+// --digests is deliberately omitted: a locally built image has no
+// registry digest, and asking ctr to record one makes the import fail
+// on some containerd versions rather than degrade.
+func importArgs(ctrCmd []string) []string {
+	return append(append([]string{}, ctrCmd...),
+		"-n", ContainerdNamespace, "images", "import", "-")
+}
+
+func progressf(w io.Writer, format string, args ...interface{}) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, format, args...)
+}

--- a/cli/pkg/devdeploy/transport_test.go
+++ b/cli/pkg/devdeploy/transport_test.go
@@ -1,0 +1,138 @@
+package devdeploy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
+)
+
+func TestImportArgsAlwaysTargetsTheKubeletNamespace(t *testing.T) {
+	got := strings.Join(importArgs([]string{"k3s", "ctr"}), " ")
+	want := "k3s ctr -n k8s.io images import -"
+	if got != want {
+		t.Errorf("importArgs = %q, want %q", got, want)
+	}
+	// An image imported into any other namespace is invisible to the
+	// kubelet, so this is not a preference to be made configurable.
+	if !strings.Contains(got, "-n "+ContainerdNamespace) {
+		t.Errorf("import must target %s", ContainerdNamespace)
+	}
+}
+
+func TestSelectRejectsUnknownTransport(t *testing.T) {
+	_, err := Select("carrier-pigeon", Options{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "auto, local, ssh, registry, api") {
+		t.Errorf("error %q should list the valid transports", err)
+	}
+}
+
+// The unimplemented transports must say what to do instead rather than
+// failing with a bare "not implemented".
+func TestSelectExplainsUnimplementedTransports(t *testing.T) {
+	for _, name := range []string{TransportRegistry, TransportAPI} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Select(name, Options{})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), "not implemented yet") {
+				t.Errorf("error %q should say it is not implemented", err)
+			}
+			if !strings.Contains(err.Error(), "set-image") {
+				t.Errorf("error %q should point at the manual alternative", err)
+			}
+		})
+	}
+}
+
+func TestSSHTransportRequiresAddressAndUser(t *testing.T) {
+	tests := map[string]struct {
+		node    *cliconfig.DevNodeConfig
+		wantMsg string
+	}{
+		"no node at all": {
+			node:    nil,
+			wantMsg: "no node configured",
+		},
+		"blank address": {
+			node:    &cliconfig.DevNodeConfig{User: "ronny"},
+			wantMsg: "no node configured",
+		},
+		"missing user": {
+			node:    &cliconfig.DevNodeConfig{Address: "olares.lan"},
+			wantMsg: "no SSH user",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, why := newSSHTransport(Options{Node: tc.node})
+			if got != nil {
+				t.Fatal("expected the ssh transport to be unavailable")
+			}
+			if !strings.Contains(why, tc.wantMsg) {
+				t.Errorf("reason %q does not mention %q", why, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// The npm/npx build never runs on the node, so offering to import into
+// "this machine's" containerd there would always be wrong — including
+// on a developer laptop that happens to run Docker.
+func TestLocalTransportRefusedUnderRemoteOnly(t *testing.T) {
+	t.Setenv("OLARES_CLI_REMOTE_ONLY", "1")
+	got, why := newLocalTransport(Options{})
+	if got != nil {
+		t.Fatal("expected the local transport to be unavailable under OLARES_CLI_REMOTE_ONLY")
+	}
+	if !strings.Contains(why, "npm/npx build") {
+		t.Errorf("reason %q should explain that this build never runs on the node", why)
+	}
+}
+
+func TestSelectAutoUnderRemoteOnlyExplainsBothLadderRungs(t *testing.T) {
+	t.Setenv("OLARES_CLI_REMOTE_ONLY", "1")
+	_, err := Select(TransportAuto, Options{})
+	if err == nil {
+		t.Fatal("expected an error when neither transport is available")
+	}
+	for _, want := range []string{"local:", "ssh:", "dev node set"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should contain %q", err, want)
+		}
+	}
+}
+
+func TestResolveImageToolRejectsMissingOverride(t *testing.T) {
+	_, err := resolveImageTool("definitely-not-a-real-binary")
+	if err == nil {
+		t.Fatal("expected an error for a missing tool")
+	}
+	if !strings.Contains(err.Error(), "not found on PATH") {
+		t.Errorf("error %q should say the tool is missing", err)
+	}
+}
+
+// hasKubeletMarker is what stops `auto` from picking a developer
+// machine's own Docker containerd. Without a marker the local transport
+// must decline even though a socket exists.
+func TestHasKubeletMarkerIsRequiredForAmbiguousSockets(t *testing.T) {
+	for _, marker := range kubeletMarkers {
+		if !strings.HasPrefix(marker, "/") {
+			t.Errorf("kubelet marker %q should be an absolute path", marker)
+		}
+	}
+	if len(kubeletMarkers) == 0 {
+		t.Fatal("there must be at least one kubelet marker or every Docker host looks like a node")
+	}
+	// The k3s socket is self-proving; the generic ones are not.
+	for _, sock := range containerdSockets {
+		if strings.Contains(sock.path, "k3s") != sock.k3sOwned {
+			t.Errorf("socket %q: k3sOwned=%v does not match its path", sock.path, sock.k3sOwned)
+		}
+	}
+}

--- a/cli/skills/olares-cluster/SKILL.md
+++ b/cli/skills/olares-cluster/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olares-cluster
-version: 4.5.0
+version: 4.6.0
 description: "Olares ControlHub K8s runtime view via olares-cli cluster — inspect pods, containers, workloads, logs, jobs, cronjobs, namespaces, nodes, and middleware; exec, scale, restart, or delete K8s objects. Use for raw runtime objects and logs, not app lifecycle (market), resource metrics (dashboard), or host install."
 compatibility: Requires olares-cli on PATH and active Olares profile
 metadata:
@@ -40,7 +40,7 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 | `context` | (single verb) | `olares-cli cluster context --help` |
 | `pod` | `list`, `get`, `yaml`, `events`, `logs`, `delete`, `restart`, `exec` | `exec` requires Olares 1.12.7+; [pod operations](references/olares-cluster-pod.md); [exec safety](references/olares-cluster-exec.md) |
 | `container` | `list`, `env`, `logs`, `exec` | `exec` requires Olares 1.12.7+; [exec safety](references/olares-cluster-exec.md) |
-| `workload` (`wl`) | `list`, `images`, `get`, `yaml`, `rollout-status`, `scale`, `restart`, `stop`, `start`, `delete` | [workload operations](references/olares-cluster-workload.md) |
+| `workload` (`wl`) | `list`, `images`, `get`, `yaml`, `rollout-status`, `scale`, `set-image`, `restart`, `stop`, `start`, `delete` | [workload operations](references/olares-cluster-workload.md) |
 | `application` (`app`) | `list`, `get`, `workloads`, `pods`, `status` | [application aggregation](references/olares-cluster-application.md) |
 | `namespace` (alias `ns`) | `list`, `get` | `olares-cli cluster namespace --help` |
 | `node` (alias `nodes`) | `list`, `get` | `olares-cli cluster node --help` |

--- a/cli/skills/olares-cluster/references/olares-cluster-workload.md
+++ b/cli/skills/olares-cluster/references/olares-cluster-workload.md
@@ -24,6 +24,7 @@
 | `yaml <ns/name> --kind X` | Full K8s-native YAML |
 | `rollout-status <ns/name> --kind X` | Reports whether the rollout has converged (kind-aware). Without `-w`: one GET, exit 0 if converged or 2 if not. With `-w`: poll on `--interval` until converged, `--timeout` (default 10m), or Ctrl-C. Emits only on state change |
 | `scale <ns/name> --kind X --replicas N` | **Destructive.** PATCH merge-patch+json `{"spec":{"replicas":N}}`. DaemonSet rejected. `--replicas=0` triggers `ConfirmDestructive`. `-w` chains into `rollout-status -w` automatically |
+| `set-image <ns/name> --kind X --image REF` | **Destructive.** PATCH **strategic**-merge-patch+json on the container entry (merge key `name`), so sibling containers survive — a plain merge-patch would replace the whole array. `-c` optional when the pod template has exactly one container; initContainers are addressed by the same flag. Records the replaced image + pull policy in the `dev.olares.io/previous-images` annotation for `dev revert`. `--pull-policy` defaults to `IfNotPresent`; `""` leaves it untouched. `-w` chains into `rollout-status -w` |
 | `restart <ns/name> --kind X` | **Destructive.** 3-step: (1) GET selector; (2) GET pods by selector; (3) parallel DELETE pods. `--concurrency` (default 5) bounds parallel deletes. NOT the kubectl `restartedAt` annotation trick |
 | `stop <ns/name> --kind X` | **Destructive.** Alias for `scale --replicas=0`. DaemonSet rejected (delete the workload instead) |
 | `start <ns/name> --kind X --replicas N` | Non-destructive. Alias for `scale --replicas=N`. `--replicas` REQUIRED (no cached previous count). No `--yes` |
@@ -36,6 +37,7 @@ Every destructive verb follows the parent SKILL.md's Mutating verb safety contra
 - **DaemonSet has no `replicas`** — `scale` / `stop` reject it client-side. `start` requires `--replicas` so it implicitly excludes DaemonSet too.
 - **`restart` deletes pods one-by-one (parallel-bounded).** During the operation pods are recreated by the controller. For Deployments with a single replica, this means a brief downtime.
 - **`delete --propagation foreground` waits for the cascade.** Pass `background` only when you intentionally want fire-and-forget.
+- **`set-image` recreates pods.** It is the same disruption as `restart`, plus the new image has to be pullable or already present on the node. Pointing a workload at an image the node cannot obtain leaves it in `ImagePullBackOff` until reverted — check with `cluster workload images <IMAGE>` before and `dev status` after.
 
 ## Examples
 
@@ -58,6 +60,10 @@ olares-cli cluster workload images docker.io/library/nginx:latest
 # Get + watch rollout to convergence.
 olares-cli cluster workload get user-system-alice/api --kind deploy
 olares-cli cluster workload rollout-status user-system-alice/api --kind deploy -w --interval 3s --timeout 5m
+
+# Repoint one container at a different image, then wait for the rollout.
+# The original image + pull policy are recorded for `olares-cli dev revert`.
+olares-cli cluster workload set-image os-framework/app-service --kind sts --image beclab/app-service:dev -w
 
 # Scale + watch (auto-chains into rollout-status).
 olares-cli cluster workload scale user-system-alice/api --kind deploy --replicas 3 -w

--- a/docs/.vitepress/developer.en.ts
+++ b/docs/.vitepress/developer.en.ts
@@ -384,6 +384,10 @@ export const developerSidebar: DefaultTheme.Sidebar = {
     {
       text: "Contribute to Olares",
       items: [
+        {
+          text: "Test a local build on your Olares",
+          link: "/developer/contribute/dev-deploy",
+        },
         /*
         {
           text: "Develop system app",

--- a/docs/developer/contribute/dev-deploy.md
+++ b/docs/developer/contribute/dev-deploy.md
@@ -1,0 +1,161 @@
+---
+outline: [2, 3]
+description: Build a component from the Olares repo locally, side-load it onto a running Olares, point the workload at it, and revert when you are done.
+head:
+  - - meta
+    - name: keywords
+      content: Olares, development, dev deploy, side-load image, containerd, set-image, contributing
+---
+
+# Test a locally built component on a running Olares
+
+When you change a component in this repo — `app-service`, `bfl`, `l4-bfl-proxy`, anything under [`framework/`](https://github.com/beclab/Olares/tree/main/framework) or [`platform/`](https://github.com/beclab/Olares/tree/main/platform) — the released chart still pins a published image tag such as `beclab/app-service:0.6.22`. `olares-cli release` packages charts and manifests but never builds images, so there is no path from "I changed some Go" to "it is running on my Olares" without help.
+
+`olares-cli dev` is that path:
+
+```bash
+make dev-deploy C=app-service
+```
+
+That builds the component's image, side-loads it into your node's containerd, repoints every workload that references the released image, and waits for the rollout. When you are done:
+
+```bash
+make dev-revert C=app-service
+```
+
+## Before you begin
+
+- **Go 1.25+** and **docker** (or podman) on the machine you build from.
+- A running Olares you are logged into: `olares-cli profile current` should show your Olares ID.
+- A way to reach the node's image store — either you are working *on* the node, or you can SSH to it. See [Transports](#transports).
+
+::: warning Not for production instances
+`dev deploy` repoints real workloads on a real instance. Side-loaded images live only in the node's image store, and the pull policy is set to `IfNotPresent` so the kubelet does not go looking for them in a registry. That combination is exactly what you want while iterating and exactly what you do not want on an instance you depend on.
+:::
+
+## The loop
+
+### One command
+
+```bash
+make dev-list                  # what can be dev-built
+make dev-deploy C=app-service  # build + push + repoint + wait
+make dev-status                # what is currently overridden
+make dev-revert C=app-service  # put it back
+```
+
+`make dev-deploy` is the three CLI verbs below in sequence. Reach for them directly when you want to build once and deploy several times, or when the component is not in the map.
+
+### The verbs underneath
+
+```bash
+docker build -t beclab/app-service:dev -f framework/app-service/Dockerfile framework/app-service
+olares-cli dev push beclab/app-service:dev
+olares-cli dev deploy beclab/app-service:dev --replaces beclab/app-service --watch
+```
+
+`push` moves bytes; `deploy` repoints workloads. They are separate because their failure modes are unrelated — a failed push is a transport or permission problem on the node, a failed deploy is an API or RBAC problem — and because one push often feeds several deploys.
+
+`--replaces` takes the repository the chart references, without a tag. The lookup normalizes tags and digests, so it finds whichever released tag is actually deployed. It is a full-cluster scan by design: a paged subset could miss a reference and leave you with a half-repointed component.
+
+Every target is listed and confirmed once before anything is patched:
+
+```
+About to repoint 1 container(s) at beclab/app-service:dev:
+
+NAMESPACE     KIND         NAME         CONTAINER    CURRENT
+os-framework  StatefulSet  app-service  app-service  beclab/app-service:0.6.22
+
+Repoint these 1 container(s)? Pods will be recreated [y/N]:
+```
+
+Pass `--yes` to skip the prompt in a script. Non-interactive callers must pass it — the verb refuses to fan out unconfirmed when stdin is not a terminal.
+
+### Watching it come up
+
+```bash
+olares-cli cluster workload rollout-status os-framework/app-service --kind sts --watch
+olares-cli cluster pod logs -f os-framework/<pod>
+```
+
+## Transports
+
+`dev push` has to get the image into the containerd namespace the kubelet reads (`k8s.io`). How depends on where you are:
+
+| `--transport` | What it does | When `auto` picks it |
+|---------------|--------------|----------------------|
+| `local` | `docker save` piped into `ctr images import` on this machine | The CLI is running on the Olares node |
+| `ssh` | The same pipeline streamed to the node over SSH, no temp file on either side | A node is configured for the active profile |
+| `registry` | Not implemented — push to a registry the node can pull from and use `olares-cli cluster workload set-image` | — |
+| `api` | Not implemented — needs a backend that can import an uploaded image | — |
+
+`auto` (the default) tries `local`, then `ssh`, and explains what each would need if neither works.
+
+::: tip A local containerd is not enough
+`local` requires evidence of a kubelet on the machine, not just a containerd socket. A developer laptop running Docker has a containerd at the same path, and importing into it would appear to succeed while putting the image somewhere no kubelet will ever look.
+:::
+
+### Configuring SSH
+
+```bash
+olares-cli dev node set --address 192.168.1.42 --user ronny
+olares-cli dev node show
+```
+
+The settings are stored per profile, so switching profiles switches nodes. There is no password option: use a key (`--private-key`) or an SSH agent. The account needs to reach containerd, which means root or a sudoer.
+
+## Reverting
+
+```bash
+olares-cli dev status
+olares-cli dev revert --image beclab/app-service:dev --watch
+olares-cli dev revert os-framework/app-service --kind sts   # or name one workload
+```
+
+`deploy` records the image *and* the pull policy it replaced in a `dev.olares.io/previous-images` annotation, and `revert` restores both. Restoring the policy matters: `deploy` forces `IfNotPresent` so a side-loaded build is usable at all, and leaving that behind would pin the workload to whatever happens to be cached on the node and quietly defeat the next chart upgrade.
+
+Overriding the same container twice keeps the *first* recorded original, so a chain of dev builds still reverts to the released image rather than to an earlier dev build.
+
+## When something goes wrong
+
+**The pod will not start and nothing looks wrong in the chart.** Run `olares-cli dev status`. A side-loaded image exists only in the node's image store; an image prune deletes it, and with `IfNotPresent` there is no registry to recover it from. Re-run `dev push`.
+
+**`exec format error` in the container log.** The image was built for the wrong architecture. `dev push` compares the image against the cluster's nodes and refuses before transferring, but the check is skipped when it cannot reach the cluster or read the local image. Rebuild with `docker build --platform linux/<arch>`, or through the Makefile:
+
+```bash
+make dev-deploy C=app-service DOCKER_BUILD_FLAGS="--platform linux/arm64"
+```
+
+**`ctr import` fails with a permission error.** containerd's socket is root-owned. Run as root on the node, or configure passwordless sudo for the SSH account.
+
+**`no such image`.** The build did not produce the tag `push` was asked for. `make dev-deploy` keeps the two in sync; when driving the verbs by hand, check that `docker build -t` and `dev push` name the same tag.
+
+## The component map
+
+[`build/dev-components.yaml`](https://github.com/beclab/Olares/blob/main/build/dev-components.yaml) maps a component name to its build context, Dockerfile, and released image repository. It mirrors the `.github/workflows/module_*_publish_*.yaml` files, which remain the source of truth for what actually gets published.
+
+```bash
+olares-cli dev components list
+olares-cli dev components get app-service
+olares-cli dev components validate    # or: make dev-validate
+```
+
+`validate` checks that every context and Dockerfile still exists, and runs as part of the test suite. The publish workflows only run on release, so without it a Dockerfile that moves during a refactor could leave the map pointing at nothing for months.
+
+If your component is not in the map, add it — or drive the verbs directly with your own `docker build`.
+
+## Repointing without the dev loop
+
+`dev deploy` is a wrapper around a verb you can use on its own, including for images that have nothing to do with this repo:
+
+```bash
+olares-cli cluster workload set-image os-framework/app-service \
+    --kind sts --image ghcr.io/me/app-service:pr-42 --watch
+```
+
+It patches one container by name (strategic merge, so sibling containers survive), records the original for `dev revert`, and works the same whether the CLI runs on the node or on your laptop.
+
+## Learn more
+
+- [Olares CLI overview](../cli-overview.md): the three modes and how each authenticates.
+- [Olares repository structure](./olares.md): what lives where, and how to build a release from source.


### PR DESCRIPTION
> ⚠️ **POC / DO NOT MERGE.** This is a proof of concept opened to validate the idea and the placement decisions before any of it is polished for review. The README asks contributors to discuss substantial changes first — this PR is that discussion, in runnable form. Happy to close it and open an issue instead if that is the preferred venue.

* **Background**

There is currently no supported path from "I changed some Go in this repo" to "it is running on my Olares".

`olares-cli release` packages charts and manifests but never builds images, and every workload template pins a published tag (`beclab/app-service:0.6.22` in `appservice_deploy.yaml`). Testing a local build today means hand-rolling `docker save` → `ssh` → `ctr images import` → `kubectl set image` on the node. That knowledge is tribal, it is unavailable to anyone driving Olares through the CLI or an agent, and each step has a failure mode that is easy to get subtly wrong (wrong containerd namespace, wrong architecture, `imagePullPolicy: Always` on an image no registry can serve).

This PR adds that path:

```bash
make dev-deploy C=app-service   # build + side-load + repoint + wait
make dev-status                 # what is currently overridden
make dev-revert C=app-service   # put it back
```

**What is here**

1. **`olares-cli cluster workload set-image`** — repoint one container, recording what it replaced.
2. **`olares-cli dev`** — `push` / `deploy` / `revert` / `status` / `node` / `components`, with `local` and `ssh` transports.
3. **`build/dev-components.yaml` + root `Makefile`** — 23 components mapped to context/Dockerfile/image, derived from the `module_*_publish_*.yaml` workflows.
4. **Docs + skill updates** so an agent knows the verbs exist.

**Design decisions worth challenging** (the reason this is a POC and not a review request):

- **`dev` is registered outside `root.go`'s `!remoteOnly` guard.** That guard marks verbs needing an Olares host filesystem, and anything behind it only reaches users when the OS is upgraded (the host binary is cut by the OS release with `publish-npm: false`, then replaced by `olares-cli upgrade`). Outside it, `dev` ships on the CLI's own npm cadence. The cost is that an `npx` user sees a `--transport local` that cannot work there. I think that trade is right, but it is the single most consequential choice in the PR.

- **The patch always goes through ControlHub, even on the node.** An on-host `dev` could patch via kube-admin directly and skip the ingress entirely. It deliberately does not: that would make the same command behave differently depending on where it runs, and bypass the RBAC the remote path is subject to. Transport is the only thing that varies by location.

- **`clusteropts` is `internal` to the cluster tree**, so `cmd/ctl/dev` cannot build an options bag. Rather than hoist it out of `internal/` — widening a deliberately narrow surface for every future caller — `workload` and `node` grew Factory-based facades (`api.go`). If hoisting is preferred, say so and I will restructure.

- **`set-image` uses strategic-merge, not the merge-patch `scale` uses.** Merge-patch replaces whole arrays, so patching one container's image would drop every sibling container in the pod template.

- **Revert state lives in a `dev.olares.io/previous-images` annotation** — one JSON-valued annotation, not one per container: a per-container key would blow the 63-char limit on the annotation name segment for long container names, and a partial write would leave a half-reverted workload.

**Two bugs the first smoke test caught**, both now fixed and covered by tests, because they illustrate the class of problem this is meant to remove:

- `--transport auto` picked `local` on a *laptop*: Docker ships its own containerd at `/var/run/containerd/containerd.sock`. Importing there looks successful and puts the image where no kubelet reads. `local` now also requires a kubelet marker.
- A failed `docker save` surfaced as `ctr: unrecognized image format` — the downstream symptom, not the mistake. Producer errors are now reported first in both transports.

**Incidental finding:** `module_bfl_publish_ingress.yaml` builds `framework/bfl/Dockerfile.ingress`, which does not exist in the tree. That component is therefore absent from the map, and `dev components validate` is what surfaced it. Worth a separate fix either way.

**What is NOT here** (later phases of the same design, deliberately out of scope):

- `--transport registry` and `--transport api`. Both error with an explanation and a working alternative. The `api` transport would let a user with no shell on the node do this; `image-service` is the natural home (privileged DaemonSet, containerd socket, already holds a containerd client) but it is a controller-runtime manager reconciling `ImageManager` CRs, not an HTTP server, so it needs a `beclab/api` CRD change first.
- `cluster raw` and `cluster port-forward`. `port-forward` additionally needs a ControlHub edge-nginx route, the same way `exec` needed one in 1.12.7.

* **Target Version for Merge**

None — do not merge. If the approach is wanted, I will split it into reviewable PRs (set-image first, then the dev group, then the repo wrapper) against whichever release line you prefer.

* **Related Issues**

None yet. Opening an issue instead of / alongside this PR is fine — tell me which you prefer.

* **PRs Involving Sub-Systems**

None. Everything is inside `cli/`, plus `build/dev-components.yaml`, a root `Makefile`, and docs. No runtime component is touched, and nothing here changes what gets published.

* **Other information**:

**Verification**

- `go build ./...`, `go vet`, and the full CI test set pass. `pkg/devdeploy` is added to `skills-ci.yml` so its tests actually run.
- Skill validation passes (11 skills); `TestEveryCommandTheSkillsDocumentResolves` still green.
- New tests cover patch construction (containers vs initContainers, annotation merge and precedence), transport selection and its refusal paths, the component map against the working tree, and `dev` being registered under **both** `OLARES_CLI_REMOTE_ONLY` states.

**Not verified:** an end-to-end push/deploy against a live instance. The transport selection and every refusal path are exercised, but the actual `ctr import` + rollout has not run on real hardware yet. That is the main thing I would want a second pair of hands on.

**Local-environment note, not part of the change:** `cli/` cannot be a member of the repo's `go.work` — it requires a *published* `framework/app-service` module version whose `api/` packages do not exist in this tree, so a workspace build fails to resolve them. The Makefile sets `GOWORK=off` for that reason. Unrelated to this PR, but it bit me first and may bite others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
