### PR TITLE
fix(l4): skip ExtAuth on wizard

### DIFF
--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -825,9 +825,10 @@ func (t *Translator) buildSystemVirtualHost(user *message.UserInfo, def systemSe
 		},
 		WebSocketUpgrade: true,
 	}
-	// desktop/wizard are system human HTTP and must use Authelia /api/verify/.
+	// desktop is system human HTTP and must use Authelia /api/verify/.
+	// wizard is pre-auth activation UI — no ExtAuth (cookie chicken-egg).
 	// auth is the IdP itself — do not attach ExtAuth (loop risk).
-	if def.Name == "desktop" || def.Name == "wizard" {
+	if def.Name == "desktop" {
 		route.ExtAuth = buildAppExtAuthConfig(user, false)
 	}
 

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -906,8 +906,7 @@ func TestBuildSystemVirtualHost_DesktopWizardVerify_AuthSkipped(t *testing.T) {
 	assert.Equal(t, autheliaVerifyPathPrefix, desktop.Routes[0].ExtAuth.PathPrefix)
 
 	wizard := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "wizard", SvcFormat: "wizard.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
-	require.NotNil(t, wizard.Routes[0].ExtAuth)
-	assert.Equal(t, autheliaVerifyPathPrefix, wizard.Routes[0].ExtAuth.PathPrefix)
+	assert.Nil(t, wizard.Routes[0].ExtAuth, "wizard must not attach ExtAuth (pre-auth activation)")
 
 	auth := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "auth", SvcFormat: "authelia-svc.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
 	assert.Nil(t, auth.Routes[0].ExtAuth, "auth IdP must not attach ExtAuth")


### PR DESCRIPTION
Skip Authelia ExtAuth on the wizard system virtual host so activation remains reachable without a login cookie.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes proxy-level authentication for the wizard hostname only; acceptable if wizard is strictly pre-auth UI, but it is a deliberate exposure change at the edge.
> 
> **Overview**
> **Wizard** (`wizard.<zone>`) no longer gets Authelia **ExtAuth** on its system virtual host in `buildSystemVirtualHost`. Previously wizard was grouped with desktop and both used `/api/verify/`; now only **desktop** attaches ExtAuth. **Auth** stays without ExtAuth (IdP loop avoidance).
> 
> This is intentional for the pre-activation wizard UI: requiring a session cookie before ExtAuth would block users who are not logged in yet. Tests now assert `wizard` routes have `ExtAuth == nil` while desktop still uses `autheliaVerifyPathPrefix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eae12e0578e927471e2c01bddff9e40fd057fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->