### PR TITLE
fix(tapr): treat a missing user workspace as empty, not as a server error

### DIFF
--- a/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
+++ b/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
@@ -231,7 +231,7 @@ spec:
           subPath: nginx.conf
 
       - name: tapr-sidecar
-        image: beclab/secret-vault:0.1.16
+        image: beclab/secret-vault:0.1.17
         imagePullPolicy: IfNotPresent
         ports:
         - name: proxy


### PR DESCRIPTION


* **Background**
fix(tapr): treat a missing user workspace as empty, not as a server error
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/Olares/pull/3886

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on a sidecar; low blast radius aside from normal rollout/restart of the Infisical pod.
> 
> **Overview**
> Rolls the Infisical **`tapr-sidecar`** container from **`beclab/secret-vault:0.1.16`** to **`0.1.17`** in `infisical_deploy.yaml`, so clusters deploy the TAPR fix that treats a **missing user workspace as empty** instead of returning a server error.
> 
> No other deployment settings (ports, env, nginx routing) change in this diff—only the sidecar image tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5196fd5eb198e8d7aa42307bc6bc6c9402feb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->