### PR TITLE
fix(l4): strip client-supplied app identity headers on the north-south path

### DIFF
--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -179,6 +179,15 @@ func SetTimeouts(tcpIdle, httpStream, connect, route, clusterIdle time.Duration)
 	clusterIdleTimeout = clusterIdle
 }
 
+// spoofableAppIdentityHeadersToRemove lists north-south client headers that
+// must not reach entrance Services. Envoy matches these case-insensitively.
+func spoofableAppIdentityHeadersToRemove() []string {
+	return []string{
+		"x-caller-appid",
+		"x-olares-app-id",
+	}
+}
+
 // mustAny marshals a proto.Message into an anypb.Any, panicking on error.
 // All callers use well-known Envoy types whose type URLs are always registered,
 // so a failure here indicates a programming error rather than a runtime condition.
@@ -561,6 +570,11 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 				{Header: &corev3.HeaderValue{Key: "X-Real-IP", Value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 				{Header: &corev3.HeaderValue{Key: "X-Original-Forwarded-For", Value: "%REQ(X-FORWARDED-FOR)%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 			},
+			// Strip client-supplied app identity headers before upstream.
+			// North-south is L4 → entrance Service only; there is no gateway
+			// rewrite of these headers on this path, so edge clients must not
+			// be able to set them. East-west does not use this L4 RDS.
+			RequestHeadersToRemove: spoofableAppIdentityHeadersToRemove(),
 		}
 		routeConfigs = append(routeConfigs, routeConfig)
 

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
@@ -903,9 +903,18 @@ func TestTranslate_HTTPSListeners(t *testing.T) {
 	require.Len(t, snap.Routes, 1)
 	rc := asRouteConfig(t, snap.Routes[0])
 	assert.Equal(t, "https_443_alice_routes", rc.Name)
+	assert.Equal(t, []string{"x-caller-appid", "x-olares-app-id"}, rc.GetRequestHeadersToRemove(),
+		"north-south RDS must strip spoofable app identity headers before upstream")
 
 	// 1 cluster
 	require.Len(t, snap.Clusters, 1)
+}
+
+func TestSpoofableAppIdentityHeadersToRemove(t *testing.T) {
+	got := spoofableAppIdentityHeadersToRemove()
+	require.Equal(t, []string{"x-caller-appid", "x-olares-app-id"}, got)
+	// Stable order for xDS determinism / snapshot diffs.
+	require.Equal(t, got, spoofableAppIdentityHeadersToRemove())
 }
 
 func TestTranslate_EmptyIR(t *testing.T) {


### PR DESCRIPTION
Strip client-supplied X-Caller-Appid and X-Olares-App-ID before forwarding to entrance Services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening on the public edge path; scope is limited to header removal on north-south HTTPS RDS with unit test coverage.
> 
> **Overview**
> **North-south HTTPS** traffic through the L4 BFL proxy now **removes** client-supplied `X-Caller-Appid` and `X-Olares-App-ID` before requests reach entrance Services. Those headers are wired via `RequestHeadersToRemove` on per-user HTTPS RDS route configs (Envoy matches them case-insensitively).
> 
> On this path there is no gateway rewrite of app identity, so without stripping, an external client could spoof caller/app context. East-west paths are unchanged and do not use this L4 RDS.
> 
> Tests assert the translated route config includes the removal list and that the helper returns a stable header order for deterministic xDS snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0950c6641353872e155aa4d343aa87afcefb5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->