### PR TITLE
fix(l4): skip ExtAuth on wizard

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -157,7 +157,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.41"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.42"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.41
+          value: v0.3.42
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.41
+      name: beclab/l4-bfl-proxy:v0.3.42
 # must have blank new line            


### PR DESCRIPTION


* **Background**
fix(l4): skip ExtAuth on wizard
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/Olares/pull/3891

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches edge proxy versioning used on upgrade and new BFL pods; risk is mainly rollout of changed Envoy/ext_authz behavior for wizard routes.
> 
> **Overview**
> Rolls **`beclab/l4-bfl-proxy`** from **v0.3.41** to **v0.3.42** so installs and upgrades pick up the L4 proxy build that **skips ExtAuth for wizard** traffic (per the linked l4 change).
> 
> The tag is updated in the **Olares upgrade** `UpgradeL4BFLProxy` task, the **BFL** launcher env **`L4_PROXY_IMAGE_VERSION`**, and **`framework/l4-bfl-proxy/.olares/Olares.yaml`** prebuilt image reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316ac3f76ea916c9d4a39831926243b39954e5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->