### PR TITLE
fix(bfl): reuse beclab/api to resolve entrance IDs with domain overrides

### DIFF
--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.50
+        image: beclab/bfl:v0.4.51
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000

--- a/framework/bfl/go.mod
+++ b/framework/bfl/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
-	github.com/beclab/api v0.0.14
+	github.com/beclab/api v0.0.24
 	github.com/beclab/lldap-client v0.0.11
 	github.com/emicklei/go-restful v2.16.0+incompatible
 	github.com/emicklei/go-restful-openapi/v2 v2.11.0

--- a/framework/bfl/go.sum
+++ b/framework/bfl/go.sum
@@ -6,10 +6,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/api v0.0.12 h1:8+pxq5I7Xt9XfSM23RuOJD2kIKggdJ/LaUYWM0gcj04=
-github.com/beclab/api v0.0.12/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
-github.com/beclab/api v0.0.14 h1:/KGHYsb1TpWzOLws2JfPhxpa0tOK9ZyLSDJlBZmY8ko=
-github.com/beclab/api v0.0.14/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/api v0.0.24 h1:Ob01wkENbiBWis/O32Sn7xLQc8sAtCVmP6zksrMAlaQ=
+github.com/beclab/api v0.0.24/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=
 github.com/beclab/lldap-client v0.0.11/go.mod h1:Y74tcKzyNL73a9pFAvImwXgzqp7S7Jb8RY1mMY90e/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/framework/bfl/pkg/apis/base.go
+++ b/framework/bfl/pkg/apis/base.go
@@ -3,7 +3,8 @@ package apis
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
 	"bytetrade.io/web3os/bfl/pkg/api/response"
 	"bytetrade.io/web3os/bfl/pkg/apis/iam/v1alpha1/operator"
@@ -11,8 +12,6 @@ import (
 	"bytetrade.io/web3os/bfl/pkg/app_service/v1"
 	"bytetrade.io/web3os/bfl/pkg/constants"
 	"bytetrade.io/web3os/bfl/pkg/userenv"
-	"bytetrade.io/web3os/bfl/pkg/utils"
-
 	iamV1alpha2 "github.com/beclab/api/iam/v1alpha2"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
@@ -61,16 +60,7 @@ func (h *Base) GetAppListAndServicePort(req *restful.Request, appService *app_se
 			continue
 		}
 
-		if len(apps[i].Entrances) == 1 {
-			apps[i].Entrances[0].ID = app.ID
-			apps[i].Entrances[0].URL = app.URL
-			if apps[i].Entrances[0].Icon == "" {
-				apps[i].Entrances[0].Icon = app.Icon
-			}
-			continue
-		}
-
-		var appDomainConfigs []utils.DefaultThirdLevelDomainConfig
+		var appDomainConfigs []appv1alpha1.DefaultThirdLevelDomainConfig
 		if len(app.DefaultThirdLevelDomainConfig) > 0 {
 			err := json.Unmarshal([]byte(app.DefaultThirdLevelDomainConfig), &appDomainConfigs)
 			if err != nil {
@@ -78,16 +68,25 @@ func (h *Base) GetAppListAndServicePort(req *restful.Request, appService *app_se
 			}
 
 		}
+		apiEntrances := make([]*appv1alpha1.Entrance, len(apps[i].Entrances))
+		for k := range apps[i].Entrances {
+			e := apps[i].Entrances[k]
+			apiEntrances[k] = &appv1alpha1.Entrance{
+				Name:       e.Name,
+				Icon:       e.Icon,
+				Title:      e.Title,
+				AuthLevel:  e.AuthLevel,
+				Invisible:  e.Invisible,
+				URL:        e.URL,
+				OpenMethod: e.OpenMethod,
+			}
+		}
+
 		// return all entrances, let the frontend filter invisible or not
 		// filteredEntrances := make([]app_service.Entrance, 0)
 		for j := range apps[i].Entrances {
-			apps[i].Entrances[j].ID = fmt.Sprintf("%s%d", app.ID, j)
-			for _, adc := range appDomainConfigs {
-				if adc.EntranceName == apps[i].Entrances[j].Name && len(adc.ThirdLevelDomain) > 0 {
-					apps[i].Entrances[j].ID = adc.ThirdLevelDomain
-				}
-			}
-			apps[i].Entrances[j].URL = appURLMulti(app.Name, app.ID, j, apps[i].Entrances, appDomainConfigs)
+			apps[i].Entrances[j].ID = appv1alpha1.ResolveEntranceIDWithDefaultThirdLevelDomainOverride(apiEntrances, j, app.ID, appDomainConfigs)
+			apps[i].Entrances[j].URL = appURLMulti(app.Name, app.ID, j, apiEntrances, appDomainConfigs)
 			if apps[i].Entrances[j].Icon == "" {
 				apps[i].Entrances[j].Icon = app.Icon
 			}

--- a/framework/bfl/pkg/app_service/v1/tools.go
+++ b/framework/bfl/pkg/app_service/v1/tools.go
@@ -2,13 +2,12 @@ package app_service
 
 import (
 	"fmt"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	"os"
 	"strings"
 
 	"bytetrade.io/web3os/bfl/pkg/apis/iam/v1alpha1/operator"
 	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
-	"bytetrade.io/web3os/bfl/pkg/utils"
-
 	"github.com/asaskevich/govalidator"
 	"github.com/emicklei/go-restful/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,7 @@ import (
 )
 
 type URLGenerator func(appname, appid string) string
-type URLGeneratorMultiEntrance func(appname, appid string, index int, entrances []Entrance, appDomainConfigs []utils.DefaultThirdLevelDomainConfig) string
+type URLGeneratorMultiEntrance func(appname, appid string, index int, entrances []*appv1alpha1.Entrance, appDomainConfigs []appv1alpha1.DefaultThirdLevelDomainConfig) string
 
 func AppUrlGenerator(req *restful.Request, user string) (URLGenerator, error) {
 	host := req.Request.Host
@@ -152,18 +151,13 @@ func AppUrlGeneratorMultiEntrance(req *restful.Request, user string) (URLGenerat
 				// the zone of the user's creator.
 				// At the meanwhile, the zone returned by the function is creator's zone.
 				klog.Info("new user: ", user)
-				appURL = func(appname, appid string, index int, entrances []Entrance, appDomainConfigs []utils.DefaultThirdLevelDomainConfig) string {
+				appURL = func(appname, appid string, index int, entrances []*appv1alpha1.Entrance, appDomainConfigs []appv1alpha1.DefaultThirdLevelDomainConfig) string {
 					return fmt.Sprintf("%s%d-%s.%s", appid, index, user, zone)
 				}
 			} else {
-				appURL = func(appname, appid string, index int, entrances []Entrance, appDomainConfigs []utils.DefaultThirdLevelDomainConfig) string {
-					for _, adc := range appDomainConfigs {
-						if adc.EntranceName == entrances[index].Name && len(adc.ThirdLevelDomain) > 0 {
-							return fmt.Sprintf("%s.%s", adc.ThirdLevelDomain, zone)
-						}
-					}
-
-					return fmt.Sprintf("%s%d.%s", appid, index, zone)
+				appURL = func(appname, appid string, index int, entrances []*appv1alpha1.Entrance, appDomainConfigs []appv1alpha1.DefaultThirdLevelDomainConfig) string {
+					prefix := appv1alpha1.ResolveEntranceIDWithDefaultThirdLevelDomainOverride(entrances, index, appid, appDomainConfigs)
+					return fmt.Sprintf("%s.%s", prefix, zone)
 				}
 			}
 
@@ -200,7 +194,7 @@ func AppUrlGeneratorMultiEntrance(req *restful.Request, user string) (URLGenerat
 			appUrlMap[sp.Name] = fmt.Sprintf("%s:%d", ip, sp.Port)
 		}
 
-		appURL = func(appname, appid string, index int, entrances []Entrance, appDomainConfigs []utils.DefaultThirdLevelDomainConfig) string {
+		appURL = func(appname, appid string, index int, entrances []*appv1alpha1.Entrance, appDomainConfigs []appv1alpha1.DefaultThirdLevelDomainConfig) string {
 			url, ok := appUrlMap["app-"+appname]
 			if !ok {
 				klog.Errorf("app [ %s ]'s ServicePort not found !", appname)


### PR DESCRIPTION




* **Background**
Convert app entrances to appv1alpha1.Entrance and call ResolveEntranceIDWithDefaultThirdLevelDomainOverride so IDs stay aligned with third-level domain overrides.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how app entrance IDs and generated hostnames are computed for multi-entrance apps with domain overrides; misalignment could break routing or bookmarks if the shared helper behavior differs from the old inline logic.
> 
> **Overview**
> **Centralizes multi-entrance app routing** so entrance IDs and host prefixes match third-level domain overrides using shared `github.com/beclab/api` helpers instead of duplicated BFL logic.
> 
> BFL bumps **`github.com/beclab/api` v0.0.14 → v0.0.24** and the deploy image **`beclab/bfl:v0.4.50` → `v0.4.51`**. In `GetAppListAndServicePort`, entrances are converted to `appv1alpha1.Entrance` and IDs/URLs are set via `ResolveEntranceIDWithDefaultThirdLevelDomainOverride`; the previous single-entrance shortcut and local `utils.DefaultThirdLevelDomainConfig` usage are removed. `AppUrlGeneratorMultiEntrance` now uses the same resolver for non-ephemeral SSL hostnames so URL prefixes stay consistent with entrance IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a32db71e6a21d7e5aeed9a8a25dfb81c8544563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->