### PR TITLE
apps, notifications: bump system-frontend to v1.11.25, user-service to v0.1.12 and notifications-api to v1.12.45

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.23
+          image: beclab/system-frontend:v1.11.25
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -365,7 +365,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.10
+          image: beclab/user-service:v0.1.12
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -815,4 +815,16 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: system-frontend
-
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tapr-images-svc
+  namespace: user-space-{{ .Values.bfl.username }}
+spec:
+  type: ExternalName
+  externalName: tapr-images-svc.user-system-{{ .Values.bfl.username }}.svc.cluster.local
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.44
+        image: beclab/notifications-api:v1.12.45
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**

Ship the cluster and node hardware management feature into `v1.12.7`, together with the fixes that shipped alongside it, by bumping three images and adding the one cluster resource the new frontend needs.

- **`system-frontend` v1.11.23 -> v1.11.25.** Settings and LarePass replace the single-device page with cluster and per-node hardware views: cluster health, node counts, node list, node details driven by olaresd capabilities, and signed power operations that poll durable progress and can recover an operation by `requestId`. LarePass falls back to the legacy mDNS single-machine view when the cluster API is unavailable, so an older Olares keeps working. Settings also decodes payload-only device `sso` values, matching the user-service redaction below. Desktop-side work rides along: local hosts-file management for LarePass desktop, the patched biometric plugin, download dialog theming and custom-domain verification copy.
- **`user-service` v0.1.10 -> v0.1.12.** Adds the thin cluster and node API proxy in front of the master `olaresd` that the new hardware views call, resolving direct node operations through the master node directory and preserving signed operation callbacks while mapping upstream failures to safe client errors. Device lists now return only the JWT payload segment of `sso`; full signed tokens stay in internal storage for online state, revocation and WebSocket routing. It also drops the `ListSecret` branch that matched one specific tapr error sentence to fake an empty list, which the tapr not-found fix in #3886 makes obsolete.
- **New `tapr-images-svc` ExternalName Service in `user-space-<user>`.** TermiPass#1341 repoints the Settings and profile-editor nginx `/images` proxy from `127.0.0.1:15080`, which is unreachable from the system-frontend pod, to `tapr-images-svc:8080`. That pod runs in `user-space-<user>` while the real images service lives in `user-system-<user>`, so this alias is what makes the short name resolve.
- **`notifications-api` v1.12.44 -> v1.12.45.** Adds six app stop reasons (Unschedulable, DiskPressure, SystemCPUPressure, SystemMemoryPressure, K8sRequestCPUPressure, K8sRequestMemoryPressure) with templates in all seven supported languages, so a stop caused by a scheduling failure or by disk, CPU or memory pressure no longer reaches the user as "unknown".

The cluster and node management control plane that these images talk to landed earlier in #3858.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1335
https://github.com/beclab/TermiPass/pull/1340
https://github.com/beclab/TermiPass/pull/1341
https://github.com/beclab/user-service/pull/95
https://github.com/beclab/user-service/pull/96
https://github.com/beclab/user-service/pull/97
https://github.com/beclab/user-service/pull/98
https://github.com/beclab/notifications/pull/24

* **Other information**
Full Changelog:
https://github.com/beclab/TermiPass/compare/v1.11.23...v1.11.25,
https://github.com/beclab/user-service/compare/v0.1.10...v0.1.12,
https://github.com/beclab/notifications/compare/v1.12.44...v1.12.45

Made with [Cursor](https://cursor.com)