### PR TITLE
feat: search upgrade to v0.3.10

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.9
+        image: beclab/search3:v0.3.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -310,7 +310,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.9
+        image: beclab/search3monitor:v0.3.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.9
+        image: beclab/search3validation:v0.3.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: adjust jina-clip-v2 call
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
search3 text-to-image search previously called the legacy jinaclipv2 APIs (`/health`, `/api/text/embed`, `/api/image/embed`). Olares now ships the new `jinaclipv2embed` App (via llm-init, OpenAI-compatible).

This PR only changes how we call the embedding service — no model switching, no DB wipe, no schema changes:
- Probe: `/health` → `/readyz`
- Embed: unified `POST /v1/embeddings` for text and images
- Parse: prefer `data[0].embedding`
- Keep env name `JINA_CLIP_V2_URL` (point it at the new service base)
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
* https://github.com/Above-Os/search3/pull/208

<!-- CURSOR_SUMMARY -->
---
