### PR TITLE
feat(app-service): collect terminal pods left behind by PodGC

### DIFF
--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -212,6 +212,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.TerminatedPodGCController{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", "TerminatedPodGC")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.TailScaleACLController{
 		Client: mgr.GetClient(),
 	}).SetUpWithManager(mgr); err != nil {

--- a/framework/app-service/config/rbac/role.yaml
+++ b/framework/app-service/config/rbac/role.yaml
@@ -8,8 +8,16 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -50,6 +58,15 @@ rules:
   - applications/finalizers
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - iam.kubesphere.io
   resources:

--- a/framework/app-service/controllers/terminated_pod_gc_controller.go
+++ b/framework/app-service/controllers/terminated_pod_gc_controller.go
@@ -1,0 +1,342 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	envTerminatedPodGCMinAge     = "TERMINATED_POD_GC_MIN_AGE"
+	envTerminatedPodGCReadyDelay = "TERMINATED_POD_GC_READY_DELAY"
+)
+
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;list;watch
+
+// TerminatedPodGCController removes terminal Pods of any Deployment in the
+// cluster once that Deployment has as many stably ready replicas as it wants. A
+// Deployment scaled to zero satisfies that trivially, so leftovers of a stopped
+// workload are collected too.
+//
+// Unknown Pods are deliberately excluded. Their workload might still be running
+// on an unreachable node, and there is nothing left for this controller to do
+// anyway: Kubernetes counts an Unknown Pod as active, so a ReplicaSet whose
+// desired count is below its active count deletes such a Pod itself, and while a
+// ReplicaSet is satisfied no replacement exists for the readiness gate to
+// accept. Pods stuck on a lost node are reclaimed by taint eviction and the
+// built-in PodGC.
+//
+// Reaching a Deployment through the ownership chain keeps Pods that no
+// Deployment governs out of scope, so completed Job Pods and bare Pods are
+// never touched.
+type TerminatedPodGCController struct {
+	client.Client
+	minPodAge  time.Duration
+	readyDelay time.Duration
+	now        func() time.Time
+}
+
+func (r *TerminatedPodGCController) SetupWithManager(mgr ctrl.Manager) error {
+	r.minPodAge = parseTimeWithDefault(envTerminatedPodGCMinAge, time.Minute)
+	r.readyDelay = parseTimeWithDefault(envTerminatedPodGCReadyDelay, time.Minute)
+	if r.now == nil {
+		r.now = time.Now
+	}
+
+	klog.Infof(
+		"terminated-pod-gc-controller initialized, minPodAge=%v, readyDelay=%v",
+		r.minPodAge,
+		r.readyDelay,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("terminated-pod-gc-controller").
+		For(&appsv1.Deployment{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForPod),
+		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(r)
+}
+
+func (r *TerminatedPodGCController) requestsForPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	podOwner := metav1.GetControllerOf(pod)
+	if podOwner == nil || podOwner.Kind != replicaSet {
+		return nil
+	}
+
+	var rs appsv1.ReplicaSet
+	if err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: podOwner.Name}, &rs); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("failed to resolve ReplicaSet for pod namespace=%s name=%s: %v", pod.Namespace, pod.Name, err)
+		}
+		return nil
+	}
+	if podOwner.UID != rs.UID {
+		return nil
+	}
+
+	rsOwner := metav1.GetControllerOf(&rs)
+	if rsOwner == nil || rsOwner.Kind != deployment {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      rsOwner.Name,
+	}}}
+}
+
+func (r *TerminatedPodGCController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, req.NamespacedName, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if deploy.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var podList corev1.PodList
+	if err := r.List(
+		ctx,
+		&podList,
+		client.InNamespace(deploy.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Resolving ownership costs a ReplicaSet lookup per Pod, so skip it for the
+	// overwhelmingly common case of a workload with nothing to collect.
+	if !anyCollectablePod(podList.Items) {
+		return ctrl.Result{}, nil
+	}
+
+	pods, err := r.podsControlledByDeployment(ctx, &deploy, podList.Items)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var terminalPods []*corev1.Pod
+	for _, pod := range pods {
+		if isCollectablePod(pod) {
+			terminalPods = append(terminalPods, pod)
+		}
+	}
+	if len(terminalPods) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	// Collect only once the Deployment carries its full complement of replicas
+	// that have stayed ready long enough to be trusted. A Deployment scaled to
+	// zero needs none, which is what makes stopped apps collectable.
+	now := r.currentTime()
+	var stablyReady int32
+	var nextCheck time.Duration
+	for _, pod := range pods {
+		readySince, ready := runningAndReadySince(pod)
+		if !ready {
+			continue
+		}
+		remaining := r.readyDelay - now.Sub(readySince)
+		if remaining <= 0 {
+			stablyReady++
+			continue
+		}
+		nextCheck = shorterPositiveDuration(nextCheck, remaining)
+	}
+	if stablyReady < deploymentReplicas(&deploy) {
+		return ctrl.Result{RequeueAfter: nextCheck}, nil
+	}
+	nextCheck = 0
+
+	for _, pod := range terminalPods {
+		remaining := r.minPodAge - now.Sub(terminalSince(pod))
+		if remaining > 0 {
+			nextCheck = shorterPositiveDuration(nextCheck, remaining)
+			continue
+		}
+
+		uid := pod.UID
+		err := r.Delete(ctx, pod, &client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		klog.Infof(
+			"deleted terminal pod namespace=%s name=%s phase=%s deployment=%s",
+			pod.Namespace,
+			pod.Name,
+			pod.Status.Phase,
+			deploy.Name,
+		)
+	}
+
+	return ctrl.Result{RequeueAfter: nextCheck}, nil
+}
+
+func (r *TerminatedPodGCController) podsControlledByDeployment(
+	ctx context.Context,
+	deploy *appsv1.Deployment,
+	pods []corev1.Pod,
+) ([]*corev1.Pod, error) {
+	replicaSets := make(map[string]*appsv1.ReplicaSet)
+	missingReplicaSets := make(map[string]struct{})
+	result := make([]*corev1.Pod, 0, len(pods))
+
+	for i := range pods {
+		pod := &pods[i]
+		owner := metav1.GetControllerOf(pod)
+		if owner == nil || owner.Kind != replicaSet {
+			continue
+		}
+		if _, missing := missingReplicaSets[owner.Name]; missing {
+			continue
+		}
+
+		rs, found := replicaSets[owner.Name]
+		if !found {
+			var fetched appsv1.ReplicaSet
+			err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}, &fetched)
+			if apierrors.IsNotFound(err) {
+				missingReplicaSets[owner.Name] = struct{}{}
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			rs = &fetched
+			replicaSets[owner.Name] = rs
+		}
+		if owner.UID != rs.UID {
+			continue
+		}
+
+		rsOwner := metav1.GetControllerOf(rs)
+		if rsOwner == nil || rsOwner.Kind != deployment || rsOwner.UID != deploy.UID {
+			continue
+		}
+		result = append(result, pod)
+	}
+
+	return result, nil
+}
+
+func (r *TerminatedPodGCController) currentTime() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func deploymentReplicas(deploy *appsv1.Deployment) int32 {
+	if deploy.Spec.Replicas == nil {
+		return 1
+	}
+	return *deploy.Spec.Replicas
+}
+
+func isTerminalPod(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
+}
+
+func isCollectablePod(pod *corev1.Pod) bool {
+	return isTerminalPod(pod) && pod.DeletionTimestamp == nil
+}
+
+func anyCollectablePod(pods []corev1.Pod) bool {
+	for i := range pods {
+		if isCollectablePod(&pods[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func runningAndReadySince(pod *corev1.Pod) (time.Time, bool) {
+	if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+		return time.Time{}, false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			if condition.LastTransitionTime.IsZero() {
+				return pod.CreationTimestamp.Time, true
+			}
+			return condition.LastTransitionTime.Time, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func terminalSince(pod *corev1.Pod) time.Time {
+	var since time.Time
+	for _, status := range pod.Status.InitContainerStatuses {
+		since = laterTime(since, terminatedAt(status))
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		since = laterTime(since, terminatedAt(status))
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady &&
+			condition.Status == corev1.ConditionFalse &&
+			!condition.LastTransitionTime.IsZero() {
+			since = laterTime(since, condition.LastTransitionTime.Time)
+		}
+	}
+	if since.IsZero() {
+		return pod.CreationTimestamp.Time
+	}
+	return since
+}
+
+func terminatedAt(status corev1.ContainerStatus) time.Time {
+	if status.State.Terminated == nil || status.State.Terminated.FinishedAt.IsZero() {
+		return time.Time{}
+	}
+	return status.State.Terminated.FinishedAt.Time
+}
+
+func laterTime(left, right time.Time) time.Time {
+	if right.After(left) {
+		return right
+	}
+	return left
+}
+
+func shorterPositiveDuration(current, candidate time.Duration) time.Duration {
+	if candidate <= 0 {
+		return current
+	}
+	if current <= 0 || candidate < current {
+		return candidate
+	}
+	return current
+}

--- a/framework/app-service/controllers/terminated_pod_gc_controller_test.go
+++ b/framework/app-service/controllers/terminated_pod_gc_controller_test.go
@@ -1,0 +1,297 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestTerminatedPodGCControllerReconcile(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 10, 0, 0, 0, time.UTC)
+
+	tests := []terminatedPodGCTestCase{
+		{
+			name:                "deletes failed pod replaced by ready pod from another ReplicaSet",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantDeleted:         true,
+		},
+		{
+			name:                "deletes succeeded pod",
+			phase:               corev1.PodSucceeded,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantDeleted:         true,
+		},
+		{
+			name:                   "deletes terminal pod that carries no application labels",
+			phase:                  corev1.PodFailed,
+			replicas:               1,
+			targetTerminalAge:      10 * time.Minute,
+			replacementReady:       true,
+			replacementReadyAge:    2 * time.Minute,
+			targetWithoutAppLabels: true,
+			wantDeleted:            true,
+		},
+		{
+			name:                "keeps unknown pod",
+			phase:               corev1.PodUnknown,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "waits for replacement to become ready",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    false,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "waits for replacement readiness delay",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 30 * time.Second,
+			wantRequeue:         true,
+		},
+		{
+			name:                "waits for terminal pod minimum age",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantRequeue:         true,
+		},
+		{
+			name:                "waits while multi replica Deployment is short of ready replicas",
+			phase:               corev1.PodFailed,
+			replicas:            2,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "deletes failed pod once every replica of a multi replica Deployment is ready",
+			phase:               corev1.PodFailed,
+			replicas:            2,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			replacementCount:    2,
+			wantDeleted:         true,
+		},
+		{
+			name:              "deletes failed pod left behind by a stopped Deployment",
+			phase:             corev1.PodFailed,
+			replicas:          0,
+			targetTerminalAge: 10 * time.Minute,
+			noReplacement:     true,
+			wantDeleted:       true,
+		},
+		{
+			name:              "waits for terminal pod minimum age on a stopped Deployment",
+			phase:             corev1.PodFailed,
+			replicas:          0,
+			targetTerminalAge: time.Minute,
+			noReplacement:     true,
+			wantRequeue:       true,
+		},
+		{
+			name:                       "does not accept replacement owned by another Deployment",
+			phase:                      corev1.PodFailed,
+			replicas:                   1,
+			targetTerminalAge:          10 * time.Minute,
+			replacementReady:           true,
+			replacementReadyAge:        2 * time.Minute,
+			replacementOtherDeployment: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploy, objects := terminatedPodGCFixture(now, tt)
+			fakeClient := testutil.NewFakeClient(objects...)
+			reconciler := &TerminatedPodGCController{
+				Client:     fakeClient,
+				minPodAge:  5 * time.Minute,
+				readyDelay: time.Minute,
+				now:        func() time.Time { return now },
+			}
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(deploy),
+			})
+			require.NoError(t, err)
+
+			var target corev1.Pod
+			err = fakeClient.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: deploy.Namespace, Name: "old-pod"},
+				&target,
+			)
+			if tt.wantDeleted {
+				assert.True(t, apierrors.IsNotFound(err), "terminal pod should be deleted")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRequeue, result.RequeueAfter > 0)
+		})
+	}
+}
+
+type terminatedPodGCTestCase struct {
+	name                       string
+	phase                      corev1.PodPhase
+	replicas                   int32
+	targetTerminalAge          time.Duration
+	replacementReady           bool
+	replacementReadyAge        time.Duration
+	replacementOtherDeployment bool
+	replacementCount           int
+	noReplacement              bool
+	targetWithoutAppLabels     bool
+	wantDeleted                bool
+	wantRequeue                bool
+}
+
+func terminatedPodGCFixture(
+	now time.Time,
+	values terminatedPodGCTestCase,
+) (*appsv1.Deployment, []client.Object) {
+	appLabels := map[string]string{
+		"workload":                      "test-app",
+		constants.ApplicationNameLabel:  "test-app",
+		constants.ApplicationOwnerLabel: "alice",
+	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-app-alice",
+			Name:      "test-app",
+			UID:       types.UID("deployment-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(values.replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"workload": "test-app"}},
+		},
+	}
+	oldRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       deploy.Namespace,
+			Name:            "test-app-old",
+			UID:             types.UID("old-rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind(deployment))},
+		},
+	}
+
+	replacementOwner := deploy
+	objects := []client.Object{deploy, oldRS}
+	if values.replacementOtherDeployment {
+		replacementOwner = deploy.DeepCopy()
+		replacementOwner.Name = "other-app"
+		replacementOwner.UID = types.UID("other-deployment-uid")
+		objects = append(objects, replacementOwner)
+	}
+	newRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       deploy.Namespace,
+			Name:            "test-app-new",
+			UID:             types.UID("new-rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replacementOwner, appsv1.SchemeGroupVersion.WithKind(deployment))},
+		},
+	}
+
+	// Only the Deployment selector has to match; the controller is not scoped to
+	// application workloads.
+	targetLabels := appLabels
+	if values.targetWithoutAppLabels {
+		targetLabels = map[string]string{"workload": "test-app"}
+	}
+
+	targetFinishedAt := metav1.NewTime(now.Add(-values.targetTerminalAge))
+	target := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         deploy.Namespace,
+			Name:              "old-pod",
+			UID:               types.UID("old-pod-uid"),
+			Labels:            targetLabels,
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(oldRS, appsv1.SchemeGroupVersion.WithKind(replicaSet))},
+		},
+		Status: corev1.PodStatus{
+			Phase: values.phase,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{FinishedAt: targetFinishedAt},
+				},
+			}},
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: targetFinishedAt,
+			}},
+		},
+	}
+
+	readyStatus := corev1.ConditionFalse
+	if values.replacementReady {
+		readyStatus = corev1.ConditionTrue
+	}
+	objects = append(objects, newRS, target)
+
+	replacementCount := values.replacementCount
+	if replacementCount == 0 {
+		replacementCount = 1
+	}
+	if values.noReplacement {
+		replacementCount = 0
+	}
+	for i := 0; i < replacementCount; i++ {
+		name := fmt.Sprintf("new-pod-%d", i)
+		objects = append(objects, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         deploy.Namespace,
+				Name:              name,
+				UID:               types.UID(name + "-uid"),
+				Labels:            appLabels,
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+				OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(newRS, appsv1.SchemeGroupVersion.WithKind(replicaSet))},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:               corev1.PodReady,
+					Status:             readyStatus,
+					LastTransitionTime: metav1.NewTime(now.Add(-values.replacementReadyAge)),
+				}},
+			},
+		})
+	}
+
+	return deploy, objects
+}


### PR DESCRIPTION
## Summary

Olares runs kube-controller-manager with `terminated-pod-gc-threshold=1`, so
Kubernetes' built-in PodGC always keeps the newest terminated pod in the cluster.
That leftover lingers forever and shows up to the user as a broken pod.

This adds a `TerminatedPodGCController` that deletes `Failed`/`Succeeded` pods of
any Deployment in the cluster, but only after the Deployment looks healthy again:
every desired replica must have been `Running`+`Ready` for at least `readyDelay`,
and the pod itself must have been terminal for at least `minPodAge`. A Deployment
scaled to zero needs no ready replicas, so leftovers of a stopped workload are
collected too.

`Unknown` pods are excluded. Their workload may still be running on an
unreachable node, and there is nothing to do anyway: Kubernetes counts an
`Unknown` pod as active, so a ReplicaSet below its active count deletes such a pod
itself, and while a ReplicaSet is satisfied no replacement exists for the
readiness gate to accept.

Pods are reached through the `Pod -> ReplicaSet -> Deployment` ownership chain,
which keeps completed Job pods and bare pods out of scope.

Both delays default to 1 minute and are overridable via `TERMINATED_POD_GC_MIN_AGE`
and `TERMINATED_POD_GC_READY_DELAY`.

## Test plan

- [x] Unit tests (12 cases): both terminal phases, the `Unknown` exclusion, both
      delay gates, single/multi/zero replica paths, pods without application
      labels, and rejection of a replacement owned by a different Deployment.
- [x] Verified on a live Olares cluster with the shipped 1m/1m defaults: terminal
      pod collected ~65s after becoming terminal, confirmed by the controller's
      own log line and confirmed *not* to be PodGC.
- [x] Deployment with no application labels — collected.
- [x] Multi-replica Deployment (`replicas=2`, both ready) — collected.
- [x] Stopped Deployment (`replicas=0`, no running pods) — collected.
- [x] Safety check: `replicas=1` whose replica never becomes ready (failing
      readiness probe) — pod retained for 120s, confirming the gate blocks
      collection while a workload is broken.
- [x] No app-service restarts, panics or reconcile errors, and no unintended pod
      deletions cluster-wide.

Made with [Cursor](https://cursor.com)