### PR TITLE
fix(cli): repair gpu enable/disable/uninstall for multi-accelerator nodes

### DIFF
--- a/cli/pkg/gpu/amdgpu/module.go
+++ b/cli/pkg/gpu/amdgpu/module.go
@@ -6,7 +6,30 @@ import (
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/prepare"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/gpu"
 )
+
+// LabelNodeModule only (re-)applies the AMD mode label, without touching the
+// device plugin or ROCm. `gpu enable` uses it to restore the label that
+// `gpu disable` wiped; the action is a no-op without a Ryzen AI Max APU or ROCm.
+type LabelNodeModule struct {
+	common.KubeModule
+}
+
+func (m *LabelNodeModule) Init() {
+	m.Name = "LabelAMDGPUNode"
+
+	labelNode := &task.LocalTask{
+		Name:    "UpdateNodeAMDInfo",
+		Prepare: new(gpu.CurrentNodeInK8s),
+		Action:  new(UpdateNodeAMDInfo),
+		Retry:   1,
+	}
+
+	m.Tasks = []task.Interface{
+		labelNode,
+	}
+}
 
 // InstallAmdContainerToolkitModule installs AMD container toolkit on supported Ubuntu if ROCm is installed.
 type InstallAmdContainerToolkitModule struct {

--- a/cli/pkg/gpu/intelgpu/module.go
+++ b/cli/pkg/gpu/intelgpu/module.go
@@ -5,7 +5,30 @@ import (
 
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/gpu"
 )
+
+// LabelNodeModule only (re-)applies the Intel mode labels, without touching the
+// device plugin or the host drivers. `gpu enable` uses it to restore the labels
+// that `gpu disable` wiped; the action is a no-op on nodes without an Intel GPU.
+type LabelNodeModule struct {
+	common.KubeModule
+}
+
+func (m *LabelNodeModule) Init() {
+	m.Name = "LabelIntelGPUNode"
+
+	labelNode := &task.LocalTask{
+		Name:    "LabelIntelGPUs",
+		Prepare: new(gpu.CurrentNodeInK8s),
+		Action:  new(LabelIntelGPUs),
+		Retry:   1,
+	}
+
+	m.Tasks = []task.Interface{
+		labelNode,
+	}
+}
 
 // InstallIntelPluginModule advertises Intel integrated-GPU support on the node.
 // There is no device plugin to install in this version (Intel iGPUs use unified

--- a/cli/pkg/gpu/module.go
+++ b/cli/pkg/gpu/module.go
@@ -282,6 +282,48 @@ func (l *NodeUnlabelingModule) Init() {
 	}
 }
 
+// NvidiaNodeUnlabelingModule clears only the NVIDIA-owned node labels. It is
+// used by the driver uninstall path, where other accelerators on the same node
+// (e.g. an Intel iGPU) are unaffected and must keep advertising their modes.
+// The full wipe lives in NodeUnlabelingModule, used by `gpu disable`.
+type NvidiaNodeUnlabelingModule struct {
+	common.KubeModule
+}
+
+func (l *NvidiaNodeUnlabelingModule) Init() {
+	l.Name = "NvidiaNodeUnlabeling"
+
+	removeNode := &task.RemoteTask{
+		Name:  "RemoveNvidiaNodeLabels",
+		Hosts: l.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+			new(CurrentNodeInK8s),
+		},
+		Action:   new(RemoveNvidiaNodeLabels),
+		Parallel: false,
+		Retry:    1,
+	}
+
+	restartPlugin := &task.RemoteTask{
+		Name:  "RestartPlugin",
+		Hosts: l.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+			new(CurrentNodeInK8s),
+			new(GpuDevicePluginInstalled),
+		},
+		Action:   new(RestartPlugin),
+		Parallel: false,
+		Retry:    1,
+	}
+
+	l.Tasks = []task.Interface{
+		removeNode,
+		restartPlugin,
+	}
+}
+
 type UninstallCudaModule struct {
 	common.KubeModule
 }

--- a/cli/pkg/gpu/mtgpu/module.go
+++ b/cli/pkg/gpu/mtgpu/module.go
@@ -3,7 +3,30 @@ package mtgpu
 import (
 	"github.com/beclab/Olares/cli/pkg/common"
 	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/gpu"
 )
+
+// LabelNodeModule only (re-)applies the Moore Threads mode label. `gpu enable`
+// uses it to restore the label that `gpu disable` wiped; the action is a no-op
+// on nodes without an MThreads AI Book M1000.
+type LabelNodeModule struct {
+	common.KubeModule
+}
+
+func (m *LabelNodeModule) Init() {
+	m.Name = "LabelMThreadsGPUNode"
+
+	labelNode := &task.LocalTask{
+		Name:    "UpdateNodeMThreadsGPUInfo",
+		Prepare: new(gpu.CurrentNodeInK8s),
+		Action:  new(UpdateNodeMThreadsGPUInfo),
+		Retry:   1,
+	}
+
+	m.Tasks = []task.Interface{
+		labelNode,
+	}
+}
 
 // InstallMThreadsPluginModule installs MThreads GPU device plugin on Kubernetes.
 type InstallMThreadsPluginModule struct {

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -24,9 +24,6 @@ import (
 	k3sGpuTemplates "github.com/beclab/Olares/cli/pkg/gpu/templates"
 	"github.com/beclab/Olares/cli/pkg/manifest"
 	"github.com/beclab/Olares/cli/pkg/utils"
-	criconfig "github.com/containerd/containerd/pkg/cri/config"
-	cdsrvconfig "github.com/containerd/containerd/services/server/config"
-	"github.com/pelletier/go-toml"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +33,12 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// nvidiaContainerdDropIn is where nvidia-ctk writes the nvidia runtime settings.
+// Keeping them out of config.toml leaves the Olares-managed registry config
+// untouched; the path is pinned explicitly on both the write and the remove side
+// so the two stay in sync.
+const nvidiaContainerdDropIn = "/etc/containerd/conf.d/99-nvidia.toml"
 
 type CheckWslGPU struct {
 }
@@ -283,7 +286,8 @@ func (t *ConfigureContainerdRuntime) Execute(runtime connector.Runtime) error {
 	// keeps the Olares-managed registry config (config_path/certs.d) untouched, so
 	// docker.io mirrors survive an `nvidia-ctk runtime configure`. The drop-in path
 	// is set explicitly to avoid the nvidia-ctk <=1.18.0 conf.d/config.d bug.
-	if _, err := runtime.GetRunner().SudoCmd("nvidia-ctk runtime configure --runtime=containerd --set-as-default --config-source=file --drop-in-config=/etc/containerd/conf.d/99-nvidia.toml", false, true); err != nil {
+	cmd := fmt.Sprintf("nvidia-ctk runtime configure --runtime=containerd --set-as-default --config-source=file --drop-in-config=%s", nvidiaContainerdDropIn)
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to nvidia-ctk runtime configure")
 	}
 
@@ -623,55 +627,14 @@ type RemoveContainerRuntimeConfig struct {
 }
 
 func (t *RemoveContainerRuntimeConfig) Execute(runtime connector.Runtime) error {
-	var configFile = "/etc/containerd/config.toml"
-	var nvidiaRuntime = "nvidia"
-	var criPluginUri = "io.containerd.grpc.v1.cri"
-
-	if !util.IsExist(configFile) {
-		logger.Infof("containerd config file not found")
-		return nil
-	}
-
-	config := &cdsrvconfig.Config{}
-	err := cdsrvconfig.LoadConfig(configFile, config)
-	if err != nil {
-		return fmt.Errorf("failed to load containerd config: %w", err)
-	}
-	plugins := config.Plugins[criPluginUri]
-	var criConfig criconfig.PluginConfig
-	if err := plugins.Unmarshal(&criConfig); err != nil {
-		logger.Error("unmarshal cri config error: ", err)
-		return err
-	}
-
-	// found nvidia runtime, remove it
-	if _, ok := criConfig.ContainerdConfig.Runtimes[nvidiaRuntime]; ok {
-		delete(criConfig.ContainerdConfig.Runtimes, nvidiaRuntime)
-		criConfig.DefaultRuntimeName = "runc"
-
-		// save config
-		criConfigData, err := toml.Marshal(criConfig)
-		if err != nil {
-			return fmt.Errorf("failed to marshal containerd cri plugin config: %w", err)
-		}
-
-		criPluginConfigTree, err := toml.LoadBytes(criConfigData)
-		if err != nil {
-			return fmt.Errorf("failed to load containerd cri plugin config: %w", err)
-		}
-
-		config.Plugins[criPluginUri] = *criPluginConfigTree
-
-		// save config to file
-		tmpConfigFile, err := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-		if err != nil {
-			return fmt.Errorf("failed to open minikube containerd config temp file for writing: %w", err)
-		}
-		defer tmpConfigFile.Close()
-		if err := toml.NewEncoder(tmpConfigFile).Encode(config); err != nil {
-			return fmt.Errorf("failed to write minikube containerd config temp file: %w", err)
-		}
-
+	// Deleting the drop-in is the exact inverse of ConfigureContainerdRuntime:
+	// the nvidia runtime lives entirely in that file, and the base config.toml
+	// still declares runc as the default runtime. Editing config.toml the way
+	// this used to is both unnecessary and impossible now — containerd's own
+	// loader caps at config version 2 and resolves `imports`, so it fails on a
+	// current install and took the whole uninstall down with it.
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -f %s", nvidiaContainerdDropIn), false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("failed to remove the nvidia containerd drop-in %s", nvidiaContainerdDropIn))
 	}
 
 	return nil

--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -400,6 +400,22 @@ func (u *RemoveNodeLabels) Execute(runtime connector.Runtime) error {
 	return RemoveAllNodeGpuLabels(context.Background(), client.CtrlRuntime())
 }
 
+// RemoveNvidiaNodeLabels is the uninstall-time counterpart of RemoveNodeLabels:
+// it only clears the NVIDIA-owned labels so other accelerators on the node keep
+// advertising their modes.
+type RemoveNvidiaNodeLabels struct {
+	common.KubeAction
+}
+
+func (u *RemoveNvidiaNodeLabels) Execute(runtime connector.Runtime) error {
+	client, err := clientset.NewKubeClient()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "kubeclient create error")
+	}
+
+	return RemoveNvidiaNodeGpuLabels(context.Background(), client.CtrlRuntime())
+}
+
 // updateCurrentNodeLabels reads the node matching the local hostname, hands its
 // label map to mutate (which returns whether it changed anything) and persists
 // the result as a merge patch carrying only the labels that were touched.
@@ -494,6 +510,23 @@ func SetNodeGpuModeLabel(ctx context.Context, client ctrlclient.Client, mode str
 // existence labels (gpu.bytetrade.io/<mode>), and the legacy
 // gpu.bytetrade.io/type label.
 func RemoveAllNodeGpuLabels(ctx context.Context, client ctrlclient.Client) error {
+	return removeNodeGpuLabels(ctx, client, AllGpuModeTypes)
+}
+
+// RemoveNvidiaNodeGpuLabels strips only the labels that the NVIDIA driver stack
+// owns: the nvidia per-mode existence labels, the driver / cuda /
+// cuda-supported labels and the legacy gpu.bytetrade.io/type label (which only
+// ever held nvidia values). Per-mode labels of other accelerators on the same
+// node are preserved, so uninstalling the NVIDIA driver on a machine that also
+// has an Intel iGPU doesn't silently drop its intel mode.
+func RemoveNvidiaNodeGpuLabels(ctx context.Context, client ctrlclient.Client) error {
+	return removeNodeGpuLabels(ctx, client, NvidiaGpuModeTypes)
+}
+
+// removeNodeGpuLabels deletes the per-mode existence labels for modes plus the
+// driver / cuda / cuda-supported and legacy type labels, which are all written
+// by the nvidia path and therefore never outlive it.
+func removeNodeGpuLabels(ctx context.Context, client ctrlclient.Client, modes []string) error {
 	return updateCurrentNodeLabels(ctx, client, func(labels map[string]string) bool {
 		update := false
 		del := func(key string) {
@@ -506,7 +539,7 @@ func RemoveAllNodeGpuLabels(ctx context.Context, client ctrlclient.Client) error
 		del(GpuCudaLabel)
 		del(GpuCudaSupportedLabel)
 		del(GpuType)
-		for _, mode := range AllGpuModeTypes {
+		for _, mode := range modes {
 			del(GpuModeLabel(mode))
 		}
 		return update

--- a/cli/pkg/gpu/tasks_test.go
+++ b/cli/pkg/gpu/tasks_test.go
@@ -1,0 +1,142 @@
+package gpu
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newFakeNodeClient builds a client holding a single node named after the local
+// hostname, since that is the node updateCurrentNodeLabels resolves and patches.
+func newFakeNodeClient(t *testing.T, labels map[string]string) ctrlclient.Client {
+	t.Helper()
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("get hostname: %v", err)
+	}
+
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   hostname,
+			Labels: labels,
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(node).Build()
+}
+
+func nodeLabels(t *testing.T, client ctrlclient.Client) map[string]string {
+	t.Helper()
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("get hostname: %v", err)
+	}
+
+	var node corev1.Node
+	if err := client.Get(context.Background(), ctrlclient.ObjectKey{Name: hostname}, &node); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	return node.GetLabels()
+}
+
+// mixedAcceleratorLabels mimics a node with both an NVIDIA discrete card and an
+// Intel iGPU, plus a stale legacy type label and an unrelated label.
+func mixedAcceleratorLabels() map[string]string {
+	return map[string]string{
+		GpuModeLabel(NvidiaCardType): "true",
+		GpuModeLabel(IntelType):      "true",
+		GpuModeLabel(AMDType):        "true",
+		GpuDriverLabel:               "595.84",
+		GpuCudaLabel:                 "13.2",
+		GpuCudaSupportedLabel:        "true",
+		GpuType:                      NvidiaCardType,
+		"kubernetes.io/arch":         "amd64",
+	}
+}
+
+func TestRemoveAllNodeGpuLabels(t *testing.T) {
+	client := newFakeNodeClient(t, mixedAcceleratorLabels())
+
+	if err := RemoveAllNodeGpuLabels(context.Background(), client); err != nil {
+		t.Fatalf("RemoveAllNodeGpuLabels: %v", err)
+	}
+
+	labels := nodeLabels(t, client)
+	for _, key := range []string{
+		GpuModeLabel(NvidiaCardType),
+		GpuModeLabel(IntelType),
+		GpuModeLabel(AMDType),
+		GpuDriverLabel,
+		GpuCudaLabel,
+		GpuCudaSupportedLabel,
+		GpuType,
+	} {
+		if _, ok := labels[key]; ok {
+			t.Errorf("label %s should have been removed", key)
+		}
+	}
+	if labels["kubernetes.io/arch"] != "amd64" {
+		t.Error("unrelated labels should be preserved")
+	}
+}
+
+func TestRemoveNvidiaNodeGpuLabelsKeepsOtherAccelerators(t *testing.T) {
+	client := newFakeNodeClient(t, mixedAcceleratorLabels())
+
+	if err := RemoveNvidiaNodeGpuLabels(context.Background(), client); err != nil {
+		t.Fatalf("RemoveNvidiaNodeGpuLabels: %v", err)
+	}
+
+	labels := nodeLabels(t, client)
+	for _, key := range []string{
+		GpuModeLabel(NvidiaCardType),
+		GpuModeLabel(GB10ChipType),
+		GpuDriverLabel,
+		GpuCudaLabel,
+		GpuCudaSupportedLabel,
+		GpuType,
+	} {
+		if _, ok := labels[key]; ok {
+			t.Errorf("nvidia-owned label %s should have been removed", key)
+		}
+	}
+	for _, key := range []string{
+		GpuModeLabel(IntelType),
+		GpuModeLabel(AMDType),
+	} {
+		if labels[key] != "true" {
+			t.Errorf("label %s of a non-nvidia accelerator should have been preserved", key)
+		}
+	}
+	if labels["kubernetes.io/arch"] != "amd64" {
+		t.Error("unrelated labels should be preserved")
+	}
+}
+
+// NvidiaGpuModeTypes must stay a subset of AllGpuModeTypes, otherwise the
+// uninstall path would leave an nvidia mode label behind.
+func TestNvidiaGpuModeTypesIsSubsetOfAllGpuModeTypes(t *testing.T) {
+	all := make(map[string]struct{}, len(AllGpuModeTypes))
+	for _, mode := range AllGpuModeTypes {
+		all[mode] = struct{}{}
+	}
+	for _, mode := range NvidiaGpuModeTypes {
+		if _, ok := all[mode]; !ok {
+			t.Errorf("nvidia mode %s is missing from AllGpuModeTypes", mode)
+		}
+	}
+}

--- a/cli/pkg/gpu/types.go
+++ b/cli/pkg/gpu/types.go
@@ -43,6 +43,15 @@ var AllGpuModeTypes = []string{
 	MooreSocType,
 }
 
+// NvidiaGpuModeTypes is the subset of AllGpuModeTypes backed by the NVIDIA
+// driver stack. Uninstalling that stack only invalidates these modes, so the
+// uninstall path strips them alone and leaves the labels of other accelerators
+// on the same node (e.g. an Intel iGPU) intact.
+var NvidiaGpuModeTypes = []string{
+	NvidiaCardType,
+	GB10ChipType,
+}
+
 // GpuModeLabel returns the existence-based per-mode node label key for a mode,
 // e.g. GpuModeLabel(NvidiaCardType) == "gpu.bytetrade.io/nvidia". A node
 // supports the mode iff it carries this label (value is "true"); a node may

--- a/cli/pkg/pipelines/gpu_enable.go
+++ b/cli/pkg/pipelines/gpu_enable.go
@@ -7,6 +7,9 @@ import (
 	"github.com/beclab/Olares/cli/pkg/core/module"
 	"github.com/beclab/Olares/cli/pkg/core/pipeline"
 	"github.com/beclab/Olares/cli/pkg/gpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/amdgpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/intelgpu"
+	"github.com/beclab/Olares/cli/pkg/gpu/mtgpu"
 )
 
 func EnableGpuNode() error {
@@ -19,10 +22,17 @@ func EnableGpuNode() error {
 		return err
 	}
 
+	// DisableGpuNode wipes the per-mode labels of every accelerator, so enabling
+	// has to relabel all of them to be its inverse. Each vendor module is
+	// idempotent and no-ops when its hardware isn't present, so this is also what
+	// makes `gpu enable` meaningful on a machine with no NVIDIA card at all.
 	p := &pipeline.Pipeline{
 		Name: "EnableGpuNode",
 		Modules: []module.Module{
 			&gpu.NodeLabelingModule{},
+			&intelgpu.LabelNodeModule{},
+			&amdgpu.LabelNodeModule{},
+			&mtgpu.LabelNodeModule{},
 		},
 		Runtime: runtime,
 	}

--- a/cli/pkg/pipelines/gpu_uninstall.go
+++ b/cli/pkg/pipelines/gpu_uninstall.go
@@ -33,7 +33,7 @@ func UninstallGpuDrivers() error {
 		Name:    "UninstallGpuDrivers",
 		Runtime: runtime,
 		Modules: []module.Module{
-			&gpu.NodeUnlabelingModule{},
+			&gpu.NvidiaNodeUnlabelingModule{},
 			&gpu.UninstallCudaModule{},
 			&gpu.RestartContainerdModule{},
 		},


### PR DESCRIPTION
## Problem

Two independent bugs, both hit on a node that has more than one accelerator (e.g. an NVIDIA card next to an Intel iGPU).

**1. `gpu enable` and `gpu disable` are no longer inverses.** Since #3394 replaced the single-value `gpu.bytetrade.io/type` label with per-mode existence labels, `disable` strips the mode label of *every* accelerator while `enable` only relabels NVIDIA (and is gated on CUDA being installed). So one `disable` + `enable` round trip permanently loses the `intel` / `amd` / `moore-soc` label, and only a reinstall brings it back. app-service reads those labels to decide which modes a node supports, so apps requiring that mode become unschedulable. On a machine with no NVIDIA card, `gpu enable` is also a silent no-op.

`gpu uninstall` reuses the same full wipe, so removing the NVIDIA driver drops the labels of a co-installed accelerator too.

**2. `gpu uninstall` always fails at `RemoveRuntime`.** It parses `/etc/containerd/config.toml` with containerd's own config loader, which caps at config version 2 and resolves `imports`, while a current install has a version 3 `config.toml` importing the version 3 nvidia drop-in written by `nvidia-ctk`. The pipeline aborts before `RestartContainerd`, leaving the driver uninstalled but nvidia still configured as containerd's default runtime:

```
[Module] UninstallCuda
  UninstallCuda   success
  RemoveRuntime   failed
    failed to load containerd config: failed to load TOML from
    /etc/containerd/conf.d/99-nvidia.toml: unsupported config version `3`
```

## Changes

- `gpu enable` now relabels all vendors, making it the exact inverse of `disable`. Added a label-only `LabelNodeModule` to `intelgpu` / `amdgpu` / `mtgpu`, composed at the pipeline level since `pkg/gpu` can't import them. Each action is idempotent and no-ops without the matching hardware.
- Added `RemoveNvidiaNodeGpuLabels` / `NvidiaNodeUnlabelingModule` and switched `gpu uninstall` to it, so only NVIDIA-owned labels are removed. `gpu disable` keeps its full wipe.
- Removing the nvidia containerd runtime is now just deleting the drop-in that `ConfigureContainerdRuntime` writes — the base `config.toml` already declares `runc` as the default runtime, so there is nothing to rewrite. The path is pinned in one constant used by both sides. This drops the `criconfig`, `cdsrvconfig` and `go-toml` imports and is a net −37 lines.
- Added unit tests for both label removal scopes.

No device-plugin restart changes are needed: only `hami-device-plugin` and `gpu-scheduler` select on `gpu.bytetrade.io/cuda-supported`, and the DaemonSet controller reacts to label changes on its own. `intel-gpu-plugin` selects on an NFD label, the AMD plugin only on arch, and Moore Threads has no plugin.

## Test plan

Verified on a node with both an Intel Arrow Lake iGPU and an NVIDIA RTX 5090 (driver 595.84 / CUDA 13.2).

- [x] Reproduced with the current release binary: `disable` → `enable` loses `gpu.bytetrade.io/intel` for good
- [x] With the fix, a full `disable` → `enable` round trip restores every label (diff against baseline empty) and `nvidia.com/gpu` returns from 0 to 30
- [x] Full `gpu uninstall` → `gpu install` cycle: uninstall now runs through `RestartContainerd`, keeps `gpu.bytetrade.io/intel`, deletes the drop-in and falls back to the `runc` default runtime without touching `config.toml`; the reinstall restores the exact baseline
- [x] `intel-gpu-plugin` never restarted throughout (`gpu.intel.com/i915` steady at 50); AMD and Moore Threads modules correctly no-op
- [x] `go build ./...`, `go vet`, `gofmt`, `go test ./pkg/gpu/...` all pass

Made with [Cursor](https://cursor.com)