### PR TITLE
feat(cli): close download-server gaps and clarify knowledge download help

### DIFF
--- a/cli/cmd/ctl/download/batch_test.go
+++ b/cli/cmd/ctl/download/batch_test.go
@@ -73,4 +73,16 @@ func TestRenderBatchResult(t *testing.T) {
 	if !strings.Contains(buf.String(), "1 succeeded, 0 failed") {
 		t.Fatalf("got %q", buf.String())
 	}
+
+	buf.Reset()
+	err = renderBatchResult(&buf, FormatJSON, "pause", BatchResult{
+		Succeeded: []int64{1},
+		Failed:    []BatchItemError{{TaskID: 2, Error: "gone"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "1 of 2") {
+		t.Fatalf("json partial failure should exit non-zero, got %v", err)
+	}
+	if !strings.Contains(buf.String(), `"task_id": 2`) && !strings.Contains(buf.String(), `"task_id":2`) {
+		t.Fatalf("json payload missing failed entry: %q", buf.String())
+	}
 }

--- a/cli/cmd/ctl/download/batch_test.go
+++ b/cli/cmd/ctl/download/batch_test.go
@@ -1,0 +1,76 @@
+package download
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseTaskIDs(t *testing.T) {
+	ids, err := parseTaskIDs([]string{"1", "2", "2", "3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("got %v", ids)
+	}
+	if _, err := parseTaskIDs(nil); err == nil {
+		t.Fatal("expected empty error")
+	}
+	if _, err := parseTaskIDs([]string{"0"}); err == nil {
+		t.Fatal("expected invalid id")
+	}
+	tooMany := make([]string, batchMaxTasks+1)
+	for i := range tooMany {
+		tooMany[i] = "1"
+	}
+	if _, err := parseTaskIDs(tooMany); err == nil || !strings.Contains(err.Error(), "too many") {
+		t.Fatalf("expected too many, got %v", err)
+	}
+}
+
+func TestValidateHFDest(t *testing.T) {
+	for _, raw := range []string{"", "cache", "CACHE", " local "} {
+		if _, err := validateHFDest(raw); err != nil {
+			t.Fatalf("%q: %v", raw, err)
+		}
+	}
+	if _, err := validateHFDest("disk"); err == nil || !strings.Contains(err.Error(), "unsupported --hf-dest") {
+		t.Fatalf("expected unsupported, got %v", err)
+	}
+}
+
+func TestInspectHFTokenHint(t *testing.T) {
+	if got := inspectHFTokenHint(InspectData{ErrorCategory: "gated"}); got == "" || !strings.Contains(got, `--extra '{"token":"hf_xxx"}'`) {
+		t.Fatalf("gated hint: %q", got)
+	}
+	if got := inspectHFTokenHint(InspectData{ErrorCategory: "PRIVATE"}); !strings.Contains(got, "token") {
+		t.Fatalf("private hint: %q", got)
+	}
+	if got := inspectHFTokenHint(InspectData{ErrorCategory: "timeout"}); got != "" {
+		t.Fatalf("unexpected hint: %q", got)
+	}
+}
+
+func TestRenderBatchResult(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderBatchResult(&buf, FormatTable, "pause", BatchResult{
+		Succeeded: []int64{1, 2},
+		Failed:    []BatchItemError{{TaskID: 3, Error: "not found"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "1 of 3") {
+		t.Fatalf("expected partial failure, got %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 succeeded, 1 failed") || !strings.Contains(out, "3: not found") {
+		t.Fatalf("table output: %q", out)
+	}
+
+	buf.Reset()
+	if err := renderBatchResult(&buf, FormatTable, "pause", BatchResult{Succeeded: []int64{1}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "1 succeeded, 0 failed") {
+		t.Fatalf("got %q", buf.String())
+	}
+}

--- a/cli/cmd/ctl/download/common.go
+++ b/cli/cmd/ctl/download/common.go
@@ -216,7 +216,10 @@ type dsEnvelope struct {
 	List    json.RawMessage `json:"list"`
 	Total   *int64          `json:"total"`
 	HasMore *bool           `json:"has_more"`
-	Exist   *bool           `json:"exist"`
+	// Batch lifecycle responses carry succeeded/failed at the top level
+	// (alongside code), not under data — see BatchResult.
+	Succeeded json.RawMessage `json:"succeeded"`
+	Failed    json.RawMessage `json:"failed"`
 }
 
 func doGet(ctx context.Context, d Doer, path string, out interface{}) error {
@@ -271,9 +274,16 @@ func doMutate(ctx context.Context, d Doer, method, path string, body, out interf
 		}
 		return nil
 	}
-	if fc, ok := out.(*FileCheckResult); ok {
-		if env.Exist != nil {
-			fc.Exist = *env.Exist
+	if br, ok := out.(*BatchResult); ok {
+		if len(env.Succeeded) > 0 {
+			if err := json.Unmarshal(env.Succeeded, &br.Succeeded); err != nil {
+				return fmt.Errorf("%s %s: decode succeeded: %w", method, path, err)
+			}
+		}
+		if len(env.Failed) > 0 {
+			if err := json.Unmarshal(env.Failed, &br.Failed); err != nil {
+				return fmt.Errorf("%s %s: decode failed: %w", method, path, err)
+			}
 		}
 		return nil
 	}
@@ -325,8 +335,6 @@ func taskErrorRecovery(method, path string, status int, message string, body int
 		return "; " + ytdlpUnavailableHint()
 	case strings.Contains(path, "/api/url/inspect") && shouldHintInspectTimeout(message):
 		return "; channel/RSS probes can exceed the server inspect timeout; retry later or create the task directly if the URL is known good"
-	case strings.Contains(path, "/api/download/file_check") && status == 404:
-		return "; confirm the path with `olares-cli files ls` or `olares-cli knowledge download list`"
 	case taskID != "" && status == 409:
 		return fmt.Sprintf(
 			"; wait for the move to finish, then retry; inspect progress with `olares-cli knowledge download info %s`",

--- a/cli/cmd/ctl/download/common.go
+++ b/cli/cmd/ctl/download/common.go
@@ -24,6 +24,9 @@ import (
 const (
 	minOlaresVersion = "1.12.7"
 	defaultApp       = "wise"
+	// allowedApps is the --app whitelist (kept in sync with validateApp).
+	// Default remains wise; larepass is the TermiPass / LarePass namespace.
+	allowedApps = "wise, larepass"
 	// ytdlpQualityValues is the server-accepted --quality enum
 	// (download-server services.IsValidYtdlpQuality). Kept here so the
 	// --help text stays in sync with what the backend validates.
@@ -34,6 +37,12 @@ const (
 	// itself applies no default (empty task.Path lands at the PVC root),
 	// so the CLI seeds this to match what wise users see.
 	defaultDownloadPath = "drive/Home/Downloads/"
+	// ytdlpMarketInstall is the next-step CTA when the yt-dlp provider
+	// is unreachable (often not installed). Chart name matches the
+	// Market listing / shared service namespace ytdlpv3-shared.
+	ytdlpMarketInstall = "olares-cli market install ytdlpv3"
+	// syncLimitMax matches the download-server sync page-size cap.
+	syncLimitMax = 100
 )
 
 var taskActionPathRE = regexp.MustCompile(`^/api/download/(?:pause|resume|cancel|info)/(\d+)(?:/|$)`)
@@ -62,7 +71,97 @@ func addOutputFlag(cmd *cobra.Command, target *string) {
 }
 
 func addAppFlag(cmd *cobra.Command, target *string) {
-	cmd.Flags().StringVar(target, "app", defaultApp, "app namespace for the download task (default: wise)")
+	cmd.Flags().StringVar(target, "app", defaultApp, "app namespace for the download task (one of: "+allowedApps+"; default: wise)")
+}
+
+// validateApp trims --app, defaults empty to wise, and rejects values
+// outside the whitelist. Returns the normalised app name.
+func validateApp(raw string) (string, error) {
+	app := strings.TrimSpace(raw)
+	if app == "" {
+		return defaultApp, nil
+	}
+	switch app {
+	case "wise", "larepass":
+		return app, nil
+	default:
+		return "", fmt.Errorf("unsupported --app %q (allowed: %s)", raw, allowedApps)
+	}
+}
+
+// validateNonNegativeFlag rejects negative paging / size flags. Zero
+// means "server default" and stays valid.
+func validateNonNegativeFlag(name string, v int) error {
+	if v < 0 {
+		return fmt.Errorf("unsupported %s %d (need >= 0; 0 = server default)", name, v)
+	}
+	return nil
+}
+
+// validateLimit rejects negative sync --limit and enforces the server
+// max of 100. Zero means "server default".
+func validateLimit(limit int) error {
+	if limit < 0 {
+		return fmt.Errorf("unsupported --limit %d (need >= 0; 0 = server default, max %d)", limit, syncLimitMax)
+	}
+	if limit > syncLimitMax {
+		return fmt.Errorf("unsupported --limit %d (max %d)", limit, syncLimitMax)
+	}
+	return nil
+}
+
+// validateSinceID rejects a negative --since-id. Zero is omitted from
+// the query (full drain / no tie-breaker).
+func validateSinceID(id int64) error {
+	if id < 0 {
+		return fmt.Errorf("unsupported --since-id %d (need >= 0)", id)
+	}
+	return nil
+}
+
+// validateDrivePath requires drive/Home/ or drive/Data/ (case-sensitive),
+// matching the create --path contract used by download-server.
+func validateDrivePath(raw string) error {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return fmt.Errorf("--path is required")
+	}
+	if strings.HasPrefix(path, "drive/Home/") || strings.HasPrefix(path, "drive/Data/") {
+		return nil
+	}
+	return fmt.Errorf("unsupported --path %q (need a path starting with drive/Home/ or drive/Data/)", raw)
+}
+
+// ytdlpUnavailableHint is printed when inspect reports Available=false
+// (or create fails because the yt-dlp daemon is unreachable).
+func ytdlpUnavailableHint() string {
+	return "yt-dlp is not available; install it with `" + ytdlpMarketInstall + "`"
+}
+
+// shouldHintYTDLPUnavailable reports whether a server message points at
+// a missing / unreachable yt-dlp provider.
+func shouldHintYTDLPUnavailable(message string) bool {
+	lower := strings.ToLower(message)
+	if !(strings.Contains(lower, "yt-dlp") || strings.Contains(lower, "ytdlp")) {
+		return false
+	}
+	return strings.Contains(lower, "unavailable") ||
+		strings.Contains(lower, "unreachable") ||
+		strings.Contains(lower, "not available") ||
+		strings.Contains(lower, "not installed") ||
+		strings.Contains(lower, "missing") ||
+		strings.Contains(lower, "no such") ||
+		strings.Contains(lower, "connection refused") ||
+		strings.Contains(lower, "dial")
+}
+
+// shouldHintInspectTimeout reports whether an inspect failure looks like
+// the server's short probe deadline (channel / RSS URLs).
+func shouldHintInspectTimeout(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "timeout") ||
+		strings.Contains(lower, "deadline exceeded") ||
+		strings.Contains(lower, "timed out")
 }
 
 // Doer is the JSON transport used by download verbs (whoami.HTTPClient).
@@ -218,9 +317,16 @@ func taskErrorRecovery(method, path string, status int, message string, body int
 	}
 	switch {
 	case method == "POST" && path == "/api/download" && status == 409 &&
-		strings.Contains(lowerMsg, "task") &&
-		(strings.Contains(lowerMsg, "already") || strings.Contains(lowerMsg, "exist")):
+		(strings.Contains(lowerMsg, "already") ||
+			strings.Contains(lowerMsg, "exist") ||
+			strings.Contains(lowerMsg, "registered")):
 		return "; inspect existing tasks with `olares-cli knowledge download list`"
+	case method == "POST" && path == "/api/download" && shouldHintYTDLPUnavailable(message):
+		return "; " + ytdlpUnavailableHint()
+	case strings.Contains(path, "/api/url/inspect") && shouldHintInspectTimeout(message):
+		return "; channel/RSS probes can exceed the server inspect timeout; retry later or create the task directly if the URL is known good"
+	case strings.Contains(path, "/api/download/file_check") && status == 404:
+		return "; confirm the path with `olares-cli files ls` or `olares-cli knowledge download list`"
 	case taskID != "" && status == 409:
 		return fmt.Sprintf(
 			"; wait for the move to finish, then retry; inspect progress with `olares-cli knowledge download info %s`",

--- a/cli/cmd/ctl/download/common_test.go
+++ b/cli/cmd/ctl/download/common_test.go
@@ -161,17 +161,6 @@ func TestDoMutateAddsRecoveryForKnownTaskErrors(t *testing.T) {
 		t.Fatalf("task 404 should refresh IDs, got %v", err)
 	}
 
-	d = &fakeDoer{resp: []byte(`{"code":404,"message":"file not found"}`)}
-	err = doGet(context.Background(), d, "/api/download/file_check/none", nil)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	for _, want := range []string{"confirm the path", "olares-cli files ls", "olares-cli knowledge download list"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("file_check 404 %q missing %q", err, want)
-		}
-	}
-
 	d = &fakeDoer{resp: []byte(`{"code":409,"message":"GID xxxx isalready registered"}`)}
 	err = doMutate(context.Background(), d, "POST", "/api/download", nil, nil)
 	if err == nil {
@@ -301,14 +290,17 @@ func TestDoMutateTransportError(t *testing.T) {
 	}
 }
 
-func TestDoMutateFileCheckEnvelope(t *testing.T) {
-	d := &fakeDoer{resp: []byte(`{"code":200,"exist":true}`)}
-	var res FileCheckResult
-	if err := doGet(context.Background(), d, "/api/download/file_check/none?user=alice&path=drive/Home/x", &res); err != nil {
+func TestDoMutateBatchEnvelope(t *testing.T) {
+	d := &fakeDoer{resp: []byte(`{"code":200,"succeeded":[1,2],"failed":[{"task_id":3,"error":"not found"}]}`)}
+	var res BatchResult
+	if err := doMutate(context.Background(), d, "PUT", "/api/download/batch/pause", BatchReq{TaskIDs: []int64{1, 2, 3}}, &res); err != nil {
 		t.Fatal(err)
 	}
-	if !res.Exist {
-		t.Fatalf("expected Exist=true, got %+v", res)
+	if len(res.Succeeded) != 2 || res.Succeeded[0] != 1 || res.Succeeded[1] != 2 {
+		t.Fatalf("succeeded: %+v", res.Succeeded)
+	}
+	if len(res.Failed) != 1 || res.Failed[0].TaskID != 3 || res.Failed[0].Error != "not found" {
+		t.Fatalf("failed: %+v", res.Failed)
 	}
 }
 

--- a/cli/cmd/ctl/download/common_test.go
+++ b/cli/cmd/ctl/download/common_test.go
@@ -166,8 +166,43 @@ func TestDoMutateAddsRecoveryForKnownTaskErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if strings.Contains(err.Error(), "knowledge download list") {
-		t.Fatalf("non-task 404 received task recovery: %q", err)
+	for _, want := range []string{"confirm the path", "olares-cli files ls", "olares-cli knowledge download list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("file_check 404 %q missing %q", err, want)
+		}
+	}
+
+	d = &fakeDoer{resp: []byte(`{"code":409,"message":"GID xxxx isalready registered"}`)}
+	err = doMutate(context.Background(), d, "POST", "/api/download", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"isalready registered", "olares-cli knowledge download list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("duplicate torrent %q missing %q", err, want)
+		}
+	}
+
+	d = &fakeDoer{resp: []byte(`{"code":500,"message":"yt-dlp unavailable: connection refused"}`)}
+	err = doMutate(context.Background(), d, "POST", "/api/download", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"yt-dlp unavailable", ytdlpMarketInstall} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("yt-dlp create failure %q missing %q", err, want)
+		}
+	}
+
+	d = &fakeDoer{resp: []byte(`{"code":500,"message":"timeout of 3000ms exceeded"}`)}
+	err = doGet(context.Background(), d, "/api/url/inspect?url=https://example.com", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"timeout of 3000ms", "channel/RSS probes", "create the task directly"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("inspect timeout %q missing %q", err, want)
+		}
 	}
 
 	d = &fakeDoer{resp: []byte(`{"code":409,"message":"task is moving to its destination"}`)}
@@ -412,5 +447,109 @@ func TestParseTaskID(t *testing.T) {
 	}
 	if _, err := parseTaskID("x"); err == nil {
 		t.Fatal("expected error for non-int")
+	}
+}
+
+func TestValidateApp(t *testing.T) {
+	for _, valid := range []string{"", "wise", " larepass ", "larepass"} {
+		got, err := validateApp(valid)
+		if err != nil {
+			t.Fatalf("validateApp(%q) unexpected error: %v", valid, err)
+		}
+		switch strings.TrimSpace(valid) {
+		case "", "wise":
+			if got != "wise" {
+				t.Fatalf("validateApp(%q)=%q want wise", valid, got)
+			}
+		default:
+			if got != "larepass" {
+				t.Fatalf("validateApp(%q)=%q want larepass", valid, got)
+			}
+		}
+	}
+	_, err := validateApp("namespace")
+	if err == nil {
+		t.Fatal("unknown app should fail")
+	}
+	for _, want := range []string{"unsupported --app", allowedApps} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateApp error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestValidateNonNegativeFlag(t *testing.T) {
+	if err := validateNonNegativeFlag("--page", 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateNonNegativeFlag("--page", 2); err != nil {
+		t.Fatal(err)
+	}
+	err := validateNonNegativeFlag("--page", -1)
+	if err == nil || !strings.Contains(err.Error(), "unsupported --page") {
+		t.Fatalf("negative page should fail, got %v", err)
+	}
+}
+
+func TestValidateLimit(t *testing.T) {
+	if err := validateLimit(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLimit(100); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLimit(-1); err == nil || !strings.Contains(err.Error(), "unsupported --limit") {
+		t.Fatalf("negative limit should fail, got %v", err)
+	}
+	if err := validateLimit(101); err == nil || !strings.Contains(err.Error(), "max 100") {
+		t.Fatalf("over-max limit should fail, got %v", err)
+	}
+}
+
+func TestValidateSinceID(t *testing.T) {
+	if err := validateSinceID(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSinceID(-1); err == nil || !strings.Contains(err.Error(), "unsupported --since-id") {
+		t.Fatalf("negative since-id should fail, got %v", err)
+	}
+}
+
+func TestValidateDrivePath(t *testing.T) {
+	for _, valid := range []string{"drive/Home/Downloads/x", "drive/Data/cache/y"} {
+		if err := validateDrivePath(valid); err != nil {
+			t.Fatalf("validateDrivePath(%q): %v", valid, err)
+		}
+	}
+	for _, bad := range []string{"", "Home/Downloads/x", "drive/home/x", "/Files/Home/x"} {
+		if err := validateDrivePath(bad); err == nil {
+			t.Fatalf("validateDrivePath(%q) should fail", bad)
+		}
+	}
+}
+
+func TestInspectYTDLPHint(t *testing.T) {
+	falseVal := false
+	trueVal := true
+	if hint := inspectYTDLPHint(InspectData{Provider: "yt-dlp", Available: &falseVal}); !strings.Contains(hint, ytdlpMarketInstall) {
+		t.Fatalf("Available=false should hint install, got %q", hint)
+	}
+	if hint := inspectYTDLPHint(InspectData{Provider: "aria2", Available: &falseVal}); hint != "" {
+		t.Fatalf("aria2 Available=false should not hint yt-dlp, got %q", hint)
+	}
+	if hint := inspectYTDLPHint(InspectData{Provider: "yt-dlp", Available: &trueVal}); hint != "" {
+		t.Fatalf("Available=true should not hint, got %q", hint)
+	}
+	if hint := inspectYTDLPHint(InspectData{Error: "yt-dlp daemon unreachable"}); !strings.Contains(hint, ytdlpMarketInstall) {
+		t.Fatalf("error text should hint install, got %q", hint)
+	}
+}
+
+func TestShouldHintInspectTimeout(t *testing.T) {
+	if !shouldHintInspectTimeout("timeout of 3000ms exceeded") {
+		t.Fatal("expected timeout hint")
+	}
+	if shouldHintInspectTimeout("bad url") {
+		t.Fatal("non-timeout should not hint")
 	}
 }

--- a/cli/cmd/ctl/download/cookies.go
+++ b/cli/cmd/ctl/download/cookies.go
@@ -110,11 +110,12 @@ func newCookiesSetCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "store or replace the cookie for a domain",
-		Long: `Store or replace a domain's cookie (PUT /api/integration/cookies).
+		Long: `Store or replace a domain's provider cookie.
 
 --cookie-file points to a local Netscape cookies.txt file whose full text
-is uploaded. --provider defaults to the server default (yt-dlp) when unset.`,
-		Args: cobra.NoArgs,
+is uploaded. --provider defaults to yt-dlp when unset.`,
+		Example: `  olares-cli knowledge download cookies set --domain youtube.com --cookie-file ./cookies.txt`,
+		Args:    cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runCookiesSet(c.Context(), f, domain, provider, cookieFile, output)
 		},
@@ -232,11 +233,12 @@ func newCookiesRetrieveCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "retrieve",
 		Short: "test-retrieve the stored cookie for a domain",
-		Long: `Retrieve the stored cookie for a domain
-(POST /api/integration/cookies/retrieve).
+		Long: `Retrieve the stored provider cookie for a domain.
 
 The plaintext cookie is only printed with -o json; the table output shows
 whether a cookie was found and when it was updated.`,
+		Example: `  olares-cli knowledge download cookies retrieve --domain youtube.com
+  olares-cli knowledge download cookies retrieve --domain youtube.com -o json`,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runCookiesRetrieve(c.Context(), f, domain, provider, output)

--- a/cli/cmd/ctl/download/create.go
+++ b/cli/cmd/ctl/download/create.go
@@ -121,22 +121,27 @@ func normalizeSelectFiles(raw string) (csv string, ok bool, err error) {
 	return joinIndicesCSV(sel), true, nil
 }
 
-// readTorrentFile validates a local --torrent path before upload: it must
-// end in .torrent (case-insensitive), exist, and be non-empty. A missing
-// path that looks space-split gets a quote hint for shell users.
-func readTorrentFile(path string) ([]byte, error) {
+// readTorrentFile validates a local torrent path before upload: it must
+// end in .torrent (case-insensitive), exist, and be non-empty. flag is the
+// CLI flag name used in error messages (e.g. "--torrent" or "--file") so
+// create and torrent inspect can share the validator without pointing at
+// the wrong flag. A missing path gets a quote hint for shell users.
+func readTorrentFile(path, flag string) ([]byte, error) {
+	if flag == "" {
+		flag = "--torrent"
+	}
 	if !strings.HasSuffix(strings.ToLower(path), ".torrent") {
-		return nil, fmt.Errorf("unsupported --torrent file %q (need a .torrent file); if the path contains spaces, quote it: --torrent './name with spaces.torrent'", path)
+		return nil, fmt.Errorf("unsupported %s file %q (need a .torrent file); if the path contains spaces, quote it: %s './name with spaces.torrent'", flag, path, flag)
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("read torrent file: %w; if the path contains spaces, quote it: --torrent './name with spaces.torrent'", err)
+			return nil, fmt.Errorf("read torrent file: %w; if the path contains spaces, quote it: %s './name with spaces.torrent'", err, flag)
 		}
 		return nil, fmt.Errorf("read torrent file: %w", err)
 	}
 	if len(raw) == 0 {
-		return nil, fmt.Errorf("unsupported --torrent file %q (file is empty)", path)
+		return nil, fmt.Errorf("unsupported %s file %q (file is empty)", flag, path)
 	}
 	return raw, nil
 }
@@ -184,7 +189,7 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 		extra["format_id"] = fid
 	}
 	if torrentFile != "" {
-		raw, err := readTorrentFile(torrentFile)
+		raw, err := readTorrentFile(torrentFile, "--torrent")
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/ctl/download/create.go
+++ b/cli/cmd/ctl/download/create.go
@@ -127,6 +127,26 @@ func normalizeSelectFiles(raw string) (csv string, ok bool, err error) {
 	return joinIndicesCSV(sel), true, nil
 }
 
+// readTorrentFile validates a local --torrent path before upload: it must
+// end in .torrent (case-insensitive), exist, and be non-empty. A missing
+// path that looks space-split gets a quote hint for shell users.
+func readTorrentFile(path string) ([]byte, error) {
+	if !strings.HasSuffix(strings.ToLower(path), ".torrent") {
+		return nil, fmt.Errorf("unsupported --torrent file %q (need a .torrent file); if the path contains spaces, quote it: --torrent './name with spaces.torrent'", path)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("read torrent file: %w; if the path contains spaces, quote it: --torrent './name with spaces.torrent'", err)
+		}
+		return nil, fmt.Errorf("read torrent file: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("unsupported --torrent file %q (file is empty)", path)
+	}
+	return raw, nil
+}
+
 func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name, quality, formatID, extraRaw, torrentFile, selectFiles, outputRaw string) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -140,9 +160,9 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 	if rawURL == "" && torrentFile == "" {
 		return fmt.Errorf("provide a URL/magnet argument or --torrent <file>")
 	}
-	app = strings.TrimSpace(app)
-	if app == "" {
-		app = defaultApp
+	app, err = validateApp(app)
+	if err != nil {
+		return err
 	}
 
 	extra := map[string]string{}
@@ -170,9 +190,9 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 		extra["format_id"] = fid
 	}
 	if torrentFile != "" {
-		raw, err := os.ReadFile(torrentFile)
+		raw, err := readTorrentFile(torrentFile)
 		if err != nil {
-			return fmt.Errorf("read torrent file: %w", err)
+			return err
 		}
 		extra["torrent_file_b64"] = base64.StdEncoding.EncodeToString(raw)
 	}

--- a/cli/cmd/ctl/download/create.go
+++ b/cli/cmd/ctl/download/create.go
@@ -28,47 +28,41 @@ func NewCreateCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [url]",
 		Short: "create a download task",
-		Long: `Create a download task (POST /api/download).
+		Long: `Create a download task from a URL, magnet link, or local .torrent file.
 
 Quote the URL. A URL with ?, & or = must be wrapped in single quotes,
-otherwise the shell splits it on & and drops the query string:
-  olares-cli knowledge download create 'https://host/v?a=1&b=2'
+otherwise your shell may split it.
 
 Torrent / magnet:
-  A magnet link is passed as an ordinary URL argument:
-    olares-cli knowledge download create 'magnet:?xt=urn:btih:...'
-  A local .torrent file is uploaded with --torrent (base64); the URL
-  argument may be omitted in that case:
-    olares-cli knowledge download create --torrent ./x.torrent --select-files 1,3
---torrent reads a local .torrent file and sends it as extra.torrent_file_b64.
+  A magnet link is passed as the URL argument. For a local .torrent file,
+  use --torrent and omit the URL.
 --select-files takes a comma-separated list of 1-based file indices (as
-reported by "torrent inspect"), normalised into extra.selected_files. Pass
---select-files all (or omit the flag) to download every file. Bad tokens
-(0, negatives, non-integers) are rejected locally, same as
-"torrent files --select".
+reported by "torrent inspect"). Pass --select-files all, or omit the flag,
+to download every file.
 
---quality maps to extra.ytdlp_quality (one of: ` + ytdlpQualityValues + `).
---format-id maps to extra.format_id.
---extra accepts a JSON object of string values merged into extra (wins last).
+--quality accepts: ` + ytdlpQualityValues + `.
+--format-id selects a specific yt-dlp format.
+--extra accepts additional provider options as a JSON object of strings.
 --path must start with drive/Home/ or drive/Data/, e.g.
   --path drive/Home/Pictures/
-The first segment is literally "drive"; the second is "Home" or "Data"
-(case-sensitive). A full API URL also works:
-  --path 'https://files.<user>.olares.cn/api/resources/drive/Home/Pictures/'
-NOT accepted: the browser address like .../Files/Home/... , or a bare
-Home/... without the drive/ prefix (both fail as unsupported file type).
-Defaults to ` + defaultDownloadPath + ` (aligned with wise). Pass --path ""
-to send an empty path (e.g. HuggingFace cache mode) and let the server decide.
+The names "drive", "Home", and "Data" are case-sensitive. Browser URLs and
+bare Home/... paths are not accepted. The default is ` + defaultDownloadPath + `.
+Pass --path "" when the provider should choose the destination.
 
-HuggingFace: the destination is picked by extra._hf_dest, not by --path/--name.
-  local (default when _hf_dest is unset): lands under <path>/<repoID>/. --path
-         applies; --name is unnecessary (the repo id is the folder name).
-  cache: shared HF_HOME (Files UI: /Common/huggingface/). --path and --name are
-         ignored; send --path "" to match wise.
-Set HF options via --extra (keys map to hf CLI flags), e.g.:
-  --extra '{"_hf_dest":"cache"}'
-  --extra '{"_hf_dest":"local","token":"hf_xxx","revision":"v1.0","include":"*.safetensors"}'
-Note wise defaults HF to cache; this CLI defaults to local unless you pass _hf_dest.`,
+For HuggingFace, set _hf_dest in --extra:
+  local (default) downloads under <path>/<repoID>/.
+  cache downloads to the shared HuggingFace cache and ignores --path/--name.`,
+		Example: `  # URL
+  olares-cli knowledge download create 'https://host/v?a=1&b=2'
+
+  # magnet link
+  olares-cli knowledge download create 'magnet:?xt=urn:btih:...'
+
+  # selected files from a local torrent
+  olares-cli knowledge download create --torrent ./x.torrent --select-files 1,3
+
+  # HuggingFace shared cache
+  olares-cli knowledge download create https://huggingface.co/org/repo --path "" --extra '{"_hf_dest":"cache"}'`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			rawURL := ""

--- a/cli/cmd/ctl/download/create_test.go
+++ b/cli/cmd/ctl/download/create_test.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 )
@@ -84,5 +85,59 @@ func TestRunCreateValidatesQualityFromExtra(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "unsupported --quality") {
 		t.Fatalf("invalid quality in --extra should fail locally, got %v", err)
+	}
+}
+
+func TestRunCreateValidatesApp(t *testing.T) {
+	err := runCreate(
+		context.Background(),
+		nil,
+		"https://example.com/video",
+		"namespace",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"table",
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported --app") {
+		t.Fatalf("unknown --app should fail locally, got %v", err)
+	}
+}
+
+func TestReadTorrentFile(t *testing.T) {
+	dir := t.TempDir()
+	good := dir + "/ok.torrent"
+	if err := os.WriteFile(good, []byte("d4:infod4:name1:aee"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readTorrentFile(good); err != nil {
+		t.Fatalf("valid torrent should pass: %v", err)
+	}
+
+	yamlPath := dir + "/test.yaml"
+	if err := os.WriteFile(yamlPath, []byte("a: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := func() error { _, e := readTorrentFile(yamlPath); return e }()
+	if err == nil || !strings.Contains(err.Error(), "need a .torrent file") || !strings.Contains(err.Error(), "quote it") {
+		t.Fatalf("non-torrent should fail with quote hint, got %v", err)
+	}
+
+	empty := dir + "/empty.torrent"
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readTorrentFile(empty); err == nil || !strings.Contains(err.Error(), "file is empty") {
+		t.Fatalf("empty torrent should fail, got %v", err)
+	}
+
+	missing := dir + "/missing with spaces.torrent"
+	_, err = readTorrentFile(missing)
+	if err == nil || !strings.Contains(err.Error(), "quote it") {
+		t.Fatalf("missing torrent should hint quoting, got %v", err)
 	}
 }

--- a/cli/cmd/ctl/download/create_test.go
+++ b/cli/cmd/ctl/download/create_test.go
@@ -114,7 +114,7 @@ func TestReadTorrentFile(t *testing.T) {
 	if err := os.WriteFile(good, []byte("d4:infod4:name1:aee"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readTorrentFile(good); err != nil {
+	if _, err := readTorrentFile(good, "--torrent"); err != nil {
 		t.Fatalf("valid torrent should pass: %v", err)
 	}
 
@@ -122,22 +122,22 @@ func TestReadTorrentFile(t *testing.T) {
 	if err := os.WriteFile(yamlPath, []byte("a: 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := func() error { _, e := readTorrentFile(yamlPath); return e }()
-	if err == nil || !strings.Contains(err.Error(), "need a .torrent file") || !strings.Contains(err.Error(), "quote it") {
-		t.Fatalf("non-torrent should fail with quote hint, got %v", err)
+	err := func() error { _, e := readTorrentFile(yamlPath, "--file"); return e }()
+	if err == nil || !strings.Contains(err.Error(), "need a .torrent file") || !strings.Contains(err.Error(), "--file") || strings.Contains(err.Error(), "--torrent") {
+		t.Fatalf("non-torrent should fail with --file quote hint, got %v", err)
 	}
 
 	empty := dir + "/empty.torrent"
 	if err := os.WriteFile(empty, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readTorrentFile(empty); err == nil || !strings.Contains(err.Error(), "file is empty") {
+	if _, err := readTorrentFile(empty, "--torrent"); err == nil || !strings.Contains(err.Error(), "file is empty") {
 		t.Fatalf("empty torrent should fail, got %v", err)
 	}
 
 	missing := dir + "/missing with spaces.torrent"
-	_, err = readTorrentFile(missing)
-	if err == nil || !strings.Contains(err.Error(), "quote it") {
+	_, err = readTorrentFile(missing, "--torrent")
+	if err == nil || !strings.Contains(err.Error(), "quote it") || !strings.Contains(err.Error(), "--torrent") {
 		t.Fatalf("missing torrent should hint quoting, got %v", err)
 	}
 }

--- a/cli/cmd/ctl/download/file.go
+++ b/cli/cmd/ctl/download/file.go
@@ -66,15 +66,17 @@ func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, n
 	if rawURL == "" {
 		return fmt.Errorf("url is required")
 	}
+	app, err = validateApp(app)
+	if err != nil {
+		return err
+	}
 	pc, err := prepare(ctx, f)
 	if err != nil {
 		return err
 	}
 	q := url.Values{}
 	q.Set("url", rawURL)
-	if a := strings.TrimSpace(app); a != "" {
-		q.Set("app", a)
-	}
+	q.Set("app", app)
 	if p := strings.TrimSpace(path); p != "" {
 		q.Set("path", p)
 	}
@@ -129,8 +131,8 @@ func runFileCheck(ctx context.Context, f *cmdutil.Factory, path, outputRaw strin
 		return err
 	}
 	path = strings.TrimSpace(path)
-	if path == "" {
-		return fmt.Errorf("--path is required")
+	if err := validateDrivePath(path); err != nil {
+		return err
 	}
 	pc, err := prepare(ctx, f)
 	if err != nil {
@@ -188,8 +190,8 @@ func runFileRemove(ctx context.Context, f *cmdutil.Factory, path, outputRaw stri
 		return err
 	}
 	path = strings.TrimSpace(path)
-	if path == "" {
-		return fmt.Errorf("--path is required")
+	if err := validateDrivePath(path); err != nil {
+		return err
 	}
 	pc, err := prepare(ctx, f)
 	if err != nil {

--- a/cli/cmd/ctl/download/file.go
+++ b/cli/cmd/ctl/download/file.go
@@ -16,10 +16,9 @@ import (
 func NewFileCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "file",
-		Short: "check / remove downloaded files and pre-check URL destinations",
+		Short: "pre-check URL destinations and remove downloaded files",
 	}
 	cmd.AddCommand(newFileExistsCommand(f))
-	cmd.AddCommand(newFileCheckCommand(f))
 	cmd.AddCommand(newFileRemoveCommand(f))
 	return cmd
 }
@@ -29,32 +28,38 @@ func newFileExistsCommand(f *cmdutil.Factory) *cobra.Command {
 		app    string
 		path   string
 		name   string
+		hfDest string
 		output string
 	)
 	cmd := &cobra.Command{
 		Use:   "exists <url>",
 		Short: "pre-check whether a URL download would collide at the destination",
-		Long: `Pre-check a URL download destination (GET /api/url/file-exists).
+		Long: `Check whether downloading a URL would overwrite an existing file.
 
 Quote the URL. A URL with ?, & or = must be wrapped in single quotes,
-otherwise the shell splits it on & and drops the query string:
-  olares-cli knowledge download file exists 'https://host/v?a=1&b=2'
+otherwise your shell may split it.
 
-The server resolves the target file name from the URL (or --name) under
---path for the given --app and reports whether it already exists.`,
+The target name is taken from the URL unless --name is provided. Use --path
+and --app to check the same destination you intend to use with create.
+
+For HuggingFace URLs, --hf-dest selects cache vs local destination
+semantics. Omit it to use the default.`,
+		Example: `  olares-cli knowledge download file exists 'https://host/v?a=1&b=2'
+  olares-cli knowledge download file exists https://huggingface.co/org/repo --hf-dest cache`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runFileExists(c.Context(), f, args[0], app, path, name, output)
+			return runFileExists(c.Context(), f, args[0], app, path, name, hfDest, output)
 		},
 	}
 	addAppFlag(cmd, &app)
 	addOutputFlag(cmd, &output)
 	cmd.Flags().StringVar(&path, "path", "", "destination path (e.g. drive/Home/Downloads/)")
 	cmd.Flags().StringVar(&name, "name", "", "expected file_name override")
+	cmd.Flags().StringVar(&hfDest, "hf-dest", "", "HuggingFace destination: cache or local (optional)")
 	return cmd
 }
 
-func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name, outputRaw string) error {
+func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name, hfDest, outputRaw string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -70,6 +75,10 @@ func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, n
 	if err != nil {
 		return err
 	}
+	hfDest, err = validateHFDest(hfDest)
+	if err != nil {
+		return err
+	}
 	pc, err := prepare(ctx, f)
 	if err != nil {
 		return err
@@ -82,6 +91,9 @@ func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, n
 	}
 	if n := strings.TrimSpace(name); n != "" {
 		q.Set("file_name", n)
+	}
+	if hfDest != "" {
+		q.Set("hf_dest", hfDest)
 	}
 	var data FileExistsData
 	if err := doGet(ctx, pc.doer, "/api/url/file-exists"+encodeQuery(q), &data); err != nil {
@@ -99,62 +111,14 @@ func runFileExists(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, n
 	}
 }
 
-func newFileCheckCommand(f *cmdutil.Factory) *cobra.Command {
-	var (
-		path   string
-		output string
-	)
-	cmd := &cobra.Command{
-		Use:   "check",
-		Short: "check whether a downloaded file exists on the PVC",
-		Long: `Check whether a file-manager resource exists
-(GET /api/download/file_check).
-
---path is a file-manager resource path such as drive/Home/xxx.`,
-		Args: cobra.NoArgs,
-		RunE: func(c *cobra.Command, _ []string) error {
-			return runFileCheck(c.Context(), f, path, output)
-		},
-	}
-	addOutputFlag(cmd, &output)
-	cmd.Flags().StringVar(&path, "path", "", "file-manager resource path, e.g. drive/Home/xxx (required)")
-	_ = cmd.MarkFlagRequired("path")
-	return cmd
-}
-
-func runFileCheck(ctx context.Context, f *cmdutil.Factory, path, outputRaw string) error {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	format, err := parseFormat(outputRaw)
-	if err != nil {
-		return err
-	}
-	path = strings.TrimSpace(path)
-	if err := validateDrivePath(path); err != nil {
-		return err
-	}
-	pc, err := prepare(ctx, f)
-	if err != nil {
-		return err
-	}
-	q := url.Values{}
-	// user only satisfies the IDL binding (required query field); the real
-	// identity is the gateway-injected X-Bfl-User, so the profile OlaresID
-	// is just a placeholder here.
-	q.Set("user", pc.profile.OlaresID)
-	q.Set("path", path)
-	var res FileCheckResult
-	// /none is a mandatory placeholder suffix in the route; do not drop it.
-	if err := doGet(ctx, pc.doer, "/api/download/file_check/none"+encodeQuery(q), &res); err != nil {
-		return err
-	}
-	switch format {
-	case FormatJSON:
-		return printJSON(os.Stdout, res)
+// validateHFDest accepts empty (omit query), "cache", or "local".
+func validateHFDest(raw string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	switch v {
+	case "", "cache", "local":
+		return v, nil
 	default:
-		fmt.Printf("Exist:  %v\n", res.Exist)
-		return nil
+		return "", fmt.Errorf("unsupported --hf-dest %q (allowed: cache, local)", raw)
 	}
 }
 
@@ -166,11 +130,12 @@ func newFileRemoveCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "remove a downloaded file from the PVC",
-		Long: `Remove a file-manager resource (DELETE /api/download/file_remove).
+		Long: `Remove a downloaded file from Olares storage.
 
 --path is a file-manager resource path such as drive/Home/xxx. A file
-that does not exist is still treated as success by the server.`,
-		Args: cobra.NoArgs,
+that does not exist is still treated as successfully removed.`,
+		Example: `  olares-cli knowledge download file remove --path drive/Home/Downloads/video.mp4`,
+		Args:    cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runFileRemove(c.Context(), f, path, output)
 		},

--- a/cli/cmd/ctl/download/inspect.go
+++ b/cli/cmd/ctl/download/inspect.go
@@ -18,14 +18,16 @@ func NewInspectCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect <url>",
 		Short: "probe a URL for provider and available qualities",
-		Long: `Probe a URL (GET /api/url/inspect).
+		Long: `Inspect a URL to identify its download provider, title, and available
+yt-dlp qualities.
 
 Quote the URL. A URL with ?, & or = must be wrapped in single quotes,
-otherwise the shell splits it on & and drops the query string:
-  olares-cli knowledge download inspect 'https://host/v?a=1&b=2'
+otherwise your shell may split it.
 
-Inspect is advisory: the server may return HTTP 200 with data.error set
-when the probe fails. That does not block create.`,
+Inspect is advisory: a probe failure does not necessarily mean that create
+will fail.`,
+		Example: `  olares-cli knowledge download inspect 'https://host/v?a=1&b=2'
+  olares-cli knowledge download inspect https://huggingface.co/org/repo -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			return runInspect(c.Context(), f, args[0], output)
@@ -75,6 +77,9 @@ func runInspect(ctx context.Context, f *cmdutil.Factory, rawURL, outputRaw strin
 	if hint := inspectYTDLPHint(data); hint != "" {
 		fmt.Fprintln(os.Stderr, hint)
 	}
+	if hint := inspectHFTokenHint(data); hint != "" {
+		fmt.Fprintln(os.Stderr, hint)
+	}
 	return nil
 }
 
@@ -89,6 +94,16 @@ func inspectYTDLPHint(d InspectData) string {
 	}
 	if shouldHintYTDLPUnavailable(d.Error) || shouldHintYTDLPUnavailable(d.ErrorCategory) {
 		return ytdlpUnavailableHint()
+	}
+	return ""
+}
+
+// inspectHFTokenHint returns a create-time token hint when HuggingFace reports
+// a gated or private repo. Empty string means no hint.
+func inspectHFTokenHint(d InspectData) string {
+	cat := strings.ToLower(strings.TrimSpace(d.ErrorCategory))
+	if cat == "gated" || cat == "private" {
+		return `HuggingFace repo needs a token; create with --extra '{"token":"hf_xxx"}'`
 	}
 	return ""
 }

--- a/cli/cmd/ctl/download/inspect.go
+++ b/cli/cmd/ctl/download/inspect.go
@@ -61,10 +61,36 @@ func runInspect(ctx context.Context, f *cmdutil.Factory, rawURL, outputRaw strin
 
 	switch format {
 	case FormatJSON:
-		return printJSON(os.Stdout, data)
+		if err := printJSON(os.Stdout, data); err != nil {
+			return err
+		}
 	default:
-		return renderInspect(os.Stdout, data)
+		if err := renderInspect(os.Stdout, data); err != nil {
+			return err
+		}
 	}
+	// Advisory probe: still exit 0, but always surface the install CTA when
+	// the yt-dlp daemon is unreachable so the next step is not buried in
+	// skill docs.
+	if hint := inspectYTDLPHint(data); hint != "" {
+		fmt.Fprintln(os.Stderr, hint)
+	}
+	return nil
+}
+
+// inspectYTDLPHint returns the install CTA when inspect reports the yt-dlp
+// provider is unavailable. Empty string means no hint.
+func inspectYTDLPHint(d InspectData) string {
+	if d.Available != nil && !*d.Available {
+		provider := strings.ToLower(strings.TrimSpace(d.Provider))
+		if provider == "" || provider == "yt-dlp" || provider == "ytdlp" {
+			return ytdlpUnavailableHint()
+		}
+	}
+	if shouldHintYTDLPUnavailable(d.Error) || shouldHintYTDLPUnavailable(d.ErrorCategory) {
+		return ytdlpUnavailableHint()
+	}
+	return ""
 }
 
 func renderInspect(w io.Writer, d InspectData) error {

--- a/cli/cmd/ctl/download/list.go
+++ b/cli/cmd/ctl/download/list.go
@@ -49,15 +49,23 @@ func runList(ctx context.Context, f *cmdutil.Factory, app, status string, page, 
 	if err != nil {
 		return err
 	}
+	app, err = validateApp(app)
+	if err != nil {
+		return err
+	}
+	if err := validateNonNegativeFlag("--page", page); err != nil {
+		return err
+	}
+	if err := validateNonNegativeFlag("--page-size", pageSize); err != nil {
+		return err
+	}
 	pc, err := prepare(ctx, f)
 	if err != nil {
 		return err
 	}
 
 	q := url.Values{}
-	if a := strings.TrimSpace(app); a != "" {
-		q.Set("app", a)
-	}
+	q.Set("app", app)
 	if s := strings.TrimSpace(status); s != "" {
 		q.Set("status", s)
 	}
@@ -94,14 +102,15 @@ func renderListTable(w io.Writer, result ListResult) error {
 // renderTasksTable prints the shared task table (list / sync / unfinished).
 func renderTasksTable(w io.Writer, tasks []DownloadTask) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tSTATUS\tPROVIDER\tPERCENT\tNAME\tAPP\tUPDATED")
+	fmt.Fprintln(tw, "ID\tSTATUS\tPROVIDER\tPERCENT\tNAME\tSOURCE\tAPP\tUPDATED")
 	for _, t := range tasks {
-		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			t.ID,
 			orDash(t.Status),
 			orDash(t.DownloadProvider),
 			fmt.Sprintf("%.1f%%", t.Percent),
-			truncate(displayName(t), 48),
+			truncate(displayName(t), 40),
+			truncate(orDash(t.URL), 48),
 			orDash(t.App),
 			formatTime(t.UpdatedAt),
 		)

--- a/cli/cmd/ctl/download/pause.go
+++ b/cli/cmd/ctl/download/pause.go
@@ -150,15 +150,20 @@ func parseTaskIDs(raws []string) ([]int64, error) {
 func renderBatchResult(w io.Writer, format Format, verb string, res BatchResult) error {
 	switch format {
 	case FormatJSON:
-		return printJSON(w, res)
+		if err := printJSON(w, res); err != nil {
+			return err
+		}
 	default:
 		fmt.Fprintf(w, "%s: %d succeeded, %d failed\n", verb, len(res.Succeeded), len(res.Failed))
 		for _, f := range res.Failed {
 			fmt.Fprintf(w, "  %d: %s\n", f.TaskID, orDash(f.Error))
 		}
-		if len(res.Failed) > 0 {
-			return fmt.Errorf("%s: %d of %d tasks failed", verb, len(res.Failed), len(res.Succeeded)+len(res.Failed))
-		}
-		return nil
 	}
+	// Both table and json print the payload first; any failed id still
+	// exits non-zero so automation that trusts the exit code cannot miss
+	// leftover tasks.
+	if len(res.Failed) > 0 {
+		return fmt.Errorf("%s: %d of %d tasks failed", verb, len(res.Failed), len(res.Succeeded)+len(res.Failed))
+	}
+	return nil
 }

--- a/cli/cmd/ctl/download/pause.go
+++ b/cli/cmd/ctl/download/pause.go
@@ -3,50 +3,94 @@ package download
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
+const batchMaxTasks = 500
+
 func NewPauseCommand(f *cmdutil.Factory) *cobra.Command {
-	return &cobra.Command{
-		Use:   "pause <id>",
-		Short: "pause a download task",
-		Args:  cobra.ExactArgs(1),
+	var output string
+	cmd := &cobra.Command{
+		Use:   "pause <id> [id...]",
+		Short: "pause one or more download tasks",
+		Long: `Pause one or more download tasks.
+
+Pass task ids separated by spaces (not commas or brackets). Up to 500 ids
+per call.`,
+		Example: `  # pause a single task
+  olares-cli knowledge download pause 42
+
+  # pause several tasks
+  olares-cli knowledge download pause 42 43 44`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runLifecycle(c.Context(), f, "pause", args[0])
+			return runLifecycle(c.Context(), f, "pause", args, output)
 		},
 	}
+	addOutputFlag(cmd, &output)
+	return cmd
 }
 
 func NewResumeCommand(f *cmdutil.Factory) *cobra.Command {
-	return &cobra.Command{
-		Use:   "resume <id>",
-		Short: "resume a download task",
-		Args:  cobra.ExactArgs(1),
+	var output string
+	cmd := &cobra.Command{
+		Use:   "resume <id> [id...]",
+		Short: "resume one or more download tasks",
+		Long: `Resume one or more download tasks.
+
+Pass task ids separated by spaces (not commas or brackets). Up to 500 ids
+per call.`,
+		Example: `  # resume a single task
+  olares-cli knowledge download resume 42
+
+  # resume several tasks
+  olares-cli knowledge download resume 42 43 44`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runLifecycle(c.Context(), f, "resume", args[0])
+			return runLifecycle(c.Context(), f, "resume", args, output)
 		},
 	}
+	addOutputFlag(cmd, &output)
+	return cmd
 }
 
 func NewCancelCommand(f *cmdutil.Factory) *cobra.Command {
-	return &cobra.Command{
-		Use:   "cancel <id>",
-		Short: "cancel a download task",
-		Args:  cobra.ExactArgs(1),
+	var output string
+	cmd := &cobra.Command{
+		Use:   "cancel <id> [id...]",
+		Short: "cancel one or more download tasks",
+		Long: `Cancel one or more download tasks.
+
+Pass task ids separated by spaces (not commas or brackets). Up to 500 ids
+per call.`,
+		Example: `  # cancel a single task
+  olares-cli knowledge download cancel 42
+
+  # cancel several tasks
+  olares-cli knowledge download cancel 42 43 44`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runLifecycle(c.Context(), f, "cancel", args[0])
+			return runLifecycle(c.Context(), f, "cancel", args, output)
 		},
 	}
+	addOutputFlag(cmd, &output)
+	return cmd
 }
 
-func runLifecycle(ctx context.Context, f *cmdutil.Factory, verb, idRaw string) error {
+func runLifecycle(ctx context.Context, f *cmdutil.Factory, verb string, idRaws []string, outputRaw string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	id, err := parseTaskID(idRaw)
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	ids, err := parseTaskIDs(idRaws)
 	if err != nil {
 		return err
 	}
@@ -54,10 +98,67 @@ func runLifecycle(ctx context.Context, f *cmdutil.Factory, verb, idRaw string) e
 	if err != nil {
 		return err
 	}
-	path := fmt.Sprintf("/api/download/%s/%d", verb, id)
-	if err := doMutate(ctx, pc.doer, "PUT", path, nil, nil); err != nil {
+	if len(ids) == 1 {
+		path := fmt.Sprintf("/api/download/%s/%d", verb, ids[0])
+		if err := doMutate(ctx, pc.doer, "PUT", path, nil, nil); err != nil {
+			return err
+		}
+		switch format {
+		case FormatJSON:
+			return printJSON(os.Stdout, map[string]interface{}{"verb": verb, "task_id": ids[0]})
+		default:
+			fmt.Printf("%s task %d\n", verb, ids[0])
+			return nil
+		}
+	}
+	var res BatchResult
+	if err := doMutate(ctx, pc.doer, "PUT", "/api/download/batch/"+verb, BatchReq{TaskIDs: ids}, &res); err != nil {
 		return err
 	}
-	fmt.Printf("%s task %d\n", verb, id)
-	return nil
+	return renderBatchResult(os.Stdout, format, verb, res)
+}
+
+// parseTaskIDs validates and de-duplicates positional task ids. Empty input,
+// non-positive / non-integer tokens, and lists longer than batchMaxTasks are
+// rejected locally.
+func parseTaskIDs(raws []string) ([]int64, error) {
+	if len(raws) == 0 {
+		return nil, fmt.Errorf("at least one task id is required")
+	}
+	if len(raws) > batchMaxTasks {
+		return nil, fmt.Errorf("too many task ids (%d); max %d per request", len(raws), batchMaxTasks)
+	}
+	seen := make(map[int64]struct{}, len(raws))
+	ids := make([]int64, 0, len(raws))
+	for _, raw := range raws {
+		id, err := parseTaskID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("at least one task id is required")
+	}
+	return ids, nil
+}
+
+func renderBatchResult(w io.Writer, format Format, verb string, res BatchResult) error {
+	switch format {
+	case FormatJSON:
+		return printJSON(w, res)
+	default:
+		fmt.Fprintf(w, "%s: %d succeeded, %d failed\n", verb, len(res.Succeeded), len(res.Failed))
+		for _, f := range res.Failed {
+			fmt.Fprintf(w, "  %d: %s\n", f.TaskID, orDash(f.Error))
+		}
+		if len(res.Failed) > 0 {
+			return fmt.Errorf("%s: %d of %d tasks failed", verb, len(res.Failed), len(res.Succeeded)+len(res.Failed))
+		}
+		return nil
+	}
 }

--- a/cli/cmd/ctl/download/prefs.go
+++ b/cli/cmd/ctl/download/prefs.go
@@ -48,10 +48,11 @@ func newPrefsSetCommand(f *cmdutil.Factory) *cobra.Command {
 		output  string
 	)
 	cmd := &cobra.Command{
-		Use:   "set",
-		Short: "set yt-dlp quality preference for an app",
-		Long:  `PUT /api/user/preferences. --quality must be one of: ` + ytdlpQualityValues + `.`,
-		Args:  cobra.NoArgs,
+		Use:     "set",
+		Short:   "set yt-dlp quality preference for an app",
+		Long:    `Set the default yt-dlp quality used when create does not specify --quality or --format-id. Allowed values: ` + ytdlpQualityValues + `.`,
+		Example: `  olares-cli knowledge download prefs set --app wise --quality 1080p`,
+		Args:    cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runPrefsSet(c.Context(), f, app, quality, output)
 		},

--- a/cli/cmd/ctl/download/prefs.go
+++ b/cli/cmd/ctl/download/prefs.go
@@ -71,9 +71,9 @@ func runPrefsGet(ctx context.Context, f *cmdutil.Factory, app, outputRaw string)
 	if err != nil {
 		return err
 	}
-	app = strings.TrimSpace(app)
-	if app == "" {
-		app = defaultApp
+	app, err = validateApp(app)
+	if err != nil {
+		return err
 	}
 	pc, err := prepare(ctx, f)
 	if err != nil {
@@ -106,9 +106,9 @@ func runPrefsSet(ctx context.Context, f *cmdutil.Factory, app, quality, outputRa
 	if err != nil {
 		return err
 	}
-	app = strings.TrimSpace(app)
-	if app == "" {
-		app = defaultApp
+	app, err = validateApp(app)
+	if err != nil {
+		return err
 	}
 	quality = strings.TrimSpace(quality)
 	if err := validateYTDLPQuality(quality, true); err != nil {

--- a/cli/cmd/ctl/download/remove.go
+++ b/cli/cmd/ctl/download/remove.go
@@ -3,6 +3,7 @@ package download
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -10,25 +11,45 @@ import (
 )
 
 func NewRemoveCommand(f *cmdutil.Factory) *cobra.Command {
-	var removeFile bool
+	var (
+		removeFile bool
+		output     string
+	)
 	cmd := &cobra.Command{
-		Use:   "remove <id>",
-		Short: "remove a download task",
-		Long:  `Remove a download task (DELETE /api/download/remove). Pass --remove-file to also delete the downloaded artefact.`,
-		Args:  cobra.ExactArgs(1),
+		Use:   "remove <id> [id...]",
+		Short: "remove one or more download tasks",
+		Long: `Remove one or more download tasks.
+
+Pass task ids separated by spaces (not commas or brackets). Up to 500 ids
+per call.
+
+By default only the task record is removed and the downloaded file is
+kept. Add --remove-file to also delete the file on disk (applies to every
+id in the call).`,
+		Example: `  # remove a single task, keep the file
+  olares-cli knowledge download remove 42
+
+  # remove several tasks and delete their files
+  olares-cli knowledge download remove 42 43 44 --remove-file`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runRemove(c.Context(), f, args[0], removeFile)
+			return runRemove(c.Context(), f, args, removeFile, output)
 		},
 	}
 	cmd.Flags().BoolVar(&removeFile, "remove-file", false, "also delete the downloaded file (remove_flag)")
+	addOutputFlag(cmd, &output)
 	return cmd
 }
 
-func runRemove(ctx context.Context, f *cmdutil.Factory, idRaw string, removeFile bool) error {
+func runRemove(ctx context.Context, f *cmdutil.Factory, idRaws []string, removeFile bool, outputRaw string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	id, err := parseTaskID(idRaw)
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	ids, err := parseTaskIDs(idRaws)
 	if err != nil {
 		return err
 	}
@@ -36,14 +57,33 @@ func runRemove(ctx context.Context, f *cmdutil.Factory, idRaw string, removeFile
 	if err != nil {
 		return err
 	}
-	req := RemoveReq{TaskID: id, RemoveFlag: removeFile}
-	if err := doMutate(ctx, pc.doer, "DELETE", "/api/download/remove", req, nil); err != nil {
+	if len(ids) == 1 {
+		req := RemoveReq{TaskID: ids[0], RemoveFlag: removeFile}
+		if err := doMutate(ctx, pc.doer, "DELETE", "/api/download/remove", req, nil); err != nil {
+			return err
+		}
+		switch format {
+		case FormatJSON:
+			return printJSON(os.Stdout, map[string]interface{}{
+				"verb":        "remove",
+				"task_id":     ids[0],
+				"remove_file": removeFile,
+			})
+		default:
+			if removeFile {
+				fmt.Printf("removed task %d (and file)\n", ids[0])
+			} else {
+				fmt.Printf("removed task %d\n", ids[0])
+			}
+			return nil
+		}
+	}
+	var res BatchResult
+	if err := doMutate(ctx, pc.doer, "DELETE", "/api/download/batch/remove", BatchReq{
+		TaskIDs:    ids,
+		RemoveFlag: removeFile,
+	}, &res); err != nil {
 		return err
 	}
-	if removeFile {
-		fmt.Printf("removed task %d (and file)\n", id)
-	} else {
-		fmt.Printf("removed task %d\n", id)
-	}
-	return nil
+	return renderBatchResult(os.Stdout, format, "remove", res)
 }

--- a/cli/cmd/ctl/download/root.go
+++ b/cli/cmd/ctl/download/root.go
@@ -43,7 +43,7 @@ Verb families:
 Universal flags:
 
   -o, --output {table,json}
-      --app <name>     default wise (create / list / prefs)
+      --app <name>     one of: wise, larepass (default wise; create / list / prefs / sync)
 
 Run "olares-cli knowledge download <verb> --help" for verb-specific flags.
 `,

--- a/cli/cmd/ctl/download/root.go
+++ b/cli/cmd/ctl/download/root.go
@@ -16,15 +16,12 @@ import (
 func NewDownloadCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download",
-		Short: "Manage download-server tasks (Settings /download edge)",
-		Long: `Manage download tasks via download-server.
+		Short: "manage download tasks",
+		Long: `Create and manage Olares download tasks.
 
 Invoked as: olares-cli knowledge download <verb>
 
-Requires Olares 1.12.7+. Calls go through the active profile's Settings
-URL with a /download prefix (user-service relay → download provider →
-download-server). Auth is the profile access token (X-Authorization);
-the gateway injects X-Bfl-User — do not set it from the CLI.
+Requires Olares 1.12.7+ and uses the active profile.
 
 This is the download *task centre* (create / list / pause / …). It is
 not the top-level "download" command (installer packages) and not
@@ -37,7 +34,7 @@ Verb families:
   prefs       prefs get, prefs set
   sync        unfinished, sync
   torrent     torrent inspect, stats, peers, files, seed stop|resume
-  file        file exists, file check, file remove
+  file        file exists, file remove
   settings    settings get, settings set  (download-server global config)
 
 Universal flags:

--- a/cli/cmd/ctl/download/settings.go
+++ b/cli/cmd/ctl/download/settings.go
@@ -16,13 +16,11 @@ func NewSettingsCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "settings",
 		Short: "download-server global settings (aria2 max concurrency)",
-		Long: `Read or update download-server global settings (GET/PUT
-/api/system/settings). Today the manager exposes a single global knob,
-aria2_max_concurrent (aria2 max-concurrent-downloads).
+		Long: `Read or update global download settings.
 
-These are server-wide, not per-user, so changing them may require
-administrator privileges — the CLI does not pre-check this and defers to
-the server, which returns an error if the caller is not allowed.`,
+Currently, aria2_max_concurrent controls the number of concurrent aria2
+downloads. This setting applies to the whole server, not just the active
+user, and changing it may require administrator privileges.`,
 	}
 	cmd.AddCommand(newSettingsGetCommand(f))
 	cmd.AddCommand(newSettingsSetCommand(f))
@@ -80,13 +78,12 @@ func newSettingsSetCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "update a download-server global setting",
-		Long: `Update a download-server global setting (PUT /api/system/settings).
+		Long: `Set the maximum number of concurrent aria2 downloads.
 
-The manager applies exactly one key/value pair per request. Today the
-only supported knob is aria2_max_concurrent, set via
---aria2-max-concurrent (server-validated range [1, 16]). The updated
-snapshot is printed on success.`,
-		Args: cobra.NoArgs,
+The accepted range is 1 through 16. The updated setting is printed on
+success.`,
+		Example: `  olares-cli knowledge download settings set --aria2-max-concurrent 4`,
+		Args:    cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			if !c.Flags().Changed("aria2-max-concurrent") {
 				return fmt.Errorf("nothing to set: provide --aria2-max-concurrent")

--- a/cli/cmd/ctl/download/sync.go
+++ b/cli/cmd/ctl/download/sync.go
@@ -26,23 +26,25 @@ func NewSyncCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "incremental cursor sync of download tasks",
-		Long: `Incrementally pull tasks by a composite cursor (GET /api/download/sync).
+		Long: `Fetch download task changes incrementally.
 
-The server keys the feed on (updated_at, id): it returns rows whose
-updated_at is newer than --since, or equal to --since with an id greater
-than --since-id, in (updated_at, id) ascending order. Unlike an id-only
-feed this DOES surface progress updates to tasks you already saw, because
-any change bumps updated_at. Remember the cursor of the last row you saw
-(printed after each page) and pass it back as --since / --since-id to fetch
-only newer changes.
+The cursor consists of --since and --since-id. The command prints the next
+cursor after each page; pass both values back to continue without missing
+tasks that share the same update time.
 
 --since accepts the local time shown in the list/sync table (e.g.
 2026-07-15T23:03 or "2026-07-15 23:03"), a bare date (2026-07-15), or a
-zoned RFC3339 value (2026-07-15T15:03:00Z); a value without a zone is read
-in your local timezone, so no UTC math is needed. Omit it for a full drain
-from the beginning. --all drains every page (advancing the cursor for you)
-and prints the combined result; without --all one page is fetched and, if
-more remain, the next --since / --since-id cursor is printed.`,
+zoned RFC3339 value (2026-07-15T15:03:00Z). Values without a zone use your
+local timezone. Omit it to start from the beginning. Use --all to fetch all
+remaining pages automatically.`,
+		Example: `  # fetch one page from the beginning
+  olares-cli knowledge download sync
+
+  # continue from a previously printed cursor
+  olares-cli knowledge download sync --since 2026-07-15T23:03 --since-id 42
+
+  # fetch all remaining pages
+  olares-cli knowledge download sync --since 2026-07-15T23:03 --since-id 42 --all`,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runSync(c.Context(), f, app, limit, since, sinceID, all, output)

--- a/cli/cmd/ctl/download/sync.go
+++ b/cli/cmd/ctl/download/sync.go
@@ -65,6 +65,16 @@ func runSync(ctx context.Context, f *cmdutil.Factory, app string, limit int, sin
 	if err != nil {
 		return err
 	}
+	app, err = validateApp(app)
+	if err != nil {
+		return err
+	}
+	if err := validateLimit(limit); err != nil {
+		return err
+	}
+	if err := validateSinceID(sinceID); err != nil {
+		return err
+	}
 	since, err := parseSince(sinceRaw)
 	if err != nil {
 		return err

--- a/cli/cmd/ctl/download/torrent.go
+++ b/cli/cmd/ctl/download/torrent.go
@@ -67,7 +67,7 @@ func runTorrentInspect(ctx context.Context, f *cmdutil.Factory, file, outputRaw 
 	if file == "" {
 		return fmt.Errorf("--file is required")
 	}
-	raw, err := readTorrentFile(file)
+	raw, err := readTorrentFile(file, "--file")
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/ctl/download/torrent.go
+++ b/cli/cmd/ctl/download/torrent.go
@@ -67,9 +67,9 @@ func runTorrentInspect(ctx context.Context, f *cmdutil.Factory, file, outputRaw 
 	if file == "" {
 		return fmt.Errorf("--file is required")
 	}
-	raw, err := os.ReadFile(file)
+	raw, err := readTorrentFile(file)
 	if err != nil {
-		return fmt.Errorf("read torrent file: %w", err)
+		return err
 	}
 	pc, err := prepare(ctx, f)
 	if err != nil {

--- a/cli/cmd/ctl/download/torrent.go
+++ b/cli/cmd/ctl/download/torrent.go
@@ -38,11 +38,12 @@ func newTorrentInspectCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "inspect a local .torrent file (metadata + file list)",
-		Long: `Inspect a local .torrent file (POST /api/download/torrent/inspect).
+		Long: `Inspect a local .torrent file before creating a download task.
 
-The file is read locally, base64-encoded and uploaded; the server parses
-the metainfo and returns the info hash, mode, piece layout and the 1-based
-file list used by torrent files --select and create --select-files.`,
+The result includes metadata and a 1-based file list. Use those indices
+with create --select-files or torrent files --select.`,
+		Example: `  olares-cli knowledge download torrent inspect --file ./x.torrent
+  olares-cli knowledge download torrent inspect --file ./x.torrent -o json`,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runTorrentInspect(c.Context(), f, file, output)
@@ -228,13 +229,13 @@ func newTorrentFilesCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "files <id>",
 		Short: "select which files of a multi-file torrent to download",
-		Long: `Set the selected files of a multi-file torrent
-(PUT /api/download/<id>/torrent/files).
+		Long: `Choose which files of a multi-file torrent task to download.
 
 --select takes a comma-separated list of 1-based file indices (as reported
 by torrent inspect), e.g. --select 1,3,5. The list is the full selection,
-not a delta. Pass --select all to download every file (sends an empty
-selection so the server keeps all files).`,
+not a delta. Pass --select all to download every file.`,
+		Example: `  olares-cli knowledge download torrent files 42 --select 1,3,5
+  olares-cli knowledge download torrent files 42 --select all`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			return runTorrentFiles(c.Context(), f, args[0], selectRaw, output)
@@ -333,12 +334,10 @@ func newTorrentSeedCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "seed",
 		Short: "control seeding for a completed torrent",
-		Long: `Start or stop seeding a completed torrent
-(POST /api/download/<id>/torrent/seed/stop|resume).
+		Long: `Start or stop seeding a completed torrent.
 
-409 semantics:
-  seed stop   requires the task to be currently seeding.
-  seed resume requires the task to be completed (download finished).`,
+"seed stop" requires a task that is currently seeding. "seed resume"
+requires a completed torrent task.`,
 	}
 	cmd.AddCommand(newTorrentSeedActionCommand(f, "stop"))
 	cmd.AddCommand(newTorrentSeedActionCommand(f, "resume"))

--- a/cli/cmd/ctl/download/types.go
+++ b/cli/cmd/ctl/download/types.go
@@ -156,10 +156,23 @@ type FileExistsData struct {
 	ConflictPath string `json:"conflict_path,omitempty"`
 }
 
-// FileCheckResult mirrors GET /api/download/file_check, whose success body is
-// top-level {code, exist} with NO data wrapper (note: "exist", not "exists").
-type FileCheckResult struct {
-	Exist bool `json:"exist"`
+// BatchReq is the body for PUT/DELETE /api/download/batch/{pause,resume,cancel,remove}.
+type BatchReq struct {
+	TaskIDs    []int64 `json:"task_ids"`
+	RemoveFlag bool    `json:"remove_flag,omitempty"`
+}
+
+// BatchItemError is one failed entry in a batch response.
+type BatchItemError struct {
+	TaskID int64  `json:"task_id"`
+	Error  string `json:"error"`
+}
+
+// BatchResult is the top-level success body for batch lifecycle endpoints
+// ({code, succeeded, failed} — not wrapped in data).
+type BatchResult struct {
+	Succeeded []int64          `json:"succeeded"`
+	Failed    []BatchItemError `json:"failed"`
 }
 
 // RemoveActionResult is the -o json body for mutating verbs whose server

--- a/cli/cmd/ctl/download/unfinished.go
+++ b/cli/cmd/ctl/download/unfinished.go
@@ -28,13 +28,13 @@ func NewUnfinishedCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unfinished",
 		Short: "list tasks that have not reached a terminal state",
-		Long: `List unfinished download tasks (GET /api/download/unfinished).
+		Long: `List download tasks that have not reached a terminal state.
 
-The server endpoint filters by a single required 'provider' (one of:
-yt-dlp, aria2, huggingface) and does not accept an app filter. Pass
---provider to scope to one; omit it to query every provider and merge
-the results. Only your own tasks are returned (scoped by the
-gateway-injected identity).`,
+Pass --provider to show only yt-dlp, aria2, or huggingface tasks. Omit it
+to combine unfinished tasks from all providers. Only tasks belonging to
+the active profile are shown.`,
+		Example: `  olares-cli knowledge download unfinished
+  olares-cli knowledge download unfinished --provider aria2`,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			return runUnfinished(c.Context(), f, provider, output)

--- a/cli/skills/olares-knowledge/SKILL.md
+++ b/cli/skills/olares-knowledge/SKILL.md
@@ -36,7 +36,7 @@ All verbs require Olares 1.12.7+ because the Settings download edge and provider
 | probe + prefs | `inspect`, `prefs get`, `prefs set` | [provider/quality inspection](references/olares-knowledge-download-inspect.md) |
 | sync | `unfinished`, `sync` | [cursor and drain semantics](references/olares-knowledge-download-sync.md) |
 | torrent | `torrent inspect`, `stats`, `peers`, `files`, `seed stop/resume`; torrent create | [torrent selection and seeding](references/olares-knowledge-download-torrent.md) |
-| file tools | `file exists`, `file check`, `file remove` | [URL vs resource-path decisions](references/olares-knowledge-download-files.md) |
+| file tools | `file exists`, `file remove` | [URL vs resource-path decisions](references/olares-knowledge-download-files.md) |
 | settings | `settings get`, `settings set` | [global download-server settings](references/olares-knowledge-download-settings.md) |
 | hidden cookies surface | production retrieval only | [why cookie writes are unavailable](references/olares-knowledge-download-cookies.md) |
 

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-files.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-files.md
@@ -3,7 +3,7 @@
 > **Flags:** `olares-cli knowledge download file <verb> --help`.
 
 Two different addressing schemes live here: `exists` pre-checks a **URL**
-before create (url family), while `check` / `remove` operate on an existing
+before create (url family), while `remove` operates on an existing
 **resource path** on the PVC (`drive/Home/...`). Identity is always the
 gateway-injected `X-Bfl-User`; the CLI never sets the user.
 
@@ -12,21 +12,15 @@ gateway-injected `X-Bfl-User`; the CLI never sets the user.
 ```bash
 olares-cli knowledge download file exists 'https://host/big.zip' --path drive/Home/Downloads/
 olares-cli knowledge download file exists 'https://host/v?a=1&b=2' -o json
+olares-cli knowledge download file exists 'https://huggingface.co/org/model' --hf-dest cache
 ```
 
 `GET /api/url/file-exists`. Quote URLs containing `?`, `&` or `=`. The
 server resolves the target name from the URL (or `--name`) under `--path`
 for `--app` and reports `Exists` plus a `Conflict` path when it collides.
 
-## check (resource path)
-
-```bash
-olares-cli knowledge download file check --path drive/Home/Downloads/clip.mp4
-```
-
-`GET /api/download/file_check`. `--path` is a file-manager resource path.
-The success body is top-level `{code, exist}` (note `exist`, not the usual
-`data` wrapper). Table prints `Exist: <bool>`.
+`--hf-dest` is optional for HuggingFace URLs: `cache` or `local` (query
+`hf_dest`). Omit it to keep the server default.
 
 ## remove (resource path)
 

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
@@ -51,19 +51,24 @@ Table columns: `ID`, `STATUS`, `PROVIDER`, `PERCENT`, `NAME`, `SOURCE`, `APP`, `
 
 ```bash
 olares-cli knowledge download pause 42
+olares-cli knowledge download pause 42 43 44
 olares-cli knowledge download resume 42
 olares-cli knowledge download cancel 42
 ```
 
-No body. 409 means the task is in the yt-dlp mover phase — wait and retry.
+One id uses the single-task route. Two or more ids use
+`PUT /api/download/batch/{pause,resume,cancel}` (max 500). Table prints
+succeeded/failed counts; any failure exits non-zero. 409 on a single-task
+call means the task is in the yt-dlp mover phase — wait and retry.
 
 ## remove
 
 ```bash
 olares-cli knowledge download remove 42
 olares-cli knowledge download remove 42 --remove-file
+olares-cli knowledge download remove 42 43 44 --remove-file
 ```
 
-`--remove-file` sets `remove_flag=true` (delete artefact on PVC). Without it the downloaded file is kept.
+`--remove-file` sets `remove_flag=true` (delete artefact on PVC). Without it the downloaded file is kept. Multiple ids use `DELETE /api/download/batch/remove`.
 
 `remove` retires the task rather than deleting it: the row stays in `list` with status `removed`, which is terminal. So a `list` that still shows the task is not a failed remove, and the id is not freed for reuse — check the status, not the presence of the row.

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
@@ -45,7 +45,7 @@ olares-cli knowledge download list --status downloading --page 1 --page-size 20 
 olares-cli knowledge download info 42
 ```
 
-Table columns: `ID`, `STATUS`, `PROVIDER`, `PERCENT`, `NAME`, `APP`, `UPDATED`. Footer shows `N of total` when the server returns `total`.
+Table columns: `ID`, `STATUS`, `PROVIDER`, `PERCENT`, `NAME`, `SOURCE`, `APP`, `UPDATED`. `SOURCE` is the task URL (magnet / http / …). Footer shows `N of total` when the server returns `total`.
 
 ## pause / resume / cancel
 


### PR DESCRIPTION
## Summary
- Add batch lifecycle for `pause` / `resume` / `cancel` / `remove` (multi-id; N>1 uses `/api/download/batch/*`, max 500; `--remove-file` maps to batch `remove_flag`).
- Add `file exists --hf-dest {cache|local}`, HF gated/private inspect token hint, and remove the unused `file check` command.
- Harden download CLI validation/recovery and rewrite `knowledge download` help toward user-facing examples (drop internal API/JSON noise); update olares-knowledge references.

## Test plan
- [ ] `cd cli && CGO_ENABLED=0 go test ./cmd/ctl/download/...`
- [ ] `cd cli && CGO_ENABLED=0 go vet ./cmd/ctl/download/...`
- [ ] `olares-cli knowledge download remove -h` shows space-separated multi-id examples (no API path dump)
- [ ] `olares-cli knowledge download pause 1 2` hits batch pause path when both ids exist
- [ ] `olares-cli knowledge download file exists <hf-url> --hf-dest cache`
- [ ] `olares-cli knowledge download inspect <gated-hf-url>` prints token create hint on stderr when `error_category` is gated/private
- [ ] Confirm `file check` is gone from help / skill docs


Made with [Cursor](https://cursor.com)