### PR TITLE
chore(l4): bump image to v0.3.43

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -157,7 +157,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.42"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.43"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.42
+          value: v0.3.43
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.42
+      name: beclab/l4-bfl-proxy:v0.3.43
 # must have blank new line            


### PR DESCRIPTION
upgrade l4-bfl-proxy image to v0.3.43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bump across upgrade and deployment config; no logic changes in this diff.
> 
> **Overview**
> Bumps the **`beclab/l4-bfl-proxy`** container from **v0.3.42** to **v0.3.43** everywhere Olares pins that image.
> 
> The Olares upgrade pipeline’s **`UpgradeL4BFLProxy`** task now deploys **v0.3.43**. New and upgraded BFL launcher installs pass **`L4_PROXY_IMAGE_VERSION=v0.3.43`** into the BFL API so per-user L4 proxy workloads use the new tag. The **`framework/l4-bfl-proxy`** prebuilt output in **`.olares/Olares.yaml`** is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b838c04d2249f654c627d1a89d67f28b0ce4622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->