### PR TITLE
fix(app-service): drop user-quota from install and resume submit gates

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -451,10 +451,10 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 	// cluster-capacity against the new chart's absolute requirements, plus
 	// cluster-pressure / k8s-request against the non-negative delta
 	// (new − old) so the running deployment is not double-counted. That
-	// discount is decided from PrevState for the steady cases (Running →
-	// delta, Stopped → full), from AppPreUpgradeStateKey on UpgradeFailed
-	// when present, and otherwise from whether prevCfg's namespace still
-	// has scheduled pods (see upgradePrevHoldsRequests).
+	// discount is decided from PrevState (Running → delta); Stopped and
+	// UpgradeFailed with pre-upgrade-state=stopped skip these checks;
+	// other UpgradeFailed cases use the annotation or a live-pod probe
+	// (see upgradePrevHoldsRequests / skipUpgradeResourceCheck).
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
 		Client:                h.ctrlClient,
 		AppConfig:             appCfg,

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -139,7 +139,7 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 	}
 
 	// Unified resume-time resource gate: cluster pressure + k8s request
-	// capacity + user quota. Compute mode and per-node pressure are
+	// capacity. User quota, compute mode and per-node pressure are
 	// skipped (resume reuses the binding chosen at install time).
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
 		Client:    h.ctrlClient,

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -525,7 +526,7 @@ func TestUpgradePrevHoldsRequestsRunningForcesDelta(t *testing.T) {
 	}
 }
 
-func TestUpgradePrevHoldsRequestsStoppedForcesFull(t *testing.T) {
+func TestUpgradePrevHoldsRequestsStoppedDoesNotHold(t *testing.T) {
 	stubKube(t, namespaceObj("app-alice"), podObj("app-alice", "app-0", corev1.PodRunning))
 
 	holds, err := upgradePrevHoldsRequests(context.Background(), upgradeConfig("app", 1000, 2<<30), v1alpha1.Stopped, "")
@@ -533,7 +534,91 @@ func TestUpgradePrevHoldsRequestsStoppedForcesFull(t *testing.T) {
 		t.Fatalf("upgradePrevHoldsRequests: %v", err)
 	}
 	if holds {
-		t.Fatal("Stopped must force the full path even when pods remain")
+		t.Fatal("Stopped must not report holding requests")
+	}
+}
+
+func TestSkipUpgradeResourceCheck(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    v1alpha1.ApplicationManagerState
+		preState string
+		want     bool
+	}{
+		{name: "stopped skips", state: v1alpha1.Stopped, want: true},
+		{name: "upgradeFailed+stopped skips", state: v1alpha1.UpgradeFailed, preState: string(v1alpha1.Stopped), want: true},
+		{name: "running does not skip", state: v1alpha1.Running, want: false},
+		{name: "upgradeFailed+running does not skip", state: v1alpha1.UpgradeFailed, preState: string(v1alpha1.Running), want: false},
+		{name: "upgradeFailed+empty does not skip", state: v1alpha1.UpgradeFailed, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipUpgradeResourceCheck(Input{
+				Op:                    v1alpha1.UpgradeOp,
+				PrevState:             tc.state,
+				PreUpgradeSteadyState: tc.preState,
+			})
+			if got != tc.want {
+				t.Fatalf("skip=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpgradeStoppedSkipsResourceChecks verifies Stopped (and
+// UpgradeFailed with pre-upgrade-state=stopped) skip capacity / pressure /
+// k8s-request without backend calls.
+func TestUpgradeStoppedSkipsResourceChecks(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	originalMetrics := clusterMetricsProvider
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+		clusterMetricsProvider = originalMetrics
+	})
+
+	var calls int
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(*appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	clusterMetricsProvider = func(string) (*prometheus.ClusterMetrics, []string, error) {
+		calls++
+		return nil, nil, errors.New("metrics should not be called")
+	}
+
+	cases := []Input{
+		{
+			AppConfig:     upgradeConfig("app", 3000, 4<<30),
+			PrevAppConfig: upgradeConfig("app", 1000, 2<<30),
+			PrevState:     v1alpha1.Stopped,
+			Op:            v1alpha1.UpgradeOp,
+		},
+		{
+			AppConfig:             upgradeConfig("app", 3000, 4<<30),
+			PrevAppConfig:         upgradeConfig("app", 1000, 2<<30),
+			PrevState:             v1alpha1.UpgradeFailed,
+			PreUpgradeSteadyState: string(v1alpha1.Stopped),
+			Op:                    v1alpha1.UpgradeOp,
+		},
+	}
+	for _, in := range cases {
+		calls = 0
+		decision, err := Run(context.Background(), in, UpgradabilityValidators()...)
+		if err != nil {
+			t.Fatalf("Run(%s): %v", in.PrevState, err)
+		}
+		if !decision.OK {
+			t.Fatalf("Run(%s) decision=%#v, want OK", in.PrevState, decision)
+		}
+		if calls != 0 {
+			t.Fatalf("Run(%s) expected zero backend calls, got %d", in.PrevState, calls)
+		}
 	}
 }
 
@@ -550,7 +635,7 @@ func TestUpgradePrevHoldsRequestsUpgradeFailedUsesAnnotation(t *testing.T) {
 			wantHolds: true,
 		},
 		{
-			name:      "annotation stopped forces full even with pods",
+			name:      "annotation stopped does not hold (skip at requirementConfigForOp)",
 			preState:  string(v1alpha1.Stopped),
 			withPod:   true,
 			wantHolds: false,

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -279,17 +279,16 @@ func TestChainShapes(t *testing.T) {
 	wantInstall := []string{
 		"cluster-capacity",
 		"compute-mode",
-		"user-quota",
 	}
 	assertChainNames(t, "InstallabilityValidators", InstallabilityValidators(), wantInstall)
 
 	// UpgradabilityValidators gates cluster-capacity on the new chart's
 	// absolute requirements, then cluster-pressure / k8s-request on the
 	// non-negative delta (new − old). user-quota, compute-mode,
-	// node-pressure and compute-allocation stay excluded: install/resume
-	// remain the quota gates, upgrade reuses the existing allocation,
-	// and helm upgrade goes through kube-scheduler. See
-	// UpgradabilityValidators in validators.go.
+	// node-pressure and compute-allocation stay excluded: user-quota is
+	// not gated on install/resume/upgrade submit, upgrade reuses the
+	// existing allocation, and helm upgrade goes through kube-scheduler.
+	// See UpgradabilityValidators in validators.go.
 	wantUpgrade := []string{
 		"cluster-capacity",
 		"cluster-pressure",
@@ -303,6 +302,15 @@ func TestChainShapes(t *testing.T) {
 		"node-pressure",
 	}
 	assertChainNames(t, "RuntimePressureValidators", RuntimePressureValidators(), wantRuntime)
+
+	// ResumePressureValidators is the resume HTTP submit gate:
+	// cluster-pressure + k8s-request only. user-quota / compute-mode /
+	// node-pressure / compute-allocation stay excluded.
+	wantResume := []string{
+		"cluster-pressure",
+		"k8s-request",
+	}
+	assertChainNames(t, "ResumePressureValidators", ResumePressureValidators(), wantResume)
 
 	// InstallRuntimePressureValidators = RuntimePressure ++ compute-allocation,
 	// with the heavier side-effecting allocator strictly last so the
@@ -341,12 +349,14 @@ func assertChainNames(t *testing.T, label string, chain []Validator, want []stri
 // node-pressure and compute-allocation stay false for UpgradeOp.
 //
 // The remaining semantic mapping (matching the comments inside
-// validators.go):
+// validators.go). Note AppliesTo for user-quota still reports
+// install+resume, but InstallabilityValidators / ResumePressureValidators
+// no longer include that validator in their chains:
 //
 //   - cluster-pressure, k8s-request : install + resume + upgrade.
 //   - node-pressure                 : install + resume.
-//   - user-quota         : install + resume only (upgrade does not
-//     re-check owner quota).
+//   - user-quota         : AppliesTo install + resume only; not wired
+//     into any exported submit chain.
 //   - cluster-capacity   : install + upgrade — resume reuses the
 //     placement chosen at install; the cluster's
 //     total schedulable capacity hasn't shrunk in
@@ -394,8 +404,9 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
-			// user-quota is install + resume only; upgrade does not
-			// re-check owner quota (see UpgradabilityValidators).
+			// user-quota.AppliesTo remains install + resume, but the
+			// validator is no longer included in InstallabilityValidators
+			// or ResumePressureValidators (see those chain constructors).
 			name: "user-quota",
 			v:    userQuotaValidator{},
 			want: map[Op]bool{

--- a/framework/app-service/pkg/compute/validation/validator.go
+++ b/framework/app-service/pkg/compute/validation/validator.go
@@ -5,10 +5,11 @@
 // runs UpgradabilityValidators at HTTP submit time: cluster-capacity
 // against the new chart's absolute requirements, plus cluster-pressure /
 // k8s-request against the non-negative delta (new − old) when the
-// deployed version still holds its requests, or against the new chart's
-// absolute requirements when the upgrade starts from a stopped state
-// (see that function). User-quota is not part of the upgrade chain
-// (install/resume remain the quota gates).
+// deployed version still holds its requests. Stopped upgrades (and
+// UpgradeFailed with pre-upgrade-state=stopped) skip those checks;
+// other upgrades with nothing to discount use absolute requirements
+// (see skipUpgradeResourceCheck / upgradePrevHoldsRequests). User-quota
+// is not part of the upgrade chain (install/resume remain the quota gates).
 //
 // Each individual check (cluster pressure, per-user quota, k8s request
 // availability, per-node pressure, GPU compute plan) is wrapped in a
@@ -36,16 +37,16 @@ type Op = v1alpha1.OpType
 // it; the others ignore unset fields.
 //
 // PrevAppConfig, PrevState and PreUpgradeSteadyState are used for
-// UpgradeOp when running cluster-pressure / k8s-request. Those validators
-// check only the non-negative resource delta (new − old) against live
-// headroom so a deployment that already holds its requests is not
-// double-counted. PrevState short-circuits the common cases (Running →
-// delta, Stopped → full). On UpgradeFailed, PreUpgradeSteadyState (the
-// bytetrade.io/pre-upgrade-state annotation: Running or Stopped intent
-// snapped before the failed attempt) short-circuits the same way when
-// set; otherwise a live-pod probe located via PrevAppConfig decides
-// (see upgradePrevHoldsRequests). Cluster-capacity always uses AppConfig
-// (the new chart) absolutely, and install/resume ignore these fields.
+// UpgradeOp when running cluster-pressure / k8s-request (and to decide
+// whether cluster-capacity may be skipped). Those headroom validators
+// check the non-negative resource delta (new − old) when the previous
+// version still holds requests (Running, or UpgradeFailed with
+// pre-upgrade-state=running). Stopped upgrades — and UpgradeFailed with
+// pre-upgrade-state=stopped — skip headroom/capacity checks entirely:
+// the release stays at replicas=0 until resume, which has its own gates.
+// UpgradeFailed without a usable annotation falls through to a live-pod
+// probe via PrevAppConfig (see upgradePrevHoldsRequests). Install/resume
+// ignore these fields.
 type Input struct {
 	Client                client.Client
 	AppConfig             *appcfg.ApplicationConfig

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -100,6 +100,10 @@ func (clusterCapacityValidator) AppliesTo(op Op) bool {
 }
 
 func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decision, error) {
+	if skipUpgradeResourceCheck(in) {
+		return ok(), nil
+	}
+
 	added := compute.AddedResourcesFromAppConfig(in.AppConfig)
 
 	// Short-circuit: when the app declares no resource requirement
@@ -312,14 +316,23 @@ func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, er
 // requirementConfigForOp returns the ApplicationConfig whose declared
 // Requirement should be checked. For install/resume that is AppConfig
 // as-is. For upgrade it is a shallow copy with Requirement set to
-// max(0, new−old), but only when the previous version still holds its
-// requests (see upgradePrevHoldsRequests); otherwise the new chart's
-// absolute requirements are checked, because nothing is being freed.
-// skip is true when the delta is zero on every dimension (caller should
-// treat as OK without hitting metrics).
+// max(0, new−old) when the previous version still holds its requests
+// (see upgradePrevHoldsRequests). skip is true when:
+//
+//   - the upgrade starts from Stopped, or UpgradeFailed with
+//     pre-upgrade-state=stopped (no live headroom check; resume gates later)
+//   - the delta is zero on every dimension while still holding requests
+//
+// Callers treat skip as OK without hitting metrics. When the previous
+// version does not hold requests for other reasons (e.g. UpgradeFailed
+// with no usable annotation and no scheduled pods), the new chart's
+// absolute requirements are checked.
 func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.ApplicationConfig, skip bool, err error) {
 	if in.Op != v1alpha1.UpgradeOp {
 		return in.AppConfig, false, nil
+	}
+	if skipUpgradeResourceCheck(in) {
+		return nil, true, nil
 	}
 	holds, err := upgradePrevHoldsRequests(ctx, in.PrevAppConfig, in.PrevState, in.PreUpgradeSteadyState)
 	if err != nil {
@@ -335,6 +348,24 @@ func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.Applicat
 	return compute.AppConfigWithRequirement(in.AppConfig, delta), false, nil
 }
 
+// skipUpgradeResourceCheck reports whether UpgradeOp should skip
+// cluster-capacity / cluster-pressure / k8s-request entirely. Stopped
+// apps (and UpgradeFailed retries that still record a Stopped pre-op
+// intent) keep the release at replicas=0, so live headroom and physical
+// capacity gates run on resume instead.
+func skipUpgradeResourceCheck(in Input) bool {
+	if in.Op != v1alpha1.UpgradeOp {
+		return false
+	}
+	switch in.PrevState {
+	case v1alpha1.Stopped:
+		return true
+	case v1alpha1.UpgradeFailed:
+		return in.PreUpgradeSteadyState == string(v1alpha1.Stopped)
+	}
+	return false
+}
+
 // upgradePrevHoldsRequests reports whether the deployed version an
 // upgrade starts from still holds its requests, so only the (new − old)
 // increase needs to fit in live headroom.
@@ -342,9 +373,9 @@ func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.Applicat
 // Decision order:
 //
 //   - Running → delta (pods are expected to be up)
-//   - Stopped → full (nothing to discount)
-//   - UpgradeFailed + preUpgradeSteadyState running/stopped → same as above
-//     (AppPreUpgradeStateKey snapshot from the attempt that failed)
+//   - Stopped → callers should use skipUpgradeResourceCheck (no check)
+//   - UpgradeFailed + preUpgradeSteadyState running → delta
+//   - UpgradeFailed + preUpgradeSteadyState stopped → skipUpgradeResourceCheck
 //   - UpgradeFailed with missing/illegal preUpgradeSteadyState, and every
 //     other state → live-pod probe in the previous config's namespace.
 //     Terminated and unscheduled pods hold nothing, so Failed,
@@ -578,18 +609,16 @@ func InstallabilityValidators() []Validator {
 //     the NEW chart's declared requirements at all?" — evaluated
 //     against the new chart's ABSOLUTE requirements (Total, not
 //     Total−Usage), since a running old version does not shrink the
-//     cluster's total schedulable size.
+//     cluster's total schedulable size. Skipped for Stopped upgrades
+//     (and UpgradeFailed with pre-upgrade-state=stopped); resume gates
+//     capacity when the app is started again.
 //   - cluster-pressure / k8s-request: "can live headroom absorb the
 //     resource INCREASE this upgrade introduces?" — each runs against
-//     the non-negative delta (new − old) computed from
-//     Input.PrevAppConfig, so the running deployment already reflected
-//     in cluster usage / scheduled requests is not double-counted.
-//     When the delta is zero on every dimension (the common case where
-//     a new version keeps or lowers its requests) these validators
-//     short-circuit to OK without any metrics round trip. Upgrades of a
-//     workload whose pods are gone have nothing to discount, so they are
-//     checked against the new chart's absolute requirements instead —
-//     see upgradePrevHoldsRequests.
+//     the non-negative delta (new − old) when the previous version still
+//     holds requests. Zero delta short-circuits to OK. Stopped /
+//     UpgradeFailed+stopped skip these checks. Other cases with nothing
+//     to discount fall back to the new chart's absolute requirements —
+//     see upgradePrevHoldsRequests / skipUpgradeResourceCheck.
 //
 // Intentionally excluded:
 //

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -224,7 +224,10 @@ func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decisio
 
 // userQuotaValidator wraps apputils.CheckUserResRequirement which
 // checks the owner's per-user memory / CPU quota via prometheus.
-
+//
+// Not currently wired into InstallabilityValidators,
+// ResumePressureValidators, or UpgradabilityValidators; retained for
+// direct/unit use and potential future re-introduction into a chain.
 type userQuotaValidator struct{}
 
 func (userQuotaValidator) Name() string { return NameUserQuota }
@@ -578,8 +581,8 @@ func (computeAllocationValidator) Validate(ctx context.Context, in Input) (Decis
 // InstallabilityValidators returns the structural feasibility chain.
 // These answer the question "can this cluster ever host this app?" —
 // they look at static / slowly-changing properties (total schedulable
-// capacity, GPU mode availability, per-user quota) and ignore the
-// momentary level of pod scheduling pressure.
+// capacity, GPU mode availability) and ignore the momentary level of
+// pod scheduling pressure.
 //
 // Used at HTTP submit time (install handler) to reject requests the
 // cluster fundamentally cannot accommodate before any helm work starts.
@@ -589,16 +592,18 @@ func (computeAllocationValidator) Validate(ctx context.Context, in Input) (Decis
 // Upgrade uses its own chain (UpgradabilityValidators) instead of this
 // one — see that function for the rationale.
 //
+// Intentionally excluded:
+//
+//   - user-quota: per-user quota is not gated at install submit time.
+//
 // Ordering matches the user-facing failure mode they reveal:
 //
 //  1. cluster-capacity     — "your cluster is too small, period."
 //  2. compute-mode         — "no node has the requested GPU mode."
-//  3. user-quota           — "your account is over its limit."
 func InstallabilityValidators() []Validator {
 	return []Validator{
 		clusterCapacityValidator{},
 		computeModeValidator{},
-		userQuotaValidator{},
 	}
 }
 
@@ -622,8 +627,8 @@ func InstallabilityValidators() []Validator {
 //
 // Intentionally excluded:
 //
-//   - user-quota: install/resume remain the per-user quota gates;
-//     upgrade does not re-check owner quota.
+//   - user-quota: per-user quota is not gated on upgrade (nor on
+//     install/resume submit chains).
 //   - compute-mode: the existing app already has an allocation, the
 //     upgrade reuses prevCfg.SelectedGpuType. Re-running the planner
 //     would either no-op or spuriously fail on a transiently-degraded
@@ -679,11 +684,21 @@ func InstallRuntimePressureValidators() []Validator {
 	return append(RuntimePressureValidators(), computeAllocationValidator{})
 }
 
+// ResumePressureValidators returns the resume-time resource gate used by
+// the resume HTTP handler. It checks live cluster headroom
+// (cluster-pressure + k8s-request) before flipping a stopped app back
+// to running.
+//
+// Intentionally excluded:
+//
+//   - user-quota: per-user quota is not gated at resume submit time.
+//   - compute-mode / node-pressure / compute-allocation: resume reuses
+//     the binding chosen at install; re-running those would either
+//     no-op or spuriously fail on a transiently-degraded node.
 func ResumePressureValidators() []Validator {
 	return []Validator{
 		clusterPressureValidator{},
 		k8sRequestValidator{},
-		userQuotaValidator{},
 	}
 }
 


### PR DESCRIPTION

* **Background**
    fix(app-service): drop user-quota from install and resume submit gates

* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes install/resume/upgrade submit-time resource enforcement (user quota and stopped-upgrade checks), which can allow operations that previously failed at the API layer until resume or other paths run.
> 
> **Overview**
> **Per-user quota is no longer enforced** on install or resume HTTP submit: `user-quota` is removed from `InstallabilityValidators` and `ResumePressureValidators` (the validator remains for direct/unit use).
> 
> **Stopped upgrades no longer run capacity/pressure gates** at submit time. New `skipUpgradeResourceCheck` bypasses `cluster-capacity`, `cluster-pressure`, and `k8s-request` when `PrevState` is `Stopped`, or `UpgradeFailed` with `pre-upgrade-state=stopped`—matching replicas=0 until resume, where existing gates apply. `upgradePrevHoldsRequests` no longer treats stopped as “full absolute requirements”; stopped paths skip instead of probing pods.
> 
> Tests and package comments are updated for the new chains and skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03074413cb484ba456aed804919451e369f98c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->