### PR TITLE
fix(app-service): drop user-quota from install and resume submit gates

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.23
+        image: beclab/app-service:0.6.24
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -212,6 +212,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.TerminatedPodGCController{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", "TerminatedPodGC")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.TailScaleACLController{
 		Client: mgr.GetClient(),
 	}).SetUpWithManager(mgr); err != nil {

--- a/framework/app-service/config/rbac/role.yaml
+++ b/framework/app-service/config/rbac/role.yaml
@@ -8,8 +8,16 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -50,6 +58,15 @@ rules:
   - applications/finalizers
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - iam.kubesphere.io
   resources:

--- a/framework/app-service/controllers/terminated_pod_gc_controller.go
+++ b/framework/app-service/controllers/terminated_pod_gc_controller.go
@@ -1,0 +1,342 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	envTerminatedPodGCMinAge     = "TERMINATED_POD_GC_MIN_AGE"
+	envTerminatedPodGCReadyDelay = "TERMINATED_POD_GC_READY_DELAY"
+)
+
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;list;watch
+
+// TerminatedPodGCController removes terminal Pods of any Deployment in the
+// cluster once that Deployment has as many stably ready replicas as it wants. A
+// Deployment scaled to zero satisfies that trivially, so leftovers of a stopped
+// workload are collected too.
+//
+// Unknown Pods are deliberately excluded. Their workload might still be running
+// on an unreachable node, and there is nothing left for this controller to do
+// anyway: Kubernetes counts an Unknown Pod as active, so a ReplicaSet whose
+// desired count is below its active count deletes such a Pod itself, and while a
+// ReplicaSet is satisfied no replacement exists for the readiness gate to
+// accept. Pods stuck on a lost node are reclaimed by taint eviction and the
+// built-in PodGC.
+//
+// Reaching a Deployment through the ownership chain keeps Pods that no
+// Deployment governs out of scope, so completed Job Pods and bare Pods are
+// never touched.
+type TerminatedPodGCController struct {
+	client.Client
+	minPodAge  time.Duration
+	readyDelay time.Duration
+	now        func() time.Time
+}
+
+func (r *TerminatedPodGCController) SetupWithManager(mgr ctrl.Manager) error {
+	r.minPodAge = parseTimeWithDefault(envTerminatedPodGCMinAge, time.Minute)
+	r.readyDelay = parseTimeWithDefault(envTerminatedPodGCReadyDelay, time.Minute)
+	if r.now == nil {
+		r.now = time.Now
+	}
+
+	klog.Infof(
+		"terminated-pod-gc-controller initialized, minPodAge=%v, readyDelay=%v",
+		r.minPodAge,
+		r.readyDelay,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("terminated-pod-gc-controller").
+		For(&appsv1.Deployment{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForPod),
+		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(r)
+}
+
+func (r *TerminatedPodGCController) requestsForPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	podOwner := metav1.GetControllerOf(pod)
+	if podOwner == nil || podOwner.Kind != replicaSet {
+		return nil
+	}
+
+	var rs appsv1.ReplicaSet
+	if err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: podOwner.Name}, &rs); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("failed to resolve ReplicaSet for pod namespace=%s name=%s: %v", pod.Namespace, pod.Name, err)
+		}
+		return nil
+	}
+	if podOwner.UID != rs.UID {
+		return nil
+	}
+
+	rsOwner := metav1.GetControllerOf(&rs)
+	if rsOwner == nil || rsOwner.Kind != deployment {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      rsOwner.Name,
+	}}}
+}
+
+func (r *TerminatedPodGCController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, req.NamespacedName, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if deploy.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var podList corev1.PodList
+	if err := r.List(
+		ctx,
+		&podList,
+		client.InNamespace(deploy.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Resolving ownership costs a ReplicaSet lookup per Pod, so skip it for the
+	// overwhelmingly common case of a workload with nothing to collect.
+	if !anyCollectablePod(podList.Items) {
+		return ctrl.Result{}, nil
+	}
+
+	pods, err := r.podsControlledByDeployment(ctx, &deploy, podList.Items)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var terminalPods []*corev1.Pod
+	for _, pod := range pods {
+		if isCollectablePod(pod) {
+			terminalPods = append(terminalPods, pod)
+		}
+	}
+	if len(terminalPods) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	// Collect only once the Deployment carries its full complement of replicas
+	// that have stayed ready long enough to be trusted. A Deployment scaled to
+	// zero needs none, which is what makes stopped apps collectable.
+	now := r.currentTime()
+	var stablyReady int32
+	var nextCheck time.Duration
+	for _, pod := range pods {
+		readySince, ready := runningAndReadySince(pod)
+		if !ready {
+			continue
+		}
+		remaining := r.readyDelay - now.Sub(readySince)
+		if remaining <= 0 {
+			stablyReady++
+			continue
+		}
+		nextCheck = shorterPositiveDuration(nextCheck, remaining)
+	}
+	if stablyReady < deploymentReplicas(&deploy) {
+		return ctrl.Result{RequeueAfter: nextCheck}, nil
+	}
+	nextCheck = 0
+
+	for _, pod := range terminalPods {
+		remaining := r.minPodAge - now.Sub(terminalSince(pod))
+		if remaining > 0 {
+			nextCheck = shorterPositiveDuration(nextCheck, remaining)
+			continue
+		}
+
+		uid := pod.UID
+		err := r.Delete(ctx, pod, &client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		klog.Infof(
+			"deleted terminal pod namespace=%s name=%s phase=%s deployment=%s",
+			pod.Namespace,
+			pod.Name,
+			pod.Status.Phase,
+			deploy.Name,
+		)
+	}
+
+	return ctrl.Result{RequeueAfter: nextCheck}, nil
+}
+
+func (r *TerminatedPodGCController) podsControlledByDeployment(
+	ctx context.Context,
+	deploy *appsv1.Deployment,
+	pods []corev1.Pod,
+) ([]*corev1.Pod, error) {
+	replicaSets := make(map[string]*appsv1.ReplicaSet)
+	missingReplicaSets := make(map[string]struct{})
+	result := make([]*corev1.Pod, 0, len(pods))
+
+	for i := range pods {
+		pod := &pods[i]
+		owner := metav1.GetControllerOf(pod)
+		if owner == nil || owner.Kind != replicaSet {
+			continue
+		}
+		if _, missing := missingReplicaSets[owner.Name]; missing {
+			continue
+		}
+
+		rs, found := replicaSets[owner.Name]
+		if !found {
+			var fetched appsv1.ReplicaSet
+			err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}, &fetched)
+			if apierrors.IsNotFound(err) {
+				missingReplicaSets[owner.Name] = struct{}{}
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			rs = &fetched
+			replicaSets[owner.Name] = rs
+		}
+		if owner.UID != rs.UID {
+			continue
+		}
+
+		rsOwner := metav1.GetControllerOf(rs)
+		if rsOwner == nil || rsOwner.Kind != deployment || rsOwner.UID != deploy.UID {
+			continue
+		}
+		result = append(result, pod)
+	}
+
+	return result, nil
+}
+
+func (r *TerminatedPodGCController) currentTime() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func deploymentReplicas(deploy *appsv1.Deployment) int32 {
+	if deploy.Spec.Replicas == nil {
+		return 1
+	}
+	return *deploy.Spec.Replicas
+}
+
+func isTerminalPod(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
+}
+
+func isCollectablePod(pod *corev1.Pod) bool {
+	return isTerminalPod(pod) && pod.DeletionTimestamp == nil
+}
+
+func anyCollectablePod(pods []corev1.Pod) bool {
+	for i := range pods {
+		if isCollectablePod(&pods[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func runningAndReadySince(pod *corev1.Pod) (time.Time, bool) {
+	if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+		return time.Time{}, false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			if condition.LastTransitionTime.IsZero() {
+				return pod.CreationTimestamp.Time, true
+			}
+			return condition.LastTransitionTime.Time, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func terminalSince(pod *corev1.Pod) time.Time {
+	var since time.Time
+	for _, status := range pod.Status.InitContainerStatuses {
+		since = laterTime(since, terminatedAt(status))
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		since = laterTime(since, terminatedAt(status))
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady &&
+			condition.Status == corev1.ConditionFalse &&
+			!condition.LastTransitionTime.IsZero() {
+			since = laterTime(since, condition.LastTransitionTime.Time)
+		}
+	}
+	if since.IsZero() {
+		return pod.CreationTimestamp.Time
+	}
+	return since
+}
+
+func terminatedAt(status corev1.ContainerStatus) time.Time {
+	if status.State.Terminated == nil || status.State.Terminated.FinishedAt.IsZero() {
+		return time.Time{}
+	}
+	return status.State.Terminated.FinishedAt.Time
+}
+
+func laterTime(left, right time.Time) time.Time {
+	if right.After(left) {
+		return right
+	}
+	return left
+}
+
+func shorterPositiveDuration(current, candidate time.Duration) time.Duration {
+	if candidate <= 0 {
+		return current
+	}
+	if current <= 0 || candidate < current {
+		return candidate
+	}
+	return current
+}

--- a/framework/app-service/controllers/terminated_pod_gc_controller_test.go
+++ b/framework/app-service/controllers/terminated_pod_gc_controller_test.go
@@ -1,0 +1,297 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestTerminatedPodGCControllerReconcile(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 10, 0, 0, 0, time.UTC)
+
+	tests := []terminatedPodGCTestCase{
+		{
+			name:                "deletes failed pod replaced by ready pod from another ReplicaSet",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantDeleted:         true,
+		},
+		{
+			name:                "deletes succeeded pod",
+			phase:               corev1.PodSucceeded,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantDeleted:         true,
+		},
+		{
+			name:                   "deletes terminal pod that carries no application labels",
+			phase:                  corev1.PodFailed,
+			replicas:               1,
+			targetTerminalAge:      10 * time.Minute,
+			replacementReady:       true,
+			replacementReadyAge:    2 * time.Minute,
+			targetWithoutAppLabels: true,
+			wantDeleted:            true,
+		},
+		{
+			name:                "keeps unknown pod",
+			phase:               corev1.PodUnknown,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "waits for replacement to become ready",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    false,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "waits for replacement readiness delay",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 30 * time.Second,
+			wantRequeue:         true,
+		},
+		{
+			name:                "waits for terminal pod minimum age",
+			phase:               corev1.PodFailed,
+			replicas:            1,
+			targetTerminalAge:   time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			wantRequeue:         true,
+		},
+		{
+			name:                "waits while multi replica Deployment is short of ready replicas",
+			phase:               corev1.PodFailed,
+			replicas:            2,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+		},
+		{
+			name:                "deletes failed pod once every replica of a multi replica Deployment is ready",
+			phase:               corev1.PodFailed,
+			replicas:            2,
+			targetTerminalAge:   10 * time.Minute,
+			replacementReady:    true,
+			replacementReadyAge: 2 * time.Minute,
+			replacementCount:    2,
+			wantDeleted:         true,
+		},
+		{
+			name:              "deletes failed pod left behind by a stopped Deployment",
+			phase:             corev1.PodFailed,
+			replicas:          0,
+			targetTerminalAge: 10 * time.Minute,
+			noReplacement:     true,
+			wantDeleted:       true,
+		},
+		{
+			name:              "waits for terminal pod minimum age on a stopped Deployment",
+			phase:             corev1.PodFailed,
+			replicas:          0,
+			targetTerminalAge: time.Minute,
+			noReplacement:     true,
+			wantRequeue:       true,
+		},
+		{
+			name:                       "does not accept replacement owned by another Deployment",
+			phase:                      corev1.PodFailed,
+			replicas:                   1,
+			targetTerminalAge:          10 * time.Minute,
+			replacementReady:           true,
+			replacementReadyAge:        2 * time.Minute,
+			replacementOtherDeployment: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploy, objects := terminatedPodGCFixture(now, tt)
+			fakeClient := testutil.NewFakeClient(objects...)
+			reconciler := &TerminatedPodGCController{
+				Client:     fakeClient,
+				minPodAge:  5 * time.Minute,
+				readyDelay: time.Minute,
+				now:        func() time.Time { return now },
+			}
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(deploy),
+			})
+			require.NoError(t, err)
+
+			var target corev1.Pod
+			err = fakeClient.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: deploy.Namespace, Name: "old-pod"},
+				&target,
+			)
+			if tt.wantDeleted {
+				assert.True(t, apierrors.IsNotFound(err), "terminal pod should be deleted")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRequeue, result.RequeueAfter > 0)
+		})
+	}
+}
+
+type terminatedPodGCTestCase struct {
+	name                       string
+	phase                      corev1.PodPhase
+	replicas                   int32
+	targetTerminalAge          time.Duration
+	replacementReady           bool
+	replacementReadyAge        time.Duration
+	replacementOtherDeployment bool
+	replacementCount           int
+	noReplacement              bool
+	targetWithoutAppLabels     bool
+	wantDeleted                bool
+	wantRequeue                bool
+}
+
+func terminatedPodGCFixture(
+	now time.Time,
+	values terminatedPodGCTestCase,
+) (*appsv1.Deployment, []client.Object) {
+	appLabels := map[string]string{
+		"workload":                      "test-app",
+		constants.ApplicationNameLabel:  "test-app",
+		constants.ApplicationOwnerLabel: "alice",
+	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-app-alice",
+			Name:      "test-app",
+			UID:       types.UID("deployment-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(values.replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"workload": "test-app"}},
+		},
+	}
+	oldRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       deploy.Namespace,
+			Name:            "test-app-old",
+			UID:             types.UID("old-rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind(deployment))},
+		},
+	}
+
+	replacementOwner := deploy
+	objects := []client.Object{deploy, oldRS}
+	if values.replacementOtherDeployment {
+		replacementOwner = deploy.DeepCopy()
+		replacementOwner.Name = "other-app"
+		replacementOwner.UID = types.UID("other-deployment-uid")
+		objects = append(objects, replacementOwner)
+	}
+	newRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       deploy.Namespace,
+			Name:            "test-app-new",
+			UID:             types.UID("new-rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replacementOwner, appsv1.SchemeGroupVersion.WithKind(deployment))},
+		},
+	}
+
+	// Only the Deployment selector has to match; the controller is not scoped to
+	// application workloads.
+	targetLabels := appLabels
+	if values.targetWithoutAppLabels {
+		targetLabels = map[string]string{"workload": "test-app"}
+	}
+
+	targetFinishedAt := metav1.NewTime(now.Add(-values.targetTerminalAge))
+	target := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         deploy.Namespace,
+			Name:              "old-pod",
+			UID:               types.UID("old-pod-uid"),
+			Labels:            targetLabels,
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(oldRS, appsv1.SchemeGroupVersion.WithKind(replicaSet))},
+		},
+		Status: corev1.PodStatus{
+			Phase: values.phase,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{FinishedAt: targetFinishedAt},
+				},
+			}},
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: targetFinishedAt,
+			}},
+		},
+	}
+
+	readyStatus := corev1.ConditionFalse
+	if values.replacementReady {
+		readyStatus = corev1.ConditionTrue
+	}
+	objects = append(objects, newRS, target)
+
+	replacementCount := values.replacementCount
+	if replacementCount == 0 {
+		replacementCount = 1
+	}
+	if values.noReplacement {
+		replacementCount = 0
+	}
+	for i := 0; i < replacementCount; i++ {
+		name := fmt.Sprintf("new-pod-%d", i)
+		objects = append(objects, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         deploy.Namespace,
+				Name:              name,
+				UID:               types.UID(name + "-uid"),
+				Labels:            appLabels,
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+				OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(newRS, appsv1.SchemeGroupVersion.WithKind(replicaSet))},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:               corev1.PodReady,
+					Status:             readyStatus,
+					LastTransitionTime: metav1.NewTime(now.Add(-values.replacementReadyAge)),
+				}},
+			},
+		})
+	}
+
+	return deploy, objects
+}

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -451,10 +451,10 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 	// cluster-capacity against the new chart's absolute requirements, plus
 	// cluster-pressure / k8s-request against the non-negative delta
 	// (new − old) so the running deployment is not double-counted. That
-	// discount is decided from PrevState for the steady cases (Running →
-	// delta, Stopped → full), from AppPreUpgradeStateKey on UpgradeFailed
-	// when present, and otherwise from whether prevCfg's namespace still
-	// has scheduled pods (see upgradePrevHoldsRequests).
+	// discount is decided from PrevState (Running → delta); Stopped and
+	// UpgradeFailed with pre-upgrade-state=stopped skip these checks;
+	// other UpgradeFailed cases use the annotation or a live-pod probe
+	// (see upgradePrevHoldsRequests / skipUpgradeResourceCheck).
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
 		Client:                h.ctrlClient,
 		AppConfig:             appCfg,

--- a/framework/app-service/pkg/apiserver/handler_suspend.go
+++ b/framework/app-service/pkg/apiserver/handler_suspend.go
@@ -139,7 +139,7 @@ func (h *Handler) resume(req *restful.Request, resp *restful.Response) {
 	}
 
 	// Unified resume-time resource gate: cluster pressure + k8s request
-	// capacity + user quota. Compute mode and per-node pressure are
+	// capacity. User quota, compute mode and per-node pressure are
 	// skipped (resume reuses the binding chosen at install time).
 	decision, err := validation.Run(req.Request.Context(), validation.Input{
 		Client:    h.ctrlClient,

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/prometheus"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -525,7 +526,7 @@ func TestUpgradePrevHoldsRequestsRunningForcesDelta(t *testing.T) {
 	}
 }
 
-func TestUpgradePrevHoldsRequestsStoppedForcesFull(t *testing.T) {
+func TestUpgradePrevHoldsRequestsStoppedDoesNotHold(t *testing.T) {
 	stubKube(t, namespaceObj("app-alice"), podObj("app-alice", "app-0", corev1.PodRunning))
 
 	holds, err := upgradePrevHoldsRequests(context.Background(), upgradeConfig("app", 1000, 2<<30), v1alpha1.Stopped, "")
@@ -533,7 +534,91 @@ func TestUpgradePrevHoldsRequestsStoppedForcesFull(t *testing.T) {
 		t.Fatalf("upgradePrevHoldsRequests: %v", err)
 	}
 	if holds {
-		t.Fatal("Stopped must force the full path even when pods remain")
+		t.Fatal("Stopped must not report holding requests")
+	}
+}
+
+func TestSkipUpgradeResourceCheck(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    v1alpha1.ApplicationManagerState
+		preState string
+		want     bool
+	}{
+		{name: "stopped skips", state: v1alpha1.Stopped, want: true},
+		{name: "upgradeFailed+stopped skips", state: v1alpha1.UpgradeFailed, preState: string(v1alpha1.Stopped), want: true},
+		{name: "running does not skip", state: v1alpha1.Running, want: false},
+		{name: "upgradeFailed+running does not skip", state: v1alpha1.UpgradeFailed, preState: string(v1alpha1.Running), want: false},
+		{name: "upgradeFailed+empty does not skip", state: v1alpha1.UpgradeFailed, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipUpgradeResourceCheck(Input{
+				Op:                    v1alpha1.UpgradeOp,
+				PrevState:             tc.state,
+				PreUpgradeSteadyState: tc.preState,
+			})
+			if got != tc.want {
+				t.Fatalf("skip=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpgradeStoppedSkipsResourceChecks verifies Stopped (and
+// UpgradeFailed with pre-upgrade-state=stopped) skip capacity / pressure /
+// k8s-request without backend calls.
+func TestUpgradeStoppedSkipsResourceChecks(t *testing.T) {
+	originalCluster := checkAppRequirement
+	originalK8s := checkAppK8sRequestResource
+	originalMetrics := clusterMetricsProvider
+	t.Cleanup(func() {
+		checkAppRequirement = originalCluster
+		checkAppK8sRequestResource = originalK8s
+		clusterMetricsProvider = originalMetrics
+	})
+
+	var calls int
+	checkAppRequirement = func(string, *appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	checkAppK8sRequestResource = func(*appcfg.ApplicationConfig, v1alpha1.OpType) (constants.ResourceType, constants.ResourceConditionType, error) {
+		calls++
+		return "", "", nil
+	}
+	clusterMetricsProvider = func(string) (*prometheus.ClusterMetrics, []string, error) {
+		calls++
+		return nil, nil, errors.New("metrics should not be called")
+	}
+
+	cases := []Input{
+		{
+			AppConfig:     upgradeConfig("app", 3000, 4<<30),
+			PrevAppConfig: upgradeConfig("app", 1000, 2<<30),
+			PrevState:     v1alpha1.Stopped,
+			Op:            v1alpha1.UpgradeOp,
+		},
+		{
+			AppConfig:             upgradeConfig("app", 3000, 4<<30),
+			PrevAppConfig:         upgradeConfig("app", 1000, 2<<30),
+			PrevState:             v1alpha1.UpgradeFailed,
+			PreUpgradeSteadyState: string(v1alpha1.Stopped),
+			Op:                    v1alpha1.UpgradeOp,
+		},
+	}
+	for _, in := range cases {
+		calls = 0
+		decision, err := Run(context.Background(), in, UpgradabilityValidators()...)
+		if err != nil {
+			t.Fatalf("Run(%s): %v", in.PrevState, err)
+		}
+		if !decision.OK {
+			t.Fatalf("Run(%s) decision=%#v, want OK", in.PrevState, decision)
+		}
+		if calls != 0 {
+			t.Fatalf("Run(%s) expected zero backend calls, got %d", in.PrevState, calls)
+		}
 	}
 }
 
@@ -550,7 +635,7 @@ func TestUpgradePrevHoldsRequestsUpgradeFailedUsesAnnotation(t *testing.T) {
 			wantHolds: true,
 		},
 		{
-			name:      "annotation stopped forces full even with pods",
+			name:      "annotation stopped does not hold (skip at requirementConfigForOp)",
 			preState:  string(v1alpha1.Stopped),
 			withPod:   true,
 			wantHolds: false,

--- a/framework/app-service/pkg/compute/validation/run_test.go
+++ b/framework/app-service/pkg/compute/validation/run_test.go
@@ -279,17 +279,16 @@ func TestChainShapes(t *testing.T) {
 	wantInstall := []string{
 		"cluster-capacity",
 		"compute-mode",
-		"user-quota",
 	}
 	assertChainNames(t, "InstallabilityValidators", InstallabilityValidators(), wantInstall)
 
 	// UpgradabilityValidators gates cluster-capacity on the new chart's
 	// absolute requirements, then cluster-pressure / k8s-request on the
 	// non-negative delta (new − old). user-quota, compute-mode,
-	// node-pressure and compute-allocation stay excluded: install/resume
-	// remain the quota gates, upgrade reuses the existing allocation,
-	// and helm upgrade goes through kube-scheduler. See
-	// UpgradabilityValidators in validators.go.
+	// node-pressure and compute-allocation stay excluded: user-quota is
+	// not gated on install/resume/upgrade submit, upgrade reuses the
+	// existing allocation, and helm upgrade goes through kube-scheduler.
+	// See UpgradabilityValidators in validators.go.
 	wantUpgrade := []string{
 		"cluster-capacity",
 		"cluster-pressure",
@@ -303,6 +302,15 @@ func TestChainShapes(t *testing.T) {
 		"node-pressure",
 	}
 	assertChainNames(t, "RuntimePressureValidators", RuntimePressureValidators(), wantRuntime)
+
+	// ResumePressureValidators is the resume HTTP submit gate:
+	// cluster-pressure + k8s-request only. user-quota / compute-mode /
+	// node-pressure / compute-allocation stay excluded.
+	wantResume := []string{
+		"cluster-pressure",
+		"k8s-request",
+	}
+	assertChainNames(t, "ResumePressureValidators", ResumePressureValidators(), wantResume)
 
 	// InstallRuntimePressureValidators = RuntimePressure ++ compute-allocation,
 	// with the heavier side-effecting allocator strictly last so the
@@ -341,12 +349,14 @@ func assertChainNames(t *testing.T, label string, chain []Validator, want []stri
 // node-pressure and compute-allocation stay false for UpgradeOp.
 //
 // The remaining semantic mapping (matching the comments inside
-// validators.go):
+// validators.go). Note AppliesTo for user-quota still reports
+// install+resume, but InstallabilityValidators / ResumePressureValidators
+// no longer include that validator in their chains:
 //
 //   - cluster-pressure, k8s-request : install + resume + upgrade.
 //   - node-pressure                 : install + resume.
-//   - user-quota         : install + resume only (upgrade does not
-//     re-check owner quota).
+//   - user-quota         : AppliesTo install + resume only; not wired
+//     into any exported submit chain.
 //   - cluster-capacity   : install + upgrade — resume reuses the
 //     placement chosen at install; the cluster's
 //     total schedulable capacity hasn't shrunk in
@@ -394,8 +404,9 @@ func TestAppliesToMatrix(t *testing.T) {
 			},
 		},
 		{
-			// user-quota is install + resume only; upgrade does not
-			// re-check owner quota (see UpgradabilityValidators).
+			// user-quota.AppliesTo remains install + resume, but the
+			// validator is no longer included in InstallabilityValidators
+			// or ResumePressureValidators (see those chain constructors).
 			name: "user-quota",
 			v:    userQuotaValidator{},
 			want: map[Op]bool{

--- a/framework/app-service/pkg/compute/validation/validator.go
+++ b/framework/app-service/pkg/compute/validation/validator.go
@@ -5,10 +5,11 @@
 // runs UpgradabilityValidators at HTTP submit time: cluster-capacity
 // against the new chart's absolute requirements, plus cluster-pressure /
 // k8s-request against the non-negative delta (new − old) when the
-// deployed version still holds its requests, or against the new chart's
-// absolute requirements when the upgrade starts from a stopped state
-// (see that function). User-quota is not part of the upgrade chain
-// (install/resume remain the quota gates).
+// deployed version still holds its requests. Stopped upgrades (and
+// UpgradeFailed with pre-upgrade-state=stopped) skip those checks;
+// other upgrades with nothing to discount use absolute requirements
+// (see skipUpgradeResourceCheck / upgradePrevHoldsRequests). User-quota
+// is not part of the upgrade chain (install/resume remain the quota gates).
 //
 // Each individual check (cluster pressure, per-user quota, k8s request
 // availability, per-node pressure, GPU compute plan) is wrapped in a
@@ -36,16 +37,16 @@ type Op = v1alpha1.OpType
 // it; the others ignore unset fields.
 //
 // PrevAppConfig, PrevState and PreUpgradeSteadyState are used for
-// UpgradeOp when running cluster-pressure / k8s-request. Those validators
-// check only the non-negative resource delta (new − old) against live
-// headroom so a deployment that already holds its requests is not
-// double-counted. PrevState short-circuits the common cases (Running →
-// delta, Stopped → full). On UpgradeFailed, PreUpgradeSteadyState (the
-// bytetrade.io/pre-upgrade-state annotation: Running or Stopped intent
-// snapped before the failed attempt) short-circuits the same way when
-// set; otherwise a live-pod probe located via PrevAppConfig decides
-// (see upgradePrevHoldsRequests). Cluster-capacity always uses AppConfig
-// (the new chart) absolutely, and install/resume ignore these fields.
+// UpgradeOp when running cluster-pressure / k8s-request (and to decide
+// whether cluster-capacity may be skipped). Those headroom validators
+// check the non-negative resource delta (new − old) when the previous
+// version still holds requests (Running, or UpgradeFailed with
+// pre-upgrade-state=running). Stopped upgrades — and UpgradeFailed with
+// pre-upgrade-state=stopped — skip headroom/capacity checks entirely:
+// the release stays at replicas=0 until resume, which has its own gates.
+// UpgradeFailed without a usable annotation falls through to a live-pod
+// probe via PrevAppConfig (see upgradePrevHoldsRequests). Install/resume
+// ignore these fields.
 type Input struct {
 	Client                client.Client
 	AppConfig             *appcfg.ApplicationConfig

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -100,6 +100,10 @@ func (clusterCapacityValidator) AppliesTo(op Op) bool {
 }
 
 func (clusterCapacityValidator) Validate(ctx context.Context, in Input) (Decision, error) {
+	if skipUpgradeResourceCheck(in) {
+		return ok(), nil
+	}
+
 	added := compute.AddedResourcesFromAppConfig(in.AppConfig)
 
 	// Short-circuit: when the app declares no resource requirement
@@ -312,14 +316,23 @@ func (k8sRequestValidator) Validate(ctx context.Context, in Input) (Decision, er
 // requirementConfigForOp returns the ApplicationConfig whose declared
 // Requirement should be checked. For install/resume that is AppConfig
 // as-is. For upgrade it is a shallow copy with Requirement set to
-// max(0, new−old), but only when the previous version still holds its
-// requests (see upgradePrevHoldsRequests); otherwise the new chart's
-// absolute requirements are checked, because nothing is being freed.
-// skip is true when the delta is zero on every dimension (caller should
-// treat as OK without hitting metrics).
+// max(0, new−old) when the previous version still holds its requests
+// (see upgradePrevHoldsRequests). skip is true when:
+//
+//   - the upgrade starts from Stopped, or UpgradeFailed with
+//     pre-upgrade-state=stopped (no live headroom check; resume gates later)
+//   - the delta is zero on every dimension while still holding requests
+//
+// Callers treat skip as OK without hitting metrics. When the previous
+// version does not hold requests for other reasons (e.g. UpgradeFailed
+// with no usable annotation and no scheduled pods), the new chart's
+// absolute requirements are checked.
 func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.ApplicationConfig, skip bool, err error) {
 	if in.Op != v1alpha1.UpgradeOp {
 		return in.AppConfig, false, nil
+	}
+	if skipUpgradeResourceCheck(in) {
+		return nil, true, nil
 	}
 	holds, err := upgradePrevHoldsRequests(ctx, in.PrevAppConfig, in.PrevState, in.PreUpgradeSteadyState)
 	if err != nil {
@@ -335,6 +348,24 @@ func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.Applicat
 	return compute.AppConfigWithRequirement(in.AppConfig, delta), false, nil
 }
 
+// skipUpgradeResourceCheck reports whether UpgradeOp should skip
+// cluster-capacity / cluster-pressure / k8s-request entirely. Stopped
+// apps (and UpgradeFailed retries that still record a Stopped pre-op
+// intent) keep the release at replicas=0, so live headroom and physical
+// capacity gates run on resume instead.
+func skipUpgradeResourceCheck(in Input) bool {
+	if in.Op != v1alpha1.UpgradeOp {
+		return false
+	}
+	switch in.PrevState {
+	case v1alpha1.Stopped:
+		return true
+	case v1alpha1.UpgradeFailed:
+		return in.PreUpgradeSteadyState == string(v1alpha1.Stopped)
+	}
+	return false
+}
+
 // upgradePrevHoldsRequests reports whether the deployed version an
 // upgrade starts from still holds its requests, so only the (new − old)
 // increase needs to fit in live headroom.
@@ -342,9 +373,9 @@ func requirementConfigForOp(ctx context.Context, in Input) (cfg *appcfg.Applicat
 // Decision order:
 //
 //   - Running → delta (pods are expected to be up)
-//   - Stopped → full (nothing to discount)
-//   - UpgradeFailed + preUpgradeSteadyState running/stopped → same as above
-//     (AppPreUpgradeStateKey snapshot from the attempt that failed)
+//   - Stopped → callers should use skipUpgradeResourceCheck (no check)
+//   - UpgradeFailed + preUpgradeSteadyState running → delta
+//   - UpgradeFailed + preUpgradeSteadyState stopped → skipUpgradeResourceCheck
 //   - UpgradeFailed with missing/illegal preUpgradeSteadyState, and every
 //     other state → live-pod probe in the previous config's namespace.
 //     Terminated and unscheduled pods hold nothing, so Failed,
@@ -578,18 +609,16 @@ func InstallabilityValidators() []Validator {
 //     the NEW chart's declared requirements at all?" — evaluated
 //     against the new chart's ABSOLUTE requirements (Total, not
 //     Total−Usage), since a running old version does not shrink the
-//     cluster's total schedulable size.
+//     cluster's total schedulable size. Skipped for Stopped upgrades
+//     (and UpgradeFailed with pre-upgrade-state=stopped); resume gates
+//     capacity when the app is started again.
 //   - cluster-pressure / k8s-request: "can live headroom absorb the
 //     resource INCREASE this upgrade introduces?" — each runs against
-//     the non-negative delta (new − old) computed from
-//     Input.PrevAppConfig, so the running deployment already reflected
-//     in cluster usage / scheduled requests is not double-counted.
-//     When the delta is zero on every dimension (the common case where
-//     a new version keeps or lowers its requests) these validators
-//     short-circuit to OK without any metrics round trip. Upgrades of a
-//     workload whose pods are gone have nothing to discount, so they are
-//     checked against the new chart's absolute requirements instead —
-//     see upgradePrevHoldsRequests.
+//     the non-negative delta (new − old) when the previous version still
+//     holds requests. Zero delta short-circuits to OK. Stopped /
+//     UpgradeFailed+stopped skip these checks. Other cases with nothing
+//     to discount fall back to the new chart's absolute requirements —
+//     see upgradePrevHoldsRequests / skipUpgradeResourceCheck.
 //
 // Intentionally excluded:
 //

--- a/framework/app-service/pkg/compute/validation/validators.go
+++ b/framework/app-service/pkg/compute/validation/validators.go
@@ -224,7 +224,10 @@ func (clusterPressureValidator) Validate(ctx context.Context, in Input) (Decisio
 
 // userQuotaValidator wraps apputils.CheckUserResRequirement which
 // checks the owner's per-user memory / CPU quota via prometheus.
-
+//
+// Not currently wired into InstallabilityValidators,
+// ResumePressureValidators, or UpgradabilityValidators; retained for
+// direct/unit use and potential future re-introduction into a chain.
 type userQuotaValidator struct{}
 
 func (userQuotaValidator) Name() string { return NameUserQuota }
@@ -578,8 +581,8 @@ func (computeAllocationValidator) Validate(ctx context.Context, in Input) (Decis
 // InstallabilityValidators returns the structural feasibility chain.
 // These answer the question "can this cluster ever host this app?" —
 // they look at static / slowly-changing properties (total schedulable
-// capacity, GPU mode availability, per-user quota) and ignore the
-// momentary level of pod scheduling pressure.
+// capacity, GPU mode availability) and ignore the momentary level of
+// pod scheduling pressure.
 //
 // Used at HTTP submit time (install handler) to reject requests the
 // cluster fundamentally cannot accommodate before any helm work starts.
@@ -589,16 +592,18 @@ func (computeAllocationValidator) Validate(ctx context.Context, in Input) (Decis
 // Upgrade uses its own chain (UpgradabilityValidators) instead of this
 // one — see that function for the rationale.
 //
+// Intentionally excluded:
+//
+//   - user-quota: per-user quota is not gated at install submit time.
+//
 // Ordering matches the user-facing failure mode they reveal:
 //
 //  1. cluster-capacity     — "your cluster is too small, period."
 //  2. compute-mode         — "no node has the requested GPU mode."
-//  3. user-quota           — "your account is over its limit."
 func InstallabilityValidators() []Validator {
 	return []Validator{
 		clusterCapacityValidator{},
 		computeModeValidator{},
-		userQuotaValidator{},
 	}
 }
 
@@ -622,8 +627,8 @@ func InstallabilityValidators() []Validator {
 //
 // Intentionally excluded:
 //
-//   - user-quota: install/resume remain the per-user quota gates;
-//     upgrade does not re-check owner quota.
+//   - user-quota: per-user quota is not gated on upgrade (nor on
+//     install/resume submit chains).
 //   - compute-mode: the existing app already has an allocation, the
 //     upgrade reuses prevCfg.SelectedGpuType. Re-running the planner
 //     would either no-op or spuriously fail on a transiently-degraded
@@ -679,11 +684,21 @@ func InstallRuntimePressureValidators() []Validator {
 	return append(RuntimePressureValidators(), computeAllocationValidator{})
 }
 
+// ResumePressureValidators returns the resume-time resource gate used by
+// the resume HTTP handler. It checks live cluster headroom
+// (cluster-pressure + k8s-request) before flipping a stopped app back
+// to running.
+//
+// Intentionally excluded:
+//
+//   - user-quota: per-user quota is not gated at resume submit time.
+//   - compute-mode / node-pressure / compute-allocation: resume reuses
+//     the binding chosen at install; re-running those would either
+//     no-op or spuriously fail on a transiently-degraded node.
 func ResumePressureValidators() []Validator {
 	return []Validator{
 		clusterPressureValidator{},
 		k8sRequestValidator{},
-		userQuotaValidator{},
 	}
 }
 


### PR DESCRIPTION

* **Background**
    fix(app-service): drop user-quota from install and resume submit gates

* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes install/resume quota enforcement and changes upgrade checks for stopped apps; the new GC controller deletes pods cluster-wide for Deployment workloads, which needs correct readiness gates to avoid premature deletion.
> 
> **Overview**
> **Install and resume** no longer run **user-quota** at HTTP submit time: `InstallabilityValidators` is now cluster-capacity + compute-mode only, and `ResumePressureValidators` is cluster-pressure + k8s-request only. The `userQuotaValidator` remains in the codebase but is not wired into those chains.
> 
> **Upgrade** resource gating changes for **stopped** workloads: `skipUpgradeResourceCheck` skips cluster-capacity, cluster-pressure, and k8s-request when `PrevState` is Stopped or UpgradeFailed with pre-upgrade-state=stopped (capacity/headroom is expected on **resume** instead). Stopped no longer forces “full” absolute requirements via `upgradePrevHoldsRequests`.
> 
> A new **`TerminatedPodGCController`** deletes Failed/Succeeded pods owned by a Deployment’s ReplicaSets once the Deployment has enough stably ready replicas (or replicas=0), with min age and readiness delays; RBAC adds pod **delete** and apps **get/list/watch**. **app-service** image **0.6.23 → 0.6.24**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a9f7111cd17cf20df89700a9e6e5bc88532b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->