### PR TITLE
market: in-memory catalog snapshot and browse APIs

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.89
+        image: beclab/market-backend:v0.6.90
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.88
+        image: beclab/market-backend:v0.6.89
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
in-memory catalog snapshot and browse APIs

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/407


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling out a new appstore-backend image can affect catalog browsing and related APIs; risk is limited to a single image tag change with no config drift.
> 
> **Overview**
> Bumps the **appstore-backend** container image in `market_deploy.yaml` from **`beclab/market-backend:v0.6.88`** to **`v0.6.90`**, aligning the cluster deployment with the market backend release that includes the in-memory catalog snapshot and browse APIs (see related market PR).
> 
> No other manifest changes—env, volumes, init containers, and RBAC are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1581e1c58b155ed0baa163c015c605f7127bacef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->