### PR TITLE
fix: wise app name replace

### DIFF
--- a/framework/backup-server/pkg/modules/backup/v1/handler.go
+++ b/framework/backup-server/pkg/modules/backup/v1/handler.go
@@ -718,7 +718,7 @@ func (h *Handler) addRestore(req *restful.Request, resp *restful.Response) {
 			return
 		}
 	} else {
-		if ok := h.handler.GetBackupHandler().CheckAppInstalled(fmt.Sprintf("wise-%s-wise", owner)); !ok {
+		if ok := h.handler.GetBackupHandler().CheckAppInstalled(fmt.Sprintf("wisev3-%s-wisev3", owner)); !ok {
 			response.HandleError(resp, fmt.Errorf("Wise is not installed. Please go to the Market to install this app."))
 			return
 		}


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string change to app name resolution in restore validation; no auth or data-path changes.
> 
> **Overview**
> Updates the **Wise install gate** in `addRestore` so non–file-type restores look up the correct Market application resource.
> 
> `CheckAppInstalled` now uses **`wisev3-{owner}-wisev3`** instead of **`wise-{owner}-wise`**, so restores are not blocked with “Wise is not installed” when only the v3 app is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2877910d59f548d5970face6d705068b85cef204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->