### PR TITLE
backup: wise name replace

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.68" }}
+{{ $backupVersion := "0.3.69" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.69" }}
+{{ $backupVersion := "0.3.70" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}

--- a/framework/backup-server/pkg/modules/backup/v1/handler.go
+++ b/framework/backup-server/pkg/modules/backup/v1/handler.go
@@ -718,7 +718,7 @@ func (h *Handler) addRestore(req *restful.Request, resp *restful.Response) {
 			return
 		}
 	} else {
-		if ok := h.handler.GetBackupHandler().CheckAppInstalled(fmt.Sprintf("wise-%s-wise", owner)); !ok {
+		if ok := h.handler.GetBackupHandler().CheckAppInstalled(fmt.Sprintf("wisev3-%s-wisev3", owner)); !ok {
 			response.HandleError(resp, fmt.Errorf("Wise is not installed. Please go to the Market to install this app."))
 			return
 		}


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
wise name replace

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small string and manifest fixes plus an image tag bump; no auth or data-path changes beyond the Wise app naming convention.
> 
> **Overview**
> Updates backup-server deployment to **v0.3.70** and fixes the NATS `MiddlewareRequest` so **`user: os-backup`** is a sibling of `subjects` instead of nested under a subject entry.
> 
> Non–file restore flows now call **`CheckAppInstalled`** with **`wisev3-{owner}-wisev3`** instead of **`wise-{owner}-wise`**, matching the renamed Wise app in the cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ebe039f0b9ad0854cb30c353d82525ac555e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->