### PR TITLE
olares: bump system-frontend to v1.11.26

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.25
+          image: beclab/system-frontend:v1.11.26
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

Bump `system-frontend` from v1.11.25 to v1.11.26 so Olares ships the Market browse rewrite from TermiPass#1339.

Market categories and composed pages now load cache-first from IndexedDB and revalidate in the background, instead of polling `/market/hash` and keeping a monolithic local catalog. Refresh runs on `catalog_changed`, tab visibility, and reconnect (debounced). Legacy `marketData` / `marketHash` localStorage keys are cleared. Categories use Dexie v4 scope-only keys (`marketCategoriesV4`) because Market ignores `arch` on `/market/categories`; page caches stay architecture-aware.

This frontend expects Market's `/market/pages` and `/market/categories` browse APIs and no longer depends on `/market/hash`. Co-deploy with the Market memory-catalog browse work (beclab/market#407) so the new client and the new server land together.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1339

* **Other information**:
None


Made with [Cursor](https://cursor.com)