### PR TITLE
fix(download-server): yt-dlp no-media handling, hf:// scheme, torrent select-file validation

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.9"
+        image: "beclab/download-server:v1.0.10"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
fixed the issue where "no media" pages  would cause tasks to hang forever at "preparing"
added parsing support for hf:// URLs
out-of-range or invalid torrent file selection are rejected with an immediate error at creation time

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag change in deploy config with no RBAC, env, or resource changes.
> 
> **Overview**
> **Rolls out** `beclab/download-server` **v1.0.10** on the download DaemonSet by updating the `download-server` container image in `download_deploy.yaml` (was v1.0.9). No other manifest fields (resources, env, mounts) change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc10ff95831b13196b696b1e175defc8d318fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->