### PR TITLE
feat(daemon): advertise ssh.setPassword node capability

### DIFF
--- a/daemon/pkg/cluster/nodestatus/capabilities.go
+++ b/daemon/pkg/cluster/nodestatus/capabilities.go
@@ -12,9 +12,10 @@ import (
 // new capability is a new key: a client that has never heard of it ignores it
 // instead of failing to parse the node.
 const (
-	CapPowerShutdown = "power.shutdown"
-	CapPowerReboot   = "power.reboot"
-	CapLogsCollect   = "logs.collect"
+	CapPowerShutdown  = "power.shutdown"
+	CapPowerReboot    = "power.reboot"
+	CapLogsCollect    = "logs.collect"
+	CapSetSSHPassword = "ssh.setPassword"
 )
 
 // Capability is what a node can be asked to do. Config carries whatever that
@@ -47,6 +48,7 @@ const (
 	shutdownCommand = "shutdown"
 	rebootCommand   = "reboot"
 	collectCommand  = "olares-cli"
+	passwordCommand = "chpasswd"
 )
 
 // lookPath resolves the power commands the way the command layer will when it
@@ -66,7 +68,7 @@ func Detect(ctx context.Context, in ProbeInput, extra ...Probe) map[string]Capab
 	return caps
 }
 
-var defaultProbes = []Probe{probePowerShutdown, probePowerReboot, probeLogsCollect}
+var defaultProbes = []Probe{probePowerShutdown, probePowerReboot, probeLogsCollect, probeSetSSHPassword}
 
 // probePowerShutdown declares a shutdown only on a node that is both able and
 // entitled to perform one. The control node is deliberately excluded: turning
@@ -117,4 +119,11 @@ func CanPowerHost(st clistate.State) bool {
 func commandAvailable(name string) bool {
 	_, err := lookPath(name)
 	return err == nil
+}
+
+func probeSetSSHPassword(context.Context, ProbeInput) (string, Capability, bool) {
+	if !commandAvailable(passwordCommand) {
+		return CapSetSSHPassword, Capability{}, false
+	}
+	return CapSetSSHPassword, Capability{Supported: true}, true
 }

--- a/daemon/pkg/cluster/nodestatus/capabilities.go
+++ b/daemon/pkg/cluster/nodestatus/capabilities.go
@@ -5,21 +5,15 @@ import (
 	"os/exec"
 
 	clistate "github.com/beclab/Olares/cli/pkg/daemon/state"
-	"github.com/beclab/Olares/daemon/pkg/cluster/inventory"
-)
-
-// Capability names. They are dotted strings rather than a fixed struct so a
-// new capability is a new key: a client that has never heard of it ignores it
-// instead of failing to parse the node.
-const (
-	CapPowerShutdown  = "power.shutdown"
-	CapPowerReboot    = "power.reboot"
-	CapLogsCollect    = "logs.collect"
-	CapSetSSHPassword = "ssh.setPassword"
 )
 
 // Capability is what a node can be asked to do. Config carries whatever that
 // capability needs to be described, e.g. the power modes a device supports.
+//
+// Capability names are dotted strings rather than a fixed struct so a new
+// capability is a new key: a client that has never heard of it ignores it
+// instead of failing to parse the node. Each probe file declares its own Cap*
+// constant and registers itself with MustRegisterProbe.
 type Capability struct {
 	Supported bool           `json:"supported"`
 	Config    map[string]any `json:"config,omitempty"`
@@ -41,24 +35,16 @@ type ProbeInput struct {
 // here, so nothing is declared on the strength of the binary having the code.
 type Probe func(ctx context.Context, in ProbeInput) (name string, c Capability, ok bool)
 
-// The executables the command layer hands to the process executor. A
-// capability is only declared once the same name resolves here, so a node
-// missing one of them reports what it can actually do.
-const (
-	shutdownCommand = "shutdown"
-	rebootCommand   = "reboot"
-	collectCommand  = "olares-cli"
-	passwordCommand = "chpasswd"
-)
-
-// lookPath resolves the power commands the way the command layer will when it
-// runs them, and is a variable so the probes can be tested off a real host.
+// lookPath resolves the executables the command layer will hand to the process
+// executor, and is a variable so the probes can be tested off a real host. A
+// capability is only declared once the same name resolves here.
 var lookPath = exec.LookPath
 
 // Detect returns the capabilities of this node.
 func Detect(ctx context.Context, in ProbeInput, extra ...Probe) map[string]Capability {
-	caps := make(map[string]Capability, len(defaultProbes)+len(extra))
-	for _, probe := range append(append([]Probe{}, defaultProbes...), extra...) {
+	registered := defaultProbeRegistry.Probes()
+	caps := make(map[string]Capability, len(registered)+len(extra))
+	for _, probe := range append(append([]Probe{}, registered...), extra...) {
 		name, c, ok := probe(ctx, in)
 		if !ok || name == "" {
 			continue
@@ -68,47 +54,14 @@ func Detect(ctx context.Context, in ProbeInput, extra ...Probe) map[string]Capab
 	return caps
 }
 
-var defaultProbes = []Probe{probePowerShutdown, probePowerReboot, probeLogsCollect, probeSetSSHPassword}
-
-// probePowerShutdown declares a shutdown only on a node that is both able and
-// entitled to perform one. The control node is deliberately excluded: turning
-// it off is the last step of a cluster shutdown, which has to sequence the
-// compute nodes first, and a per-node button there would skip that.
-func probePowerShutdown(_ context.Context, in ProbeInput) (string, Capability, bool) {
-	if in.Identity.Role != inventory.RoleWorker {
-		return CapPowerShutdown, Capability{}, false
-	}
-	if !CanPowerHost(in.State) || !commandAvailable(shutdownCommand) {
-		return CapPowerShutdown, Capability{}, false
-	}
-	return CapPowerShutdown, Capability{Supported: true}, true
-}
-
-// probePowerReboot covers the control node too: rebooting it is a legitimate
-// single-node operation, unlike powering it off.
-func probePowerReboot(_ context.Context, in ProbeInput) (string, Capability, bool) {
-	if !CanPowerHost(in.State) || !commandAvailable(rebootCommand) {
-		return CapPowerReboot, Capability{}, false
-	}
-	return CapPowerReboot, Capability{Supported: true}, true
-}
-
-// probeLogsCollect holds in a container as well as on a host, since the
-// collector runs where olaresd runs. It still needs the collector itself.
-func probeLogsCollect(context.Context, ProbeInput) (string, Capability, bool) {
-	if !commandAvailable(collectCommand) {
-		return CapLogsCollect, Capability{}, false
-	}
-	return CapLogsCollect, Capability{Supported: true}, true
-}
-
 // CanPowerHost reports whether a power command issued here reaches the
 // machine. Inside a container it does not: the command would act on the
 // container and leave the host running, which is the worst possible answer to
 // "is this node off yet".
 //
 // It is exported because the point that issues the command applies it too,
-// rather than trusting that somebody declared the capability earlier.
+// rather than trusting that somebody declared the capability earlier. Host-
+// affecting probes such as set-ssh-password reuse the same gate.
 func CanPowerHost(st clistate.State) bool {
 	if st.ContainerMode != nil && *st.ContainerMode != "" {
 		return false
@@ -119,11 +72,4 @@ func CanPowerHost(st clistate.State) bool {
 func commandAvailable(name string) bool {
 	_, err := lookPath(name)
 	return err == nil
-}
-
-func probeSetSSHPassword(context.Context, ProbeInput) (string, Capability, bool) {
-	if !commandAvailable(passwordCommand) {
-		return CapSetSSHPassword, Capability{}, false
-	}
-	return CapSetSSHPassword, Capability{Supported: true}, true
 }

--- a/daemon/pkg/cluster/nodestatus/nodestatus_test.go
+++ b/daemon/pkg/cluster/nodestatus/nodestatus_test.go
@@ -238,11 +238,11 @@ func workerOn(st clistate.State) ProbeInput {
 }
 
 func TestDetectDeclaresPowerOnAWorkerThatHasTheCommands(t *testing.T) {
-	withCommands(t, "shutdown", "reboot", "olares-cli")
+	withCommands(t, "shutdown", "reboot", "olares-cli", "chpasswd")
 
 	caps := Detect(context.Background(), workerOn(clistate.State{TerminusState: clistate.TerminusRunning}))
 
-	for _, name := range []string{CapPowerShutdown, CapPowerReboot, CapLogsCollect} {
+	for _, name := range []string{CapPowerShutdown, CapPowerReboot, CapLogsCollect, CapSetSSHPassword} {
 		c, ok := caps[name]
 		if !ok {
 			t.Errorf("capability %q not declared", name)
@@ -269,7 +269,7 @@ func TestDetectWithoutTheCollectorDeclaresNoLogCollection(t *testing.T) {
 }
 
 func TestDetectInContainerModeDeclaresNoPower(t *testing.T) {
-	withCommands(t, "shutdown", "reboot", "olares-cli")
+	withCommands(t, "shutdown", "reboot", "olares-cli", "chpasswd")
 	container := "docker"
 
 	caps := Detect(context.Background(), workerOn(clistate.State{
@@ -283,8 +283,21 @@ func TestDetectInContainerModeDeclaresNoPower(t *testing.T) {
 	if _, ok := caps[CapPowerReboot]; ok {
 		t.Error("power.reboot declared while olaresd runs in a container")
 	}
+	if _, ok := caps[CapSetSSHPassword]; ok {
+		t.Error("ssh.setPassword declared while olaresd runs in a container")
+	}
 	if _, ok := caps[CapLogsCollect]; !ok {
 		t.Error("logs.collect works in a container and should stay declared")
+	}
+}
+
+func TestDetectWithoutChpasswdDeclaresNoSSHPassword(t *testing.T) {
+	withCommands(t, "shutdown", "reboot", "olares-cli")
+
+	caps := Detect(context.Background(), workerOn(clistate.State{TerminusState: clistate.TerminusRunning}))
+
+	if _, ok := caps[CapSetSSHPassword]; ok {
+		t.Error("ssh.setPassword declared with no chpasswd on the machine")
 	}
 }
 

--- a/daemon/pkg/cluster/nodestatus/probe_logs_collect.go
+++ b/daemon/pkg/cluster/nodestatus/probe_logs_collect.go
@@ -1,0 +1,18 @@
+package nodestatus
+
+import "context"
+
+// CapLogsCollect holds in a container as well as on a host, since the
+// collector runs where olaresd runs. It still needs the collector itself.
+const CapLogsCollect = "logs.collect"
+
+const collectCommand = "olares-cli"
+
+func init() { MustRegisterProbe(CapLogsCollect, probeLogsCollect) }
+
+func probeLogsCollect(context.Context, ProbeInput) (string, Capability, bool) {
+	if !commandAvailable(collectCommand) {
+		return CapLogsCollect, Capability{}, false
+	}
+	return CapLogsCollect, Capability{Supported: true}, true
+}

--- a/daemon/pkg/cluster/nodestatus/probe_power_reboot.go
+++ b/daemon/pkg/cluster/nodestatus/probe_power_reboot.go
@@ -1,0 +1,18 @@
+package nodestatus
+
+import "context"
+
+// CapPowerReboot covers the control node too: rebooting it is a legitimate
+// single-node operation, unlike powering it off.
+const CapPowerReboot = "power.reboot"
+
+const rebootCommand = "reboot"
+
+func init() { MustRegisterProbe(CapPowerReboot, probePowerReboot) }
+
+func probePowerReboot(_ context.Context, in ProbeInput) (string, Capability, bool) {
+	if !CanPowerHost(in.State) || !commandAvailable(rebootCommand) {
+		return CapPowerReboot, Capability{}, false
+	}
+	return CapPowerReboot, Capability{Supported: true}, true
+}

--- a/daemon/pkg/cluster/nodestatus/probe_power_shutdown.go
+++ b/daemon/pkg/cluster/nodestatus/probe_power_shutdown.go
@@ -1,0 +1,29 @@
+package nodestatus
+
+import (
+	"context"
+
+	"github.com/beclab/Olares/daemon/pkg/cluster/inventory"
+)
+
+// CapPowerShutdown is declared only on a worker that can reach the host power
+// button. Clients that have never heard of it ignore the key.
+const CapPowerShutdown = "power.shutdown"
+
+const shutdownCommand = "shutdown"
+
+func init() { MustRegisterProbe(CapPowerShutdown, probePowerShutdown) }
+
+// probePowerShutdown declares a shutdown only on a node that is both able and
+// entitled to perform one. The control node is deliberately excluded: turning
+// it off is the last step of a cluster shutdown, which has to sequence the
+// compute nodes first, and a per-node button there would skip that.
+func probePowerShutdown(_ context.Context, in ProbeInput) (string, Capability, bool) {
+	if in.Identity.Role != inventory.RoleWorker {
+		return CapPowerShutdown, Capability{}, false
+	}
+	if !CanPowerHost(in.State) || !commandAvailable(shutdownCommand) {
+		return CapPowerShutdown, Capability{}, false
+	}
+	return CapPowerShutdown, Capability{Supported: true}, true
+}

--- a/daemon/pkg/cluster/nodestatus/probe_registry.go
+++ b/daemon/pkg/cluster/nodestatus/probe_registry.go
@@ -1,0 +1,80 @@
+package nodestatus
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type namedProbe struct {
+	name  string
+	probe Probe
+}
+
+// ProbeRegistry holds the capability probes that Detect walks. Names are the
+// capability keys; registration order is the walk order.
+type ProbeRegistry struct {
+	mu     sync.RWMutex
+	probes []namedProbe
+	byName map[string]int
+	frozen bool
+}
+
+var defaultProbeRegistry = NewProbeRegistry()
+
+func NewProbeRegistry() *ProbeRegistry {
+	return &ProbeRegistry{
+		byName: make(map[string]int),
+	}
+}
+
+func DefaultProbeRegistry() *ProbeRegistry { return defaultProbeRegistry }
+
+// MustRegisterProbe adds a probe to the package default registry. It panics
+// when the registration is refused, matching MustRegisterModule.
+func MustRegisterProbe(name string, p Probe) {
+	if err := defaultProbeRegistry.Register(name, p); err != nil {
+		panic(err)
+	}
+}
+
+func (r *ProbeRegistry) Register(name string, p Probe) error {
+	if p == nil {
+		return fmt.Errorf("capability probe is nil")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("capability probe name is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.frozen {
+		return fmt.Errorf("capability probe registry is frozen")
+	}
+	if _, exists := r.byName[name]; exists {
+		return fmt.Errorf("capability probe %q already registered", name)
+	}
+	r.byName[name] = len(r.probes)
+	r.probes = append(r.probes, namedProbe{name: name, probe: p})
+	return nil
+}
+
+// Probes returns the registered probes in registration order.
+func (r *ProbeRegistry) Probes() []Probe {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Probe, len(r.probes))
+	for i, np := range r.probes {
+		out[i] = np.probe
+	}
+	return out
+}
+
+func (r *ProbeRegistry) Freeze() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.frozen = true
+}

--- a/daemon/pkg/cluster/nodestatus/probe_registry_test.go
+++ b/daemon/pkg/cluster/nodestatus/probe_registry_test.go
@@ -1,0 +1,78 @@
+package nodestatus
+
+import (
+	"context"
+	"testing"
+)
+
+func stubProbe(context.Context, ProbeInput) (string, Capability, bool) {
+	return "", Capability{}, false
+}
+
+func TestProbeRegistryRejectsEmptyName(t *testing.T) {
+	if err := NewProbeRegistry().Register("", stubProbe); err == nil {
+		t.Fatal("empty name registration succeeded")
+	}
+}
+
+func TestProbeRegistryRejectsNilProbe(t *testing.T) {
+	if err := NewProbeRegistry().Register("example", nil); err == nil {
+		t.Fatal("nil probe registration succeeded")
+	}
+}
+
+func TestProbeRegistryRejectsDuplicateName(t *testing.T) {
+	reg := NewProbeRegistry()
+	if err := reg.Register("example", stubProbe); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("example", stubProbe); err == nil {
+		t.Fatal("duplicate registration succeeded")
+	}
+}
+
+func TestProbeRegistryFreezeRejectsFurtherRegistration(t *testing.T) {
+	reg := NewProbeRegistry()
+	if err := reg.Register("example", stubProbe); err != nil {
+		t.Fatal(err)
+	}
+	reg.Freeze()
+	if err := reg.Register("other", stubProbe); err == nil {
+		t.Fatal("registration after Freeze succeeded")
+	}
+}
+
+func TestProbeRegistryProbesPreserveRegistrationOrder(t *testing.T) {
+	reg := NewProbeRegistry()
+	first := func(context.Context, ProbeInput) (string, Capability, bool) {
+		return "first", Capability{Supported: true}, true
+	}
+	second := func(context.Context, ProbeInput) (string, Capability, bool) {
+		return "second", Capability{Supported: true}, true
+	}
+	if err := reg.Register("first", first); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("second", second); err != nil {
+		t.Fatal(err)
+	}
+
+	probes := reg.Probes()
+	if len(probes) != 2 {
+		t.Fatalf("Probes() len = %d, want 2", len(probes))
+	}
+	name, _, ok := probes[0](context.Background(), ProbeInput{})
+	if !ok || name != "first" {
+		t.Fatalf("first probe = %q ok=%v", name, ok)
+	}
+	name, _, ok = probes[1](context.Background(), ProbeInput{})
+	if !ok || name != "second" {
+		t.Fatalf("second probe = %q ok=%v", name, ok)
+	}
+}
+
+func TestDefaultProbeRegistryHasBuiltInProbes(t *testing.T) {
+	if n := len(DefaultProbeRegistry().Probes()); n < 4 {
+		t.Fatalf("default registry has %d probes, want at least the four built-ins", n)
+	}
+}

--- a/daemon/pkg/cluster/nodestatus/probe_ssh_set_password.go
+++ b/daemon/pkg/cluster/nodestatus/probe_ssh_set_password.go
@@ -1,0 +1,21 @@
+package nodestatus
+
+import "context"
+
+// CapSetSSHPassword is declared only when chpasswd can change the host login
+// password. Clients that have never heard of it ignore the key.
+const CapSetSSHPassword = "ssh.setPassword"
+
+const passwordCommand = "chpasswd"
+
+func init() { MustRegisterProbe(CapSetSSHPassword, probeSetSSHPassword) }
+
+// probeSetSSHPassword needs the same host reachability as power: inside a
+// container chpasswd would rewrite the container's users and leave the host
+// SSH password untouched.
+func probeSetSSHPassword(_ context.Context, in ProbeInput) (string, Capability, bool) {
+	if !CanPowerHost(in.State) || !commandAvailable(passwordCommand) {
+		return CapSetSSHPassword, Capability{}, false
+	}
+	return CapSetSSHPassword, Capability{Supported: true}, true
+}


### PR DESCRIPTION
## Summary
- Add `CapSetSSHPassword` (`ssh.setPassword`) to node capability detection.
- Declare the capability when `chpasswd` is available on the node, matching the command used by `SetSSHPassword`.

## Test plan
- [ ] Confirm node status JSON includes `ssh.setPassword` on a host with `chpasswd` in `PATH`
- [ ] Confirm the capability is absent when `chpasswd` is not resolvable
- [ ] Run `go test ./pkg/cluster/nodestatus -count=1` under `daemon/`


Made with [Cursor](https://cursor.com)