### PR TITLE
fix(gateway): honour defaultThirdLevel in application SRR hostPatterns

### DIFF
--- a/framework/app-service/pkg/gateway/producer.go
+++ b/framework/app-service/pkg/gateway/producer.go
@@ -87,8 +87,10 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 			return fmt.Errorf("build SRR spec for entrance %q: %w", entrance.Name, err)
 		}
 		name := ResourceNameForEntrance(appid, entrance.Name)
-		if err := CheckLogicalPatternUniqueness(ctx, r.Client, spec.HostPatterns[0], app.Spec.Namespace, name); err != nil {
-			return fmt.Errorf("uniqueness check for entrance %q: %w", entrance.Name, err)
+		for _, hp := range spec.HostPatterns {
+			if err := CheckLogicalPatternUniqueness(ctx, r.Client, hp, app.Spec.Namespace, name); err != nil {
+				return fmt.Errorf("uniqueness check for entrance %q pattern %q: %w", entrance.Name, hp, err)
+			}
 		}
 		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec); err != nil {
 			return err
@@ -119,8 +121,10 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 			return fmt.Errorf("build SRR spec for application entrance %q: %w", entrance.Name, err)
 		}
 		name := ResourceNameForEntranceApp(appid, entrance.Name)
-		if err := CheckLogicalPatternUniqueness(ctx, r.Client, spec.HostPatterns[0], app.Spec.Namespace, name); err != nil {
-			return fmt.Errorf("uniqueness check for application entrance %q: %w", entrance.Name, err)
+		for _, hp := range spec.HostPatterns {
+			if err := CheckLogicalPatternUniqueness(ctx, r.Client, hp, app.Spec.Namespace, name); err != nil {
+				return fmt.Errorf("uniqueness check for application entrance %q pattern %q: %w", entrance.Name, hp, err)
+			}
 		}
 		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec); err != nil {
 			return err

--- a/framework/app-service/pkg/gateway/producer_test.go
+++ b/framework/app-service/pkg/gateway/producer_test.go
@@ -126,6 +126,58 @@ func TestSharedRouteProducerReconcilerBuildsApplicationSRRs(t *testing.T) {
 	}
 }
 
+func TestSharedRouteProducerReconcilerApplicationUsesThirdLevelOverride(t *testing.T) {
+	cluster.PrimePlatformDomainForTest("olares.com")
+	defer cluster.ResetPlatformDomainForTest()
+
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationRouteMode: AnnotationRouteModeGateway,
+			},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:      "router",
+			Namespace: "router-shared",
+			Appid:     "f3395cd5",
+			Settings: map[string]string{
+				"defaultThirdLevelDomainConfig": `[{"appName":"router","entranceName":"web","thirdLevelDomain":"router"}]`,
+			},
+			Entrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "web-svc", Port: 8080},
+				{Name: "api", Host: "api-svc", Port: 9090},
+			},
+		},
+	}
+	webSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-svc", Namespace: "router-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	apiSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-svc", Namespace: "router-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090, Protocol: corev1.ProtocolTCP}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(producerTestScheme(t)).WithObjects(app, webSvc, apiSvc).Build()
+	r := &SharedRouteProducerReconciler{Client: c}
+	if err := r.reconcileApp(context.Background(), app); err != nil {
+		t.Fatalf("reconcileApp: %v", err)
+	}
+
+	webName := ResourceNameForEntranceApp(app.Spec.Appid, "web")
+	got := &srrv1alpha1.SharedRouteRegistry{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: app.Spec.Namespace, Name: webName}, got); err != nil {
+		t.Fatalf("get web SRR: %v", err)
+	}
+	if len(got.Spec.HostPatterns) != 2 ||
+		got.Spec.HostPatterns[0] != "router.*.olares.com" ||
+		got.Spec.HostPatterns[1] != appv1alpha1.EntranceID(app.Spec.Appid, 0, len(app.Spec.Entrances))+".*.olares.com" {
+		t.Fatalf("web hostPatterns = %v, want [router.*.olares.com, hash.*.olares.com]", got.Spec.HostPatterns)
+	}
+}
+
 func TestSharedRouteProducerReconcilerSingleApplicationEntranceUsesBareAppID(t *testing.T) {
 	cluster.PrimePlatformDomainForTest("olares.com")
 	defer cluster.ResetPlatformDomainForTest()

--- a/framework/app-service/pkg/gateway/srr.go
+++ b/framework/app-service/pkg/gateway/srr.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
@@ -95,21 +97,37 @@ func BuildSpecForEntrance(app *appv1alpha1.Application, entrance appv1alpha1.Ent
 		class = srrv1alpha1.EntranceClassShared
 	}
 
-	var pattern string
+	var patterns []string
 	switch class {
 	case srrv1alpha1.EntranceClassApplication:
-		pattern = fmt.Sprintf("%s.*.%s", appv1alpha1.EntranceID(appid, entranceIndex, entranceCount), platformDomain)
+		// Primary = Resolve(defaultThirdLevel|EntranceID); when default
+		// overrides, also keep the hash EntranceID so both friendly and
+		// canonical hosts hit app-gateway (CoreDNS + HTTPRoute).
+		patterns = applicationEntranceHostPatterns(app, entranceIndex, platformDomain)
 	default:
 		var err error
 		isShared := appv1alpha1.IsShared(app)
-		pattern, err = appcfg.LogicalHostPattern(appid, entranceIndex, entranceCount, platformDomain, isShared)
+		pattern, err := appcfg.LogicalHostPattern(appid, entranceIndex, entranceCount, platformDomain, isShared)
 		if err != nil {
 			return srrv1alpha1.SharedRouteRegistrySpec{}, err
 		}
+		patterns = []string{pattern}
 	}
-	norm, err := NormalizeHostOrLogicalPattern(pattern)
-	if err != nil {
-		return srrv1alpha1.SharedRouteRegistrySpec{}, fmt.Errorf("normalize host pattern %q: %w", pattern, err)
+	norms := make([]string, 0, len(patterns))
+	seen := make(map[string]struct{}, len(patterns))
+	for _, pattern := range patterns {
+		norm, err := NormalizeHostOrLogicalPattern(pattern)
+		if err != nil {
+			return srrv1alpha1.SharedRouteRegistrySpec{}, fmt.Errorf("normalize host pattern %q: %w", pattern, err)
+		}
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		norms = append(norms, norm)
+	}
+	if len(norms) == 0 {
+		return srrv1alpha1.SharedRouteRegistrySpec{}, errors.New("no usable host patterns")
 	}
 
 	upstream := srrv1alpha1.UpstreamRef{
@@ -125,9 +143,52 @@ func BuildSpecForEntrance(app *appv1alpha1.Application, entrance appv1alpha1.Ent
 	return srrv1alpha1.SharedRouteRegistrySpec{
 		RouteMode:     srrv1alpha1.RouteModeGateway,
 		EntranceClass: class,
-		HostPatterns:  []string{norm},
+		HostPatterns:  norms,
 		Upstream:      upstream,
 	}, nil
+}
+
+// applicationEntranceHostPatterns returns SRR hostPatterns for an application
+// entrance. Order: resolved primary (defaultThirdLevel or EntranceID), then
+// the bare EntranceID when an override is active so hash hosts stay on
+// app-gateway alongside the friendly name.
+func applicationEntranceHostPatterns(app *appv1alpha1.Application, entranceIndex int, platformDomain string) []string {
+	appid := strings.ToLower(strings.TrimSpace(app.Spec.Appid))
+	entrances := app.Spec.Entrances
+	canonical := appv1alpha1.EntranceID(appid, entranceIndex, len(entrances))
+	primary := applicationEntranceHostPrefix(app, entranceIndex)
+
+	out := []string{fmt.Sprintf("%s.*.%s", primary, platformDomain)}
+	if primary != canonical && canonical != "" {
+		out = append(out, fmt.Sprintf("%s.*.%s", canonical, platformDomain))
+	}
+	return out
+}
+
+// applicationEntranceHostPrefix returns the Host label used for an application
+// entrance SRR primary pattern. It mirrors l4 buildAppVirtualHosts: parse
+// defaultThirdLevelDomainConfig and call the shared api helper; on missing or
+// malformed settings it falls back to EntranceID.
+func applicationEntranceHostPrefix(app *appv1alpha1.Application, entranceIndex int) string {
+	appid := strings.ToLower(strings.TrimSpace(app.Spec.Appid))
+	entrances := app.Spec.Entrances
+	if entranceIndex < 0 || entranceIndex >= len(entrances) {
+		return appv1alpha1.EntranceID(appid, entranceIndex, len(entrances))
+	}
+
+	var cfgs []appv1alpha1.DefaultThirdLevelDomainConfig
+	if raw := app.Spec.Settings["defaultThirdLevelDomainConfig"]; raw != "" {
+		if err := json.Unmarshal([]byte(raw), &cfgs); err != nil {
+			klog.Warningf("applicationEntranceHostPrefix: defaultThirdLevelDomainConfig unmarshal error app=%s: %v",
+				app.Spec.Name, err)
+		}
+	}
+
+	ptrs := make([]*appv1alpha1.Entrance, len(entrances))
+	for i := range entrances {
+		ptrs[i] = &entrances[i]
+	}
+	return appv1alpha1.ResolveEntranceIDWithDefaultThirdLevelDomainOverride(ptrs, entranceIndex, appid, cfgs)
 }
 
 // pickHTTPPort prefers the entrance-declared port; otherwise the first TCP port

--- a/framework/app-service/pkg/gateway/srr_test.go
+++ b/framework/app-service/pkg/gateway/srr_test.go
@@ -134,3 +134,81 @@ func TestBuildSpecForEntranceApplication(t *testing.T) {
 		t.Errorf("entranceClass = %q, want %q", spec.EntranceClass, srrv1alpha1.EntranceClassApplication)
 	}
 }
+
+func TestBuildSpecForEntranceApplicationUsesThirdLevelOverride(t *testing.T) {
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "router"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Appid:     "f3395cd5",
+			Name:      "router",
+			Namespace: "router-shared",
+			Settings: map[string]string{
+				"defaultThirdLevelDomainConfig": `[{"appName":"router","entranceName":"web","thirdLevelDomain":"router"}]`,
+			},
+			Entrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "router-svc", Port: 8080},
+				{Name: "api", Host: "router-api", Port: 9090},
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "router-svc", Namespace: "router-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+
+	spec, err := BuildSpecForEntrance(app, app.Spec.Entrances[0], 0, len(app.Spec.Entrances), svc, "olares.com",
+		srrv1alpha1.EntranceClassApplication)
+	if err != nil {
+		t.Fatalf("BuildSpecForEntrance: %v", err)
+	}
+	wantHost := "router.*.olares.com"
+	wantHash := appv1alpha1.EntranceID(app.Spec.Appid, 0, len(app.Spec.Entrances)) + ".*.olares.com"
+	if len(spec.HostPatterns) != 2 || spec.HostPatterns[0] != wantHost || spec.HostPatterns[1] != wantHash {
+		t.Fatalf("hostPatterns = %v, want [%q %q]", spec.HostPatterns, wantHost, wantHash)
+	}
+
+	// Unmatched entrance keeps positional EntranceID.
+	apiSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "router-api", Namespace: "router-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090, Protocol: corev1.ProtocolTCP}}},
+	}
+	apiSpec, err := BuildSpecForEntrance(app, app.Spec.Entrances[1], 1, len(app.Spec.Entrances), apiSvc, "olares.com",
+		srrv1alpha1.EntranceClassApplication)
+	if err != nil {
+		t.Fatalf("BuildSpecForEntrance api: %v", err)
+	}
+	wantAPI := appv1alpha1.EntranceID(app.Spec.Appid, 1, len(app.Spec.Entrances)) + ".*.olares.com"
+	if len(apiSpec.HostPatterns) != 1 || apiSpec.HostPatterns[0] != wantAPI {
+		t.Fatalf("api hostPatterns = %v, want %q", apiSpec.HostPatterns, wantAPI)
+	}
+}
+
+func TestBuildSpecForEntranceApplicationMalformedThirdLevelFallsBack(t *testing.T) {
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Appid: "demo1234",
+			Name:  "demo",
+			Settings: map[string]string{
+				"defaultThirdLevelDomainConfig": `{not-json`,
+			},
+			Entrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "demo-svc", Port: 8080},
+				{Name: "api", Host: "demo-api", Port: 9090},
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-user"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	spec, err := BuildSpecForEntrance(app, app.Spec.Entrances[0], 0, len(app.Spec.Entrances), svc, "olares.com",
+		srrv1alpha1.EntranceClassApplication)
+	if err != nil {
+		t.Fatalf("BuildSpecForEntrance: %v", err)
+	}
+	wantHost := appv1alpha1.EntranceID(app.Spec.Appid, 0, len(app.Spec.Entrances)) + ".*.olares.com"
+	if len(spec.HostPatterns) != 1 || spec.HostPatterns[0] != wantHost {
+		t.Fatalf("hostPatterns = %v, want fallback %q", spec.HostPatterns, wantHost)
+	}
+}

--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -94,7 +94,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.25
+        image: beclab/sys-event:0.2.26
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -804,29 +804,25 @@ func sharedInclusterEntrancesFromSRRItems(
 		if err != nil || !found || len(patterns) == 0 {
 			continue
 		}
-		entranceID := ""
-		platformDomain := ""
-		hostPattern := ""
+		// One CoreDNS rewrite per logical hostPattern so friendly + hash
+		// aliases on the same SRR both point at app-gateway-data.
 		for _, pattern := range patterns {
 			id, domain, _, ok := parseLogicalHostPattern(pattern)
 			if !ok {
 				continue
 			}
-			entranceID = id
-			platformDomain = domain
-			hostPattern = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(pattern, ".")))
-			break
+			hostPattern := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(pattern, ".")))
+			if domain == "" || id == "" || hostPattern == "" {
+				continue
+			}
+			entrances = append(entrances, SharedInclusterEntrance{
+				AppID:          appid,
+				EntranceName:   entranceName,
+				EntranceID:     id,
+				PlatformDomain: domain,
+				HostPattern:    hostPattern,
+			})
 		}
-		if platformDomain == "" || entranceID == "" || hostPattern == "" {
-			continue
-		}
-		entrances = append(entrances, SharedInclusterEntrance{
-			AppID:          appid,
-			EntranceName:   entranceName,
-			EntranceID:     entranceID,
-			PlatformDomain: platformDomain,
-			HostPattern:    hostPattern,
-		})
 	}
 	return entrances
 }

--- a/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
@@ -337,14 +337,33 @@ func TestSharedInclusterEntrancesFromSRRItems_logicalPatternNotFirst(t *testing.
 		[]unstructured.Unstructured{*srr},
 		nil,
 	)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 entrance, got %d (%+v)", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entrances (one per hostPattern), got %d (%+v)", len(got), got)
 	}
-	if got[0].EntranceID != "api" {
-		t.Fatalf("unexpected entranceID %q", got[0].EntranceID)
+	if got[0].EntranceID != "api" || got[0].HostPattern != "api.*.olares.com" {
+		t.Fatalf("first = %+v, want api / api.*.olares.com", got[0])
 	}
-	if got[0].HostPattern != "api.*.olares.com" {
-		t.Fatalf("unexpected hostPattern %q", got[0].HostPattern)
+	if got[1].EntranceID != prefix || got[1].HostPattern != prefix+".shared.olares.com" {
+		t.Fatalf("second = %+v, want %s / %s.shared.olares.com", got[1], prefix, prefix)
+	}
+}
+
+func TestSharedInclusterEntrancesFromSRRItems_friendlyAndHash(t *testing.T) {
+	srr := unstructuredSRR("router-shared", "app-f3395cd5-web", map[string]string{
+		labelSRRAppID: "f3395cd5", labelSRREntrance: "web",
+	}, "gateway", []string{
+		"router.*.olares.com",
+		"f3395cd5.*.olares.com",
+	})
+	got := sharedInclusterEntrancesFromSRRItems(
+		[]unstructured.Unstructured{*srr},
+		nil,
+	)
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d (%+v)", len(got), got)
+	}
+	if got[0].HostPattern != "router.*.olares.com" || got[1].HostPattern != "f3395cd5.*.olares.com" {
+		t.Fatalf("patterns = %q, %q", got[0].HostPattern, got[1].HostPattern)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Application SRR `hostPatterns` now include the friendly `defaultThirdLevelDomainConfig` prefix **and** the canonical EntranceID, so both hosts route via app-gateway (not L4).
- CoreDNS incluster rewrite emits one template per logical `hostPattern`.
- Bump `sys-event` image to `0.2.26`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway host routing and CoreDNS rewrite generation for application entrances, so mis-resolved patterns could send traffic to the wrong path. Scope is limited to opted-in gateway apps and is covered by new unit tests.
> 
> **Overview**
> Application gateway SRRs now honour `defaultThirdLevelDomainConfig`. When a friendly third-level override is set, `hostPatterns` include **both** the friendly prefix and the canonical EntranceID hash so both hosts stay on app-gateway (CoreDNS + HTTPRoute) instead of falling back to L4.
> 
> Uniqueness checks now validate every pattern on the SRR, not only the first. CoreDNS incluster rewrite emits one template per logical `hostPattern`, and `sys-event` is bumped to `0.2.26`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7e964c1dd3a41e300426ada2f1aafa256ccb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->