### PR TITLE
fix(bfl): skip non-owned apps when collecting frpc custom domains

### DIFF
--- a/cli/pkg/upgrade/1_12_7.go
+++ b/cli/pkg/upgrade/1_12_7.go
@@ -47,6 +47,7 @@ func (u upgrader_1_12_7) PrepareForUpgrade() []task.Interface {
 		Action: new(plugins.CopyEmbedFiles),
 	})
 	tasks = append(tasks, upgradeKubernetesPrometheusRule()...)
+	tasks = append(tasks, upgradeUserReverseProxy()...)
 
 	tasks = append(tasks, u.upgraderBase.PrepareForUpgrade()...)
 	return tasks

--- a/cli/pkg/upgrade/1_12_7_20260610.go
+++ b/cli/pkg/upgrade/1_12_7_20260610.go
@@ -23,7 +23,7 @@ type upgrader_1_12_7_20260610 struct {
 	upgrader_1_12_7_20260605
 }
 
-const reverseProxyAgentImage = "beclab/reverse-proxy:v0.1.11"
+const reverseProxyAgentImage = "beclab/reverse-proxy:v0.1.12"
 
 func (u upgrader_1_12_7_20260610) Version() *semver.Version {
 	return semver.MustParse("1.12.7-20260610")

--- a/cli/pkg/upgrade/1_12_7_20260812.go
+++ b/cli/pkg/upgrade/1_12_7_20260812.go
@@ -1,0 +1,33 @@
+package upgrade
+
+import (
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260812 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260812) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260812")
+}
+
+func (u upgrader_1_12_7_20260812) PrepareForUpgrade() []task.Interface {
+	pre := []task.Interface{
+		&task.LocalTask{
+			Name:   "UpgradeUserReverseProxyAgent",
+			Action: new(upgradeUserReverseProxyAgent),
+			Retry:  5,
+			Delay:  10 * time.Second,
+		},
+	}
+	return append(pre, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260812{})
+}

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -309,7 +309,7 @@ spec:
         - name: L4_PROXY_NAMESPACE
           value: os-network
         - name: REVERSE_PROXY_AGENT_IMAGE_VERSION
-          value: v0.1.11
+          value: v0.1.12
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/framework/bfl/internal/frpc/controllers/controllers.go
+++ b/framework/bfl/internal/frpc/controllers/controllers.go
@@ -354,11 +354,13 @@ func (f *FrpcController) getApps(parentCtx context.Context) (*v1alpha1App.Applic
 func (f *FrpcController) getCustomDomains(apps *v1alpha1App.ApplicationList) (customDomains []string, err error) {
 	for i := range apps.Items {
 		app := &apps.Items[i]
-		// For shared apps, the customDomain blob lives in
-		// Spec.UserSettings[constants.Username]; for v1/v2 it stays in
-		// Spec.Settings. EffectiveSettings hides the difference. We
-		// reject shared apps that this BFL has no overlay for so we don't
-		// publish another user's domains via this user's frpc.
+		// Same ownership gate as reverse-proxy conf sync: non-shared apps are
+		// only published by their owner. Shared apps keep using EffectiveSettings
+		// so Spec.UserSettings[username] overlays Spec.Settings.
+		if !v1alpha1App.IsShared(app) && app.Spec.Owner != constants.Username {
+			continue
+		}
+
 		settings := app.EffectiveSettings(constants.Username)
 		if len(settings) == 0 {
 			continue

--- a/framework/reverse-proxy/.olares/Olares.yaml
+++ b/framework/reverse-proxy/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/reverse-proxy:v0.1.11
+      name: beclab/reverse-proxy:v0.1.12
 
 
       


### PR DESCRIPTION

* **Background**
fix(bfl): skip non-owned apps when collecting frpc custom domains
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes custom-domain publishing ownership and rolls out a reverse-proxy agent upgrade, which can affect user tunnel/domain routing if the gate or image bump misbehaves.
> 
> **Overview**
> Stops each user's frpc from publishing **other users' custom domains** by applying the same ownership gate used for reverse-proxy conf sync.
> 
> In `getCustomDomains`, non-shared apps are skipped unless `app.Spec.Owner` matches the current BFL user. Shared apps still use `EffectiveSettings` overlays.
> 
> Also bumps the reverse-proxy agent to **`v0.1.12`** (BFL launcher env, image manifest, and upgrade constants) and wires upgrade tasks so existing clusters pick up the new agent via the `1.12.7` path and a new daily upgrader `1.12.7-20260812`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decdc81ccdd1c4f25de8dc38f79a02ecb39a44e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->