### PR TITLE
docs: resolve content conflicts

### DIFF
--- a/docs/reusables/ai-service-connections.md
+++ b/docs/reusables/ai-service-connections.md
@@ -68,6 +68,18 @@ When a client connects to another Olares app, it uses that app's endpoint as the
 2. Wait until **Model** shows **READY** and **Engine** shows **RUNNING**.
 
    ![EmbeddingGemma model console](/images/manual/use-cases/embedding-gemma-model-console-openai.png#bordered)
+
+3. Under **Model**, copy the **Model name** exactly as shown.
+4. Under **Engine**:
+
+   a. **Connection source**: Select **Apps in Olares**.
+   
+   b. **API format**: Select **OpenAI-Compatible**.
+   
+   c. Copy the provided **Base URL** exactly as shown.
+
+<!-- #endregion get-embedding-model-connection-details-openai -->
+
 <!-- #region get-model-connection-details-ollama -->
 1. Open the model app from Launchpad. Its Model Console opens automatically.
 2. Wait until **Model** shows **READY** and **Engine** shows **RUNNING**.
@@ -79,11 +91,6 @@ When a client connects to another Olares app, it uses that app's endpoint as the
 
    a. **Connection source**: Select **Apps in Olares**. 
    
-   b. **API format**: Select **OpenAI-Compatible**.
-   
-   c. Copy the provided **Base URL** exactly as shown.
-
-<!-- #endregion get-embedding-model-connection-details-openai -->
    b. **API format**: Select **Ollama**.
    
    c. Copy the provided **Base URL** exactly as shown.

--- a/docs/zh/reusables/ai-service-connections.md
+++ b/docs/zh/reusables/ai-service-connections.md
@@ -68,11 +68,6 @@ Olares 上的独立模型作为与客户端应用分开的服务运行。要连�
 2. 等待**模型**显示**就绪**，且**引擎**显示**运行中**。
 
    ![EmbeddingGemma model console](/images/zh/manual/use-cases/embedding-gemma-model-console-openai.png#bordered)
-<!-- #region get-model-connection-details-ollama -->
-1. 从启动台打开模型应用。其模型控制台会自动打开。
-2. 等待**模型**显示**就绪**，且**引擎**显示**运行中**。
-
-   ![Gemma4 26B model console](/images/manual/use-cases/gemma4-26b-model-console1.png#bordered)
 
 3. 在**模型**部分，按显示内容原样复制**模型名称**。
 4. 在**引擎**部分：
@@ -84,6 +79,16 @@ Olares 上的独立模型作为与客户端应用分开的服务运行。要连�
    c. 按显示内容原样复制 **Base URL** 地址。
 
 <!-- #endregion get-embedding-model-connection-details-openai -->
+
+<!-- #region get-model-connection-details-ollama -->
+1. 从启动台打开模型应用。其模型控制台会自动打开。
+2. 等待**模型**显示**就绪**，且**引擎**显示**运行中**。
+
+   ![Gemma4 26B model console](/images/manual/use-cases/gemma4-26b-model-console1.png#bordered)
+
+3. 在**模型**部分，按显示内容原样复制**模型名称**。
+4. 在**引擎**部分：
+
    a. **连接来源**：选择 **Olares 内应用**。
 
    b. **API 格式**：选择 **Ollama**。


### PR DESCRIPTION
Title: <subsystem>:  <what changed>
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
<!-- Provide background information about the changes here -->

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only fix to reusable include regions; no code, auth, or runtime behavior changes.
> 
> **Overview**
> Fixes a merge conflict in the EN and ZH `ai-service-connections` reusables that had mixed the **embedding OpenAI** and **Ollama** connection steps.
> 
> Restores complete, separate regions so embedding docs correctly use **OpenAI-Compatible**, and Ollama docs correctly use **Ollama**, for includes in tutorials like Open WebUI and OpenClaw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daea0ee686ac84a42850276b57f71c445789474c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->