### PR TITLE
feat(app-service): bypass nested ifaces past linkerd PROXY_INIT

### DIFF
--- a/framework/app-service/.olares/Olares.yaml
+++ b/framework/app-service/.olares/Olares.yaml
@@ -6,3 +6,5 @@ output:
       name: beclab/mesh-in-agent:1.30.0-r5
     -
       name: beclab/mesh-out-agent:1.30.0-r4
+    -
+      name: beclab/init:v1.2.3

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.24
+        image: beclab/app-service:0.6.25
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_uninstall.go
@@ -66,7 +66,6 @@ func (h *HelmOps) UninstallAll() error {
 	err = h.ClearCache(client, appCacheDirs)
 	if err != nil {
 		klog.Errorf("Failed to clear app cache dirs %v err=%v", appCacheDirs, err)
-		return err
 	}
 	if deleteData {
 		// Non-fatal: the release is already gone, so a failed data wipe must
@@ -79,9 +78,10 @@ func (h *HelmOps) UninstallAll() error {
 	err = h.DeleteNamespace(client, h.app.Namespace)
 	if err != nil {
 		klog.Errorf("Failed to delete namespace %s err=%v", h.app.Namespace, err)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (h *HelmOps) Uninstall_(client kubernetes.Interface, actionConfig *action.Configuration,

--- a/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass.go
+++ b/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass.go
@@ -1,0 +1,260 @@
+package sidecar
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	NestedIfaceBypassInitContainerName = "nested-iface-bypass-iptables"
+	AnnotMeshBypassInterfaces          = "gateway.olares.io/mesh-bypass-interfaces"
+
+	nestedIfaceBypassImage = "beclab/init:v1.2.3"
+	nestedIfaceBypassEnv   = "MESH_BYPASS_IFACES"
+	defaultNestedIface     = "docker"
+)
+
+// ResolveNestedIfaceBypass decides whether to inject the nested-iface bypass init.
+// Annotation CSV wins; none|off|-|false disables; else auto on dockurr image or kvm∧tun.
+func ResolveNestedIfaceBypass(pod *corev1.Pod) (ifaces []string, ok bool) {
+	if pod == nil || !podHasLinkerdMesh(pod) {
+		return nil, false
+	}
+	if pod.Annotations != nil {
+		if raw, exists := pod.Annotations[AnnotMeshBypassInterfaces]; exists {
+			v := strings.TrimSpace(raw)
+			switch strings.ToLower(v) {
+			case "", "none", "off", "-", "false", "disable", "disabled":
+				return nil, false
+			}
+			if parsed := parseIfaceList(v); len(parsed) > 0 {
+				return parsed, true
+			}
+			return nil, false
+		}
+	}
+	if podHasDockurrImage(pod) || podHasKvmAndTun(pod) {
+		return []string{defaultNestedIface}, true
+	}
+	return nil, false
+}
+
+// ApplyNestedIfaceBypass injects/refreshes the bypass init when Resolve says so.
+// Reports whether the pod spec changed (for probe-only admission).
+func ApplyNestedIfaceBypass(pod *corev1.Pod) bool {
+	ifaces, ok := ResolveNestedIfaceBypass(pod)
+	if !ok {
+		return false
+	}
+	want := strings.Join(ifaces, ",")
+	changed := nestedBypassEnv(pod) != want || !nestedBypassIsLast(pod)
+	EnsureNestedIfaceBypassLast(pod, ifaces)
+	return changed
+}
+
+func parseIfaceList(raw string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, p := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t'
+	}) {
+		if p == "" || len(p) > 15 || !ifaceNameOK(p) {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func ifaceNameOK(name string) bool {
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return name != ""
+}
+
+func podHasLinkerdMesh(pod *corev1.Pod) bool {
+	if pod.Annotations != nil &&
+		strings.EqualFold(strings.TrimSpace(pod.Annotations["linkerd.io/inject"]), "enabled") {
+		return true
+	}
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "linkerd-proxy" {
+			return true
+		}
+	}
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == "linkerd-init" {
+			return true
+		}
+	}
+	return false
+}
+
+func podHasDockurrImage(pod *corev1.Pod) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "linkerd-proxy" || c.Name == "olares-mesh-in-agent" {
+			continue
+		}
+		base := imageBase(c.Image)
+		if base == "dockurr-windows" || strings.HasPrefix(base, "dockurr-windows-") ||
+			base == "dockurr-macos" || strings.HasPrefix(base, "dockurr-macos-") {
+			return true
+		}
+	}
+	return false
+}
+
+func imageBase(image string) string {
+	s := strings.ToLower(strings.TrimSpace(image))
+	if i := strings.Index(s, "@"); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.Index(s, ":"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+func podHasKvmAndTun(pod *corev1.Pod) bool {
+	var kvm, tun bool
+	for _, v := range pod.Spec.Volumes {
+		if v.HostPath == nil {
+			continue
+		}
+		switch strings.TrimSpace(v.HostPath.Path) {
+		case "/dev/kvm":
+			kvm = true
+		case "/dev/net/tun":
+			tun = true
+		}
+	}
+	return kvm && tun
+}
+
+func NestedIfaceBypassScript() string {
+	return `set -u
+IFACES="${MESH_BYPASS_IFACES:-docker}"
+IPTABLES_BIN="${IPTABLES_BIN:-iptables-nft}"
+command -v "$IPTABLES_BIN" >/dev/null 2>&1 || { echo "nested-iface-bypass: missing $IPTABLES_BIN" >&2; exit 1; }
+case "$("$IPTABLES_BIN" --version 2>/dev/null || true)" in *nf_tables*) ;; *)
+  echo "nested-iface-bypass: need nf_tables" >&2; exit 1 ;;
+esac
+reinsert() {
+  t=$1; c=$2; d=$3; iface=$4
+  while "$IPTABLES_BIN" -t "$t" -C "$c" "$d" "$iface" -j ACCEPT 2>/dev/null; do
+    "$IPTABLES_BIN" -t "$t" -D "$c" "$d" "$iface" -j ACCEPT || exit 1
+  done
+  "$IPTABLES_BIN" -t "$t" -I "$c" 1 "$d" "$iface" -j ACCEPT || exit 1
+}
+verify() {
+  t=$1; c=$2; d=$3; iface=$4; last=$5
+  dump=$("$IPTABLES_BIN" -t "$t" -S "$c" 2>/dev/null || true)
+  echo "$dump" | grep -Fq -- "-A $c $d $iface -j ACCEPT" || {
+    echo "nested-iface-bypass: missing ACCEPT $iface on $t/$c" >&2; exit 1
+  }
+  first=$(printf '%s\n' "$dump" | awk '/^-A /{print; exit}')
+  want="-A $c $d $last -j ACCEPT"
+  [ "$first" = "$want" ] || {
+    echo "nested-iface-bypass: $t/$c head want $want got ${first:-empty}" >&2; exit 1
+  }
+  echo "$dump" | awk -v want="-A $c $d $iface -j ACCEPT" '
+    /PROXY_INIT_REDIRECT|PROXY_INIT_OUTPUT/ { bad=1; exit }
+    $0 == want { ok=1; exit }
+    END { exit !(ok && !bad) }
+  ' || {
+    echo "nested-iface-bypass: $iface ACCEPT not before PROXY_INIT on $t/$c" >&2; exit 1
+  }
+}
+list=$(printf '%s' "$IFACES" | tr ',;' ' ')
+last=""; n=0
+for iface in $list; do
+  [ -n "$iface" ] || continue
+  ip link show "$iface" >/dev/null 2>&1 || true
+  reinsert nat PREROUTING -i "$iface"
+  reinsert nat OUTPUT -o "$iface"
+  reinsert filter INPUT -i "$iface"
+  reinsert filter OUTPUT -o "$iface"
+  last=$iface; n=$((n+1))
+done
+[ "$n" -gt 0 ] || { echo "nested-iface-bypass: empty MESH_BYPASS_IFACES" >&2; exit 1; }
+for iface in $list; do
+  [ -n "$iface" ] || continue
+  verify nat PREROUTING -i "$iface" "$last"
+  verify nat OUTPUT -o "$iface" "$last"
+  verify filter INPUT -i "$iface" "$last"
+  verify filter OUTPUT -o "$iface" "$last"
+done
+echo "nested-iface-bypass: verified ACCEPT heads for $n iface(s) on nft"
+`
+}
+
+func GetNestedIfaceBypassInitContainer(ifaces []string) corev1.Container {
+	list := strings.Join(ifaces, ",")
+	if list == "" {
+		list = defaultNestedIface
+	}
+	return corev1.Container{
+		Name:            NestedIfaceBypassInitContainerName,
+		Image:           nestedIfaceBypassImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                pointer.Int64Ptr(0),
+			RunAsNonRoot:             pointer.BoolPtr(false),
+			AllowPrivilegeEscalation: pointer.BoolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+			},
+		},
+		Command:                  []string{"/bin/sh", "-c", NestedIfaceBypassScript()},
+		Env:                      []corev1.EnvVar{{Name: nestedIfaceBypassEnv, Value: list}},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+func EnsureNestedIfaceBypassLast(pod *corev1.Pod, ifaces []string) {
+	if pod == nil || len(ifaces) == 0 {
+		return
+	}
+	kept := make([]corev1.Container, 0, len(pod.Spec.InitContainers)+1)
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name != NestedIfaceBypassInitContainerName {
+			kept = append(kept, c)
+		}
+	}
+	pod.Spec.InitContainers = append(kept, GetNestedIfaceBypassInitContainer(ifaces))
+}
+
+func nestedBypassEnv(pod *corev1.Pod) string {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name != NestedIfaceBypassInitContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == nestedIfaceBypassEnv {
+				return e.Value
+			}
+		}
+	}
+	return ""
+}
+
+func nestedBypassIsLast(pod *corev1.Pod) bool {
+	n := len(pod.Spec.InitContainers)
+	return n > 0 && pod.Spec.InitContainers[n-1].Name == NestedIfaceBypassInitContainerName
+}

--- a/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_script_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_script_test.go
@@ -1,0 +1,125 @@
+package sidecar
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type nestedBypassScriptRun struct {
+	t     *testing.T
+	state string
+	bin   string
+}
+
+func newNestedBypassScriptRun(t *testing.T) *nestedBypassScriptRun {
+	t.Helper()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	state := filepath.Join(root, "state")
+	for _, d := range []string{bin, state} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(bin, "iptables-nft"), []byte(iptablesMock), 0o755); err != nil {
+		t.Fatalf("write iptables-nft mock: %v", err)
+	}
+	return &nestedBypassScriptRun{t: t, state: state, bin: bin}
+}
+
+func (r *nestedBypassScriptRun) seed(table, chain, rule string) {
+	r.t.Helper()
+	path := filepath.Join(r.state, table+"_"+chain)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		r.t.Fatalf("seed %s/%s: %v", table, chain, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(rule + "\n"); err != nil {
+		r.t.Fatalf("seed write: %v", err)
+	}
+}
+
+func (r *nestedBypassScriptRun) run(ifaces string) (string, error) {
+	r.t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", NestedIfaceBypassScript())
+	cmd.Env = append(os.Environ(),
+		"PATH="+r.bin+":"+os.Getenv("PATH"),
+		"IPT_STATE="+r.state,
+		"MESH_BYPASS_IFACES="+ifaces,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func (r *nestedBypassScriptRun) rules(table, chain string) []string {
+	r.t.Helper()
+	raw, err := os.ReadFile(filepath.Join(r.state, table+"_"+chain))
+	if err != nil {
+		r.t.Fatalf("read %s/%s: %v", table, chain, err)
+	}
+	lines := make([]string, 0, 4)
+	for _, l := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if l != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
+}
+
+func TestNestedIfaceBypassScriptWinsOverProxyInit(t *testing.T) {
+	r := newNestedBypassScriptRun(t)
+	r.seed("nat", "PREROUTING", "-p tcp -j PROXY_INIT_REDIRECT")
+	r.seed("nat", "OUTPUT", "-p tcp -j PROXY_INIT_OUTPUT")
+	r.seed("filter", "INPUT", "-p tcp -j DROP")
+	r.seed("filter", "OUTPUT", "-p tcp -j DROP")
+
+	out, err := r.run("docker")
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", out, err)
+	}
+	if !strings.Contains(out, "verified ACCEPT heads") {
+		t.Fatalf("missing verify log:\n%s", out)
+	}
+	if got := r.rules("nat", "PREROUTING"); got[0] != "-i docker -j ACCEPT" {
+		t.Fatalf("PREROUTING head=%v", got)
+	}
+	if got := r.rules("nat", "PREROUTING"); len(got) < 2 || got[1] != "-p tcp -j PROXY_INIT_REDIRECT" {
+		t.Fatalf("PROXY_INIT must remain after ACCEPT: %v", got)
+	}
+}
+
+func TestNestedIfaceBypassScriptMultiIface(t *testing.T) {
+	r := newNestedBypassScriptRun(t)
+	r.seed("nat", "PREROUTING", "-p tcp -j PROXY_INIT_REDIRECT")
+	r.seed("nat", "OUTPUT", "-p tcp -j PROXY_INIT_OUTPUT")
+	r.seed("filter", "INPUT", "-j DROP")
+	r.seed("filter", "OUTPUT", "-j DROP")
+
+	if out, err := r.run("docker,br0"); err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+	pre := r.rules("nat", "PREROUTING")
+	if len(pre) < 3 {
+		t.Fatalf("expected two ACCEPT + PROXY_INIT, got %v", pre)
+	}
+	joined := strings.Join(pre, "\n")
+	if !strings.Contains(joined, "-i docker -j ACCEPT") || !strings.Contains(joined, "-i br0 -j ACCEPT") {
+		t.Fatalf("missing iface ACCEPT: %v", pre)
+	}
+	if pre[0] == "-p tcp -j PROXY_INIT_REDIRECT" {
+		t.Fatalf("PROXY_INIT must not stay at head: %v", pre)
+	}
+}
+
+func TestNestedIfaceBypassScriptFailsWithoutNft(t *testing.T) {
+	r := newNestedBypassScriptRun(t)
+	_ = os.Remove(filepath.Join(r.bin, "iptables-nft"))
+	out, err := r.run("docker")
+	if err == nil {
+		t.Fatalf("expected failure, out=%s", out)
+	}
+}

--- a/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_test.go
@@ -1,0 +1,187 @@
+package sidecar
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func linkerdPod(ann map[string]string, spec corev1.PodSpec) *corev1.Pod {
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann["linkerd.io/inject"] = "enabled"
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: ann}, Spec: spec}
+}
+
+func hostPathVol(name, path string) corev1.Volume {
+	return corev1.Volume{Name: name, VolumeSource: corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{Path: path},
+	}}
+}
+
+func TestResolveNestedIfaceBypass(t *testing.T) {
+	cases := []struct {
+		name    string
+		pod     *corev1.Pod
+		wantOK  bool
+		wantIF  []string
+	}{
+		{
+			name: "annot CSV",
+			pod: linkerdPod(map[string]string{AnnotMeshBypassInterfaces: "docker, br0"}, corev1.PodSpec{}),
+			wantOK: true, wantIF: []string{"docker", "br0"},
+		},
+		{
+			name: "annot none disables",
+			pod: linkerdPod(map[string]string{AnnotMeshBypassInterfaces: "none"}, corev1.PodSpec{
+				Volumes:    []corev1.Volume{hostPathVol("kvm", "/dev/kvm"), hostPathVol("tun", "/dev/net/tun")},
+				Containers: []corev1.Container{{Name: "windows", Image: "beclab/dockurr-windows:igpu1"}},
+			}),
+		},
+		{
+			name: "dockurr-macos primary",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "windows", Image: "beclab/dockurr-macos:5.14"}},
+			}),
+			wantOK: true, wantIF: []string{"docker"},
+		},
+		{
+			name: "dockurr-windows primary",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "windows", Image: "ghcr.io/beclab/dockurr-windows:igpu1"}},
+			}),
+			wantOK: true, wantIF: []string{defaultNestedIface},
+		},
+		{
+			name: "kvm and tun secondary",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Volumes:    []corev1.Volume{hostPathVol("kvm", "/dev/kvm"), hostPathVol("tun", "/dev/net/tun")},
+				Containers: []corev1.Container{{Name: "windows", Image: "myorg/custom-win-vm:1"}},
+			}),
+			wantOK: true, wantIF: []string{defaultNestedIface},
+		},
+		{
+			name: "kvm alone",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Volumes:    []corev1.Volume{hostPathVol("kvm", "/dev/kvm")},
+				Containers: []corev1.Container{{Name: "windows", Image: "busybox"}},
+			}),
+		},
+		{
+			name: "tun alone",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Volumes:    []corev1.Volume{hostPathVol("tun", "/dev/net/tun")},
+				Containers: []corev1.Container{{Name: "vpn", Image: "busybox"}},
+			}),
+		},
+		{
+			name: "dri vfio",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Volumes:    []corev1.Volume{hostPathVol("dri", "/dev/dri"), hostPathVol("vfio", "/dev/vfio")},
+				Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
+			}),
+		},
+		{
+			name: "sidecar image ignored",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "linkerd-proxy", Image: "beclab/dockurr-windows:fake"},
+					{Name: "app", Image: "nginx:1.25"},
+				},
+			}),
+		},
+		{
+			name: "no linkerd",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "windows", Image: "beclab/dockurr-windows:igpu1"}},
+			}},
+		},
+		{
+			name: "ordinary app",
+			pod: linkerdPod(nil, corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25"}},
+			}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ResolveNestedIfaceBypass(tc.pod)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v want %v ifaces=%v", ok, tc.wantOK, got)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if len(got) != len(tc.wantIF) {
+				t.Fatalf("ifaces=%v want %v", got, tc.wantIF)
+			}
+			for i := range tc.wantIF {
+				if got[i] != tc.wantIF[i] {
+					t.Fatalf("ifaces=%v want %v", got, tc.wantIF)
+				}
+			}
+		})
+	}
+}
+
+func TestImageBase(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"beclab/dockurr-windows:igpu1", "dockurr-windows"},
+		{"ghcr.io/beclab/dockurr-macos:5.14", "dockurr-macos"},
+		{"dockurr-windows-custom@sha256:abc", "dockurr-windows-custom"},
+		{"docker.io/library/nginx:1.25", "nginx"},
+		{"", ""},
+	} {
+		if got := imageBase(tc.in); got != tc.want {
+			t.Fatalf("base(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEnsureNestedIfaceBypassLast(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+		{Name: "linkerd-init"},
+		{Name: "olares-mesh-in-agent-iptables"},
+		{Name: NestedIfaceBypassInitContainerName},
+	}}}
+	EnsureNestedIfaceBypassLast(pod, []string{"docker"})
+	if n := len(pod.Spec.InitContainers); n != 3 ||
+		pod.Spec.InitContainers[2].Name != NestedIfaceBypassInitContainerName ||
+		nestedBypassEnv(pod) != "docker" {
+		t.Fatalf("inits=%v env=%q", pod.Spec.InitContainers, nestedBypassEnv(pod))
+	}
+	EnsureNestedIfaceBypassLast(nil, []string{"docker"})
+	EnsureNestedIfaceBypassLast(&corev1.Pod{}, nil)
+}
+
+func TestApplyNestedIfaceBypass(t *testing.T) {
+	pod := linkerdPod(nil, corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "windows", Image: "beclab/dockurr-windows:1"}},
+	})
+	if !ApplyNestedIfaceBypass(pod) {
+		t.Fatal("first apply must report change")
+	}
+	if ApplyNestedIfaceBypass(pod) {
+		t.Fatal("idempotent apply must report no change")
+	}
+	pod.Annotations[AnnotMeshBypassInterfaces] = "docker,br0"
+	if !ApplyNestedIfaceBypass(pod) || nestedBypassEnv(pod) != "docker,br0" {
+		t.Fatalf("env update: %q", nestedBypassEnv(pod))
+	}
+}
+
+func TestGetNestedIfaceBypassInitContainerSpec(t *testing.T) {
+	c := GetNestedIfaceBypassInitContainer([]string{"docker"})
+	if c.Name != NestedIfaceBypassInitContainerName || c.Image != nestedIfaceBypassImage {
+		t.Fatalf("name=%s image=%s", c.Name, c.Image)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Fatal("must run as root")
+	}
+	if !strings.Contains(NestedIfaceBypassScript(), "iptables-nft") {
+		t.Fatal("script must use iptables-nft")
+	}
+}

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -187,6 +187,7 @@ func (wh *Webhook) CreatePatch(
 		// TODO: force mutate
 		klog.Infof("Pod is injected with uuid=%s namespace=%s", prevUUID, req.Namespace)
 		mesh.HardenLinkerdProxyAdminProbes(pod)
+		sidecar.ApplyNestedIfaceBypass(pod)
 		if err := wh.patchProbeHeaders(ctx, pod); err != nil {
 			klog.Errorf("Failed to patch probe headers for already-injected pod=%s/%s err=%v", pod.Namespace, pod.Name, err)
 			return nil, err
@@ -239,6 +240,9 @@ func (wh *Webhook) CreatePatch(
 	if injectMacvlanBypass {
 		sidecar.EnsureMacvlanBypassLast(pod)
 	}
+	if sidecar.ApplyNestedIfaceBypass(pod) {
+		klog.Infof("nested-iface-bypass: inject pod=%s/%s", req.Namespace, pod.Name)
+	}
 
 	if injectSharedPod != nil {
 		if *injectSharedPod {
@@ -276,7 +280,12 @@ func (wh *Webhook) PatchLinkerdAdminProbesOnly(
 	req *admissionv1.AdmissionRequest,
 	pod *corev1.Pod,
 ) (patchBytes []byte, patched bool, err error) {
-	if !mesh.HardenLinkerdProxyAdminProbes(pod) {
+	changed := mesh.HardenLinkerdProxyAdminProbes(pod)
+	if sidecar.ApplyNestedIfaceBypass(pod) {
+		changed = true
+		klog.Infof("nested-iface-bypass: inject (probe-only) pod=%s/%s", req.Namespace, pod.Name)
+	}
+	if !changed {
 		return nil, false, nil
 	}
 	if err := wh.patchProbeHeaders(ctx, pod); err != nil {


### PR DESCRIPTION

* **Background**
feat(app-service): bypass nested ifaces past linkerd PROXY_INIT
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pod admission changes networking init order with NET_ADMIN iptables rules on selected workloads; Helm uninstall behavior changes which errors abort teardown.
> 
> **Overview**
> Adds **nested-interface mesh bypass** for Linkerd-injected pods so traffic on interfaces like `docker` is not captured by `PROXY_INIT` rules—needed for dockurr Windows/macOS VMs and similar workloads that expose `/dev/kvm` and `/dev/net/tun`.
> 
> Admission now injects a last-order init container (`nested-iface-bypass-iptables`, `beclab/init:v1.2.3`) when mesh is present and either `gateway.olares.io/mesh-bypass-interfaces` lists interfaces, the annotation disables bypass, or auto-detection hits dockurr images or kvm+tun. The init reorders **nftables** `iptables-nft` ACCEPT rules ahead of Linkerd redirect chains.
> 
> **Helm uninstall** no longer fails the whole uninstall when **cache** cleanup errors (still logged); namespace delete failures still return an error, and success returns `nil` instead of a stale `err`.
> 
> Ships **app-service 0.6.25** and bundles **`beclab/init:v1.2.3`** in Olares prebuilt output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9328e6951c82a0660ea1c82e5ccfb6afd1e292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->