### PR TITLE
market: compute entrance id via the appv1alpha1 resolver

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.90
+        image: beclab/market-backend:v0.6.91
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
compute entrance id via the appv1alpha1 resolver, tell the gateway which catalog apps are templates

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/409
https://github.com/beclab/market/pull/410


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys new market-backend behavior around entrance ID resolution and gateway catalog/template handling, which can affect app routing. The change in this repo is only an image tag bump.
> 
> **Overview**
> Bumps the `appstore-backend` image from `beclab/market-backend:v0.6.90` to `v0.6.91` in `market_deploy.yaml`.
> 
> This pulls in market backend changes that compute entrance IDs via the `appv1alpha1` resolver and inform the gateway which catalog apps are templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469bcde843b2a4fa6a709e9017a6ce4888a09c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->