### PR TITLE
fix(l4): unify Authelia ExtAuth

### DIFF
--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -230,7 +230,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -455,7 +455,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -670,80 +670,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -893,80 +820,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1221,80 +1075,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1444,80 +1225,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -257,7 +257,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -482,7 +482,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -697,80 +697,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -860,80 +787,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1170,80 +1024,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1333,80 +1114,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -419,7 +419,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -624,7 +624,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -849,7 +849,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1054,7 +1054,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1307,80 +1307,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1470,80 +1397,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1738,80 +1592,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1889,80 +1670,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2112,80 +1820,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2440,80 +2075,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2603,80 +2165,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2871,80 +2360,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3022,80 +2438,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3245,80 +2588,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -581,7 +581,7 @@
                           "cluster": "authelia_backend_admin",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -786,7 +786,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -991,7 +991,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1216,7 +1216,7 @@
                           "cluster": "authelia_backend_admin",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1421,7 +1421,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1626,7 +1626,7 @@
                           "cluster": "authelia_backend_bob",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -1841,80 +1841,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1962,80 +1889,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2125,80 +1979,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2393,80 +2174,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2514,80 +2222,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2677,80 +2312,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -2945,80 +2507,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3066,80 +2555,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3229,80 +2645,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3497,80 +2840,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3618,80 +2888,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -3781,80 +2978,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-admin.svc.cluster.local",
-                        "cluster": "authelia_backend_admin",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "admin"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4049,80 +3173,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4170,80 +3221,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4333,80 +3311,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4601,80 +3506,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4722,80 +3554,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/authz/ext-authz/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -4885,80 +3644,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-bob.svc.cluster.local",
-                        "cluster": "authelia_backend_bob",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "bob"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -284,7 +284,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -509,7 +509,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -762,80 +762,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -883,80 +810,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1046,80 +900,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1314,80 +1095,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1435,80 +1143,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1598,80 +1233,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -284,7 +284,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -509,7 +509,7 @@
                           "cluster": "authelia_backend_alice",
                           "timeout": "15s"
                         },
-                        "pathPrefix": "/api/authz/ext-authz/",
+                        "pathPrefix": "/api/verify/",
                         "authorizationRequest": {
                           "headersToAdd": [
                             {
@@ -745,80 +745,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -866,80 +793,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1029,80 +883,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1297,80 +1078,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1418,80 +1126,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [
@@ -1581,80 +1216,7 @@
               "typedPerFilterConfig": {
                 "envoy.filters.http.ext_authz": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-                  "checkSettings": {
-                    "httpService": {
-                      "serverUri": {
-                        "uri": "http://authelia-backend.user-system-alice.svc.cluster.local",
-                        "cluster": "authelia_backend_alice",
-                        "timeout": "15s"
-                      },
-                      "pathPrefix": "/api/verify/",
-                      "authorizationRequest": {
-                        "headersToAdd": [
-                          {
-                            "key": "X-Forwarded-Proto",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%"
-                          },
-                          {
-                            "key": "X-Original-URL",
-                            "value": "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Uri",
-                            "value": "%REQ(:PATH)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Host",
-                            "value": "%REQ(:AUTHORITY)%"
-                          },
-                          {
-                            "key": "X-Original-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-Forwarded-Method",
-                            "value": "%REQ(:METHOD)%"
-                          },
-                          {
-                            "key": "X-BFL-USER",
-                            "value": "alice"
-                          }
-                        ]
-                      },
-                      "authorizationResponse": {
-                        "allowedUpstreamHeaders": {
-                          "patterns": [
-                            {
-                              "prefix": "remote-"
-                            },
-                            {
-                              "prefix": "authelia-"
-                            }
-                          ]
-                        },
-                        "allowedClientHeaders": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            },
-                            {
-                              "exact": "location"
-                            },
-                            {
-                              "exact": "www-authenticate"
-                            }
-                          ]
-                        },
-                        "allowedClientHeadersOnSuccess": {
-                          "patterns": [
-                            {
-                              "exact": "set-cookie"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
+                  "checkSettings": {}
                 }
               },
               "requestHeadersToAdd": [

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -20,7 +20,6 @@ const (
 	autheliaHostFormat       = "authelia-backend.user-system-%s.svc.cluster.local"
 	fileserverHostFormat     = "files-%s.user-system-%s.svc.cluster.local"
 	autheliaPort             = uint32(9091)
-	autheliaPathPrefix       = "/api/authz/ext-authz/"
 	autheliaVerifyPathPrefix = "/api/verify/"
 
 	// probeUARegex matches webhook.getProbeUA shape: {uuid}/{md5hex}.
@@ -476,7 +475,7 @@ func (t *Translator) buildUserVirtualHosts(user *message.UserInfo, zone string, 
 				"X-BFL-USER": user.Name,
 			},
 			// Zone root is human HTTP (profile); EDGE N/S PEP is l4 Authelia verify.
-			ExtAuth: buildAppExtAuthConfig(user, false),
+			ExtAuth: buildAppExtAuthConfig(user),
 		}},
 		Priority: systemServicePriority,
 	}
@@ -609,9 +608,9 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 		}
 
 		// Gate private/internal apps behind Authelia. public skips ExtAuth
-		// (EDGE AC-AL-1). Ordinary/system use /api/verify/; Shared keeps ext-authz.
+		// (EDGE AC-AL-1). All non-public routes use Authelia /api/verify/.
 		if !isPublicAuthLevel(entrance.AuthLevel) {
-			defaultRoute.ExtAuth = buildAppExtAuthConfig(user, app.IsShared)
+			defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
 		}
 
 		// F3: Exact probe paths with signed UA bypass ExtAuth (oes parity).
@@ -684,15 +683,11 @@ func sanitizeProbePath(path string) string {
 }
 
 // buildAppExtAuthConfig returns Authelia ext_auth for app routes.
-// shared=true keeps the historic Shared path; otherwise /api/verify/ is used.
-func buildAppExtAuthConfig(user *message.UserInfo, shared bool) *ir.ExtAuthConfigIR {
-	path := autheliaVerifyPathPrefix
-	if shared {
-		path = autheliaPathPrefix
-	}
+// All non-public routes use Legacy /api/verify/ (filter default; no path split).
+func buildAppExtAuthConfig(user *message.UserInfo) *ir.ExtAuthConfigIR {
 	return &ir.ExtAuthConfigIR{
 		Cluster:    fmt.Sprintf("%s_%s", autheliaClusterPrefix, user.Name),
-		PathPrefix: path,
+		PathPrefix: autheliaVerifyPathPrefix,
 		RequestHeaders: []string{
 			"X-Original-URL",
 			"X-Original-Method",
@@ -710,7 +705,7 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 	autheliaClName := fmt.Sprintf("%s_%s", autheliaClusterPrefix, user.Name)
 	extAuthCfg := &ir.ExtAuthConfigIR{
 		Cluster:    autheliaClName,
-		PathPrefix: autheliaPathPrefix,
+		PathPrefix: autheliaVerifyPathPrefix,
 		RequestHeaders: []string{
 			"X-Original-URL",
 			"X-Original-Method",
@@ -829,7 +824,7 @@ func (t *Translator) buildSystemVirtualHost(user *message.UserInfo, def systemSe
 	// wizard is pre-auth activation UI — no ExtAuth (cookie chicken-egg).
 	// auth is the IdP itself — do not attach ExtAuth (loop risk).
 	if def.Name == "desktop" {
-		route.ExtAuth = buildAppExtAuthConfig(user, false)
+		route.ExtAuth = buildAppExtAuthConfig(user)
 	}
 
 	return &ir.VirtualHostIR{
@@ -885,7 +880,7 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 		}
 
 		if !isPublicAuthLevel(entrance.AuthLevel) {
-			customRoute.ExtAuth = buildAppExtAuthConfig(user, app.IsShared)
+			customRoute.ExtAuth = buildAppExtAuthConfig(user)
 		}
 
 		routes := buildProbeBypassRoutes(

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -601,7 +601,7 @@ func TestBuildAppVirtualHosts_SharedApp_OpenToAllUsers(t *testing.T) {
 
 			require.NotNil(t, r.ExtAuth, "shared apps must be gated behind Authelia ext_auth")
 			assert.Equal(t, fmt.Sprintf("authelia_backend_%s", name), r.ExtAuth.Cluster)
-			assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
+			assert.Equal(t, autheliaVerifyPathPrefix, r.ExtAuth.PathPrefix)
 			assert.False(t, r.ExtAuth.Disabled)
 		})
 	}
@@ -619,7 +619,7 @@ func TestBuildCustomDomainVirtualHosts_SharedApp_ExtAuth(t *testing.T) {
 	r := vhosts[0].Routes[0]
 	require.NotNil(t, r.ExtAuth, "shared apps must stay gated even on a custom domain")
 	assert.Equal(t, "authelia_backend_alice", r.ExtAuth.Cluster)
-	assert.Equal(t, autheliaPathPrefix, r.ExtAuth.PathPrefix)
+	assert.Equal(t, autheliaVerifyPathPrefix, r.ExtAuth.PathPrefix)
 }
 
 // v1/v2 (non-shared) apps reach their upstream cluster and are gated behind
@@ -876,6 +876,10 @@ func TestBuildFileserverRoutes_NodeScopedBeforeMasterGeneric(t *testing.T) {
 	assert.Equal(t, "files_testip162_olares-work", routes[nodeExternal].Cluster)
 	assert.Equal(t, "files_testip162_olares", routes[masterExternal].Cluster)
 	assert.Equal(t, "olares-work", routes[nodeExternal].RequestHeaders["X-Terminus-Node"])
+	require.NotNil(t, routes[nodeExternal].ExtAuth)
+	assert.Equal(t, autheliaVerifyPathPrefix, routes[nodeExternal].ExtAuth.PathPrefix)
+	require.NotNil(t, routes[masterExternal].ExtAuth)
+	assert.Equal(t, autheliaVerifyPathPrefix, routes[masterExternal].ExtAuth.PathPrefix)
 
 	// Every node-scoped prefix that overlaps a master prefix must precede ALL
 	// master generic routes. Compute the first master-route index and assert

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -164,6 +164,10 @@ const xForwardedProtoValue = "%REQ(x-forwarded-proto?:SCHEME)%"
 // without this header Authelia builds rd from the check URI (e.g. /api/verify//).
 const xOriginalURLValue = "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
 
+// autheliaVerifyPathPrefix is the filter-default Authelia Legacy verify path.
+// Per-route overrides are only emitted when PathPrefix differs from this value.
+const autheliaVerifyPathPrefix = "/api/verify/"
+
 var (
 	tcpIdleTimeout        = time.Hour
 	httpStreamIdleTimeout = 30 * time.Minute
@@ -917,11 +921,12 @@ func translateRoute(routeIR *ir.HTTPRouteIR, clusterMap map[string]*ir.ClusterIR
 
 	if routeIR.ExtAuth != nil && !routeIR.ExtAuth.Disabled {
 		checkSettings := &extauthzv3.CheckSettings{}
-		if path := routeIR.ExtAuth.PathPrefix; path != "" && clusterMap != nil {
+		// CheckSettings.http_service replaces the filter-level HttpService
+		// entirely. When PathPrefix matches the filter default (/api/verify/),
+		// emit an empty CheckSettings only so the filter Auth block is reused
+		// and we never ship a path-only override shell.
+		if path := routeIR.ExtAuth.PathPrefix; path != "" && path != autheliaVerifyPathPrefix && clusterMap != nil {
 			if c, ok := clusterMap[routeIR.ExtAuth.Cluster]; ok && c.Host != "" {
-				// CheckSettings.http_service replaces the filter-level HttpService
-				// entirely, so reuse the same AuthorizationRequest/Response as
-				// buildExtAuthzFilter (only PathPrefix differs).
 				userName := ""
 				if routeIR.RequestHeaders != nil {
 					userName = routeIR.RequestHeaders["X-BFL-USER"]
@@ -967,7 +972,7 @@ func buildExtAuthzFilter(autheliaClusterName string, clusterMap map[string]*ir.C
 
 	extAuthz := &extauthzv3.ExtAuthz{
 		Services: &extauthzv3.ExtAuthz_HttpService{
-			HttpService: buildAutheliaHttpService(autheliaClusterName, clusterIR.Host, "/api/authz/ext-authz/", userName),
+			HttpService: buildAutheliaHttpService(autheliaClusterName, clusterIR.Host, autheliaVerifyPathPrefix, userName),
 		},
 		// AllowedHeaders is filter-level (not part of HttpService); per-route
 		// CheckSettings.http_service does not override it.

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
@@ -950,7 +950,7 @@ func TestSubFilterLuaScript_RewritesSetCookieDomain(t *testing.T) {
 	assert.Contains(t, subFilterLuaScript, `headers:replace("Set-Cookie"`)
 }
 
-func TestTranslateRoute_PerRouteHttpServicePathPrefix(t *testing.T) {
+func TestTranslateRoute_VerifyPathSkipsServiceOverride(t *testing.T) {
 	clusterMap := map[string]*ir.ClusterIR{
 		"authelia_backend_alice": {Name: "authelia_backend_alice", Host: "authelia-backend.user-system-alice.svc.cluster.local", Port: 9091},
 	}
@@ -974,39 +974,56 @@ func TestTranslateRoute_PerRouteHttpServicePathPrefix(t *testing.T) {
 	require.NoError(t, anyCfg.UnmarshalTo(&perRoute))
 	cs := perRoute.GetCheckSettings()
 	require.NotNil(t, cs)
-	hs := cs.GetHttpService()
-	require.NotNil(t, hs, "ordinary apps must override Authelia HttpService PathPrefix")
+	assert.Nil(t, cs.GetHttpService(), "verify path must reuse filter default HttpService without ServiceOverride")
+}
+
+func TestBuildExtAuthzFilter_DefaultVerifyPath(t *testing.T) {
+	clusterMap := map[string]*ir.ClusterIR{
+		"authelia_backend_alice": {Name: "authelia_backend_alice", Host: "authelia-backend.user-system-alice.svc.cluster.local", Port: 9091},
+	}
+	filter := buildExtAuthzFilter("authelia_backend_alice", clusterMap, "alice")
+	require.NotNil(t, filter)
+	var extAuthz extauthzv3.ExtAuthz
+	require.NoError(t, filter.GetTypedConfig().UnmarshalTo(&extAuthz))
+	hs := extAuthz.GetHttpService()
+	require.NotNil(t, hs)
 	assert.Equal(t, "/api/verify/", hs.GetPathPrefix())
+	require.NotNil(t, hs.GetAuthorizationRequest())
+	require.NotEmpty(t, hs.GetAuthorizationRequest().GetHeadersToAdd())
+}
+
+func TestTranslateRoute_NonDefaultPathKeepsFullOverride(t *testing.T) {
+	clusterMap := map[string]*ir.ClusterIR{
+		"authelia_backend_alice": {Name: "authelia_backend_alice", Host: "authelia-backend.user-system-alice.svc.cluster.local", Port: 9091},
+	}
+	route := translateRoute(&ir.HTTPRouteIR{
+		Name:       "legacy",
+		PathPrefix: "/",
+		Cluster:    "app_upstream",
+		RequestHeaders: map[string]string{
+			"X-BFL-USER": "alice",
+		},
+		ExtAuth: &ir.ExtAuthConfigIR{
+			Cluster:    "authelia_backend_alice",
+			PathPrefix: "/api/authz/ext-authz/",
+		},
+	}, clusterMap)
+	require.NotNil(t, route.TypedPerFilterConfig)
+	anyCfg := route.TypedPerFilterConfig["envoy.filters.http.ext_authz"]
+	require.NotNil(t, anyCfg)
+
+	var perRoute extauthzv3.ExtAuthzPerRoute
+	require.NoError(t, anyCfg.UnmarshalTo(&perRoute))
+	cs := perRoute.GetCheckSettings()
+	require.NotNil(t, cs)
+	hs := cs.GetHttpService()
+	require.NotNil(t, hs, "non-default Authelia path still needs a full HttpService override")
+	assert.Equal(t, "/api/authz/ext-authz/", hs.GetPathPrefix())
 	require.NotNil(t, hs.GetAuthorizationRequest())
 	headers := hs.GetAuthorizationRequest().GetHeadersToAdd()
 	require.Len(t, headers, 7)
-	assert.Equal(t, "X-Forwarded-Proto", headers[0].GetKey())
-	assert.Equal(t, "X-Original-URL", headers[1].GetKey())
-	assert.Equal(t, "%REQ(x-forwarded-proto?:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%", headers[1].GetValue())
-	assert.Equal(t, "X-Forwarded-Uri", headers[2].GetKey())
-	assert.Equal(t, "%REQ(:PATH)%", headers[2].GetValue())
-	assert.Equal(t, "X-Forwarded-Host", headers[3].GetKey())
-	assert.Equal(t, "%REQ(:AUTHORITY)%", headers[3].GetValue())
-	assert.Equal(t, "X-Original-Method", headers[4].GetKey())
-	assert.Equal(t, "%REQ(:METHOD)%", headers[4].GetValue())
-	assert.Equal(t, "X-Forwarded-Method", headers[5].GetKey())
-	assert.Equal(t, "%REQ(:METHOD)%", headers[5].GetValue())
 	assert.Equal(t, "X-BFL-USER", headers[6].GetKey())
 	assert.Equal(t, "alice", headers[6].GetValue())
-	resp := hs.GetAuthorizationResponse()
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.GetAllowedUpstreamHeaders())
-	require.Len(t, resp.GetAllowedUpstreamHeaders().GetPatterns(), 2)
-	assert.Equal(t, "remote-", resp.GetAllowedUpstreamHeaders().GetPatterns()[0].GetPrefix())
-	assert.Equal(t, "authelia-", resp.GetAllowedUpstreamHeaders().GetPatterns()[1].GetPrefix())
-	require.NotNil(t, resp.GetAllowedClientHeaders())
-	require.Len(t, resp.GetAllowedClientHeaders().GetPatterns(), 3)
-	assert.Equal(t, "set-cookie", resp.GetAllowedClientHeaders().GetPatterns()[0].GetExact())
-	assert.Equal(t, "location", resp.GetAllowedClientHeaders().GetPatterns()[1].GetExact())
-	assert.Equal(t, "www-authenticate", resp.GetAllowedClientHeaders().GetPatterns()[2].GetExact())
-	require.NotNil(t, resp.GetAllowedClientHeadersOnSuccess())
-	require.Len(t, resp.GetAllowedClientHeadersOnSuccess().GetPatterns(), 1)
-	assert.Equal(t, "set-cookie", resp.GetAllowedClientHeadersOnSuccess().GetPatterns()[0].GetExact())
 }
 
 func TestTranslateRoute_ProbeBypassHeaderMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route all Authelia ExtAuth  through Legacy `/api/verify/`.
- Remove the Shared/fileserver `/api/authz/ext-authz/` split; omit per-route `ServiceOverride` when the path matches the filter default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes which Authelia authorization endpoint shared apps and fileserver hit, which can alter authz behavior for those routes.
> 
> **Overview**
> **Unifies Authelia ExtAuth** so every non-public route — apps, shared apps, profile, desktop, and fileserver — uses Legacy `/api/verify/` instead of splitting Shared/fileserver onto `/api/authz/ext-authz/`.
> 
> `buildAppExtAuthConfig` no longer takes a shared flag; the unused `autheliaPathPrefix` constant is removed. Because the path now matches the filter default, per-route `ServiceOverride` shells are omitted (`checkSettings: {}`), and e2e golden configs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c8f5dd0047c880ce35a0aa15ff20bb1c64b559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->