### PR TITLE
fix(download-server): guard torrent resume-seeding, add aria2 inspect title

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.10"
+        image: "beclab/download-server:v1.0.11"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
now probes the on-disk content before handing off to aria2. If the content is definitively absent, it returns the new ErrSeedSourceMissing sentinel.
aria2 now implements Inspector and reports Title via the same probe used by dedup, keeping inspect title and rename hint aligned.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single container image tag bump with unchanged deployment config; behavior changes are confined to the download service workload.
> 
> **Overview**
> Rolls out **`beclab/download-server:v1.0.11`** on the download DaemonSet (was `v1.0.10`). No env, volume, or resource changes—only the `download-server` container image tag in `download_deploy.yaml`.
> 
> That release (per PR notes) adds **torrent resume-seeding guards** (on-disk probe before aria2; missing seed source surfaces `ErrSeedSourceMissing`) and **aria2 inspect `Title`** via the same probe used for dedup, so inspect titles and rename hints stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5dbf4415f4783560817242772982a4c01cccebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->