### PR TITLE
olares: bump system-frontend to v1.11.27

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.26
+          image: beclab/system-frontend:v1.11.27
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

Bump the bundled `olares-app-init` (system-frontend) image from `v1.11.26` to `v1.11.27`, pulling in two TermiPass changes:

- beclab/TermiPass#1345 — Files module consolidation plus LarePass mobile fixes. Pure types, path helpers, archive/share models, route sync, and preview sources move into `domain/files`, `composables/files`, and `components/files/preview`, with compatibility re-exports kept for high-fan-in import paths. Source adapters now declare an explicit `capabilities` object (Common supports `smb` alongside `public`; cloud-drive and share adapters declare sharing as not permitted), and `FilesRuntimeContext` is bound lazily instead of at boot. Behavioral fixes: the LarePass mobile Files tab restores the last files route instead of getting stuck on Transfer (`/transfer` and `/shard` are excluded), and copying into Common/Data refreshes the correct listing path rather than Drive Home. Dead code (`shareToUser`, `ShareDialog`, unused layouts/components) is removed and the `files` store is slimmed while preserving listing and navigation behavior.
- beclab/TermiPass#1349 — Localize the Desktop clock widget (desktop and mobile `DailyDescription`). Weekday, AM/PM, and resource labels now follow the active vue-i18n locale instead of always rendering in English: `formatNow()` returns a stable `weekdayKey` rather than relying on Quasar's `date.formatDate(..., 'dddd')`, which had no language pack configured. New `widget.weekday` / `widget.meridiem` / `widget.resource` keys are added for all Desktop locales (`zh-CN`, `en-US`, `de-DE`, `es-ES`, `fr-FR`, `it-IT`, `ja-JP`), while the monitor store keeps machine ids (`cpu` / `disk` / `memory`).

This is a frontend-only image bump with no accompanying backend or API changes required.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1349
https://github.com/beclab/TermiPass/pull/1345

* **Other information**
Full Changelog:
https://github.com/beclab/TermiPass/compare/v1.11.26...v1.11.27

Image reference is updated in `apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml` for the `olares-app-init` container.

Made with [Cursor](https://cursor.com)