### PR TITLE
feat(app-service): validate custom domain cert on setup

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/provider"
 	"github.com/beclab/Olares/framework/app-service/pkg/tapr"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
@@ -225,6 +226,31 @@ func (h *Handler) setupAppEntranceDomain(req *restful.Request, resp *restful.Res
 		if err = checkEntranceDomainDuplicate(req.Request.Context(), kclient.AppClient, caller, appCopy.Spec.Name, entranceName, reqThirdLevel, reqThirdParty); err != nil {
 			api.HandleBadRequest(resp, req, err)
 			return
+		}
+
+		// Validate cert/key only when the request newly adds or changes them.
+		reqCert, _ := customDomain["cert"].(string)
+		reqKey, _ := customDomain["key"].(string)
+		var oldCert, oldKey, oldThirdParty string
+		if len(existing) > 0 {
+			var origins map[string]interface{}
+			if err = json.Unmarshal([]byte(existing), &origins); err == nil {
+				if originV, ok := origins[entranceName].(map[string]interface{}); ok {
+					oldCert, _ = originV["cert"].(string)
+					oldKey, _ = originV["key"].(string)
+					oldThirdParty, _ = originV["third_party_domain"].(string)
+				}
+			}
+		}
+		if (reqCert != "" || reqKey != "") && (reqCert != oldCert || reqKey != oldKey) {
+			hostname := reqThirdParty
+			if hostname == "" {
+				hostname = oldThirdParty
+			}
+			if err = utils.CheckSSLCertificate([]byte(reqCert), []byte(reqKey), hostname); err != nil {
+				api.HandleBadRequest(resp, req, err)
+				return
+			}
 		}
 	}
 

--- a/framework/app-service/pkg/utils/encrypt.go
+++ b/framework/app-service/pkg/utils/encrypt.go
@@ -1,80 +1,30 @@
 package utils
 
 import (
-	"bytes"
-	"crypto"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 )
 
-var ErrUnPadding = errors.New("UnPadding error")
-
-func pKCS7Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext)%blockSize
-	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(ciphertext, padtext...)
-}
-
-func pKCS7UnPadding(origin []byte) ([]byte, error) {
-	length := len(origin)
-	if length == 0 {
-		return origin, ErrUnPadding
+// ValidateKeyPair checks that certPEM and keyPEM form a parseable, matching TLS key pair.
+func ValidateKeyPair(certPEM, keyPEM string) error {
+	if certPEM == "" || keyPEM == "" {
+		return fmt.Errorf("empty cert or key")
 	}
-	unpadding := int(origin[length-1])
-	if length < unpadding {
-		return origin, ErrUnPadding
+	if _, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
+		return fmt.Errorf("invalid TLS key pair: %w", err)
 	}
-	return origin[:(length - unpadding)], nil
-}
-
-// AesEncrypt encrypts the given plaintext using AES encryption with the specified key.
-func AesEncrypt(origin, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	blockSize := block.BlockSize()
-	origin = pKCS7Padding(origin, blockSize)
-	blockMode := cipher.NewCBCEncrypter(block, key[:blockSize])
-	crypted := make([]byte, len(origin))
-	blockMode.CryptBlocks(crypted, origin)
-	return crypted, nil
-}
-
-// AesDecrypt decrypts the given ciphertext using AES encryption with the specified key.
-func AesDecrypt(crypted, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	blockSize := block.BlockSize()
-	blockMode := cipher.NewCBCDecrypter(block, key[:blockSize])
-	origin := make([]byte, len(crypted))
-	blockMode.CryptBlocks(origin, crypted)
-	origin, err = pKCS7UnPadding(origin)
-	if err != nil {
-		return origin, err
-	}
-	return origin, nil
-}
-
-func getTimestamp() string {
-	t := time.Now().Unix()
-	return strconv.Itoa(int(t))
+	return nil
 }
 
 // CheckSSLCertificate checks the validity of an SSL certificate and private key for a given hostname.
 func CheckSSLCertificate(cert, key []byte, hostname string) error {
+	if err := ValidateKeyPair(string(cert), string(key)); err != nil {
+		return err
+	}
 	block, _ := pem.Decode(cert)
 	if block == nil {
 		return errors.New("certificate is invalid")
@@ -96,70 +46,6 @@ func CheckSSLCertificate(cert, key []byte, hostname string) error {
 	}
 	if currentTime.After(pub.NotAfter) {
 		return errors.New("certificate has expired")
-	}
-
-	block, _ = pem.Decode(key)
-	if block == nil {
-		return errors.New("error decoding private key PEM block")
-	}
-
-	hash := sha256.Sum256([]byte("hello"))
-
-	switch block.Type {
-	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing pkcs#8 private key: %v", err)
-		}
-		signature, err := rsa.SignPKCS1v15(rand.Reader, key.(*rsa.PrivateKey), crypto.SHA256, hash[:])
-		if err != nil {
-			return errors.New("failed to sign message")
-		}
-		rsaPub, ok := pub.PublicKey.(*rsa.PublicKey)
-		if !ok {
-			return errors.New("not RSA public key")
-		}
-		err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], signature)
-		if err != nil {
-			return errors.New("certificate and private key not match")
-		}
-	case "EC PRIVATE KEY":
-		key, err := x509.ParseECPrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing ecdsa private key: %v", err)
-		}
-
-		r, s, err := ecdsa.Sign(rand.Reader, key, hash[:])
-		if err != nil {
-			return fmt.Errorf("ecdsa sign err: %v", err)
-		}
-		verified := ecdsa.Verify(pub.PublicKey.(*ecdsa.PublicKey), hash[:], r, s)
-		if !verified {
-			return errors.New("certificate and private key not match")
-		}
-	case "RSA PRIVATE KEY":
-		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing rsa private key: %v", err)
-		}
-		err = key.Validate()
-		if err != nil {
-			return fmt.Errorf("rsa private key failed validation: %v", err)
-		}
-		signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
-		if err != nil {
-			return errors.New("failed to sign message")
-		}
-		rsaPub, ok := pub.PublicKey.(*rsa.PublicKey)
-		if !ok {
-			return errors.New("not RSA public key")
-		}
-		err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], signature)
-		if err != nil {
-			return errors.New("certificate and private key not match")
-		}
-	default:
-		return fmt.Errorf("unknown private key type: %s", block.Type)
 	}
 
 	return nil

--- a/framework/app-service/pkg/utils/encrypt_test.go
+++ b/framework/app-service/pkg/utils/encrypt_test.go
@@ -4,26 +4,6 @@ import (
 	"testing"
 )
 
-func TestAesEncryptDecrypt(t *testing.T) {
-	key := []byte("ZyCUs5znsmk7GTAiNXdE7RpkSRz1zsIm")
-
-	plaintext := []byte("Hello, bytetrade!")
-
-	ciphertext, err := AesEncrypt(plaintext, key)
-	if err != nil {
-		t.Fatalf("Encryption error: %v", err)
-	}
-
-	decrypted, err := AesDecrypt(ciphertext, key)
-	if err != nil {
-		t.Fatalf("Decryption error: %v", err)
-	}
-
-	if string(decrypted) != string(plaintext) {
-		t.Errorf("Decrypted data does not match original data")
-	}
-}
-
 func TestMatchVersion(t *testing.T) {
 	testCases := []struct {
 		version    string


### PR DESCRIPTION
* **Background**
Reject invalid or mismatched TLS cert/key when setupAppEntranceDomain adds or changes them, and reuse tls.X509KeyPair inside CheckSSLCertificate.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds API-time TLS validation for user-supplied certs on custom domains; behavior change is limited to rejecting invalid pairs earlier, with a refactor of how cert/key matching is verified.
> 
> **Overview**
> **Custom entrance domains** now reject bad TLS material at save time. When `setupAppEntranceDomain` receives new or changed `cert`/`key` in `customDomain`, it compares them to the caller’s existing stored values and only then runs `utils.CheckSSLCertificate`, using the request’s `third_party_domain` or the previously saved hostname so re-saves without cert changes are not re-validated.
> 
> **`CheckSSLCertificate`** is simplified: a new `ValidateKeyPair` uses `tls.X509KeyPair` for parseable, matching PEM pairs instead of hand-rolled RSA/ECDSA sign/verify. Hostname, not-before, and not-after checks are unchanged. Unused **AES encrypt/decrypt** helpers and their test were removed from `encrypt.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9ce960694b7a0d0ee3b99a978ee45f429f7b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->