### PR TITLE
Validate v2 market taxonomy in OAC

### DIFF
--- a/cli/pkg/preinstall/deployment_contract_test.go
+++ b/cli/pkg/preinstall/deployment_contract_test.go
@@ -74,6 +74,28 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 	}
 }
 
+func TestMarketDeploymentPinsV2SourceAPIPaths(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "framework", "market", ".olares", "config", "cluster", "deploy", "market_deploy.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment := deploymentDocument(t, string(data), "market-deployment")
+	container := between(t, deployment, "      - name: appstore-backend\n", "      volumes:\n")
+
+	for name, value := range map[string]string{
+		"API_CATALOG_PATH":      "/api/v2/catalog",
+		"API_TAXONOMY_PATH":     "/api/v2/taxonomy",
+		"API_APPLICATIONS_PATH": "/api/v2/applications",
+		"API_BROWSE_PATH":       "/api/v2/browse/applications",
+	} {
+		required := "- name: " + name + "\n            value: " + value
+		if !strings.Contains(container, required) {
+			t.Errorf("appstore-backend container missing contract:\n%s", required)
+		}
+	}
+}
+
 func TestMarketPreinstallDeploymentPublishesManifestsButNotPayloads(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
 	artifact, _ := addMaterializeArtifactFixture(t, installerDir)

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -210,6 +210,14 @@ spec:
             value: /api/v1/applications/{chart_name}/chart
           - name: API_DETAIL_PATH
             value: /api/v1/applications/info
+          - name: API_CATALOG_PATH
+            value: /api/v2/catalog
+          - name: API_TAXONOMY_PATH
+            value: /api/v2/taxonomy
+          - name: API_APPLICATIONS_PATH
+            value: /api/v2/applications
+          - name: API_BROWSE_PATH
+            value: /api/v2/browse/applications
           - name: CHART_ROOT
             value: /opt/app/data
           - name: NATS_SUBJECT_SYSTEM_USER_STATE

--- a/framework/oac/appdata_test.go
+++ b/framework/oac/appdata_test.go
@@ -91,6 +91,7 @@ func (p permManifest) AppName() string               { return "stub" }
 func (p permManifest) AppVersion() string            { return "0.0.0" }
 func (p permManifest) Entrances() []EntranceInfo     { return nil }
 func (p permManifest) OptionsImages() []string       { return nil }
+func (p permManifest) Taxonomy() Taxonomy            { return Taxonomy{} }
 func (p permManifest) PermissionAppData() bool       { return p.appData }
 func (p permManifest) PermissionAppCommon() bool     { return p.appCommon }
 func (p permManifest) PermissionExternalData() bool { return p.externalData }

--- a/framework/oac/go.mod
+++ b/framework/oac/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/beclab/api v0.0.24
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/thoas/go-funk v0.9.3
+	golang.org/x/text v0.37.0
 	helm.sh/helm/v3 v3.19.5
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
@@ -111,7 +112,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/framework/oac/internal/chartfolder/folder_test.go
+++ b/framework/oac/internal/chartfolder/folder_test.go
@@ -21,6 +21,7 @@ func (s stubManifest) AppName() string               { return s.name }
 func (s stubManifest) AppVersion() string            { return s.version }
 func (s stubManifest) Entrances() []olm.EntranceInfo { return nil }
 func (s stubManifest) OptionsImages() []string       { return nil }
+func (s stubManifest) Taxonomy() olm.Taxonomy        { return olm.Taxonomy{} }
 func (s stubManifest) PermissionAppData() bool      { return false }
 func (s stubManifest) PermissionAppCommon() bool    { return false }
 func (s stubManifest) PermissionExternalData() bool { return false }

--- a/framework/oac/internal/manifest/parse.go
+++ b/framework/oac/internal/manifest/parse.go
@@ -17,11 +17,11 @@ func (s *ManifestStrategy) Parse(rendered []byte) (Manifest, error) {
 	if err := yaml.Unmarshal(rendered, &cfg); err != nil {
 		return nil, err
 	}
-	taxonomy, err := ParseTaxonomy(rendered)
+	taxonomy, metadataFields, err := parseTaxonomy(rendered, &cfg)
 	if err != nil {
 		return nil, err
 	}
-	return &parsedManifest{cfg: &cfg, taxonomy: taxonomy}, nil
+	return &parsedManifest{cfg: &cfg, taxonomy: taxonomy, metadataFields: metadataFields}, nil
 }
 
 // Validate runs structural and cross-field checks.
@@ -32,6 +32,7 @@ func (s *ManifestStrategy) Validate(m Manifest) error {
 	}
 	return errors.Join(
 		ValidateAppConfiguration(mm.cfg),
+		validateMetadataFields(mm.metadataFields),
 		ValidateTaxonomy(mm.taxonomy),
 	)
 }
@@ -39,6 +40,10 @@ func (s *ManifestStrategy) Validate(m Manifest) error {
 type parsedManifest struct {
 	cfg      *AppConfiguration
 	taxonomy Taxonomy
+	// metadataFields is every key the manifest spelled under `metadata`,
+	// kept from the parse so validation can name one the schema has no
+	// field for.
+	metadataFields []string
 }
 
 // Taxonomy exposes the catalog fields the shared AppConfiguration does not

--- a/framework/oac/internal/manifest/parse.go
+++ b/framework/oac/internal/manifest/parse.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/yaml"
@@ -16,7 +17,11 @@ func (s *ManifestStrategy) Parse(rendered []byte) (Manifest, error) {
 	if err := yaml.Unmarshal(rendered, &cfg); err != nil {
 		return nil, err
 	}
-	return &parsedManifest{cfg: &cfg}, nil
+	taxonomy, err := ParseTaxonomy(rendered)
+	if err != nil {
+		return nil, err
+	}
+	return &parsedManifest{cfg: &cfg, taxonomy: taxonomy}, nil
 }
 
 // Validate runs structural and cross-field checks.
@@ -25,12 +30,20 @@ func (s *ManifestStrategy) Validate(m Manifest) error {
 	if !ok {
 		return fmt.Errorf("manifest strategy received foreign manifest type: %T", m)
 	}
-	return ValidateAppConfiguration(mm.cfg)
+	return errors.Join(
+		ValidateAppConfiguration(mm.cfg),
+		ValidateTaxonomy(mm.taxonomy),
+	)
 }
 
 type parsedManifest struct {
-	cfg *AppConfiguration
+	cfg      *AppConfiguration
+	taxonomy Taxonomy
 }
+
+// Taxonomy exposes the catalog fields the shared AppConfiguration does not
+// carry; callers that only build cluster resources never ask for it.
+func (m *parsedManifest) Taxonomy() Taxonomy { return m.taxonomy }
 
 func (m *parsedManifest) APIVersion() string {
 	if m.cfg.APIVersion == "" {
@@ -61,8 +74,8 @@ func (m *parsedManifest) OptionsImages() []string {
 	return out
 }
 
-func (m *parsedManifest) PermissionAppData() bool       { return m.cfg.Permission.AppData }
-func (m *parsedManifest) PermissionAppCommon() bool     { return m.cfg.Permission.AppCommon }
-func (m *parsedManifest) PermissionExternalData() bool  { return m.cfg.Permission.ExternalData }
+func (m *parsedManifest) PermissionAppData() bool      { return m.cfg.Permission.AppData }
+func (m *parsedManifest) PermissionAppCommon() bool    { return m.cfg.Permission.AppCommon }
+func (m *parsedManifest) PermissionExternalData() bool { return m.cfg.Permission.ExternalData }
 
 func (m *parsedManifest) Raw() any { return m.cfg }

--- a/framework/oac/internal/manifest/pipeline.go
+++ b/framework/oac/internal/manifest/pipeline.go
@@ -31,6 +31,7 @@ type Manifest interface {
 	AppVersion() string
 	Entrances() []EntranceInfo
 	OptionsImages() []string
+	Taxonomy() Taxonomy
 	PermissionAppData() bool
 	PermissionAppCommon() bool
 	PermissionExternalData() bool

--- a/framework/oac/internal/manifest/pipeline_test.go
+++ b/framework/oac/internal/manifest/pipeline_test.go
@@ -11,6 +11,7 @@ import (
 type fakeManifest struct {
 	apiVersion    string
 	configVersion string
+	taxonomy      Taxonomy
 	raw           any
 }
 
@@ -21,6 +22,7 @@ func (f *fakeManifest) AppName() string               { return "x" }
 func (f *fakeManifest) AppVersion() string            { return "0.0.0" }
 func (f *fakeManifest) Entrances() []EntranceInfo     { return nil }
 func (f *fakeManifest) OptionsImages() []string       { return nil }
+func (f *fakeManifest) Taxonomy() Taxonomy            { return f.taxonomy }
 func (f *fakeManifest) PermissionAppData() bool      { return false }
 func (f *fakeManifest) PermissionAppCommon() bool    { return false }
 func (f *fakeManifest) PermissionExternalData() bool { return false }

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/text/language"
 	"sigs.k8s.io/yaml"
 )
 
@@ -44,20 +45,11 @@ type taxonomyEnvelope struct {
 	} `json:"spec"`
 }
 
-const (
-	maxCategoriesV2 = 5
-	maxTags         = 10
-)
-
 // A category id and a tag slug are the same shape: they are typed into a
 // manifest by hand and then compared for equality across three services, so
 // anything that has a second spelling -- case, spaces, underscores -- is a
 // mismatch waiting to be reported as "unknown category".
 var taxonomySlug = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
-
-// Language codes follow the BCP 47 subset the market registers: a lowercase
-// language, optionally a titled script, optionally an uppercase region.
-var localeCode = regexp.MustCompile(`^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2})?$`)
 
 // ParseTaxonomy reads the taxonomy fields out of an already-rendered manifest.
 func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
@@ -77,18 +69,15 @@ func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
 // back to its legacy `categories`.
 func ValidateTaxonomy(t Taxonomy) error {
 	return errors.Join(
-		validateSlugList("metadata.categories_v2", t.CategoriesV2, maxCategoriesV2),
-		validateSlugList("metadata.tags", t.Tags, maxTags),
+		validateSlugList("metadata.categories_v2", t.CategoriesV2),
+		validateSlugList("metadata.tags", t.Tags),
 		validateLocaleList(t.Locale),
 	)
 }
 
-func validateSlugList(field string, values []string, max int) error {
+func validateSlugList(field string, values []string) error {
 	if len(values) == 0 {
 		return nil
-	}
-	if len(values) > max {
-		return fmt.Errorf("%s must have at most %d items", field, max)
 	}
 
 	seen := make(map[string]struct{}, len(values))
@@ -119,8 +108,13 @@ func validateLocaleList(values []string) error {
 	seen := make(map[string]struct{}, len(values))
 	var errs []error
 	for _, value := range values {
-		if !localeCode.MatchString(value) {
-			errs = append(errs, fmt.Errorf("spec.locale value %q must be a language code such as en-US or zh-CN", value))
+		tag, err := language.Parse(value)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("spec.locale value %q must be a valid BCP 47 language tag", value))
+			continue
+		}
+		if tag.String() != value {
+			errs = append(errs, fmt.Errorf("spec.locale value %q must use canonical spelling %q", value, tag.String()))
 			continue
 		}
 		if _, dup := seen[value]; dup {

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -1,0 +1,133 @@
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// The two-tier taxonomy an app declares: `metadata.categories_v2` picks the
+// sections it appears under, `metadata.tags` refines that within a section, and
+// `spec.locale` says which languages its own text is written in.
+//
+// These are decoded here rather than through github.com/beclab/api's
+// AppMetaData because that type is shared with the cluster runtime, which has
+// no use for them: the values are consumed by the market catalog. Decoding the
+// same bytes twice is cheaper than a version bump across every consumer of a
+// shared schema for three fields none of them read.
+//
+// What is checked here is shape, not membership. Whether `agents` is a category
+// this market actually offers depends on the market's own registry, which oac
+// cannot see -- gitbot answers that against adminv2. Checking shape here means
+// a developer running `oac lint` locally still learns that a comma-separated
+// string is not a list before opening a pull request.
+
+// Taxonomy is the catalog-facing slice of a manifest.
+type Taxonomy struct {
+	CategoriesV2 []string `json:"categories_v2,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	Locale       []string `json:"locale,omitempty"`
+}
+
+// taxonomyEnvelope mirrors just enough of the manifest to reach the three
+// fields; every other key is ignored.
+type taxonomyEnvelope struct {
+	Metadata struct {
+		CategoriesV2 []string `json:"categories_v2,omitempty"`
+		Tags         []string `json:"tags,omitempty"`
+	} `json:"metadata"`
+	Spec struct {
+		Locale []string `json:"locale,omitempty"`
+	} `json:"spec"`
+}
+
+const (
+	maxCategoriesV2 = 5
+	maxTags         = 10
+)
+
+// A category id and a tag slug are the same shape: they are typed into a
+// manifest by hand and then compared for equality across three services, so
+// anything that has a second spelling -- case, spaces, underscores -- is a
+// mismatch waiting to be reported as "unknown category".
+var taxonomySlug = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// Language codes follow the BCP 47 subset the market registers: a lowercase
+// language, optionally a titled script, optionally an uppercase region.
+var localeCode = regexp.MustCompile(`^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2})?$`)
+
+// ParseTaxonomy reads the taxonomy fields out of an already-rendered manifest.
+func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
+	var envelope taxonomyEnvelope
+	if err := yaml.Unmarshal(rendered, &envelope); err != nil {
+		return Taxonomy{}, err
+	}
+	return Taxonomy{
+		CategoriesV2: envelope.Metadata.CategoriesV2,
+		Tags:         envelope.Metadata.Tags,
+		Locale:       envelope.Spec.Locale,
+	}, nil
+}
+
+// ValidateTaxonomy checks the shape of the three lists. All three are optional:
+// an app that predates the new taxonomy keeps working, and the market falls
+// back to its legacy `categories`.
+func ValidateTaxonomy(t Taxonomy) error {
+	return errors.Join(
+		validateSlugList("metadata.categories_v2", t.CategoriesV2, maxCategoriesV2),
+		validateSlugList("metadata.tags", t.Tags, maxTags),
+		validateLocaleList(t.Locale),
+	)
+}
+
+func validateSlugList(field string, values []string, max int) error {
+	if len(values) == 0 {
+		return nil
+	}
+	if len(values) > max {
+		return fmt.Errorf("%s must have at most %d items", field, max)
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	var errs []error
+	for _, value := range values {
+		if value != strings.TrimSpace(value) {
+			errs = append(errs, fmt.Errorf("%s value %q must not have surrounding whitespace", field, value))
+			continue
+		}
+		if !taxonomySlug.MatchString(value) {
+			errs = append(errs, fmt.Errorf("%s value %q must be lowercase alphanumeric words joined by single hyphens", field, value))
+			continue
+		}
+		if _, dup := seen[value]; dup {
+			errs = append(errs, fmt.Errorf("%s value %q is listed more than once", field, value))
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return errors.Join(errs...)
+}
+
+func validateLocaleList(values []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	var errs []error
+	for _, value := range values {
+		if !localeCode.MatchString(value) {
+			errs = append(errs, fmt.Errorf("spec.locale value %q must be a language code such as en-US or zh-CN", value))
+			continue
+		}
+		if _, dup := seen[value]; dup {
+			errs = append(errs, fmt.Errorf("spec.locale value %q is listed more than once", value))
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return errors.Join(errs...)
+}

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -182,6 +182,15 @@ func foldMetadataField(field string) string {
 	return folded.String()
 }
 
+// namesUndefinedLanguage reports whether a canonical tag has `und` as its
+// language subtag. It parses and canonicalizes cleanly, but a catalog cannot
+// offer it to anybody: an app declaring it has declared nothing. A wholly
+// private-use tag such as `x-private` carries no language subtag at all and is
+// left alone -- it is unknown to the standard, not undefined by the app.
+func namesUndefinedLanguage(canonical string) bool {
+	return canonical == "und" || strings.HasPrefix(canonical, "und-")
+}
+
 func validateSlugList(field string, values []string) error {
 	if len(values) == 0 {
 		return nil
@@ -222,6 +231,10 @@ func validateLocaleList(values []string) error {
 		}
 		if tag.String() != value {
 			errs = append(errs, fmt.Errorf("spec.locale value %q must use canonical spelling %q", value, tag.String()))
+			continue
+		}
+		if namesUndefinedLanguage(value) {
+			errs = append(errs, fmt.Errorf("spec.locale value %q names the undefined language; list the languages the app is actually written in", value))
 			continue
 		}
 		if _, dup := seen[value]; dup {

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -196,22 +196,29 @@ func validateSlugList(field string, values []string) error {
 		return nil
 	}
 
+	// Duplicates are looked for before shape, so a value that is both
+	// misspelt and repeated is reported as two distinct mistakes rather than
+	// as the same shape complaint twice.
 	seen := make(map[string]struct{}, len(values))
 	var errs []error
 	for _, value := range values {
+		if _, dup := seen[value]; dup {
+			errs = append(errs, fmt.Errorf("%s value %q is listed more than once", field, value))
+			continue
+		}
+		seen[value] = struct{}{}
+
+		if value == "" {
+			errs = append(errs, fmt.Errorf("%s must not be empty", field))
+			continue
+		}
 		if value != strings.TrimSpace(value) {
 			errs = append(errs, fmt.Errorf("%s value %q must not have surrounding whitespace", field, value))
 			continue
 		}
 		if !taxonomySlug.MatchString(value) {
 			errs = append(errs, fmt.Errorf("%s value %q must be lowercase alphanumeric words joined by single hyphens", field, value))
-			continue
 		}
-		if _, dup := seen[value]; dup {
-			errs = append(errs, fmt.Errorf("%s value %q is listed more than once", field, value))
-			continue
-		}
-		seen[value] = struct{}{}
 	}
 	return errors.Join(errs...)
 }
@@ -224,6 +231,16 @@ func validateLocaleList(values []string) error {
 	seen := make(map[string]struct{}, len(values))
 	var errs []error
 	for _, value := range values {
+		if _, dup := seen[value]; dup {
+			errs = append(errs, fmt.Errorf("spec.locale value %q is listed more than once", value))
+			continue
+		}
+		seen[value] = struct{}{}
+
+		if value == "" {
+			errs = append(errs, errors.New("spec.locale must not be empty"))
+			continue
+		}
 		tag, err := language.BCP47.Parse(value)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("spec.locale value %q must be a valid BCP 47 language tag", value))
@@ -235,13 +252,7 @@ func validateLocaleList(values []string) error {
 		}
 		if namesUndefinedLanguage(value) {
 			errs = append(errs, fmt.Errorf("spec.locale value %q names the undefined language; list the languages the app is actually written in", value))
-			continue
 		}
-		if _, dup := seen[value]; dup {
-			errs = append(errs, fmt.Errorf("spec.locale value %q is listed more than once", value))
-			continue
-		}
-		seen[value] = struct{}{}
 	}
 	return errors.Join(errs...)
 }

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -108,7 +108,7 @@ func validateLocaleList(values []string) error {
 	seen := make(map[string]struct{}, len(values))
 	var errs []error
 	for _, value := range values {
-		tag, err := language.Parse(value)
+		tag, err := language.BCP47.Parse(value)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("spec.locale value %q must be a valid BCP 47 language tag", value))
 			continue

--- a/framework/oac/internal/manifest/taxonomy.go
+++ b/framework/oac/internal/manifest/taxonomy.go
@@ -1,9 +1,12 @@
 package manifest
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"golang.org/x/text/language"
@@ -14,11 +17,13 @@ import (
 // sections it appears under, `metadata.tags` refines that within a section, and
 // `spec.locale` says which languages its own text is written in.
 //
-// These are decoded here rather than through github.com/beclab/api's
+// The first two are decoded here rather than through github.com/beclab/api's
 // AppMetaData because that type is shared with the cluster runtime, which has
 // no use for them: the values are consumed by the market catalog. Decoding the
 // same bytes twice is cheaper than a version bump across every consumer of a
-// shared schema for three fields none of them read.
+// shared schema for two fields none of them read. `spec.locale` is not in that
+// position -- AppSpec already carries it -- so it is read off the parsed
+// AppConfiguration instead of decoded again.
 //
 // What is checked here is shape, not membership. Whether `agents` is a category
 // this market actually offers depends on the market's own registry, which oac
@@ -33,16 +38,23 @@ type Taxonomy struct {
 	Locale       []string `json:"locale,omitempty"`
 }
 
-// taxonomyEnvelope mirrors just enough of the manifest to reach the three
-// fields; every other key is ignored.
-type taxonomyEnvelope struct {
-	Metadata struct {
-		CategoriesV2 []string `json:"categories_v2,omitempty"`
-		Tags         []string `json:"tags,omitempty"`
-	} `json:"metadata"`
-	Spec struct {
-		Locale []string `json:"locale,omitempty"`
-	} `json:"spec"`
+const (
+	categoriesV2Field = "categories_v2"
+	tagsField         = "tags"
+)
+
+// catalogMetadata mirrors the two catalog fields inside `metadata`; every other
+// key is decoded through AppMetaData.
+type catalogMetadata struct {
+	CategoriesV2 []string `json:"categories_v2,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+}
+
+// metadataEnvelope keeps `metadata` as raw bytes so it can be read twice: once
+// for the catalog fields, once as a plain mapping whose keys are checked
+// against the schema.
+type metadataEnvelope struct {
+	Metadata json.RawMessage `json:"metadata"`
 }
 
 // A category id and a tag slug are the same shape: they are typed into a
@@ -53,15 +65,46 @@ var taxonomySlug = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // ParseTaxonomy reads the taxonomy fields out of an already-rendered manifest.
 func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
-	var envelope taxonomyEnvelope
-	if err := yaml.Unmarshal(rendered, &envelope); err != nil {
+	var cfg AppConfiguration
+	if err := yaml.Unmarshal(rendered, &cfg); err != nil {
 		return Taxonomy{}, err
 	}
+	taxonomy, _, err := parseTaxonomy(rendered, &cfg)
+	return taxonomy, err
+}
+
+// parseTaxonomy also returns the keys the manifest spelled under `metadata`,
+// which is what lets a misspelt catalog field be reported rather than silently
+// dropped by the YAML decoder.
+func parseTaxonomy(rendered []byte, cfg *AppConfiguration) (Taxonomy, []string, error) {
+	var envelope metadataEnvelope
+	if err := yaml.Unmarshal(rendered, &envelope); err != nil {
+		return Taxonomy{}, nil, err
+	}
+	if len(envelope.Metadata) == 0 {
+		return Taxonomy{Locale: cfg.Spec.Locale}, nil, nil
+	}
+
+	var catalog catalogMetadata
+	if err := json.Unmarshal(envelope.Metadata, &catalog); err != nil {
+		return Taxonomy{}, nil, fmt.Errorf("read metadata: %w", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Metadata, &fields); err != nil {
+		return Taxonomy{}, nil, fmt.Errorf("metadata must be a mapping: %w", err)
+	}
+
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	return Taxonomy{
-		CategoriesV2: envelope.Metadata.CategoriesV2,
-		Tags:         envelope.Metadata.Tags,
-		Locale:       envelope.Spec.Locale,
-	}, nil
+		CategoriesV2: catalog.CategoriesV2,
+		Tags:         catalog.Tags,
+		Locale:       cfg.Spec.Locale,
+	}, names, nil
 }
 
 // ValidateTaxonomy checks the shape of the three lists. All three are optional:
@@ -69,10 +112,74 @@ func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
 // back to its legacy `categories`.
 func ValidateTaxonomy(t Taxonomy) error {
 	return errors.Join(
-		validateSlugList("metadata.categories_v2", t.CategoriesV2),
-		validateSlugList("metadata.tags", t.Tags),
+		validateSlugList("metadata."+categoriesV2Field, t.CategoriesV2),
+		validateSlugList("metadata."+tagsField, t.Tags),
 		validateLocaleList(t.Locale),
 	)
+}
+
+// validateMetadataFields rejects keys `metadata` has no schema for. A YAML
+// decoder drops them without a word, so `categoriesV2` produces an app with no
+// categories and no explanation; the near-miss spelling is named in the error
+// because that is the mistake this check is here to catch.
+func validateMetadataFields(fields []string) error {
+	var errs []error
+	for _, field := range fields {
+		if _, known := knownMetadataFields[field]; known {
+			continue
+		}
+		if suggestion, ok := nearestMetadataField(field); ok {
+			errs = append(errs, fmt.Errorf("metadata field %q is not part of the manifest schema; did you mean %q?", field, suggestion))
+			continue
+		}
+		errs = append(errs, fmt.Errorf("metadata field %q is not part of the manifest schema", field))
+	}
+	return errors.Join(errs...)
+}
+
+// knownMetadataFields is every key `metadata` may spell: the json names of the
+// shared AppMetaData plus the two catalog fields that type does not carry.
+// Reading the names off the struct means a field added upstream is accepted
+// here without a second list to keep in step.
+var knownMetadataFields = collectMetadataFields()
+
+func collectMetadataFields() map[string]struct{} {
+	fields := map[string]struct{}{
+		categoriesV2Field: {},
+		tagsField:         {},
+	}
+	meta := reflect.TypeOf(AppMetaData{})
+	for i := 0; i < meta.NumField(); i++ {
+		field := meta.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			name = field.Name
+		}
+		fields[name] = struct{}{}
+	}
+	return fields
+}
+
+// nearestMetadataField finds the schema field an unknown key differs from only
+// in case and separators -- `categoriesV2` for `categories_v2`.
+func nearestMetadataField(field string) (string, bool) {
+	target := foldMetadataField(field)
+	for known := range knownMetadataFields {
+		if foldMetadataField(known) == target {
+			return known, true
+		}
+	}
+	return "", false
+}
+
+func foldMetadataField(field string) string {
+	var folded strings.Builder
+	for _, r := range strings.ToLower(field) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			folded.WriteRune(r)
+		}
+	}
+	return folded.String()
 }
 
 func validateSlugList(field string, values []string) error {

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -1,0 +1,120 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTaxonomyReadsBothLevelsAndLocale(t *testing.T) {
+	raw := []byte(`
+metadata:
+  name: wise
+  categories_v2:
+    - agents
+    - workspace
+  tags:
+    - coding
+    - self-hosted
+spec:
+  locale:
+    - en-US
+    - zh-CN
+`)
+
+	got, err := ParseTaxonomy(raw)
+	if err != nil {
+		t.Fatalf("ParseTaxonomy: %v", err)
+	}
+	if len(got.CategoriesV2) != 2 || got.CategoriesV2[0] != "agents" {
+		t.Fatalf("categories_v2 = %v", got.CategoriesV2)
+	}
+	if len(got.Tags) != 2 || got.Tags[1] != "self-hosted" {
+		t.Fatalf("tags = %v", got.Tags)
+	}
+	if len(got.Locale) != 2 || got.Locale[1] != "zh-CN" {
+		t.Fatalf("locale = %v", got.Locale)
+	}
+	if err := ValidateTaxonomy(got); err != nil {
+		t.Fatalf("valid manifest rejected: %v", err)
+	}
+}
+
+// An app written before the new taxonomy declares none of it and must still
+// pass: the market falls back to its legacy categories.
+func TestValidateTaxonomyAcceptsAbsence(t *testing.T) {
+	if err := ValidateTaxonomy(Taxonomy{}); err != nil {
+		t.Fatalf("empty taxonomy rejected: %v", err)
+	}
+}
+
+func TestValidateTaxonomyRejectsShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		taxonomy Taxonomy
+		want     string
+	}{
+		{
+			name:     "category with capitals",
+			taxonomy: Taxonomy{CategoriesV2: []string{"Agents"}},
+			want:     "lowercase",
+		},
+		{
+			name:     "category with a space",
+			taxonomy: Taxonomy{CategoriesV2: []string{"social network"}},
+			want:     "lowercase",
+		},
+		{
+			name:     "category with an underscore",
+			taxonomy: Taxonomy{CategoriesV2: []string{"social_network"}},
+			want:     "lowercase",
+		},
+		{
+			name:     "duplicate category",
+			taxonomy: Taxonomy{CategoriesV2: []string{"agents", "agents"}},
+			want:     "more than once",
+		},
+		{
+			name:     "too many categories",
+			taxonomy: Taxonomy{CategoriesV2: []string{"a", "b", "c", "d", "e", "f"}},
+			want:     "at most 5",
+		},
+		{
+			name:     "padded tag",
+			taxonomy: Taxonomy{Tags: []string{" coding"}},
+			want:     "whitespace",
+		},
+		{
+			name:     "duplicate tag",
+			taxonomy: Taxonomy{Tags: []string{"coding", "coding"}},
+			want:     "more than once",
+		},
+		{
+			name:     "locale is not a language code",
+			taxonomy: Taxonomy{Locale: []string{"english"}},
+			want:     "language code",
+		},
+		{
+			name:     "locale region is lowercase",
+			taxonomy: Taxonomy{Locale: []string{"zh-cn"}},
+			want:     "language code",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTaxonomy(tc.taxonomy)
+			if err == nil {
+				t.Fatalf("%+v was accepted", tc.taxonomy)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateTaxonomyAcceptsScriptedLocale(t *testing.T) {
+	if err := ValidateTaxonomy(Taxonomy{Locale: []string{"zh-Hans-CN", "en", "pt-BR"}}); err != nil {
+		t.Fatalf("scripted locale rejected: %v", err)
+	}
+}

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -74,11 +74,6 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 			want:     "more than once",
 		},
 		{
-			name:     "too many categories",
-			taxonomy: Taxonomy{CategoriesV2: []string{"a", "b", "c", "d", "e", "f"}},
-			want:     "at most 5",
-		},
-		{
 			name:     "padded tag",
 			taxonomy: Taxonomy{Tags: []string{" coding"}},
 			want:     "whitespace",
@@ -91,12 +86,12 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 		{
 			name:     "locale is not a language code",
 			taxonomy: Taxonomy{Locale: []string{"english"}},
-			want:     "language code",
+			want:     "BCP 47",
 		},
 		{
 			name:     "locale region is lowercase",
 			taxonomy: Taxonomy{Locale: []string{"zh-cn"}},
-			want:     "language code",
+			want:     "canonical",
 		},
 	}
 
@@ -113,8 +108,25 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 	}
 }
 
-func TestValidateTaxonomyAcceptsScriptedLocale(t *testing.T) {
-	if err := ValidateTaxonomy(Taxonomy{Locale: []string{"zh-Hans-CN", "en", "pt-BR"}}); err != nil {
-		t.Fatalf("scripted locale rejected: %v", err)
+func TestValidateTaxonomyDoesNotImposeBusinessCountLimits(t *testing.T) {
+	taxonomy := Taxonomy{
+		CategoriesV2: []string{"a", "b", "c", "d", "e", "f"},
+		Tags:         []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
+	}
+	if err := ValidateTaxonomy(taxonomy); err != nil {
+		t.Fatalf("valid taxonomy rejected: %v", err)
+	}
+}
+
+func TestValidateTaxonomyAcceptsCanonicalBCP47Locales(t *testing.T) {
+	locales := []string{
+		"es-419",
+		"de-DE-1996",
+		"sl-rozaj",
+		"en-US-u-ca-gregory",
+		"x-private",
+	}
+	if err := ValidateTaxonomy(Taxonomy{Locale: locales}); err != nil {
+		t.Fatalf("valid BCP 47 locales rejected: %v", err)
 	}
 }

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -99,6 +99,16 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 			taxonomy: Taxonomy{Locale: []string{"en-Latn"}},
 			want:     "canonical",
 		},
+		{
+			name:     "locale is the undefined language",
+			taxonomy: Taxonomy{Locale: []string{"und"}},
+			want:     "undefined",
+		},
+		{
+			name:     "locale is the undefined language with a region",
+			taxonomy: Taxonomy{Locale: []string{"und-US"}},
+			want:     "undefined",
+		},
 	}
 
 	for _, tc := range cases {
@@ -209,6 +219,8 @@ func TestValidateTaxonomyAcceptsCanonicalBCP47Locales(t *testing.T) {
 		"de-DE-1996",
 		"sl-rozaj",
 		"en-US-u-ca-gregory",
+		// Wholly private use: nothing standard names this language, but the
+		// tag is well-formed and an app is entitled to say so.
 		"x-private",
 	}
 	if err := ValidateTaxonomy(Taxonomy{Locale: locales}); err != nil {

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -121,6 +122,84 @@ func TestValidateTaxonomyDoesNotImposeBusinessCountLimits(t *testing.T) {
 	if err := ValidateTaxonomy(taxonomy); err != nil {
 		t.Fatalf("valid taxonomy rejected: %v", err)
 	}
+}
+
+// A misspelt catalog field is the failure this gate exists for: YAML decoding
+// drops the key silently, so the app ships with no categories at all and
+// nothing anywhere says why.
+func TestValidateRejectsUnknownMetadataFields(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "camel-cased categories_v2", key: "categoriesV2", want: "categories_v2"},
+		{name: "singular category_v2", key: "category_v2", want: "category_v2"},
+		{name: "plain typo", key: "tagz", want: "tagz"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateManifestYAML(t, `
+metadata:
+  name: demo
+  `+tc.key+`:
+    - agents
+`)
+			if err == nil {
+				t.Fatalf("metadata.%s was accepted", tc.key)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The counterweight: every field the shared AppMetaData carries must still
+// pass, or the gate rejects manifests that have always been legal.
+func TestValidateAcceptsEveryDeclaredMetadataField(t *testing.T) {
+	err := validateManifestYAML(t, `
+metadata:
+  name: demo
+  icon: https://example.com/icon.png
+  description: a demo
+  appid: 1234abcd
+  title: Demo
+  version: 1.0.0
+  categories:
+    - Productivity
+  rating: 4.5
+  target: browser
+  type: app
+  categories_v2:
+    - agents
+  tags:
+    - coding
+`)
+	if err != nil {
+		t.Fatalf("declared metadata fields rejected: %v", err)
+	}
+}
+
+// validateManifestYAML runs one manifest fragment through the real parse and
+// validate path and returns only what the taxonomy rules said about it; the
+// fragments here are deliberately not complete manifests.
+func validateManifestYAML(t *testing.T, doc string) error {
+	t.Helper()
+	strategy := &ManifestStrategy{}
+	m, err := strategy.Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	parsed, ok := m.(*parsedManifest)
+	if !ok {
+		t.Fatalf("unexpected manifest type %T", m)
+	}
+	return errors.Join(
+		validateMetadataFields(parsed.metadataFields),
+		ValidateTaxonomy(parsed.Taxonomy()),
+	)
 }
 
 func TestValidateTaxonomyAcceptsCanonicalBCP47Locales(t *testing.T) {

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -93,6 +93,11 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 			taxonomy: Taxonomy{Locale: []string{"zh-cn"}},
 			want:     "canonical",
 		},
+		{
+			name:     "locale includes a suppressed script",
+			taxonomy: Taxonomy{Locale: []string{"en-Latn"}},
+			want:     "canonical",
+		},
 	}
 
 	for _, tc := range cases {
@@ -120,6 +125,7 @@ func TestValidateTaxonomyDoesNotImposeBusinessCountLimits(t *testing.T) {
 
 func TestValidateTaxonomyAcceptsCanonicalBCP47Locales(t *testing.T) {
 	locales := []string{
+		"en",
 		"es-419",
 		"de-DE-1996",
 		"sl-rozaj",

--- a/framework/oac/internal/manifest/taxonomy_test.go
+++ b/framework/oac/internal/manifest/taxonomy_test.go
@@ -75,6 +75,16 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 			want:     "more than once",
 		},
 		{
+			name:     "empty category",
+			taxonomy: Taxonomy{CategoriesV2: []string{""}},
+			want:     "must not be empty",
+		},
+		{
+			name:     "empty locale",
+			taxonomy: Taxonomy{Locale: []string{""}},
+			want:     "must not be empty",
+		},
+		{
 			name:     "padded tag",
 			taxonomy: Taxonomy{Tags: []string{" coding"}},
 			want:     "whitespace",
@@ -119,6 +129,44 @@ func TestValidateTaxonomyRejectsShape(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A value that is both misspelt and repeated is two separate mistakes, and the
+// reader needs to be told each of them once: repeating the shape complaint
+// hides the fact that the list has a duplicate in it at all.
+func TestValidateTaxonomyReportsARepeatedValueAsADuplicate(t *testing.T) {
+	cases := []struct {
+		name     string
+		taxonomy Taxonomy
+		shape    string
+	}{
+		{
+			name:     "misspelt category twice",
+			taxonomy: Taxonomy{CategoriesV2: []string{"Agents", "Agents"}},
+			shape:    "lowercase",
+		},
+		{
+			name:     "misspelt locale twice",
+			taxonomy: Taxonomy{Locale: []string{"english", "english"}},
+			shape:    "BCP 47",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTaxonomy(tc.taxonomy)
+			if err == nil {
+				t.Fatalf("%+v was accepted", tc.taxonomy)
+			}
+			msg := err.Error()
+			if got := strings.Count(msg, tc.shape); got != 1 {
+				t.Fatalf("shape complaint appears %d times in %q, want once", got, msg)
+			}
+			if !strings.Contains(msg, "more than once") {
+				t.Fatalf("error %q does not report the duplicate", msg)
 			}
 		})
 	}

--- a/framework/oac/options_test.go
+++ b/framework/oac/options_test.go
@@ -16,6 +16,7 @@ func (stubManifest) AppName() string               { return "stub" }
 func (stubManifest) AppVersion() string            { return "0.0.0" }
 func (stubManifest) Entrances() []olm.EntranceInfo { return nil }
 func (stubManifest) OptionsImages() []string       { return nil }
+func (stubManifest) Taxonomy() olm.Taxonomy        { return olm.Taxonomy{} }
 func (stubManifest) PermissionAppData() bool       { return false }
 func (stubManifest) PermissionAppCommon() bool     { return false }
 func (stubManifest) PermissionExternalData() bool  { return false }

--- a/framework/oac/taxonomy.go
+++ b/framework/oac/taxonomy.go
@@ -1,0 +1,22 @@
+package oac
+
+import (
+	"github.com/beclab/Olares/framework/oac/internal/manifest"
+)
+
+// Taxonomy is the catalog-facing slice of a manifest: the sections an app
+// appears under (`metadata.categories_v2`), the tags that refine that within a
+// section (`metadata.tags`), and the languages its own text is written in
+// (`spec.locale`).
+//
+// oac checks the shape of these values; whether a given category or tag is one
+// the market actually offers lives in the market's own registry, so gitbot
+// answers that question and reads the declared values from here.
+type Taxonomy = manifest.Taxonomy
+
+// ParseTaxonomy reads the taxonomy out of an already-rendered manifest, for
+// callers holding manifest bytes rather than a parsed Manifest. A Manifest
+// loaded through this package carries the same values on its Taxonomy method.
+func ParseTaxonomy(rendered []byte) (Taxonomy, error) {
+	return manifest.ParseTaxonomy(rendered)
+}

--- a/framework/oac/taxonomy_test.go
+++ b/framework/oac/taxonomy_test.go
@@ -1,0 +1,86 @@
+package oac_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/beclab/Olares/framework/oac"
+)
+
+const taxonomyManifest = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: demo
+  title: Demo
+  version: 1.0.0
+  categories: 
+    - Productivity
+  categories_v2:
+    - agents
+    - workspace
+  tags:
+    - coding
+    - self-hosted
+spec:
+  versionName: v1
+  locale:
+    - en-US
+    - zh-CN
+`
+
+// gitbot and the market tools read the taxonomy off a manifest they already
+// loaded, so it has to be reachable through the exported Manifest.
+func TestLoadedManifestCarriesItsTaxonomy(t *testing.T) {
+	m, err := oac.New().LoadManifestContent([]byte(taxonomyManifest))
+	if err != nil {
+		t.Fatalf("LoadManifestContent: %v", err)
+	}
+
+	got := m.Taxonomy()
+	want := oac.Taxonomy{
+		CategoriesV2: []string{"agents", "workspace"},
+		Tags:         []string{"coding", "self-hosted"},
+		Locale:       []string{"en-US", "zh-CN"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Taxonomy() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseTaxonomyReadsRenderedBytes(t *testing.T) {
+	got, err := oac.ParseTaxonomy([]byte(taxonomyManifest))
+	if err != nil {
+		t.Fatalf("ParseTaxonomy: %v", err)
+	}
+	want := oac.Taxonomy{
+		CategoriesV2: []string{"agents", "workspace"},
+		Tags:         []string{"coding", "self-hosted"},
+		Locale:       []string{"en-US", "zh-CN"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseTaxonomy = %+v, want %+v", got, want)
+	}
+}
+
+// An app that predates the taxonomy declares none of it, and reading it back
+// must not invent empty lists a caller would have to distinguish from real ones.
+func TestTaxonomyIsAbsentWhenUndeclared(t *testing.T) {
+	const bare = `olaresManifest.version: 0.12.0
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: demo
+  title: Demo
+  version: 1.0.0
+spec:
+  versionName: v1
+`
+	m, err := oac.New().LoadManifestContent([]byte(bare))
+	if err != nil {
+		t.Fatalf("LoadManifestContent: %v", err)
+	}
+	if got := m.Taxonomy(); len(got.CategoriesV2) != 0 || len(got.Tags) != 0 || len(got.Locale) != 0 {
+		t.Fatalf("Taxonomy() = %+v, want empty", got)
+	}
+}

--- a/framework/oac/taxonomy_test.go
+++ b/framework/oac/taxonomy_test.go
@@ -63,6 +63,24 @@ func TestParseTaxonomyReadsRenderedBytes(t *testing.T) {
 	}
 }
 
+// spec.locale is a field of the shared AppConfiguration, and the taxonomy view
+// of it must be that same value rather than a second decode of the same bytes:
+// two decoders of one field can disagree, and then lint and the market read
+// different languages off the same manifest.
+func TestTaxonomyLocaleIsTheParsedSpecLocale(t *testing.T) {
+	m, err := oac.New().LoadManifestContent([]byte(taxonomyManifest))
+	if err != nil {
+		t.Fatalf("LoadManifestContent: %v", err)
+	}
+	cfg, ok := oac.AsAppConfiguration(m)
+	if !ok {
+		t.Fatal("expected an *AppConfiguration")
+	}
+	if !reflect.DeepEqual(m.Taxonomy().Locale, cfg.Spec.Locale) {
+		t.Fatalf("Taxonomy().Locale = %v, spec.locale = %v", m.Taxonomy().Locale, cfg.Spec.Locale)
+	}
+}
+
 // An app that predates the taxonomy declares none of it, and reading it back
 // must not invent empty lists a caller would have to distinguish from real ones.
 func TestTaxonomyIsAbsentWhenUndeclared(t *testing.T) {


### PR DESCRIPTION
## Summary
- validate `categories_v2`, `tags`, and canonical BCP 47 locales in OAC manifests without business-count limits
- expose parsed taxonomy through the OAC public API and reject unknown metadata fields
- pin the four source API v2 paths in the live Market deployment contract

## Dependencies
- the API path settings are consumed by the matching Market taxonomy PR
- app catalog data cleanup remains intentionally deferred to a separate PR

## Test plan
- [x] OAC taxonomy unit and public API tests
- [x] OAC build and vet
- [x] Market deployment contract test
- [x] scanned existing apps and terminus-apps manifests for schema compatibility
- [x] final defect-first review: no Critical or Important findings in this branch

## Known baseline issues
- the existing reserved-app-id manifest test fails on the base branch as well

Made with [Cursor](https://cursor.com)