### PR TITLE
Gate cluster operation RequireSignature by self-registered op type

### DIFF
--- a/daemon/internel/apiserver/handlers/cluster_group.go
+++ b/daemon/internel/apiserver/handlers/cluster_group.go
@@ -18,10 +18,10 @@ func init() {
 	cluster.Get("/nodes", handlers.RequireAuthorizationOrOwnerSignature(
 		handlers.RequireMaster(handlers.RequireLocal(handlers.GetClusterNodes))))
 
-	// Powering the cluster is the owner's decision, so the scan callback's
-	// operation-bound owner signature is sufficient. Read routes still require
-	// an access token.
-	cluster.Post("/operations", handlers.RequireSignature(
+	// Creating a cluster operation is the owner's decision. Types that
+	// register themselves as needing a signature must present one; others
+	// are admitted with an access token. RequireOwner still runs either way.
+	cluster.Post("/operations", handlers.RequireSignatureForRegisteredClusterOp(
 		handlers.RequireOwner(
 			handlers.RequireMaster(handlers.PostClusterOperation))))
 

--- a/daemon/internel/apiserver/handlers/cluster_operation_signature_gate_test.go
+++ b/daemon/internel/apiserver/handlers/cluster_operation_signature_gate_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/daemon/pkg/cluster/clusterop"
+)
+
+// A type that registered itself as needing a signature still cannot be created
+// with only an access token.
+func TestClusterOperationSignatureGateStillRequiresSignatureForRegisteredTypes(t *testing.T) {
+	operationsMustNotBeCreated(t)
+	asAuthorizedUser(t)
+	asMaster(t)
+
+	resp, body := callRegisteredMethod(t, http.MethodPost, "/cluster/operations",
+		`{"type":"reboot","requestId":"client-1"}`, authHeaders())
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for a registered type without a signature: %s", resp.StatusCode, body)
+	}
+}
+
+// An empty type fails closed to the signature path rather than falling through
+// to the access-token path.
+func TestClusterOperationSignatureGateFailsClosedOnEmptyType(t *testing.T) {
+	operationsMustNotBeCreated(t)
+	asAuthorizedUser(t)
+	asMaster(t)
+
+	resp, body := callRegisteredMethod(t, http.MethodPost, "/cluster/operations",
+		`{"requestId":"client-1"}`, authHeaders())
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for an empty type without a signature: %s", resp.StatusCode, body)
+	}
+}
+
+// A type that did not register a signature requirement is admitted with an
+// access token past the signature middleware. It still fails later at
+// ParseType for an unknown module — this test only proves RequireSignature
+// was not the gate that stopped it.
+func TestClusterOperationSignatureGateAdmitsUnregisteredTypeWithAccessToken(t *testing.T) {
+	operationsMustNotBeCreated(t)
+	asAuthorizedUser(t)
+	asMaster(t)
+
+	typ := "no-signature-required-example"
+	if clusterop.RequiresSignature(clusterop.Type(typ)) {
+		t.Fatalf("%q unexpectedly requires a signature", typ)
+	}
+
+	resp, body := callRegisteredMethod(t, http.MethodPost, "/cluster/operations",
+		`{"type":"`+typ+`","requestId":"client-1"}`, authHeaders())
+
+	if resp.StatusCode == http.StatusForbidden && strings.Contains(string(body), "request is forbidden") {
+		t.Fatalf("signature middleware rejected an unregistered type that presented an access token: %s", body)
+	}
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("orchestrator accepted %q; the request should not create an operation", typ)
+	}
+}

--- a/daemon/internel/apiserver/handlers/command_group.go
+++ b/daemon/internel/apiserver/handlers/command_group.go
@@ -69,11 +69,17 @@ func init() {
 	cmd.Post("/power-node", handlers.RequireSignature(
 		handlers.RequireOwner(handlers.PostPowerNode)))
 
-	// The same hop for every other cluster operation, guarded identically.
+	// The same hop for every other cluster operation. Types that registered
+	// themselves as needing a signature are admitted the same way power-node
+	// is — signature only, no access token — so the master never forwards a
+	// general-purpose credential. Types that did not register still need the
+	// owner, and are admitted with the access token the master forwards for
+	// that hop alone; see clusterop.DispatchNodeOperation.
+	//
 	// It is a second path rather than a wider power-node because an older
 	// worker serves power-node and nothing else, so that one's request JSON
 	// cannot grow; see clusterop.ClusterOperationPath.
-	cmd.Post("/cluster-operation", handlers.RequireSignature(
+	cmd.Post("/cluster-operation", handlers.RequireSignatureForRegisteredClusterOp(
 		handlers.RequireOwner(handlers.PostClusterOperationNode)))
 
 	cmd.Post("/connect-wifi", handlers.RequireSignature(

--- a/daemon/internel/apiserver/handlers/handler_cluster_operation_node.go
+++ b/daemon/internel/apiserver/handlers/handler_cluster_operation_node.go
@@ -30,18 +30,19 @@ const nodeExecutionUnavailable = "this node cannot carry out cluster operations 
 // are still dispatched to the power endpoint instead: an older worker has
 // that one and nothing else.
 //
-// It is guarded exactly as the power endpoint is — the owner's signature,
-// bound to this operation and checked here rather than trusted from the
-// master — and it can only act on the machine it reached, so reaching it
-// grants no authority over any other node in the cluster.
+// Types that require an owner signature are guarded exactly as the power
+// endpoint is — the owner's signature, bound to this operation and checked
+// here rather than trusted from the master. Types that do not were admitted
+// with an access token on the route; they still act only on the machine they
+// reached, so reaching them grants no authority over any other node.
 //
 // The request carries the module's params. They are not covered by the
 // owner's signature: what the owner signed is the operation, the request id,
 // the cluster and the scope, and nothing under params is part of that. A
 // module must therefore treat params as input from whoever could reach this
 // route, and Validate is where it says what it will accept — which is why it
-// is asked before anything is carried out, and after the signature that got
-// the request this far has already been spent.
+// is asked before anything is carried out, and after a signature that got
+// the request this far has already been spent when one was required.
 func (h *Handlers) PostClusterOperationNode(ctx *fiber.Ctx) error {
 	var req clusterop.NodeRequest
 	if err := ctx.BodyParser(&req); err != nil {
@@ -72,10 +73,6 @@ func (h *Handlers) PostClusterOperationNode(ctx *fiber.Ctx) error {
 		return h.errPower(ctx, http.StatusConflict,
 			clusterop.CodeNodeIdentityUnknown, "this node's cluster identity is unavailable")
 	}
-	binding, err := bindNodeRequest(ctx, registry, req.PeerRequest, nodeName)
-	if err != nil {
-		return h.errBinding(ctx, err)
-	}
 
 	module, ok := registry.Lookup(opType)
 	if !ok {
@@ -85,33 +82,55 @@ func (h *Handlers) PostClusterOperationNode(ctx *fiber.Ctx) error {
 			"this daemon does not perform that operation")
 	}
 
-	// Spent before the module is asked anything, and not given back if the
-	// module then refuses. Judging a request is work this node performs on
-	// the strength of the signature, and a caller who could present the same
-	// one repeatedly would have an unlimited way to drive somebody else's
-	// code with params nothing signed.
-	claim, spent, unspent := h.spendSignature(ctx, clusterOperationNodeEndpoint, binding)
-	if !spent {
-		return unspent
+	var (
+		signed clusterop.PeerRequest
+		claim  string
+	)
+	if clusterop.RequiresSignature(opType) {
+		binding, err := bindNodeRequest(ctx, registry, req.PeerRequest, nodeName)
+		if err != nil {
+			return h.errBinding(ctx, err)
+		}
+
+		// Spent before the module is asked anything, and not given back if the
+		// module then refuses. Judging a request is work this node performs on
+		// the strength of the signature, and a caller who could present the same
+		// one repeatedly would have an unlimited way to drive somebody else's
+		// code with params nothing signed.
+		var spent bool
+		var unspent error
+		claim, spent, unspent = h.spendSignature(ctx, clusterOperationNodeEndpoint, binding)
+		if !spent {
+			return unspent
+		}
+
+		// Every field the module judges the request by comes from the binding
+		// rather than from the body. The two agree — the binding was checked
+		// against the body to get here — but only one of them the owner signed,
+		// and they are not character for character the same: the request id was
+		// compared after trimming, so a body may still carry a padded one.
+		signed = clusterop.PeerRequest{
+			Type:        binding.Type,
+			RequestID:   binding.RequestID,
+			Scope:       binding.Scope,
+			Target:      binding.Target,
+			ClusterID:   binding.ClusterID,
+			OperationID: req.OperationID,
+		}
+	} else {
+		if err := authorizeNodeRequestScope(ctx, req.PeerRequest, nodeName); err != nil {
+			return h.errBinding(ctx, err)
+		}
+		signed = clusterop.PeerRequest{
+			Type:        opType,
+			RequestID:   strings.TrimSpace(req.RequestID),
+			Scope:       req.Scope,
+			Target:      req.Target,
+			ClusterID:   req.ClusterID,
+			OperationID: req.OperationID,
+		}
 	}
 
-	// Every field the module judges the request by comes from the binding
-	// rather than from the body. The two agree — the binding was checked
-	// against the body to get here — but only one of them the owner signed,
-	// and they are not character for character the same: the request id was
-	// compared after trimming, so a body may still carry a padded one.
-	signed := clusterop.PeerRequest{
-		Type:      binding.Type,
-		RequestID: binding.RequestID,
-		Scope:     binding.Scope,
-		Target:    binding.Target,
-		ClusterID: binding.ClusterID,
-
-		// The master's own id for the run. Nothing signs it and nothing is
-		// decided by it; it is carried so this node's log and the master's
-		// record name the same operation.
-		OperationID: req.OperationID,
-	}
 	// The same boundary the master's own Create asks a module through: a
 	// module that cannot answer is not a module that refused, and neither
 	// end of the operation may decide that differently from the other.
@@ -141,4 +160,25 @@ func (h *Handlers) PostClusterOperationNode(ctx *fiber.Ctx) error {
 	// module was shown can differ from what it is then asked to act on.
 	return h.runNodeOperation(ctx, clusterOperationNodeEndpoint, registry,
 		clusterop.NodeRequest{PeerRequest: signed, Params: req.Params}, claim)
+}
+
+// authorizeNodeRequestScope checks the scope/target and cluster id of a
+// node request that was not admitted by an operation-bound signature. The
+// target is still compared to nodeName from the directory, so this hop
+// cannot be aimed at another machine.
+func authorizeNodeRequestScope(ctx *fiber.Ctx, req clusterop.PeerRequest, nodeName string) error {
+	if req.Scope != clusterop.ScopeCluster && req.Scope != clusterop.ScopeNode ||
+		(req.Scope == clusterop.ScopeCluster && req.Target != "") ||
+		(req.Scope == clusterop.ScopeNode && req.Target != nodeName) {
+		return &clusterop.BindingError{
+			Code: clusterop.CodeSignatureUnbound, Message: "the signature does not authorize this operation",
+		}
+	}
+	localClusterID, err := clusterIDOf(ctx.Context())
+	if err != nil || localClusterID == "" || req.ClusterID != localClusterID {
+		return &clusterop.BindingError{
+			Code: clusterop.CodeSignatureMismatch, Message: "the signature authorizes a different operation",
+		}
+	}
+	return nil
 }

--- a/daemon/internel/apiserver/handlers/handler_cluster_operation_node_test.go
+++ b/daemon/internel/apiserver/handlers/handler_cluster_operation_node_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -16,12 +17,26 @@ import (
 // operations that happen to be built in.
 const testOperationType = clusterop.Type("bake-cake")
 
+func init() {
+	// Registered before any test freezes the default signature-requirement
+	// set (InitClusterOperations), so the signature-bound node tests below
+	// keep taking that path for bake-cake.
+	if err := clusterop.DefaultSignatureRequirementRegistry().Register(testOperationType); err != nil {
+		panic(err)
+	}
+}
+
 // withTestNodeOperation installs one module of a type this daemon does not
 // have, plus somewhere to record spent signatures, and returns the module.
+// The type must already require an owner signature — bake-cake does via init
+// above; built-in power types do via their own modules.
 func withTestNodeOperation(t *testing.T, module *nodeModuleRecorder) *nodeModuleRecorder {
 	t.Helper()
 	if module.typ == "" {
 		module.typ = testOperationType
+	}
+	if !clusterop.RequiresSignature(module.typ) {
+		t.Fatalf("%q must require a signature for these tests", module.typ)
 	}
 	withNodeOperations(t, module)
 	withReplayGuard(t)
@@ -174,15 +189,17 @@ func TestClusterOperationNodeRejectsAnotherCluster(t *testing.T) {
 }
 
 // A type no module in this node's set holds is refused with the same stable
-// code the power endpoint refuses an unknown operation with.
+// code the power endpoint refuses an unknown operation with. Unknown types
+// are not signature-registered, so the route admits them with an access
+// token and the handler is what refuses them.
 func TestClusterOperationNodeRefusesAnUnknownType(t *testing.T) {
 	module := withTestNodeOperation(t, &nodeModuleRecorder{})
-	asOwnerSignature(t)
+	asAuthorizedUser(t)
 	asWorker(t)
 
 	resp, body := callRegisteredMethod(t, http.MethodPost, "/command/cluster-operation",
 		`{"type":"no-such-operation","operationId":"op-1","requestId":"client-1"}`,
-		signedFor(t, testOperationType, "client-1"))
+		authHeaders())
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
@@ -542,5 +559,36 @@ func TestClusterOperationNodeAnswersOnTheControlNode(t *testing.T) {
 	}
 	if len(module.ran()) != 1 {
 		t.Errorf("the control node did not carry out the operation: %+v", module.ran())
+	}
+}
+
+// A type that did not register a signature requirement is admitted with the
+// access token the master forwards. Binding and replay spending stay with
+// the signature-bound path.
+func TestClusterOperationNodeAdmitsTokenWhenSignatureNotRequired(t *testing.T) {
+	const typ = clusterop.Type("fold-laundry")
+	if clusterop.RequiresSignature(typ) {
+		t.Fatalf("%q unexpectedly requires a signature", typ)
+	}
+	module := &nodeModuleRecorder{typ: typ}
+	withNodeOperations(t, module)
+	asAuthorizedUser(t)
+	asWorker(t)
+	prev := clusterIDOf
+	clusterIDOf = func(context.Context) (string, error) { return "cluster-test", nil }
+	t.Cleanup(func() { clusterIDOf = prev })
+
+	resp, body := callRegisteredMethod(t, http.MethodPost, "/command/cluster-operation",
+		`{"type":"fold-laundry","operationId":"op-1","requestId":"client-1","params":{}}`,
+		authHeaders())
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, body)
+	}
+	if len(module.ran()) != 1 {
+		t.Fatalf("the module was asked to act %d times, want once", len(module.ran()))
+	}
+	if module.ran()[0].Type != typ || module.ran()[0].RequestID != "client-1" {
+		t.Errorf("request = %+v", module.ran()[0].PeerRequest)
 	}
 }

--- a/daemon/internel/apiserver/handlers/handler_cluster_operations.go
+++ b/daemon/internel/apiserver/handlers/handler_cluster_operations.go
@@ -46,13 +46,14 @@ const orchestratorUnavailable = "cluster operations are not available on this no
 // rather than something built here so that no test can install one wired to a
 // real cluster and a real power command by accident.
 //
-// What this daemon can be asked to do is settled here too. The module set is
-// closed before the orchestrator is built over it, so what the routes accept,
-// what the owner's signature can be read against, and what the manager can
-// carry out are one set decided once — and a module registering itself after
-// the daemon started serving is refused rather than becoming an operation
-// half of this process knows about. The same set is what main gives the node
-// routes; see InstallNodeOperations.
+// What this daemon can be asked to do is settled here too. The module set and
+// the signature-requirement set are closed before the orchestrator is built
+// over them, so what the routes accept, which types demand an owner signature
+// on create, what the owner's signature can be read against, and what the
+// manager can carry out are decided once — and a module registering itself
+// after the daemon started serving is refused rather than becoming an
+// operation half of this process knows about. The same module set is what
+// main gives the node routes; see InstallNodeOperations.
 func InitClusterOperations(dir string, deps clusterop.Deps) error {
 	// Closed first, and whatever happens next: a daemon that could not open
 	// its records still serves the routes, and the set they answer from must
@@ -60,6 +61,7 @@ func InitClusterOperations(dir string, deps clusterop.Deps) error {
 	// idempotent, so a second call is not a failure.
 	registry := clusterop.DefaultRegistry()
 	registry.Freeze()
+	clusterop.DefaultSignatureRequirementRegistry().Freeze()
 
 	store, err := clusterop.NewStore(dir)
 	if err != nil {
@@ -130,17 +132,21 @@ func (h *Handlers) PostClusterOperation(ctx *fiber.Ctx) error {
 		})
 	}
 
-	// The owner signed this operation, not "anything dangerous for the next
-	// twenty minutes". Without the check, a signature captured from any other
-	// owner-only route would power the cluster off.
-	if _, err := requireBinding(ctx, clusterop.Binding{
-		ClusterID: req.ClusterID,
-		Type:      opType,
-		RequestID: strings.TrimSpace(req.RequestID),
-		Scope:     req.Scope,
-		Target:    req.Target,
-	}); err != nil {
-		return h.errBinding(ctx, err)
+	// Types that require a signature bind it to this exact operation, not
+	// "anything dangerous for the next twenty minutes". Without the check, a
+	// signature captured from any other owner-only route would power the
+	// cluster off. Types that do not require one were already admitted by an
+	// access token on the route.
+	if clusterop.RequiresSignature(opType) {
+		if _, err := requireBinding(ctx, clusterop.Binding{
+			ClusterID: req.ClusterID,
+			Type:      opType,
+			RequestID: strings.TrimSpace(req.RequestID),
+			Scope:     req.Scope,
+			Target:    req.Target,
+		}); err != nil {
+			return h.errBinding(ctx, err)
+		}
 	}
 	localClusterID, err := clusterIDOf(ctx.Context())
 	if err != nil || localClusterID == "" || localClusterID != req.ClusterID {
@@ -163,8 +169,9 @@ func (h *Handlers) PostClusterOperation(ctx *fiber.Ctx) error {
 		Owner:     owner,
 		Params:    req.Params,
 		Creds: clusterop.Credentials{
-			// The token authorizes this request and stays on this node; only
-			// the operation-bound signature is presented to a worker.
+			// The token stays available for types that fan out without a
+			// signature; signature-bound types still present only the JWS to
+			// workers — see clusterop.DispatchNodeOperation.
 			Token:     ctx.Get(AUTH_HEADER),
 			Signature: ctx.Get(SIGNATURE_HEADER),
 		},

--- a/daemon/internel/apiserver/handlers/handler_power_node.go
+++ b/daemon/internel/apiserver/handlers/handler_power_node.go
@@ -192,9 +192,10 @@ func (h *Handlers) spendSignature(ctx *fiber.Ctx, ep nodeEndpoint,
 // releaseClaim gives a spent signature back, for the one case that warrants
 // it: the operation was attempted and failed, so the caller may retry the
 // same request. A signature spent on work this node actually did — including
-// asking a module to judge the request — is not given back.
+// asking a module to judge the request — is not given back. An empty claim
+// is a no-op: types admitted without a signature never spent one.
 func releaseClaim(claim string) {
-	if powerClaims == nil {
+	if claim == "" || powerClaims == nil {
 		return
 	}
 	if err := powerClaims.Forget(claim); err != nil {

--- a/daemon/internel/apiserver/handlers/middlewares.go
+++ b/daemon/internel/apiserver/handlers/middlewares.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/beclab/Olares/daemon/internel/client"
+	"github.com/beclab/Olares/daemon/pkg/cluster/clusterop"
 	"github.com/beclab/Olares/daemon/pkg/cluster/inventory"
 	"github.com/beclab/Olares/daemon/pkg/cluster/state"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -57,6 +59,24 @@ func (h *Handlers) RequireSignature(next func(ctx *fiber.Ctx) error) func(ctx *f
 		}
 
 		return next(ctx)
+	}
+}
+
+// RequireSignatureForRegisteredClusterOp admits POST /cluster/operations with
+// an owner signature when the requested type has registered itself as needing
+// one, and with an access token otherwise. An empty type fails closed to the
+// signature path. The signature verification itself is unchanged.
+func (h *Handlers) RequireSignatureForRegisteredClusterOp(next func(ctx *fiber.Ctx) error) func(ctx *fiber.Ctx) error {
+	return func(ctx *fiber.Ctx) error {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(ctx.Body(), &peek)
+		typ := strings.TrimSpace(peek.Type)
+		if typ == "" || clusterop.RequiresSignature(clusterop.Type(typ)) {
+			return h.RequireSignature(next)(ctx)
+		}
+		return h.RequireAuthorization(next)(ctx)
 	}
 }
 

--- a/daemon/pkg/cluster/clusterop/module_reboot.go
+++ b/daemon/pkg/cluster/clusterop/module_reboot.go
@@ -19,7 +19,10 @@ const observationTimeout = 10 * time.Second
 // node. It is declared here because this module is what answers for it.
 const TypeReboot Type = "reboot"
 
-func init() { registerBuiltInPowerOperation(rebootModule{}) }
+func init() {
+	registerBuiltInPowerOperation(rebootModule{})
+	MustRequireSignature(TypeReboot)
+}
 
 // rebootModule is the cluster reboot: every compute node restarts, is watched
 // back onto a new boot, and only then is the control node told to go.

--- a/daemon/pkg/cluster/clusterop/module_set_ssh_password.go
+++ b/daemon/pkg/cluster/clusterop/module_set_ssh_password.go
@@ -32,7 +32,10 @@ const (
 	codeSetSSHPasswordFailed = "set_ssh_password_failed"
 )
 
-func init() { MustRegisterModule(setSSHPasswordModule{}) }
+func init() {
+	MustRegisterModule(setSSHPasswordModule{})
+	MustRequireSignature(TypeSetSSHPassword)
+}
 
 // setSSHPasswordModule sets the SSH login password on the nodes the request
 // names. It reuses the same node-local command the single-node /ssh-password

--- a/daemon/pkg/cluster/clusterop/module_shutdown.go
+++ b/daemon/pkg/cluster/clusterop/module_shutdown.go
@@ -13,7 +13,10 @@ import (
 // node. It is declared here because this module is what answers for it.
 const TypeShutdown Type = "shutdown"
 
-func init() { registerBuiltInPowerOperation(shutdownModule{}) }
+func init() {
+	registerBuiltInPowerOperation(shutdownModule{})
+	MustRequireSignature(TypeShutdown)
+}
 
 // shutdownModule is the cluster shutdown: every compute node is told to
 // switch off, and then the control node is.

--- a/daemon/pkg/cluster/clusterop/peer.go
+++ b/daemon/pkg/cluster/clusterop/peer.go
@@ -84,30 +84,47 @@ func dispatchPower(ctx context.Context, nodes []inventory.Node, req PeerRequest,
 // to the generic endpoint, which only a daemon that has this package's
 // module registry serves.
 //
-// It presents the same single credential dispatchPower does, for the same
-// reason: the operation-bound signature names what it authorizes, and the
-// caller's access token does not. That signature covers the operation, the
-// request id, the cluster and the scope — and not the params, which are
-// outside what the owner signed at every hop they travel. The module the
-// node hands them to is what decides whether they are acceptable.
+// Types that require an owner signature present only that credential, for the
+// same reason dispatchPower does: the signature names what it authorizes, and
+// the caller's access token does not. Types that do not require a signature
+// present the access token instead, which is the credential the master's
+// create route already admitted them with — see RequiresSignature.
 func DispatchNodeOperation(ctx context.Context, nodes []inventory.Node, req NodeRequest,
 	creds Credentials) []DispatchOutcome {
-	return dispatchToPeers(ctx, ClusterOperationPath, nodes, req, creds)
+	return dispatchToPeersWithHeaders(ctx, ClusterOperationPath, nodes, req,
+		clusterOperationHeaders(req.Type, creds))
 }
 
-// dispatchToPeers is the transport both dispatches share, so the path is the
-// only thing that separates them and neither can acquire a credential the
-// other does not have.
+// dispatchToPeers is the transport power dispatch uses: signature only.
 func dispatchToPeers(ctx context.Context, path string, nodes []inventory.Node, body any,
 	creds Credentials) []DispatchOutcome {
+	return dispatchToPeersWithHeaders(ctx, path, nodes, body, signatureHeader(creds))
+}
+
+func dispatchToPeersWithHeaders(ctx context.Context, path string, nodes []inventory.Node, body any,
+	headers map[string]string) []DispatchOutcome {
 	d := &fanout.Dispatcher{
 		PeerPath: path,
-		Headers:  signatureHeader(creds),
+		Headers:  headers,
 		Port:     peerPort,
 		Timeout:  dispatchTimeout,
 	}
 	results := d.Run(ctx, peerTargets(nodes), func(fanout.NodeTarget) any { return body })
 	return peerOutcomes(results)
+}
+
+// clusterOperationHeaders chooses the credential the generic node hop may
+// carry. A type that registered itself as needing a signature still leaves
+// the access token behind; every other type forwards the token the master
+// already checked.
+func clusterOperationHeaders(typ Type, creds Credentials) map[string]string {
+	if RequiresSignature(typ) {
+		return signatureHeader(creds)
+	}
+	if creds.Token == "" {
+		return nil
+	}
+	return map[string]string{authorizationHeaderName: creds.Token}
 }
 
 func signatureHeader(creds Credentials) map[string]string {

--- a/daemon/pkg/cluster/clusterop/peer_test.go
+++ b/daemon/pkg/cluster/clusterop/peer_test.go
@@ -209,15 +209,16 @@ func TestGenericNodeDispatchCarriesTheParamsUnchanged(t *testing.T) {
 	}
 }
 
-// The generic hop is no wider than the power hop: the operation-bound
-// signature crosses it and the caller's access token does not, because a
-// token opens every route that user can reach for as long as it lives.
+// The generic hop for a signature-bound type is no wider than the power hop:
+// the operation-bound signature crosses it and the caller's access token does
+// not, because a token opens every route that user can reach for as long as
+// it lives.
 func TestGenericNodeDispatchPresentsOnlyTheOperationSignature(t *testing.T) {
 	peer := newPeerRecorder(t)
 
 	DispatchNodeOperation(context.Background(), recordingNode(), NodeRequest{
 		PeerRequest: PeerRequest{
-			Type: Type("bake-cake"), OperationID: "op-1", RequestID: "client-1",
+			Type: TypeReboot, OperationID: "op-1", RequestID: "client-1",
 			Scope: ScopeNode, Target: "worker-1", ClusterID: "cluster-1",
 		},
 	}, Credentials{Token: "access-token", Signature: "signature"})
@@ -228,6 +229,32 @@ func TestGenericNodeDispatchPresentsOnlyTheOperationSignature(t *testing.T) {
 	}
 	if got := header.Get(authorizationHeaderName); got != "" {
 		t.Errorf("%s = %q, want the access token left behind", authorizationHeaderName, got)
+	}
+}
+
+// A type that did not register a signature requirement is admitted on the
+// master with an access token, so that same token is what the fan-out presents
+// to the node — otherwise the node hop would have no credential at all.
+func TestGenericNodeDispatchPresentsTokenWhenSignatureNotRequired(t *testing.T) {
+	peer := newPeerRecorder(t)
+	typ := Type("fold-laundry")
+	if RequiresSignature(typ) {
+		t.Fatalf("%q unexpectedly requires a signature", typ)
+	}
+
+	DispatchNodeOperation(context.Background(), recordingNode(), NodeRequest{
+		PeerRequest: PeerRequest{
+			Type: typ, OperationID: "op-1", RequestID: "client-1",
+			Scope: ScopeNode, Target: "worker-1", ClusterID: "cluster-1",
+		},
+	}, Credentials{Token: "access-token", Signature: "signature"})
+
+	header := peer.oneCall(t).header
+	if got := header.Get(authorizationHeaderName); got != "access-token" {
+		t.Errorf("%s = %q, want the access token", authorizationHeaderName, got)
+	}
+	if got := header.Get(signatureHeaderName); got != "" {
+		t.Errorf("%s = %q, want the signature left behind for a token-admitted type", signatureHeaderName, got)
 	}
 }
 

--- a/daemon/pkg/cluster/clusterop/signature_requirement.go
+++ b/daemon/pkg/cluster/clusterop/signature_requirement.go
@@ -1,0 +1,76 @@
+package clusterop
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// SignatureRequirementRegistry holds the operation types that the master's
+// POST /cluster/operations route must admit only with an owner signature.
+// Types not registered here may be admitted with an access token instead;
+// the handler's binding check is separate and unchanged.
+type SignatureRequirementRegistry struct {
+	mu     sync.RWMutex
+	types  map[Type]struct{}
+	frozen bool
+}
+
+var defaultSignatureRequirements = NewSignatureRequirementRegistry()
+
+func NewSignatureRequirementRegistry() *SignatureRequirementRegistry {
+	return &SignatureRequirementRegistry{
+		types: make(map[Type]struct{}),
+	}
+}
+
+func DefaultSignatureRequirementRegistry() *SignatureRequirementRegistry {
+	return defaultSignatureRequirements
+}
+
+// MustRequireSignature records that typ must present an owner signature on
+// the master's create route. It panics when the registration is refused,
+// matching MustRegisterModule.
+func MustRequireSignature(typ Type) {
+	if err := defaultSignatureRequirements.Register(typ); err != nil {
+		panic(err)
+	}
+}
+
+// RequiresSignature reports whether the default registry requires an owner
+// signature for typ on the master's create route.
+func RequiresSignature(typ Type) bool {
+	return defaultSignatureRequirements.Requires(typ)
+}
+
+func (r *SignatureRequirementRegistry) Register(typ Type) error {
+	typ = Type(strings.TrimSpace(string(typ)))
+	if typ == "" {
+		return fmt.Errorf("cluster operation signature requirement type is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.frozen {
+		return fmt.Errorf("cluster operation signature requirement registry is frozen")
+	}
+	if _, exists := r.types[typ]; exists {
+		return fmt.Errorf("cluster operation signature requirement %q already registered", typ)
+	}
+	r.types[typ] = struct{}{}
+	return nil
+}
+
+func (r *SignatureRequirementRegistry) Requires(typ Type) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.types[Type(strings.TrimSpace(string(typ)))]
+	return ok
+}
+
+func (r *SignatureRequirementRegistry) Freeze() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.frozen = true
+}

--- a/daemon/pkg/cluster/clusterop/signature_requirement_test.go
+++ b/daemon/pkg/cluster/clusterop/signature_requirement_test.go
@@ -1,0 +1,64 @@
+package clusterop
+
+import "testing"
+
+func TestSignatureRequirementRegistryRequiresRegisteredType(t *testing.T) {
+	reg := NewSignatureRequirementRegistry()
+	if err := reg.Register(Type("example")); err != nil {
+		t.Fatal(err)
+	}
+	if !reg.Requires(Type("example")) {
+		t.Fatal("registered type was not required")
+	}
+	if reg.Requires(Type("other")) {
+		t.Fatal("unregistered type was required")
+	}
+}
+
+func TestSignatureRequirementRegistryTrimsType(t *testing.T) {
+	reg := NewSignatureRequirementRegistry()
+	if err := reg.Register(Type("  example  ")); err != nil {
+		t.Fatal(err)
+	}
+	if !reg.Requires(Type("example")) {
+		t.Fatal("trimmed type was not found")
+	}
+	if !reg.Requires(Type("  example  ")) {
+		t.Fatal("lookup did not trim")
+	}
+}
+
+func TestSignatureRequirementRegistryRejectsEmptyType(t *testing.T) {
+	if err := NewSignatureRequirementRegistry().Register(Type("")); err == nil {
+		t.Fatal("empty type registration succeeded")
+	}
+	if err := NewSignatureRequirementRegistry().Register(Type("   ")); err == nil {
+		t.Fatal("whitespace type registration succeeded")
+	}
+}
+
+func TestSignatureRequirementRegistryRejectsDuplicateType(t *testing.T) {
+	reg := NewSignatureRequirementRegistry()
+	if err := reg.Register(Type("example")); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(Type("example")); err == nil {
+		t.Fatal("duplicate registration succeeded")
+	}
+}
+
+func TestSignatureRequirementRegistryRejectsRegistrationAfterFreeze(t *testing.T) {
+	reg := NewSignatureRequirementRegistry()
+	reg.Freeze()
+	if err := reg.Register(Type("late")); err == nil {
+		t.Fatal("registration after Freeze succeeded")
+	}
+}
+
+func TestDefaultSignatureRequirementsHasBuiltInTypes(t *testing.T) {
+	for _, typ := range []Type{TypeReboot, TypeShutdown, TypeSetSSHPassword} {
+		if !RequiresSignature(typ) {
+			t.Errorf("RequiresSignature(%q) = false, want true for built-in module", typ)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a self-registration registry (`MustRequireSignature`) so each cluster operation module declares whether create/node hops need an owner signature.
- `POST /cluster/operations` and `POST /command/cluster-operation` use `RequireSignatureForRegisteredClusterOp`: registered types keep the existing signature path; others use access-token auth + `RequireOwner`.
- Fan-out for non-signature types forwards `X-Authorization` instead of `X-Signature`, and skips binding/spend checks so master → worker stays consistent. Built-in reboot/shutdown/set-ssh-password still require signatures.

## Test plan
- [ ] `go test ./pkg/cluster/clusterop/ -run 'SignatureRequirement|GenericNodeDispatch'`
- [ ] `go test ./internel/apiserver/handlers/ -run 'ClusterOperation|SignatureGate|CreateClusterOperation'`
- [ ] Confirm reboot/shutdown still require `X-Signature` on create and node hops
- [ ] Confirm a non-signature-registered type can create with owner token and fan out with `X-Authorization`


Made with [Cursor](https://cursor.com)