### PR TITLE
fix(app-gateway): set Linkerd proxy-injector reinvocationPolicy to IfNeeded

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-webhook-certgen.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-webhook-certgen.yaml
@@ -18,6 +18,10 @@ metadata:
     app.kubernetes.io/component: linkerd-webhook-certgen
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  # IfNeeded: sandbox webhook may set linkerd.io/inject=enabled after this
+  # webhook's first pass; re-invoke so mesh-in callers still get linkerd-proxy
+  # (default full inject for Shared-caller apps). Never left half-injected pods.
+  reinvocationPolicy: IfNeeded
   namespaceSelector:
     matchExpressions:
     - key: config.linkerd.io/admission-webhooks


### PR DESCRIPTION
## Summary
- Shared-caller apps default to full inject (mesh-in + `linkerd-proxy`).
- Sandbox may set `linkerd.io/inject=enabled` after the injector’s first admission pass; with `reinvocationPolicy: Never`, Linkerd never runs again → mesh-in without proxy.
- Set proxy-injector webhook to `IfNeeded` so Linkerd re-runs and completes injection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster-wide pod admission ordering for Linkerd injection; misconfiguration could affect mesh sidecar behavior on pod create, though scope is limited to one webhook field.
> 
> **Overview**
> Fixes **half-injected** Shared-caller pods where mesh-in was applied but **`linkerd-proxy` was missing**.
> 
> The **`linkerd-proxy-injector`** `MutatingWebhookConfiguration` now sets **`reinvocationPolicy: IfNeeded`**. A sandbox mutating webhook can add **`linkerd.io/inject=enabled`** after Linkerd’s first admission pass; with the default **`Never`**, the injector does not run again, so pods stay mesh-in without a proxy. **`IfNeeded`** lets Kubernetes re-invoke the injector so full inject completes for those workloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5631317643d4f3a168e8d42d314eeafef7ad582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->