### PR TITLE
fix: GenEntranceURL with default third level domain config

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -6,6 +6,7 @@ replace (
 	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.17
 	bytetrade.io/web3os/bfl => github.com/beclab/bfl v0.3.36
 	github.com/beclab/Olares/cli => ../cli
+	github.com/beclab/Olares/framework/app-service => ../framework/app-service
 	github.com/labstack/echo/v4 => github.com/eball/echo/v4 v4.13.4-patch
 	k8s.io/api => k8s.io/api v0.34.0
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.0

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -46,8 +46,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82 h1:BE/T9N2OyH0ZKMTzK7RY/EvKy8pfr0dokDBINJHLE8g=
-github.com/beclab/Olares/framework/app-service v0.0.0-20260528090802-b69f2bf96b82/go.mod h1:LYHBxvVI3cDiRa116LbDQ09Uiphi3i3tWX2Cjeoyi9w=
 github.com/beclab/api v0.0.24 h1:Ob01wkENbiBWis/O32Sn7xLQc8sAtCVmP6zksrMAlaQ=
 github.com/beclab/api v0.0.24/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/bfl v0.3.36 h1:PgeSPGc+XoONiwFsKq9xX8rqcL4kVM1G/ut0lYYj/js=

--- a/framework/app-service/pkg/appcfg/helpers.go
+++ b/framework/app-service/pkg/appcfg/helpers.go
@@ -24,13 +24,7 @@ var getUserZone = kubesphere.GetUserZone
 // github.com/beclab/api types, methods cannot be defined on them directly,
 // so the helpers are exposed as package-level functions instead.
 
-// DefaultThirdLevelDomainConfig is re-exported here for backwards
-// compatibility with call sites that referenced the in-tree alias.
-type DefaultThirdLevelDomainConfig struct {
-	AppName          string `json:"appName"`
-	EntranceName     string `json:"entranceName"`
-	ThirdLevelDomain string `json:"thirdLevelDomain"`
-}
+type DefaultThirdLevelDomainConfig = appv1alpha1.DefaultThirdLevelDomainConfig
 
 // IsV3 reports whether the given object (Application or
 // ApplicationManager) carries the v3 SCHEMA marker label. This does NOT
@@ -167,18 +161,14 @@ func GenEntranceURL(ctx context.Context, app *Application) ([]Entrance, error) {
 		}
 
 		appid := strings.ToLower(strings.TrimSpace(app.Spec.Appid))
-		if len(app.Spec.Entrances) == 1 {
-			app.Spec.Entrances[0] = app.Spec.Entrances[0].ForZone(appid, zone, 0, 1)
-		} else {
-			entrancesForZone := appv1alpha1.Entrances(app.Spec.Entrances).ForZone(appid, zone)
-			for i := range app.Spec.Entrances {
-				app.Spec.Entrances[i] = entrancesForZone[i]
-				for _, adc := range appDomainConfigs {
-					if adc.AppName == app.Spec.Name && adc.EntranceName == app.Spec.Entrances[i].Name && len(adc.ThirdLevelDomain) > 0 {
-						app.Spec.Entrances[i].URL = fmt.Sprintf("%s.%s", adc.ThirdLevelDomain, zone)
-					}
-				}
-			}
+		apiEntrances := make([]*appv1alpha1.Entrance, len(app.Spec.Entrances))
+		for k := range app.Spec.Entrances {
+			entrance := app.Spec.Entrances[k]
+			apiEntrances[k] = &entrance
+		}
+		for i := range app.Spec.Entrances {
+			prefix := appv1alpha1.ResolveEntranceIDWithDefaultThirdLevelDomainOverride(apiEntrances, i, appid, appDomainConfigs)
+			app.Spec.Entrances[i].URL = fmt.Sprintf("%s.%s", prefix, zone)
 		}
 	}
 	return app.Spec.Entrances, nil


### PR DESCRIPTION


* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how per-user entrance hostnames are computed when custom third-level domain settings exist; wrong behavior would break routing but scope is limited to that configuration path.
> 
> **Overview**
> **Fixes entrance URL generation** when apps define `defaultThirdLevelDomainConfig` in settings. `GenEntranceURL` no longer uses separate single- vs multi-entrance paths (`ForZone` plus a manual override loop); it builds entrance pointers and sets each URL from `ResolveEntranceIDWithDefaultThirdLevelDomainOverride`, matching BFL, gateway, and proxy code.
> 
> `DefaultThirdLevelDomainConfig` is now a type alias to the `github.com/beclab/api` type instead of a duplicate struct.
> 
> **Daemon** adds a `go.mod` **replace** for `framework/app-service` to the local tree so it picks up this fix; `go.sum` drops the old remote module checksum for that dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2300d2d8bf1a0551c0195e7db4fa941a098414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->