### PR TITLE
feat(app-service): own userspace dirs at uid 1000 from admission

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.25
+        image: beclab/app-service:0.6.27
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,14 +6,13 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421
+	github.com/beclab/Olares/framework/oac v0.0.0-20260813100235-217f8c798b53
 	github.com/beclab/api v0.0.24
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29
 	github.com/containers/image/v5 v5.36.1
 	github.com/emicklei/go-restful-openapi/v2 v2.11.0
 	github.com/emicklei/go-restful/v3 v3.13.0
-	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-crypt/crypt v0.4.5
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -132,6 +131,7 @@ require (
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,8 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421 h1:+nDNYQHujaVK0FIWdLKLZmmXhEmWkGWpp4r3/uTowvg=
-github.com/beclab/Olares/framework/oac v0.0.0-20260806133352-17b88f3cc421/go.mod h1:5hm6YNfFzaiiSOsCvCapYiJhtGQeNxd1oXnp4+2LNBw=
+github.com/beclab/Olares/framework/oac v0.0.0-20260813100235-217f8c798b53 h1:1JVwkEHO313kGYr3oJpHIFhzklj3IZ5xt/h39XMdahY=
+github.com/beclab/Olares/framework/oac v0.0.0-20260813100235-217f8c798b53/go.mod h1:+gNq8OLTjI60zxFhSdJrtHtgKBr9wBQd3Y7tGnbBdVk=
 github.com/beclab/api v0.0.24 h1:Ob01wkENbiBWis/O32Sn7xLQc8sAtCVmP6zksrMAlaQ=
 github.com/beclab/api v0.0.24/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/provider"
 	"github.com/beclab/Olares/framework/app-service/pkg/tapr"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	"github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	"github.com/beclab/api/pkg/generated/clientset/versioned"
@@ -225,6 +226,31 @@ func (h *Handler) setupAppEntranceDomain(req *restful.Request, resp *restful.Res
 		if err = checkEntranceDomainDuplicate(req.Request.Context(), kclient.AppClient, caller, appCopy.Spec.Name, entranceName, reqThirdLevel, reqThirdParty); err != nil {
 			api.HandleBadRequest(resp, req, err)
 			return
+		}
+
+		// Validate cert/key only when the request newly adds or changes them.
+		reqCert, _ := customDomain["cert"].(string)
+		reqKey, _ := customDomain["key"].(string)
+		var oldCert, oldKey, oldThirdParty string
+		if len(existing) > 0 {
+			var origins map[string]interface{}
+			if err = json.Unmarshal([]byte(existing), &origins); err == nil {
+				if originV, ok := origins[entranceName].(map[string]interface{}); ok {
+					oldCert, _ = originV["cert"].(string)
+					oldKey, _ = originV["key"].(string)
+					oldThirdParty, _ = originV["third_party_domain"].(string)
+				}
+			}
+		}
+		if (reqCert != "" || reqKey != "") && (reqCert != oldCert || reqKey != oldKey) {
+			hostname := reqThirdParty
+			if hostname == "" {
+				hostname = oldThirdParty
+			}
+			if err = utils.CheckSSLCertificate([]byte(reqCert), []byte(reqKey), hostname); err != nil {
+				api.HandleBadRequest(resp, req, err)
+				return
+			}
 		}
 	}
 

--- a/framework/app-service/pkg/utils/encrypt.go
+++ b/framework/app-service/pkg/utils/encrypt.go
@@ -1,80 +1,30 @@
 package utils
 
 import (
-	"bytes"
-	"crypto"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 )
 
-var ErrUnPadding = errors.New("UnPadding error")
-
-func pKCS7Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext)%blockSize
-	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(ciphertext, padtext...)
-}
-
-func pKCS7UnPadding(origin []byte) ([]byte, error) {
-	length := len(origin)
-	if length == 0 {
-		return origin, ErrUnPadding
+// ValidateKeyPair checks that certPEM and keyPEM form a parseable, matching TLS key pair.
+func ValidateKeyPair(certPEM, keyPEM string) error {
+	if certPEM == "" || keyPEM == "" {
+		return fmt.Errorf("empty cert or key")
 	}
-	unpadding := int(origin[length-1])
-	if length < unpadding {
-		return origin, ErrUnPadding
+	if _, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
+		return fmt.Errorf("invalid TLS key pair: %w", err)
 	}
-	return origin[:(length - unpadding)], nil
-}
-
-// AesEncrypt encrypts the given plaintext using AES encryption with the specified key.
-func AesEncrypt(origin, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	blockSize := block.BlockSize()
-	origin = pKCS7Padding(origin, blockSize)
-	blockMode := cipher.NewCBCEncrypter(block, key[:blockSize])
-	crypted := make([]byte, len(origin))
-	blockMode.CryptBlocks(crypted, origin)
-	return crypted, nil
-}
-
-// AesDecrypt decrypts the given ciphertext using AES encryption with the specified key.
-func AesDecrypt(crypted, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	blockSize := block.BlockSize()
-	blockMode := cipher.NewCBCDecrypter(block, key[:blockSize])
-	origin := make([]byte, len(crypted))
-	blockMode.CryptBlocks(origin, crypted)
-	origin, err = pKCS7UnPadding(origin)
-	if err != nil {
-		return origin, err
-	}
-	return origin, nil
-}
-
-func getTimestamp() string {
-	t := time.Now().Unix()
-	return strconv.Itoa(int(t))
+	return nil
 }
 
 // CheckSSLCertificate checks the validity of an SSL certificate and private key for a given hostname.
 func CheckSSLCertificate(cert, key []byte, hostname string) error {
+	if err := ValidateKeyPair(string(cert), string(key)); err != nil {
+		return err
+	}
 	block, _ := pem.Decode(cert)
 	if block == nil {
 		return errors.New("certificate is invalid")
@@ -96,70 +46,6 @@ func CheckSSLCertificate(cert, key []byte, hostname string) error {
 	}
 	if currentTime.After(pub.NotAfter) {
 		return errors.New("certificate has expired")
-	}
-
-	block, _ = pem.Decode(key)
-	if block == nil {
-		return errors.New("error decoding private key PEM block")
-	}
-
-	hash := sha256.Sum256([]byte("hello"))
-
-	switch block.Type {
-	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing pkcs#8 private key: %v", err)
-		}
-		signature, err := rsa.SignPKCS1v15(rand.Reader, key.(*rsa.PrivateKey), crypto.SHA256, hash[:])
-		if err != nil {
-			return errors.New("failed to sign message")
-		}
-		rsaPub, ok := pub.PublicKey.(*rsa.PublicKey)
-		if !ok {
-			return errors.New("not RSA public key")
-		}
-		err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], signature)
-		if err != nil {
-			return errors.New("certificate and private key not match")
-		}
-	case "EC PRIVATE KEY":
-		key, err := x509.ParseECPrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing ecdsa private key: %v", err)
-		}
-
-		r, s, err := ecdsa.Sign(rand.Reader, key, hash[:])
-		if err != nil {
-			return fmt.Errorf("ecdsa sign err: %v", err)
-		}
-		verified := ecdsa.Verify(pub.PublicKey.(*ecdsa.PublicKey), hash[:], r, s)
-		if !verified {
-			return errors.New("certificate and private key not match")
-		}
-	case "RSA PRIVATE KEY":
-		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("error parsing rsa private key: %v", err)
-		}
-		err = key.Validate()
-		if err != nil {
-			return fmt.Errorf("rsa private key failed validation: %v", err)
-		}
-		signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
-		if err != nil {
-			return errors.New("failed to sign message")
-		}
-		rsaPub, ok := pub.PublicKey.(*rsa.PublicKey)
-		if !ok {
-			return errors.New("not RSA public key")
-		}
-		err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], signature)
-		if err != nil {
-			return errors.New("certificate and private key not match")
-		}
-	default:
-		return fmt.Errorf("unknown private key type: %s", block.Type)
 	}
 
 	return nil

--- a/framework/app-service/pkg/utils/encrypt_test.go
+++ b/framework/app-service/pkg/utils/encrypt_test.go
@@ -4,26 +4,6 @@ import (
 	"testing"
 )
 
-func TestAesEncryptDecrypt(t *testing.T) {
-	key := []byte("ZyCUs5znsmk7GTAiNXdE7RpkSRz1zsIm")
-
-	plaintext := []byte("Hello, bytetrade!")
-
-	ciphertext, err := AesEncrypt(plaintext, key)
-	if err != nil {
-		t.Fatalf("Encryption error: %v", err)
-	}
-
-	decrypted, err := AesDecrypt(ciphertext, key)
-	if err != nil {
-		t.Fatalf("Decryption error: %v", err)
-	}
-
-	if string(decrypted) != string(plaintext) {
-		t.Errorf("Decrypted data does not match original data")
-	}
-}
-
 func TestMatchVersion(t *testing.T) {
 	testCases := []struct {
 		version    string


### PR DESCRIPTION




* **Summary**
Market apps mount their userspace through hostPath + DirectoryOrCreate. Kubelet creates the missing paths as root:root and explicitly excludes hostPath from fsGroup ownership management, so the process dropped to uid 1000 while the directory stayed root and the app could not write. Charts worked around this with `chown -R`, whose cost scales with the data tree and which fails with EPERM on a single un-chownable inode inside a FUSE / JuiceFS mount, leaving the pod stuck in Initializing.

Inject an olares-prepare-userspace init container that owns only the directories the app process did not create itself: the volume roots, the conventional roots above them, and any static subPath kubernetes needs to exist before the mount succeeds. Every chown is non-recursive and stat-guarded, so the cost is proportional to the number of entries rather than to the data, and every start after the first is a no-op. Ownership is self-sustaining from there -- once the writer is uid 1000, everything it creates is already 1000.

Decide per namespace instead of walking the pod's owner chain. That lookup only ever reached the app's main Deployment or StatefulSet, the two workloads carrying the runasuser label, so a second Deployment, a Job, a CronJob, a DaemonSet or a bare Pod in the same application silently ran as root. Pin runAsGroup as well, or files land as 1000:<image gid> and stop matching the directories prepare just handed over. fsGroup stays unset: kubelet ignores it for hostPath, and setting it would make kubelet walk every PVC in the pod on each start.

Resolve namespaces through the sidecar path's GetAppConfig, now split into a package-level GetAppConfigForNamespace that reads through the controller-runtime cache. This drops an uncached List of every ApplicationManager plus a Namespace Get from a path reached several times per admission, and it picks up shared server namespaces, which are claimed by namespace labels rather than by Spec.AppNamespace and were missed by a lookup keyed on the latter. Every failure path skips rather than denies, matching the webhook's failurePolicy: Ignore -- a transient informer lag should not keep an app from starting.

On the oac side, reject volumeMounts.subPathExpr, which admission cannot expand and therefore cannot prepare, and add a check for blind `chown -R` over a hostPath mount. The chown rule is off by default and opt-in via WithBlindChownCheck, because oac.Lint also guards install and upgrade, where a default-on rule would reject existing charts at the moment a user clicks install. Widen walkPodSpecs to Job, CronJob and bare Pods so both rules, and the pre-existing non-beclab securityContext check, see every workload that carries a PodSpec.

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom domain settings now fail fast on invalid TLS material, which can block misconfigured uploads but reduces bad certs reaching the gateway; AES helpers were removed with no remaining references in app-service.
> 
> **Overview**
> **Validates TLS material when users configure custom entrance domains**, rejecting bad cert/key pairs before they are saved. In `setupAppEntranceDomain`, cert and key are checked only when the request adds or changes them (unchanged re-saves are skipped), using the requested or stored `third_party_domain` as the hostname via `utils.CheckSSLCertificate`.
> 
> **Simplifies SSL utilities** in `pkg/utils/encrypt.go`: adds `ValidateKeyPair` using `crypto/tls.X509KeyPair`, wires it into `CheckSSLCertificate`, and removes the hand-rolled RSA/ECDSA sign-verify path plus unused AES encrypt/decrypt helpers and their tests.
> 
> **Release alignment**: bumps the `app-service` deployment image to `0.6.27` and updates the `framework/oac` module dependency (with a minor `go.mod` tidy for `envoy` as indirect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09bb8bd3c904dba54f0e3a93919b4c137c066ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->