### PR TITLE
chore(l4): bump l4 image to v0.3.45

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -157,7 +157,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.44"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.45"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.44
+          value: v0.3.45
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.44
+      name: beclab/l4-bfl-proxy:v0.3.45
 # must have blank new line            


### PR DESCRIPTION


* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bump with no logic changes; risk is limited to L4 proxy rollout behavior in the new image tag.
> 
> **Overview**
> Bumps the **`beclab/l4-bfl-proxy`** container from **v0.3.44** to **v0.3.45** so installs, upgrades, and BFL-driven L4 proxy rollouts use the same tag.
> 
> The **Olares** prebuilt manifest, the **BFL** launcher template env **`L4_PROXY_IMAGE_VERSION`**, and the CLI **`UpgradeL4BFLProxy`** upgrade task are updated together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ccdd4d76e1e827c60146d7e96372234db60b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->