### PR TITLE
feat(gateway): in-cluster Shared auth for third-party custom domains

### DIFF
--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -78,10 +78,18 @@ const (
 	MeshInSharedHostsCMName         = "olares-mesh-in-shared-hosts"
 	MeshInSharedHostsFileName       = "shared-hosts.txt"
 	MeshInTLSHostsFileName          = "tls-hosts.txt"
+	// MeshInCustomTLSHostsFileName lists exact third-party FQDNs that must present
+	// CustomDomainTLS material (fail closed — never the viewer platform cert).
+	MeshInCustomTLSHostsFileName = "custom-tls-hosts.txt"
 	MeshInSharedHostsManagedByLabel = "gateway.olares.io/mesh-in-shared-hosts-managed-by"
 	MeshInTLSSecretNamePrefix       = "olares-mesh-in-tls-"
 	MeshInCertsVolumeName           = "olares-mesh-in-certs"
-	MeshInAgentContainerName        = "olares-mesh-in-agent"
+	// MeshInCustomTLSSecretName is the per-caller aggregate of CustomDomainTLS
+	// material (keys <fqdn>.crt / <fqdn>.key) for mesh-in SNI cert selection.
+	MeshInCustomTLSSecretName = "olares-mesh-in-custom-tls"
+	// MeshInCustomCertsVolumeName mounts MeshInCustomTLSSecretName into the agent.
+	MeshInCustomCertsVolumeName = "olares-mesh-in-custom-certs"
+	MeshInAgentContainerName    = "olares-mesh-in-agent"
 	MeshInCertCacheMax              = 16
 	MeshInCertCacheInactive         = "10m"
 	MeshInCertCacheValid            = "1m"

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -102,6 +102,10 @@ const (
 	// the full body in the 64Mi sidecar.
 	MeshInMaxBodySize               = "100m"
 	LabelTLSReplica                 = "gateway.olares.io/tls-replica"
+	// LabelTLSCustomReplica marks the per-caller aggregate of CustomDomainTLS
+	// material (olares-mesh-in-custom-tls). Mount admission must only allow the
+	// mesh-in agent via MeshInCustomCertsVolumeName.
+	LabelTLSCustomReplica = "gateway.olares.io/tls-custom-replica"
 	DefaultEnvoyLogLevel            = "debug"
 	EnvoyImageVersion               = "beclab/envoy:v1.25.11.1"
 	EnvoyContainerName              = "olares-envoy-sidecar"

--- a/framework/app-service/pkg/gateway/eligible_custom_host.go
+++ b/framework/app-service/pkg/gateway/eligible_custom_host.go
@@ -451,9 +451,9 @@ func NewConfigMapCertMaterializer(ctx context.Context, c client.Client) CertMate
 		if loaded {
 			return
 		}
-		loaded = true
 		list := &corev1.ConfigMapList{}
 		if err := c.List(ctx, list, client.MatchingLabels{customDomainCertLabel: customDomainCertLabelValue}); err != nil {
+			// Do not set loaded: retry on the next materializer call in this reconcile.
 			klog.Errorf("gateway-tpd: list custom-domain-cert ConfigMaps failed: %v", err)
 			return
 		}
@@ -467,6 +467,7 @@ func NewConfigMapCertMaterializer(ctx context.Context, c client.Client) CertMate
 			}
 			cache[zone] = pair{cert: cert, key: key}
 		}
+		loaded = true
 	}
 	return func(host string) (string, string, bool) {
 		load()

--- a/framework/app-service/pkg/gateway/eligible_custom_host.go
+++ b/framework/app-service/pkg/gateway/eligible_custom_host.go
@@ -1,0 +1,480 @@
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Exact-host ownership annotation on SharedRouteRegistry (JSON map host→viewer).
+const AnnotationExactHostOwners = "gateway.olares.io/exact-host-owners"
+
+const (
+	customDomainCertLabel      = "app.bytetrade.io/custom-domain-cert"
+	customDomainCertLabelValue = "true"
+
+	// indexApplicationThirdPartyDomain indexes Application objects by each
+	// normalized customDomain.third_party_domain so cert ConfigMap events can
+	// enqueue only referring apps (O(refs) not O(all apps)).
+	indexApplicationThirdPartyDomain = "gateway.olares.io/third-party-domain"
+)
+
+// Deny reasons for EligibleCustomHost (stable; safe for metrics labels).
+const (
+	DenyInvalidDNS       = "invalid_dns"
+	DenyReservedSuffix   = "reserved_suffix"
+	DenyNoCert           = "no_cert"
+	DenyCertNameMismatch = "cert_name_mismatch"
+	DenyCNAMENotActive   = "cname_not_active"
+)
+
+// ExactHostOwner is one Eligible host owned by a viewer (or app owner).
+type ExactHostOwner struct {
+	Host  string
+	Owner string
+}
+
+// CertMaterializer supplies cert/key for a FQDN when settings omit them (e.g. CM).
+type CertMaterializer func(host string) (cert, key string, ok bool)
+
+// customDomainEntranceFields is the per-entrance JSON shape under customDomain.
+type customDomainEntranceFields struct {
+	ThirdPartyDomain  string `json:"third_party_domain"`
+	ThirdLevelDomain  string `json:"third_level_domain"`
+	Cert              string `json:"cert"`
+	Key               string `json:"key"`
+	CnameTargetStatus string `json:"cname_target_status"`
+	CnameStatus       string `json:"cname_status"`
+}
+
+// EligibleCustomHost reports whether a third-party custom domain may be
+// projected into SRR / CoreDNS / mesh-in allowlists. materializer is optional
+// and used only when settings omit cert/key (ARCH: settings or CM).
+func EligibleCustomHost(cfg customDomainEntranceFields, platformDomain string, materializer CertMaterializer) (bool, string) {
+	raw := strings.TrimSpace(cfg.ThirdPartyDomain)
+	if raw == "" {
+		return false, DenyInvalidDNS
+	}
+	host, err := NormalizeHostPattern(raw)
+	if err != nil || strings.Contains(host, "*") {
+		return false, DenyInvalidDNS
+	}
+	if reason := reservedExactHostReason(host, platformDomain); reason != "" {
+		return false, reason
+	}
+	cert := strings.TrimSpace(cfg.Cert)
+	key := strings.TrimSpace(cfg.Key)
+	if cert == "" || key == "" {
+		if materializer != nil {
+			if c, k, ok := materializer(host); ok {
+				cert, key = c, k
+			}
+		}
+	}
+	if cert == "" || key == "" {
+		return false, DenyNoCert
+	}
+	if !certCoversHost(cert, key, host) {
+		return false, DenyCertNameMismatch
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.CnameTargetStatus), "set") ||
+		!strings.EqualFold(strings.TrimSpace(cfg.CnameStatus), "active") {
+		return false, DenyCNAMENotActive
+	}
+	return true, ""
+}
+
+func reservedExactHostReason(host, platformDomain string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if h == "" {
+		return DenyInvalidDNS
+	}
+	if net.ParseIP(h) != nil {
+		return DenyReservedSuffix
+	}
+	for _, suf := range []string{"localhost", "cluster.local"} {
+		if h == suf || strings.HasSuffix(h, "."+suf) {
+			return DenyReservedSuffix
+		}
+	}
+	if h == "svc" || strings.HasSuffix(h, ".svc") || strings.Contains(h, ".svc.") {
+		return DenyReservedSuffix
+	}
+	dom := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(platformDomain, ".")))
+	if dom != "" {
+		if h == dom || strings.HasSuffix(h, "."+dom) {
+			return DenyReservedSuffix
+		}
+	}
+	// Reserved system prefixes only when the remainder is under platformDomain
+	// (align with reservedThirdLevelDomains), not arbitrary public FQDNs.
+	first, rest, ok := strings.Cut(h, ".")
+	if ok {
+		switch first {
+		case "auth", "desktop", "wizard":
+			if dom != "" && (rest == dom || strings.HasSuffix(rest, "."+dom)) {
+				return DenyReservedSuffix
+			}
+		}
+	}
+	return ""
+}
+
+func certCoversHost(certPEM, keyPEM, host string) bool {
+	if _, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
+		return false
+	}
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	if err := cert.VerifyHostname(host); err != nil {
+		return false
+	}
+	return true
+}
+
+// CollectEligibleExactHosts returns Eligible third_party_domain hosts for one
+// entrance. Duplicate FQDNs keep the lexicographically smallest owner and log.
+func CollectEligibleExactHosts(app *appv1alpha1.Application, entranceName, platformDomain string, materializer CertMaterializer) []ExactHostOwner {
+	if app == nil || strings.TrimSpace(entranceName) == "" {
+		return nil
+	}
+	byHost := map[string]string{}
+
+	consider := func(owner, blob string) {
+		owner = strings.ToLower(strings.TrimSpace(owner))
+		if owner == "" || blob == "" {
+			return
+		}
+		cfg, ok := parseEntranceCustomDomain(blob, entranceName)
+		if !ok {
+			return
+		}
+		okElig, reason := EligibleCustomHost(cfg, platformDomain, materializer)
+		if !okElig {
+			klog.V(4).Infof("gateway-tpd: eligible deny app=%s entrance=%s owner=%s reason=%s",
+				app.Spec.Name, entranceName, owner, reason)
+			return
+		}
+		host, err := NormalizeHostPattern(cfg.ThirdPartyDomain)
+		if err != nil {
+			return
+		}
+		if prev, dup := byHost[host]; dup {
+			if owner < prev {
+				klog.Warningf("gateway-tpd: duplicate exact host app=%s entrance=%s host_hash=%s keep_owner=%s drop_owner=%s",
+					app.Spec.Name, entranceName, shortHostHash(host), owner, prev)
+				byHost[host] = owner
+			} else if owner != prev {
+				klog.Warningf("gateway-tpd: duplicate exact host app=%s entrance=%s host_hash=%s keep_owner=%s drop_owner=%s",
+					app.Spec.Name, entranceName, shortHostHash(host), prev, owner)
+			}
+			return
+		}
+		byHost[host] = owner
+	}
+
+	if blob := app.Spec.Settings["customDomain"]; blob != "" {
+		owner := strings.ToLower(strings.TrimSpace(app.Spec.Owner))
+		if owner == "" {
+			klog.Warningf("gateway-tpd: app=%s has customDomain in settings but empty spec.owner; skipping settings blob",
+				app.Spec.Name)
+		} else {
+			consider(owner, blob)
+		}
+	}
+	users := make([]string, 0, len(app.Spec.UserSettings))
+	for user := range app.Spec.UserSettings {
+		users = append(users, user)
+	}
+	sort.Strings(users)
+	for _, user := range users {
+		us := app.Spec.UserSettings[user]
+		if us == nil {
+			continue
+		}
+		consider(user, us["customDomain"])
+	}
+	return sortedExactHostOwners(byHost)
+}
+
+// CollectUserThirdLevelExactHosts projects per-owner third_level_domain as
+// exact Hosts <prefix>.<owner>.<platformDomain> so Shared overlays do not
+// broadcast other users' prefixes via logical prefix.*.
+func CollectUserThirdLevelExactHosts(app *appv1alpha1.Application, entranceName, platformDomain string) []ExactHostOwner {
+	if app == nil || strings.TrimSpace(entranceName) == "" {
+		return nil
+	}
+	platformDomain = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(platformDomain, ".")))
+	if platformDomain == "" {
+		return nil
+	}
+	byHost := map[string]string{}
+
+	consider := func(owner, blob string) {
+		owner = strings.ToLower(strings.TrimSpace(owner))
+		if owner == "" || blob == "" {
+			return
+		}
+		cfg, ok := parseEntranceCustomDomain(blob, entranceName)
+		if !ok {
+			return
+		}
+		prefix := strings.ToLower(strings.TrimSpace(cfg.ThirdLevelDomain))
+		if prefix == "" || strings.Contains(prefix, ".") || strings.Contains(prefix, "*") {
+			return
+		}
+		switch prefix {
+		case "auth", "desktop", "wizard":
+			return
+		}
+		host := fmt.Sprintf("%s.%s.%s", prefix, owner, platformDomain)
+		norm, err := NormalizeHostPattern(host)
+		if err != nil {
+			klog.Warningf("gateway-tpd: third_level exact host normalize failed entrance=%s: %v", entranceName, err)
+			return
+		}
+		if prev, dup := byHost[norm]; dup {
+			if owner < prev {
+				byHost[norm] = owner
+			}
+			return
+		}
+		byHost[norm] = owner
+	}
+
+	if blob := app.Spec.Settings["customDomain"]; blob != "" {
+		owner := strings.ToLower(strings.TrimSpace(app.Spec.Owner))
+		if owner != "" {
+			consider(owner, blob)
+		}
+	}
+	users := make([]string, 0, len(app.Spec.UserSettings))
+	for user := range app.Spec.UserSettings {
+		users = append(users, user)
+	}
+	sort.Strings(users)
+	for _, user := range users {
+		us := app.Spec.UserSettings[user]
+		if us == nil {
+			continue
+		}
+		consider(user, us["customDomain"])
+	}
+	return sortedExactHostOwners(byHost)
+}
+
+// MergeExactHostOwners unions owner maps; on conflict keeps lexicographically
+// smaller owner.
+func MergeExactHostOwners(parts ...[]ExactHostOwner) []ExactHostOwner {
+	byHost := map[string]string{}
+	for _, part := range parts {
+		for _, o := range part {
+			host := strings.ToLower(strings.TrimSpace(o.Host))
+			owner := strings.ToLower(strings.TrimSpace(o.Owner))
+			if host == "" || owner == "" {
+				continue
+			}
+			if prev, ok := byHost[host]; ok {
+				if owner < prev {
+					byHost[host] = owner
+				}
+				continue
+			}
+			byHost[host] = owner
+		}
+	}
+	return sortedExactHostOwners(byHost)
+}
+
+func sortedExactHostOwners(byHost map[string]string) []ExactHostOwner {
+	if len(byHost) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(byHost))
+	for h := range byHost {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	out := make([]ExactHostOwner, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, ExactHostOwner{Host: h, Owner: byHost[h]})
+	}
+	return out
+}
+
+func shortHostHash(host string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if len(h) <= 12 {
+		return h
+	}
+	return h[:8] + "…"
+}
+
+func parseEntranceCustomDomain(blob, entranceName string) (customDomainEntranceFields, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		klog.Warningf("gateway-tpd: customDomain unmarshal: %v", err)
+		return customDomainEntranceFields{}, false
+	}
+	entry, ok := raw[entranceName]
+	if !ok || len(entry) == 0 {
+		return customDomainEntranceFields{}, false
+	}
+	var cfg customDomainEntranceFields
+	if err := json.Unmarshal(entry, &cfg); err != nil {
+		klog.Warningf("gateway-tpd: customDomain entrance unmarshal: %v", err)
+		return customDomainEntranceFields{}, false
+	}
+	return cfg, true
+}
+
+// EncodeExactHostOwnersJSON serializes host→owner for the SRR annotation.
+func EncodeExactHostOwnersJSON(owners []ExactHostOwner) string {
+	if len(owners) == 0 {
+		return ""
+	}
+	m := make(map[string]string, len(owners))
+	for _, o := range owners {
+		if o.Host == "" || o.Owner == "" {
+			continue
+		}
+		m[o.Host] = o.Owner
+	}
+	if len(m) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// ParseExactHostOwnersJSON decodes the SRR ownership annotation.
+func ParseExactHostOwnersJSON(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		k = strings.ToLower(strings.TrimSpace(k))
+		v = strings.ToLower(strings.TrimSpace(v))
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// CollectApplicationThirdPartyDomains returns every normalized
+// customDomain.third_party_domain across Spec.Settings and UserSettings.
+// Used for field indexing so cert ConfigMap changes enqueue only referring apps.
+func CollectApplicationThirdPartyDomains(app *appv1alpha1.Application) []string {
+	if app == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	addBlob := func(blob string) {
+		if blob == "" {
+			return
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+			return
+		}
+		for _, entry := range raw {
+			if len(entry) == 0 {
+				continue
+			}
+			var cfg customDomainEntranceFields
+			if err := json.Unmarshal(entry, &cfg); err != nil {
+				continue
+			}
+			host, err := NormalizeHostPattern(cfg.ThirdPartyDomain)
+			if err != nil || host == "" {
+				continue
+			}
+			seen[host] = struct{}{}
+		}
+	}
+	addBlob(app.Spec.Settings["customDomain"])
+	for _, us := range app.Spec.UserSettings {
+		if us == nil {
+			continue
+		}
+		addBlob(us["customDomain"])
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for h := range seen {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// NewConfigMapCertMaterializer returns a CertMaterializer that reads labeled
+// custom-domain-cert ConfigMaps whose Data["zone"] matches the host.
+func NewConfigMapCertMaterializer(ctx context.Context, c client.Client) CertMaterializer {
+	if c == nil {
+		return nil
+	}
+	type pair struct{ cert, key string }
+	cache := map[string]pair{}
+	loaded := false
+	load := func() {
+		if loaded {
+			return
+		}
+		loaded = true
+		list := &corev1.ConfigMapList{}
+		if err := c.List(ctx, list, client.MatchingLabels{customDomainCertLabel: customDomainCertLabelValue}); err != nil {
+			klog.Errorf("gateway-tpd: list custom-domain-cert ConfigMaps failed: %v", err)
+			return
+		}
+		for i := range list.Items {
+			cm := &list.Items[i]
+			zone := strings.ToLower(strings.TrimSpace(cm.Data["zone"]))
+			cert := strings.TrimSpace(cm.Data["cert"])
+			key := strings.TrimSpace(cm.Data["key"])
+			if zone == "" || cert == "" || key == "" {
+				continue
+			}
+			cache[zone] = pair{cert: cert, key: key}
+		}
+	}
+	return func(host string) (string, string, bool) {
+		load()
+		host = strings.ToLower(strings.TrimSpace(host))
+		p, ok := cache[host]
+		if !ok {
+			return "", "", false
+		}
+		return p.cert, p.key, true
+	}
+}

--- a/framework/app-service/pkg/gateway/eligible_custom_host_test.go
+++ b/framework/app-service/pkg/gateway/eligible_custom_host_test.go
@@ -1,0 +1,281 @@
+package gateway
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
+)
+
+func mustTestCertPEM(t *testing.T, dnsNames ...string) (certPEM, keyPEM string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: dnsNames[0]},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     dnsNames,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	return certPEM, keyPEM
+}
+
+func eligibleCustomDomainBlob(t *testing.T, entrance, fqdn, cert, key string) string {
+	t.Helper()
+	entry := map[string]interface{}{
+		"third_party_domain":  fqdn,
+		"cert":                cert,
+		"key":                 key,
+		"cname_target_status": "set",
+		"cname_status":        "active",
+	}
+	b, err := json.Marshal(map[string]interface{}{entrance: entry})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestEligibleCustomHost(t *testing.T) {
+	cert, key := mustTestCertPEM(t, "chat.example.com")
+	base := customDomainEntranceFields{
+		ThirdPartyDomain:  "chat.example.com",
+		Cert:              cert,
+		Key:               key,
+		CnameTargetStatus: "set",
+		CnameStatus:       "active",
+	}
+	if ok, reason := EligibleCustomHost(base, "olares.com", nil); !ok || reason != "" {
+		t.Fatalf("want pass, got ok=%v reason=%q", ok, reason)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*customDomainEntranceFields)
+		reason string
+	}{
+		{"platform suffix", func(c *customDomainEntranceFields) { c.ThirdPartyDomain = "x.olares.com" }, DenyReservedSuffix},
+		{"no cert", func(c *customDomainEntranceFields) { c.Cert = "" }, DenyNoCert},
+		{"cname", func(c *customDomainEntranceFields) { c.CnameStatus = "pending" }, DenyCNAMENotActive},
+		{"bad dns", func(c *customDomainEntranceFields) { c.ThirdPartyDomain = "http://x.com" }, DenyInvalidDNS},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.mutate(&cfg)
+			ok, reason := EligibleCustomHost(cfg, "olares.com", nil)
+			if ok || reason != tc.reason {
+				t.Fatalf("ok=%v reason=%q want %q", ok, reason, tc.reason)
+			}
+		})
+	}
+
+	wrongCert, wrongKey := mustTestCertPEM(t, "other.example.com")
+	badSAN := base
+	badSAN.Cert, badSAN.Key = wrongCert, wrongKey
+	if ok, reason := EligibleCustomHost(badSAN, "olares.com", nil); ok || reason != DenyCertNameMismatch {
+		t.Fatalf("SAN mismatch: ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestCollectEligibleExactHostsSharedOverlay(t *testing.T) {
+	cert, key := mustTestCertPEM(t, "chat.example.com")
+	blob := eligibleCustomDomainBlob(t, "web", "chat.example.com", cert, key)
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name:  "demo",
+			Owner: "installer",
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": blob},
+			},
+		},
+	}
+	got := CollectEligibleExactHosts(app, "web", "olares.com", nil)
+	if len(got) != 1 || got[0].Host != "chat.example.com" || got[0].Owner != "alice" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestBuildSpecForEntranceAppendsEligibleExactHost(t *testing.T) {
+	cert, key := mustTestCertPEM(t, "chat.example.com")
+	blob := eligibleCustomDomainBlob(t, "web", "chat.example.com", cert, key)
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "demo",
+			Labels: map[string]string{
+				constants.AppApiVersionLabel: "v3",
+				constants.AppSharedLabel:     constants.AppSharedTrue,
+			},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Appid:     "demo1234",
+			Name:      "demo",
+			Namespace: "demo-shared",
+			Owner:     "alice",
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": blob},
+			},
+			SharedEntrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "demo-svc", Port: 8080},
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	spec, err := BuildSpecForEntrance(app, app.Spec.SharedEntrances[0], 0, 1, svc, "olares.com",
+		srrv1alpha1.EntranceClassShared, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.HostPatterns) < 2 {
+		t.Fatalf("want dual-host, got %v", spec.HostPatterns)
+	}
+	foundExact := false
+	for _, h := range spec.HostPatterns {
+		if h == "chat.example.com" {
+			foundExact = true
+		}
+	}
+	if !foundExact {
+		t.Fatalf("exact host missing: %v", spec.HostPatterns)
+	}
+}
+
+func TestCollectUserThirdLevelExactHosts(t *testing.T) {
+	blobAlice := `{"web":{"third_level_domain":"api"}}`
+	blobBob := `{"web":{"third_level_domain":"chat"}}`
+	app := &appv1alpha1.Application{
+		Spec: appv1alpha1.ApplicationSpec{
+			Owner: "installer",
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": blobAlice},
+				"bob":   {"customDomain": blobBob},
+			},
+		},
+	}
+	got := CollectUserThirdLevelExactHosts(app, "web", "olares.com")
+	want := map[string]string{
+		"api.alice.olares.com":  "alice",
+		"chat.bob.olares.com":   "bob",
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %#v", got)
+	}
+	for _, o := range got {
+		if want[o.Host] != o.Owner {
+			t.Fatalf("unexpected %#v want %v", got, want)
+		}
+	}
+}
+
+func TestBuildSpecForEntranceAppendsUserThirdLevelExact(t *testing.T) {
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "demo",
+			Labels: map[string]string{
+				constants.AppApiVersionLabel: "v3",
+				constants.AppSharedLabel:     constants.AppSharedTrue,
+			},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Appid:     "demo1234",
+			Name:      "demo",
+			Namespace: "demo-shared",
+			Owner:     "alice",
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": `{"web":{"third_level_domain":"api"}}`},
+				"bob":   {"customDomain": `{"web":{"third_level_domain":"chat"}}`},
+			},
+			SharedEntrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "demo-svc", Port: 8080},
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	spec, err := BuildSpecForEntrance(app, app.Spec.SharedEntrances[0], 0, 1, svc, "olares.com",
+		srrv1alpha1.EntranceClassShared, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundAlice, foundBob, foundLogical := false, false, false
+	for _, h := range spec.HostPatterns {
+		switch h {
+		case "api.alice.olares.com":
+			foundAlice = true
+		case "chat.bob.olares.com":
+			foundBob = true
+		case "api.*.olares.com", "chat.*.olares.com":
+			foundLogical = true
+		}
+	}
+	if !foundAlice || !foundBob {
+		t.Fatalf("per-owner exact third_level missing: %v", spec.HostPatterns)
+	}
+	if foundLogical {
+		t.Fatalf("must not broadcast logical third_level prefixes: %v", spec.HostPatterns)
+	}
+}
+
+func TestEligibleCustomHostUsesMaterializer(t *testing.T) {
+	cert, key := mustTestCertPEM(t, "chat.example.com")
+	cfg := customDomainEntranceFields{
+		ThirdPartyDomain:  "chat.example.com",
+		CnameTargetStatus: "set",
+		CnameStatus:       "active",
+	}
+	if ok, reason := EligibleCustomHost(cfg, "olares.com", nil); ok || reason != DenyNoCert {
+		t.Fatalf("without materializer: ok=%v reason=%q", ok, reason)
+	}
+	mat := CertMaterializer(func(host string) (string, string, bool) {
+		if host == "chat.example.com" {
+			return cert, key, true
+		}
+		return "", "", false
+	})
+	if ok, reason := EligibleCustomHost(cfg, "olares.com", mat); !ok || reason != "" {
+		t.Fatalf("with materializer: ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestReservedExactHostAllowsAuthOnPublicDomain(t *testing.T) {
+	if reason := reservedExactHostReason("auth.myshop.com", "olares.com"); reason != "" {
+		t.Fatalf("public auth.myshop.com should not be reserved, got %q", reason)
+	}
+	if reason := reservedExactHostReason("auth.olares.com", "olares.com"); reason != DenyReservedSuffix {
+		t.Fatalf("auth under platform must be reserved, got %q", reason)
+	}
+}

--- a/framework/app-service/pkg/gateway/eligible_custom_host_test.go
+++ b/framework/app-service/pkg/gateway/eligible_custom_host_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -8,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -16,6 +18,9 @@ import (
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 )
@@ -269,6 +274,43 @@ func TestEligibleCustomHostUsesMaterializer(t *testing.T) {
 	if ok, reason := EligibleCustomHost(cfg, "olares.com", mat); !ok || reason != "" {
 		t.Fatalf("with materializer: ok=%v reason=%q", ok, reason)
 	}
+}
+
+func TestConfigMapCertMaterializerRetriesAfterListFailure(t *testing.T) {
+	cert, key := mustTestCertPEM(t, "shop.example.com")
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shop-cert",
+			Namespace: "user-space-alice",
+			Labels:    map[string]string{customDomainCertLabel: customDomainCertLabelValue},
+		},
+		Data: map[string]string{"zone": "shop.example.com", "cert": cert, "key": key},
+	}
+	okClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	fc := &flakyListClient{Client: okClient, failLeft: 1}
+	mat := NewConfigMapCertMaterializer(context.Background(), fc)
+	if _, _, ok := mat("shop.example.com"); ok {
+		t.Fatal("first call should miss while list fails")
+	}
+	gotCert, gotKey, ok := mat("shop.example.com")
+	if !ok || gotCert == "" || gotKey == "" {
+		t.Fatalf("second call should load after list succeeds: ok=%v", ok)
+	}
+}
+
+type flakyListClient struct {
+	client.Client
+	failLeft int
+}
+
+func (c *flakyListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.failLeft > 0 {
+		c.failLeft--
+		return fmt.Errorf("simulated list failure")
+	}
+	return c.Client.List(ctx, list, opts...)
 }
 
 func TestReservedExactHostAllowsAuthOnPublicDomain(t *testing.T) {

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs.go
@@ -11,31 +11,44 @@ func BearerJS() string {
 		JWTSecretMountPath+"/token",
 		HostsMountPath+"/"+SharedHostsFileName,
 		HostsMountPath+"/"+TLSHostsFileName,
+		HostsMountPath+"/"+CustomTLSHostsFileName,
 		HTTPSTerminatePort,
 		CertsMountPath,
 		PlaceholderCertDir,
+		CustomCertsMountPath,
 	)
 }
 
 // BearerJSWith builds the njs module with explicit paths (tests / render).
-func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile string, terminatePort int, certDir, placeholderDir string) string {
+func BearerJSWith(jwtPath, authHostsFile, tlsHostsFile, customTLSHostsFile string, terminatePort int, certDir, placeholderDir, customCertsDir string) string {
 	if certDir == "" {
 		certDir = CertsMountPath
 	}
 	if placeholderDir == "" {
 		placeholderDir = PlaceholderCertDir
 	}
+	if customCertsDir == "" {
+		customCertsDir = CustomCertsMountPath
+	}
+	if customTLSHostsFile == "" {
+		customTLSHostsFile = HostsMountPath + "/" + CustomTLSHostsFileName
+	}
 	return fmt.Sprintf(`var fs = require('fs');
 
 const JWT_PATH = '%s';
 const AUTH_HOSTS_FILE = '%s';
 const TLS_HOSTS_FILE = '%s';
+const CUSTOM_TLS_HOSTS_FILE = '%s';
 const TERMINATE = '127.0.0.1:%d';
 const CACHE_TTL_MS = 5000;
 const REAL_CERT = '%s/tls.crt';
 const REAL_KEY = '%s/tls.key';
 const PH_CERT = '%s/tls.crt';
 const PH_KEY = '%s/tls.key';
+const CUSTOM_CERTS_DIR = '%s';
+// Nonexistent paths: nginx aborts the handshake instead of presenting a wrong cert.
+const REJECT_CERT = CUSTOM_CERTS_DIR + '/.reject/tls.crt';
+const REJECT_KEY = CUSTOM_CERTS_DIR + '/.reject/tls.key';
 
 let cachedAuthHosts = null;
 let cachedAuthMtimeMs = 0;
@@ -43,8 +56,12 @@ let cachedAuthAtMs = 0;
 let cachedTLSHosts = null;
 let cachedTLSMtimeMs = 0;
 let cachedTLSAtMs = 0;
+let cachedCustomTLSHosts = null;
+let cachedCustomTLSMtimeMs = 0;
+let cachedCustomTLSAtMs = 0;
 let tlsModeCached = null;
 let tlsModeAtMs = 0;
+let tlsModeCachedHost = '';
 
 function nowMs() { return Date.now(); }
 
@@ -102,6 +119,19 @@ function reloadTLSHosts() {
   return cachedTLSHosts;
 }
 
+function reloadCustomTLSHosts() {
+  const r = reloadHostsFile(CUSTOM_TLS_HOSTS_FILE, cachedCustomTLSHosts, cachedCustomTLSMtimeMs, cachedCustomTLSAtMs);
+  cachedCustomTLSHosts = r.hosts;
+  cachedCustomTLSMtimeMs = r.mtimeMs;
+  cachedCustomTLSAtMs = r.atMs;
+  return cachedCustomTLSHosts;
+}
+
+function customTLSRequired(host) {
+  if (!host) { return false; }
+  return !!reloadCustomTLSHosts()[host];
+}
+
 function realCertReady() {
   try {
     const c = fs.statSync(REAL_CERT);
@@ -112,21 +142,68 @@ function realCertReady() {
   }
 }
 
+function requestHost(r) {
+  if (!r) { return ''; }
+  if (r.headersIn && r.headersIn.host) {
+    return normalizeHost(r.headersIn.host);
+  }
+  if (r.variables) {
+    return normalizeHost(r.variables.ssl_server_name || r.variables.host || '');
+  }
+  return '';
+}
+
+function resolveCertPair(host) {
+  if (!host) { return null; }
+  const cert = CUSTOM_CERTS_DIR + '/' + host + '.crt';
+  const key = CUSTOM_CERTS_DIR + '/' + host + '.key';
+  try {
+    if (fs.statSync(cert).size > 0 && fs.statSync(key).size > 0) {
+      return { cert: cert, key: key };
+    }
+  } catch (e) {}
+  return null;
+}
+
+function customCertReady(host) {
+  return resolveCertPair(host) !== null;
+}
+
 function tlsMode(r) {
+  const host = requestHost(r);
   const now = nowMs();
-  if (tlsModeCached !== null && now - tlsModeAtMs < CACHE_TTL_MS) {
+  if (tlsModeCached !== null && tlsModeCachedHost === host && now - tlsModeAtMs < CACHE_TTL_MS) {
     return tlsModeCached;
   }
-  tlsModeCached = realCertReady() ? 'real' : 'placeholder';
+  // Common path: platform Hosts are not on custom-tls-hosts — skip custom stats.
+  if (!customTLSRequired(host)) {
+    tlsModeCached = realCertReady() ? 'real' : 'placeholder';
+  } else {
+    tlsModeCached = customCertReady(host) ? 'real' : 'reject';
+  }
+  tlsModeCachedHost = host;
   tlsModeAtMs = now;
   return tlsModeCached;
 }
 
 function pickCert(r) {
+  const host = requestHost(r);
+  // Third-party FQDNs are rare: gate on custom-tls-hosts before any disk stat.
+  if (customTLSRequired(host)) {
+    const pair = resolveCertPair(host);
+    if (pair) { return pair.cert; }
+    return REJECT_CERT;
+  }
   return tlsMode(r) === 'real' ? REAL_CERT : PH_CERT;
 }
 
 function pickKey(r) {
+  const host = requestHost(r);
+  if (customTLSRequired(host)) {
+    const pair = resolveCertPair(host);
+    if (pair) { return pair.key; }
+    return REJECT_KEY;
+  }
   return tlsMode(r) === 'real' ? REAL_KEY : PH_KEY;
 }
 
@@ -183,5 +260,5 @@ function decideOffload(s) {
 }
 
 export default {readJWT, checkHost, callerJwt, authDeny, decideOffload, tlsMode, pickCert, pickKey};
-`, jwtPath, authHostsFile, tlsHostsFile, terminatePort, certDir, certDir, placeholderDir, placeholderDir)
+`, jwtPath, authHostsFile, tlsHostsFile, customTLSHostsFile, terminatePort, certDir, certDir, placeholderDir, placeholderDir, customCertsDir)
 }

--- a/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/bearerjs_test.go
@@ -59,3 +59,57 @@ func TestBearerJSDecideOffloadUsesTLSHostsOnly(t *testing.T) {
 		}
 	}
 }
+
+func TestBearerJSPickCertBySNICustomDomain(t *testing.T) {
+	js := BearerJS()
+	for _, want := range []string{
+		"CUSTOM_CERTS_DIR",
+		"CUSTOM_TLS_HOSTS_FILE",
+		CustomCertsMountPath,
+		"function customTLSRequired",
+		"function pickCert",
+		"REJECT_CERT",
+		"ssl_server_name",
+	} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("bearer.js missing %q", want)
+		}
+	}
+	idx := strings.Index(js, "function pickCert")
+	if idx < 0 {
+		t.Fatal("missing pickCert")
+	}
+	fn := js[idx:]
+	end := strings.Index(fn, "\nfunction pickKey")
+	if end > 0 {
+		fn = fn[:end]
+	}
+	if !strings.Contains(fn, "return pair.cert") {
+		t.Fatal("pickCert must return custom cert path when ready")
+	}
+	if !strings.Contains(fn, "customTLSRequired(host)") || !strings.Contains(fn, "return REJECT_CERT") {
+		t.Fatal("pickCert must fail closed for third-party FQDN without material")
+	}
+	if !strings.Contains(fn, "REAL_CERT") {
+		t.Fatal("pickCert must fall back to viewer REAL_CERT for platform hosts")
+	}
+}
+
+func TestBearerJSTlsModeCustomBypassesPlaceholder(t *testing.T) {
+	js := BearerJS()
+	idx := strings.Index(js, "function tlsMode")
+	if idx < 0 {
+		t.Fatal("missing tlsMode")
+	}
+	fn := js[idx:]
+	end := strings.Index(fn, "\nfunction pickCert")
+	if end > 0 {
+		fn = fn[:end]
+	}
+	if !strings.Contains(fn, "customTLSRequired(host)") {
+		t.Fatal("tlsMode must gate third-party hosts separately from viewer replica")
+	}
+	if !strings.Contains(fn, "'reject'") {
+		t.Fatal("tlsMode must expose reject when custom material is missing")
+	}
+}

--- a/framework/app-service/pkg/gateway/meshinagent/container.go
+++ b/framework/app-service/pkg/gateway/meshinagent/container.go
@@ -22,6 +22,8 @@ const (
 
 	CertsVolumeName   = constants.MeshInCertsVolumeName
 	CertsMountPath    = "/var/run/olares/mesh-in-certs"
+	CustomCertsVolumeName = constants.MeshInCustomCertsVolumeName
+	CustomCertsMountPath  = "/var/run/olares/mesh-in-custom-certs"
 	HostsVolumeName   = constants.MeshInSharedHostsCMName
 	HostsMountPath    = "/var/run/olares/mesh-in-shared-hosts"
 	ConfVolumeName    = "olares-mesh-in-agent-conf"
@@ -66,6 +68,7 @@ func ContainerSpec() corev1.Container {
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: JWTSecretVolumeName, MountPath: JWTSecretMountPath, ReadOnly: true},
 			{Name: CertsVolumeName, MountPath: CertsMountPath, ReadOnly: true},
+			{Name: CustomCertsVolumeName, MountPath: CustomCertsMountPath, ReadOnly: true},
 			{Name: HostsVolumeName, MountPath: HostsMountPath, ReadOnly: true},
 		},
 		SecurityContext: &corev1.SecurityContext{
@@ -261,6 +264,21 @@ func CertsVolumeForViewer(viewer string) corev1.Volume {
 	}
 }
 
+// CustomCertsVolume mounts the aggregate CustomDomainTLS Secret for SNI pickCert.
+// Optional so pods start before the control plane projects any custom domains;
+// kubelet updates files in place when the Secret gains keys (no restart).
+func CustomCertsVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: CustomCertsVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: constants.MeshInCustomTLSSecretName,
+				Optional:   boolPtr(true),
+			},
+		},
+	}
+}
+
 // SharedHostsVolume mounts auth-hosts and tls-hosts allowlists from ConfigMap.
 func SharedHostsVolume() corev1.Volume {
 	return corev1.Volume{
@@ -272,6 +290,7 @@ func SharedHostsVolume() corev1.Volume {
 				Items: []corev1.KeyToPath{
 					{Key: SharedHostsFileName, Path: SharedHostsFileName},
 					{Key: TLSHostsFileName, Path: TLSHostsFileName},
+					{Key: CustomTLSHostsFileName, Path: CustomTLSHostsFileName},
 				},
 			},
 		},

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
@@ -20,6 +20,8 @@ const (
 	SharedHostsFileName = "shared-hosts.txt"
 	// TLSHostsFileName is the TLS-offload allowlist ConfigMap key / projected file.
 	TLSHostsFileName = "tls-hosts.txt"
+	// CustomTLSHostsFileName lists third-party FQDNs that require custom certs.
+	CustomTLSHostsFileName = "custom-tls-hosts.txt"
 
 	placeholderJSONBody = `{"error":"mesh_in_tls_placeholder","message":"Platform TLS replica not ready; using pod-local placeholder certificate. Retry or use http:// for in-cluster Shared access.","tlsMode":"placeholder","retryAfterSeconds":5}`
 )
@@ -94,6 +96,7 @@ func RenderNginxConf(in NginxConfInput) string {
 			lb.WriteString("      js_set $mesh_in_tls_mode main.tlsMode;\n")
 			lb.WriteString("      if ($mesh_in_host_ok = \"0\") { return 421; }\n")
 			lb.WriteString("      if ($mesh_in_tls_mode = \"placeholder\") { return 503; }\n")
+			lb.WriteString("      if ($mesh_in_tls_mode = \"reject\") { return 421; }\n")
 		}
 		if in.FailClosed {
 			lb.WriteString("      js_set $mesh_in_auth_deny main.authDeny;\n")

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -40,6 +40,8 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 		"ssl_certificate $tls_cert_path",
 		"js_set $tls_cert_path main.pickCert",
 		"js_set $mesh_in_tls_mode main.tlsMode",
+		`if ($mesh_in_tls_mode = "placeholder")`,
+		`if ($mesh_in_tls_mode = "reject")`,
 		"@mesh_in_placeholder",
 		"X-Olares-Mesh-In-TLS",
 		"mesh_in_tls_placeholder",
@@ -261,15 +263,15 @@ func TestSharedHostsVolumeProjectsAuthAndTLSHosts(t *testing.T) {
 	if v.ConfigMap.Name != constants.MeshInSharedHostsCMName {
 		t.Fatalf("name = %q", v.ConfigMap.Name)
 	}
-	if len(v.ConfigMap.Items) != 2 {
-		t.Fatalf("items = %#v, want 2 keys", v.ConfigMap.Items)
+	if len(v.ConfigMap.Items) != 3 {
+		t.Fatalf("items = %#v, want 3 keys", v.ConfigMap.Items)
 	}
 	keys := map[string]bool{}
 	for _, it := range v.ConfigMap.Items {
 		keys[it.Key] = true
 	}
-	if !keys[SharedHostsFileName] || !keys[TLSHostsFileName] {
-		t.Fatalf("items = %#v, want %s and %s", v.ConfigMap.Items, SharedHostsFileName, TLSHostsFileName)
+	if !keys[SharedHostsFileName] || !keys[TLSHostsFileName] || !keys[CustomTLSHostsFileName] {
+		t.Fatalf("items = %#v, want %s, %s and %s", v.ConfigMap.Items, SharedHostsFileName, TLSHostsFileName, CustomTLSHostsFileName)
 	}
 }
 
@@ -281,5 +283,28 @@ func TestCertsVolumeForViewer(t *testing.T) {
 	v2 := CertsVolumeForViewer("")
 	if v2.Secret == nil || v2.Secret.SecretName != "olares-mesh-in-certs" {
 		t.Fatalf("empty viewer secret = %#v", v2.Secret)
+	}
+}
+
+func TestCustomCertsVolume(t *testing.T) {
+	v := CustomCertsVolume()
+	if v.Name != CustomCertsVolumeName {
+		t.Fatalf("name = %q", v.Name)
+	}
+	if v.Secret == nil || v.Secret.SecretName != constants.MeshInCustomTLSSecretName {
+		t.Fatalf("secret = %#v", v.Secret)
+	}
+	if v.Secret.Optional == nil || !*v.Secret.Optional {
+		t.Fatal("custom certs volume must be optional")
+	}
+	c := ContainerSpec()
+	found := false
+	for _, m := range c.VolumeMounts {
+		if m.Name == CustomCertsVolumeName && m.MountPath == CustomCertsMountPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ContainerSpec missing custom certs mount: %#v", c.VolumeMounts)
 	}
 }

--- a/framework/app-service/pkg/gateway/producer.go
+++ b/framework/app-service/pkg/gateway/producer.go
@@ -8,9 +8,15 @@ import (
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/cluster"
@@ -66,6 +72,7 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 	if appid == "" {
 		return fmt.Errorf("invalid appid in app.spec.appid for app %q", app.Spec.Name)
 	}
+	materializer := NewConfigMapCertMaterializer(ctx, r.Client)
 	desired := make(map[string]struct{}, len(app.Spec.SharedEntrances)+len(app.Spec.Entrances))
 
 	for i := range app.Spec.SharedEntrances {
@@ -82,7 +89,7 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 			return fmt.Errorf("resolve backing service for entrance %q: %w", entrance.Name, err)
 		}
 		spec, err := BuildSpecForEntrance(app, entrance, i, len(app.Spec.SharedEntrances), svc, platformDomain,
-			srrv1alpha1.EntranceClassShared)
+			srrv1alpha1.EntranceClassShared, materializer)
 		if err != nil {
 			return fmt.Errorf("build SRR spec for entrance %q: %w", entrance.Name, err)
 		}
@@ -92,7 +99,7 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 				return fmt.Errorf("uniqueness check for entrance %q pattern %q: %w", entrance.Name, hp, err)
 			}
 		}
-		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec); err != nil {
+		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec, platformDomain, materializer); err != nil {
 			return err
 		}
 		desired[name] = struct{}{}
@@ -116,7 +123,7 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 			return fmt.Errorf("resolve backing service for application entrance %q: %w", entrance.Name, err)
 		}
 		spec, err := BuildSpecForEntrance(app, entrance, i, len(app.Spec.Entrances), svc, platformDomain,
-			srrv1alpha1.EntranceClassApplication)
+			srrv1alpha1.EntranceClassApplication, materializer)
 		if err != nil {
 			return fmt.Errorf("build SRR spec for application entrance %q: %w", entrance.Name, err)
 		}
@@ -126,7 +133,7 @@ func (r *SharedRouteProducerReconciler) reconcileApp(ctx context.Context, app *a
 				return fmt.Errorf("uniqueness check for application entrance %q pattern %q: %w", entrance.Name, hp, err)
 			}
 		}
-		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec); err != nil {
+		if _, err := ReconcileForEntrance(ctx, r.Client, app, entrance, spec, platformDomain, materializer); err != nil {
 			return err
 		}
 		desired[name] = struct{}{}
@@ -159,7 +166,8 @@ func resolveApplicationEntranceService(ctx context.Context, c client.Client,
 	return svc, nil
 }
 
-// SetupWithManager registers the producer against Applications.
+// SetupWithManager registers the producer against Applications and custom-domain
+// cert ConfigMaps (cert late-arrival / rotation must re-run Eligible).
 func (r *SharedRouteProducerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r == nil {
 		return nil
@@ -167,8 +175,121 @@ func (r *SharedRouteProducerReconciler) SetupWithManager(mgr ctrl.Manager) error
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(),
+		&appv1alpha1.Application{},
+		indexApplicationThirdPartyDomain,
+		indexApplicationByThirdPartyDomain,
+	); err != nil {
+		return fmt.Errorf("index Applications by third_party_domain: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("shared-route-producer").
 		For(&appv1alpha1.Application{}).
+		Watches(&corev1.ConfigMap{}, r.customDomainCertEventHandler(),
+			builder.WithPredicates(customDomainCertConfigMapPredicate())).
 		Complete(r)
+}
+
+func indexApplicationByThirdPartyDomain(obj client.Object) []string {
+	app, ok := obj.(*appv1alpha1.Application)
+	if !ok || app == nil {
+		return nil
+	}
+	return CollectApplicationThirdPartyDomains(app)
+}
+
+func (r *SharedRouteProducerReconciler) customDomainCertEventHandler() handler.EventHandler {
+	enqueue := func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		for _, req := range r.fanOutAppsOnCustomDomainCert(ctx, obj) {
+			q.Add(req)
+		}
+	}
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			// Zone corrections must refresh both old and new referring apps.
+			enqueue(ctx, e.ObjectOld, q)
+			enqueue(ctx, e.ObjectNew, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+	}
+}
+
+// fanOutAppsOnCustomDomainCert enqueues only Applications that declare the CM
+// zone as third_party_domain. Empty/unknown zone → no enqueue (fail closed,
+// never broadcast to all apps).
+func (r *SharedRouteProducerReconciler) fanOutAppsOnCustomDomainCert(ctx context.Context, obj client.Object) []reconcile.Request {
+	if r == nil || r.Client == nil || obj == nil {
+		return nil
+	}
+	zone := customDomainCertZone(obj)
+	if zone == "" {
+		klog.V(4).Infof("gateway-tpd: custom-domain-cert %s/%s missing zone; skip fan-out",
+			obj.GetNamespace(), obj.GetName())
+		return nil
+	}
+	list := &appv1alpha1.ApplicationList{}
+	if err := r.Client.List(ctx, list, client.MatchingFields{indexApplicationThirdPartyDomain: zone}); err != nil {
+		klog.Errorf("gateway-tpd: list Applications by third_party_domain=%s failed: %v", zone, err)
+		return nil
+	}
+	if len(list.Items) == 0 {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	seen := make(map[types.NamespacedName]struct{}, len(list.Items))
+	for i := range list.Items {
+		key := client.ObjectKeyFromObject(&list.Items[i])
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, reconcile.Request{NamespacedName: key})
+	}
+	klog.V(4).Infof("gateway-tpd: custom-domain-cert zone=%s enqueue %d Application(s)", zone, len(out))
+	return out
+}
+
+func customDomainCertZone(obj client.Object) string {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok || cm == nil || cm.Data == nil {
+		return ""
+	}
+	zone, err := NormalizeHostPattern(cm.Data["zone"])
+	if err != nil {
+		return ""
+	}
+	return zone
+}
+
+func customDomainCertConfigMapPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isCustomDomainCertConfigMap(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Cert rotation or zone fix — either generation of the labeled CM.
+			return isCustomDomainCertConfigMap(e.ObjectNew) || isCustomDomainCertConfigMap(e.ObjectOld)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isCustomDomainCertConfigMap(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isCustomDomainCertConfigMap(e.Object)
+		},
+	}
+}
+
+func isCustomDomainCertConfigMap(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	return obj.GetLabels()[customDomainCertLabel] == customDomainCertLabelValue
 }

--- a/framework/app-service/pkg/gateway/producer_test.go
+++ b/framework/app-service/pkg/gateway/producer_test.go
@@ -364,3 +364,73 @@ func TestSharedRouteProducerReconcilerPrunesSharedAndApplicationSeparately(t *te
 		}
 	}
 }
+
+func TestCollectApplicationThirdPartyDomains(t *testing.T) {
+	app := &appv1alpha1.Application{
+		Spec: appv1alpha1.ApplicationSpec{
+			Settings: map[string]string{
+				"customDomain": `{"web":{"third_party_domain":"Chat.Example.com"}}`,
+			},
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": `{"api":{"third_party_domain":"alice.example.org"}}`},
+				"bob":   {"customDomain": `{"web":{"third_level_domain":"api"}}`},
+			},
+		},
+	}
+	got := CollectApplicationThirdPartyDomains(app)
+	want := map[string]bool{"chat.example.com": true, "alice.example.org": true}
+	if len(got) != 2 {
+		t.Fatalf("got %v", got)
+	}
+	for _, h := range got {
+		if !want[h] {
+			t.Fatalf("unexpected %q in %v", h, got)
+		}
+	}
+}
+
+func TestFanOutAppsOnCustomDomainCertIndexed(t *testing.T) {
+	hit := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "hit", Namespace: "ns-a"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name: "hit",
+			UserSettings: map[string]map[string]string{
+				"alice": {"customDomain": `{"web":{"third_party_domain":"chat.example.com"}}`},
+			},
+		},
+	}
+	miss := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "miss", Namespace: "ns-b"},
+		Spec: appv1alpha1.ApplicationSpec{
+			Name: "miss",
+			Settings: map[string]string{
+				"customDomain": `{"web":{"third_party_domain":"other.example.com"}}`,
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(producerTestScheme(t)).
+		WithIndex(&appv1alpha1.Application{}, indexApplicationThirdPartyDomain, indexApplicationByThirdPartyDomain).
+		WithObjects(hit, miss).Build()
+	r := &SharedRouteProducerReconciler{Client: c}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chat-example-com-ssl-config",
+			Namespace: "user-space-alice",
+			Labels:    map[string]string{customDomainCertLabel: customDomainCertLabelValue},
+		},
+		Data: map[string]string{"zone": "chat.example.com", "cert": "x", "key": "y"},
+	}
+	reqs := r.fanOutAppsOnCustomDomainCert(context.Background(), cm)
+	if len(reqs) != 1 || reqs[0].Name != "hit" || reqs[0].Namespace != "ns-a" {
+		t.Fatalf("want only hit app, got %#v", reqs)
+	}
+
+	if got := r.fanOutAppsOnCustomDomainCert(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-zone", Labels: map[string]string{customDomainCertLabel: customDomainCertLabelValue}},
+		Data:       map[string]string{},
+	}); got != nil {
+		t.Fatalf("empty zone must not fan-out, got %#v", got)
+	}
+}
+

--- a/framework/app-service/pkg/gateway/routecontrol/hostpattern.go
+++ b/framework/app-service/pkg/gateway/routecontrol/hostpattern.go
@@ -151,3 +151,56 @@ func HTTPRouteHostHeaderMatches(patterns []string) []map[string]any {
 	}
 	return out
 }
+
+// HTTPRouteExactHostHeaderMatches builds Host Exact header matches for
+// non-logical hostPatterns. Used when logical patterns already force Host
+// regex matches: without these, exact FQDNs in hostnames never match a rule.
+func HTTPRouteExactHostHeaderMatches(patterns []string) []map[string]any {
+	out := make([]map[string]any, 0, len(patterns))
+	seen := make(map[string]struct{}, len(patterns))
+	for _, p := range patterns {
+		if IsLogicalPattern(p) {
+			continue
+		}
+		host := strings.ToLower(strings.TrimSpace(p))
+		if host == "" || strings.Contains(host, "*") {
+			continue
+		}
+		if _, dup := seen[host]; dup {
+			continue
+		}
+		seen[host] = struct{}{}
+		out = append(out, map[string]any{
+			"name":  "Host",
+			"type":  "Exact",
+			"value": host,
+		})
+	}
+	return out
+}
+
+// HTTPRouteMatches builds HTTPRoute rule matches from hostPatterns.
+// - No logical patterns: a single path-only match (exact hosts rely on hostnames).
+// - With logical patterns: one Host RegularExpression match per logical pattern,
+//   plus one Host Exact match per exact FQDN so dual-host SRRs remain reachable.
+func HTTPRouteMatches(patterns []string) []any {
+	path := map[string]any{"type": "PathPrefix", "value": "/"}
+	logical := HTTPRouteHostHeaderMatches(patterns)
+	if len(logical) == 0 {
+		return []any{map[string]any{"path": path}}
+	}
+	out := make([]any, 0, len(logical)+len(patterns))
+	for _, hm := range logical {
+		out = append(out, map[string]any{
+			"path":    path,
+			"headers": []any{hm},
+		})
+	}
+	for _, em := range HTTPRouteExactHostHeaderMatches(patterns) {
+		out = append(out, map[string]any{
+			"path":    path,
+			"headers": []any{em},
+		})
+	}
+	return out
+}

--- a/framework/app-service/pkg/gateway/routecontrol/hostpattern_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/hostpattern_test.go
@@ -57,4 +57,51 @@ func TestHTTPRouteHostnamesAndHeaderMatches(t *testing.T) {
 	if matches[0]["type"] != "RegularExpression" || matches[0]["name"] != "Host" {
 		t.Errorf("header match = %v", matches[0])
 	}
+	exact := HTTPRouteExactHostHeaderMatches(patterns)
+	if len(exact) != 2 {
+		t.Fatalf("exact host matches = %v, want 2", exact)
+	}
+	if exact[0]["type"] != "Exact" || exact[0]["value"] != "ab12cd34.shared.olares.com" {
+		t.Errorf("exact[0] = %v", exact[0])
+	}
+	if exact[1]["value"] != "exact.example.com" {
+		t.Errorf("exact[1] = %v", exact[1])
+	}
+}
+
+func TestHTTPRouteMatchesLogicalPlusExact(t *testing.T) {
+	patterns := []string{"4030c2e0.*.olares.com", "app-test.example.com"}
+	matches := HTTPRouteMatches(patterns)
+	if len(matches) != 2 {
+		t.Fatalf("matches len=%d want 2: %v", len(matches), matches)
+	}
+	first, ok := matches[0].(map[string]any)
+	if !ok {
+		t.Fatalf("match[0] type %T", matches[0])
+	}
+	headers, _ := first["headers"].([]any)
+	h0, _ := headers[0].(map[string]any)
+	if h0["type"] != "RegularExpression" {
+		t.Fatalf("first match should be logical regex, got %v", h0)
+	}
+	second, ok := matches[1].(map[string]any)
+	if !ok {
+		t.Fatalf("match[1] type %T", matches[1])
+	}
+	headers2, _ := second["headers"].([]any)
+	h1, _ := headers2[0].(map[string]any)
+	if h1["type"] != "Exact" || h1["value"] != "app-test.example.com" {
+		t.Fatalf("second match should Exact app-test.example.com, got %v", h1)
+	}
+}
+
+func TestHTTPRouteMatchesExactOnlyPathOnly(t *testing.T) {
+	matches := HTTPRouteMatches([]string{"a0e84c5c.shared.olares.com"})
+	if len(matches) != 1 {
+		t.Fatalf("matches=%v", matches)
+	}
+	m, _ := matches[0].(map[string]any)
+	if _, hasHeaders := m["headers"]; hasHeaders {
+		t.Fatalf("exact-only should stay path-only, got %v", m)
+	}
 }

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"sort"
 	"strings"
 
@@ -66,7 +67,17 @@ func syncMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS s
 		return customTLSOK(callerNS, "created", len(data)/2)
 	case err != nil:
 		return customTLSErr(callerNS, "get", err)
-	case dst.Annotations != nil && dst.Annotations[annotationTLSContentHash] == aggHash:
+	}
+
+	// Never adopt a pre-existing Secret that we do not manage (private keys).
+	if !isManagedMeshInCustomTLSReplica(dst) {
+		customTLSSyncTotal.WithLabelValues("unmanaged").Inc()
+		klog.Errorf("mesh-in-custom-tls: refuse overwrite unmanaged secret ns=%s name=%s",
+			hashCallerNS(callerNS), constants.MeshInCustomTLSSecretName)
+		return customTLSErr(callerNS, "refuse unmanaged", errUnmanagedCustomTLSReplica)
+	}
+
+	if dst.Annotations != nil && dst.Annotations[annotationTLSContentHash] == aggHash {
 		customTLSSyncTotal.WithLabelValues("noop").Inc()
 		return nil
 	}
@@ -90,6 +101,18 @@ func syncMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS s
 	return customTLSOK(callerNS, "updated", len(data)/2)
 }
 
+var errUnmanagedCustomTLSReplica = errors.New("secret exists but is not managed by app-service")
+
+func isManagedMeshInCustomTLSReplica(sec *corev1.Secret) bool {
+	if sec == nil || sec.Labels == nil {
+		return false
+	}
+	if sec.Labels[ManagedByLabel] == ManagedByValue {
+		return true
+	}
+	return sec.Labels[labelTLSCustomReplica] == "true"
+}
+
 func deleteMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS string) error {
 	if c == nil || callerNS == "" {
 		return nil
@@ -102,7 +125,7 @@ func deleteMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS
 	if err != nil {
 		return customTLSErr(callerNS, "get for delete", err)
 	}
-	if sec.Labels[ManagedByLabel] != ManagedByValue && sec.Labels[labelTLSCustomReplica] != "true" {
+	if !isManagedMeshInCustomTLSReplica(sec) {
 		return nil
 	}
 	if err := c.Delete(ctx, sec); err != nil && !apierrors.IsNotFound(err) {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const labelTLSCustomReplica = "gateway.olares.io/tls-custom-replica"
+const labelTLSCustomReplica = constants.LabelTLSCustomReplica
 
 var customTLSSyncTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica.go
@@ -1,0 +1,259 @@
+package routecontrol
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const labelTLSCustomReplica = "gateway.olares.io/tls-custom-replica"
+
+var customTLSSyncTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "olares_mesh_in_custom_tls_sync_total",
+		Help: "mesh-in custom-domain TLS aggregate sync by result",
+	},
+	[]string{"result"},
+)
+
+func init() { prometheus.MustRegister(customTLSSyncTotal) }
+
+type customTLSMaterial struct {
+	Cert, Key []byte
+	Hash      string
+}
+
+// syncMeshInCustomTLSReplica projects CustomDomainTLS into callerNS Secret
+// olares-mesh-in-custom-tls (keys <fqdn>.crt/.key). In-place Update so kubelet
+// refreshes files without restarting mesh-in; viewer cert volume is untouched.
+func syncMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS string, tlsHosts []string) error {
+	if c == nil || callerNS == "" {
+		return nil
+	}
+	material, err := loadCustomDomainTLSMaterial(ctx, c)
+	if err != nil {
+		return customTLSErr(callerNS, "list source", err)
+	}
+
+	data, aggHash := buildCustomTLSData(tlsHosts, material)
+	if len(data) == 0 {
+		return deleteMeshInCustomTLSReplica(ctx, c, callerNS)
+	}
+
+	nsObj := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: callerNS}, nsObj); err != nil {
+		return customTLSErr(callerNS, "get namespace", err)
+	}
+
+	dst := &corev1.Secret{}
+	err = c.Get(ctx, types.NamespacedName{Namespace: callerNS, Name: constants.MeshInCustomTLSSecretName}, dst)
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := c.Create(ctx, desiredMeshInCustomTLSSecret(callerNS, nsObj, data, aggHash)); err != nil {
+			return customTLSErr(callerNS, "create", err)
+		}
+		return customTLSOK(callerNS, "created", len(data)/2)
+	case err != nil:
+		return customTLSErr(callerNS, "get", err)
+	case dst.Annotations != nil && dst.Annotations[annotationTLSContentHash] == aggHash:
+		customTLSSyncTotal.WithLabelValues("noop").Inc()
+		return nil
+	}
+
+	if dst.Labels == nil {
+		dst.Labels = map[string]string{}
+	}
+	dst.Labels[ManagedByLabel] = ManagedByValue
+	dst.Labels[labelTLSCustomReplica] = "true"
+	if dst.Annotations == nil {
+		dst.Annotations = map[string]string{}
+	}
+	dst.Annotations[annotationTLSContentHash] = aggHash
+	dst.Type = corev1.SecretTypeOpaque
+	dst.StringData = nil
+	dst.Data = data
+	ensureNamespaceOwnerRef(dst, nsObj)
+	if err := c.Update(ctx, dst); err != nil {
+		return customTLSErr(callerNS, "update", err)
+	}
+	return customTLSOK(callerNS, "updated", len(data)/2)
+}
+
+func deleteMeshInCustomTLSReplica(ctx context.Context, c client.Client, callerNS string) error {
+	if c == nil || callerNS == "" {
+		return nil
+	}
+	sec := &corev1.Secret{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: callerNS, Name: constants.MeshInCustomTLSSecretName}, sec)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return customTLSErr(callerNS, "get for delete", err)
+	}
+	if sec.Labels[ManagedByLabel] != ManagedByValue && sec.Labels[labelTLSCustomReplica] != "true" {
+		return nil
+	}
+	if err := c.Delete(ctx, sec); err != nil && !apierrors.IsNotFound(err) {
+		return customTLSErr(callerNS, "delete", err)
+	}
+	return customTLSOK(callerNS, "deleted", 0)
+}
+
+func buildCustomTLSData(tlsHosts []string, material map[string]customTLSMaterial) (map[string][]byte, string) {
+	seen := map[string]struct{}{}
+	var hosts, parts []string
+	for _, h := range tlsHosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" {
+			continue
+		}
+		m, ok := material[h]
+		if !ok {
+			continue
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+		parts = append(parts, h+"="+m.Hash)
+	}
+	sort.Strings(hosts)
+	sort.Strings(parts)
+	if len(hosts) == 0 {
+		return nil, ""
+	}
+	data := make(map[string][]byte, len(hosts)*2)
+	for _, h := range hosts {
+		m := material[h]
+		data[h+".crt"] = append([]byte(nil), m.Cert...)
+		data[h+".key"] = append([]byte(nil), m.Key...)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return data, hex.EncodeToString(sum[:])
+}
+
+func loadCustomDomainTLSMaterial(ctx context.Context, c client.Client) (map[string]customTLSMaterial, error) {
+	var list corev1.SecretList
+	if err := c.List(ctx, &list, client.InNamespace(defaultGatewayNS), client.MatchingLabels{
+		ManagedByLabel: ManagedByValue,
+	}); err != nil {
+		return nil, err
+	}
+	out := make(map[string]customTLSMaterial)
+	for i := range list.Items {
+		sec := &list.Items[i]
+		if !strings.HasPrefix(sec.Name, customDomainTLSPrefix) && strings.TrimSpace(sec.Labels[labelTLSCustomDomain]) == "" {
+			continue
+		}
+		domain := strings.ToLower(strings.TrimSpace(sec.Labels[labelTLSCustomDomain]))
+		if domain == "" {
+			domain = strings.ToLower(strings.TrimSpace(sec.Annotations[annotationTLSHostname]))
+		}
+		if domain == "" {
+			continue
+		}
+		cert, key := secretTLSBytes(sec)
+		if len(cert) == 0 || len(key) == 0 {
+			continue
+		}
+		hash := strings.TrimSpace(sec.Annotations[annotationTLSContentHash])
+		if hash == "" {
+			hash = tlsMaterialHash(string(cert), string(key))
+		}
+		out[domain] = customTLSMaterial{Cert: cert, Key: key, Hash: hash}
+	}
+	return out, nil
+}
+
+func secretTLSBytes(sec *corev1.Secret) (cert, key []byte) {
+	if sec == nil {
+		return nil, nil
+	}
+	cert, key = sec.Data[corev1.TLSCertKey], sec.Data[corev1.TLSPrivateKeyKey]
+	if len(cert) == 0 && sec.StringData != nil {
+		cert = []byte(sec.StringData[corev1.TLSCertKey])
+	}
+	if len(key) == 0 && sec.StringData != nil {
+		key = []byte(sec.StringData[corev1.TLSPrivateKeyKey])
+	}
+	return cert, key
+}
+
+func desiredMeshInCustomTLSSecret(callerNS string, ns *corev1.Namespace, data map[string][]byte, aggHash string) *corev1.Secret {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.MeshInCustomTLSSecretName,
+			Namespace: callerNS,
+			Labels: map[string]string{
+				ManagedByLabel:        ManagedByValue,
+				labelTLSCustomReplica: "true",
+			},
+			Annotations: map[string]string{annotationTLSContentHash: aggHash},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	ensureNamespaceOwnerRef(sec, ns)
+	return sec
+}
+
+func ensureNamespaceOwnerRef(sec *corev1.Secret, ns *corev1.Namespace) {
+	if sec == nil || ns == nil || ns.UID == "" {
+		return
+	}
+	for _, o := range sec.OwnerReferences {
+		if o.UID == ns.UID {
+			return
+		}
+	}
+	f := false
+	sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "v1", Kind: "Namespace", Name: ns.Name, UID: ns.UID,
+		Controller: &f, BlockOwnerDeletion: &f,
+	})
+}
+
+func collectTLSHosts(targets []SharedHostsTarget) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, t := range targets {
+		for _, h := range t.TLSHosts {
+			h = strings.ToLower(strings.TrimSpace(h))
+			if h == "" {
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			out = append(out, h)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func customTLSErr(ns, op string, err error) error {
+	customTLSSyncTotal.WithLabelValues("error").Inc()
+	klog.Errorf("mesh-in-custom-tls: %s failed ns=%s: %v", op, hashCallerNS(ns), err)
+	return err
+}
+
+func customTLSOK(ns, result string, domains int) error {
+	customTLSSyncTotal.WithLabelValues(result).Inc()
+	klog.Infof("mesh-in-custom-tls: sync ns=%s domains=%d result=%s", hashCallerNS(ns), domains, result)
+	return nil
+}

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica_test.go
@@ -1,0 +1,110 @@
+package routecontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSyncMeshInCustomTLSReplica_createsAggregate(t *testing.T) {
+	s := testScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "caller-alice", UID: "ns-uid-1"}}
+	src := desiredCustomDomainTLSSecret(
+		customDomainTLSPrefix+"shop", "shop.example.com",
+		"user-space-alice", "CERT-SHOP", "KEY-SHOP", "hash-shop")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, src).Build()
+
+	if err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice",
+		[]string{"abcd.alice.olares.com", "shop.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	got := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: "caller-alice", Name: constants.MeshInCustomTLSSecretName,
+	}, got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Data["shop.example.com.crt"]) != "CERT-SHOP" {
+		t.Fatalf("crt = %q", got.Data["shop.example.com.crt"])
+	}
+	if string(got.Data["shop.example.com.key"]) != "KEY-SHOP" {
+		t.Fatalf("key = %q", got.Data["shop.example.com.key"])
+	}
+	if _, ok := got.Data["abcd.alice.olares.com.crt"]; ok {
+		t.Fatal("platform host must not appear in custom aggregate")
+	}
+	if got.Labels[labelTLSCustomReplica] != "true" {
+		t.Fatalf("labels = %#v", got.Labels)
+	}
+}
+
+func TestSyncMeshInCustomTLSReplica_removesStaleAndDeletesEmpty(t *testing.T) {
+	s := testScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "caller-alice", UID: "ns-uid-1"}}
+	src := desiredCustomDomainTLSSecret(
+		customDomainTLSPrefix+"shop", "shop.example.com",
+		"user-space-alice", "CERT-SHOP", "KEY-SHOP", "hash-shop")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, src).Build()
+	if err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice",
+		[]string{"shop.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice", nil); err != nil {
+		t.Fatal(err)
+	}
+	err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: "caller-alice", Name: constants.MeshInCustomTLSSecretName,
+	}, &corev1.Secret{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected delete, got %v", err)
+	}
+}
+
+func TestSyncMeshInCustomTLSReplica_noopSameHash(t *testing.T) {
+	s := testScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "caller-alice", UID: "ns-uid-1"}}
+	src := desiredCustomDomainTLSSecret(
+		customDomainTLSPrefix+"shop", "shop.example.com",
+		"user-space-alice", "CERT-SHOP", "KEY-SHOP", "hash-shop")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, src).Build()
+	if err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice",
+		[]string{"shop.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	first := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: "caller-alice", Name: constants.MeshInCustomTLSSecretName,
+	}, first); err != nil {
+		t.Fatal(err)
+	}
+	rv := first.ResourceVersion
+	if err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice",
+		[]string{"shop.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	second := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: "caller-alice", Name: constants.MeshInCustomTLSSecretName,
+	}, second); err != nil {
+		t.Fatal(err)
+	}
+	if second.ResourceVersion != rv {
+		t.Fatalf("noop should not bump resourceVersion: %s -> %s", rv, second.ResourceVersion)
+	}
+}
+
+func TestCollectTLSHosts(t *testing.T) {
+	got := collectTLSHosts([]SharedHostsTarget{
+		{TLSHosts: []string{"a.example.com", "b.alice.olares.com"}},
+		{TLSHosts: []string{"a.example.com"}},
+	})
+	if len(got) != 2 || got[0] != "a.example.com" || got[1] != "b.alice.olares.com" {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_custom_tls_replica_test.go
@@ -108,3 +108,39 @@ func TestCollectTLSHosts(t *testing.T) {
 		t.Fatalf("got %#v", got)
 	}
 }
+
+func TestSyncMeshInCustomTLSReplica_refusesUnmanagedSecret(t *testing.T) {
+	s := testScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "caller-alice", UID: "ns-uid-1"}}
+	src := desiredCustomDomainTLSSecret(
+		customDomainTLSPrefix+"shop", "shop.example.com",
+		"user-space-alice", "CERT-SHOP", "KEY-SHOP", "hash-shop")
+	preexisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.MeshInCustomTLSSecretName,
+			Namespace: "caller-alice",
+			// No managed-by / tls-custom-replica labels.
+		},
+		Data: map[string][]byte{"planted.key": []byte("steal-me")},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, src, preexisting).Build()
+
+	err := syncMeshInCustomTLSReplica(context.Background(), c, "caller-alice",
+		[]string{"shop.example.com"})
+	if err == nil {
+		t.Fatal("expected refuse unmanaged")
+	}
+
+	got := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: "caller-alice", Name: constants.MeshInCustomTLSSecretName,
+	}, got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Data["shop.example.com.key"]; ok {
+		t.Fatal("must not write private keys into unmanaged secret")
+	}
+	if string(got.Data["planted.key"]) != "steal-me" {
+		t.Fatalf("preexisting data mutated: %#v", got.Data)
+	}
+}

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
@@ -279,6 +279,13 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 			tlsByKey[k][h] = struct{}{}
 		}
 	}
+	customTLSDomains, err := listMaterializedCustomTLSDomains(ctx, c)
+	if err != nil {
+		// Auth-hosts must still converge (fail-closed on SRR ownership). TLS list
+		// failure only drops custom-domain tls-hosts for this pass.
+		klog.Errorf("mesh-in-shared-hosts: list CustomDomainTLS secrets failed; continuing auth-hosts without custom tls filter: %v", err)
+		customTLSDomains = map[string]struct{}{}
+	}
 	for i := range nsList.Items {
 		callerNS := nsList.Items[i].Name
 		for _, app := range appsByNS[callerNS] {
@@ -315,6 +322,7 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 			tlsList = append(tlsList, h)
 		}
 		sort.Strings(tlsList)
+		tlsList = filterTLSHostsForCustomMaterialization(tlsList, platformDomain, customTLSDomains)
 		out = append(out, SharedHostsTarget{
 			CallerNamespace: k.ns,
 			Viewer:          k.viewer,
@@ -329,6 +337,47 @@ func BuildSharedHostsDemand(ctx context.Context, c client.Client, platformDomain
 		return out[i].CallerNamespace < out[j].CallerNamespace
 	})
 	return out, nil
+}
+
+func listMaterializedCustomTLSDomains(ctx context.Context, c client.Client) (map[string]struct{}, error) {
+	secrets, err := listCustomDomainTLSSecrets(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(secrets))
+	for _, s := range secrets {
+		d := strings.ToLower(strings.TrimSpace(s.Domain))
+		if d == "" {
+			continue
+		}
+		out[d] = struct{}{}
+	}
+	return out, nil
+}
+
+// filterTLSHostsForCustomMaterialization keeps platform hosts and only those
+// exact custom domains that already have a CustomDomainTLS Secret. Settings-only
+// certs (Eligible but CM not synced) must not appear in tls-hosts.
+func filterTLSHostsForCustomMaterialization(tlsHosts []string, platformDomain string, custom map[string]struct{}) []string {
+	if len(tlsHosts) == 0 {
+		return tlsHosts
+	}
+	dom := strings.ToLower(strings.TrimSpace(platformDomain))
+	out := make([]string, 0, len(tlsHosts))
+	for _, h := range tlsHosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" {
+			continue
+		}
+		if isPlatformHostGo(h, dom) {
+			out = append(out, h)
+			continue
+		}
+		if _, ok := custom[h]; ok {
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 // SetupWithManager registers the reconciler on the shared manager. The shared
@@ -352,6 +401,10 @@ func (r *MeshInSharedHostsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(inClusterCallerNamespacePredicate())).
 		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.fanOutOnPod),
 			builder.WithPredicates(predicate.NewPredicateFuncs(isSharedEntrancePod))).
+		// CustomDomainTLS Secrets gate tls-hosts; without this watch, Secret create
+		// after SRR/auth converge leaves mesh-in HTTPS unload lagging.
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.fanOutOnCustomDomainTLSSecret),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isCustomDomainTLSSecret))).
 		Complete(r)
 }
 
@@ -359,6 +412,9 @@ func (r *MeshInSharedHostsReconciler) fanOutOnSRR(ctx context.Context, _ client.
 	return r.fanOutOptInNamespaces(ctx)
 }
 func (r *MeshInSharedHostsReconciler) fanOutOnPod(ctx context.Context, _ client.Object) []reconcile.Request {
+	return r.fanOutOptInNamespaces(ctx)
+}
+func (r *MeshInSharedHostsReconciler) fanOutOnCustomDomainTLSSecret(ctx context.Context, _ client.Object) []reconcile.Request {
 	return r.fanOutOptInNamespaces(ctx)
 }
 func (r *MeshInSharedHostsReconciler) fanOutOnApplication(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts.go
@@ -65,6 +65,9 @@ func (r *MeshInSharedHostsReconciler) Reconcile(ctx context.Context, req reconci
 			sharedHostsReconcileTotal.WithLabelValues(rResUpdateFailed).Inc()
 			return reconcile.Result{}, err
 		}
+		if err := deleteMeshInCustomTLSReplica(ctx, r.Client, req.Namespace); err != nil {
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{}, nil
 	}
 	platformDomain := r.resolvePlatformDomain(ctx)
@@ -91,7 +94,7 @@ func (r *MeshInSharedHostsReconciler) Reconcile(ctx context.Context, req reconci
 	}
 	sharedHostsTargetCount.WithLabelValues(hashCallerNS(req.Namespace)).Set(float64(len(nsTargets)))
 	noteEmptySharedHostsTargets(req.Namespace, nsTargets)
-	return reconcile.Result{}, r.ReconcileNamespace(ctx, req.Namespace, nsTargets)
+	return reconcile.Result{}, r.ReconcileNamespace(ctx, req.Namespace, nsTargets, platformDomain)
 }
 
 // resolvePlatformDomain returns the domain used to materialize viewer hosts.
@@ -110,7 +113,7 @@ func (r *MeshInSharedHostsReconciler) resolvePlatformDomain(ctx context.Context)
 
 // ReconcileNamespace upserts the per-NS olares-mesh-in-shared-hosts ConfigMap.
 // fail-safe: List/Get/Update failures leave the existing ConfigMap intact.
-func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, callerNS string, targets []SharedHostsTarget) error {
+func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, callerNS string, targets []SharedHostsTarget, platformDomain string) error {
 	if r == nil || r.Client == nil || callerNS == "" {
 		return nil
 	}
@@ -119,7 +122,7 @@ func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, ca
 		Namespace: callerNS, Name: constants.MeshInSharedHostsCMName,
 	}, cm)
 	if apierrors.IsNotFound(err) {
-		desiredData := buildSharedHostsConfigMapData(targets)
+		desiredData := buildSharedHostsConfigMapData(targets, platformDomain)
 		desiredHash := sharedHostsContentHash(desiredData)
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -142,7 +145,7 @@ func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, ca
 		sharedHostsReconcileTotal.WithLabelValues(rResUpdated).Inc()
 		updateSharedHostsHashAge(callerNS, desiredHash, true)
 		sharedHostsCount.WithLabelValues(hashCallerNS(callerNS)).Set(float64(countSharedHostsRows(targets)))
-		return nil
+		return syncMeshInCustomTLSReplica(ctx, r.Client, callerNS, collectTLSHosts(targets))
 	}
 	if err != nil {
 		sharedHostsReconcileTotal.WithLabelValues(rResGetFailed).Inc()
@@ -154,17 +157,20 @@ func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, ca
 			hashCallerNS(callerNS), cm.Name)
 		return nil
 	}
-	desiredData := buildSharedHostsConfigMapData(targets)
+	desiredData := buildSharedHostsConfigMapData(targets, platformDomain)
 	desiredHash := sharedHostsContentHash(desiredData)
 	desiredHostsCount := countSharedHostsRows(targets)
 	if cm.Annotations != nil && cm.Annotations[sharedHostsContentHashAnnotation] == desiredHash {
 		sharedHostsReconcileTotal.WithLabelValues(rResSkipped).Inc()
 		updateSharedHostsHashAge(callerNS, desiredHash, false)
 		sharedHostsCount.WithLabelValues(hashCallerNS(callerNS)).Set(float64(desiredHostsCount))
-		return nil
+		// CM unchanged still refresh custom TLS: source Secret may have rotated.
+		return syncMeshInCustomTLSReplica(ctx, r.Client, callerNS, collectTLSHosts(targets))
 	}
 	for key := range cm.Data {
-		if key == constants.MeshInSharedHostsFileName || key == constants.MeshInTLSHostsFileName {
+		if key == constants.MeshInSharedHostsFileName ||
+			key == constants.MeshInTLSHostsFileName ||
+			key == constants.MeshInCustomTLSHostsFileName {
 			continue
 		}
 		if _, ok := desiredData[key]; !ok {
@@ -192,7 +198,7 @@ func (r *MeshInSharedHostsReconciler) ReconcileNamespace(ctx context.Context, ca
 	sharedHostsReconcileTotal.WithLabelValues(rResUpdated).Inc()
 	updateSharedHostsHashAge(callerNS, desiredHash, true)
 	sharedHostsCount.WithLabelValues(hashCallerNS(callerNS)).Set(float64(desiredHostsCount))
-	return nil
+	return syncMeshInCustomTLSReplica(ctx, r.Client, callerNS, collectTLSHosts(targets))
 }
 
 func (r *MeshInSharedHostsReconciler) gcSharedHostsConfigMap(ctx context.Context, callerNS, reason string) error {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
@@ -401,11 +401,13 @@ func validDNSChars(s string) bool {
 	return true
 }
 
-func buildSharedHostsConfigMapData(targets []SharedHostsTarget) map[string]string {
+func buildSharedHostsConfigMapData(targets []SharedHostsTarget, platformDomain string) map[string]string {
 	data := map[string]string{}
 	perViewer := map[string]map[string]struct{}{}
 	allAuth := map[string]struct{}{}
 	allTLS := map[string]struct{}{}
+	customTLS := map[string]struct{}{}
+	dom := strings.ToLower(strings.TrimSpace(platformDomain))
 	for _, t := range targets {
 		viewer := strings.ToLower(strings.TrimSpace(t.Viewer))
 		if viewer == "" || viewer == constants.MeshInSharedHostsFileName {
@@ -419,11 +421,20 @@ func buildSharedHostsConfigMapData(targets []SharedHostsTarget) map[string]strin
 			perViewer[viewer][h] = struct{}{}
 		}
 		for _, h := range t.TLSHosts {
+			h = strings.ToLower(strings.TrimSpace(h))
+			if h == "" {
+				continue
+			}
 			allTLS[h] = struct{}{}
+			// Exact third-party FQDNs must never present the viewer platform cert.
+			if dom != "" && !isPlatformHostGo(h, dom) {
+				customTLS[h] = struct{}{}
+			}
 		}
 	}
 	data[constants.MeshInSharedHostsFileName] = sharedHostsFileText(sortedKeys(allAuth))
 	data[constants.MeshInTLSHostsFileName] = sharedHostsFileText(sortedKeys(allTLS))
+	data[constants.MeshInCustomTLSHostsFileName] = sharedHostsFileText(sortedKeys(customTLS))
 	for viewer, set := range perViewer {
 		data[viewer] = sharedHostsFileText(sortedKeys(set))
 	}

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
@@ -46,6 +46,7 @@ const (
 	rDropOwnerUnresolved = "owner_unresolved"
 	rDropMultiRef        = "multi_ref_unsupported"
 	rDropNonPlatformHost = "non_platform_host"
+	rDropCrossViewerHost = "cross_viewer_host"
 	rDropMultiWildcard   = "multi_wildcard"
 	rDropInvalidChars    = "invalid_chars"
 	rDropEmptyPatterns   = "empty_patterns"
@@ -182,6 +183,22 @@ type SharedHostsTarget struct {
 func isSharedHostsConfigMap(obj client.Object) bool {
 	return obj != nil && obj.GetName() == constants.MeshInSharedHostsCMName
 }
+
+// isCustomDomainTLSSecret matches os-gateway CustomDomainTLS Secrets that
+// listMaterializedCustomTLSDomains uses to admit exact FQDNs into tls-hosts.
+func isCustomDomainTLSSecret(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	if obj.GetNamespace() != defaultGatewayNS {
+		return false
+	}
+	if strings.HasPrefix(obj.GetName(), customDomainTLSPrefix) {
+		return true
+	}
+	labels := obj.GetLabels()
+	return labels != nil && strings.TrimSpace(labels[labelTLSCustomDomain]) != ""
+}
 func isGatewayModeSRR(obj client.Object) bool {
 	srr, ok := obj.(*srrv1alpha1.SharedRouteRegistry)
 	if !ok || srr == nil {
@@ -283,16 +300,21 @@ func sharedHostsManagedByUs(cm *corev1.ConfigMap) bool {
 func enumerateHostsForViewer(viewer string, srrs []srrv1alpha1.SharedRouteRegistry, platformDomain string) (auth, tls []string) {
 	authSeen := map[string]struct{}{}
 	tlsSeen := map[string]struct{}{}
+	domLower := strings.ToLower(strings.TrimSpace(platformDomain))
 	for i := range srrs {
 		patterns := srrs[i].Spec.HostPatterns
 		if len(patterns) == 0 {
 			sharedHostsDropTotal.WithLabelValues(rDropEmptyPatterns).Inc()
 			continue
 		}
+		owners := map[string]string{}
+		if srrs[i].Annotations != nil {
+			owners = gateway.ParseExactHostOwnersJSON(srrs[i].Annotations[gateway.AnnotationExactHostOwners])
+		}
 		// Empty EntranceClass matches HTTPRoute parent selection: treat as shared.
-		allowTLS := srrs[i].Spec.EntranceClass == srrv1alpha1.EntranceClassApplication
+		allowTLSApp := srrs[i].Spec.EntranceClass == srrv1alpha1.EntranceClassApplication
 		for _, pattern := range patterns {
-			h, reason := materializeHost(pattern, viewer, platformDomain)
+			h, reason := materializeHost(pattern, viewer, platformDomain, owners)
 			if h == "" {
 				if reason != "" {
 					sharedHostsDropTotal.WithLabelValues(reason).Inc()
@@ -300,7 +322,8 @@ func enumerateHostsForViewer(viewer string, srrs []srrv1alpha1.SharedRouteRegist
 				continue
 			}
 			authSeen[h] = struct{}{}
-			if allowTLS {
+			exactCustom := isExactCustomHost(pattern, domLower)
+			if allowTLSApp || exactCustom {
 				tlsSeen[h] = struct{}{}
 			} else {
 				sharedHostsDropTotal.WithLabelValues(rDropSharedAuthOnly).Inc()
@@ -310,7 +333,15 @@ func enumerateHostsForViewer(viewer string, srrs []srrv1alpha1.SharedRouteRegist
 	return sortedKeys(authSeen), sortedKeys(tlsSeen)
 }
 
-func materializeHost(pattern, viewer, platformDomain string) (string, string) {
+func isExactCustomHost(pattern, platformDomain string) bool {
+	p := strings.ToLower(strings.TrimSpace(pattern))
+	if p == "" || strings.Contains(p, "*") {
+		return false
+	}
+	return !isPlatformHostGo(p, platformDomain)
+}
+
+func materializeHost(pattern, viewer, platformDomain string, owners map[string]string) (string, string) {
 	pattern = strings.TrimSpace(pattern)
 	if pattern == "" {
 		return "", rDropEmptyPatterns
@@ -333,10 +364,19 @@ func materializeHost(pattern, viewer, platformDomain string) (string, string) {
 	if !validDNSChars(p) {
 		return "", rDropInvalidChars
 	}
-	if !isPlatformHostGo(p, domLower) {
-		return "", rDropNonPlatformHost
+	// Owned exact hosts (third_party or per-owner third_level) must match viewer
+	// even when the FQDN is under platformDomain (e.g. api.alice.olares.com).
+	if owner, ok := owners[p]; ok {
+		if owner == viewerLower {
+			return p, ""
+		}
+		return "", rDropCrossViewerHost
 	}
-	return p, ""
+	// Unowned platform hosts (e.g. hash8.shared.<platform>) stay cluster-shared.
+	if isPlatformHostGo(p, domLower) {
+		return p, ""
+	}
+	return "", rDropNonPlatformHost
 }
 
 func isPlatformHostGo(host, platformDomain string) bool {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
@@ -37,7 +37,7 @@ func TestMeshInSharedHostsReconcileCreatesCM(t *testing.T) {
 		Viewer:          "alice",
 		Hosts:           []string{"abcd1234.alice.olares.com"},
 	}}
-	if err := r.ReconcileNamespace(context.Background(), "litellm-alice", targets); err != nil {
+	if err := r.ReconcileNamespace(context.Background(), "litellm-alice", targets, "olares.com"); err != nil {
 		t.Fatal(err)
 	}
 	cm := &corev1.ConfigMap{}
@@ -326,10 +326,11 @@ func TestBuildSharedHostsConfigMapDataWritesTLSKey(t *testing.T) {
 		CallerNamespace: "chat-alice",
 		Viewer:          "alice",
 		Hosts:           []string{"abcd1234.alice.olares.com", "deadbeef.shared.olares.com"},
-		TLSHosts:        []string{"abcd1234.alice.olares.com"},
-	}})
+		TLSHosts:        []string{"abcd1234.alice.olares.com", "chat.example.com"},
+	}}, "olares.com")
 	authBody := data[constants.MeshInSharedHostsFileName]
 	tlsBody := data[constants.MeshInTLSHostsFileName]
+	customBody := data[constants.MeshInCustomTLSHostsFileName]
 	if !strings.Contains(authBody, "deadbeef.shared.olares.com") || !strings.Contains(authBody, "abcd1234.alice.olares.com") {
 		t.Fatalf("auth body=%q", authBody)
 	}
@@ -338,6 +339,12 @@ func TestBuildSharedHostsConfigMapDataWritesTLSKey(t *testing.T) {
 	}
 	if strings.Contains(tlsBody, "deadbeef.shared.olares.com") {
 		t.Fatalf("tls body must not include shared host: %q", tlsBody)
+	}
+	if !strings.Contains(customBody, "chat.example.com") {
+		t.Fatalf("custom-tls-hosts missing third-party FQDN: %q", customBody)
+	}
+	if strings.Contains(customBody, "abcd1234.alice.olares.com") {
+		t.Fatalf("custom-tls-hosts must not list platform host: %q", customBody)
 	}
 }
 

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/cluster"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/gateway"
 	srrv1alpha1 "github.com/beclab/Olares/framework/app-service/pkg/gateway/v1alpha1"
 	"github.com/beclab/Olares/framework/app-service/pkg/security"
 	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
@@ -55,13 +56,83 @@ func TestMeshInSharedHostsReconcileCreatesCM(t *testing.T) {
 }
 
 func TestMaterializeHostLogicalPattern(t *testing.T) {
-	h, reason := materializeHost("abcd1234.*.olares.com", "alice", "olares.com")
+	h, reason := materializeHost("abcd1234.*.olares.com", "alice", "olares.com", nil)
 	if reason != "" || h != "abcd1234.alice.olares.com" {
 		t.Fatalf("got host=%q reason=%q", h, reason)
 	}
-	h, reason = materializeHost("x.shared.olares.com", "alice", "olares.com")
+	h, reason = materializeHost("x.shared.olares.com", "alice", "olares.com", nil)
 	if reason != "" || h != "x.shared.olares.com" {
 		t.Fatalf("shared exact host=%q reason=%q, want kept", h, reason)
+	}
+	owners := map[string]string{"chat.example.com": "alice"}
+	h, reason = materializeHost("chat.example.com", "alice", "olares.com", owners)
+	if reason != "" || h != "chat.example.com" {
+		t.Fatalf("owned exact host=%q reason=%q", h, reason)
+	}
+	h, reason = materializeHost("chat.example.com", "bob", "olares.com", owners)
+	if h != "" || reason != rDropCrossViewerHost {
+		t.Fatalf("bob must not get alice host: host=%q reason=%q", h, reason)
+	}
+}
+
+func TestMaterializeHostOwnedPlatformThirdLevel(t *testing.T) {
+	// B-3: per-owner third_level Hosts are under platformDomain but must not
+	// leak across viewers; unowned *.shared.* stays available to all.
+	owners := map[string]string{
+		"api.alice.olares.com": "alice",
+		"chat.bob.olares.com":  "bob",
+	}
+	h, reason := materializeHost("api.alice.olares.com", "alice", "olares.com", owners)
+	if reason != "" || h != "api.alice.olares.com" {
+		t.Fatalf("alice own third_level: host=%q reason=%q", h, reason)
+	}
+	h, reason = materializeHost("api.alice.olares.com", "bob", "olares.com", owners)
+	if h != "" || reason != rDropCrossViewerHost {
+		t.Fatalf("bob must not get alice third_level: host=%q reason=%q", h, reason)
+	}
+	h, reason = materializeHost("deadbeef.shared.olares.com", "bob", "olares.com", owners)
+	if reason != "" || h != "deadbeef.shared.olares.com" {
+		t.Fatalf("unowned shared host must remain for bob: host=%q reason=%q", h, reason)
+	}
+}
+
+func TestEnumerateHostsOwnedPlatformThirdLevel(t *testing.T) {
+	srrs := []srrv1alpha1.SharedRouteRegistry{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					gateway.AnnotationExactHostOwners: `{"api.alice.olares.com":"alice","chat.bob.olares.com":"bob"}`,
+				},
+			},
+			Spec: srrv1alpha1.SharedRouteRegistrySpec{
+				EntranceClass: srrv1alpha1.EntranceClassShared,
+				HostPatterns: []string{
+					"deadbeef.shared.olares.com",
+					"api.alice.olares.com",
+					"chat.bob.olares.com",
+				},
+				RouteMode: srrv1alpha1.RouteModeGateway,
+			},
+		},
+	}
+	aliceAuth, _ := enumerateHostsForViewer("alice", srrs, "olares.com")
+	bobAuth, _ := enumerateHostsForViewer("bob", srrs, "olares.com")
+	aliceSet := map[string]bool{}
+	for _, h := range aliceAuth {
+		aliceSet[h] = true
+	}
+	bobSet := map[string]bool{}
+	for _, h := range bobAuth {
+		bobSet[h] = true
+	}
+	if !aliceSet["api.alice.olares.com"] || aliceSet["chat.bob.olares.com"] {
+		t.Fatalf("alice auth=%v", aliceAuth)
+	}
+	if !bobSet["chat.bob.olares.com"] || bobSet["api.alice.olares.com"] {
+		t.Fatalf("bob auth=%v", bobAuth)
+	}
+	if !aliceSet["deadbeef.shared.olares.com"] || !bobSet["deadbeef.shared.olares.com"] {
+		t.Fatalf("shared host missing alice=%v bob=%v", aliceAuth, bobAuth)
 	}
 }
 
@@ -104,6 +175,149 @@ func TestEnumerateHostsSplitsAuthAndTLSByEntranceClass(t *testing.T) {
 	}
 	if len(tlsHosts) != 1 || tlsHosts[0] != "abcd1234.alice.olares.com" {
 		t.Fatalf("tls=%v, want only application viewer host", tlsHosts)
+	}
+}
+
+func TestEnumerateHostsOwnedExactCustom(t *testing.T) {
+	srrs := []srrv1alpha1.SharedRouteRegistry{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					gateway.AnnotationExactHostOwners: `{"chat.example.com":"alice"}`,
+				},
+			},
+			Spec: srrv1alpha1.SharedRouteRegistrySpec{
+				EntranceClass: srrv1alpha1.EntranceClassShared,
+				HostPatterns:  []string{"deadbeef.shared.olares.com", "chat.example.com"},
+				RouteMode:     srrv1alpha1.RouteModeGateway,
+			},
+		},
+	}
+	auth, tlsHosts := enumerateHostsForViewer("alice", srrs, "olares.com")
+	if len(auth) != 2 {
+		t.Fatalf("alice auth=%v", auth)
+	}
+	bobAuth, _ := enumerateHostsForViewer("bob", srrs, "olares.com")
+	for _, h := range bobAuth {
+		if h == "chat.example.com" {
+			t.Fatalf("bob must not receive alice exact host: %v", bobAuth)
+		}
+	}
+	// Exact custom is a TLS candidate before Secret materialization filter.
+	foundTLS := false
+	for _, h := range tlsHosts {
+		if h == "chat.example.com" {
+			foundTLS = true
+		}
+	}
+	if !foundTLS {
+		t.Fatalf("tls candidates=%v", tlsHosts)
+	}
+}
+
+func TestFilterTLSHostsForCustomMaterialization(t *testing.T) {
+	custom := map[string]struct{}{"chat.example.com": {}}
+	got := filterTLSHostsForCustomMaterialization(
+		[]string{"abcd1234.alice.olares.com", "chat.example.com", "other.example.com"},
+		"olares.com", custom)
+	if len(got) != 2 || got[0] != "abcd1234.alice.olares.com" || got[1] != "chat.example.com" {
+		t.Fatalf("got %v", got)
+	}
+	// Empty custom map (TLS list failure path): platform hosts kept, custom dropped.
+	got = filterTLSHostsForCustomMaterialization(
+		[]string{"abcd1234.alice.olares.com", "chat.example.com"},
+		"olares.com", map[string]struct{}{})
+	if len(got) != 1 || got[0] != "abcd1234.alice.olares.com" {
+		t.Fatalf("fail-closed custom tls on empty map: %v", got)
+	}
+}
+
+func TestIsCustomDomainTLSSecret(t *testing.T) {
+	if !isCustomDomainTLSSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: customDomainTLSPrefix + "shop", Namespace: defaultGatewayNS,
+	}}) {
+		t.Fatal("prefix secret in gateway NS must match")
+	}
+	if !isCustomDomainTLSSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "other", Namespace: defaultGatewayNS,
+		Labels: map[string]string{labelTLSCustomDomain: "shop.example.com"},
+	}}) {
+		t.Fatal("label secret in gateway NS must match")
+	}
+	if isCustomDomainTLSSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: customDomainTLSPrefix + "shop", Namespace: "user-space-alice",
+	}}) {
+		t.Fatal("same-name secret outside gateway NS must not match")
+	}
+	if isCustomDomainTLSSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "shared-entrance-tls-alice", Namespace: defaultGatewayNS,
+	}}) {
+		t.Fatal("viewer TLS secret must not match custom-domain watch")
+	}
+}
+
+// TestBuildSharedHostsDemandCustomTLSAfterSecret: exact third-party FQDN stays in
+// auth-hosts before Secret exists, and only enters tls-hosts once CustomDomainTLS
+// Secret is listed (Secret watch re-runs this demand).
+func TestBuildSharedHostsDemandCustomTLSAfterSecret(t *testing.T) {
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-chat",
+			Namespace: "chat-shared",
+			Annotations: map[string]string{
+				gateway.AnnotationExactHostOwners: `{"chat.example.com":"alice"}`,
+			},
+		},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			EntranceClass: srrv1alpha1.EntranceClassApplication,
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			HostPatterns:  []string{"abcd1234.*.olares.com", "chat.example.com"},
+		},
+	}
+	objs := []client.Object{
+		callerNamespace("caller-alice"),
+		eligibilityCallerApp("desk", "caller-alice", "alice"),
+		sharedServerApp("chat", "chat-shared", "admin"),
+		srr,
+	}
+	c := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(objs...).Build()
+	got, err := BuildSharedHostsDemand(context.Background(), c, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice := demandFor(t, got, "caller-alice", "alice")
+	hasAuthCustom := false
+	for _, h := range alice.Hosts {
+		if h == "chat.example.com" {
+			hasAuthCustom = true
+		}
+	}
+	if !hasAuthCustom {
+		t.Fatalf("auth-hosts missing custom FQDN: %v", alice.Hosts)
+	}
+	for _, h := range alice.TLSHosts {
+		if h == "chat.example.com" {
+			t.Fatalf("tls-hosts must omit custom FQDN before Secret: %v", alice.TLSHosts)
+		}
+	}
+
+	sec := desiredCustomDomainTLSSecret(
+		customDomainTLSPrefix+"chat-example-com", "chat.example.com",
+		"user-space-alice", "CERT", "KEY", "hash")
+	c2 := fake.NewClientBuilder().WithScheme(sharedHostsScheme()).WithObjects(append(objs, sec)...).Build()
+	got2, err := BuildSharedHostsDemand(context.Background(), c2, "olares.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice2 := demandFor(t, got2, "caller-alice", "alice")
+	foundTLS := false
+	for _, h := range alice2.TLSHosts {
+		if h == "chat.example.com" {
+			foundTLS = true
+		}
+	}
+	if !foundTLS {
+		t.Fatalf("tls-hosts must include custom FQDN after Secret: %v", alice2.TLSHosts)
 	}
 }
 

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile.go
@@ -239,7 +239,6 @@ func resolveServicePort(svc *corev1.Service, ref srrv1alpha1.UpstreamRef) (int32
 func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *srrv1alpha1.SharedRouteRegistry, port int32) (string, error) {
 	name := httpRouteName(srr)
 	hosts := HTTPRouteHostnames(srr.Spec.HostPatterns)
-	headerMatches := HTTPRouteHostHeaderMatches(srr.Spec.HostPatterns)
 	if len(hosts) == 0 {
 		return "", fmt.Errorf("hostPatterns produced no usable hostnames: %v", srr.Spec.HostPatterns)
 	}
@@ -274,19 +273,7 @@ func applyHTTPRoute(ctx context.Context, c client.Client, gw GatewayRef, srr *sr
 		backendRef["namespace"] = ns
 	}
 
-	matches := []any{}
-	if len(headerMatches) == 0 {
-		matches = append(matches, map[string]any{
-			"path": map[string]any{"type": "PathPrefix", "value": "/"},
-		})
-	} else {
-		for _, hm := range headerMatches {
-			matches = append(matches, map[string]any{
-				"path":    map[string]any{"type": "PathPrefix", "value": "/"},
-				"headers": []any{hm},
-			})
-		}
-	}
+	matches := HTTPRouteMatches(srr.Spec.HostPatterns)
 	rule := map[string]any{
 		"matches":     matches,
 		"backendRefs": []any{backendRef},

--- a/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/reconcile_test.go
@@ -301,6 +301,51 @@ func TestReconcileSharedRouteGatewayModeApplicationHostContracts(t *testing.T) {
 	}
 }
 
+func TestReconcileSharedRouteGatewayModeLogicalPlusExactHostMatches(t *testing.T) {
+	s := testScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	srr := &srrv1alpha1.SharedRouteRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-dual-host", Namespace: "demo-shared", UID: "uid-dual-host"},
+		Spec: srrv1alpha1.SharedRouteRegistrySpec{
+			RouteMode:     srrv1alpha1.RouteModeGateway,
+			EntranceClass: srrv1alpha1.EntranceClassApplication,
+			HostPatterns:  []string{"4030c2e0.*.olares.com", "app-test.example.com"},
+			Upstream:      srrv1alpha1.UpstreamRef{ServiceName: "demo-svc", Port: 8080},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(svc, srr).Build()
+	if _, err := ReconcileSharedRoute(context.Background(), c, GatewayRef{}, srr); err != nil {
+		t.Fatalf("ReconcileSharedRoute: %v", err)
+	}
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo-shared", Name: "app-dual-host"}, route); err != nil {
+		t.Fatalf("HTTPRoute: %v", err)
+	}
+	hostnames, _, err := unstructured.NestedSlice(route.Object, "spec", "hostnames")
+	if err != nil || len(hostnames) != 2 {
+		t.Fatalf("hostnames=%v err=%v", hostnames, err)
+	}
+	rules, _, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil || len(rules) == 0 {
+		t.Fatalf("rules: %v", err)
+	}
+	firstRule, _ := rules[0].(map[string]any)
+	matches, _ := firstRule["matches"].([]any)
+	if len(matches) != 2 {
+		t.Fatalf("matches len=%d want 2 (regex + exact): %v", len(matches), matches)
+	}
+	m1, _ := matches[1].(map[string]any)
+	headers, _ := m1["headers"].([]any)
+	h, _ := headers[0].(map[string]any)
+	if h["type"] != "Exact" || h["value"] != "app-test.example.com" {
+		t.Fatalf("second match = %v, want Exact app-test.example.com", h)
+	}
+}
+
 func TestReconcileSharedRouteGatewayModeApplicationMultiEntranceHostPattern(t *testing.T) {
 	s := testScheme(t)
 	svc := &corev1.Service{

--- a/framework/app-service/pkg/gateway/srr.go
+++ b/framework/app-service/pkg/gateway/srr.go
@@ -69,7 +69,7 @@ func IsOptedIn(app *appv1alpha1.Application) bool {
 // resolves the backing Service so this helper stays I/O-free.
 func BuildSpecForEntrance(app *appv1alpha1.Application, entrance appv1alpha1.Entrance,
 	entranceIndex, entranceCount int, svc *corev1.Service, platformDomain string,
-	entranceClass srrv1alpha1.EntranceClass) (srrv1alpha1.SharedRouteRegistrySpec, error) {
+	entranceClass srrv1alpha1.EntranceClass, materializer CertMaterializer) (srrv1alpha1.SharedRouteRegistrySpec, error) {
 	if app == nil {
 		return srrv1alpha1.SharedRouteRegistrySpec{}, errors.New("application is nil")
 	}
@@ -119,6 +119,25 @@ func BuildSpecForEntrance(app *appv1alpha1.Application, entrance appv1alpha1.Ent
 		norm, err := NormalizeHostOrLogicalPattern(pattern)
 		if err != nil {
 			return srrv1alpha1.SharedRouteRegistrySpec{}, fmt.Errorf("normalize host pattern %q: %w", pattern, err)
+		}
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		norms = append(norms, norm)
+	}
+	// Eligible third_party_domain + per-owner third_level exact Hosts (Scheme A).
+	// Keep default/logical patterns above; append only gated / owned exact FQDNs.
+	exactOwners := MergeExactHostOwners(
+		CollectEligibleExactHosts(app, entrance.Name, platformDomain, materializer),
+		CollectUserThirdLevelExactHosts(app, entrance.Name, platformDomain),
+	)
+	for _, eh := range exactOwners {
+		norm, err := NormalizeHostOrLogicalPattern(eh.Host)
+		if err != nil {
+			klog.Warningf("BuildSpecForEntrance: skip exact host app=%s entrance=%s: %v",
+				app.Spec.Name, entrance.Name, err)
+			continue
 		}
 		if _, dup := seen[norm]; dup {
 			continue
@@ -218,8 +237,21 @@ func pickHTTPPort(svc *corev1.Service, preferred int32) int32 {
 
 // ReconcileForEntrance creates or updates the per-entrance SRR in the
 // Application's workload namespace, owned by the Application for GC.
+// platformDomain is required to recompute exact-host ownership for the
+// gateway.olares.io/exact-host-owners annotation.
 func ReconcileForEntrance(ctx context.Context, c client.Client, app *appv1alpha1.Application,
-	entrance appv1alpha1.Entrance, spec srrv1alpha1.SharedRouteRegistrySpec) (*srrv1alpha1.SharedRouteRegistry, error) {
+	entrance appv1alpha1.Entrance, spec srrv1alpha1.SharedRouteRegistrySpec,
+	platformDomain string, materializer CertMaterializer) (*srrv1alpha1.SharedRouteRegistry, error) {
+	owners := MergeExactHostOwners(
+		CollectEligibleExactHosts(app, entrance.Name, platformDomain, materializer),
+		CollectUserThirdLevelExactHosts(app, entrance.Name, platformDomain),
+	)
+	return reconcileForEntranceWithOwners(ctx, c, app, entrance, spec, owners)
+}
+
+func reconcileForEntranceWithOwners(ctx context.Context, c client.Client, app *appv1alpha1.Application,
+	entrance appv1alpha1.Entrance, spec srrv1alpha1.SharedRouteRegistrySpec,
+	owners []ExactHostOwner) (*srrv1alpha1.SharedRouteRegistry, error) {
 	if app == nil {
 		return nil, errors.New("application is nil")
 	}
@@ -232,11 +264,16 @@ func ReconcileForEntrance(ctx context.Context, c client.Client, app *appv1alpha1
 	if name == "" {
 		return nil, fmt.Errorf("compute SRR name for entrance %q on app %s", entrance.Name, app.Spec.Name)
 	}
+	ownersJSON := EncodeExactHostOwnersJSON(owners)
 
 	got := &srrv1alpha1.SharedRouteRegistry{}
 	getErr := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, got)
 	switch {
 	case apierrors.IsNotFound(getErr):
+		anns := map[string]string{}
+		if ownersJSON != "" {
+			anns[AnnotationExactHostOwners] = ownersJSON
+		}
 		obj := &srrv1alpha1.SharedRouteRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -247,6 +284,7 @@ func ReconcileForEntrance(ctx context.Context, c client.Client, app *appv1alpha1
 					"gateway.olares.io/appid":      appid,
 					"gateway.olares.io/entrance":   entrance.Name,
 				},
+				Annotations:     anns,
 				OwnerReferences: ownerRefs(app),
 			},
 			Spec: spec,
@@ -271,6 +309,14 @@ func ReconcileForEntrance(ctx context.Context, c client.Client, app *appv1alpha1
 	patched.Labels["app.kubernetes.io/instance"] = app.Spec.Name
 	patched.Labels["gateway.olares.io/appid"] = appid
 	patched.Labels["gateway.olares.io/entrance"] = entrance.Name
+	if patched.Annotations == nil {
+		patched.Annotations = map[string]string{}
+	}
+	if ownersJSON == "" {
+		delete(patched.Annotations, AnnotationExactHostOwners)
+	} else {
+		patched.Annotations[AnnotationExactHostOwners] = ownersJSON
+	}
 
 	if err := c.Patch(ctx, patched, client.MergeFrom(got)); err != nil {
 		return nil, fmt.Errorf("patch SRR %s/%s: %w", ns, name, err)

--- a/framework/app-service/pkg/gateway/srr_test.go
+++ b/framework/app-service/pkg/gateway/srr_test.go
@@ -64,7 +64,7 @@ func TestBuildSpecForEntrance(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
 	}
 	spec, err := BuildSpecForEntrance(app, app.Spec.SharedEntrances[0], 0, len(app.Spec.SharedEntrances), svc, "olares.com",
-		srrv1alpha1.EntranceClassShared)
+		srrv1alpha1.EntranceClassShared, nil)
 	if err != nil {
 		t.Fatalf("BuildSpecForEntrance: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestBuildSpecForEntranceRequiresAppID(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
 	}
 	_, err := BuildSpecForEntrance(app, app.Spec.SharedEntrances[0], 0, len(app.Spec.SharedEntrances), svc, "olares.com",
-		srrv1alpha1.EntranceClassShared)
+		srrv1alpha1.EntranceClassShared, nil)
 	if err == nil {
 		t.Fatal("expected error when app.spec.appid is empty")
 	}
@@ -121,7 +121,7 @@ func TestBuildSpecForEntranceApplication(t *testing.T) {
 	}
 
 	spec, err := BuildSpecForEntrance(app, app.Spec.Entrances[0], 0, len(app.Spec.Entrances), svc, "olares.com",
-		srrv1alpha1.EntranceClassApplication)
+		srrv1alpha1.EntranceClassApplication, nil)
 	if err != nil {
 		t.Fatalf("BuildSpecForEntrance application: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestBuildSpecForEntranceApplicationUsesThirdLevelOverride(t *testing.T) {
 	}
 
 	spec, err := BuildSpecForEntrance(app, app.Spec.Entrances[0], 0, len(app.Spec.Entrances), svc, "olares.com",
-		srrv1alpha1.EntranceClassApplication)
+		srrv1alpha1.EntranceClassApplication, nil)
 	if err != nil {
 		t.Fatalf("BuildSpecForEntrance: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestBuildSpecForEntranceApplicationUsesThirdLevelOverride(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090, Protocol: corev1.ProtocolTCP}}},
 	}
 	apiSpec, err := BuildSpecForEntrance(app, app.Spec.Entrances[1], 1, len(app.Spec.Entrances), apiSvc, "olares.com",
-		srrv1alpha1.EntranceClassApplication)
+		srrv1alpha1.EntranceClassApplication, nil)
 	if err != nil {
 		t.Fatalf("BuildSpecForEntrance api: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestBuildSpecForEntranceApplicationMalformedThirdLevelFallsBack(t *testing.
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
 	}
 	spec, err := BuildSpecForEntrance(app, app.Spec.Entrances[0], 0, len(app.Spec.Entrances), svc, "olares.com",
-		srrv1alpha1.EntranceClassApplication)
+		srrv1alpha1.EntranceClassApplication, nil)
 	if err != nil {
 		t.Fatalf("BuildSpecForEntrance: %v", err)
 	}

--- a/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard.go
+++ b/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard.go
@@ -13,11 +13,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// labelTLSReplica mirrors routecontrol's per-viewer TLS replica Secret label
-// key. The owning constant lives in pkg/gateway/routecontrol (unexported, in a
-// guarded file), so the value is restated here as the single string source for
-// the mount guard; the two must stay byte-equal.
-const labelTLSReplica = "gateway.olares.io/tls-replica"
+// labelTLSReplica mirrors constants.LabelTLSReplica (viewer platform TLS replica).
+const labelTLSReplica = constants.LabelTLSReplica
+
+// labelTLSCustomReplica mirrors constants.LabelTLSCustomReplica (third-party
+// aggregate Secret). Must stay byte-equal with routecontrol writers.
+const labelTLSCustomReplica = constants.LabelTLSCustomReplica
 
 // Admission deny error codes surfaced to the user (status message) and runbook.
 const (
@@ -41,6 +42,14 @@ const (
 	tlsReplicaAllowResultNoReplica = "allow_no_replica"
 )
 
+type tlsProtectedKind int
+
+const (
+	tlsProtectedNone tlsProtectedKind = iota
+	tlsProtectedViewer
+	tlsProtectedCustom
+)
+
 var tlsReplicaMountDeniedTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "app_service_d2_tls_replica_mount_denied_total",
@@ -58,8 +67,7 @@ var tlsReplicaMountValidatedTotal = prometheus.NewCounterVec(
 )
 
 func init() {
-	prometheus.MustRegister(tlsReplicaMountDeniedTotal)
-	prometheus.MustRegister(tlsReplicaMountValidatedTotal)
+	prometheus.MustRegister(tlsReplicaMountDeniedTotal, tlsReplicaMountValidatedTotal)
 }
 
 // recordTLSReplicaMountDenied increments the deny counter. The reason switch is
@@ -76,60 +84,58 @@ func recordTLSReplicaMountDenied(ns, reason string) {
 	tlsReplicaMountDeniedTotal.WithLabelValues(hashCallerNamespace(ns), reason).Inc()
 }
 
-// recordTLSReplicaMountValidated increments the allow counter.
 func recordTLSReplicaMountValidated(result string) {
 	tlsReplicaMountValidatedTotal.WithLabelValues(result).Inc()
 }
 
-// hashCallerNamespace returns a non-PII, low-cardinality digest of a caller
-// namespace (which embeds <app>-<user>) for use as a metric label value.
 func hashCallerNamespace(ns string) string {
 	sum := sha256.Sum256([]byte(ns))
 	return hex.EncodeToString(sum[:8])
 }
 
-// ValidateTLSReplicaMount enforces that any volume referencing a tls-replica
-// private-key Secret is mounted only by the platform-injected d2 sidecar.
+// ValidateTLSReplicaMount enforces that private-key TLS Secrets projected for
+// mesh-in are mounted only by the platform-injected mesh-in agent:
+//   - tls-replica            → volume olares-mesh-in-certs
+//   - tls-custom-replica     → volume olares-mesh-in-custom-certs
 //
-// requirement: WI-T1-8 §2.2 — a tls-replica=true Secret may be consumed only by
-// the olares-d2-sidecar container via the olares-d2-certs volume; any reference
-// by another container (raw secret or projected source) is a cross-tenant
-// private-key bypass and is denied.
-//
-// behavior: fail-closed — a Secret label lookup API error denies admission
-// (private-key red line over availability). Pods with no tls-replica volume take
-// an allow fast path. Returns (allowed, errorCode); errorCode is empty on allow.
+// behavior: fail-closed on Secret label lookup errors. Pods with no protected
+// TLS volume take an allow fast path. Returns (allowed, errorCode).
 func (wh *Webhook) ValidateTLSReplicaMount(ctx context.Context, pod *corev1.Pod, namespace string) (bool, string) {
-	hasReplicaVolume := false
+	hasProtectedVolume := false
 
 	for _, vol := range pod.Spec.Volumes {
 		secretNames := referencedSecretNames(vol)
 		if len(secretNames) == 0 {
 			continue
 		}
-		isReplica := false
+		kind := tlsProtectedNone
 		for _, secretName := range secretNames {
-			ok, err := wh.secretIsTLSReplica(ctx, namespace, secretName)
+			k, err := wh.secretTLSProtectedKind(ctx, namespace, secretName)
 			if err != nil {
 				recordTLSReplicaMountDenied(namespace, tlsReplicaDenyReasonLabelLookupFailed)
 				return false, codeTLSReplicaLabelLookupFail
 			}
-			if ok {
-				isReplica = true
+			if k != tlsProtectedNone {
+				kind = k
+				break
 			}
 		}
-		if !isReplica {
+		if kind == tlsProtectedNone {
 			continue
 		}
-		hasReplicaVolume = true
+		hasProtectedVolume = true
 
-		if !isLegitMeshInReplicaVolume(pod, vol.Name) {
+		expectedVol := constants.MeshInCertsVolumeName
+		if kind == tlsProtectedCustom {
+			expectedVol = constants.MeshInCustomCertsVolumeName
+		}
+		if !isLegitMeshInProtectedVolume(pod, vol.Name, expectedVol) {
 			recordTLSReplicaMountDenied(namespace, tlsReplicaDenyReasonNonD2Container)
 			return false, codeTLSReplicaMountDenied
 		}
 	}
 
-	if hasReplicaVolume {
+	if hasProtectedVolume {
 		recordTLSReplicaMountValidated(tlsReplicaAllowResultD2)
 	} else {
 		recordTLSReplicaMountValidated(tlsReplicaAllowResultNoReplica)
@@ -137,8 +143,6 @@ func (wh *Webhook) ValidateTLSReplicaMount(ctx context.Context, pod *corev1.Pod,
 	return true, ""
 }
 
-// referencedSecretNames collects every Secret name a volume references, covering
-// both raw Secret volumes and projected sources.
 func referencedSecretNames(vol corev1.Volume) []string {
 	var names []string
 	if vol.Secret != nil && vol.Secret.SecretName != "" {
@@ -154,25 +158,29 @@ func referencedSecretNames(vol corev1.Volume) []string {
 	return names
 }
 
-// secretIsTLSReplica reports whether the named Secret carries tls-replica=true.
-// A missing Secret is not a replica (skip); any other API error is returned so
-// the caller can fail closed.
-func (wh *Webhook) secretIsTLSReplica(ctx context.Context, namespace, name string) (bool, error) {
+// secretTLSProtectedKind classifies Secrets that carry mesh-in private-key
+// material. Missing Secret → none (optional mounts at Pod start).
+func (wh *Webhook) secretTLSProtectedKind(ctx context.Context, namespace, name string) (tlsProtectedKind, error) {
 	secret, err := wh.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			return tlsProtectedNone, nil
 		}
-		return false, err
+		return tlsProtectedNone, err
 	}
-	return secret.Labels[labelTLSReplica] == "true", nil
+	if secret.Labels[labelTLSCustomReplica] == "true" {
+		return tlsProtectedCustom, nil
+	}
+	if secret.Labels[labelTLSReplica] == "true" {
+		return tlsProtectedViewer, nil
+	}
+	return tlsProtectedNone, nil
 }
 
-// isLegitMeshInReplicaVolume reports whether a tls-replica-bearing volume is the
-// platform-injected d2 cert volume mounted exclusively by the d2 sidecar
-// (decision A: source type agnostic; discriminator is volume name + mounters).
-func isLegitMeshInReplicaVolume(pod *corev1.Pod, volumeName string) bool {
-	if volumeName != constants.MeshInCertsVolumeName {
+// isLegitMeshInProtectedVolume requires the volume name to match the platform
+// cert volume for that Secret kind and that only mesh-in-agent mounts it.
+func isLegitMeshInProtectedVolume(pod *corev1.Pod, volumeName, expectedVolumeName string) bool {
+	if volumeName != expectedVolumeName {
 		return false
 	}
 	mounted := false
@@ -188,4 +196,9 @@ func isLegitMeshInReplicaVolume(pod *corev1.Pod, volumeName string) bool {
 		}
 	}
 	return mounted
+}
+
+// isLegitMeshInReplicaVolume is the viewer-cert helper kept for existing tests.
+func isLegitMeshInReplicaVolume(pod *corev1.Pod, volumeName string) bool {
+	return isLegitMeshInProtectedVolume(pod, volumeName, constants.MeshInCertsVolumeName)
 }

--- a/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard.go
+++ b/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 
@@ -97,6 +98,7 @@ func hashCallerNamespace(ns string) string {
 // mesh-in are mounted only by the platform-injected mesh-in agent:
 //   - tls-replica            → volume olares-mesh-in-certs
 //   - tls-custom-replica     → volume olares-mesh-in-custom-certs
+//   - well-known Secret names (even if missing / unlabeled) use the same rules
 //
 // behavior: fail-closed on Secret label lookup errors. Pods with no protected
 // TLS volume take an allow fast path. Returns (allowed, errorCode).
@@ -158,9 +160,45 @@ func referencedSecretNames(vol corev1.Volume) []string {
 	return names
 }
 
+// wellKnownTLSProtectedKind classifies platform mesh-in TLS Secret names even
+// when the object is missing or unlabeled. Optional mounts must not skip the
+// guard: kubelet can project keys later without re-running admission.
+func wellKnownTLSProtectedKind(name string) tlsProtectedKind {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return tlsProtectedNone
+	}
+	if name == constants.MeshInCustomTLSSecretName {
+		return tlsProtectedCustom
+	}
+	// Empty-viewer fallback Secret name matches the certs volume name.
+	if name == constants.MeshInCertsVolumeName ||
+		strings.HasPrefix(name, constants.MeshInTLSSecretNamePrefix) {
+		return tlsProtectedViewer
+	}
+	return tlsProtectedNone
+}
+
 // secretTLSProtectedKind classifies Secrets that carry mesh-in private-key
-// material. Missing Secret → none (optional mounts at Pod start).
+// material. Well-known names stay protected when missing or unlabeled.
 func (wh *Webhook) secretTLSProtectedKind(ctx context.Context, namespace, name string) (tlsProtectedKind, error) {
+	if k := wellKnownTLSProtectedKind(name); k != tlsProtectedNone {
+		// Prefer live labels when present; name alone is enough to protect.
+		secret, err := wh.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return k, nil
+			}
+			return tlsProtectedNone, err
+		}
+		if secret.Labels[labelTLSCustomReplica] == "true" {
+			return tlsProtectedCustom, nil
+		}
+		if secret.Labels[labelTLSReplica] == "true" {
+			return tlsProtectedViewer, nil
+		}
+		return k, nil
+	}
 	secret, err := wh.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard_test.go
+++ b/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard_test.go
@@ -1,11 +1,13 @@
 package webhook
 
 import (
+	"context"
 	"testing"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestIsLegitMeshInReplicaVolume(t *testing.T) {
@@ -36,5 +38,120 @@ func TestIsLegitMeshInReplicaVolume(t *testing.T) {
 	}
 	if isLegitMeshInReplicaVolume(pod, "other-vol") {
 		t.Fatal("wrong volume name must deny")
+	}
+}
+
+func TestIsLegitMeshInProtectedVolumeCustom(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: constants.MeshInAgentContainerName,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: constants.MeshInCustomCertsVolumeName, MountPath: "/custom"},
+				},
+			}},
+		},
+	}
+	if !isLegitMeshInProtectedVolume(pod, constants.MeshInCustomCertsVolumeName, constants.MeshInCustomCertsVolumeName) {
+		t.Fatal("mesh-in custom vol must allow")
+	}
+	if isLegitMeshInProtectedVolume(pod, constants.MeshInCertsVolumeName, constants.MeshInCustomCertsVolumeName) {
+		t.Fatal("viewer vol name must not satisfy custom expected name")
+	}
+}
+
+func TestValidateTLSReplicaMount_customSecretDenyAppMount(t *testing.T) {
+	ns := "caller-alice"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.MeshInCustomTLSSecretName,
+			Namespace: ns,
+			Labels:    map[string]string{constants.LabelTLSCustomReplica: "true"},
+		},
+	}
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset(sec)}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "steal",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: constants.MeshInCustomTLSSecretName},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name: "app",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "steal", MountPath: "/keys"},
+				},
+			}},
+		},
+	}
+	ok, code := wh.ValidateTLSReplicaMount(context.Background(), pod, ns)
+	if ok || code != codeTLSReplicaMountDenied {
+		t.Fatalf("want deny %s, got ok=%v code=%s", codeTLSReplicaMountDenied, ok, code)
+	}
+}
+
+func TestValidateTLSReplicaMount_customSecretAllowMeshIn(t *testing.T) {
+	ns := "caller-alice"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.MeshInCustomTLSSecretName,
+			Namespace: ns,
+			Labels:    map[string]string{constants.LabelTLSCustomReplica: "true"},
+		},
+	}
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset(sec)}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: constants.MeshInCustomCertsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: constants.MeshInCustomTLSSecretName},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name: constants.MeshInAgentContainerName,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: constants.MeshInCustomCertsVolumeName, MountPath: "/custom"},
+				},
+			}},
+		},
+	}
+	ok, code := wh.ValidateTLSReplicaMount(context.Background(), pod, ns)
+	if !ok || code != "" {
+		t.Fatalf("want allow, got ok=%v code=%s", ok, code)
+	}
+}
+
+func TestValidateTLSReplicaMount_customSecretWrongVolumeName(t *testing.T) {
+	ns := "caller-alice"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.MeshInCustomTLSSecretName,
+			Namespace: ns,
+			Labels:    map[string]string{constants.LabelTLSCustomReplica: "true"},
+		},
+	}
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset(sec)}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: constants.MeshInCertsVolumeName, // wrong: viewer vol name
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: constants.MeshInCustomTLSSecretName},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name: constants.MeshInAgentContainerName,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: constants.MeshInCertsVolumeName, MountPath: "/custom"},
+				},
+			}},
+		},
+	}
+	ok, code := wh.ValidateTLSReplicaMount(context.Background(), pod, ns)
+	if ok || code != codeTLSReplicaMountDenied {
+		t.Fatalf("want deny for wrong volume name, got ok=%v code=%s", ok, code)
 	}
 }

--- a/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard_test.go
+++ b/framework/app-service/pkg/webhook/mesh_in_tls_replica_mount_guard_test.go
@@ -155,3 +155,61 @@ func TestValidateTLSReplicaMount_customSecretWrongVolumeName(t *testing.T) {
 		t.Fatalf("want deny for wrong volume name, got ok=%v code=%s", ok, code)
 	}
 }
+
+func TestValidateTLSReplicaMount_missingCustomSecretDenyAppMount(t *testing.T) {
+	ns := "caller-alice"
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset()}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "steal",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: constants.MeshInCustomTLSSecretName,
+						Optional:   boolPtr(true),
+					},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name: "app",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "steal", MountPath: "/keys"},
+				},
+			}},
+		},
+	}
+	ok, code := wh.ValidateTLSReplicaMount(context.Background(), pod, ns)
+	if ok || code != codeTLSReplicaMountDenied {
+		t.Fatalf("missing well-known custom secret must still deny app mount, got ok=%v code=%s", ok, code)
+	}
+}
+
+func TestValidateTLSReplicaMount_missingCustomSecretAllowMeshIn(t *testing.T) {
+	ns := "caller-alice"
+	wh := &Webhook{kubeClient: fake.NewSimpleClientset()}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: constants.MeshInCustomCertsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: constants.MeshInCustomTLSSecretName,
+						Optional:   boolPtr(true),
+					},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name: constants.MeshInAgentContainerName,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: constants.MeshInCustomCertsVolumeName, MountPath: "/custom"},
+				},
+			}},
+		},
+	}
+	ok, code := wh.ValidateTLSReplicaMount(context.Background(), pod, ns)
+	if !ok || code != "" {
+		t.Fatalf("mesh-in optional mount of missing custom secret must allow, got ok=%v code=%s", ok, code)
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }

--- a/framework/app-service/pkg/webhook/webhook.go
+++ b/framework/app-service/pkg/webhook/webhook.go
@@ -211,6 +211,7 @@ func (wh *Webhook) CreatePatch(
 			pod.Spec.Volumes = append(pod.Spec.Volumes,
 				meshinagent.JWTSecretVolume(),
 				meshinagent.CertsVolumeForViewer(viewer),
+				meshinagent.CustomCertsVolume(),
 				meshinagent.SharedHostsVolume(),
 			)
 			gatewayIPs := wh.lookupMeshInGatewayIPs(ctx)

--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -94,7 +94,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.26
+        image: beclab/sys-event:0.2.27
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -634,17 +634,27 @@ type SharedInclusterEntrance struct {
 const (
 	hostPatternSharedExact    = "shared-exact"
 	hostPatternViewerWildcard = "viewer-wildcard"
+	hostPatternExactFQDN      = "exact-fqdn"
 )
 
 // matchRegex returns an anchored host regex for one SRR host pattern:
 // - shared exact host:  ^<id>\.shared\.<base>\.$
 // - application logical: ^<id>\.[^.]+\.<base>\.$
+// - eligible third-party exact FQDN: ^<fqdn>\.$
 func (e SharedInclusterEntrance) matchRegex() string {
 	entranceID, platformDomain, hostPatternType, ok := parseLogicalHostPattern(e.HostPattern)
 	if !ok {
 		platformDomain = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(e.PlatformDomain, ".")))
 		entranceID = strings.ToLower(strings.TrimSpace(e.EntranceID))
 		hostPatternType = hostPatternSharedExact
+	}
+	if hostPatternType == hostPatternExactFQDN {
+		fqdn := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(e.HostPattern, ".")))
+		if fqdn == "" {
+			return ""
+		}
+		escaped := strings.ReplaceAll(fqdn, ".", `\.`)
+		return `"^` + escaped + `\.$"`
 	}
 	if platformDomain == "" || entranceID == "" || hostPatternType == "" {
 		return ""
@@ -774,7 +784,37 @@ func parseLogicalHostPattern(pattern string) (entranceID, platformDomain, hostPa
 		}
 		return entranceID, platformDomain, hostPatternViewerWildcard, true
 	}
-	return "", "", "", false
+
+	// Eligible third-party exact FQDN (no wildcards; not a shared/logical pattern).
+	if strings.Contains(pattern, "*") {
+		return "", "", "", false
+	}
+	if !validExactFQDNHost(pattern) {
+		return "", "", "", false
+	}
+	return pattern, "", hostPatternExactFQDN, true
+}
+
+func validExactFQDNHost(host string) bool {
+	if host == "" || strings.Contains(host, "..") {
+		return false
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 {
+		return false
+	}
+	for _, lab := range labels {
+		if lab == "" || len(lab) > 63 {
+			return false
+		}
+		for i, r := range lab {
+			ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || (r == '-' && i > 0 && i < len(lab)-1)
+			if !ok {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func sharedInclusterEntrancesFromSRRItems(
@@ -807,12 +847,24 @@ func sharedInclusterEntrancesFromSRRItems(
 		// One CoreDNS rewrite per logical hostPattern so friendly + hash
 		// aliases on the same SRR both point at app-gateway-data.
 		for _, pattern := range patterns {
-			id, domain, _, ok := parseLogicalHostPattern(pattern)
+			id, domain, hostType, ok := parseLogicalHostPattern(pattern)
 			if !ok {
 				continue
 			}
 			hostPattern := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(pattern, ".")))
-			if domain == "" || id == "" || hostPattern == "" {
+			if hostPattern == "" {
+				continue
+			}
+			if hostType == hostPatternExactFQDN {
+				entrances = append(entrances, SharedInclusterEntrance{
+					AppID:        appid,
+					EntranceName: entranceName,
+					EntranceID:   id,
+					HostPattern:  hostPattern,
+				})
+				continue
+			}
+			if domain == "" || id == "" {
 				continue
 			}
 			entrances = append(entrances, SharedInclusterEntrance{

--- a/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
@@ -240,7 +240,6 @@ func TestParseLogicalHostPattern(t *testing.T) {
 	}
 
 	for _, pattern := range []string{
-		"bc2bd381.bob.olares.com",
 		".shared.olares.com",
 		"*.shared.olares.com",
 		"bc2bd381.*.",
@@ -248,6 +247,62 @@ func TestParseLogicalHostPattern(t *testing.T) {
 		if _, _, _, ok := parseLogicalHostPattern(pattern); ok {
 			t.Fatalf("expected pattern %q to be rejected", pattern)
 		}
+	}
+
+	id, domain, hostType, ok = parseLogicalHostPattern("chat.example.com")
+	if !ok || hostType != hostPatternExactFQDN || id != "chat.example.com" || domain != "" {
+		t.Fatalf("exact FQDN: id=%q domain=%q hostType=%q ok=%v", id, domain, hostType, ok)
+	}
+	// Platform-shaped exact hosts are accepted as exact FQDN at parse time;
+	// Eligible gates keep them out of SRR.
+	id, domain, hostType, ok = parseLogicalHostPattern("bc2bd381.bob.olares.com")
+	if !ok || hostType != hostPatternExactFQDN {
+		t.Fatalf("platform exact as FQDN: id=%q domain=%q hostType=%q ok=%v", id, domain, hostType, ok)
+	}
+}
+
+func TestBuildSharedInclusterTemplates_exactFQDN(t *testing.T) {
+	plugins := buildSharedInclusterTemplates([]SharedInclusterEntrance{
+		{
+			AppID:        "demo1234",
+			EntranceName: "web",
+			EntranceID:   "chat.example.com",
+			HostPattern:  "chat.example.com",
+		},
+	}, "10.0.0.8")
+	if len(plugins) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(plugins))
+	}
+	wantMatch := `"^chat\.example\.com\.$"`
+	if !templateMatchesRegex(plugins[0], wantMatch, "10.0.0.8") {
+		t.Fatalf("template missing exact FQDN match: %s", plugins[0].ToString())
+	}
+}
+
+func TestSharedInclusterEntrancesFromSRRItems_exactFQDN(t *testing.T) {
+	srr := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "gateway.olares.io/v1alpha1",
+		"kind":       "SharedRouteRegistry",
+		"metadata": map[string]interface{}{
+			"name":      "shared-demo-web",
+			"namespace": "demo-shared",
+			"labels": map[string]interface{}{
+				labelSRRAppID:    "demo1234",
+				labelSRREntrance: "web",
+			},
+		},
+		"spec": map[string]interface{}{
+			"routeMode":    srrRouteModeGateway,
+			"hostPatterns": []interface{}{"deadbeef.shared.olares.com", "chat.example.com"},
+		},
+	}}
+	got := sharedInclusterEntrancesFromSRRItems([]unstructured.Unstructured{srr}, nil)
+	if len(got) != 2 {
+		t.Fatalf("got %d entrances: %#v", len(got), got)
+	}
+	plugins := buildSharedInclusterTemplates(got, "10.0.0.5")
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 templates, got %d", len(plugins))
 	}
 }
 


### PR DESCRIPTION
## Summary
Enable in-cluster Shared access via Eligible third-party custom domains (same auth as platform hosts).
- SRR: append Eligible `third_party_domain` + per-owner `third_level` exact hosts; owners annotation
- CoreDNS: exact-FQDN in-cluster rewrite
- Mesh-in: auth-hosts + tls-hosts ∩ CustomDomainTLS Secret; watch Secrets for HTTPS converge
- Producer: index/fan-out cert ConfigMaps by `third_party_domain`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches gateway routing, TLS private-key replication, admission webhooks, and mesh-in SNI behavior—security-sensitive paths where misconfiguration could leak certs or break in-cluster access.
> 
> **Overview**
> Adds **Eligible third-party custom domains** to in-cluster Shared gateway routing: SRRs gain exact `third_party_domain` and per-user `third_level` host patterns plus a `gateway.olares.io/exact-host-owners` annotation so mesh-in can scope hosts per viewer without broadcasting logical wildcards.
> 
> The **shared-route producer** now gates hosts via cert/CNAME/DNS checks (optional ConfigMap cert materializer), indexes Applications by `third_party_domain`, and re-reconciles when labeled custom-domain-cert ConfigMaps change.
> 
> **HTTPRoutes** with both logical and exact patterns get separate Host **Exact** matches so dual-host SRRs remain reachable. **CoreDNS (sys-event)** rewrites eligible exact FQDNs in-cluster.
> 
> **Mesh-in** projects `custom-tls-hosts.txt`, syncs per-caller `olares-mesh-in-custom-tls` from gateway CustomDomainTLS Secrets (only after materialization for tls-hosts), and **fail-closed SNI** (custom cert or reject—never the viewer platform cert). Pod admission extends the TLS replica mount guard to custom aggregate secrets. Webhook injects the custom certs volume on mesh-in pods.
> 
> Also bumps `beclab/sys-event` to **0.2.27**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32682fe9710b83ab1cd72f19deba3c7a9ffc495c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->