### PR TITLE
fix(download-server): converge torrent seed-control stop/resume to aria2's real state

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.11"
+        image: "beclab/download-server:v1.0.12"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
The root cause is that aria2's asynchronous pause creates a race where rapid stop/resume toggles can desync the DB from aria2's real state, and the poll's blind spot for tellWaiting (where paused seeders live) prevents automatic recovery.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the download DaemonSet image only, but the new binary changes torrent seeding control and aria2/DB synchronization on a cluster-critical workload.
> 
> **Overview**
> Rolls out **`beclab/download-server:v1.0.12`** on the download DaemonSet (from `v1.0.11`), deploying the fix described for torrent seed stop/resume.
> 
> That release is intended to align seed-control state with aria2’s real status—addressing races from async pause on rapid toggles and gaps when polling paused seeders in `tellWaiting`—so DB and aria2 stay in sync without relying on blind recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f544a97bc2ab6eaf9719ac83d03358e44a88a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->