### PR TITLE
chore: update system frontend images to v1.11.28

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.27
+          image: beclab/system-frontend:v1.11.28
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
+++ b/apps/.olares/config/user/helm-charts/wizard/templates/wizard_deploy.yaml
@@ -29,7 +29,7 @@ spec:
 
       containers:
       - name: wizard
-        image: beclab/wizard:v1.11.3
+        image: beclab/wizard:v1.11.28
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/framework/authelia/.olares/config/user/helm-charts/auth/templates/auth_deploy.yaml
+++ b/framework/authelia/.olares/config/user/helm-charts/auth/templates/auth_deploy.yaml
@@ -29,7 +29,7 @@ spec:
         name: check-auth
       containers:
       - name: auth-front
-        image: beclab/login:v1.10.14
+        image: beclab/login:v1.11.28
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80


### PR DESCRIPTION
* **Background**

  This PR bumps the three user-facing frontend images shipped by TermiPass to `v1.11.28` so that the Olares v1.12.7 release picks up the latest Wizard, Login and Settings fixes.

  Image changes:

  | Chart | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.27` | `beclab/system-frontend:v1.11.28` |
  | `apps/.olares/.../wizard` | `wizard` | `beclab/wizard:v1.11.3` | `beclab/wizard:v1.11.28` |
  | `framework/authelia/.../auth` | `auth-front` | `beclab/login:v1.10.14` | `beclab/login:v1.11.28` |

  The `wizard` and `login` images had been left behind on much older tags, so this change also realigns them with the current TermiPass release train.

  What the new image contains:

  1. **Wizard recovers from FRP list request failures** (TermiPass [#1352](https://github.com/beclab/TermiPass/pull/1352)). Loading the FRP server list is now retried up to three times when the request fails or returns no usable server. Once the retries are exhausted, the wizard shows an error notification and returns to the previous step instead of leaving activation blocked on a dead screen. A stale response from an unmounted Step 3 can no longer redirect a newer wizard session. The Login nginx configuration also disables gzip compression to improve compatibility with certain clients.
  2. **Settings log collection history is read from Files** (TermiPass [#1353](https://github.com/beclab/TermiPass/pull/1353)). History now comes from the live `/Files/Home/pod_logs/` directory rather than file paths persisted locally, so deleted logs can no longer leave stale links behind. Only in-progress collection IDs stay in IndexedDB and are dropped once a run reaches a terminal state, and a log directory that has not been created yet is treated as an empty history instead of raising an error toast.
  3. **LarePass device Tailscale status is reported correctly** (TermiPass [#1354](https://github.com/beclab/TermiPass/pull/1354)). Offline Android and Linux LarePass devices that leave a stale `tailScaled` flag after the process is killed are now forced to `Deactivated`. Other platforms with a valid `tailScale_id` resolve their state from the matched Headscale node's `online` field, and a Headscale failure falls back to the previous `tailScaled + id` rule.

  This is a chart-only change: no Olares-side logic is touched, only the image tags in the three Helm templates.

* **Target Version for Merge**

  v1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/TermiPass/pull/1352
  https://github.com/beclab/TermiPass/pull/1353
  https://github.com/beclab/TermiPass/pull/1354

* **Other information**

  Full Changelog:
  https://github.com/beclab/TermiPass/compare/v1.11.27...v1.11.28