### PR TITLE
fix(l4): public authlevel also need set ext_auth

### DIFF
--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -607,11 +607,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			WebSocketUpgrade: true,
 		}
 
-		// Gate private/internal apps behind Authelia. public skips ExtAuth
-		// (EDGE AC-AL-1). All non-public routes use Authelia /api/verify/.
-		if !isPublicAuthLevel(entrance.AuthLevel) {
-			defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
-		}
+		defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		// F3: Exact probe paths with signed UA bypass ExtAuth (oes parity).
 		// Emit before the catch-all so Envoy matches them first.
@@ -628,10 +624,6 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 	}
 
 	return vhosts
-}
-
-func isPublicAuthLevel(level string) bool {
-	return strings.EqualFold(strings.TrimSpace(level), "public")
 }
 
 // buildProbeBypassRoutes emits Exact path routes that skip ExtAuth only when
@@ -879,9 +871,7 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			WebSocketUpgrade: true,
 		}
 
-		if !isPublicAuthLevel(entrance.AuthLevel) {
-			customRoute.ExtAuth = buildAppExtAuthConfig(user)
-		}
+		customRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		routes := buildProbeBypassRoutes(
 			fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -1014,6 +1014,8 @@ func buildExtAuthzFilter(autheliaClusterName string, clusterMap map[string]*ir.C
 var (
 	autheliaAllowedUpstreamHeaders = &matcherv3.ListStringMatcher{
 		Patterns: []*matcherv3.StringMatcher{
+			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "authorization"}},
+			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "proxy-authorization"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "remote-"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "authelia-"}},
 		},


### PR DESCRIPTION


* **Background**
fix(l4): public authlevel also need set ext_auth
* **Target Version for Merge**
v1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes north-south auth for public-labeled apps (previously no ext_auth) and alters which auth headers reach backends; probe UA bypass routes are unchanged.
> 
> **Overview**
> **Public app entrances now go through Authelia ext_auth** instead of skipping it when `authLevel` is `public`. Default and custom-domain catch-all routes always get `buildAppExtAuthConfig(user)`; the `isPublicAuthLevel` gate and helper are removed.
> 
> **Envoy xDS** forwards `authorization` and `proxy-authorization` from Authelia responses to upstreams by adding them to `autheliaAllowedUpstreamHeaders`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986b569ec3cb0f507fdcb38a417f3b8be2e51b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->