### PR TITLE
chore: bump system-frontend to v1.11.29 and user-service to v0.1.13

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.28
+          image: beclab/system-frontend:v1.11.29
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -365,7 +365,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.12
+          image: beclab/user-service:v0.1.13
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**

  This PR bumps the two images shipped in the `system-apps` chart's user space pod so that the Olares v1.12.7 release picks up the latest TermiPass and user-service fixes.

  Image changes:

  | Chart | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.28` | `beclab/system-frontend:v1.11.29` |
  | `apps/.olares/.../system-apps` | `user-service` | `beclab/user-service:v0.1.12` | `beclab/user-service:v0.1.13` |

  The `wizard` and `login` images stay on `v1.11.28`, because everything in the TermiPass `v1.11.29` range lives in the Settings / LarePass app and does not affect the activation or login bundles.

  What the new `system-frontend` image contains:

  1. **Cluster pages and cluster operations work on a LAN-only Olares** (TermiPass [#1343](https://github.com/beclab/TermiPass/pull/1343)). On an Olares reachable only over the LAN, the cluster pages used to report the cluster as unavailable and its operations were rejected, for three separate reasons on the same path. First, pages loaded on `onMounted`, one mDNS discovery round too early, so they started with nothing addressable; the new `useClusterMachine` composable now starts discovery, holds the load until a machine is addressable, reruns it when the machine changes, and gives up after 10s instead of spinning forever. Shutdown had the mirrored problem — `MachineOperation` asked for the cluster id before discovery answered, so a multi-machine cluster silently degraded into a single-machine shutdown — and now waits through `waitForActivedMachine`. Second, signed operation bodies were missing the `scope` and `target` fields that olaresd's `ParseBinding` binds against, so verification failed on the node routes; both the direct and the settings path now build the body through `buildSignedOperationBody`, with a signed `expiresAt` that stays inside olaresd's 10-minute `MaxSignatureLifetime`. Third, cluster reads (`GET /cluster`, `/cluster/nodes` and friends) sit behind `RequireAuthorization` and were sent without a token; the proxied axios instance now forwards `X-Authorization`. On top of that, an unreachable node no longer opens a detail page it cannot load, since node detail is served by the node itself.
  2. **Remote LarePass sessions stop polling the Olares they cannot reach** (TermiPass [#1356](https://github.com/beclab/TermiPass/pull/1356)). LAN reachability is now taken from the TermiPass locality result instead of probing the public settings endpoint, and host IP and app list refreshes are skipped while the client is remote, while forced refreshes for the Windows/Linux hosts dialogs are preserved. Local sessions keep their 30s refresh cycle.
  3. **The Files list Modified column lines up with its neighbours** (TermiPass [#1355](https://github.com/beclab/TermiPass/pull/1355)). Values in the final Modified column are left-aligned to match the adjacent columns, and the Modified header sort arrow is moved to the right side without being clipped.

  What the new `user-service` image contains:

  1. **Cluster operations accept session authorization as well as JWS signatures** (user-service [#100](https://github.com/beclab/user-service/pull/100)). Operation creation now admits either a JWS signature or a session token, and forwards operation-specific parameters to olaresd unchanged, so node settings driven from an authenticated Settings session work while signed operations keep their existing behaviour. This is the server half of the LarePass fix above, and it pairs with the olaresd change that gates `RequireSignature` by self-registered operation type ([#3941](https://github.com/beclab/Olares/pull/3941)).
  2. **New `hymt` ability** (user-service [#99](https://github.com/beclab/user-service/pull/99)). The abilities interface and the `HOOK_APPS` hook list gain a `hymt` entry backed by the `llamacpphymt218bggufv3` app, so clients can discover whether that local model app is running and where to reach it.
  3. **Market requests get a 30s timeout** (user-service [#101](https://github.com/beclab/user-service/pull/101)). The market provider client used the default timeout, which was too short for slow catalog and chart responses and surfaced as spurious failures; it is now given an explicit 30s budget.

  This is a chart-only change: no Olares-side logic is touched, only the two image tags in the `system-apps` Helm template.

* **Target Version for Merge**

  v1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/TermiPass/pull/1343
  https://github.com/beclab/TermiPass/pull/1355
  https://github.com/beclab/TermiPass/pull/1356
  https://github.com/beclab/user-service/pull/99
  https://github.com/beclab/user-service/pull/100
  https://github.com/beclab/user-service/pull/101

* **Other information**

  Full Changelog:
  https://github.com/beclab/TermiPass/compare/v1.11.28...v1.11.29
  https://github.com/beclab/user-service/compare/v0.1.12...v0.1.13

Made with [Cursor](https://cursor.com)