### PR TITLE
fix: ensure app info

### DIFF
--- a/cli/pkg/preinstall/ensure-apps.json
+++ b/cli/pkg/preinstall/ensure-apps.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "apps": [
     {
-      "appId": "ai-router",
-      "appName": "ai-router",
+      "appId": "f3395cd5",
+      "appName": "router",
       "installScope": "shared",
       "installOrder": 20
     }


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
ensure app name fix

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON metadata change for one preinstall-ensured app; no auth or runtime logic in this diff.
> 
> **Overview**
> **Preinstall ensure contract** for the Router app is corrected in `cli/pkg/preinstall/ensure-apps.json`, which is embedded and published as `ensure-apps.json` for Market’s ensure-apps flow.
> 
> The ensured entry now uses **`appId` `f3395cd5`** and **`appName` `router`**, replacing the previous **`ai-router`** values for both fields. **`installScope`** (`shared`) and **`installOrder`** (`20`) are unchanged. This lines up with how Router is identified elsewhere (e.g. CLI discovery treats the Market app name as `router` and documents the per-install hash host prefix `f3395cd5`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d3d324e2211bab507644ae34d8d061902dc02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->