### PR TITLE
fix(l4): public authlevel also need set ext_auth

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -157,7 +157,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.45"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.46"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.45
+          value: v0.3.46
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.45
+      name: beclab/l4-bfl-proxy:v0.3.46
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -607,11 +607,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			WebSocketUpgrade: true,
 		}
 
-		// Gate private/internal apps behind Authelia. public skips ExtAuth
-		// (EDGE AC-AL-1). All non-public routes use Authelia /api/verify/.
-		if !isPublicAuthLevel(entrance.AuthLevel) {
-			defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
-		}
+		defaultRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		// F3: Exact probe paths with signed UA bypass ExtAuth (oes parity).
 		// Emit before the catch-all so Envoy matches them first.
@@ -628,10 +624,6 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 	}
 
 	return vhosts
-}
-
-func isPublicAuthLevel(level string) bool {
-	return strings.EqualFold(strings.TrimSpace(level), "public")
 }
 
 // buildProbeBypassRoutes emits Exact path routes that skip ExtAuth only when
@@ -879,9 +871,7 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			WebSocketUpgrade: true,
 		}
 
-		if !isPublicAuthLevel(entrance.AuthLevel) {
-			customRoute.ExtAuth = buildAppExtAuthConfig(user)
-		}
+		customRoute.ExtAuth = buildAppExtAuthConfig(user)
 
 		routes := buildProbeBypassRoutes(
 			fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -1014,6 +1014,8 @@ func buildExtAuthzFilter(autheliaClusterName string, clusterMap map[string]*ir.C
 var (
 	autheliaAllowedUpstreamHeaders = &matcherv3.ListStringMatcher{
 		Patterns: []*matcherv3.StringMatcher{
+			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "authorization"}},
+			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "proxy-authorization"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "remote-"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "authelia-"}},
 		},


### PR DESCRIPTION

* **Background**
fix(l4): public authlevel also need set ext_auth
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes north-south auth for all entrances labeled public and touches Authelia header forwarding on the edge proxy; misconfiguration could block previously anonymous endpoints or affect token-based flows until apps are adjusted.
> 
> **Overview**
> Bumps **l4-bfl-proxy** to **v0.3.46** in the Olares upgrade path, BFL launcher env (`L4_PROXY_IMAGE_VERSION`), and prebuilt image manifest.
> 
> **Routing / auth behavior:** App default and custom-domain catch-all routes no longer skip Authelia when `authLevel` is **public**—they always set `ExtAuth` via `buildAppExtAuthConfig`, and the `isPublicAuthLevel` helper is removed. Signed webhook probe paths still bypass auth on their dedicated routes.
> 
> **Envoy xDS:** Authelia `ext_authz` now allows **`authorization`** and **`proxy-authorization`** on upstream responses from the auth check (in addition to existing `remote-` / `authelia-` prefixes), so credential-related headers can flow correctly through the verify path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994fe2a5f875f76893cdf359a4751aeaf9897460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->