### PR TITLE
market: serve the installed-app directory to its consumers

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.91
+        image: beclab/market-backend:v0.6.93
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_provider.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_provider.yaml
@@ -30,6 +30,7 @@ rules:
       - "/app-store/api/v2/tasks/*"
       - "/app-store/api/v2/llm-providers"
       - "/app-store/api/v2/llm-providers/*"
+      - "/app-store/api/v2/installed-apps"
     verbs: ["*"]
 
 ---


### PR DESCRIPTION
## Summary

Router turns the `x-caller-appid` header a calling application arrives with into
that application's name, icon and owner. The directory it needs is a projection
of the Application CRs, which an application namespace cannot read for itself,
so [beclab/market#415](https://github.com/beclab/market/pull/415) has the Market
project it — it watches every Application CR already — as
`GET /app-store/api/v2/installed-apps`.

Two lines here are what make that endpoint reachable on a cluster:

- `market_deploy.yaml`: `beclab/market-backend` `v0.6.91` → `v0.6.93`, the first
  tag carrying the endpoint.
- `market_provider.yaml`: the path joins `backend:market-provider`'s
  `nonResourceURLs`.

## Why the second one is not optional

`market-provider-svc:28080` is system-server's provider proxy, not the Market. It
authorizes a request by looking the path up in that ClusterRole before forwarding
anything (the non-resource branch of
`framework/system-server/pkg/permission/v2alpha1/filters.go`), so a path that is
not listed is answered with 403 by the proxy and the Market never sees the
request. Verified on a running cluster, one service account, two paths:

```
/app-store/api/v2/llm-providers  200 [{"app_name":"embeddinggemmav3",...}]
/app-store/api/v2/installed-apps 403 Forbidden (user=system:serviceaccount:router-shared:default, verb=get, resource=market-provider-svc.os-framework:28080)
```

No consumer-side change goes with this. Router's OAC already binds
`backend:market-provider` to its own service account, which is how it reads
`/llm-providers` today.

## Scope

The endpoint is read-only and additive. Nothing that exists today changes
behaviour: `v0.6.93` also carries beclab/market #412 and #413, both of which are
already on that repository's main.

Made with [Cursor](https://cursor.com)