### PR TITLE
fix(cli): pin nvidia container runtime dependencies apt version

### DIFF
--- a/cli/pkg/gpu/tasks.go
+++ b/cli/pkg/gpu/tasks.go
@@ -40,6 +40,15 @@ import (
 // so the two stay in sync.
 const nvidiaContainerdDropIn = "/etc/containerd/conf.d/99-nvidia.toml"
 
+const nvidiaContainerToolkitVersion = "1.19.1-1"
+
+var nvidiaContainerToolkitPackages = []string{
+	"nvidia-container-toolkit",
+	"nvidia-container-toolkit-base",
+	"libnvidia-container-tools",
+	"libnvidia-container1",
+}
+
 type CheckWslGPU struct {
 }
 
@@ -213,7 +222,12 @@ func (t *InstallNvidiaContainerToolkit) Execute(runtime connector.Runtime) error
 		}
 	}
 	logger.Debugf("install nvidia-container-toolkit")
-	if _, err := runtime.GetRunner().SudoCmd("apt-get update && sudo apt-get install -y --allow-downgrades nvidia-container-toolkit=1.19.1-1 nvidia-container-toolkit-base=1.19.1-1 jq", false, true); err != nil {
+	pinned := make([]string, 0, len(nvidiaContainerToolkitPackages))
+	for _, pkg := range nvidiaContainerToolkitPackages {
+		pinned = append(pinned, fmt.Sprintf("%s=%s", pkg, nvidiaContainerToolkitVersion))
+	}
+	cmd := fmt.Sprintf("apt-get update && sudo apt-get install -y --allow-downgrades %s jq", strings.Join(pinned, " "))
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "failed to apt-get install nvidia-container-toolkit")
 	}
 	return nil


### PR DESCRIPTION
* **Background**
Starting from APT 3.x, the dependencies of an APT package should also be pinned to a specific version to avoid conflict or else the APT will refuse to install dependencies.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the GPU toolkit install apt command; same version as before for the main packages, with additional explicit pins for dependencies.
> 
> **Overview**
> **GPU install** now pins every NVIDIA container runtime APT package to **`1.19.1-1`**, not only `nvidia-container-toolkit` and `nvidia-container-toolkit-base`. The list also includes `libnvidia-container-tools` and `libnvidia-container1`, built into the `apt-get install` command from shared constants in `tasks.go`.
> 
> This matches **APT 3.x** behavior where unpinned dependencies can block installs when the top-level packages are version-pinned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769ce309f3a9e89491036207c49508c896a52761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->