### PR TITLE
feat(gpu): add sriov-report mode to control PF/VF advertisement

### DIFF
--- a/cli/pkg/upgrade/1_12_7_20260817.go
+++ b/cli/pkg/upgrade/1_12_7_20260817.go
@@ -1,0 +1,24 @@
+package upgrade
+
+import (
+	"github.com/beclab/Olares/cli/pkg/core/task"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type upgrader_1_12_7_20260817 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260817) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260817")
+}
+
+func (u upgrader_1_12_7_20260817) PrepareForUpgrade() []task.Interface {
+	tasks := upgradeIntelGPUPlugin()
+	return append(tasks, u.upgraderBase.PrepareForUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260817{})
+}

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -720,6 +720,35 @@ func upgradeKubernetesPrometheusRule() []task.Interface {
 	}
 }
 
+// applyIntelGPUPluginAction applies infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
+// (packaged as wizard/config/gpu/intel/gpu-plugin.yaml in the installer).
+type applyIntelGPUPluginAction struct {
+	common.KubeAction
+}
+
+func (a *applyIntelGPUPluginAction) Execute(runtime connector.Runtime) error {
+	kubectlpath, err := util.GetCommand(common.CommandKubectl)
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "kubectl not found")
+	}
+	manifest := path.Join(runtime.GetInstallerDir(), "wizard/config/gpu/intel/gpu-plugin.yaml")
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s apply -f %s", kubectlpath, manifest), false, true); err != nil {
+		return errors.Wrap(errors.WithStack(err), "apply intel gpu-plugin failed")
+	}
+	return nil
+}
+
+func upgradeIntelGPUPlugin() []task.Interface {
+	return []task.Interface{
+		&task.LocalTask{
+			Name:   "ApplyIntelGPUPlugin",
+			Action: new(applyIntelGPUPluginAction),
+			Retry:  5,
+			Delay:  5 * time.Second,
+		},
+	}
+}
+
 func upgradePrometheusOperator() []task.Interface {
 	return []task.Interface{
 		// prometheus operator

--- a/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/intel/gpu-plugin.yaml
@@ -86,6 +86,7 @@ spec:
         - -enable-monitoring
         - -shared-dev-num=50
         - -health-management
+        - -sriov-report=pf
         - -v=4
         env:
         - name: NODE_NAME
@@ -96,7 +97,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: beclab/intel-device-plugin:1.1.1
+        image: beclab/intel-device-plugin:1.1.2
         imagePullPolicy: IfNotPresent
         name: intel-gpu-plugin
         resources:


### PR DESCRIPTION




* **Background**
Allow advertising only the PF while leaving host VFs enabled, so pods can keep a stable renderD node across recreates. Also skip node-register PCI ID failures without dropping the GPU from kubelet.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
https://github.com/beclab/intel-device-plugins-for-kubernetes/pull/3

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes kubelet GPU device advertisement on Intel GPU nodes during upgrade; misconfiguration could affect GPU scheduling until the DaemonSet rolls out successfully.
> 
> **Overview**
> Rolls out an updated **Intel GPU device plugin** for v1.12.7 clusters so SR-IOV-capable nodes advertise only the physical function (PF) to the scheduler while host VFs can stay enabled—aimed at keeping a stable renderD node across pod recreates. The bundled manifest now passes **`-sriov-report=pf`** and bumps **`beclab/intel-device-plugin`** from **1.1.1** to **1.1.2** (behavior aligned with the forked intel-device-plugins change).
> 
> Upgrade path adds an **`ApplyIntelGPUPlugin`** local task (kubectl apply of `wizard/config/gpu/intel/gpu-plugin.yaml`, retried like other apply tasks) and wires it into a new daily upgrader **`1.12.7-20260817`** via **`upgradeIntelGPUPlugin()`** ahead of the standard prepare steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de576aa734f1bf28a0c85ff244d1917b33dd6e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->