### PR TITLE
docs: update Grafana config

### DIFF
--- a/docs/developer/develop/mw-view-grafana-data.md
+++ b/docs/developer/develop/mw-view-grafana-data.md
@@ -8,11 +8,19 @@ head:
 ---
 # Use Grafana dashboards
 
-To visualize system metrics in Olares, you can run Grafana and connect it to the built-in Prometheus service. This guide explains how to install Grafana, connect the data source, and import a standard dashboard.
+To visualize system metrics in Olares, you can run Grafana and connect it to the Prometheus service. This guide explains how to install Prometheus and Grafana, connect the data source, and import a standard dashboard.
+
+## Install Prometheus
+
+Before installing Grafana, install Prometheus from Market. Prometheus collects system metrics for Grafana to visualize.
+
+1. Open Market from Launchpad and search for "Prometheus".
+2. Click **Get**, then **Install**.
+3. Wait for the installation to complete.
 
 ## Install Grafana
 
-Before using Grafana, install it from Market.
+After Prometheus is installed, install Grafana from Market.
 
 1. Open Market from Launchpad and search for "Grafana".
 2. Click **Get**, then **Install**.
@@ -34,15 +42,15 @@ After logging in, you will see the Grafana home page.
 
 ## Add Prometheus data source
 
-Olares runs a built-in Prometheus service that collects system metrics. 
+To connect Grafana to Prometheus, first get the Prometheus API endpoint URL, then add it as a data source in Grafana.
 
-To connect Grafana to this internal service:
+### Get the Prometheus API endpoint URL
 
-1. In the Grafana left navigation pane, go to **Connections** > **Data sources**.
-2. Click **Add data source**, then select **Prometheus**.
-3. For the **Prometheus server URL** field, enter:  
+1. Open Olares **Settings**, and then go to **Applications** > **Prometheus**.
+2. Under **Entrances**, find **Prometheus API**, and then click to open it.
+3. Copy the endpoint URL displayed on the page. For example:
     ```text
-    http://dashboard.<olaresid>.olares.com
+    https://4ae9f19e1.<olaresid>.olares.com
     ```
     Replace `<olaresid>` with your Olares ID.
 4. Click **Save & test** at the bottom of the page. If the connection is successful, you will see the prompt below.
@@ -51,6 +59,7 @@ To connect Grafana to this internal service:
 ## Create a dashboard
 
 This approach is suitable when you need custom metrics and visualizations and are familiar with PromQL.
+
 1. In the left navigation pane, click **Dashboards**.
 2. Click **+ Create dashboard**, then select **+ Add visualization**.
 3. Select **prometheus** as the data source.
@@ -68,4 +77,5 @@ If you do not need to build dashboards from scratch, you can import existing das
 5. Click **Import** to complete the import.
 
 Imported dashboards provide predefined panels and queries and can be customized after import.
+
 ![Imported dashboard](/images/developer/develop/middleware/mw-grafana-dashboard.png#bordered){width=90%}

--- a/docs/developer/develop/mw-view-grafana-data.md
+++ b/docs/developer/develop/mw-view-grafana-data.md
@@ -46,13 +46,24 @@ To connect Grafana to Prometheus, first get the Prometheus API endpoint URL, the
 
 ### Get the Prometheus API endpoint URL
 
-1. Open Olares **Settings**, and then go to **Applications** > **Prometheus**.
-2. Under **Entrances**, find **Prometheus API**, and then click to open it.
-3. Copy the endpoint URL displayed on the page. For example:
+<!--@include: ../../reusables/ai-service-connections.md#app-endpoint-overview-->
+
+For Prometheus:
+
+1. Go to Olares **Settings** > **Applications** > **Prometheus** > **Entrances**.
+2. Select **Prometheus API**, then copy the **Endpoint** URL. For example:
     ```text
     https://4ae9f19e1.<olaresid>.olares.com
     ```
     Replace `<olaresid>` with your Olares ID.
+
+Use this Endpoint as the **Prometheus server URL** in Grafana.
+
+### Configure the data source in Grafana
+
+1. In the Grafana left navigation pane, go to **Connections** > **Data sources**.
+2. Click **Add data source**, then select **Prometheus**.
+3. For the **Prometheus server URL** field, enter the Prometheus API Endpoint you just copied.
 4. Click **Save & test** at the bottom of the page. If the connection is successful, you will see the prompt below.
     ![Successful connection](/images/developer/develop/middleware/mw-grafana-connect.png#bordered){width=90% style="margin-left:0"}
 

--- a/docs/zh/developer/develop/mw-view-grafana-data.md
+++ b/docs/zh/developer/develop/mw-view-grafana-data.md
@@ -8,11 +8,19 @@ head:
 ---
 # 使用 Grafana 查看数据
 
-在 Olares 中，你可以运行 Grafana，并连接到内置的 Prometheus 服务，从而可视化系统指标。本文将介绍如何安装流程，并说明如何连接数据源，以及导入仪表板。
+在 Olares 中，你可以运行 Grafana，并连接到 Prometheus 服务，从而可视化系统指标。本文将介绍如何安装 Prometheus 和 Grafana，并说明如何连接数据源，以及导入仪表板。
+
+## 安装 Prometheus
+
+在安装 Grafana 之前，需要先通过应用市场安装 Prometheus。Prometheus 负责收集系统指标，供 Grafana 可视化使用。
+
+1. 从启动台打开应用市场，搜索“Prometheus”。
+2. 点击**获取**，然后点击**安装**。
+3. 等待安装完成。
 
 ## 安装 Grafana
 
-在使用 Grafana 之前，需要先通过应用市场安装 Grafana。
+Prometheus 安装完成后，再通过应用市场安装 Grafana。
 
 1. 从启动台打开应用市场，搜索“Grafana”。
 2. 点击**获取**，然后点击**安装**。
@@ -34,17 +42,22 @@ head:
 
 ## 添加 Prometheus 数据源
 
-Olares 内置了 Prometheus 服务，可以收集系统指标。
+要将 Grafana 连接到 Prometheus，请先获取 Prometheus API 的端点 URL，再在 Grafana 中添加数据源。
 
-要将 Grafana 连接到该服务，请按以下步骤操作：
+### 获取 Prometheus API 端点 URL
+
+1. 打开 Olares **设置**，然后前往**应用** > **Prometheus**。
+2. 在**入口**下，找到 **Prometheus API**，点击进入
+3. 复制页面上显示的端点 URL, 如
+    ```text
+    https://4ae9f19e1.<olaresid>.olares.com
+    ```
+    将 `<olaresid>` 替换为你的 Olares ID。
+### 在 Grafana 中配置数据源
 
 1. 在 Grafana 左侧导航栏中，进入**连接** > **数据源**。
 2. 点击**添加数据源**，然后选择 **Prometheus**。
-3. 在 **Prometheus server URL** 字段输入：  
-    ```text
-    http://dashboard.<olaresid>.olares.com
-    ```
-    将 `<olaresid>` 替换为你的 Olares ID。
+3. 在 **Prometheus server URL** 字段中，输入你刚才复制的 Prometheus API 端点 URL。
 4. 点击页面底部的**保存并测试**。如果连接成功，你将看到如下提示。
 
     ![连接成功](/images/zh/manual/developer/mw-grafana-connect.png#bordered){width=90% style="margin-left:0"}

--- a/docs/zh/developer/develop/mw-view-grafana-data.md
+++ b/docs/zh/developer/develop/mw-view-grafana-data.md
@@ -46,13 +46,19 @@ Prometheus 安装完成后，再通过应用市场安装 Grafana。
 
 ### 获取 Prometheus API 端点 URL
 
-1. 打开 Olares **设置**，然后前往**应用** > **Prometheus**。
-2. 在**入口**下，找到 **Prometheus API**，点击进入
-3. 复制页面上显示的端点 URL, 如
+<!--@include: ../../reusables/ai-service-connections.md#app-endpoint-overview-->
+
+对于 Prometheus：
+
+1. 前往 Olares **Settings** > **Applications** > **Prometheus** > **Entrances**。
+2. 选择 **Prometheus API**，然后复制 **Endpoint** URL。例如：
     ```text
     https://4ae9f19e1.<olaresid>.olares.com
     ```
     将 `<olaresid>` 替换为你的 Olares ID。
+
+在 Grafana 中，将该 Endpoint 用作 **Prometheus server URL**。
+
 ### 在 Grafana 中配置数据源
 
 1. 在 Grafana 左侧导航栏中，进入**连接** > **数据源**。


### PR DESCRIPTION
* **Background**
provider is removed in 1.12.6 and grafana cannot connect directly to dashboard.
this docs fix the config by using the Prometheus client api url as the data source

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to developer guides; no application code or runtime behavior is modified.
> 
> **Overview**
> Updates the **English and Chinese** Grafana guides so they match Olares **1.12.6**, where Grafana can no longer use the old `dashboard` URL as a Prometheus data source after the provider change.
> 
> The flow now treats Prometheus as a **Market app**: add an **Install Prometheus** section before Grafana, then document copying the **Prometheus API** endpoint from **Settings → Applications → Prometheus → Entrances** (with the shared `app-endpoint-overview` include) instead of `http://dashboard.<olaresid>.olares.com`. The **Add Prometheus data source** section is split into **get the endpoint** and **configure in Grafana**, using an `https://…<olaresid>.olares.com` example URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa2787f6195c587905310c99811e116d856a06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->