### PR TITLE
fix(app-service,bfl): clear stale SSH ACL when VPN SSH toggle is disabled

### DIFF
--- a/framework/app-service/controllers/tailscale_acl_controller.go
+++ b/framework/app-service/controllers/tailscale_acl_controller.go
@@ -233,11 +233,9 @@ func (r *TailScaleACLController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	// If no ACLs need to be applied there is no need to update.
-	if len(acls) == 0 {
-		return ctrl.Result{}, nil
-	}
-
+	// Always rebuild acl.json from app ACLs + defaults. An empty app ACL
+	// set must still rewrite the ConfigMap so stale entries (e.g. *:22 left
+	// behind after "Allow SSH over VPN" is disabled) are cleared.
 	aclPolicyByte, err := makeACLPolicy(acls)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/framework/bfl/pkg/apis/settings/v1alpha1/handle_headscale.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/handle_headscale.go
@@ -11,7 +11,6 @@ import (
 	"bytetrade.io/web3os/bfl/pkg/api/response"
 	v1alpha1client "bytetrade.io/web3os/bfl/pkg/client/clientset/v1alpha1"
 	"bytetrade.io/web3os/bfl/pkg/constants"
-	"bytetrade.io/web3os/bfl/pkg/utils"
 
 	appv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	appclientset "github.com/beclab/api/pkg/generated/clientset/versioned"
@@ -75,20 +74,7 @@ func (h *Handler) handleGetHeadscaleSshAcl(req *restful.Request, resp *restful.R
 	}
 
 	// get headscale acl env
-	allowSSH := false
-	for _, acl := range app.Spec.TailScale.ACLs {
-		if utils.ListContains(acl.Dst, "*:22") && strings.ToLower(acl.Proto) == "tcp" {
-			allowSSH = true
-			break
-		}
-	}
-
-	for _, acl := range app.Spec.TailScaleACLs {
-		if utils.ListContains(acl.Dst, "*:22") && strings.ToLower(acl.Proto) == "tcp" {
-			allowSSH = true
-			break
-		}
-	}
+	allowSSH := hasTCPSSHACL(app.Spec.TailScale.ACLs) || hasTCPSSHACL(app.Spec.TailScaleACLs)
 
 	response.Success(resp, SshAcl{AllowSSH: allowSSH, State: AclStateApplied})
 }
@@ -99,15 +85,7 @@ func (h *Handler) handleDisableHeadscaleSshAcl(req *restful.Request, resp *restf
 		response.HandleError(resp, err)
 		return
 	}
-	acls := make([]appv1.ACL, 0)
-	for _, acl := range app.Spec.TailScale.ACLs {
-		if acl.Dst[0] == "*:22" {
-			continue
-		}
-		acls = append(acls, acl)
-	}
-
-	h.setHeadscaleAcl(req, resp, systemAppName, acls)
+	h.setHeadscaleAcl(req, resp, systemAppName, disableTCPSSHACL(app.Spec.TailScale.ACLs))
 }
 
 func (h *Handler) handleEnableHeadscaleSshAcl(req *restful.Request, resp *restful.Response) {
@@ -116,9 +94,7 @@ func (h *Handler) handleEnableHeadscaleSshAcl(req *restful.Request, resp *restfu
 		response.HandleError(resp, err)
 		return
 	}
-	acls := app.Spec.TailScale.ACLs
-	acls = append(acls, appv1.ACL{Proto: "tcp", Dst: []string{"*:22"}})
-	h.setHeadscaleAcl(req, resp, systemAppName, acls)
+	h.setHeadscaleAcl(req, resp, systemAppName, enableTCPSSHACL(app.Spec.TailScale.ACLs))
 }
 
 // app's acl

--- a/framework/bfl/pkg/apis/settings/v1alpha1/headscale_acl_helpers.go
+++ b/framework/bfl/pkg/apis/settings/v1alpha1/headscale_acl_helpers.go
@@ -46,6 +46,65 @@ func CheckTailScaleACLs(acls []appv1.ACL) error {
 	return nil
 }
 
+const sshACLDst = "*:22"
+
+// hasTCPSSHACL reports whether acls already contain the SSH allow rule
+// (tcp *:22) that Settings -> VPN -> Allow SSH manages.
+func hasTCPSSHACL(acls []appv1.ACL) bool {
+	for _, acl := range acls {
+		if strings.ToLower(acl.Proto) != "tcp" {
+			continue
+		}
+		for _, dst := range acl.Dst {
+			if dst == sshACLDst {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enableTCPSSHACL appends tcp *:22 when missing. Idempotent — repeated
+// enables do not create duplicate entries (duplicates break the ACL
+// editor via isPortDuplicate).
+func enableTCPSSHACL(acls []appv1.ACL) []appv1.ACL {
+	if hasTCPSSHACL(acls) {
+		out := make([]appv1.ACL, len(acls))
+		copy(out, acls)
+		return out
+	}
+	out := make([]appv1.ACL, 0, len(acls)+1)
+	out = append(out, acls...)
+	return append(out, appv1.ACL{Proto: "tcp", Dst: []string{sshACLDst}})
+}
+
+// disableTCPSSHACL removes *:22 from tcp ACL entries. Entries whose dst
+// list empties out are dropped. Non-tcp rules (including udp *:22) and
+// other destinations on the same entry are preserved. Safe when Dst is
+// empty (unlike the previous Dst[0] index).
+func disableTCPSSHACL(acls []appv1.ACL) []appv1.ACL {
+	out := make([]appv1.ACL, 0, len(acls))
+	for _, acl := range acls {
+		if strings.ToLower(acl.Proto) != "tcp" {
+			out = append(out, acl)
+			continue
+		}
+		kept := make([]string, 0, len(acl.Dst))
+		for _, dst := range acl.Dst {
+			if dst == sshACLDst {
+				continue
+			}
+			kept = append(kept, dst)
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		acl.Dst = kept
+		out = append(out, acl)
+	}
+	return out
+}
+
 func parseProtocol(protocol string) error {
 	if ACLProto.Has(protocol) {
 		return nil


### PR DESCRIPTION
* **Background**

Always rewrite tailscale-acl ConfigMap from app ACLs + defaults so an empty ACL set drops leftover *:22. Make SSH enable/disable idempotent and match only tcp *:22.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VPN firewall policy propagation and SSH ACL mutation paths; incorrect behavior could leave SSH open or break ACL editing, but scope is limited to tailscale ACL reconciliation and settings handlers.
> 
> **Overview**
> Fixes VPN **Allow SSH** leaving `tcp *:22` in the tailscale ACL ConfigMap after the toggle is turned off.
> 
> **app-service:** The tailscale ACL reconciler no longer skips updates when there are no app ACLs; it always rebuilds `acl.json` from current app rules plus defaults so removed rules (including SSH) are not left in the ConfigMap.
> 
> **bfl settings API:** SSH enable/disable/read now go through shared helpers that only manage **`tcp *:22`**: detection scans all destinations (not just the first), enable is idempotent (avoids duplicate rules that break the ACL editor), and disable strips `*:22` from TCP entries without dropping other protocols or destinations on the same rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f411a6ed00d076b5ec84b2f9a9548ac91c6174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->