### PR TITLE
fix(app-service,bfl): clear stale SSH ACL when VPN SSH toggle is disabled

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.27
+        image: beclab/app-service:0.6.28
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/apiserver/handler_settings.go
+++ b/framework/app-service/pkg/apiserver/handler_settings.go
@@ -712,6 +712,11 @@ func (h *Handler) setupAppAuthLevel(req *restful.Request, resp *restful.Response
 		return
 	}
 
+	if app.Spec.Name == constants.OLARES_APP_NAME {
+		api.HandleBadRequest(resp, req, fmt.Errorf("auth level cannot be set for system app %s", constants.OLARES_APP_NAME))
+		return
+	}
+
 	entranceName := req.PathParameter(ParamEntranceName)
 
 	bodyData, err := ioutil.ReadAll(req.Request.Body)

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -265,7 +265,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.4.51
+        image: beclab/bfl:v0.4.52
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION


* **Background**
clear stale SSH ACL when VPN SSH toggle is disabled
disallow setting auth level for olares-app
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization-level API behavior for a system app and ships new app-service/BFL images that may affect VPN SSH ACL state; scope is small in-repo but runtime impact is security-adjacent.
> 
> **Overview**
> **app-service** rejects entrance **authorization level** updates for the system app **`olares-app`**: `setupAppAuthLevel` returns a bad request before applying patches, so callers cannot change auth level on that app.
> 
> Deploy manifests bump **`beclab/app-service`** to **0.6.28** and **`beclab/bfl`** to **v0.4.52** (per release notes, the BFL build includes clearing stale VPN SSH ACL when the SSH toggle is turned off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae101d67241ff9a5ef5b8329ad221a732f8b3534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->