### PR TITLE
fix(download-server): machine-readable error contract, create idempotency, and torrent file_type fix

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.12"
+        image: "beclab/download-server:v1.0.13"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Stable error_code on every download error envelope. file_remove used to fail with a text/plain 500 because its route came from the Hertz IDL; it was pulled out of download.thrift and re-registered by hand in router.go, and all download routes now emit a JSON envelope with one of six stable codes .
Short-window Idempotency-Key on create. An in-memory (username, key) -> task_id map with a 24h TTL collapses a timed-out request's retry. Deliberately does not change the existing semantics that a user re-submitting the same URL gets a new task.
An uploaded torrent blob now counts as file_type evidence. --torrent <file> on the CLI omits the URL, so inferFileType returned "" and every file_type-gated torrent capability silently skipped the row: the LarePass/Wise seed-control icons, the torrent live-stats / peers / seed stop-resume routes (404 via resolveTorrentTask), and aria2's per-download unlimited seed-ratio. The UI path never hit this because its .torrent picker synthesises a magnet URL first.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in a DaemonSet with no config or RBAC changes; risk is limited to whatever is in the new image at deploy time.
> 
> **Overview**
> **Rolls out `beclab/download-server:v1.0.13`** on the download DaemonSet by updating the `download-server` container image tag from **v1.0.12** in `download_deploy.yaml`. No other manifest fields change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2271c218f70108004036f61c69a23d42929129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->