### PR TITLE
fix(app-gateway): skip Linkerd inbound capture of TCP 3389

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
@@ -312,7 +312,7 @@ data:
       waitBeforeExitSeconds: 0
     proxyInit:
       closeWaitTimeoutSecs: 0
-      ignoreInboundPorts: 4567,4568
+      ignoreInboundPorts: 3389,4567,4568
       ignoreOutboundPorts: 4567,4568
       iptablesMode: nft
       kubeAPIServerPorts: 443,6443
@@ -1199,7 +1199,7 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - "4190,4191,4567,4568"
+        - "3389,4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
         image: cr.l5d.io/linkerd/proxy:edge-26.5.1
@@ -1544,7 +1544,7 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - "4190,4191,4567,4568"
+        - "3389,4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
         image: cr.l5d.io/linkerd/proxy:edge-26.5.1
@@ -1892,7 +1892,7 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - "4190,4191,4567,4568"
+        - "3389,4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
         image: cr.l5d.io/linkerd/proxy:edge-26.5.1


### PR DESCRIPTION
Inbound TCP 3389 was redirected to Linkerd before dockurr DNAT, so RDP never reached the guest; add 3389 to proxyInit.ignoreInboundPorts for all meshed pods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e015b87e6558364d3a2f0ea391c04e84e1cedd57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->