### PR TITLE
feat(app-service): tighten shared-entrance NetworkPolicy

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -171,7 +171,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.28
+        image: beclab/app-service:0.6.29
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -490,33 +490,21 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 		} else if scope, ok := ns.Labels[constants.AppSharedLabel]; ok && scope == constants.AppSharedTrue {
 			// Shared-app namespace.
 			//
-			// Emits exactly 4 NetworkPolicies into <app>-shared:
-			//   - app-np            (main, from NPAppSpace template; npFix
-			//                       below rewrites the owner placeholder for
-			//                       the user-internal peer AND drops the
-			//                       owner constraint on the user-space-bfl
-			//                       peer so ANY user's BFL can dial
-			//                       the shared app — shared apps are open to
-			//                       all users.)
-			//   - shared-np         (from NPSharedSpace; the template has no
-			//                       default Name, so we set it explicitly
-			//                       before handing it to Additional())
-			//   - system-provider-np (fixed name on the template)
-			//   - shared-entrance-np (fixed name on the template)
+			// Emits exactly 4 NetworkPolicies into <app>-shared via
+			// SharedNamespacePolicies: app-np / shared-np exclude
+			// shared-entrance pods so remaining OR policies cannot reopen
+			// ClusterIP bypass; system-provider-np and shared-entrance-np
+			// keep their own selectors. npFix below still rewrites the
+			// owner placeholder on app-np (main only) and drops the owner
+			// constraint on the user-space-bfl peer so any user's BFL can
+			// dial non-entrance pods.
 			//
 			// Putting this branch ABOVE the generic ns-owner branch is
 			// intentional: V3 namespaces also carry ns-owner (so npFix has
 			// an admin to fill in), and without this priority they would
 			// otherwise be served by the v1/v2 app-np branch and miss the
 			// other three policies.
-			sharedSpace := security.NPSharedSpace.DeepCopy()
-			sharedSpace.Name = "shared-np"
-			networkPolicy = security.NetworkPolicies{
-				security.NPAppSpace.DeepCopy(),
-				sharedSpace,
-				security.NPSystemProvider.DeepCopy(),
-				security.NPSharedEntrance.DeepCopy(),
-			}
+			networkPolicy = security.SharedNamespacePolicies()
 			networkPolicy.SetName("app-np")
 			networkPolicy.SetNamespace(ns.Name)
 			npFix = func(np *netv1.NetworkPolicy) {

--- a/framework/app-service/pkg/security/shared_entrance_np.go
+++ b/framework/app-service/pkg/security/shared_entrance_np.go
@@ -1,0 +1,73 @@
+package security
+
+import (
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// L4ProxyNamespace hosts the single l4-bfl-proxy replica.
+	L4ProxyNamespace = "os-network"
+	// L4ProxyAppLabel is the app= label on l4-bfl-proxy pods.
+	L4ProxyAppLabel = "l4-bfl-proxy"
+)
+
+// SharedEntranceOSNamespaces is the frozen allow-list of platform namespaces
+// whose pods may reach Shared entrance ClusterIPs. kubernetes namespaceSelector
+// cannot match a name prefix, so new os-* namespaces must be added here.
+var SharedEntranceOSNamespaces = []string{
+	"os-framework",
+	"os-platform",
+	"os-network",
+	"os-gateway",
+	"os-mesh",
+	"os-protected",
+	"os-gpu",
+}
+
+// ExcludeSharedEntrancePods appends a NotIn expression so the selector
+// no longer matches pods labeled shared-entrance=true. Used only on the
+// Shared-namespace copies of app-np / shared-np; the package-level
+// NPAppSpace / NPSharedSpace templates stay unchanged.
+func ExcludeSharedEntrancePods(sel *metav1.LabelSelector) {
+	if sel == nil {
+		return
+	}
+	if hasSharedEntranceNotIn(sel) {
+		return
+	}
+	sel.MatchExpressions = append(sel.MatchExpressions, metav1.LabelSelectorRequirement{
+		Key:      constants.AppSharedEntrancesLabel,
+		Operator: metav1.LabelSelectorOpNotIn,
+		Values:   []string{"true"},
+	})
+}
+
+func hasSharedEntranceNotIn(sel *metav1.LabelSelector) bool {
+	for _, expr := range sel.MatchExpressions {
+		if expr.Key == constants.AppSharedEntrancesLabel && expr.Operator == metav1.LabelSelectorOpNotIn {
+			return true
+		}
+	}
+	return false
+}
+
+// SharedNamespacePolicies returns the four NetworkPolicies emitted into a
+// Shared app namespace. app-np and shared-np exclude entrance pods so the
+// remaining OR policies cannot reopen ClusterIP bypass.
+func SharedNamespacePolicies() NetworkPolicies {
+	appSpace := NPAppSpace.DeepCopy()
+	ExcludeSharedEntrancePods(&appSpace.Spec.PodSelector)
+
+	sharedSpace := NPSharedSpace.DeepCopy()
+	sharedSpace.Name = "shared-np"
+	ExcludeSharedEntrancePods(&sharedSpace.Spec.PodSelector)
+
+	return NetworkPolicies{
+		appSpace,
+		sharedSpace,
+		NPSystemProvider.DeepCopy(),
+		NPSharedEntrance.DeepCopy(),
+	}
+}

--- a/framework/app-service/pkg/security/shared_entrance_np_test.go
+++ b/framework/app-service/pkg/security/shared_entrance_np_test.go
@@ -1,0 +1,176 @@
+package security
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSharedEntranceOSNamespacesFrozen(t *testing.T) {
+	want := []string{
+		"os-framework",
+		"os-platform",
+		"os-network",
+		"os-gateway",
+		"os-mesh",
+		"os-protected",
+		"os-gpu",
+	}
+	if !reflect.DeepEqual(SharedEntranceOSNamespaces, want) {
+		t.Fatalf("SharedEntranceOSNamespaces=%v, want %v", SharedEntranceOSNamespaces, want)
+	}
+	if slices.Contains(SharedEntranceOSNamespaces, "os-mesh-viz") {
+		t.Fatal("os-mesh-viz must not be in the os-* allow-list")
+	}
+}
+
+func TestExcludeSharedEntrancePodsNil(t *testing.T) {
+	ExcludeSharedEntrancePods(nil)
+}
+
+func TestExcludeSharedEntrancePodsIdempotent(t *testing.T) {
+	sel := &metav1.LabelSelector{}
+	ExcludeSharedEntrancePods(sel)
+	ExcludeSharedEntrancePods(sel)
+	if !hasSharedEntranceNotIn(sel) {
+		t.Fatal("expected NotIn shared-entrance after exclude")
+	}
+	if n := countSharedEntranceNotIn(sel); n != 1 {
+		t.Fatalf("expected one NotIn expression, got %d", n)
+	}
+}
+
+func TestNPAppSpaceTemplateUnchanged(t *testing.T) {
+	if hasSharedEntranceNotIn(&NPAppSpace.Spec.PodSelector) {
+		t.Fatal("NPAppSpace package template must stay empty (regular app NS)")
+	}
+	if hasSharedEntranceNotIn(&NPSharedSpace.Spec.PodSelector) {
+		t.Fatal("NPSharedSpace package template must stay empty")
+	}
+	_ = SharedNamespacePolicies()
+	if hasSharedEntranceNotIn(&NPAppSpace.Spec.PodSelector) {
+		t.Fatal("SharedNamespacePolicies mutated NPAppSpace template")
+	}
+	if hasSharedEntranceNotIn(&NPSharedSpace.Spec.PodSelector) {
+		t.Fatal("SharedNamespacePolicies mutated NPSharedSpace template")
+	}
+}
+
+func TestNPSharedEntranceAllowList(t *testing.T) {
+	np := NPSharedEntrance
+	if got := np.Spec.PodSelector.MatchLabels[constants.AppSharedEntrancesLabel]; got != "true" {
+		t.Fatalf("podSelector shared-entrance=%q, want true", got)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != netv1.PolicyTypeIngress {
+		t.Fatalf("policyTypes=%v, want [Ingress]", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("ingress rules=%d, want 1", len(np.Spec.Ingress))
+	}
+	from := np.Spec.Ingress[0].From
+	if len(from) != 3 {
+		t.Fatalf("from peers=%d, want 3", len(from))
+	}
+	for i, peer := range from {
+		if peer.IPBlock != nil {
+			t.Fatalf("peer%d must not set IPBlock, got %+v", i, peer.IPBlock)
+		}
+	}
+
+	if from[0].PodSelector == nil || from[0].NamespaceSelector != nil {
+		t.Fatalf("peer0 should be same-NS empty podSelector, got %+v", from[0])
+	}
+	if len(from[0].PodSelector.MatchLabels) != 0 || len(from[0].PodSelector.MatchExpressions) != 0 {
+		t.Fatalf("peer0 podSelector must be empty, got %+v", from[0].PodSelector)
+	}
+
+	nsSel := from[1].NamespaceSelector
+	if nsSel == nil || from[1].PodSelector != nil {
+		t.Fatalf("peer1 should be os-* namespaceSelector only, got %+v", from[1])
+	}
+	if len(nsSel.MatchExpressions) != 1 {
+		t.Fatalf("peer1 matchExpressions=%d, want 1", len(nsSel.MatchExpressions))
+	}
+	expr := nsSel.MatchExpressions[0]
+	if expr.Key != "kubernetes.io/metadata.name" || expr.Operator != metav1.LabelSelectorOpIn {
+		t.Fatalf("peer1 expression key/op = %s %s", expr.Key, expr.Operator)
+	}
+	if !reflect.DeepEqual(expr.Values, SharedEntranceOSNamespaces) {
+		t.Fatalf("peer1 In values=%v, want %v", expr.Values, SharedEntranceOSNamespaces)
+	}
+	if slices.Contains(expr.Values, "os-mesh-viz") {
+		t.Fatal("peer1 must not include os-mesh-viz")
+	}
+
+	if from[2].NamespaceSelector == nil || from[2].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != L4ProxyNamespace {
+		t.Fatalf("peer2 ns should be %s, got %+v", L4ProxyNamespace, from[2])
+	}
+	if from[2].PodSelector == nil || from[2].PodSelector.MatchLabels["app"] != L4ProxyAppLabel {
+		t.Fatalf("peer2 pod should be app=%s, got %+v", L4ProxyAppLabel, from[2].PodSelector)
+	}
+	if isEmptyIngressRule(np.Spec.Ingress[0]) {
+		t.Fatal("shared-entrance-np must not use empty {} allow-all")
+	}
+}
+
+func TestSharedNamespacePoliciesExcludeEntrance(t *testing.T) {
+	nps := SharedNamespacePolicies()
+	if len(nps) != 4 {
+		t.Fatalf("policies=%d, want 4", len(nps))
+	}
+	appNP := nps.Main()
+	if appNP == nil {
+		t.Fatal("missing app-np main")
+	}
+	if !hasSharedEntranceNotIn(&appNP.Spec.PodSelector) {
+		t.Fatal("app-np copy must exclude shared-entrance")
+	}
+
+	var sharedNP, providerNP, entranceNP *netv1.NetworkPolicy
+	for _, np := range nps.Additional() {
+		switch np.Name {
+		case "shared-np":
+			sharedNP = np
+		case "system-provider-np":
+			providerNP = np
+		case "shared-entrance-np":
+			entranceNP = np
+		}
+	}
+	if sharedNP == nil || !hasSharedEntranceNotIn(&sharedNP.Spec.PodSelector) {
+		t.Fatal("shared-np copy must exclude shared-entrance")
+	}
+	if providerNP == nil || hasSharedEntranceNotIn(&providerNP.Spec.PodSelector) {
+		t.Fatal("system-provider-np must not get the entrance exclude")
+	}
+	if entranceNP == nil {
+		t.Fatal("missing shared-entrance-np")
+	}
+	if isEmptyIngressRule(entranceNP.Spec.Ingress[0]) {
+		t.Fatal("shared-entrance-np must keep the tightened From list")
+	}
+	for i, peer := range entranceNP.Spec.Ingress[0].From {
+		if peer.IPBlock != nil {
+			t.Fatalf("entrance peer%d must not set IPBlock, got %+v", i, peer.IPBlock)
+		}
+	}
+}
+
+func countSharedEntranceNotIn(sel *metav1.LabelSelector) int {
+	n := 0
+	for _, expr := range sel.MatchExpressions {
+		if expr.Key == constants.AppSharedEntrancesLabel && expr.Operator == metav1.LabelSelectorOpNotIn {
+			n++
+		}
+	}
+	return n
+}
+
+func isEmptyIngressRule(rule netv1.NetworkPolicyIngressRule) bool {
+	return len(rule.From) == 0 && len(rule.Ports) == 0
+}

--- a/framework/app-service/pkg/security/templates.go
+++ b/framework/app-service/pkg/security/templates.go
@@ -523,19 +523,40 @@ var (
 					constants.AppSharedEntrancesLabel: "true",
 				},
 			},
+			PolicyTypes: []netv1.PolicyType{
+				netv1.PolicyTypeIngress,
+			},
 			Ingress: []netv1.NetworkPolicyIngressRule{
-				{},
-				// {
-				// 	From: []netv1.NetworkPolicyPeer{
-				// 		{
-				// 			NamespaceSelector: &metav1.LabelSelector{
-				// 				MatchLabels: map[string]string{
-				// 					NamespaceSharedLabel: "true",
-				// 				},
-				// 			},
-				// 		},
-				// 	},
-				// },
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "kubernetes.io/metadata.name",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   SharedEntranceOSNamespaces,
+									},
+								},
+							},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": L4ProxyNamespace,
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": L4ProxyAppLabel,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	} // end NPSharedEntrance


### PR DESCRIPTION
Tighten Shared entrance NetworkPolicy so tenant pods cannot hit the entrance Service in-cluster.
Allow only: same namespace, seven listed `os-*` namespaces, and L4 (`app=l4-bfl-proxy`). No ipBlock.
Ship `beclab/app-service:0.6.29`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cluster network isolation for shared-app entrance Services; misconfigured allow-lists or selectors could block platform/L4 traffic or leave unintended in-cluster access paths.
> 
> **Overview**
> **Tightens in-cluster access to shared-app entrance pods** so tenant workloads can no longer reach those ClusterIPs through permissive catch-all rules.
> 
> `shared-entrance-np` replaces the empty ingress allow-all with **ingress-only** peers: same namespace, a **fixed list of seven `os-*` platform namespaces**, and **`l4-bfl-proxy` in `os-network`** (no `ipBlock`). Shared V3 namespaces now build their four policies via **`SharedNamespacePolicies()`**, which adds a **`shared-entrance=true` NotIn** pod selector on **`app-np` and `shared-np` copies only**, so broader OR policies do not still apply to entrance pods.
> 
> Ships **`beclab/app-service:0.6.29`** with unit tests locking the allow-list and selector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e511e266cb2dc75614897066face7076df54c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->