### PR TITLE
chore: bump system-frontend to v1.11.31, user-service to v0.1.15 and notifications-api to v1.12.46

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.29
+          image: beclab/system-frontend:v1.11.31
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -365,7 +365,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.13
+          image: beclab/user-service:v0.1.15
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -146,7 +146,7 @@ spec:
             value: os_framework_notifications
       containers:
       - name: notifications-api
-        image: beclab/notifications-api:v1.12.45
+        image: beclab/notifications-api:v1.12.46
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3010


### PR DESCRIPTION
* **Background**

  This PR bumps three images shipped by Olares so that the v1.12.7 release picks up the latest TermiPass, user-service and notifications changes. It is a chart/manifest-only change: no Olares-side logic is touched, only image tags.

  Image changes:

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.29` | `beclab/system-frontend:v1.11.31` |
  | `apps/.olares/.../system-apps` | `user-service` | `beclab/user-service:v0.1.13` | `beclab/user-service:v0.1.15` |
  | `framework/notifications/.olares/.../notification_deploy.yaml` | `notifications-api` | `beclab/notifications-api:v1.12.45` | `beclab/notifications-api:v1.12.46` |

  The `wizard` and `login` images stay on `v1.11.28`. Everything in the TermiPass `v1.11.30`/`v1.11.31` range lives in the Market, Settings and LarePass bundles and does not affect the activation or login bundles.

  **What the new `system-frontend` image contains**

  1. **Multi-source taxonomy storefronts in Market** (TermiPass [#1350](https://github.com/beclab/TermiPass/pull/1350)). The Market frontend now renders the new source taxonomy — categories, tags, curated topic pages, and the `Newest` / `Hottest` blocks — in both the cluster build and the public build. It adds source switching with locale-scoped SWR and detail caches, app-id based detail lookup, and wire compatibility with both the new and the legacy Market responses so the rollout can be staged. The public build is isolated from cluster-only routes and chart operations, and stale or unsupported catalogs are surfaced to the user instead of failing silently. The legacy `All` and topic field spellings are preserved for the duration of the coordinated rollout. This is the frontend half of a cross-repo change whose server-side pieces are already merged: OAC v2 taxonomy validation ([Olares #3940](https://github.com/beclab/Olares/pull/3940)), the watermark-based multi-source taxonomy sync in the Market backend ([market #411](https://github.com/beclab/market/pull/411)), and the source API ([Above-Os/source #10](https://github.com/Above-Os/source/pull/10)), so shipping this image completes the rollout order.
  2. **Stopped apps can be updated from the updates list** (TermiPass [#1357](https://github.com/beclab/TermiPass/pull/1357)). The available-updates page listed stopped apps but gave no way to update them: `isUpgradable` treats `stopped` as upgradable so those apps entered the update list, while `InstallButton` required `state === RUNNING` for its `update` action, so a stopped card fell through to a `stopCompleted` label with no handler. The only working path was `Update all` at the top of the page, which calls `upgradeApp` directly. `InstallButton` now takes an `isUpdate` prop, and inside the updates list the update action wins over the stopped state label — everywhere else (My Apps, app detail, the various card variants) the state keeps priority and the update stays in the dropdown.
  3. **Olares Download is gated on OS >= 1.12.7 and fully localized** (TermiPass [#1359](https://github.com/beclab/TermiPass/pull/1359)). On 1.12.6 the download-server does not exist, so the cloud sidebar entry, the `Save to Olares` action and the download settings are hidden, and the LarePass clouder skips `/download/sync` until the OS becomes eligible. The whole download workflow is now translated for de, es, fr, it and ja at full parity with en-US (205 `download.*` keys covering add-task parsing, Hugging Face options, torrent panels, details, tooltips, seeding, errors, settings and remove confirmations), with regression tests for key parity and interpolation. It also fixes localized error presentation in the detail panel, renames the misspelled `transmission.transfering` key, and avoids a transfer-boot circular-import crash by deferring the first poll tick.
  4. **`#HttpOnly_` cookies survive a `cookies.txt` import** (TermiPass [#1366](https://github.com/beclab/TermiPass/pull/1366)). Netscape marks httpOnly cookies with a `#HttpOnly_` domain prefix, which the parser treated as a comment and dropped — so YouTube login cookies (`SID`, `HSID`, `__Secure-3PSID`, …) could silently disappear from an otherwise successful import, which in turn breaks authenticated downloads. Those records are now kept, the prefix is stripped from the stored domain, and `httpOnly: true` is recorded.
  5. **Search keyboard navigation can scroll back to the top** (TermiPass [#1363](https://github.com/beclab/TermiPass/pull/1363)). Arrow-key navigation used `scrollIntoView({ block: 'nearest' })`, so the group header above the first row and the list's top padding never became visible and the list looked stuck. Scroll offsets are now computed against the container and clamped to zero, the active row is tracked by index rather than by a `title + type` string (which selected the wrong row for duplicate titles), row refs are registered per index, grouping moved into a computed, and arrow keys call `preventDefault` so they no longer move the caret in the search input.
  6. **The hosts help tooltip wraps** (TermiPass [#1362](https://github.com/beclab/TermiPass/pull/1362)). The tooltip in the `Edit local service domain` dialog relied on a class no stylesheet defined, so it fell back to Quasar's unconstrained default and overflowed the dialog. It now uses the `max-width` prop like the other help tooltips.

  The `v1.11.29...v1.11.31` range also contains LarePass desktop-only fixes (vault read-only detail items, the stacked launch-hint dialog, the macOS universal build merge, and Linux quit/orphan handling) and two dependency-advisory sweeps; they ride along in the tag range but do not change the web bundle shipped by this image.

  **What the new `user-service` image contains**

  1. **The cookie cache is restored independently of account recovery** (user-service [#102](https://github.com/beclab/user-service/pull/102)). The in-memory cookie cache was rebuilt in `AccountService.onModuleInit`, in a loop that ran after the integration-account restore loop. That loop had no per-item guard, so a single unparseable or unknown-type `integration-account:` secret threw out of `onModuleInit` and the cookie restore never ran. `GET /api/cookie/all` then returned an empty array even though the secrets were still in Infisical, so the Settings cookie page showed no cookies; worse, `updateCookie` picks `CreateSecret` vs `UpdateSecret` from that in-memory view, so with an empty cache it took the `create` branch for an already-existing name, which Infisical rejects — locking that domain out of further updates. The restore now lives in `SecretService.onModuleInit` next to the cache, both restore loops are guarded per item, and `CreateSecret` falls back to `UpdateSecret` on an existing name.
  2. **`@bytetrade/core` dropped and all Dependabot advisories cleared** (user-service [#103](https://github.com/beclab/user-service/pull/103)). The package is unmaintained; the subset the service actually uses (result helpers, notification types, intent interfaces, the SSI encoder, device/search/secret/backup helpers) is vendored into `src/core` and every import switched to a relative path. On the dependency side, 135 open alerts across 43 unique packages are cleared: unused `bcrypt` is removed (the only path to the critical `tar` advisory), Nest is bumped to 11.2.1, `axios` to ^1.19.0, `nodemailer` to ^9.0.5, `uuid` to ^11.1.1 and `webpack` to ^5.104.1, `@nestjs/common` is made an explicit dependency, `@nestjs/schematics` is pinned to 11.0.9 (later 11.x declares an optional peer on `prettier@^3` and breaks `npm ci` in the Docker build), and the remaining transitive advisories are pinned through per-major `overrides`. `npm audit` now reports 0 vulnerabilities. No behaviour change is intended, but the `axios` 0.x→1.x, `nodemailer` 7→9 and `uuid` 9→11 majors are worth watching on outbound HTTP and SMTP after this rolls out.

  **What the new `notifications-api` image contains**

  1. **`@bytetrade/core` dropped and all Dependabot advisories cleared** (notifications [#25](https://github.com/beclab/notifications/pull/25)). The same maintenance as above, scoped to this service: the `Result` helpers, `autoFuncWithRetry` and the `MessageTopic` enum are vendored into `src/core`, and the jest stub that used to fake the package was deleted so the tests exercise the real code. Unused `bcrypt` and `uuid` are removed, Nest is bumped to 11.2.1, `axios` to ^1.19.0 and `webpack` to ^5.104.1, `@nestjs/common` is added explicitly, `@nestjs/schematics` is pinned to 11.0.9, and the rest is pinned through per-major `overrides`. This clears all 93 advisories (1 critical, 47 high, 39 moderate, 6 low) and `npm audit` now reports 0 vulnerabilities.

* **Target Version for Merge**

  v1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/TermiPass/pull/1350
  https://github.com/beclab/TermiPass/pull/1357
  https://github.com/beclab/TermiPass/pull/1359
  https://github.com/beclab/TermiPass/pull/1362
  https://github.com/beclab/TermiPass/pull/1363
  https://github.com/beclab/TermiPass/pull/1366
  https://github.com/beclab/user-service/pull/102
  https://github.com/beclab/user-service/pull/103
  https://github.com/beclab/notifications/pull/25

* **Other information**

  Full Changelog:
  https://github.com/beclab/TermiPass/compare/v1.11.29...v1.11.31
  https://github.com/beclab/user-service/compare/v0.1.13...v0.1.15
  https://github.com/beclab/notifications/compare/v1.12.45...v1.12.46

Made with [Cursor](https://cursor.com)