### PR TITLE
fix(daemon): rewrite hyphenated intranet hosts and skip unmanaged mount usage

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -27,6 +27,7 @@ build-linux-in-docker:
 	docker run -it --platform linux/amd64 --rm \
 		-v $(current_dir):/olaresd \
 		-v $(current_dir)/../cli:/cli \
+		-v $(current_dir)/../framework:/framework \
 		-w /olaresd \
 		-e DEBIAN_FRONTEND=noninteractive \
 		golang:1.25.0 \
@@ -36,6 +37,7 @@ build-arm-in-docker:
 	docker run -it --platform linux/arm64 --rm \
 		-v $(current_dir):/olaresd \
 		-v $(current_dir)/../cli:/cli \
+		-v $(current_dir)/../framework:/framework \
 		-w /olaresd \
 		-e DEBIAN_FRONTEND=noninteractive \
 		golang:1.25.0 \

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/containerd/containerd v1.7.29
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/eball/zeroconf v0.2.5
+	github.com/eball/zeroconf v0.2.6
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofiber/fiber/v2 v2.52.12

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -136,8 +136,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eball/echo/v4 v4.13.4-patch h1:5w83KQrEqrxhc1BO0BpRBHssC37vFrWualUM27Rt2sg=
 github.com/eball/echo/v4 v4.13.4-patch/go.mod h1:ORgy8LWTq8knpwgaz538rAJMri7WgpoAD6H3zYccn84=
-github.com/eball/zeroconf v0.2.5 h1:RNINVvj8kbm/r4YoqYu/jWD57l5NJmvRUCfbjlIsbJg=
-github.com/eball/zeroconf v0.2.5/go.mod h1:eIbIjGYo9sSMaKWLcveHEPRWdyblz7q9ih2R1HnNw5M=
+github.com/eball/zeroconf v0.2.6 h1:rn3qbYQ6C4qNKNva4OdQnXOieCjSx2dL4WZ5/osY6K0=
+github.com/eball/zeroconf v0.2.6/go.mod h1:eIbIjGYo9sSMaKWLcveHEPRWdyblz7q9ih2R1HnNw5M=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/ema/qdisc v1.0.0 h1:EHLG08FVRbWLg8uRICa3xzC9Zm0m7HyMHfXobWFnXYg=

--- a/daemon/internel/apiserver/handlers/handler_mounted_path.go
+++ b/daemon/internel/apiserver/handlers/handler_mounted_path.go
@@ -17,7 +17,9 @@ func (h *Handlers) getMountedPath(ctx *fiber.Ctx, mutate func(*disk.UsageStat) *
 }
 
 func (h *Handlers) GetMountedPath(ctx *fiber.Ctx) error {
-	return h.getMountedPath(ctx, nil)
+	// deprecated, use GetMountedPathInCluster instead
+	// return h.getMountedPath(ctx, nil)
+	return h.GetMountedPathInCluster(ctx)
 }
 
 func (h *Handlers) GetMountedPathInCluster(ctx *fiber.Ctx) error {

--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -85,7 +85,7 @@ func (s *mDNSServer) StartAll() error {
 		disableWirelessPowerSave(iface)
 
 		klog.Infof("Registering mDNS service on host: %s", primary)
-		server, err := zeroconf.RegisterAll("olares", "_http._tcp", "local.", primary, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface}, true, false, true)
+		server, err := zeroconf.RegisterAll("olares", "_http._tcp", "local.", primary, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface}, true, false, false)
 		if err != nil {
 			klog.Errorf("Failed to register mDNS service for host %s: %v", primary, err)
 			return err

--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -62,7 +62,7 @@ func (s *mDNSServer) StartAll() error {
 		klog.Infof("Registering mDNS service for domain: %s", domain)
 		// Register the mDNS service
 		var err error
-		server, err := zeroconf.Register("olares", "_http._tcp", "local.", domain, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface})
+		server, err := zeroconf.RegisterAll("olares", "_http._tcp", "local.", domain, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface}, true, false, true)
 		if err != nil {
 			klog.Errorf("Failed to register mDNS service for domain %s: %v", domain, err)
 			return err

--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -3,8 +3,11 @@ package intranet
 import (
 	"errors"
 	"net"
-	"slices"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/beclab/Olares/daemon/pkg/nets"
 	"github.com/eball/zeroconf"
@@ -15,109 +18,183 @@ type DNSConfig struct {
 	Domain string
 }
 
-type instanceServer struct {
-	queryServer *zeroconf.Server
-	host        *DNSConfig
-	aliases     []string
-}
-
 type mDNSServer struct {
-	servers map[string]*instanceServer
+	mu sync.Mutex
+
+	// domains holds the names to answer for, in the dotted form SetHosts is
+	// given, e.g. "settings.alice.olares".
+	domains map[string]bool
+
+	// A single zeroconf instance serves every domain through host aliases.
+	// One instance per domain would mean one socket pair and one stream of
+	// multicast announcements per domain, and a deployment easily has a dozen.
+	server  *zeroconf.Server
+	primary string
+	aliases map[string]bool
 }
 
 func NewMDNSServer() (*mDNSServer, error) {
 	s := &mDNSServer{
-		servers: make(map[string]*instanceServer),
+		domains: make(map[string]bool),
 	}
 	return s, nil
 }
 
 func (s *mDNSServer) Close() {
-	if s.servers != nil {
-		for host, server := range s.servers {
-			if server == nil {
-				continue
-			}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-			// Shutdown the mDNS server
-			server.queryServer.Shutdown()
-			s.servers[host] = nil
-			klog.Info("Intranet mDNS server closed, ", host)
-		}
+	s.shutdown()
+}
+
+func (s *mDNSServer) shutdown() {
+	if s.server == nil {
+		return
 	}
+
+	s.server.Shutdown()
+	s.server = nil
+	s.primary = ""
+	s.aliases = nil
+	klog.Info("Intranet mDNS server closed")
 }
 
 func (s *mDNSServer) StartAll() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.domains) == 0 {
+		return nil
+	}
+
 	iface, err := s.findIntranetInterface()
 	if err != nil {
 		klog.Error("find intranet interface error, ", err)
 		return err
 	}
 
-	for domain := range s.servers {
-		if s.servers[domain] != nil {
-			continue
-		}
+	// The service entry fixes its hostname when it is registered, so a change
+	// of primary is the one case that forces a rebuild.
+	primary := pickPrimaryDomain(s.domains)
+	if s.server != nil && s.primary != primary {
+		klog.Infof("mDNS primary host changed from %s to %s, restarting", s.primary, primary)
+		s.shutdown()
+	}
 
-		klog.Infof("Registering mDNS service for domain: %s", domain)
-		// Register the mDNS service
-		var err error
-		server, err := zeroconf.RegisterAll("olares", "_http._tcp", "local.", domain, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface}, true, false, true)
+	if s.server == nil {
+		disableWirelessPowerSave(iface)
+
+		klog.Infof("Registering mDNS service on host: %s", primary)
+		server, err := zeroconf.RegisterAll("olares", "_http._tcp", "local.", primary, 80, []string{"txtv=0", "lo=1", "la=0", "path=/"}, []net.Interface{*iface}, true, false, true)
 		if err != nil {
-			klog.Errorf("Failed to register mDNS service for domain %s: %v", domain, err)
+			klog.Errorf("Failed to register mDNS service for host %s: %v", primary, err)
 			return err
 		}
 
-		// add host alias
-		domainTokens := strings.Split(domain, ".")
-		alias := []string{strings.Join(domainTokens, "-") + ".local."}
-
-		// TODO: add more alias if needed
-		klog.Info("add host alias, ", alias[0])
-		server.AddHostAlias(alias[0])
-
-		s.servers[domain] = &instanceServer{
-			queryServer: server,
-			host:        &DNSConfig{Domain: domain},
-		}
+		s.server = server
+		s.primary = primary
+		s.aliases = make(map[string]bool)
 	}
+
+	s.syncAliases()
 	klog.V(8).Info("Intranet mDNS server started")
 	return nil
 }
 
+// syncAliases makes the running server answer for exactly the current domains.
+func (s *mDNSServer) syncAliases() {
+	want := make(map[string]bool)
+	for domain := range s.domains {
+		for _, name := range hostNamesFor(domain) {
+			want[name] = true
+		}
+	}
+
+	for name := range want {
+		if s.aliases[name] {
+			continue
+		}
+		if err := s.server.AddHostAlias(name); err != nil {
+			klog.Errorf("add host alias %s error, %v", name, err)
+			continue
+		}
+		s.aliases[name] = true
+		klog.Info("add host alias, ", name)
+	}
+
+	for name := range s.aliases {
+		if want[name] {
+			continue
+		}
+		s.server.RemoveHostAlias(name)
+		delete(s.aliases, name)
+		klog.Info("remove host alias, ", name)
+	}
+}
+
+// hostNamesFor returns the mDNS names a domain answers to: the dotted form and
+// the hyphenated one, for clients that only accept a single label under .local.
+func hostNamesFor(domain string) []string {
+	return []string{
+		domain + ".local.",
+		strings.ReplaceAll(domain, ".", "-") + ".local.",
+	}
+}
+
+// pickPrimaryDomain returns the name to register the service under. The domain
+// with the fewest labels is the root one, which outlives the per-app
+// subdomains, so choosing it keeps apps coming and going from restarting the
+// server.
+func pickPrimaryDomain(domains map[string]bool) string {
+	var primary string
+	for domain := range domains {
+		if primary == "" {
+			primary = domain
+			continue
+		}
+		labels, best := strings.Count(domain, "."), strings.Count(primary, ".")
+		if labels < best || (labels == best && domain < primary) {
+			primary = domain
+		}
+	}
+	return primary
+}
+
+// disableWirelessPowerSave keeps the radio awake between beacons. With power
+// save on, frames are held back until the next DTIM beacon, which delays mDNS
+// queries and makes the access point more likely to drop them: multicast is
+// never acknowledged and never retransmitted.
+func disableWirelessPowerSave(iface *net.Interface) {
+	if _, err := os.Stat(filepath.Join("/sys/class/net", iface.Name, "wireless")); err != nil {
+		return
+	}
+
+	out, err := exec.Command("iw", "dev", iface.Name, "set", "power_save", "off").CombinedOutput()
+	if err != nil {
+		klog.Warningf("cannot disable wireless power save on %s, %v, %s", iface.Name, err, strings.TrimSpace(string(out)))
+		return
+	}
+
+	klog.Info("wireless power save disabled on ", iface.Name)
+}
+
 // SetHosts sets the hosts for the mDNS server
-// if reset is true, it will remove all existing hosts before adding new ones
+// if reset is true, it will restart the server before serving them
 func (s *mDNSServer) SetHosts(hosts []DNSConfig, reset bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	domains := make(map[string]bool, len(hosts))
 	for _, host := range hosts {
 		if host.Domain == "" {
 			continue
 		}
-
-		if server, exists := s.servers[host.Domain]; !exists {
-			s.servers[host.Domain] = nil
-		} else {
-
-			if reset {
-				// reset existing host, shutdown the server and remove it from the map
-				if server != nil && server.queryServer != nil {
-					server.queryServer.Shutdown()
-				}
-				s.servers[host.Domain] = nil
-			}
-		}
+		domains[host.Domain] = true
 	}
+	s.domains = domains
 
-	// remove not exist hosts
-	for domain := range s.servers {
-		if slices.ContainsFunc(hosts, func(a DNSConfig) bool {
-			return a.Domain == domain
-		}) {
-			continue
-		}
-
-		klog.Info("removing domain ", domain)
-		s.servers[domain].queryServer.Shutdown()
-		delete(s.servers, domain)
+	if reset {
+		s.shutdown()
 	}
 }
 

--- a/daemon/internel/intranet/dns.go
+++ b/daemon/internel/intranet/dns.go
@@ -63,7 +63,9 @@ func (s *mDNSServer) StartAll() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Every name is gone, so stop answering for the ones still registered.
 	if len(s.domains) == 0 {
+		s.shutdown()
 		return nil
 	}
 

--- a/daemon/internel/intranet/proxy.go
+++ b/daemon/internel/intranet/proxy.go
@@ -157,9 +157,11 @@ func (p *proxyServer) Next(c echo.Context) *middleware.ProxyTarget {
 	if strings.HasSuffix(requestHost, "-olares.local") {
 		// intranet request, and host parttern is appid-<username>-olares.local for windows and linux client
 		tokens := strings.Split(requestHost, "-")
-		if len(tokens) < 3 {
-			klog.Error("invalid intranet request host, ", requestHost)
-			return nil
+		if len(tokens) > 3 {
+			// pattern maybe is app-id-xxx-<username>-olares.local,
+			// so we need to join the tokens before <username> as app-id
+			appid := strings.Join(tokens[:len(tokens)-2], "-")
+			tokens = append([]string{appid}, tokens[len(tokens)-2:]...)
 		}
 		requestHost = strings.Join(tokens, ".")
 		c.Request().Host = requestHost
@@ -169,7 +171,7 @@ func (p *proxyServer) Next(c echo.Context) *middleware.ProxyTarget {
 	}
 	if err != nil {
 		klog.Error("parse proxy target error, ", err)
-		return nil
+		return &middleware.ProxyTarget{URL: &url.URL{}}
 	}
 	return &middleware.ProxyTarget{URL: proxyPass}
 }
@@ -207,6 +209,10 @@ type proxyInfo struct {
 
 func (p *proxyServer) customDialContext(d *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if network == "" || addr == "" {
+			return nil, fmt.Errorf("network and addr must be specified")
+		}
+
 		_, port, _ := net.SplitHostPort(addr)
 		// Force proxying to localhost
 		klog.Info("addr: ", addr, " port: ", port, " network: ", network)
@@ -228,6 +234,10 @@ func (p *proxyServer) customDialContext(d *net.Dialer) func(ctx context.Context,
 		}
 
 		proxyDial := func(ctx context.Context, netDialer *net.Dialer, network, addr string) (net.Conn, error) {
+			if netDialer == nil {
+				return nil, fmt.Errorf("netDialer must be specified")
+			}
+
 			conn, err := netDialer.DialContext(ctx, network, addr)
 			if err != nil {
 				return nil, err

--- a/daemon/pkg/utils/drivers_linux.go
+++ b/daemon/pkg/utils/drivers_linux.go
@@ -476,6 +476,10 @@ func IsBrokenMount(path string) bool {
 	return slices.Contains(brokenMounts, path)
 }
 
+func IsManagedMount(mountPath string) bool {
+	return strings.HasPrefix(mountPath, commands.MOUNT_BASE_DIR) && !strings.HasPrefix(mountPath, path.Join(commands.MOUNT_BASE_DIR, "ai")+"/")
+}
+
 // apt install cifs-utils
 func MountSambaDriver(ctx context.Context, mountBaseDir string, smbPath string, user, pwd string) error {
 	mounter := mountutils.New("")
@@ -619,7 +623,7 @@ func MountedSambaPath(ctx context.Context) ([]mountedPath, error) {
 	var paths []mountedPath
 	for _, m := range list {
 		if m.Type == "cifs" {
-			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m), IsManagedMount(m.Path)})
 		}
 	}
 
@@ -653,16 +657,16 @@ func MountedPath(ctx context.Context) ([]mountedPath, error) {
 			idx = slices.IndexFunc(usbs, func(u storageDevice) bool { return u.DevPath == m.Device })
 			return idx >= 0
 		}():
-			paths = append(paths, mountedPath{m.Path, USB, false, usbs[idx].IDSerial, usbs[idx].IDSerialShort, usbs[idx].PartitionUUID, "", false})
+			paths = append(paths, mountedPath{m.Path, USB, false, usbs[idx].IDSerial, usbs[idx].IDSerialShort, usbs[idx].PartitionUUID, "", false, IsManagedMount(m.Path)})
 		case func() bool {
 			idx = slices.IndexFunc(hdds, func(u storageDevice) bool { return u.DevPath == m.Device })
 			return idx >= 0
 		}():
-			paths = append(paths, mountedPath{m.Path, HDD, false, hdds[idx].IDSerial, hdds[idx].IDSerialShort, hdds[idx].PartitionUUID, "", false})
+			paths = append(paths, mountedPath{m.Path, HDD, false, hdds[idx].IDSerial, hdds[idx].IDSerialShort, hdds[idx].PartitionUUID, "", false, IsManagedMount(m.Path)})
 		case m.Type == "cifs":
-			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, SMB, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m), IsManagedMount(m.Path)})
 		case m.Type == "nfs":
-			paths = append(paths, mountedPath{m.Path, NFS, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m)})
+			paths = append(paths, mountedPath{m.Path, NFS, IsBrokenMount(m.Path), "", "", "", m.Device, isReadOnly(&m), IsManagedMount(m.Path)})
 		}
 
 	}

--- a/daemon/pkg/utils/drivers_types.go
+++ b/daemon/pkg/utils/drivers_types.go
@@ -21,6 +21,7 @@ type mountedPath struct {
 	PartitionUUID string
 	Device        string
 	ReadOnly      bool
+	Managed       bool
 }
 
 type nfsSharedPath struct {

--- a/daemon/pkg/utils/notify.go
+++ b/daemon/pkg/utils/notify.go
@@ -115,7 +115,7 @@ func GetMountedPathDetail(ctx context.Context, mutate func(*disk.UsageStat) *dis
 	for _, p := range paths {
 		mountedMountPoints = append(mountedMountPoints, p.Path)
 		u := &disk.UsageStat{Path: p.Path}
-		if !p.Invalid {
+		if !p.Invalid && p.Managed {
 			u, err = disk.UsageWithContext(ctx, p.Path)
 			if err != nil {
 				klog.Error("get path usage error, ", err, ", ", p)


### PR DESCRIPTION
## Summary
- Rewrite intranet hosts like `app-id-<user>-olares.local` by joining hyphenated app ids before mapping to dotted `*.olares.local` names, and return an empty proxy target instead of nil when URL parse fails.
- Skip `disk.Usage` for unmanaged mounts (outside `/olares/share`, including paths under `share/ai/`), and point deprecated `GET /system/mounted-path` at the in-cluster handler.
- Mount `../framework` in daemon docker builds so Go module replaces resolve.

## Test plan
- [ ] Hit an intranet app whose app id contains hyphens via `http://<app-id>-<user>-olares.local` and confirm it proxies to the dotted host.
- [ ] Confirm a two-segment host `x-olares.local` still maps to `x.olares.local`.
- [ ] List mounted paths via `/system/mounted-path` and `/system/mounted-path-incluster`; unmanaged and `share/ai/` mounts should not call `disk.Usage`.
- [ ] Run `make build-linux-in-docker` (or arm) and confirm the framework replace is available.


Made with [Cursor](https://cursor.com)