### PR TITLE
feat(l4): omit outbound X-BFL-USER on public entrances

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -161,7 +161,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.46"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.47"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.46
+          value: v0.3.47
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.46
+      name: beclab/l4-bfl-proxy:v0.3.47
 # must have blank new line            

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -21,6 +21,7 @@ const (
 	fileserverHostFormat     = "files-%s.user-system-%s.svc.cluster.local"
 	autheliaPort             = uint32(9091)
 	autheliaVerifyPathPrefix = "/api/verify/"
+	authLevelPublic          = "public"
 
 	// probeUARegex matches webhook.getProbeUA shape: {uuid}/{md5hex}.
 	probeUARegex = `^[0-9a-fA-F-]+/[0-9a-fA-F]+$`
@@ -38,6 +39,24 @@ const (
 	// than one virtual host in the same route config.
 	systemServicePriority = 100
 )
+
+// isPublicAuthLevel reports whether the entrance is public. Public routes still
+// call Authelia (Bypass) but must not overwrite outbound X-BFL-USER with the
+// zone owner — that header would make anonymous callers look like the owner.
+func isPublicAuthLevel(level string) bool {
+	return strings.EqualFold(strings.TrimSpace(level), authLevelPublic)
+}
+
+// outboundIdentityHeaders returns the route RequestHeaders overwrite map for
+// upstream identity. Public entrances omit X-BFL-USER so the upstream sees no
+// zone-owner constant after RDS strips client-spoofed values. ExtAuth inbound
+// pre-injection uses VH UserName independently of this map.
+func outboundIdentityHeaders(userName string, public bool) map[string]string {
+	if public || userName == "" {
+		return nil
+	}
+	return map[string]string{"X-BFL-USER": userName}
+}
 
 var nodeLocationPrefixes = []string{
 	"/api/resources/cache/",
@@ -597,13 +616,12 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			routes = append(routes, t.buildFileserverRoutes(user, clusterSet)...)
 		}
 
+		public := isPublicAuthLevel(entrance.AuthLevel)
 		defaultRoute := &ir.HTTPRouteIR{
-			Name:       fmt.Sprintf("default_%s_%s_%s", user.Name, app.Name, entrance.Name),
-			PathPrefix: "/",
-			Cluster:    clusterName,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": user.Name,
-			},
+			Name:             fmt.Sprintf("default_%s_%s_%s", user.Name, app.Name, entrance.Name),
+			PathPrefix:       "/",
+			Cluster:          clusterName,
+			RequestHeaders:   outboundIdentityHeaders(user.Name, public),
 			WebSocketUpgrade: true,
 		}
 
@@ -615,6 +633,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 			fmt.Sprintf("%s_%s_%s", user.Name, app.Name, entrance.Name),
 			clusterName,
 			user.Name,
+			public,
 			app.EntranceProbePaths[entrance.Name],
 		)...)
 		routes = append(routes, defaultRoute)
@@ -629,7 +648,8 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 // buildProbeBypassRoutes emits Exact path routes that skip ExtAuth only when
 // User-Agent matches the webhook probe signature format. Requests to the same
 // path without a valid UA fall through to the default authenticated route.
-func buildProbeBypassRoutes(namePrefix, cluster, userName string, paths []string) []*ir.HTTPRouteIR {
+// public mirrors the catch-all: omit outbound X-BFL-USER on public entrances.
+func buildProbeBypassRoutes(namePrefix, cluster, userName string, public bool, paths []string) []*ir.HTTPRouteIR {
 	if len(paths) == 0 {
 		return nil
 	}
@@ -648,12 +668,10 @@ func buildProbeBypassRoutes(namePrefix, cluster, userName string, paths []string
 		}
 		seen[path] = struct{}{}
 		routes = append(routes, &ir.HTTPRouteIR{
-			Name:      fmt.Sprintf("probe_%s_%s", namePrefix, sanitizeProbePath(path)),
-			PathExact: path,
-			Cluster:   cluster,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": userName,
-			},
+			Name:           fmt.Sprintf("probe_%s_%s", namePrefix, sanitizeProbePath(path)),
+			PathExact:      path,
+			Cluster:        cluster,
+			RequestHeaders: outboundIdentityHeaders(userName, public),
 			HeaderMatches: []ir.HeaderMatchIR{{
 				Name:      "user-agent",
 				SafeRegex: probeUARegex,
@@ -861,13 +879,12 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			Name: clusterName, Host: upstreamHost, Port: uint32(entrance.Port), UseDNS: true,
 		}
 
+		public := isPublicAuthLevel(entrance.AuthLevel)
 		customRoute := &ir.HTTPRouteIR{
-			Name:       fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
-			PathPrefix: "/",
-			Cluster:    clusterName,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": user.Name,
-			},
+			Name:             fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
+			PathPrefix:       "/",
+			Cluster:          clusterName,
+			RequestHeaders:   outboundIdentityHeaders(user.Name, public),
 			WebSocketUpgrade: true,
 		}
 
@@ -877,6 +894,7 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 			fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),
 			clusterName,
 			user.Name,
+			public,
 			app.EntranceProbePaths[entrance.Name],
 		)
 		routes = append(routes, customRoute)

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -651,7 +651,7 @@ func TestBuildAppVirtualHosts_NonSharedApp(t *testing.T) {
 	assert.NotEmpty(t, clusterSet)
 }
 
-func TestBuildAppVirtualHosts_PublicSkipsExtAuth(t *testing.T) {
+func TestBuildAppVirtualHosts_PublicOmitsOutboundUserHeader(t *testing.T) {
 	tr := &Translator{cfg: &Config{}}
 	user := &message.UserInfo{Name: "alice", Language: "en"}
 	clusterSet := make(map[string]*ir.ClusterIR)
@@ -660,27 +660,105 @@ func TestBuildAppVirtualHosts_PublicSkipsExtAuth(t *testing.T) {
 		Appid:     "pub",
 		Namespace: "pub-alice",
 		Owner:     "alice",
+		EntranceProbePaths: map[string][]string{
+			"web": {"/healthz"},
+		},
 		Entrances: []*message.EntranceInfo{
 			{Name: "web", Host: "pub-svc", Port: 8080, AuthLevel: "public"},
 		},
 	}
 	vhosts := tr.buildAppVirtualHosts(user, app, "alice.example.com", false, clusterSet)
 	require.Len(t, vhosts, 1)
-	require.Len(t, vhosts[0].Routes, 1)
-	assert.Nil(t, vhosts[0].Routes[0].ExtAuth, "public must skip ExtAuth")
+	require.GreaterOrEqual(t, len(vhosts[0].Routes), 2)
+
+	probe := vhosts[0].Routes[0]
+	assert.Equal(t, "/healthz", probe.PathExact)
+	assert.Nil(t, probe.ExtAuth)
+	assert.Empty(t, probe.RequestHeaders, "public probe must not overwrite outbound X-BFL-USER")
+
+	last := vhosts[0].Routes[len(vhosts[0].Routes)-1]
+	assert.Equal(t, "/", last.PathPrefix)
+	require.NotNil(t, last.ExtAuth, "public must still call Authelia (Bypass), not skip ExtAuth")
+	assert.Equal(t, "authelia_backend_alice", last.ExtAuth.Cluster)
+	assert.Equal(t, autheliaVerifyPathPrefix, last.ExtAuth.PathPrefix)
+	assert.Empty(t, last.RequestHeaders, "public default route must omit outbound X-BFL-USER")
+}
+
+func TestBuildAppVirtualHosts_PrivateAndInternalKeepOutboundUserHeader(t *testing.T) {
+	tr := &Translator{cfg: &Config{}}
+	user := &message.UserInfo{Name: "alice", Language: "en"}
+
+	for _, level := range []string{"", "private", "internal"} {
+		t.Run(level+"_or_default", func(t *testing.T) {
+			clusterSet := make(map[string]*ir.ClusterIR)
+			app := &message.AppInfo{
+				Name:      "app",
+				Appid:     "app",
+				Namespace: "app-alice",
+				Owner:     "alice",
+				Entrances: []*message.EntranceInfo{
+					{Name: "web", Host: "app-svc", Port: 8080, AuthLevel: level},
+				},
+			}
+			vhosts := tr.buildAppVirtualHosts(user, app, "alice.example.com", false, clusterSet)
+			require.Len(t, vhosts, 1)
+			require.Len(t, vhosts[0].Routes, 1)
+			r := vhosts[0].Routes[0]
+			require.NotNil(t, r.ExtAuth)
+			require.Equal(t, map[string]string{"X-BFL-USER": "alice"}, r.RequestHeaders)
+		})
+	}
+}
+
+func TestBuildCustomDomainVirtualHosts_PublicOmitsOutboundUserHeader(t *testing.T) {
+	tr := &Translator{cfg: &Config{}}
+	user := &message.UserInfo{Name: "alice", Language: "en", Zone: "alice.example.com"}
+	clusterSet := make(map[string]*ir.ClusterIR)
+	app := &message.AppInfo{
+		Name:      "pub",
+		Appid:     "pub",
+		Namespace: "pub-alice",
+		Owner:     "alice",
+		Settings: map[string]string{
+			settingsCustomDomain: `{"web":{"third_party_domain":"share.example.org"}}`,
+		},
+		EntranceProbePaths: map[string][]string{
+			"web": {"/healthz"},
+		},
+		Entrances: []*message.EntranceInfo{
+			{Name: "web", Host: "pub-svc", Port: 8080, AuthLevel: "public"},
+		},
+	}
+	vhosts := tr.buildCustomDomainVirtualHosts(user, app, clusterSet)
+	require.Len(t, vhosts, 1)
+	require.GreaterOrEqual(t, len(vhosts[0].Routes), 2)
+	assert.Equal(t, []string{"share.example.org"}, vhosts[0].Domains)
+
+	probe := vhosts[0].Routes[0]
+	assert.Equal(t, "/healthz", probe.PathExact)
+	assert.Empty(t, probe.RequestHeaders)
+
+	last := vhosts[0].Routes[len(vhosts[0].Routes)-1]
+	require.NotNil(t, last.ExtAuth)
+	assert.Empty(t, last.RequestHeaders)
 }
 
 func TestBuildProbeBypassRoutes_ExactPathAndUA(t *testing.T) {
-	routes := buildProbeBypassRoutes("alice_app_web", "cluster", "alice", []string{"/healthz", "/ready", "/", "healthz", "/healthz"})
+	routes := buildProbeBypassRoutes("alice_app_web", "cluster", "alice", false, []string{"/healthz", "/ready", "/", "healthz", "/healthz"})
 	require.Len(t, routes, 2, "dedupe and drop root path")
 	assert.Equal(t, "/healthz", routes[0].PathExact)
 	assert.Equal(t, "/ready", routes[1].PathExact)
 	for _, r := range routes {
 		assert.Nil(t, r.ExtAuth, "probe bypass must not re-enable ExtAuth")
+		require.Equal(t, map[string]string{"X-BFL-USER": "alice"}, r.RequestHeaders)
 		require.Len(t, r.HeaderMatches, 1)
 		assert.Equal(t, "user-agent", r.HeaderMatches[0].Name)
 		assert.Equal(t, probeUARegex, r.HeaderMatches[0].SafeRegex)
 	}
+
+	publicRoutes := buildProbeBypassRoutes("alice_pub_web", "cluster", "alice", true, []string{"/healthz"})
+	require.Len(t, publicRoutes, 1)
+	assert.Empty(t, publicRoutes[0].RequestHeaders)
 }
 
 func TestBuildAppVirtualHosts_ProbeBypassBeforeDefault(t *testing.T) {


### PR DESCRIPTION
## Summary
- For `authLevel=public` entrances, L4 no longer sets outbound `X-BFL-USER`.
- `private` / `internal` behavior is unchanged.
- Bump `beclab/l4-bfl-proxy` image to `v0.3.47`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upstream identity headers on public routes (auth-adjacent edge behavior); scope is limited to the L4 translator and a version bump with expanded tests.
> 
> **Overview**
> **Public app entrances** no longer get an outbound **`X-BFL-USER`** overwrite on default routes, custom-domain routes, or signed User-Agent probe bypass paths. **`private`**, **`internal`**, and default auth levels still send **`X-BFL-USER`** as before.
> 
> Public traffic **still goes through Authelia ext_auth** (Bypass); only the constant zone-owner identity header on the upstream request is dropped so anonymous callers are not presented to backends as the zone owner after RDS strips spoofed client headers.
> 
> Ships as **`beclab/l4-bfl-proxy:v0.3.47`**, wired through the CLI upgrade task, BFL launcher env, and Olares prebuilt manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37326ffb1879aeba85ad1ee0166c081c0ebd5838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->