### PR TITLE
olares: bump system-frontend to v1.11.32

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.31
+          image: beclab/system-frontend:v1.11.32
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.99
+        image: beclab/market-backend:v0.6.100
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image so that the v1.12.7 release picks up the latest Market source-management changes from TermiPass. It is a chart/manifest-only change: no Olares-side logic is touched, only the image tag.

  Image change:

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.31` | `beclab/system-frontend:v1.11.32` |

  `user-service` stays on `v0.1.15`.

  **What the new `system-frontend` image contains**

  1. **Adding a Market source now probes the URL first** (TermiPass [#1373](https://github.com/beclab/TermiPass/pull/1373)). The add-source dialog calls `POST /settings/market-source/probe` before writing anything, so a typo, a non-https URL, or an already-registered source is caught in the dialog. `useMarketSourceProbe` debounces edits and discards a superseded probe result. Sources now name themselves via `short_label`, `display_name`, `icon` and `is_official` from the source API; the client-side label map for `market.olares` / `cli` is gone, and switching UI language re-renders titles and app-card badges. Catalogue state (browse scope, sidebar, page data) is owned by the source that published it, so a previous source's data is no longer treated as the current one. Category tags gained counts (including apps in topic blocks), an All chip, and an Expand toggle that appears only when the chips wrap past one row.

* **Target Version for Merge**

  1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/TermiPass/pull/1373
https://github.com/beclab/market/pull/420

* **Other information**

  None

Made with [Cursor](https://cursor.com)