### PR TITLE
fix(app-service): admit node tunnel IPs on user-system-np

### DIFF
--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -467,6 +467,12 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 				owner := ns.Labels[security.NamespaceOwnerLabel]
 				logger.Info("update network policy", "name", networkPolicy.Name(), "owner", owner)
 				np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[security.NamespaceOwnerLabel] = owner
+				// hostNetwork l4-bfl-proxy (os-network) sources from the node
+				// tunnel/IP, not a pod IP. Same NodeTunnelRule as user-space-np; pinning
+				// user pods to the gateway node only works on a single node.
+				np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+					From: security.NodeTunnelRule(),
+				})
 			}
 		} else if security.IsUserSpaceNamespaces(ns.Name) {
 			networkPolicy = security.NetworkPolicies{security.NPUserSpace.DeepCopy(), security.NPIngress.DeepCopy()}
@@ -970,6 +976,11 @@ func (r *SecurityReconciler) namespacesShouldAllowNodeTunnel(ctx context.Context
 		reqs = append(reqs, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name: "user-space-" + u.GetName(),
+			},
+		})
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: "user-system-" + u.GetName(),
 			},
 		})
 	}


### PR DESCRIPTION



* **Background**
hostNetwork l4-bfl-proxy reaches user-system :9091 from the node tunnel/IP.
Reuse the same NodeTunnelRule as user-space-np so multi-node clusters do not depend on pinning user pods to the gateway node.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens NetworkPolicy ingress on user-system namespaces to node tunnel IPs. Scope is small and matches existing user-space behavior, but it is a cluster network-isolation change.
> 
> **Overview**
> Allows hostNetwork `l4-bfl-proxy` traffic into `user-system` namespaces on multi-node clusters by appending the same `NodeTunnelRule` ingress already used on `user-space-np`.
> 
> Node change events now also enqueue `user-system-<user>` namespaces so tunnel CIDR updates refresh those policies without pinning user pods to the gateway node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4d1337067a39da21561d87207b556ec0ecba99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->