### PR TITLE
fix(app-gateway): force-clear spoofable Shared identity headers

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/app-gateway-strip-identity-headers.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/app-gateway-strip-identity-headers.yaml
@@ -1,0 +1,22 @@
+# Strip client-supplied platform identity headers before jwt_authn, then
+# SecurityPolicy claimToHeaders re-injects verified values (L4-equivalent
+# clear-then-inject on the Shared east-west path through app-gateway).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: app-gateway-strip-identity-headers
+  namespace: os-gateway
+  labels:
+    applications.app.bytetrade.io/author: bytetrade.io
+    app.kubernetes.io/name: app-gateway
+    app.kubernetes.io/component: client-traffic-policy
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: app-gateway
+  headers:
+    earlyRequestHeaders:
+      remove:
+        - x-bfl-user
+        - x-caller-appid


### PR DESCRIPTION
## Summary
- Add Envoy Gateway `ClientTrafficPolicy` `app-gateway-strip-identity-headers` so client-supplied `x-bfl-user` and `x-caller-appid` are **force-removed** via `earlyRequestHeaders` before `jwt_authn` on `Gateway/app-gateway`.
- Verified identity is re-injected only through existing SecurityPolicy `claimToHeaders` (same clear-then-inject order as L4 north-south).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches identity-header handling on the east-west gateway: incorrect strip/re-inject order could allow spoofing or drop legitimate identity.
> 
> **Overview**
> Stops clients from spoofing platform identity on the Shared east-west path through `app-gateway`.
> 
> Adds a `ClientTrafficPolicy` that **force-removes** `x-bfl-user` and `x-caller-appid` via `earlyRequestHeaders` before `jwt_authn`. Verified values are re-injected only by existing SecurityPolicy `claimToHeaders` (same clear-then-inject pattern as L4 north-south).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa287f8d40daf944d61f88e9dbc77708f318c047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->