### PR TITLE
fix(app-service): pin Shared entrance hosts to shared.olares.com

### DIFF
--- a/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
+++ b/framework/app-service/pkg/appcfg/helpers_gateway_shared.go
@@ -31,7 +31,8 @@ func IsSharedServerApp(app *appv1alpha1.Application) bool {
 }
 
 // LogicalHostPattern returns the canonical shared gateway host pattern:
-// <sharedEntranceID>.shared.<platformDomain>.
+// <sharedEntranceID>.shared.<SharedMeshDomain>. platformDomain is retained for
+// call-site compatibility but is not used for the host suffix.
 func LogicalHostPattern(appid string, entranceIndex, entranceCount int, platformDomain string, isShared bool) (string, error) {
 	appid = strings.ToLower(strings.TrimSpace(appid))
 	if appid == "" {
@@ -40,12 +41,9 @@ func LogicalHostPattern(appid string, entranceIndex, entranceCount int, platform
 	if entranceIndex < 0 || entranceIndex >= entranceCount {
 		return "", fmt.Errorf("shared entrance index out of range: index=%d count=%d", entranceIndex, entranceCount)
 	}
-	platformDomain = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(platformDomain, ".")))
-	if platformDomain == "" {
-		return "", fmt.Errorf("platformDomain is empty")
-	}
+	_ = platformDomain
 	if isShared {
-		return fmt.Sprintf("%s.shared.%s", appv1alpha1.SharedEntranceID(appid, entranceIndex, entranceCount), platformDomain), nil
+		return fmt.Sprintf("%s.shared.%s", appv1alpha1.SharedEntranceID(appid, entranceIndex, entranceCount), SharedMeshDomain), nil
 	}
-	return fmt.Sprintf("%s.shared.%s", appv1alpha1.SharedEntranceIDV2(appid, entranceIndex, entranceCount), platformDomain), nil
+	return fmt.Sprintf("%s.shared.%s", appv1alpha1.SharedEntranceIDV2(appid, entranceIndex, entranceCount), SharedMeshDomain), nil
 }

--- a/framework/app-service/pkg/appcfg/helpers_gateway_shared_test.go
+++ b/framework/app-service/pkg/appcfg/helpers_gateway_shared_test.go
@@ -146,43 +146,69 @@ func TestLogicalHostPattern(t *testing.T) {
 		}
 	})
 
+	t.Run("non-com platformDomain still uses SharedMeshDomain", func(t *testing.T) {
+		got, err := LogicalHostPattern("demo1234", 0, 1, "bytetrade.io", true)
+		if err != nil {
+			t.Fatalf("LogicalHostPattern() error = %v", err)
+		}
+		want := appv1alpha1.SharedEntranceID("demo1234", 0, 1) + ".shared." + SharedMeshDomain
+		if got != want {
+			t.Fatalf("LogicalHostPattern() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty platformDomain still succeeds", func(t *testing.T) {
+		got, err := LogicalHostPattern("demo1234", 0, 1, "", true)
+		if err != nil {
+			t.Fatalf("LogicalHostPattern() error = %v", err)
+		}
+		want := appv1alpha1.SharedEntranceID("demo1234", 0, 1) + ".shared." + SharedMeshDomain
+		if got != want {
+			t.Fatalf("LogicalHostPattern() = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("invalid inputs", func(t *testing.T) {
 		cases := []struct {
-			name           string
-			appid          string
-			entranceIndex  int
-			entranceCount  int
-			platformDomain string
+			name          string
+			appid         string
+			entranceIndex int
+			entranceCount int
 		}{
 			{
-				name:           "empty appid",
-				appid:          "",
-				entranceIndex:  0,
-				entranceCount:  1,
-				platformDomain: "olares.com",
+				name:          "empty appid",
+				appid:         "",
+				entranceIndex: 0,
+				entranceCount: 1,
 			},
 			{
-				name:           "invalid index",
-				appid:          "demo1234",
-				entranceIndex:  1,
-				entranceCount:  1,
-				platformDomain: "olares.com",
-			},
-			{
-				name:           "empty platform domain",
-				appid:          "demo1234",
-				entranceIndex:  0,
-				entranceCount:  1,
-				platformDomain: "",
+				name:          "invalid index",
+				appid:         "demo1234",
+				entranceIndex: 1,
+				entranceCount: 1,
 			},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				if _, err := LogicalHostPattern(tc.appid, tc.entranceIndex, tc.entranceCount, tc.platformDomain, true); err == nil {
-					t.Fatalf("LogicalHostPattern(%q, %d, %d, %q) expected error", tc.appid, tc.entranceIndex, tc.entranceCount,
-						tc.platformDomain)
+				if _, err := LogicalHostPattern(tc.appid, tc.entranceIndex, tc.entranceCount, "olares.com", true); err == nil {
+					t.Fatalf("LogicalHostPattern(%q, %d, %d) expected error", tc.appid, tc.entranceIndex, tc.entranceCount)
 				}
 			})
 		}
 	})
+}
+
+func TestIsSharedMeshExactHost(t *testing.T) {
+	if !IsSharedMeshExactHost("deadbeef.shared.olares.com") {
+		t.Fatal("expected shared mesh exact host")
+	}
+	if IsSharedMeshExactHost("shared.olares.com") {
+		t.Fatal("bare shared zone must not match")
+	}
+	if IsSharedMeshExactHost("deadbeef.shared.olares.cn") {
+		t.Fatal("non-com shared host must not match")
+	}
+	if IsSharedMeshExactHost("*.shared.olares.com") {
+		t.Fatal("wildcard must not match")
+	}
 }

--- a/framework/app-service/pkg/appcfg/shared_mesh_domain.go
+++ b/framework/app-service/pkg/appcfg/shared_mesh_domain.go
@@ -1,0 +1,26 @@
+package appcfg
+
+import "strings"
+
+// SharedMeshDomain is the fixed DNS suffix for gateway sharedEntrances
+// (SRR hostPatterns and in-cluster chart URLs). Application entrances keep
+// using cluster.GetPlatformDomain(). UI GenSharedEntranceURL is owned by a
+// separate change.
+const SharedMeshDomain = "olares.com"
+
+// SharedZone returns "shared." + SharedMeshDomain.
+func SharedZone() string {
+	return "shared." + SharedMeshDomain
+}
+
+// IsSharedMeshExactHost reports whether host is an exact shared mesh FQDN
+// "{label}.shared.olares.com" (no wildcards). Used by mesh-in allow-lists so
+// contract hosts survive when platformDomain is not olares.com.
+func IsSharedMeshExactHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || strings.Contains(host, "*") {
+		return false
+	}
+	suffix := "." + SharedZone()
+	return host != SharedZone() && strings.HasSuffix(host, suffix)
+}

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_helpers.go
@@ -333,10 +333,10 @@ func materializeHost(pattern, viewer, platformDomain string) (string, string) {
 	if !validDNSChars(p) {
 		return "", rDropInvalidChars
 	}
-	if !isPlatformHostGo(p, domLower) {
-		return "", rDropNonPlatformHost
+	if appcfg.IsSharedMeshExactHost(p) || isPlatformHostGo(p, domLower) {
+		return p, ""
 	}
-	return p, ""
+	return "", rDropNonPlatformHost
 }
 
 func isPlatformHostGo(host, platformDomain string) bool {

--- a/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
+++ b/framework/app-service/pkg/gateway/routecontrol/mesh_in_shared_hosts_test.go
@@ -63,6 +63,22 @@ func TestMaterializeHostLogicalPattern(t *testing.T) {
 	if reason != "" || h != "x.shared.olares.com" {
 		t.Fatalf("shared exact host=%q reason=%q, want kept", h, reason)
 	}
+	h, reason = materializeHost("x.shared.olares.com", "alice", "olares.cn")
+	if reason != "" || h != "x.shared.olares.com" {
+		t.Fatalf("contract host with cn platformDomain host=%q reason=%q, want kept", h, reason)
+	}
+	h, reason = materializeHost("x.shared.olares.com", "alice", "bytetrade.io")
+	if reason != "" || h != "x.shared.olares.com" {
+		t.Fatalf("contract host with custom platformDomain host=%q reason=%q, want kept", h, reason)
+	}
+	h, reason = materializeHost("x.shared.olares.cn", "alice", "olares.cn")
+	if reason != "" || h != "x.shared.olares.cn" {
+		t.Fatalf("legacy platform shared host host=%q reason=%q, want kept via platform suffix", h, reason)
+	}
+	h, reason = materializeHost("evil.olares.com", "alice", "olares.cn")
+	if reason == "" || h != "" {
+		t.Fatalf("arbitrary .olares.com host must drop, got host=%q reason=%q", h, reason)
+	}
 }
 
 func TestEnumerateHostsSplitsAuthAndTLSByEntranceClass(t *testing.T) {

--- a/framework/app-service/pkg/gateway/srr.go
+++ b/framework/app-service/pkg/gateway/srr.go
@@ -64,9 +64,9 @@ func IsOptedIn(app *appv1alpha1.Application) bool {
 	return app.Annotations[AnnotationRouteMode] == AnnotationRouteModeGateway
 }
 
-// BuildSpecForEntrance projects one sharedEntrance into a SharedRouteRegistrySpec
-// carrying the shared hostPattern (<hash8>.shared.<platformDomain>). The caller
-// resolves the backing Service so this helper stays I/O-free.
+// BuildSpecForEntrance projects one entrance into a SharedRouteRegistrySpec.
+// Shared class hostPatterns use <hash>.shared.olares.com (SharedMeshDomain);
+// application class patterns keep <prefix>.*.<platformDomain>.
 func BuildSpecForEntrance(app *appv1alpha1.Application, entrance appv1alpha1.Entrance,
 	entranceIndex, entranceCount int, svc *corev1.Service, platformDomain string,
 	entranceClass srrv1alpha1.EntranceClass) (srrv1alpha1.SharedRouteRegistrySpec, error) {

--- a/framework/app-service/pkg/gateway/srr_test.go
+++ b/framework/app-service/pkg/gateway/srr_test.go
@@ -83,6 +83,39 @@ func TestBuildSpecForEntrance(t *testing.T) {
 	}
 }
 
+func TestBuildSpecForEntranceSharedIgnoresPlatformDomain(t *testing.T) {
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "demo",
+			Labels: map[string]string{
+				constants.AppApiVersionLabel: "v3",
+				constants.AppSharedLabel:     constants.AppSharedTrue,
+			},
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Appid:     "demo1234",
+			Name:      "demo",
+			Namespace: "demo-shared",
+			SharedEntrances: []appv1alpha1.Entrance{
+				{Name: "web", Host: "demo-svc", Port: 8080},
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "demo-shared"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+	}
+	spec, err := BuildSpecForEntrance(app, app.Spec.SharedEntrances[0], 0, len(app.Spec.SharedEntrances), svc, "bytetrade.io",
+		srrv1alpha1.EntranceClassShared)
+	if err != nil {
+		t.Fatalf("BuildSpecForEntrance: %v", err)
+	}
+	wantHost := appv1alpha1.SharedEntranceID(app.Spec.Appid, 0, len(app.Spec.SharedEntrances)) + ".shared.olares.com"
+	if len(spec.HostPatterns) != 1 || spec.HostPatterns[0] != wantHost {
+		t.Errorf("hostPatterns = %v, want %q", spec.HostPatterns, wantHost)
+	}
+}
+
 func TestBuildSpecForEntranceRequiresAppID(t *testing.T) {
 	app := &appv1alpha1.Application{
 		Spec: appv1alpha1.ApplicationSpec{


### PR DESCRIPTION
## Summary
- Shared gateway routes always use {id}.shared.olares.com, no matter what the cluster platform domain is.
- Mesh-in keeps those exact Shared hosts in the allow-list even when the platform domain is not olares.com. Only {label}.shared.olares.com is allowed—not every *.olares.com host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway hostPatterns and mesh-in allow-list matching, which affects which hosts in-cluster callers can reach. Scope is limited to shared-class routes and includes tests that reject arbitrary `.olares.com` hosts.
> 
> **Overview**
> Shared-class gateway routes now always use `{id}.shared.olares.com` (`SharedMeshDomain`), independent of the cluster platform domain. Application-class patterns still use `*.<platformDomain>`. Empty `platformDomain` is no longer an error for shared host generation.
> 
> Mesh-in `materializeHost` keeps exact `{label}.shared.olares.com` hosts on non-com clusters, while still allowing legacy `*.<platformDomain>` suffixes. Arbitrary `.olares.com` hosts are dropped (not a blanket `*.olares.com` allow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b898a2adda068f794f44a36c7ea018ba3fb7bc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->