### PR TITLE
feat(system-server):  add files system provider 

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_provider.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_provider.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: files-provider-svc
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: system-provider
+  ports:
+    - name: server
+      protocol: TCP
+      port: 28080
+      targetPort: 28080
+
+---
+# provider role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backend:files-provider
+  annotations:
+    provider-registry-ref: {{ .Release.Namespace }}/files-provider-svc
+    provider-service-ref: files-provider-svc.{{ .Release.Namespace }}:28080
+rules:
+  - nonResourceURLs:
+      - "/api/resources/*"
+      - "/api/paste/*"
+      - "/api/raw/*"
+      - "/api/md5/*"
+      - "/api/permission/*"
+      - "/api/preview/*"
+      - "/api/repos/*"
+      - "/api/nodes/*"
+      - "/api/stream/*"
+      - "/api/tree/*"
+      - "/api/share/*"
+      - "/api/users/*"
+      - "/api/archive/*"
+      - "/upload/*"
+      - "/videos/*"
+    verbs: ["*"]
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: files-provider-nginx-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubesphere.io/creator: bytetrade.io
+data:
+  files.conf: |-
+    server {
+        listen 8080;
+        server_name  files-provider-svc.{{ .Release.Namespace }};
+        # Gzip Settings
+        gzip on;
+        gzip_disable "msie6";
+        gzip_min_length 1k;
+        gzip_buffers 16 64k;
+        gzip_http_version 1.1;
+        gzip_comp_level 6;
+        gzip_types *;
+        index index.html;
+        # wise uploads / large file downloads; keep in step with wise.conf.
+        client_max_body_size 4000M;
+        location / {
+          proxy_pass http://files-service.os-framework:80;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection '$connection_upgrade';
+        }
+    }

--- a/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
+++ b/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
@@ -76,6 +76,9 @@ spec:
             - name: auth-provider-nginx-config
               mountPath: /etc/nginx/conf.d/auth.conf
               subPath: auth.conf
+            - name: files-provider-nginx-config
+              mountPath: /etc/nginx/conf.d/files.conf
+              subPath: files.conf
       volumes:
         - name: system-app-nginx-config
           configMap:
@@ -113,6 +116,12 @@ spec:
             items:
               - key: auth.conf
                 path: auth.conf
+        - name: files-provider-nginx-config
+          configMap:
+            name: files-provider-nginx-config
+            items:
+              - key: files.conf
+                path: files.conf
 
       dnsPolicy: ClusterFirst
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
Background
Expose the files backend as a cluster-level **system provider** (mirroring the existing `download` provider), so shared / admin-installed apps can reach the files APIs through the os-framework provider-proxy using a ServiceAccount identity — instead of the per-user frontend-domain (`files-proxy`) path, which does not fit single-instance shared apps.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens cluster RBAC with a new ClusterRole granting `*` on many files API paths and proxies large uploads (4000M) through system-provider. Follows the existing provider pattern but expands who can reach file operations.
> 
> **Overview**
> Exposes the files backend as a cluster-level system provider so shared/admin apps can call files APIs through the os-framework provider-proxy with a ServiceAccount, instead of the per-user `files-proxy` path.
> 
> Adds `files_provider.yaml` (Service, `backend:files-provider` ClusterRole with files API nonResourceURLs, nginx ConfigMap proxying to `files-service.os-framework`) and mounts that config into the existing `system-provider` nginx sidecar, matching the download/auth/search providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494151d2a760eedefca9314a5e9f39a2f66c49e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->