### PR TITLE
feat: add seafile search

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.11
+        image: beclab/search3:v0.3.14
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -312,7 +312,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.11
+        image: beclab/search3monitor:v0.3.14
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.11
+        image: beclab/search3validation:v0.3.14
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: add seafile search
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
* Wire Olares Sync (Seafile) into search3 for both sync search and NATS federated search.

- Add `ServiceEnum::SEAFILE` (wire name `seafile`); call files `POST /api/search/sync_search/` via `FILES_SERVICE_URL`
- Sync: `POST /search/init` with `app=seafile` searches Sync files
- NATS: add `SeafileNatsHandler` — search `seafile` alone or mix with `files_v2` and others
- Map results to shared `DocumentHitView` (`resource_uri` like `/sync/...`)
- Add parity / NATS seafile-only / files_v2+seafile mix test scripts
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
*  https://github.com/Above-Os/search3/pull/210
*  https://github.com/Above-Os/search3/pull/211
*  https://github.com/Above-Os/search3/pull/212

<!-- CURSOR_SUMMARY -->
---
