### PR TITLE
market: change dynamicBlockLimit, allow private ip

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -141,7 +141,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.100
+        image: beclab/market-backend:v0.6.101
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
change dynamicBlockLimit, allow private ip

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/422


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy-only image bump, but the new backend allows private IPs and changes block limits, which can affect network/security behavior of the market service.
> 
> **Overview**
> Bumps the `appstore-backend` image from `beclab/market-backend:v0.6.100` to `v0.6.101` in the market cluster deploy.
> 
> This ships the related market backend changes (dynamic block limit and allowing private IPs) into the Olares v1.12.7 deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b6969ef8d4c844c788e6227892e19f719ac658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->