### PR TITLE
cli: publish ensured apps declaration during fresh install

### DIFF
--- a/cli/pkg/preinstall/ensure_test.go
+++ b/cli/pkg/preinstall/ensure_test.go
@@ -35,7 +35,7 @@ func TestPublishEnsureAppsIsIdempotent(t *testing.T) {
 	if contract.SchemaVersion != SupportedSchemaVersion || len(contract.Apps) != 1 {
 		t.Fatalf("unexpected ensure apps contract: %+v", contract)
 	}
-	if app := contract.Apps[0]; app.AppID != "ai-router" || app.AppName != "ai-router" ||
+	if app := contract.Apps[0]; app.AppID != "f3395cd5" || app.AppName != "router" ||
 		app.InstallScope != InstallScopeShared || app.InstallOrder != 20 {
 		t.Fatalf("unexpected ensured app: %+v", app)
 	}

--- a/cli/pkg/terminus/ossystem.go
+++ b/cli/pkg/terminus/ossystem.go
@@ -355,6 +355,15 @@ func (m *InstallOsSystemModule) Init() {
 		Action: &storage.CreateAppCommonDir{},
 	}
 
+	// InstallOsSystem reads whether the declaration is published to decide the
+	// ensureApps Helm value, so publishing has to happen before it. A fresh
+	// install that skipped this reached Market without the declaration, and
+	// Market cannot know an app the OS requires until an upgrade publishes it.
+	publishMarketEnsureApps := &task.LocalTask{
+		Name:   "PublishMarketEnsureApps",
+		Action: new(preinstall.PublishEnsureAppsAction),
+	}
+
 	installOsSystem := &task.LocalTask{
 		Name:   "InstallOsSystem",
 		Action: &InstallOsSystem{},
@@ -394,6 +403,7 @@ func (m *InstallOsSystemModule) Init() {
 		createUserEnvConfigMap,
 		createSharedLibDir,
 		createAppCommonDir,
+		publishMarketEnsureApps,
 		installOsSystem,
 		createBackupConfigMap,
 		checkSystemService,

--- a/cli/pkg/terminus/ossystem_ensure_order_test.go
+++ b/cli/pkg/terminus/ossystem_ensure_order_test.go
@@ -1,0 +1,42 @@
+package terminus
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/cli/pkg/core/task"
+	"github.com/beclab/Olares/cli/pkg/preinstall"
+)
+
+// InstallOsSystem reads EnsureAppsPublished to decide the ensureApps Helm value,
+// so a declaration published after it would reach the file system but never the
+// Market deployment. That is invisible until an app the OS requires goes
+// missing, and it took an upgrade to repair.
+func TestFreshInstallPublishesEnsureAppsBeforeInstallingOsSystem(t *testing.T) {
+	module := &InstallOsSystemModule{}
+	module.Init()
+
+	publish, install := -1, -1
+	for index, current := range module.Tasks {
+		local, ok := current.(*task.LocalTask)
+		if !ok {
+			continue
+		}
+		switch local.Action.(type) {
+		case *preinstall.PublishEnsureAppsAction:
+			publish = index
+		case *InstallOsSystem:
+			install = index
+		}
+	}
+
+	if publish < 0 {
+		t.Fatal("fresh install does not publish the ensured apps declaration")
+	}
+	if install < 0 {
+		t.Fatal("InstallOsSystem task is missing")
+	}
+	if publish >= install {
+		t.Fatalf("declaration is published after the chart is installed: publish=%d install=%d",
+			publish, install)
+	}
+}


### PR DESCRIPTION
## Summary
- publish the Market ensured-apps declaration before installing the OS system chart on fresh installations
- ensure Router receives the same must-exist guarantee on a fresh ISO install as it does during the 1.12.7 upgrade
- correct the declaration fixture assertion and protect task ordering with a regression test

## Test plan
- [x] `go test ./pkg/preinstall ./pkg/terminus -count=1`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)