### PR TITLE
market: let Market read the Olares version record

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -36,11 +36,15 @@ rules:
       - get
       - list
       - watch
-  # Access to systemenvs resources
+  # systemenvs carries the device's settings; terminus carries the Olares
+  # version, which the upgrade pipeline writes near its end. Market reads that
+  # version to tell an upgrade that is still running from one that has finished,
+  # and holds preinstalled apps until it has.
   - apiGroups:
       - sys.bytetrade.io
     resources:
       - systemenvs
+      - terminus
     verbs:
       - get
       - list


### PR DESCRIPTION
## Background

`UpdateOlaresVersion`, the last step of the upgrade pipeline, writes the target
version into the `Terminus` record's `spec.version`, after both the system and
the user components have finished rolling. Declaring which apps this machine
must have is the *first* task of that same pipeline, and Market starts acting on
the declaration as soon as it restarts with it mounted. Installing inside that
window spends a retry budget meant for the app's own problems against an
app-service that has not finished upgrading.

The Market side of this change (beclab/market#434) uses this record to decide
whether the upgrade has finished: it compares the recorded version against the
`OLARES_VERSION` its own deployment carries, and holds off while the record is
behind. Every way of failing to read the record lets installs through, so a
missing permission raises no error — it just leaves the gate permanently open,
which is the same as not having it.

## Change

The `sys.bytetrade.io` rule in market's ClusterRole gains `terminus`, read-only
(get/list/watch), beside the `systemenvs` it already has.

The resource is spelled the way the CRD declares it — `plural: terminus` in
`sys.bytetrade.io_terminus.yaml` — and not as the English plural `terminuses`,
which resolves to nothing.

## Verification

One RBAC rule, no code. The spelling on the Market side is pinned by that
repository's `TestTheResourceIsSpelledTheWayTheCRDDeclaresIt`.

Made with [Cursor](https://cursor.com)