### PR TITLE
hami: bump hami core version to v2.6.25 in configuration files

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.24"
+version: "v2.6.25"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.24
+      name: beclab/hami:v2.6.25
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
Bump hami core version to v2.6.25

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/commit/9c7fa2a9c67a0b0a4d0c73b63c51b97d7896985c


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin only; no config or scheduling logic changes. Runtime risk depends on the upstream HAMi v2.6.25 image, not this repo diff.
> 
> **Overview**
> Bumps HAMi core from **v2.6.24** to **v2.6.25** in Helm values (`infrastructure/gpu/.../hami/values.yaml`) and the prebuilt container list in `platform/hami/.olares/Olares.yaml`.
> 
> No other HAMi components (webui, DCGM exporter) are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b066af3ce2147d02e6ef0c61f9ac2df0b9936ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->