### PR TITLE
tapr: regenerate Corefile before l4-bfl-proxy exists

### DIFF
--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -94,7 +94,7 @@ spec:
         runAsUser: 0
       containers:
       - name: tapr-sysevent
-        image: beclab/sys-event:0.2.26
+        image: beclab/sys-event:0.2.28
         imagePullPolicy: IfNotPresent
 
 ---

--- a/platform/tapr/cmd/sys-event/watchers/corefile.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -188,41 +187,39 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 		return err
 	}
 
-	for _, u := range userList.Items {
-		userzone := u.GetAnnotations()[UserAnnotationZoneKey]
-		if userzone == "" {
-			klog.Info("user ", u.GetName(), " has no zone annotation, skip corefile update")
-			continue
-		}
+	if ingressIp != "" {
+		for _, u := range userList.Items {
 
-		ip, err := getUserLocalIp(&u)
-		if err != nil {
-			klog.Error("get user local ip error, ", err)
-			return err
-		}
-		if ip == nil || ip.String() == "" {
-			klog.Info("user ", u.GetName(), " has no valid local ip, skip corefile update")
-			continue
-		}
+			userzone := u.GetAnnotations()[UserAnnotationZoneKey]
+			if userzone == "" {
+				klog.Info("user ", u.GetName(), " has no zone annotation, skip corefile update")
+				continue
+			}
 
-		if ingressIp == "" {
-			klog.Info("user ", u.GetName(), " has no valid ingress ip, skip corefile update")
-			continue
-		}
+			ip, err := getUserLocalIp(&u)
+			if err != nil {
+				klog.Error("get user local ip error, ", err)
+				return err
+			}
+			if ip == nil || ip.String() == "" {
+				klog.Info("user ", u.GetName(), " has no valid local ip, skip corefile update")
+				continue
+			}
 
-		templatesPlugins = addUserTemplates(userzone, ip.String(), templatesPlugins)
-		inclusterTemplatesPlugins = addUserTemplates(userzone, ingressIp, inclusterTemplatesPlugins)
+			templatesPlugins = addUserTemplates(userzone, ip.String(), templatesPlugins)
+			inclusterTemplatesPlugins = addUserTemplates(userzone, ingressIp, inclusterTemplatesPlugins)
 
-		if masterNodeIp == "" {
-			klog.Info("no master node ip found, skip adding local domain dns record")
-			continue
-		}
+			if masterNodeIp == "" {
+				klog.Info("no master node ip found, skip adding local domain dns record")
+				continue
+			}
 
-		username := u.GetName()
-		userLocalZone := fmt.Sprintf("%s.olares.local", username)
-		localTemplatesPlugins = addUserTemplates(userzone, masterNodeIp, localTemplatesPlugins)
-		localDomainTemplatesPlugins = addUserTemplates(userLocalZone, masterNodeIp, localDomainTemplatesPlugins)
-	}
+			username := u.GetName()
+			userLocalZone := fmt.Sprintf("%s.olares.local", username)
+			localTemplatesPlugins = addUserTemplates(userzone, masterNodeIp, localTemplatesPlugins)
+			localDomainTemplatesPlugins = addUserTemplates(userLocalZone, masterNodeIp, localDomainTemplatesPlugins)
+		} // end of for loop
+	} // end of if ingressIp != ""
 
 	// Degrade on failure: without the app-gateway-data ClusterIP the shared
 	// in-cluster templates are skipped, while the rest of the Corefile still
@@ -350,6 +347,10 @@ func RegenerateCorefile(ctx context.Context, kubeClient kubernetes.Interface, dy
 			corefileSizeWarnBytes,
 			corefileSizeRejectBytes,
 		)
+	}
+	if newCorefileData == corefileData {
+		klog.Info("coredns corefile unchanged, skip configmap update")
+		return nil
 	}
 	corefileConfigMap.Data["Corefile"] = newCorefileData
 
@@ -557,7 +558,8 @@ func getUserIngressIP(ctx context.Context, kubeClient kubernetes.Interface) (str
 		return "", err
 	}
 	if len(pods.Items) == 0 {
-		return "", errors.New("no l4 proxy pod found")
+		klog.Info("no l4 proxy pod found, users are not initialized yet")
+		return "", nil
 	}
 	pod := pods.Items[0]
 

--- a/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
+++ b/platform/tapr/cmd/sys-event/watchers/corefile_incluster_test.go
@@ -555,6 +555,26 @@ func TestRegenerateCorefileReloadAndSizeGuard(t *testing.T) {
 			t.Fatalf("corefile ConfigMap must remain unchanged on reject")
 		}
 	})
+
+	t.Run("skip configmap update when regenerated corefile is unchanged", func(t *testing.T) {
+		kubeClient, dynamicClient := buildCorefileRegenerateHarness(t, true)
+		if err := RegenerateCorefile(ctx, kubeClient, dynamicClient); err != nil {
+			t.Fatalf("first RegenerateCorefile failed: %v", err)
+		}
+		afterFirst := mustReadCorefileConfigMap(t, ctx, kubeClient)
+		resourceVersionAfterFirst := mustReadCorefileResourceVersion(t, ctx, kubeClient)
+
+		if err := RegenerateCorefile(ctx, kubeClient, dynamicClient); err != nil {
+			t.Fatalf("second RegenerateCorefile failed: %v", err)
+		}
+		afterSecond := mustReadCorefileConfigMap(t, ctx, kubeClient)
+		if afterSecond != afterFirst {
+			t.Fatalf("corefile content changed on no-op regen")
+		}
+		if got := mustReadCorefileResourceVersion(t, ctx, kubeClient); got != resourceVersionAfterFirst {
+			t.Fatalf("expected ConfigMap resourceVersion unchanged, first=%s second=%s", resourceVersionAfterFirst, got)
+		}
+	})
 }
 
 func buildCorefileRegenerateHarness(t *testing.T, inClusterEnabled bool) (*kubefake.Clientset, *dynamicfake.FakeDynamicClient) {
@@ -689,11 +709,21 @@ func setClusterConfigInclusterGateway(ctx context.Context, dynamicClient *dynami
 
 func mustReadCorefileConfigMap(t *testing.T, ctx context.Context, kubeClient *kubefake.Clientset) string {
 	t.Helper()
+	return mustGetCorefileConfigMap(t, ctx, kubeClient).Data["Corefile"]
+}
+
+func mustReadCorefileResourceVersion(t *testing.T, ctx context.Context, kubeClient *kubefake.Clientset) string {
+	t.Helper()
+	return mustGetCorefileConfigMap(t, ctx, kubeClient).ResourceVersion
+}
+
+func mustGetCorefileConfigMap(t *testing.T, ctx context.Context, kubeClient *kubefake.Clientset) *corev1.ConfigMap {
+	t.Helper()
 	cm, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get coredns ConfigMap failed: %v", err)
 	}
-	return cm.Data["Corefile"]
+	return cm
 }
 
 func assertContainsSharedExactTemplate(t *testing.T, corefileBody string) {


### PR DESCRIPTION
## Summary
- Treat a missing `l4-bfl-proxy` pod as “users not initialized yet” instead of failing Corefile regeneration, so CoreDNS can still be updated before the network wizard deploys L4.
- Skip the CoreDNS ConfigMap update when the regenerated Corefile is unchanged, to avoid no-op writes and CoreDNS reloads.
- Bump `sys-event` to `0.2.28` so the change is shipped.

## Test plan
- [ ] Regen Corefile with no `l4-bfl-proxy` pods: function returns nil and writes non-user Corefile pieces (hosts/reload/views)
- [ ] After users complete network init and L4 is up: user / local / in-cluster templates appear
- [ ] Run `RegenerateCorefile` twice with unchanged cluster state: second run does not bump ConfigMap `resourceVersion`
- [ ] `go test ./cmd/sys-event/watchers/ -run TestRegenerateCorefileReloadAndSizeGuard`


Made with [Cursor](https://cursor.com)