### PR TITLE
fix(cli): size the kubelet memory reserve to the host

### DIFF
--- a/cli/pkg/k3s/tasks.go
+++ b/cli/pkg/k3s/tasks.go
@@ -187,8 +187,8 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 	}
 
 	defaultKubeletArs := map[string]string{
-		"kube-reserved":           "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
-		"system-reserved":         "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
+		"kube-reserved":           fmt.Sprintf("cpu=200m,memory=%s,ephemeral-storage=1Gi", utils.KubeReservedMemory),
+		"system-reserved":         fmt.Sprintf("cpu=200m,memory=%s,ephemeral-storage=1Gi", utils.SystemReservedMemory(runtime, g.KubeConf.Arg.EnablePodSwap)),
 		"eviction-hard":           "memory.available<5%,nodefs.available<5%,imagefs.available<5%",
 		"config":                  "/etc/rancher/k3s/kubelet.config",
 		"containerd":              container.DefaultContainerdCRISocket,

--- a/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cli/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -289,11 +289,11 @@ func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeCon
 		"failSwapOn":                      false,
 		"kubeReserved": map[string]string{
 			"cpu":    "200m",
-			"memory": "250Mi",
+			"memory": utils.KubeReservedMemory,
 		},
 		"systemReserved": map[string]string{
 			"cpu":    "200m",
-			"memory": "250Mi",
+			"memory": utils.SystemReservedMemory(runtime, kubeConf.Arg.EnablePodSwap),
 		},
 		"evictionHard": map[string]string{
 			"memory.available":  "5%",

--- a/cli/pkg/upgrade/1_12_7_20260824.go
+++ b/cli/pkg/upgrade/1_12_7_20260824.go
@@ -1,0 +1,37 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+// upgrader_1_12_7_20260824 regenerates the kubelet configuration so an existing
+// node picks up the larger system-reserved memory. The reserve is computed from
+// the host's RAM and swap at generation time, so regenerating the files is all
+// it takes.
+//
+// getUpgraderByVersion matches the target version exactly, so this only runs for
+// a release cut as 1.12.7-20260824. If the release carrying this change ends up
+// stamped with another date, rename this file and the version below to match, or
+// existing clusters silently keep the old reserve.
+type upgrader_1_12_7_20260824 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260824) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260824")
+}
+
+// PostUpgrade, rather than PrepareForUpgrade, is where the regeneration goes:
+// it restarts k3s, and every phase before this one runs tasks that exec into
+// pods. Doing it up front made those tasks race the kubelet's re-sync and fail
+// with "pod does not exist". Here the only thing that follows is the base's
+// wait for the system components to come back, which is exactly the guard a
+// restart wants.
+func (u upgrader_1_12_7_20260824) PostUpgrade() []task.Interface {
+	return append(regenerateKubeFiles(), u.upgraderBase.PostUpgrade()...)
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260824{})
+}

--- a/cli/pkg/utils/kubelet_reserved.go
+++ b/cli/pkg/utils/kubelet_reserved.go
@@ -1,0 +1,139 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+)
+
+const (
+	// kubeReservedMemoryMi is what kubelet holds back for the Kubernetes
+	// daemons themselves (kubelet, the container runtime). It stays a flat
+	// amount because those daemons' footprint does not scale with the size of
+	// the machine.
+	kubeReservedMemoryMi = 250
+
+	// reservedMemoryPercent is the share of physical RAM held back for the OS:
+	// the kernel, page cache, and on a GPU node the driver allocations that
+	// back unified memory.
+	reservedMemoryPercent = 3
+
+	// maxReservedMemoryPercent caps the total reserve, so the swap term can add
+	// at most two more points of physical RAM on top of the base share. Without
+	// it a large swap device — a ZRAM one defaults to half of RAM — would eat an
+	// arbitrary fraction of what the node can schedule.
+	maxReservedMemoryPercent = 5
+
+	// minTotalReservedMemoryMi floors the total reserve at the flat 500Mi that
+	// preceded this calculation, so a small machine never ends up reserving
+	// less than it used to.
+	minTotalReservedMemoryMi = 500
+)
+
+// KubeReservedMemory is kubeReservedMemoryMi as a Kubernetes quantity.
+var KubeReservedMemory = fmt.Sprintf("%dMi", kubeReservedMemoryMi)
+
+// SystemReservedMemory returns the value for kubelet's system-reserved memory,
+// as a Kubernetes quantity string.
+//
+// The total a node holds back is 3% of physical RAM plus, when pods may not use
+// swap, the size of the swap device, capped at 5% of RAM and floored at the
+// legacy 500Mi. KubeReservedMemory is part of that total, so this returns the
+// remainder.
+//
+// The flat 250Mi + 250Mi it replaces was nowhere near enough on a large machine:
+// a 96Gi host was left with 500Mi of headroom for the kernel, the container
+// runtime and page cache combined, so it would happily commit itself to the point
+// where reclaim could no longer keep up. That is unrecoverable in a way a per-pod
+// OOM kill is not — the box stalls with every cgroup still inside its own limit,
+// which is exactly how a GPU node dies once several unified-memory apps swap
+// their VRAM into host RAM at once.
+//
+// Swap counts toward the reserve because with NoSwap pods it is not usable
+// capacity, yet a node that commits everything still thrashes against it. When
+// pods are allowed to swap it is real capacity and is left out.
+//
+// Determining the host's memory needs a command on that host, so a failure here
+// is reported as a warning and the legacy flat value is returned rather than
+// failing the install outright.
+func SystemReservedMemory(runtime connector.Runtime, podSwapEnabled bool) string {
+	out, err := runtime.GetRunner().Cmd("cat /proc/meminfo", false, false)
+	if err == nil {
+		var memTotal, swapTotal int64
+		memTotal, swapTotal, err = parseMemInfo(out)
+		if err == nil {
+			return fmt.Sprintf("%dMi", systemReservedMemoryMi(memTotal, swapTotal, podSwapEnabled))
+		}
+	}
+	logger.Warnf("failed to read host memory, reserving a flat %s for the system: %v", KubeReservedMemory, err)
+	return KubeReservedMemory
+}
+
+// systemReservedMemoryMi is the arithmetic behind SystemReservedMemory, in MiB,
+// taking MemTotal and SwapTotal in KiB as /proc/meminfo reports them.
+func systemReservedMemoryMi(memTotalKiB, swapTotalKiB int64, podSwapEnabled bool) int64 {
+	memMi := memTotalKiB / 1024
+	totalMi := memMi * reservedMemoryPercent / 100
+	if !podSwapEnabled {
+		totalMi += swapTotalKiB / 1024
+	}
+	// The cap comes before the floor: on a machine small enough for the two to
+	// disagree, never reserving less than the legacy flat amount wins.
+	if capMi := memMi * maxReservedMemoryPercent / 100; totalMi > capMi {
+		totalMi = capMi
+	}
+	if totalMi < minTotalReservedMemoryMi {
+		totalMi = minTotalReservedMemoryMi
+	}
+
+	// kubeReservedMemoryMi is reserved separately and counts toward the same
+	// total, so hand back only what is left for the OS.
+	systemMi := totalMi - kubeReservedMemoryMi
+	if systemMi < 1 {
+		systemMi = 1
+	}
+	return systemMi
+}
+
+// parseMemInfo returns MemTotal and SwapTotal in KiB, the unit /proc/meminfo
+// reports them in.
+func parseMemInfo(out string) (memTotal, swapTotal int64, err error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), ":")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "MemTotal", "SwapTotal":
+		default:
+			continue
+		}
+		// The value looks like "  98231692 kB"; SwapTotal is 0 with no unit
+		// when there is no swap device.
+		fields := strings.Fields(value)
+		if len(fields) == 0 {
+			continue
+		}
+		parsed, parseErr := strconv.ParseInt(fields[0], 10, 64)
+		if parseErr != nil {
+			return 0, 0, fmt.Errorf("unexpected %s in /proc/meminfo: %q", key, strings.TrimSpace(value))
+		}
+		if key == "MemTotal" {
+			memTotal = parsed
+		} else {
+			swapTotal = parsed
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, 0, err
+	}
+	if memTotal <= 0 {
+		return 0, 0, fmt.Errorf("no usable MemTotal in /proc/meminfo")
+	}
+	return memTotal, swapTotal, nil
+}


### PR DESCRIPTION
## Summary

A node reserved a flat 250Mi for the OS plus 250Mi for the Kubernetes daemons no
matter how big it was, so a large machine would commit itself to within 500Mi of
physical RAM. That leaves nothing for the kernel, the container runtime or page
cache. On a GPU node whose unified memory spills VRAM into host RAM it is how the
box stalls with every cgroup still inside its own limit — unrecoverable, unlike a
per-pod OOM kill.

`system-reserved` memory is now 3% of physical RAM plus the swap device, minus the
250Mi `kube-reserved` already holds, so the two together are the intended total.
Swap only counts when pods may not use it; when they can it is real capacity and
is left out, which also keeps a ZRAM device sized at half of RAM out of the
reserve. If the host's memory cannot be read the old flat value is used rather
than failing the install. Both the k3s and the kubeadm path go through it.
`eviction-hard` is unchanged at `memory.available<5%`.

The upgrader regenerates the kubelet configuration so existing nodes pick this up.
It runs in `PostUpgrade` rather than `PrepareForUpgrade` because it restarts k3s:
doing it up front races the kubelet's re-sync, and the phases before it run tasks
that exec into pods.

Note that `getUpgraderByVersion` matches the target version exactly, so the
upgrader only runs for a release cut as `1.12.7-20260824`. If the release carrying
this change is stamped with another date, the file and its version need to be
renamed to match, or existing clusters silently keep the old reserve.

## Test plan

- [x] fresh install: kubelet's `system-reserved` reflects the host's RAM and swap,
      and the node's allocatable memory drops accordingly
- [x] upgrade an existing cluster: the kubelet configuration is regenerated, k3s
      restarts, and the system components come back
- [ ] a host with no swap device, and one where pods are allowed to swap: the
      reserve is 3% of RAM in both cases

Made with [Cursor](https://cursor.com)