### PR TITLE
fix(gpu): collect correct stats in multi-container pod

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.25"
+version: "v2.6.26"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.25
+      name: beclab/hami:v2.6.26
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
The hami device plugin always bind the gpu stats to the first container rather than the real gpu consuming container in a multi-container pod, the container should be selected from the correct pod device allocation index.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
https://github.com/beclab/HAMi/pull/23


* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin only; no local logic changes. Residual risk is whatever ships in the upstream HAMi image.
> 
> **Overview**
> Bumps HAMi from `v2.6.25` to `v2.6.26` in Helm values and the prebuilt image list.
> 
> This picks up a device-plugin fix so GPU stats bind to the actual GPU-consuming container in multi-container pods, using the correct pod device allocation index instead of always the first container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7cb05b9f928488d72a06518605a910ef4417b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->