### PR TITLE
feat(sitemap): enhance sitemap generation to support dynamic locale handling

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -395,7 +395,7 @@ export default defineVersionedConfig2(withMermaid({
   // runs generateSitemap immediately before buildEnd) instead of rebuilding the
   // entries, so it inherits transformItems' filtering, the git-derived lastmod
   // values, and the xhtml:link alternates VitePress computes from `locales`.
-  buildEnd: async ({ outDir }) => {
+  buildEnd: async ({ outDir, site }) => {
     // Archived builds disable the sitemap entirely, so there is nothing to
     // split and waiting below would time out.
     if (isArchivedVersionBuild) return;
@@ -410,11 +410,22 @@ export default defineVersionedConfig2(withMermaid({
     if (!openTag) throw new Error('sitemap.xml has no <urlset> element');
     if (entries.length === 0) throw new Error('sitemap.xml has no <url> entries');
 
-    const buckets: Record<string, string[]> = { en: [], zh: [] };
+    // Derive one bucket per declared locale instead of hardcoding en/zh, so
+    // adding a locale has no silent failure mode here: its URLs get their own
+    // file rather than being lumped in with English. VitePress calls the
+    // unprefixed locale "root", which for this site is English; every other
+    // locale key doubles as its URL prefix (zh -> /docs/zh/...).
+    const localeDirs = Object.keys(site.locales ?? {}).filter((l) => l !== 'root');
+    if (localeDirs.length === 0) {
+      throw new Error('no non-root locales found — cannot split the sitemap per locale');
+    }
+    const buckets: Record<string, string[]> = { en: [] };
+    for (const dir of localeDirs) buckets[dir] = [];
+
     for (const entry of entries) {
       // Mirror the x-default alternate injected into each page's <head> so both
-      // annotation channels agree. Pages with no counterpart in the other
-      // locale carry no alternates at all, so there is nothing to mirror.
+      // annotation channels agree; English is x-default in both. Pages with no
+      // counterpart in another locale carry no alternates, so nothing to mirror.
       const annotated = entry.replace(/<xhtml:link[^>]*hreflang="en"[^>]*\/>/, (link) => {
         const href = link.match(/href="([^"]*)"/)?.[1];
         return href
@@ -422,10 +433,16 @@ export default defineVersionedConfig2(withMermaid({
           : link;
       });
       const loc = entry.match(/<loc>([^<]*)<\/loc>/)?.[1] ?? '';
-      buckets[loc.startsWith(`${SITEMAP_HOSTNAME}zh/`) ? 'zh' : 'en'].push(annotated);
+      const dir = localeDirs.find((d) => loc.startsWith(`${SITEMAP_HOSTNAME}${d}/`));
+      buckets[dir ?? 'en'].push(annotated);
     }
 
     for (const [lang, urls] of Object.entries(buckets)) {
+      // An empty file would quietly drop a whole locale out of Search Console,
+      // which looks identical to "that language just isn't indexed yet".
+      if (urls.length === 0) {
+        throw new Error(`sitemap-${lang}.xml would be empty — no URLs matched locale "${lang}"`);
+      }
       fs.writeFileSync(
         path.join(outDir, `sitemap-${lang}.xml`),
         `${prolog}${openTag}${urls.join('')}</urlset>`


### PR DESCRIPTION
* **Background**
  - Updated the sitemap generation logic to dynamically create buckets for each declared locale instead of hardcoding them.
  - Added error handling to ensure that non-root locales are present before generating sitemap files.
  - Improved comments for clarity on the sitemap structure and locale handling.
  
  This change allows for better scalability when adding new locales in the future.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
None


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only sitemap post-processing. Risk is a stricter build that can fail if locale URL prefixes do not match sitemap `<loc>` values.
> 
> **Overview**
> The docs `buildEnd` sitemap split no longer hardcodes `en`/`zh`. It now buckets URLs from VitePress `site.locales` (root → English, other keys as URL prefixes) so a new locale gets its own `sitemap-<locale>.xml` instead of being mixed into English.
> 
> The hook also fails the build if there are no non-root locales or if any locale bucket would be empty, so a missing language cannot silently disappear from Search Console.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2718959907c23960c56e56c5c89d7b752dc5486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->