### PR TITLE
olares: bump system-frontend to v1.11.34

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.33
+          image: beclab/system-frontend:v1.11.34
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image so that the v1.12.7 release picks up the latest LarePass/TermiPass fixes. It is a chart/manifest-only change: no Olares-side logic is touched, only the image tag.

  Image change:

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.33` | `beclab/system-frontend:v1.11.34` |

  `user-service` stays on its current version.

  **What the new `system-frontend` image contains**

  1. **Download paths are stored once, unencoded, and several runtime crashes are guarded** (TermiPass [#1382](https://github.com/beclab/TermiPass/pull/1382)). Cloud download destinations are now persisted as plain storage paths via `downloadRecordToStoragePath`, so Wise playback and "open location" in Files each encode exactly once — a destination containing a space no longer resolves to a `%2520` URL that misses the file. Three defensive fixes ride along: `tld-extract` is skipped for opaque origins (`magnet:`, `about:blank`, `chrome:`) so cookie-collection init no longer throws while still resolving real hosts; the video.js `timeupdate` throttle is torn down in the right order (`off` → `cancel` → `dispose`) so leaving a Wise video entry cannot read `.ended` off a disposed tech; and a missing `repoSyncInfo` payload is treated as "not in sync" instead of dereferencing `.length` on `undefined`.

  2. **LAN reachability, session expiry, and the vault address each get a single owner** (TermiPass [#1383](https://github.com/beclab/TermiPass/pull/1383)). Three pieces of state that were derived in more than one place and drifted apart are consolidated:

     - `HostsLanReachabilityMachine` (`unknown | confirming | local | remote`) replaces `LocalReachabilityController` and its parallel flags. It probes the auth entrance (`http://auth-<localName>-olares.local/bfl/info/v1/olares-info`) and never reads or writes `user.isLocal`, so the hosts feature stops inheriting a verdict meant for TermiPass connectivity. A definitive DNS no-address answer resolves to `remote` immediately, while an ambiguous HTTP failure re-probes once after ~2s. The auth entrance is used instead of the bare account name because `/api/olares-info` on the bare name is broken on Windows against Olares older than 1.12.7.
     - Session expiry became a latch: `TermiPassState.sessionExpired` is the only writer of `ssoInvalid`, so a reactivation check or a network event can no longer clear it. This is what made the "log in again" entry flicker away right after appearing. The VPN is now stopped exactly once, on the latch's rising edge.
     - The vault sender URL now follows `user.isLocal` like every other module URL. Previously enabling hosts left `/server` on the public domain while token refresh had already moved to `.olares.local`; a session renewed on one domain could not satisfy the other, which produced an unbounded refresh/recheck loop. The sync now lives with the controller that writes `isLocal`, and the recovery path is bounded — repeated rejection of a freshly minted token hands over to the session-expired latch instead of spinning.

     Smaller items in the same change: a pending hosts update raises an OS notification deduped by a content signature of the diff and persisted per account; the 30s cadence re-reads the app list while resting in `local`, so installing or removing an app is picked up mid-session; local and regular domains are written to the hosts file as separate groups; the editor states why Update is disabled (duplicate domain, invalid IP); enabling the feature re-reads the Olares LAN IP; the Hosts CTA reports an expired session as "log in again" rather than "connect to the LAN"; `TerminusUserStatus` responds to clicks again (it had been bound with a dynamic event name resolving to `'click.stop'`, an event nothing dispatches); and Files API cancellations from the deliberate connection sweep after a hosts write no longer surface as error toasts.

  The hosts and VPN work above is scoped to the LarePass desktop client; what reaches the web bundle shipped in this image are the shared download-path, media-player, sync-payload, and account/session modules touched by both PRs.

* **Target Version for Merge**

  v1.12.7

* **Related Issues**

  None

* **PRs Involving Sub-Systems**

  https://github.com/beclab/TermiPass/pull/1382
https://github.com/beclab/TermiPass/pull/1383

* **Other information**

  Full Changelog: https://github.com/beclab/TermiPass/compare/v1.11.33...v1.11.34

Made with [Cursor](https://cursor.com)