### PR TITLE
feat(l4): set session X-BFL-USER from Authelia and strip forged identity headers

### DIFF
--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -221,6 +221,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -266,6 +282,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -369,6 +394,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -446,6 +487,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -491,6 +548,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -594,6 +660,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -672,16 +754,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -744,16 +817,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -822,16 +886,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -894,16 +949,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1051,7 +1097,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_bob_bob_snowinning_com_routes",
@@ -1077,16 +1127,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1149,16 +1190,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1227,16 +1259,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1299,16 +1322,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1456,7 +1470,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/deny-all-with-allowed-domains.json
@@ -817,7 +817,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -949,7 +958,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1190,7 +1208,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1322,7 +1349,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -814,7 +814,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -886,7 +895,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -919,7 +937,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "tempuser"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1100,7 +1127,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1172,7 +1208,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1205,7 +1250,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "tempuser"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/ephemeral-user.json
@@ -248,6 +248,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -293,6 +309,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -396,6 +421,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -473,6 +514,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -518,6 +575,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -621,6 +687,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -699,16 +781,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -741,16 +814,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -789,16 +853,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -831,16 +886,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -873,16 +919,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "tempuser"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1000,7 +1037,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_alice_alice_snowinning_com_routes",
@@ -1026,16 +1067,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1068,16 +1100,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1116,16 +1139,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1158,16 +1172,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1200,16 +1205,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "tempuser"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1327,7 +1323,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -1506,7 +1506,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1578,7 +1587,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1858,7 +1876,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1990,7 +2017,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2201,7 +2237,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2273,7 +2318,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2553,7 +2607,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2685,7 +2748,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/multiple-users-and-apps.json
@@ -410,6 +410,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -455,6 +471,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -558,6 +583,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -615,6 +656,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -660,6 +717,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -763,6 +829,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -840,6 +922,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -885,6 +983,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -988,6 +1095,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1045,6 +1168,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -1090,6 +1229,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -1193,6 +1341,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1309,16 +1473,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1351,16 +1506,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1399,16 +1545,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1441,16 +1578,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1568,7 +1696,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_443_bob_bob_snowinning_com_routes",
@@ -1594,16 +1726,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1672,16 +1795,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1744,16 +1858,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1822,16 +1927,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1894,16 +1990,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2051,7 +2138,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_alice_alice_snowinning_com_routes",
@@ -2077,16 +2168,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2119,16 +2201,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2167,16 +2240,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2209,16 +2273,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2336,7 +2391,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_bob_bob_snowinning_com_routes",
@@ -2362,16 +2421,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2440,16 +2490,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2512,16 +2553,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2590,16 +2622,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2662,16 +2685,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2819,7 +2833,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -2161,7 +2161,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "admin"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2233,7 +2242,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "admin"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2453,7 +2471,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2525,7 +2552,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2745,7 +2781,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -2817,7 +2862,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3037,7 +3091,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "admin"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3109,7 +3172,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "admin"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3329,7 +3401,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3401,7 +3482,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3621,7 +3711,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -3693,7 +3792,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "bob"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/shared-app-open.json
@@ -572,6 +572,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -617,6 +633,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -720,6 +745,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -777,6 +818,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -822,6 +879,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -925,6 +991,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -982,6 +1064,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -1027,6 +1125,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -1130,6 +1237,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1207,6 +1330,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -1252,6 +1391,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -1355,6 +1503,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1412,6 +1576,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -1457,6 +1637,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -1560,6 +1749,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1617,6 +1822,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -1662,6 +1883,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -1765,6 +1995,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -1843,16 +2089,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1891,16 +2128,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1933,16 +2161,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1981,16 +2200,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2023,16 +2233,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2150,7 +2351,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_443_alice_alice_snowinning_com_routes",
@@ -2176,16 +2381,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2224,16 +2420,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2266,16 +2453,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2314,16 +2492,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2356,16 +2525,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2483,7 +2643,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_443_bob_bob_snowinning_com_routes",
@@ -2509,16 +2673,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2557,16 +2712,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2599,16 +2745,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2647,16 +2784,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2689,16 +2817,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2816,7 +2935,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_admin_admin_snowinning_com_routes",
@@ -2842,16 +2965,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2890,16 +3004,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2932,16 +3037,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -2980,16 +3076,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3022,16 +3109,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "admin"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3149,7 +3227,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_alice_alice_snowinning_com_routes",
@@ -3175,16 +3257,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3223,16 +3296,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3265,16 +3329,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3313,16 +3368,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3355,16 +3401,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3482,7 +3519,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_bob_bob_snowinning_com_routes",
@@ -3508,16 +3549,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3556,16 +3588,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3598,16 +3621,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3646,16 +3660,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3688,16 +3693,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "bob"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -3815,7 +3811,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -275,6 +275,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -320,6 +336,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -423,6 +448,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -500,6 +541,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -545,6 +602,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -648,6 +714,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -764,16 +846,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -812,16 +885,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -854,16 +918,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -902,16 +957,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -944,16 +990,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1071,7 +1108,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_alice_alice_snowinning_com_routes",
@@ -1097,16 +1138,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1145,16 +1177,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1187,16 +1210,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1235,16 +1249,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1277,16 +1282,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1404,7 +1400,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/single-admin-user.json
@@ -918,7 +918,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -990,7 +999,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1210,7 +1228,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1282,7 +1309,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -275,6 +275,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -320,6 +336,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -423,6 +448,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -500,6 +541,22 @@
                 },
                 "httpFilters": [
                   {
+                    "name": "envoy.filters.http.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation",
+                      "mutations": {
+                        "requestMutations": [
+                          {
+                            "remove": "x-bfl-user"
+                          },
+                          {
+                            "remove": "x-caller-appid"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "name": "envoy.filters.http.ext_authz",
                     "typedConfig": {
                       "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -545,6 +602,15 @@
                         "authorizationResponse": {
                           "allowedUpstreamHeaders": {
                             "patterns": [
+                              {
+                                "exact": "authorization"
+                              },
+                              {
+                                "exact": "proxy-authorization"
+                              },
+                              {
+                                "exact": "x-bfl-user"
+                              },
                               {
                                 "prefix": "remote-"
                               },
@@ -648,6 +714,22 @@
                 ],
                 "useRemoteAddress": true,
                 "xffNumTrustedHops": 1,
+                "earlyHeaderMutationExtensions": [
+                  {
+                    "name": "envoy.http.early_header_mutation.header_mutation",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation",
+                      "mutations": [
+                        {
+                          "remove": "x-bfl-user"
+                        },
+                        {
+                          "remove": "x-caller-appid"
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "upgradeConfigs": [
                   {
                     "upgradeType": "websocket"
@@ -747,16 +829,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -795,16 +868,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -837,16 +901,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -885,16 +940,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -927,16 +973,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1054,7 +1091,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     },
     {
       "name": "https_444_alice_alice_snowinning_com_routes",
@@ -1080,16 +1121,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1128,16 +1160,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1170,16 +1193,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1218,16 +1232,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                   "checkSettings": {}
                 }
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1260,16 +1265,7 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              },
-              "requestHeadersToAdd": [
-                {
-                  "header": {
-                    "key": "X-BFL-USER",
-                    "value": "alice"
-                  },
-                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
-                }
-              ]
+              }
             }
           ],
           "typedPerFilterConfig": {
@@ -1387,7 +1383,11 @@
           },
           "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
         }
-      ]
+      ],
+      "requestHeadersToRemove": [
+        "x-caller-appid"
+      ],
+      "mostSpecificHeaderMutationsWins": true
     }
   ]
 }

--- a/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
+++ b/framework/l4-bfl-proxy/internal/e2e/testdata/udp-port.json
@@ -901,7 +901,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -973,7 +982,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1193,7 +1211,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {
@@ -1265,7 +1292,16 @@
                     "upgradeType": "tailscale-control-protocol"
                   }
                 ]
-              }
+              },
+              "requestHeadersToAdd": [
+                {
+                  "header": {
+                    "key": "X-BFL-USER",
+                    "value": "alice"
+                  },
+                  "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD"
+                }
+              ]
             }
           ],
           "typedPerFilterConfig": {

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -801,6 +801,18 @@ func (t *Translator) buildSystemVirtualHost(user *message.UserInfo, def systemSe
 	// desktop is system human HTTP and must use Authelia /api/verify/.
 	// wizard is pre-auth activation UI — no ExtAuth (cookie chicken-egg).
 	// auth is the IdP itself — do not attach ExtAuth (loop risk).
+	//
+	// auth/wizard have no ExtAuth, so Authelia Bridge never receives the
+	// ExtAuth HeadersToAdd owner stamp. Stamp zone-owner X-BFL-USER on those
+	// routes only (after early client-header strip) so /api/firstfactor and
+	// similar IdP APIs can resolve the user. desktop keeps no IR stamp:
+	// ExtAuth supplies the bridge header; outbound session identity comes
+	// from Authelia on allow.
+	if def.Name == "auth" || def.Name == "wizard" {
+		route.RequestHeaders = map[string]string{
+			"X-BFL-USER": user.Name,
+		}
+	}
 	if def.Name == "desktop" {
 		route.ExtAuth = buildAppExtAuthConfig(user)
 	}

--- a/framework/l4-bfl-proxy/internal/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator.go
@@ -471,10 +471,8 @@ func (t *Translator) buildUserVirtualHosts(user *message.UserInfo, zone string, 
 			Name:       fmt.Sprintf("profile_root_%s", user.Name),
 			PathPrefix: "/",
 			Cluster:    profileCluster,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": user.Name,
-			},
-			// Zone root is human HTTP (profile); EDGE N/S PEP is l4 Authelia verify.
+			// Outbound X-BFL-USER is set by Authelia on ExtAuth allow (session user);
+			// do not stamp zone owner here.
 			ExtAuth: buildAppExtAuthConfig(user),
 		}},
 		Priority: systemServicePriority,
@@ -598,12 +596,9 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 		}
 
 		defaultRoute := &ir.HTTPRouteIR{
-			Name:       fmt.Sprintf("default_%s_%s_%s", user.Name, app.Name, entrance.Name),
-			PathPrefix: "/",
-			Cluster:    clusterName,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": user.Name,
-			},
+			Name:             fmt.Sprintf("default_%s_%s_%s", user.Name, app.Name, entrance.Name),
+			PathPrefix:       "/",
+			Cluster:          clusterName,
 			WebSocketUpgrade: true,
 		}
 
@@ -614,7 +609,6 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 		routes = append(routes, buildProbeBypassRoutes(
 			fmt.Sprintf("%s_%s_%s", user.Name, app.Name, entrance.Name),
 			clusterName,
-			user.Name,
 			app.EntranceProbePaths[entrance.Name],
 		)...)
 		routes = append(routes, defaultRoute)
@@ -629,7 +623,7 @@ func (t *Translator) buildAppVirtualHosts(user *message.UserInfo, app *message.A
 // buildProbeBypassRoutes emits Exact path routes that skip ExtAuth only when
 // User-Agent matches the webhook probe signature format. Requests to the same
 // path without a valid UA fall through to the default authenticated route.
-func buildProbeBypassRoutes(namePrefix, cluster, userName string, paths []string) []*ir.HTTPRouteIR {
+func buildProbeBypassRoutes(namePrefix, cluster string, paths []string) []*ir.HTTPRouteIR {
 	if len(paths) == 0 {
 		return nil
 	}
@@ -651,14 +645,12 @@ func buildProbeBypassRoutes(namePrefix, cluster, userName string, paths []string
 			Name:      fmt.Sprintf("probe_%s_%s", namePrefix, sanitizeProbePath(path)),
 			PathExact: path,
 			Cluster:   cluster,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": userName,
-			},
 			HeaderMatches: []ir.HeaderMatchIR{{
 				Name:      "user-agent",
 				SafeRegex: probeUARegex,
 			}},
 			// ExtAuth nil → keep VH-level ext_authz Disabled (auth bypass).
+			// No outbound zone-owner X-BFL-USER stamp (Authelia owns identity headers).
 		})
 	}
 	return routes
@@ -734,7 +726,6 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 				PathPrefix: fmt.Sprintf("%s%s/", pfx, node.NodeName),
 				Cluster:    proxyCluster,
 				RequestHeaders: map[string]string{
-					"X-BFL-USER":       user.Name,
 					"X-Terminus-Node":  node.NodeName,
 					"X-Provider-Proxy": proxyHost,
 				},
@@ -749,7 +740,6 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 				PathRegex: fmt.Sprintf("^%s%s_.*", pfx, node.NodeName),
 				Cluster:   proxyCluster,
 				RequestHeaders: map[string]string{
-					"X-BFL-USER":       user.Name,
 					"X-Terminus-Node":  node.NodeName,
 					"X-Provider-Proxy": proxyHost,
 				},
@@ -773,7 +763,6 @@ func (t *Translator) buildFileserverRoutes(user *message.UserInfo, clusterSet ma
 				PathPrefix: pfx,
 				Cluster:    proxyCluster,
 				RequestHeaders: map[string]string{
-					"X-BFL-USER":       user.Name,
 					"X-Terminus-Node":  node.NodeName,
 					"X-Provider-Proxy": proxyHost,
 				},
@@ -804,12 +793,9 @@ func (t *Translator) buildSystemVirtualHost(user *message.UserInfo, def systemSe
 	}
 
 	route := &ir.HTTPRouteIR{
-		Name:       fmt.Sprintf("nonapp_%s_root_%s", def.Name, user.Name),
-		PathPrefix: "/",
-		Cluster:    clusterName,
-		RequestHeaders: map[string]string{
-			"X-BFL-USER": user.Name,
-		},
+		Name:             fmt.Sprintf("nonapp_%s_root_%s", def.Name, user.Name),
+		PathPrefix:       "/",
+		Cluster:          clusterName,
 		WebSocketUpgrade: true,
 	}
 	// desktop is system human HTTP and must use Authelia /api/verify/.
@@ -862,12 +848,9 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 		}
 
 		customRoute := &ir.HTTPRouteIR{
-			Name:       fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
-			PathPrefix: "/",
-			Cluster:    clusterName,
-			RequestHeaders: map[string]string{
-				"X-BFL-USER": user.Name,
-			},
+			Name:             fmt.Sprintf("custom_%s_%s_%s_root", user.Name, app.Name, entrance.Name),
+			PathPrefix:       "/",
+			Cluster:          clusterName,
 			WebSocketUpgrade: true,
 		}
 
@@ -876,7 +859,6 @@ func (t *Translator) buildCustomDomainVirtualHosts(user *message.UserInfo, app *
 		routes := buildProbeBypassRoutes(
 			fmt.Sprintf("custom_%s_%s_%s", user.Name, app.Name, entrance.Name),
 			clusterName,
-			user.Name,
 			app.EntranceProbePaths[entrance.Name],
 		)
 		routes = append(routes, customRoute)

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -651,7 +651,7 @@ func TestBuildAppVirtualHosts_NonSharedApp(t *testing.T) {
 	assert.NotEmpty(t, clusterSet)
 }
 
-func TestBuildAppVirtualHosts_PublicSkipsExtAuth(t *testing.T) {
+func TestBuildAppVirtualHosts_PublicKeepsExtAuthOmitsOutboundXBFLUser(t *testing.T) {
 	tr := &Translator{cfg: &Config{}}
 	user := &message.UserInfo{Name: "alice", Language: "en"}
 	clusterSet := make(map[string]*ir.ClusterIR)
@@ -667,16 +667,20 @@ func TestBuildAppVirtualHosts_PublicSkipsExtAuth(t *testing.T) {
 	vhosts := tr.buildAppVirtualHosts(user, app, "alice.example.com", false, clusterSet)
 	require.Len(t, vhosts, 1)
 	require.Len(t, vhosts[0].Routes, 1)
-	assert.Nil(t, vhosts[0].Routes[0].ExtAuth, "public must skip ExtAuth")
+	r := vhosts[0].Routes[0]
+	require.NotNil(t, r.ExtAuth, "public must still mount ExtAuth (Bypass at Authelia)")
+	assert.Equal(t, "authelia_backend_alice", r.ExtAuth.Cluster)
+	assert.Nil(t, r.RequestHeaders, "outbound zone-owner X-BFL-USER stamp must be omitted")
 }
 
 func TestBuildProbeBypassRoutes_ExactPathAndUA(t *testing.T) {
-	routes := buildProbeBypassRoutes("alice_app_web", "cluster", "alice", []string{"/healthz", "/ready", "/", "healthz", "/healthz"})
+	routes := buildProbeBypassRoutes("alice_app_web", "cluster", []string{"/healthz", "/ready", "/", "healthz", "/healthz"})
 	require.Len(t, routes, 2, "dedupe and drop root path")
 	assert.Equal(t, "/healthz", routes[0].PathExact)
 	assert.Equal(t, "/ready", routes[1].PathExact)
 	for _, r := range routes {
 		assert.Nil(t, r.ExtAuth, "probe bypass must not re-enable ExtAuth")
+		assert.Nil(t, r.RequestHeaders, "probe must not stamp outbound X-BFL-USER")
 		require.Len(t, r.HeaderMatches, 1)
 		assert.Equal(t, "user-agent", r.HeaderMatches[0].Name)
 		assert.Equal(t, probeUARegex, r.HeaderMatches[0].SafeRegex)
@@ -876,10 +880,14 @@ func TestBuildFileserverRoutes_NodeScopedBeforeMasterGeneric(t *testing.T) {
 	assert.Equal(t, "files_testip162_olares-work", routes[nodeExternal].Cluster)
 	assert.Equal(t, "files_testip162_olares", routes[masterExternal].Cluster)
 	assert.Equal(t, "olares-work", routes[nodeExternal].RequestHeaders["X-Terminus-Node"])
+	_, hasOutboundBFL := routes[nodeExternal].RequestHeaders["X-BFL-USER"]
+	assert.False(t, hasOutboundBFL, "fileserver must not stamp outbound zone-owner X-BFL-USER")
 	require.NotNil(t, routes[nodeExternal].ExtAuth)
 	assert.Equal(t, autheliaVerifyPathPrefix, routes[nodeExternal].ExtAuth.PathPrefix)
 	require.NotNil(t, routes[masterExternal].ExtAuth)
 	assert.Equal(t, autheliaVerifyPathPrefix, routes[masterExternal].ExtAuth.PathPrefix)
+	_, hasMasterBFL := routes[masterExternal].RequestHeaders["X-BFL-USER"]
+	assert.False(t, hasMasterBFL, "fileserver master route must not stamp outbound X-BFL-USER")
 
 	// Every node-scoped prefix that overlaps a master prefix must precede ALL
 	// master generic routes. Compute the first master-route index and assert
@@ -908,12 +916,15 @@ func TestBuildSystemVirtualHost_DesktopWizardVerify_AuthSkipped(t *testing.T) {
 	require.Len(t, desktop.Routes, 1)
 	require.NotNil(t, desktop.Routes[0].ExtAuth)
 	assert.Equal(t, autheliaVerifyPathPrefix, desktop.Routes[0].ExtAuth.PathPrefix)
+	assert.Nil(t, desktop.Routes[0].RequestHeaders, "desktop must not stamp outbound zone-owner X-BFL-USER")
 
 	wizard := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "wizard", SvcFormat: "wizard.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
 	assert.Nil(t, wizard.Routes[0].ExtAuth, "wizard must not attach ExtAuth (pre-auth activation)")
+	assert.Nil(t, wizard.Routes[0].RequestHeaders, "wizard must not stamp outbound X-BFL-USER")
 
 	auth := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "auth", SvcFormat: "authelia-svc.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
 	assert.Nil(t, auth.Routes[0].ExtAuth, "auth IdP must not attach ExtAuth")
+	assert.Nil(t, auth.Routes[0].RequestHeaders, "auth must not stamp outbound X-BFL-USER")
 }
 
 func TestBuildUserVirtualHosts_ProfileRootVerify(t *testing.T) {
@@ -938,4 +949,5 @@ func TestBuildUserVirtualHosts_ProfileRootVerify(t *testing.T) {
 	require.Len(t, profile.Routes, 1)
 	require.NotNil(t, profile.Routes[0].ExtAuth, "zone root profile must attach ExtAuth")
 	assert.Equal(t, autheliaVerifyPathPrefix, profile.Routes[0].ExtAuth.PathPrefix)
+	assert.Nil(t, profile.Routes[0].RequestHeaders, "profile must not stamp outbound zone-owner X-BFL-USER")
 }

--- a/framework/l4-bfl-proxy/internal/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/translator/translator_test.go
@@ -920,11 +920,15 @@ func TestBuildSystemVirtualHost_DesktopWizardVerify_AuthSkipped(t *testing.T) {
 
 	wizard := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "wizard", SvcFormat: "wizard.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
 	assert.Nil(t, wizard.Routes[0].ExtAuth, "wizard must not attach ExtAuth (pre-auth activation)")
-	assert.Nil(t, wizard.Routes[0].RequestHeaders, "wizard must not stamp outbound X-BFL-USER")
+	require.NotNil(t, wizard.Routes[0].RequestHeaders)
+	assert.Equal(t, "alice", wizard.Routes[0].RequestHeaders["X-BFL-USER"],
+		"wizard must stamp zone-owner X-BFL-USER for Authelia Bridge (no ExtAuth)")
 
 	auth := tr.buildSystemVirtualHost(user, systemServiceDef{Name: "auth", SvcFormat: "authelia-svc.%s.svc.cluster.local"}, "alice.example.com", false, user.Namespace, clusterSet)
 	assert.Nil(t, auth.Routes[0].ExtAuth, "auth IdP must not attach ExtAuth")
-	assert.Nil(t, auth.Routes[0].RequestHeaders, "auth must not stamp outbound X-BFL-USER")
+	require.NotNil(t, auth.Routes[0].RequestHeaders)
+	assert.Equal(t, "alice", auth.Routes[0].RequestHeaders["X-BFL-USER"],
+		"auth must stamp zone-owner X-BFL-USER for Authelia Bridge (no ExtAuth)")
 }
 
 func TestBuildUserVirtualHosts_ProfileRootVerify(t *testing.T) {

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator.go
@@ -15,8 +15,10 @@ import (
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	rbac_configv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	mutationrulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	accesslogfilev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	headermutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	luav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	rbac_filterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
@@ -25,6 +27,7 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	udpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/udp/udp_proxy/v3"
+	earlyheadermutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/early_header_mutation/header_mutation/v3"
 	ppupstreamv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/proxy_protocol/v3"
 	rawtransportv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/raw_buffer/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -188,17 +191,65 @@ func SetTimeouts(tcpIdle, httpStream, connect, route, clusterIdle time.Duration)
 	clusterIdleTimeout = clusterIdle
 }
 
-// spoofableAppIdentityHeadersToRemove lists north-south client headers that
-// must not reach entrance Services as client-supplied values. Envoy matches
-// these case-insensitively.
-//
-// x-bfl-user is force-removed here, then re-injected from the trusted viewer
-// on each route via RequestHeadersToAdd (OVERWRITE_IF_EXISTS_OR_ADD).
-// x-caller-appid is removed and never rewritten on this L4 path.
-func spoofableAppIdentityHeadersToRemove() []string {
+// clientSpoofableIdentityHeaders are stripped at HCM early mutation (before
+// any HTTP filter, including ExtAuth) so forged client values never enter the
+// filter chain or reach Authelia/upstream. Envoy matches case-insensitively.
+func clientSpoofableIdentityHeaders() []string {
 	return []string{
 		"x-bfl-user",
 		"x-caller-appid",
+	}
+}
+
+// spoofableAppIdentityHeadersToRemove is the RDS RequestHeadersToRemove list.
+// x-bfl-user is intentionally absent: Authelia may set it via
+// AllowedUpstreamHeaders after ExtAuth allow; an RDS remove would strip that
+// session identity. x-caller-appid stays here as a second strip (never
+// reinjected on this path).
+func spoofableAppIdentityHeadersToRemove() []string {
+	return []string{
+		"x-caller-appid",
+	}
+}
+
+const earlyHeaderMutationExtensionName = "envoy.http.early_header_mutation.header_mutation"
+
+// buildEarlyClientIdentityStripExtensions strips forged north-south identity
+// headers before the HTTP filter chain runs.
+func buildEarlyClientIdentityStripExtensions() []*corev3.TypedExtensionConfig {
+	mutations := make([]*mutationrulesv3.HeaderMutation, 0, len(clientSpoofableIdentityHeaders()))
+	for _, h := range clientSpoofableIdentityHeaders() {
+		mutations = append(mutations, &mutationrulesv3.HeaderMutation{
+			Action: &mutationrulesv3.HeaderMutation_Remove{Remove: h},
+		})
+	}
+	return []*corev3.TypedExtensionConfig{{
+		Name: earlyHeaderMutationExtensionName,
+		TypedConfig: mustAny(&earlyheadermutationv3.HeaderMutation{
+			Mutations: mutations,
+		}),
+	}}
+}
+
+// buildClientIdentityStripFilter strips the same forged headers again as the
+// first HTTP filter (before ExtAuth) so any path that skipped early mutation
+// still cannot carry client-supplied identity into ExtAuth or upstream.
+func buildClientIdentityStripFilter() *hcmv3.HttpFilter {
+	mutations := make([]*mutationrulesv3.HeaderMutation, 0, len(clientSpoofableIdentityHeaders()))
+	for _, h := range clientSpoofableIdentityHeaders() {
+		mutations = append(mutations, &mutationrulesv3.HeaderMutation{
+			Action: &mutationrulesv3.HeaderMutation_Remove{Remove: h},
+		})
+	}
+	return &hcmv3.HttpFilter{
+		Name: "envoy.filters.http.header_mutation",
+		ConfigType: &hcmv3.HttpFilter_TypedConfig{
+			TypedConfig: mustAny(&headermutationv3.HeaderMutation{
+				Mutations: &headermutationv3.Mutations{
+					RequestMutations: mutations,
+				},
+			}),
+		},
 	}
 }
 
@@ -584,11 +635,11 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 				{Header: &corev3.HeaderValue{Key: "X-Real-IP", Value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 				{Header: &corev3.HeaderValue{Key: "X-Original-Forwarded-For", Value: "%REQ(X-FORWARDED-FOR)%"}, AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD},
 			},
-			// Force-delete client identity headers at RDS, then re-inject
-			// X-BFL-USER on each route (see translateRoute). Default Envoy
-			// order is most→least specific (route add before RDS remove),
-			// which would strip the reinjected header; reverse so RDS remove
-			// runs first and route add wins (envoy#5858).
+			// Client identity forgeries are stripped in HCM early mutation + a
+			// HeaderMutation filter before ExtAuth. RDS must not remove
+			// x-bfl-user here: Authelia sets session identity via
+			// AllowedUpstreamHeaders after allow, and a late RDS remove would
+			// drop it. x-caller-appid stays (never reinjected on this path).
 			MostSpecificHeaderMutationsWins: true,
 			RequestHeadersToRemove:          spoofableAppIdentityHeadersToRemove(),
 		}
@@ -608,7 +659,7 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 		// toggles deny_all, only the per-VH RBAC overrides in the RDS route
 		// config change — the filter chain itself is byte-identical → no
 		// Envoy listener drain on deny_all policy switch.
-		httpFilters := []*hcmv3.HttpFilter{}
+		httpFilters := []*hcmv3.HttpFilter{buildClientIdentityStripFilter()}
 		extAuthzFilter := buildExtAuthzFilter(autheliaClusterName, clusterMap, httpIR.UserName)
 		if extAuthzFilter != nil {
 			httpFilters = append(httpFilters, extAuthzFilter)
@@ -648,7 +699,8 @@ func buildMultiUserHTTPSListener(port uint32, proxyProtocol bool, httpListeners 
 					},
 				},
 			},
-			HttpFilters: httpFilters,
+			HttpFilters:                    httpFilters,
+			EarlyHeaderMutationExtensions:  buildEarlyClientIdentityStripExtensions(),
 			UpgradeConfigs: []*hcmv3.HttpConnectionManager_UpgradeConfig{
 				{UpgradeType: "websocket"},
 				{UpgradeType: "tailscale-control-protocol"},
@@ -1016,6 +1068,7 @@ var (
 		Patterns: []*matcherv3.StringMatcher{
 			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "authorization"}},
 			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "proxy-authorization"}},
+			{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "x-bfl-user"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "remote-"}},
 			{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "authelia-"}},
 		},

--- a/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
+++ b/framework/l4-bfl-proxy/internal/xds/translator/translator_test.go
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	mutationrulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	headermutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	earlyheadermutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/early_header_mutation/header_mutation/v3"
 	ppupstreamv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/proxy_protocol/v3"
 	cachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/stretchr/testify/assert"
@@ -42,6 +45,25 @@ func asRouteConfig(t *testing.T, r interface{}) *routev3.RouteConfiguration {
 	rc, ok := r.(*routev3.RouteConfiguration)
 	require.True(t, ok, "expected *routev3.RouteConfiguration")
 	return rc
+}
+
+func hcmFromListener(t *testing.T, l *listenerv3.Listener) *hcmv3.HttpConnectionManager {
+	t.Helper()
+	require.NotEmpty(t, l.FilterChains)
+	require.NotEmpty(t, l.FilterChains[0].Filters)
+	hcm := &hcmv3.HttpConnectionManager{}
+	require.NoError(t, l.FilterChains[0].Filters[0].GetTypedConfig().UnmarshalTo(hcm))
+	return hcm
+}
+
+func headerMutationRemoves(t *testing.T, mutations []*mutationrulesv3.HeaderMutation) []string {
+	t.Helper()
+	out := make([]string, 0, len(mutations))
+	for _, m := range mutations {
+		require.NotEmpty(t, m.GetRemove())
+		out = append(out, m.GetRemove())
+	}
+	return out
 }
 
 func socketAddr(l *listenerv3.Listener) *corev3.SocketAddress {
@@ -879,9 +901,6 @@ func TestTranslate_HTTPSListeners(t *testing.T) {
 							Name:       "profile_root",
 							PathPrefix: "/",
 							Cluster:    "profile_service_alice",
-							RequestHeaders: map[string]string{
-								"X-BFL-USER": "alice",
-							},
 						}},
 					},
 				},
@@ -891,6 +910,7 @@ func TestTranslate_HTTPSListeners(t *testing.T) {
 		},
 		Clusters: []*ir.ClusterIR{
 			{Name: "profile_service_alice", Host: "profile-service.user-space-alice.svc.cluster.local", Port: 3000, UseDNS: true},
+			{Name: "authelia_backend_alice", Host: "authelia-backend.user-system-alice.svc.cluster.local", Port: 9091, UseDNS: true},
 		},
 	}
 
@@ -903,16 +923,32 @@ func TestTranslate_HTTPSListeners(t *testing.T) {
 	assert.Equal(t, "https_443", l.Name)
 	require.Len(t, l.FilterChains, 1)
 
+	hcm := hcmFromListener(t, l)
+	require.Len(t, hcm.GetEarlyHeaderMutationExtensions(), 1)
+	early := &earlyheadermutationv3.HeaderMutation{}
+	require.NoError(t, hcm.GetEarlyHeaderMutationExtensions()[0].GetTypedConfig().UnmarshalTo(early))
+	assert.Equal(t, []string{"x-bfl-user", "x-caller-appid"}, headerMutationRemoves(t, early.GetMutations()),
+		"early mutation must strip forged client identity before any HTTP filter")
+
+	require.GreaterOrEqual(t, len(hcm.GetHttpFilters()), 2)
+	assert.Equal(t, "envoy.filters.http.header_mutation", hcm.GetHttpFilters()[0].GetName(),
+		"HeaderMutation must be the first HTTP filter (before ExtAuth)")
+	stripFilter := &headermutationv3.HeaderMutation{}
+	require.NoError(t, hcm.GetHttpFilters()[0].GetTypedConfig().UnmarshalTo(stripFilter))
+	assert.Equal(t, []string{"x-bfl-user", "x-caller-appid"},
+		headerMutationRemoves(t, stripFilter.GetMutations().GetRequestMutations()))
+	assert.Equal(t, "envoy.filters.http.ext_authz", hcm.GetHttpFilters()[1].GetName(),
+		"ExtAuth must run after client identity strip")
+
 	// 1 route config
 	require.Len(t, snap.Routes, 1)
 	rc := asRouteConfig(t, snap.Routes[0])
 	assert.Equal(t, "https_443_alice_routes", rc.Name)
-	assert.Equal(t, []string{"x-bfl-user", "x-caller-appid"}, rc.GetRequestHeadersToRemove(),
-		"north-south RDS must force-delete client identity headers before upstream")
-	assert.True(t, rc.GetMostSpecificHeaderMutationsWins(),
-		"RDS must apply remove before route reinject (most_specific_header_mutations_wins)")
+	assert.Equal(t, []string{"x-caller-appid"}, rc.GetRequestHeadersToRemove(),
+		"RDS must not remove x-bfl-user (would strip Authelia session identity)")
+	assert.True(t, rc.GetMostSpecificHeaderMutationsWins())
 
-	// Trusted X-BFL-USER must be re-injected on the app route after the RDS remove.
+	// R1: IR no longer stamps zone-owner X-BFL-USER on outbound routes.
 	var sawBFL bool
 	for _, vh := range rc.GetVirtualHosts() {
 		for _, route := range vh.GetRoutes() {
@@ -922,23 +958,32 @@ func TestTranslate_HTTPSListeners(t *testing.T) {
 			for _, h := range route.GetRequestHeadersToAdd() {
 				if strings.EqualFold(h.GetHeader().GetKey(), "X-BFL-USER") {
 					sawBFL = true
-					assert.Equal(t, "alice", h.GetHeader().GetValue())
-					assert.Equal(t, corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD, h.GetAppendAction())
 				}
 			}
 		}
 	}
-	require.True(t, sawBFL, "route must re-inject X-BFL-USER after force-delete")
+	require.False(t, sawBFL, "outbound zone-owner X-BFL-USER stamp must be absent; Authelia ExtAuth supplies session identity")
 
-	// 1 cluster
-	require.Len(t, snap.Clusters, 1)
+	// profile + authelia clusters
+	require.Len(t, snap.Clusters, 2)
 }
 
 func TestSpoofableAppIdentityHeadersToRemove(t *testing.T) {
 	got := spoofableAppIdentityHeadersToRemove()
-	require.Equal(t, []string{"x-bfl-user", "x-caller-appid"}, got)
-	// Stable order for xDS determinism / snapshot diffs.
+	require.Equal(t, []string{"x-caller-appid"}, got)
 	require.Equal(t, got, spoofableAppIdentityHeadersToRemove())
+	require.Equal(t, []string{"x-bfl-user", "x-caller-appid"}, clientSpoofableIdentityHeaders())
+}
+
+func TestAutheliaAllowedUpstreamHeadersIncludesXBFLUser(t *testing.T) {
+	var foundExact bool
+	for _, p := range autheliaAllowedUpstreamHeaders.GetPatterns() {
+		if p.GetExact() == "x-bfl-user" {
+			foundExact = true
+			break
+		}
+	}
+	require.True(t, foundExact, "ExtAuth must allow Authelia response X-BFL-USER through to upstream")
 }
 
 // applyEnvoyRequestHeaderMutations models Envoy request-header mutation order
@@ -1003,7 +1048,10 @@ func findNamedRoute(t *testing.T, rc *routev3.RouteConfiguration, name string) *
 	return nil
 }
 
-func TestNorthSouthXBFLUserForceDeleteThenReinject_EnvoyOrder(t *testing.T) {
+// TestNorthSouthClientIdentityStripBeforeExtAuth models the R1 path:
+// early/filter strip removes forged client x-bfl-user; Authelia then sets
+// session identity; RDS must not remove x-bfl-user again.
+func TestNorthSouthClientIdentityStripBeforeExtAuth(t *testing.T) {
 	xdsIR := &ir.Xds{
 		HTTPListeners: []*ir.HTTPListenerIR{{
 			Name:       "https_443_alice",
@@ -1020,46 +1068,54 @@ func TestNorthSouthXBFLUserForceDeleteThenReinject_EnvoyOrder(t *testing.T) {
 					Name:       "profile_root",
 					PathPrefix: "/",
 					Cluster:    "profile_service_alice",
-					RequestHeaders: map[string]string{
-						"X-BFL-USER": "alice",
-					},
 				}},
 			}},
 			DefaultResponse: &ir.DirectResponseIR{Status: 421, Body: "err"},
 		}},
 		Clusters: []*ir.ClusterIR{
 			{Name: "profile_service_alice", Host: "profile-service.user-space-alice.svc.cluster.local", Port: 3000, UseDNS: true},
+			{Name: "authelia_backend_alice", Host: "authelia-backend.user-system-alice.svc.cluster.local", Port: 9091, UseDNS: true},
 		},
 	}
-	rc := asRouteConfig(t, (&XdsTranslator{}).Translate(xdsIR).Routes[0])
+	snap := (&XdsTranslator{}).Translate(xdsIR)
+	hcm := hcmFromListener(t, asListener(t, snap.Listeners[0]))
+	rc := asRouteConfig(t, snap.Routes[0])
 	route := findNamedRoute(t, rc, "profile_root")
-	require.True(t, rc.GetMostSpecificHeaderMutationsWins())
 
-	client := map[string]string{
-		"x-bfl-user":     "attacker",
+	require.Equal(t, []string{"x-caller-appid"}, rc.GetRequestHeadersToRemove())
+	require.Equal(t, "envoy.filters.http.header_mutation", hcm.GetHttpFilters()[0].GetName())
+	require.Equal(t, "envoy.filters.http.ext_authz", hcm.GetHttpFilters()[1].GetName())
+
+	// Simulate: client forge present → early/filter strip → Authelia allow sets session user.
+	afterStrip := map[string]string{
 		"x-caller-appid": "spoofed-app",
 		"host":           "alice.example.com",
 	}
-	got := applyEnvoyRequestHeaderMutations(client, rc, route)
-	assert.Equal(t, "alice", got["x-bfl-user"],
-		"with most_specific_header_mutations_wins, RDS remove then route add must yield trusted viewer")
+	for _, h := range clientSpoofableIdentityHeaders() {
+		delete(afterStrip, h)
+	}
+	// ExtAuth AllowedUpstreamHeaders injects session identity after strip.
+	afterStrip["x-bfl-user"] = "bob"
+
+	got := applyEnvoyRequestHeaderMutations(afterStrip, rc, route)
+	assert.Equal(t, "bob", got["x-bfl-user"],
+		"Authelia session X-BFL-USER must survive RDS mutations")
 	_, hasAppid := got["x-caller-appid"]
-	assert.False(t, hasAppid, "spoofed x-caller-appid must stay removed")
+	assert.False(t, hasAppid, "spoofed x-caller-appid must stay removed at RDS")
 	assert.Equal(t, "alice.example.com", got["host"])
 
-	// Characterization: without the flag, RDS remove runs after route add and
-	// strips the reinjected viewer — the bug this flag closes.
-	rcNoFlag := protoCloneRouteConfig(t, rc)
-	rcNoFlag.MostSpecificHeaderMutationsWins = false
-	broken := applyEnvoyRequestHeaderMutations(client, rcNoFlag, route)
+	// Characterization: if x-bfl-user were still on RDS remove, session identity would be lost.
+	rcLegacy := protoCloneRouteConfig(t, rc)
+	rcLegacy.RequestHeadersToRemove = []string{"x-bfl-user", "x-caller-appid"}
+	broken := applyEnvoyRequestHeaderMutations(afterStrip, rcLegacy, route)
 	_, hasBFL := broken["x-bfl-user"]
 	assert.False(t, hasBFL,
-		"default Envoy order must drop reinjected X-BFL-USER (documents why the flag is required)")
+		"RDS remove of x-bfl-user after ExtAuth would drop Authelia session identity")
 }
 
 func protoCloneRouteConfig(t *testing.T, rc *routev3.RouteConfiguration) *routev3.RouteConfiguration {
 	t.Helper()
-	// Shallow field copy is enough: test only toggles MostSpecificHeaderMutationsWins.
+	// Shallow field copy is enough: test only toggles RequestHeadersToRemove.
 	out := *rc
 	return &out
 }


### PR DESCRIPTION
North–south identity on l4-bfl-proxy:
Session X-BFL-USER is set from Authelia after ExtAuth allow and passed upstream.
Client x-bfl-user / x-caller-appid are stripped before the HTTP filter chain.
auth / wizard routes stamp zone-owner X-BFL-USER so Authelia Bridge APIs (e.g. /api/firstfactor) can resolve the user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes edge authentication identity propagation and header trust boundaries; misconfiguration could break upstream user resolution or allow header spoofing.
> 
> **Overview**
> **North–south user identity** no longer comes from Envoy stamping the zone owner on every route. After ExtAuth allow, **`X-BFL-USER` is expected from Authelia** (via `allowedUpstreamHeaders`); profile, apps, fileserver, desktop, and probe routes drop IR-level `RequestHeaders` for `X-BFL-USER`. **`auth` and `wizard`** still add zone-owner `X-BFL-USER` because they skip ExtAuth and Authelia Bridge needs a user hint (e.g. first-factor APIs).
> 
> **Spoofing defense** is layered: HCM **early header mutation** and a **first HTTP `header_mutation` filter** remove client `x-bfl-user` and `x-caller-appid` before ExtAuth. RDS **`requestHeadersToRemove`** now only drops **`x-caller-appid`** so a post-allow Authelia `x-bfl-user` is not stripped by route-level mutations. E2E golden Envoy JSON and translator/xDS tests reflect the new filter chain and header rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cb6d64652ea5a9ed4295fa21d856cd2c6d8d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->