### PR TITLE
market: bump to v0.6.104, and stop stating the version twice

### DIFF
--- a/cli/pkg/preinstall/declaration.go
+++ b/cli/pkg/preinstall/declaration.go
@@ -50,7 +50,6 @@ func (s ChartSource) Valid() bool {
 
 type DeclarationV2 struct {
 	SchemaVersion string             `json:"schemaVersion"`
-	OSVersion     string             `json:"osVersion"`
 	GeneratedAt   string             `json:"generatedAt,omitempty"`
 	Apps          []DeclarationAppV2 `json:"apps"`
 }
@@ -101,7 +100,8 @@ func TrunkVersion(version string) string {
 }
 
 // DeclarationFileName is the contract with Market: one file per trunk, named for
-// it, and looked for under that name and no other.
+// it, and looked for under that name and no other. The name is also the only
+// place the trunk is written down -- the declaration does not restate it.
 func DeclarationFileName(trunk string) string {
 	return declarationFilePrefix + TrunkVersion(trunk) + declarationFileSuffix
 }
@@ -111,11 +111,10 @@ func DeclarationFileName(trunk string) string {
 // allows here rather than published beside it: a choice the bundle never offered
 // is a mistake in this program, and the device it would break is this one.
 func BuildDeclaration(
-	osVersion string, bundle BundleV1, selections ProfileSelections, catalog []DeclarationAppV2,
+	bundle BundleV1, selections ProfileSelections, catalog []DeclarationAppV2,
 ) (DeclarationV2, error) {
 	declaration := DeclarationV2{
 		SchemaVersion: DeclarationSchemaVersion,
-		OSVersion:     strings.TrimSpace(osVersion),
 		GeneratedAt:   generatedNow(),
 	}
 	for _, app := range bundle.Apps {
@@ -208,9 +207,6 @@ func localDeclarationApp(app BundleAppV1, selections ProfileSelections) (Declara
 func ValidateDeclaration(declaration *DeclarationV2) error {
 	if declaration.SchemaVersion != DeclarationSchemaVersion {
 		return fmt.Errorf("declaration schemaVersion %q is not supported", declaration.SchemaVersion)
-	}
-	if strings.TrimSpace(declaration.OSVersion) == "" {
-		return fmt.Errorf("declaration osVersion is required")
 	}
 	if generated := strings.TrimSpace(declaration.GeneratedAt); generated != "" {
 		if _, err := time.Parse(time.RFC3339, generated); err != nil {

--- a/cli/pkg/preinstall/declaration_test.go
+++ b/cli/pkg/preinstall/declaration_test.go
@@ -44,7 +44,7 @@ func TestBuildDeclarationMergesDefaultsWithoutMutatingInputs(t *testing.T) {
 		testBundledAppID: {SelectedGPUType: "nvidia", Envs: runtimeEnvs},
 	}}
 
-	declaration, err := BuildDeclaration(testOSVersion, bundle, selections, nil)
+	declaration, err := BuildDeclaration(bundle, selections, nil)
 	if err != nil {
 		t.Fatalf("BuildDeclaration() error = %v", err)
 	}
@@ -79,7 +79,7 @@ func TestBuildDeclarationAppliesDetectedGPUOnlyToAllowedApps(t *testing.T) {
 	unsupported.AllowedGPUTypes = []string{"cpu"}
 	bundle.Apps = append(bundle.Apps, unsupported)
 
-	declaration, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{
+	declaration, err := BuildDeclaration(bundle, ProfileSelections{
 		HardwareProfile: "nvidia",
 		DetectedGPUType: "nvidia",
 	}, nil)
@@ -99,7 +99,7 @@ func TestBuildDeclarationExplicitGPUOverridesDetectedGPU(t *testing.T) {
 	bundle := decodeBundle(t, validBundleJSON)
 	bundle.Apps[0].AllowedGPUTypes = []string{"nvidia", "cpu"}
 
-	declaration, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{
+	declaration, err := BuildDeclaration(bundle, ProfileSelections{
 		DetectedGPUType: "nvidia",
 		Apps:            map[string]AppSelection{testBundledAppID: {SelectedGPUType: "cpu"}},
 	}, nil)
@@ -131,7 +131,7 @@ func TestBuildDeclarationRefusesSelectionsTheBundleDoesNotAllow(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			bundle := decodeBundle(t, validBundleJSON)
 
-			_, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{
+			_, err := BuildDeclaration(bundle, ProfileSelections{
 				Apps: map[string]AppSelection{testBundledAppID: test.selection},
 			}, nil)
 
@@ -148,7 +148,7 @@ func TestBuildDeclarationRefusesSensitiveEnvs(t *testing.T) {
 	bundle := decodeBundle(t, validBundleJSON)
 	bundle.Apps[0].AllowedEnvs = append(bundle.Apps[0].AllowedEnvs, "API_TOKEN")
 
-	_, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{
+	_, err := BuildDeclaration(bundle, ProfileSelections{
 		Apps: map[string]AppSelection{testBundledAppID: {Envs: map[string]string{"API_TOKEN": "x"}}},
 	}, nil)
 
@@ -172,7 +172,7 @@ func TestBuildDeclarationPrefersABundledAppOverTheCatalogEntryForIt(t *testing.T
 		},
 	}
 
-	declaration, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{}, catalog)
+	declaration, err := BuildDeclaration(bundle, ProfileSelections{}, catalog)
 	if err != nil {
 		t.Fatalf("BuildDeclaration() error = %v", err)
 	}
@@ -197,7 +197,7 @@ func TestBuildDeclarationTreatsANameCollisionAsTheSameApp(t *testing.T) {
 		InstallScope: InstallScopeShared, InstallOrder: 20,
 	}}
 
-	declaration, err := BuildDeclaration(testOSVersion, bundle, ProfileSelections{}, catalog)
+	declaration, err := BuildDeclaration(bundle, ProfileSelections{}, catalog)
 	if err != nil {
 		t.Fatalf("BuildDeclaration() error = %v", err)
 	}
@@ -213,7 +213,6 @@ func TestValidateDeclarationRefusesWhatMarketRefuses(t *testing.T) {
 	valid := func() DeclarationV2 {
 		return DeclarationV2{
 			SchemaVersion: DeclarationSchemaVersion,
-			OSVersion:     testOSVersion,
 			Apps: []DeclarationAppV2{{
 				AppID: "f3395cd5", AppName: "router", InstallScope: InstallScopeShared,
 				InstallOrder: 20, ChartSource: ChartSourceCatalog,
@@ -221,7 +220,7 @@ func TestValidateDeclarationRefusesWhatMarketRefuses(t *testing.T) {
 		}
 	}
 	if err := ValidateDeclaration(&DeclarationV2{
-		SchemaVersion: DeclarationSchemaVersion, OSVersion: testOSVersion,
+		SchemaVersion: DeclarationSchemaVersion,
 	}); err != nil {
 		t.Fatalf("ValidateDeclaration() on an empty declaration = %v", err)
 	}
@@ -232,9 +231,6 @@ func TestValidateDeclarationRefusesWhatMarketRefuses(t *testing.T) {
 	}{
 		"no schema": {
 			func(d *DeclarationV2) { d.SchemaVersion = "1" }, "schemaVersion",
-		},
-		"no version": {
-			func(d *DeclarationV2) { d.OSVersion = " " }, "osVersion",
 		},
 		"unparsable timestamp": {
 			func(d *DeclarationV2) { d.GeneratedAt = "yesterday" }, "RFC3339",
@@ -288,7 +284,7 @@ func TestValidateDeclarationRefusesOverlappingPayloadPaths(t *testing.T) {
 		}
 	}
 	declaration := DeclarationV2{
-		SchemaVersion: DeclarationSchemaVersion, OSVersion: testOSVersion,
+		SchemaVersion: DeclarationSchemaVersion,
 		Apps: []DeclarationAppV2{
 			local("app-a", "app-a", "chart/app.tgz"),
 			local("app-b", "app-b", "chart/app.tgz/nested.tgz"),
@@ -307,7 +303,6 @@ func TestValidateDeclarationRefusesOverlappingPayloadPaths(t *testing.T) {
 func TestEmbeddedCatalogAppsAreDeclarable(t *testing.T) {
 	declaration := DeclarationV2{
 		SchemaVersion: DeclarationSchemaVersion,
-		OSVersion:     testOSVersion,
 		Apps:          catalogDeclarationApps(),
 	}
 

--- a/cli/pkg/preinstall/deployment_contract_test.go
+++ b/cli/pkg/preinstall/deployment_contract_test.go
@@ -25,7 +25,6 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 	// the next one.
 	for _, required := range []string{
 		"- name: PREINSTALL_DIR\n            value: /opt/app/preinstall",
-		"- name: OLARES_VERSION\n            value: \"1.12.7\"",
 		"- name: opt-data\n            mountPath: /opt/app/data",
 		"- name: market-preinstall\n            mountPath: /opt/app/preinstall\n            readOnly: true",
 	} {
@@ -33,7 +32,16 @@ func TestMarketDeploymentMountsPreinstallReadOnlyBesideWritableData(t *testing.T
 			t.Errorf("appstore-backend container missing contract:\n%s", required)
 		}
 	}
-	for _, forbidden := range []string{"PREINSTALL_ENABLED", "PREINSTALL_BUNDLE_DIR", "ENSURE_APPS_FILE", "market-ensure"} {
+	// OLARES_VERSION is forbidden rather than pinned. Which version this device
+	// runs is written by the OS into the terminus record at the end of an
+	// install or an upgrade, and Market reads it from there -- both to choose a
+	// declaration and to query the catalog. A literal in this chart is a second
+	// answer to the same question, rendered before the upgrade that changes it,
+	// so it was wrong exactly while an upgrade was running.
+	for _, forbidden := range []string{
+		"OLARES_VERSION",
+		"PREINSTALL_ENABLED", "PREINSTALL_BUNDLE_DIR", "ENSURE_APPS_FILE", "market-ensure",
+	} {
 		if strings.Contains(deployment, forbidden) {
 			t.Errorf("market deployment still carries the retired %q", forbidden)
 		}

--- a/cli/pkg/preinstall/publish.go
+++ b/cli/pkg/preinstall/publish.go
@@ -23,6 +23,10 @@ import (
 // no medium is the ordinary case rather than a reason to leave Market with no
 // declaration for the release it is now running.
 func Publish(installerDir, rootDir, osVersion string, selections ProfileSelections) error {
+	trunk := TrunkVersion(osVersion)
+	if trunk == "" {
+		return fmt.Errorf("publish declaration: no Olares version to name it after")
+	}
 	source, err := openStaticBundle(installerDir)
 	if err != nil {
 		return err
@@ -36,11 +40,11 @@ func Publish(installerDir, rootDir, osVersion string, selections ProfileSelectio
 			return err
 		}
 	}
-	declaration, err := BuildDeclaration(osVersion, source.bundle, selections, catalogDeclarationApps())
+	declaration, err := BuildDeclaration(source.bundle, selections, catalogDeclarationApps())
 	if err != nil {
 		return err
 	}
-	return publishDeclaration(source, rootDir, declaration)
+	return publishDeclaration(source, rootDir, trunk, declaration)
 }
 
 // publishDeclaration writes one trunk's declaration and does nothing if that
@@ -48,11 +52,7 @@ func Publish(installerDir, rootDir, osVersion string, selections ProfileSelectio
 // presence is what says the payload beside it is complete; a publish interrupted
 // halfway leaves verified files and no declaration, and the next attempt
 // finishes the job.
-func publishDeclaration(source medium, rootDir string, declaration DeclarationV2) error {
-	trunk := TrunkVersion(declaration.OSVersion)
-	if trunk == "" {
-		return fmt.Errorf("publish declaration: no Olares version")
-	}
+func publishDeclaration(source medium, rootDir, trunk string, declaration DeclarationV2) error {
 	declarationData, err := json.MarshalIndent(declaration, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode declaration: %w", err)

--- a/cli/pkg/preinstall/publish_test.go
+++ b/cli/pkg/preinstall/publish_test.go
@@ -386,7 +386,7 @@ func TestPublishRefusesAPublishWithNoVersionToNameItAfter(t *testing.T) {
 
 	err := Publish(installerDir, baseDir, "  ", ProfileSelections{})
 
-	if err == nil || !strings.Contains(err.Error(), "osVersion") {
+	if err == nil || !strings.Contains(err.Error(), "no Olares version") {
 		t.Fatalf("Publish() error = %v, want a missing version rejection", err)
 	}
 }
@@ -577,9 +577,6 @@ func readPublishedDeclaration(t *testing.T, target, osVersion string) Declaratio
 	}
 	if err := ValidateDeclaration(&declaration); err != nil {
 		t.Fatalf("published declaration is not one Market would read: %v", err)
-	}
-	if TrunkVersion(declaration.OSVersion) != TrunkVersion(osVersion) {
-		t.Fatalf("declaration osVersion = %q, want trunk %q", declaration.OSVersion, TrunkVersion(osVersion))
 	}
 	return declaration
 }

--- a/cli/pkg/preinstall/testdata/materialized-declaration/golden/preinstall-1.12.7.json
+++ b/cli/pkg/preinstall/testdata/materialized-declaration/golden/preinstall-1.12.7.json
@@ -1,6 +1,5 @@
 {
   "schemaVersion": "2",
-  "osVersion": "1.12.7",
   "generatedAt": "2026-07-25T00:00:00Z",
   "apps": [
     {

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.101
+        image: beclab/market-backend:v0.6.103
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -156,8 +156,6 @@ spec:
           - configMapRef:
               name: login-olares-cli-allow-list
         env:
-          - name: OLARES_VERSION
-            value: "1.12.7"
           - name: APP_SOTRE_SERVICE_SERVICE_PORT
             value: "443"
           - name: APP_SERVICE_SERVICE_HOST

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.103
+        image: beclab/market-backend:v0.6.104
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
## Background

This started as the one commit #4005 left behind — it was pushed to that branch
after the squash merge had already taken `5ca2f2d78`, so `main` has the
declaration work and not this. It has since picked up a second removal of the
same shape, and a newer image than it originally named.

## What this does

Three commits, and two of them delete a fact that was written down twice.

**The chart stopped telling Market which version this device runs.** It set
`OLARES_VERSION` to the literal `"1.12.7"`, and Market's catalog sync read it.
Which version a device runs is written by the OS into its `terminus` record at
the end of an install or an upgrade, and Market reads it from there to choose a
`preinstall-<trunk>.json` — so the variable was a second answer to the same
question, rendered before the upgrade that changes it, and therefore wrong
exactly while an upgrade was running, which is when preinstall runs. Market no
longer reads it at all (beclab/market#435): the record is the single authority,
consulted per sync cycle rather than copied at startup, and Market refuses to
start without one. The contract test now forbids the variable instead of pinning
its value, so it cannot come back with the next chart edit — verified in both
directions, putting the two lines back fails the test with `market deployment
still carries the retired "OLARES_VERSION"`.

**The declaration stopped restating its own trunk.** `preinstall-<trunk>.json`
carried an `osVersion` field saying what the file name already said. Market
cross-checked only the trunk portion of it, so a full version string with a
suffix passed a check that read as exact — and the example in both documents was
written that way, `"1.12.7-rc.1"`, which is not a trunk. The field is gone from
the CLI that writes it and from the Market that reads it (beclab/market@488960a),
and the file name is now the only place the trunk is written down.

**The image moves to `beclab/market-backend:v0.6.104`.** Two reasons, and the
second is not the one this PR was opened with:

- The `osVersion` removal is lockstep. This Market refuses a declaration
  carrying the field, and `v0.6.103` refuses one without it, so shipping the CLI
  half of it without moving the image would have a fresh install write a file the
  pod will not read. Both halves are in this branch, which is the only place they
  can land together — the CLI and the chart are built from the same commit.
- `:v0.6.103` no longer identifies the release this chart claimed. market's
  publish workflow runs on a push to `main` as well as on a tag, and tags the
  image after the repository's latest git tag — so the two commits that landed on
  `main` today each overwrote `:v0.6.103`, and the label now means "whatever main
  last held". `v0.6.104` was cut for those commits so the deployment names what
  it actually runs.

`v0.6.104` therefore also carries the change that arrived on `main` after
`v0.6.103` was cut: the catalog answers for this machine's hardware, read from
the nodes rather than from a client's `arch` query parameter, so an app the box
cannot run is not offered and then refused by app-service.

## One consequence worth knowing before this merges

Publishing a declaration is first-write-wins: a `preinstall-<trunk>.json` that
already exists for a trunk is never rewritten. So a device already on a 1.12.7
daily or rc has a file on disk with `osVersion` in it, this Market's strict
decoding refuses it, and nothing rewrites it — it reports `preinstall_degraded`
until someone deletes the file. The release channel has never seen this format,
so only internal machines are affected, and the fix is to delete the file and
republish.

## Scope

Two other things share the `OLARES_VERSION` name and are deliberately untouched:

- `framework/files/.olares/config/cluster/deploy/files_deploy.yaml` sets its own
  `OLARES_VERSION: '1.12'` for the Files app — a different consumer.
- `cli/pkg/common`'s `ENV_OLARES_VERSION` is the shell environment the CLI
  renders templates with, not an environment variable in the Market container.

`Publish` now refuses an empty version outright rather than deriving a trunk from
a field it wrote itself, which is where that check used to live.

## Verification

- `go build ./...`
- `go test ./pkg/preinstall/... ./pkg/upgrade/... ./pkg/phase/...`
- `gofmt -l pkg/preinstall` clean
- `beclab/market-backend:v0.6.104` inspected on Docker Hub: `linux/amd64` and
  `linux/arm64` both present in the manifest list, from a green tag build.

## Ordering

beclab/market#435 is merged, and `v0.6.104` is tagged and published, so the
release this chart names exists. Within this branch the ordering has no bad
intermediate state: the variable and the image that stopped reading it move in
the same commit, and the `osVersion` removal lands with the image that requires
it.

Made with [Cursor](https://cursor.com)