### PR TITLE
chore(images) bump auth to 0.2.61 and l4-bfl-proxy to v0.3.48

### DIFF
--- a/cli/pkg/upgrade/base.go
+++ b/cli/pkg/upgrade/base.go
@@ -159,7 +159,7 @@ func (u upgraderBase) UpgradeSystemComponents() []task.Interface {
 		},
 		&task.LocalTask{
 			Name:   "UpgradeL4BFLProxy",
-			Action: &upgradeL4BFLProxy{Tag: "v0.3.46"},
+			Action: &upgradeL4BFLProxy{Tag: "v0.3.48"},
 			Retry:  6,
 			Delay:  15 * time.Second,
 		},

--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -431,7 +431,7 @@ spec:
           privileged: true
       containers:      
       - name: authelia
-        image: beclab/auth:0.2.60
+        image: beclab/auth:0.2.61
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
+++ b/framework/bfl/.olares/config/launcher/templates/bfl_deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-framework:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.3.46
+          value: v0.3.48
         - name: L4_PROXY_SERVICE_ACCOUNT
           value: os-network-internal
         - name: L4_PROXY_NAMESPACE

--- a/framework/l4-bfl-proxy/.olares/Olares.yaml
+++ b/framework/l4-bfl-proxy/.olares/Olares.yaml
@@ -3,5 +3,5 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/l4-bfl-proxy:v0.3.46
+      name: beclab/l4-bfl-proxy:v0.3.48
 # must have blank new line            


### PR DESCRIPTION
Bump `beclab/auth` to `0.2.61` and `beclab/l4-bfl-proxy` to `v0.3.48` for session identity header support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and edge proxy images on the session/request path; risk is limited to rollout of tagged images with no manifest logic changes in this diff.
> 
> **Overview**
> Bumps **`beclab/auth`** to **`0.2.61`** and **`beclab/l4-bfl-proxy`** to **`v0.3.48`** across deploy, upgrade, and prebuilt metadata so fresh installs, upgrades, and BFL-provisioned L4 proxies stay on the same versions. The stated motivation is **session identity header** support between auth and the L4 proxy path.
> 
> **`auth_backend_deploy.yaml`** updates the Authelia backend container image. **`bfl_deploy.yaml`** changes **`L4_PROXY_IMAGE_VERSION`** so user launcher/BFL rolls out the new proxy tag. **`cli/pkg/upgrade/base.go`** updates the default **`UpgradeL4BFLProxy`** task tag, and **`framework/l4-bfl-proxy/.olares/Olares.yaml`** pins the prebuilt container reference to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c150e6e417c71253e69c78c5952d48ae2117d721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->