### PR TITLE
fix(cli): keep JuiceFS and k3s startable across an Olares stop/start

### DIFF
--- a/cli/pkg/phase/cluster/enable_juicefs.go
+++ b/cli/pkg/phase/cluster/enable_juicefs.go
@@ -261,11 +261,23 @@ func (m *RegenerateRuntimeServiceModule) Init() {
 			Name:   "RegenerateK3sService",
 			Action: new(k3s.GenerateK3sService),
 		},
-		// EnableK3sService does `systemctl daemon-reload && systemctl enable --now k3s`,
-		// which picks up the regenerated unit (with the JuiceFS pre-check).
+		// daemon-reload picks up the regenerated unit (with the JuiceFS
+		// pre-check); `enable` (idempotent, no --now) keeps it enabled at boot.
+		//
+		// Deliberately NOT k3s.EnableK3sService: that runs `enable --now`, which
+		// starts k3s here. This module runs while Olares is stopped (the
+		// migration requires it), so etcd and containerd are both down and k3s
+		// cannot come up - it either dies with "Failed to validate datastore
+		// connection" or hangs forever in "Waiting for CRI startup" while
+		// systemd blocks on the unit becoming active. StartOlaresModule, which
+		// runs right after this one, starts the whole stack in dependency order.
 		&task.LocalTask{
-			Name:   "EnableK3sService",
-			Action: new(k3s.EnableK3sService),
+			Name: "ReloadSystemdUnits",
+			Action: &terminus.SystemctlCommand{
+				DaemonReloadPreExec: true,
+				Command:             "enable",
+				UnitNames:           []string{"k3s"},
+			},
 		},
 	}
 }

--- a/cli/pkg/storage/juicefs.go
+++ b/cli/pkg/storage/juicefs.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/beclab/Olares/cli/pkg/core/util"
@@ -10,6 +11,7 @@ import (
 	"github.com/beclab/Olares/cli/pkg/common"
 	cc "github.com/beclab/Olares/cli/pkg/core/common"
 	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
 	"github.com/beclab/Olares/cli/pkg/core/task"
 	"github.com/beclab/Olares/cli/pkg/manifest"
 	"github.com/beclab/Olares/cli/pkg/utils"
@@ -199,6 +201,49 @@ func (t *ConfigJuiceFsMetaDB) Execute(runtime connector.Runtime) error {
 
 	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return err
+	}
+	return nil
+}
+
+// CleanupStaleJuiceFSMount detaches a dead JuiceFS FUSE mount left behind at
+// the rootfs mount point, so that the next mount attempt can succeed.
+//
+// On shutdown the juicefs client gives its own umount 30 seconds and then
+// force-exits ("umount does not finish in 30 seconds, force exit"), leaving the
+// fuse.juicefs entry in /proc/self/mounts with no process serving it. systemd
+// still reports the unit as cleanly deactivated. Every later access to the path
+// then fails with ENOTCONN, and a fresh `juicefs mount` cannot recover on its
+// own: fusermount3 has to stat the mount point first and gets ENOTCONN too, so
+// juicefs.service crash-loops indefinitely. k3s never starts either, because
+// its ExecStartPre runs `juicefs summary` on the same path.
+//
+// A lazy umount detaches the dead mount immediately while letting any remaining
+// references drain, which is exactly what is needed before remounting. This is
+// a no-op when the mount point is absent, or when juicefs.service is running
+// (so an already-started Olares is never disturbed).
+type CleanupStaleJuiceFSMount struct {
+	common.KubeAction
+}
+
+func (t *CleanupStaleJuiceFSMount) Execute(runtime connector.Runtime) error {
+	mounted, err := isJuiceFSMounted(runtime, OlaresJuiceFSRootDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to read the mount table")
+	}
+	if !mounted {
+		return nil
+	}
+	// Liveness is decided by the unit state, not by touching the path: the
+	// client mounts with --attr-cache 300, so the kernel keeps answering stat()
+	// on the mount root from its attribute cache for minutes after the serving
+	// process is gone. A mount whose unit is not active has nothing behind it.
+	if out, _ := runtime.GetRunner().SudoCmd("systemctl is-active juicefs", false, false); strings.TrimSpace(out) == "active" {
+		return nil
+	}
+	logger.Infof("detaching stale JuiceFS mount at %s (juicefs.service is not active)", OlaresJuiceFSRootDir)
+	if _, err := runtime.GetRunner().SudoCmd(
+		fmt.Sprintf("umount -l %s", OlaresJuiceFSRootDir), false, false); err != nil {
+		return errors.Wrapf(err, "failed to detach the stale JuiceFS mount at %s", OlaresJuiceFSRootDir)
 	}
 	return nil
 }

--- a/cli/pkg/terminus/modules.go
+++ b/cli/pkg/terminus/modules.go
@@ -325,8 +325,18 @@ func (m *StopOlaresModule) Init() {
 		minIOServiceName,
 		cniDhcpServiceName,
 	} {
-		if serviceExists(service) {
-			m.Tasks = append(m.Tasks, newStopServiceTask(service))
+		if !serviceExists(service) {
+			continue
+		}
+		m.Tasks = append(m.Tasks, newStopServiceTask(service))
+		// The juicefs client force-exits when its own umount does not finish in
+		// 30s, leaving a dead mount behind that systemd reports as a clean stop.
+		// Detach it here so the node is not left with a poisoned mount point.
+		if service == juiceFSServiceName {
+			m.Tasks = append(m.Tasks, &task.LocalTask{
+				Name:   "CleanupStaleJuiceFSMount",
+				Action: new(storage.CleanupStaleJuiceFSMount),
+			})
 		}
 	}
 	if len(m.Tasks) == 0 {
@@ -370,9 +380,19 @@ func (m *StartOlaresModule) Init() {
 		// backupETCDServiceName,
 		containerdServiceName,
 	} {
-		if serviceExists(service) {
-			m.Tasks = append(m.Tasks, newStartServiceTask(service))
+		if !serviceExists(service) {
+			continue
 		}
+		// A previous shutdown (or a crash) can leave a dead fuse.juicefs mount
+		// on the rootfs, which makes every subsequent mount fail. Detach it
+		// first, otherwise juicefs.service crash-loops and k3s never starts.
+		if service == juiceFSServiceName {
+			m.Tasks = append(m.Tasks, &task.LocalTask{
+				Name:   "CleanupStaleJuiceFSMount",
+				Action: new(storage.CleanupStaleJuiceFSMount),
+			})
+		}
+		m.Tasks = append(m.Tasks, newStartServiceTask(service))
 	}
 	k3sServiceExists := serviceExists(k3sServiceName)
 	kubeletServiceExists := serviceExists(kubeletServiceName)


### PR DESCRIPTION
* **Background**
If any juicefs mount point are left uncleaned after stop with a limited timeout, systemd considers the mount points alive and affects the normal start of k3s service, these need to be cleaned up manually

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes systemd orchestration for k3s during JuiceFS migration and adds mount teardown on stop/start; incorrect cleanup could affect a live JuiceFS mount, but the implementation gates on `juicefs.service` not being active.
> 
> **Overview**
> Fixes **Olares stop/start** and **JuiceFS migration** paths where a timed JuiceFS shutdown can leave a dead `fuse.juicefs` mount on the rootfs while systemd still reports a clean stop. That poisons the mount point (`ENOTCONN`), makes `juicefs.service` crash-loop, and blocks **k3s** because its pre-start checks the same path.
> 
> Adds **`CleanupStaleJuiceFSMount`**, which lazy-unmounts the rootfs mount when it is present but `juicefs.service` is not active (using unit state instead of `stat()` because attribute cache can lie). It is wired into **`StopOlaresModule`** (after stopping juicefs) and **`StartOlaresModule`** (before starting juicefs).
> 
> During **enable-juicefs**, **`RegenerateRuntimeServiceModule`** no longer calls **`k3s.EnableK3sService`** (`enable --now`). It only **daemon-reloads** and **`enable`** k3s without starting it, because migration runs with Olares stopped; **`StartOlaresModule`** starts the stack in order afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc43b811222ab4164c8821ea5b2c4c6ea479c423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->