### PR TITLE
daemon: let a node power command reach the worker it names

### DIFF
--- a/daemon/internel/apiserver/handlers/handler_cluster_operations.go
+++ b/daemon/internel/apiserver/handlers/handler_cluster_operations.go
@@ -172,8 +172,14 @@ func (h *Handlers) PostClusterOperation(ctx *fiber.Ctx) error {
 			// The token stays available for types that fan out without a
 			// signature; signature-bound types still present only the JWS to
 			// workers — see clusterop.DispatchNodeOperation.
-			Token:     ctx.Get(AUTH_HEADER),
-			Signature: ctx.Get(SIGNATURE_HEADER),
+			//
+			// Both are copied because Create hands them to a run that outlives
+			// this request. ctx.Get returns a string aliasing the fasthttp
+			// header buffer, and that buffer is reused by the next request on
+			// this connection the moment the handler returns: what the run
+			// would otherwise present to a worker is whatever arrived after it.
+			Token:     strings.Clone(ctx.Get(AUTH_HEADER)),
+			Signature: strings.Clone(ctx.Get(SIGNATURE_HEADER)),
 		},
 	})
 	if err != nil {

--- a/daemon/internel/apiserver/handlers/handler_collect_logs.go
+++ b/daemon/internel/apiserver/handlers/handler_collect_logs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/beclab/Olares/daemon/internel/client"
 	"github.com/beclab/Olares/daemon/pkg/commands"
@@ -40,8 +41,10 @@ func (h *Handlers) PostCollectLogs(ctx *fiber.Ctx, cmd commands.Interface) error
 	param.CallerUsername = userData.Username
 	param.CallerRole = roleOf(userData)
 	// Forward the verified access token so the orchestrator can authenticate to
-	// each node's node-local endpoint as the same caller.
-	param.CallerToken = ctx.Get(AUTH_HEADER)
+	// each node's node-local endpoint as the same caller. Copied because the
+	// collection runs on after this handler returns, and ctx.Get aliases the
+	// fasthttp header buffer that the next request overwrites.
+	param.CallerToken = strings.Clone(ctx.Get(AUTH_HEADER))
 
 	res, err := cmd.Execute(ctx.Context(), &param)
 	if err != nil {

--- a/daemon/internel/apiserver/handlers/signature_binding_test.go
+++ b/daemon/internel/apiserver/handlers/signature_binding_test.go
@@ -73,6 +73,47 @@ func TestCreateClusterOperationAcceptsASignatureBoundToIt(t *testing.T) {
 	}
 }
 
+// The run outlives the request that started it, so the credential handed to it
+// has to own its bytes. ctx.Get returns a string pointing into the fasthttp
+// header buffer, and that buffer belongs to the next request the moment this
+// handler returns — on a master whose caller is already polling the record it
+// was just given, milliseconds later. A run left holding the alias presents
+// whatever arrived after it, which every worker refuses as a malformed JWS.
+func TestCreateClusterOperationHandsTheRunASignatureItKeeps(t *testing.T) {
+	f := withClusterOperations(t, &fakeOperations{op: sampleOperation()})
+	asAuthorizedUser(t)
+	asOwnerSignature(t)
+	asMaster(t)
+
+	headers := signedFor(t, clusterop.TypeReboot, "client-1")
+	signature := headers[SIGNATURE_HEADER]
+	resp, body := callRegisteredMethod(t, http.MethodPost, "/cluster/operations",
+		`{"type":"reboot","requestId":"client-1"}`, headers)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, body)
+	}
+
+	// The next request through the same app. It carries the same header names,
+	// so its signature lands in the slot the first one used, and one of the
+	// same length, so it overwrites those bytes rather than reallocating.
+	later := signedFor(t, clusterop.TypeReboot, "client-2")
+	if len(later[SIGNATURE_HEADER]) != len(signature) {
+		t.Fatalf("this test overwrites in place, so the follow-up signature has to be "+
+			"the same length: %d vs %d", len(later[SIGNATURE_HEADER]), len(signature))
+	}
+	callRegisteredMethod(t, http.MethodPost, "/cluster/operations",
+		`{"type":"reboot","requestId":"client-2"}`, later)
+
+	reqs := f.requests()
+	if len(reqs) == 0 {
+		t.Fatal("the orchestrator was never called")
+	}
+	if reqs[0].Creds.Signature != signature {
+		t.Errorf("the run's signature became %q, want the one it was started with %q",
+			reqs[0].Creds.Signature, signature)
+	}
+}
+
 // The worker hop presents the same operation-bound signature. It is not the
 // access token: forwarding that would hand every node a credential good for
 // every route the user can reach.

--- a/daemon/pkg/cluster/state/current.go
+++ b/daemon/pkg/cluster/state/current.go
@@ -84,7 +84,11 @@ func refreshCurrentStatus(ctx context.Context) error {
 	name, err := utils.GetOlaresNameFromReleaseFile()
 	if err != nil {
 		klog.Error("get olares name from release file error, ", err)
-	} else {
+	} else if name != "" {
+		// Only when the file actually names one. A node that joined an
+		// existing cluster has no OLARES_NAME — that file is written where the
+		// activation happened — and assigning the empty string here would
+		// erase the ID resolved from the cluster below on every pass.
 		CurrentState.TerminusName = &name
 	}
 
@@ -360,6 +364,22 @@ func refreshCurrentStatus(ctx context.Context) error {
 	if err != nil {
 		currentTerminusState = SystemError
 		return err
+	}
+
+	// A node whose release file does not name the owner learns the Olares ID
+	// from the cluster. It is resolved here rather than only once every system
+	// component is ready, because a degraded cluster is exactly when an
+	// operator reaches for a power command, and the routes that authorize one
+	// have no other way to tell whose signature they are holding.
+	if CurrentState.TerminusName == nil || *CurrentState.TerminusName == "" {
+		if terminusName, err := utils.GetAdminUserTerminusName(ctx); err != nil {
+			// Quiet: this runs on a 5s poll, and a cluster still coming up has
+			// no user record for it to find yet.
+			klog.V(4).Info("resolve the owner's olares name from the cluster, ", err)
+		} else {
+			klog.Info("resolved the owner's olares name from the cluster: ", terminusName)
+			CurrentState.TerminusName = &terminusName
+		}
 	}
 
 	pressure, err := utils.GetNodesPressure(ctx, kubeClient)


### PR DESCRIPTION
* **Background**

A reboot or shutdown aimed at a compute node was refused by the target worker and the machine stayed up. Two independent bugs, both found while tracing one failed `shutdown` of a worker in a three-node cluster.

**1. The master forwarded a credential that no longer existed.**

olaresd builds its API with `fiber.New()` and no `Immutable` setting, so `ctx.Get` returns a string aliasing the fasthttp header buffer. That buffer belongs to the next request the moment the handler returns, while `Manager.Create` hands the credentials to a run that keeps going long after it. On a master whose caller is already polling the record it was just given, the run presented whatever arrived next:

```
11:18:38.485  jws.go:57]  JWS validation successful   type=shutdown target=olares-work
11:18:38.488  200  POST /cluster/operations                        <- handler returns
11:18:38.519  W reason.go:183] dispatch the power command to node olares-work:
              node returned 403: {"code":403,"message":"invalid jws: wrong number of segments"}
```

The same signature verified on the master 30 ms before the worker rejected it as malformed. Log collection took the access token the same way, into a goroutine that fans out to every node.

**2. A joined node could not tell who its owner was.**

A node that joined an existing cluster has no `OLARES_NAME` in its release file — that file is written where the activation happened — so `RequireOwner` falls back to the Olares ID in the published state snapshot. The refresh only resolved that ID from the cluster once every system component was ready, and it overwrote whatever it had found with the release file's empty value on the next pass, so on such a node the snapshot never carried one.

A degraded cluster is exactly when an operator reaches for a power command. With one worker `NotReady` and its calico-node, multus and node-exporter pods `Pending`, the remaining worker refused a shutdown the owner had signed:

```
09:46:39  node returned 403: {"code":403,"message":"cannot determine the owner of this Olares"}
```

**What changed**

- Both credentials are copied at the HTTP boundary before they are handed to anything that outlives the request. `collect_logs` copies its access token alongside.
- The release file names the owner only when it actually does, and the cluster is asked for the Olares ID ahead of the readiness gate rather than behind it. Only the owner's user record is read, out of the informer cache.

* **Target Version for Merge**

1.12.7

* **Related Issues**

None.

* **PRs Involving Sub-Systems**

None.

* **Other information**

The regression test reproduces the race rather than asserting the copy: it starts an operation, sends a follow-up carrying a same-length signature so the pooled buffer is overwritten in place, and checks the run still holds the one it was started with. Reverting the fix fails it 3 times out of 3, with the first run's signature showing the second request's `requestId`.

`go vet` and the tests for the touched packages pass. Not yet verified end to end on a live cluster.

Made with [Cursor](https://cursor.com)