### PR TITLE
olares: bump system-frontend to v1.11.36

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.34
+          image: beclab/system-frontend:v1.11.36
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image so that the v1.12.7 release picks up the latest LarePass/TermiPass fixes. It is a chart/manifest-only change: no Olares-side logic is touched, only the image tag.

  Image change:

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.34` | `beclab/system-frontend:v1.11.36` |

  `user-service` stays on its current version.

  Because the previous bump ([#4011](https://github.com/beclab/Olares/pull/4011)) stopped at `v1.11.34`, this one carries everything tagged in `v1.11.35` **and** `v1.11.36`.

  **What the new `system-frontend` image contains**

  1. **Access policies are read-only for apps whose entrances the user must not repoint** (TermiPass [#1384](https://github.com/beclab/TermiPass/pull/1384), released in `v1.11.35`). System apps and `wisev3` — including clones, matched on `rawAppName` so a cloned instance is covered too — now render Access policies as plain text: no selects, no chevron into sub-policies, no Submit. Endpoint settings on the same page stay editable, and ordinary third-party apps keep the full editable form. Two build-side items ride along: the listing SCSS moved out of Quasar's `variables.scss` into the Settings/Files `app.scss`, so `dev:settings` no longer dies on a circular `@import` (`This file is already being loaded`), and the Wise nginx knowledge/ws proxies now point at `wisev3-shared`.

  2. **Self-built FRP settings are validated before they can be saved** (TermiPass [#1385](https://github.com/beclab/TermiPass/pull/1385)). Switching the reverse proxy can leave Olares unreachable for roughly ten minutes, so a malformed server address or port must never reach the confirmation dialog. The address and port fields now surface inline errors, and the save button is disabled until every rule passes — including the auth token, which previously had no message of its own and left the button looking alive while `onSubmit` returned silently. Address normalization is shared between validation and submission, so the value that gets checked is exactly the value that gets stored: a pasted scheme (`https://frp.example.com`) is still tolerated because people copy one out of a browser, while a path or an inline `:port` is now rejected instead of being silently dropped. An empty port remains valid and persists as `0`, which is how the backend already spells "unset". The reverse proxy page also renders a localized "No need (IP Direct)" label in all seven locales instead of a hardcoded string.

  3. **The pre-login local vault is selected by identity instead of array position** (TermiPass [#1385](https://github.com/beclab/TermiPass/pull/1385)). On login the vault to merge was taken as `state.vaults[0]`, but that index is not stable: the `vaults` getter calls `sort()` with no comparator, which sorts the array **in place** by `Vault.toString()`. Position 0 could therefore land on an organization vault, in which case every item in it was copied into the user's main vault under its original id — a persistent cross-vault leak — and the org vault was dropped from local state. The vault is now chosen by what it actually is (no org, and not the account's main vault), so the merge only ever touches the vault created before login.

  4. **Non-retryable upload failures surface immediately with localized copy** (TermiPass [#1385](https://github.com/beclab/TermiPass/pull/1385)). Native upload errors that cannot recover by retrying — starting with `permission denied` — now skip the 5-attempt exponential backoff (about 62s of dead waiting) and show a localized message rather than the raw server string. Electron, iOS and Android all funnel through `onFileError`, so a single match list covers every platform, and the translations were added for de/en/es/fr/it/ja/zh. This depends on the refreshed native transfer binaries from `files-frontend-sdk` v0.0.4 (desktop `DesktopAddon.node` for mac / win / linux x64 / linux arm64, Android `libtransfer.so`, iOS `BTLarePassTransfer.framework`), which are what make the native callback actually include the server's error body — without them a permission failure still arrives as `HTTP response code said error|22` and the TS matcher never fires. The iOS framework is now a static archive and no longer ships `_CodeSignature`; Xcode's `CodeSignOnCopy` re-signs it on embed.

  5. **Login redirection follows the current page protocol** (TermiPass [#1385](https://github.com/beclab/TermiPass/pull/1385)). `redirectToLogin` derives the auth server base URL from the protocol of the page it is redirecting from, so a page served over HTTP is no longer forced onto an HTTPS auth server. This matters for LAN / `.olares.local` access, where the forced upgrade produced a failed redirect instead of a login page.

  6. **Wi-Fi selection during onboarding connects Olares to the network the user picked** (TermiPass [#1360](https://github.com/beclab/TermiPass/pull/1360), mobile-app scope). Choosing a network other than the phone's current one was effectively ignored: the password dialog title and `connectWifiMachineTerminus` both used the phone's SSID, and the follow-up IP lookup keyed on that same SSID could never match, so the flow stalled with no error. Both now use the selected SSID (HTML-escaped before being rendered into the dialog message), and once the host IP switch succeeds a single-button reminder names the Wi-Fi Olares moved to and asks the user to move the phone onto it as well, before navigating back. Picking the phone's own Wi-Fi, or a wired network, behaves exactly as before.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
 None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1385

* **Other information**
 Full Changelog: 
https://github.com/beclab/TermiPass/compare/v1.11.35...v1.11.36,

Made with [Cursor](https://cursor.com)