### PR TITLE
feat: bind user-backend to download/files providers for shared apps

### DIFF
--- a/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/permission.yaml
+++ b/framework/system-server/.olares/config/user/helm-charts/systemserver/templates/permission.yaml
@@ -19,3 +19,44 @@ subjects:
 - kind: ServiceAccount
   name: user-backend
   namespace: user-system-{{ .Values.bfl.username }}
+
+---
+# Grant every user's user-backend SA access to the os-framework download
+# provider. Shared apps (e.g. wisev3) that serve many users cannot present a
+# per-user identity through their own shared-namespace SA (the provider gateway
+# collapses it to the install owner). Instead they mint this user-backend token
+# so UserFromServiceAccount resolves the real end user (user-system-<user> is a
+# user namespace). The ClusterRole `backend:download-provider` is defined by the
+# download-server framework component (download_provider.yaml).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend:{{ .Values.bfl.username }}:user-backend:download-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backend:download-provider
+subjects:
+- kind: ServiceAccount
+  name: user-backend
+  namespace: user-system-{{ .Values.bfl.username }}
+
+---
+# Same rationale as the download binding above, for the (new) os-framework
+# files system provider. The wisev3 frontend's provider-inject sidecar mints
+# this user-backend token per request (from the gateway-stamped X-Bfl-User) so
+# file uploads / browsing are attributed to the real end user instead of the
+# shared install owner. ClusterRole `backend:files-provider` is defined by the
+# Olares files framework component (files_provider.yaml).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backend:{{ .Values.bfl.username }}:user-backend:files-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backend:files-provider
+subjects:
+- kind: ServiceAccount
+  name: user-backend
+  namespace: user-system-{{ .Values.bfl.username }}


### PR DESCRIPTION
Background
Bind every user's `user-backend` ServiceAccount (in `user-system-<user>`) to the os-framework `backend:download-provider` and `backend:files-provider` ClusterRoles, in the per-user `systemserver` chart.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Per-user ClusterRoleBindings broaden what every user's `user-backend` SA can access at the cluster level for download and files providers; changes are RBAC-only but affect cross-user identity and provider authorization.
> 
> **Overview**
> Extends the per-user **systemserver** Helm chart so each `user-backend` ServiceAccount in `user-system-<user>` is explicitly bound to the existing **settings-provider** ClusterRole and to two new bindings for **`backend:download-provider`** and **`backend:files-provider`**.
> 
> This enables **shared multi-user apps** (e.g. wisev3) to mint a per-user `user-backend` token instead of relying on a shared-namespace SA, so os-framework download and files provider gateways can attribute requests to the real end user via `UserFromServiceAccount` / gateway-stamped identity rather than the install owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df67d887559344ffec427e12aa9ad8d608be1bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->