### PR TITLE
Add Cloud Agent dev environment setup for the Olares monorepo

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Olares monorepo",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent bootstrap for the Olares monorepo.
+#
+# Installs the toolchains the repository needs (Go 1.25 for the Go modules,
+# plus the CGO system libraries the olaresd daemon links against), warms the
+# module/npm caches, and builds the two flagship Go applications so a fresh
+# agent starts from a known-good state. Safe to run repeatedly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Go version required by cli/go.mod and daemon/go.mod (the `go` directive).
+GO_VERSION="1.25.0"
+ARCH="$(dpkg --print-architecture)"
+
+echo "==> Ensuring Go ${GO_VERSION} is installed"
+if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION} "; then
+  curl -fsSL -o /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz"
+  sudo rm -rf /usr/local/go
+  sudo tar -C /usr/local -xzf /tmp/go.tgz
+  rm -f /tmp/go.tgz
+fi
+# Make the toolchain available on the default PATH (/usr/local/bin is already there).
+sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
+sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+go version
+
+echo "==> Installing system build dependencies (CGO libs for olaresd)"
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libudev-dev libpcap-dev
+
+echo "==> Building olares-cli"
+make -C cli build
+
+echo "==> Building olaresd daemon"
+( cd daemon && CGO_ENABLED=1 go build -o bin/olaresd ./cmd/terminusd/main.go )
+
+echo "==> Installing frontend (apps) workspace dependencies"
+if command -v npm >/dev/null 2>&1; then
+  ( cd apps && npm install )
+else
+  echo "npm not found; skipping frontend dependency install"
+fi
+
+echo "==> Bootstrap complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a reproducible Cloud Agent development environment for the Olares monorepo so a fresh agent can build and run the project's flagship applications out of the box.

Before this change there was no `.cursor/environment.json`, and the base image ships Go 1.22, while both `cli/go.mod` and `daemon/go.mod` require **Go 1.25**. The daemon additionally needs CGO system libraries that are not present by default.

## What this sets up

- **Go 1.25 toolchain** — required by `cli/go.mod` and `daemon/go.mod` (installed to `/usr/local/go`, symlinked onto `PATH`).
- **CGO build dependencies** — `libudev-dev` and `libpcap-dev`, needed to build the `olaresd` daemon.
- **Builds the Go applications** — `olares-cli` (via `make -C cli build`) and `olaresd` (`daemon`), so the toolchain is validated during setup and module caches are warmed.
- **Frontend workspace deps** — `npm install` in `apps/` (lerna monorepo), enabling the Quasar dev servers documented in `apps/README.md`.

## Files

- `.cursor/environment.json` — declares the environment and runs the bootstrap script as the `install` step.
- `.cursor/install.sh` — idempotent bootstrap: installs Go 1.25, installs CGO libs, builds `olares-cli` and `olaresd`, installs `apps/` deps.

## Verification

All setup steps were run and verified in the agent VM. `olares-cli --version`, `olares-cli --help`, `olares-cli skills list`, and `olaresd --help`/`--version` all run successfully, and the `apps/` frontend dependencies install and produce a working Quasar dev server. Evidence is attached in the agent summary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff177742-87c0-4961-a4d0-332db83000be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff177742-87c0-4961-a4d0-332db83000be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

