### PR TITLE
docs: hide installation guides for Windows, PVE, and Raspberry Pi

### DIFF
--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -159,10 +159,10 @@ const side = {
                   text: "Using script",
                   link: "/manual/get-started/install-windows-script",
                 },
-                {
-                  text: "Using Docker image",
-                  link: "/manual/get-started/install-windows-docker",
-                },
+                // {
+                //   text: "Using Docker image",
+                //   link: "/manual/get-started/install-windows-docker",
+                // },
               ],
             }, */
             /* {

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -137,7 +137,7 @@ const side = {
 
               ],
             },
-            {
+            /* {
               text: "macOS",
               collapsed: true,
               items: [
@@ -150,8 +150,8 @@ const side = {
                   link: "/manual/get-started/install-mac-docker",
                 },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "Windows (WSL 2)",
               collapsed: true,
               items: [
@@ -159,13 +159,13 @@ const side = {
                   text: "Using script",
                   link: "/manual/get-started/install-windows-script",
                 },
-                /* {
+                {
                   text: "Using Docker image",
                   link: "/manual/get-started/install-windows-docker",
-                },*/
+                },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "PVE",
               collapsed: true,
               items: [
@@ -179,11 +179,11 @@ const side = {
                 },
                 { text: "LXC on PVE", link: "/manual/get-started/install-lxc" },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "Raspberry Pi",
               link: "/manual/get-started/install-raspberry-pi",
-            },
+            }, */
           ],
         },
         {

--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -135,7 +135,7 @@ const side = {
                 },
               ],
             },
-            {
+            /* {
               text: "macOS",
               collapsed: true,
               items: [
@@ -148,8 +148,8 @@ const side = {
                   link: "/zh/manual/get-started/install-mac-docker",
                 },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "Windows (WSL 2)",
               collapsed: true,
               items: [
@@ -157,13 +157,13 @@ const side = {
                   text: "使用脚本",
                   link: "/zh/manual/get-started/install-windows-script",
                 },
-                /*{
+                {
                   text: "使用 Docker 镜像",
                   link: "/zh/manual/get-started/install-windows-docker",
-                },*/
+                },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "PVE",
               collapsed: true,
               items: [
@@ -177,11 +177,11 @@ const side = {
                 },
                 { text: "LXC", link: "/zh/manual/get-started/install-lxc" },
               ],
-            },
-            {
+            }, */
+            /* {
               text: "树莓派",
               link: "/zh/manual/get-started/install-raspberry-pi",
-            },
+            }, */
           ],
         },
         {

--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -157,10 +157,10 @@ const side = {
                   text: "使用脚本",
                   link: "/zh/manual/get-started/install-windows-script",
                 },
-                {
-                  text: "使用 Docker 镜像",
-                  link: "/zh/manual/get-started/install-windows-docker",
-                },
+                // {
+                //   text: "使用 Docker 镜像",
+                //   link: "/zh/manual/get-started/install-windows-docker",
+                // },
               ],
             }, */
             /* {

--- a/docs/manual/get-started/install-olares.md
+++ b/docs/manual/get-started/install-olares.md
@@ -35,13 +35,13 @@ NVIDIA DGX Spark is a compact AI development platform featuring a high-performan
 - [**One-line script**](install-spark-script.md) (Recommended): Quick install via command line on DGX Spark.
 - [**ISO image**](install-spark-iso.md): Install Olares using the official ISO image for DGX Spark.
 
-### Alternative installation methods
+<!-- ### Alternative installation methods
 
 These methods are suitable for development, testing, or lightweight environments. 
 
 #### Windows
 - [**One-line script**](install-windows-script.md): Install Olares in Windows Subsystem for Linux 2 (WSL 2).
-<!--  [**Docker image**](install-windows-docker.md): Run Olares in Docker with WSL 2 integration. -->
+[**Docker image**](install-windows-docker.md): Run Olares in Docker with WSL 2 integration.
 
 #### macOS
 - [**One-line script**](install-mac-script.md): Install Olares in a containerized environment via MiniKube.
@@ -53,4 +53,4 @@ These methods are suitable for development, testing, or lightweight environments
 - [**LXC container**](install-lxc.md): Deploy Olares in Proxmox VE using Linux containers (LXC).
 
 #### Raspberry Pi (ARM)
-- [**One-line script**](install-raspberry-pi.md): Install Olares on ARM-based Raspberry Pi devices.
+- [**One-line script**](install-raspberry-pi.md): Install Olares on ARM-based Raspberry Pi devices. -->

--- a/docs/zh/manual/get-started/install-olares.md
+++ b/docs/zh/manual/get-started/install-olares.md
@@ -35,13 +35,13 @@ NVIDIA DGX Spark 是一款紧凑型 AI 开发平台，配备高性能 GPU。Olar
 - [**一行命令**](install-spark-script.md)（推荐）：通过命令行在 DGX Spark 上快速安装。
 - [**ISO 镜像**](install-spark-iso.md)：使用官方 ISO 镜像在 DGX Spark 上安装 Olares。
 
-### 其他安装方式
+<!-- ### 其他安装方式
 
 以下方式适用于开发、测试或轻量级环境。
 
 #### Windows
 - [**一行命令**](install-windows-script.md)：在 WSL2 虚拟化环境中安装 Olares。
-<!-- [**Docker 镜像**](install-windows-docker.md) — 在 WSL2 的 Docker 容器中运行 Olares。 -->
+[**Docker 镜像**](install-windows-docker.md) — 在 WSL2 的 Docker 容器中运行 Olares。
 
 #### macOS
 - [**一行命令**](install-mac-script.md)：使用 MiniKube 在容器化环境中安装 Olares。
@@ -53,4 +53,4 @@ NVIDIA DGX Spark 是一款紧凑型 AI 开发平台，配备高性能 GPU。Olar
 - [**LXC 容器**](install-lxc.md)：在 PVE 中使用 Linux 容器（LXC）部署 Olares。
 
 #### Raspberry Pi（ARM）
-- [**一行命令**](install-raspberry-pi.md)：在基于 ARM 架构的 Raspberry Pi 设备上安装 Olares。
+- [**一行命令**](install-raspberry-pi.md)：在基于 ARM 架构的 Raspberry Pi 设备上安装 Olares。 -->


### PR DESCRIPTION
* **Background**
This change only promotes Linux and DGX Spark as the primary installation methods. The hidden pages remain accessible through direct links and search engines.

* **Target Version for Merge**

* **Related Issues**

* **PRs Involving Sub-Systems** 


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only navigation and landing-page visibility changes with no runtime or security impact.
> 
> **Overview**
> **Hides non-primary install documentation** so the Get Started flow emphasizes **Linux** and **DGX Spark** only.
> 
> English and Chinese VitePress sidebars under **Install Olares** now wrap **macOS**, **Windows (WSL 2)**, **PVE**, and **Raspberry Pi** entries in block comments, so those sections no longer appear in the site nav. The same **Alternative installation methods** block on `install-olares.md` (EN/ZH) is wrapped in HTML comments, removing Windows, macOS, PVE, and Raspberry Pi links from the install hub while leaving the underlying guide pages in the repo (still reachable by direct URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c012bffa41d51ab0be6f67440dcc0d641855391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->