### PR TITLE
chore(cli): add system mem reserve to mainline upgrader

### DIFF
--- a/cli/pkg/upgrade/1_12_7.go
+++ b/cli/pkg/upgrade/1_12_7.go
@@ -53,6 +53,10 @@ func (u upgrader_1_12_7) PrepareForUpgrade() []task.Interface {
 	return tasks
 }
 
+func (u upgrader_1_12_7) PostUpgrade() []task.Interface {
+	return append(regenerateKubeFiles(), u.upgraderBase.PostUpgrade()...)
+}
+
 func init() {
 	registerMainUpgrader(upgrader_1_12_7{})
 }


### PR DESCRIPTION
* **Background**
Add upgrade task to reserve kube system memory to the mainline 1.12.7 upgrader

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade post-phase now regenerates kube config and restarts K3s or kubeadm-managed components, which can briefly disrupt the API during upgrades.
> 
> **Overview**
> The mainline **1.12.7** upgrader now implements **`PostUpgrade`**, appending **`regenerateKubeFiles()`** before the shared base post-upgrade tasks. That regeneration rewrites K3s/kubeadm/kubelet-related files and restarts the cluster runtime so nodes apply the **system-reserved memory** settings computed at generation time.
> 
> Placing this in **post-upgrade** (instead of prepare) matches the existing dated 1.12.7 upgrader pattern: earlier phases run tasks that exec into pods, and an upfront restart would race kubelet resync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59105e2653944ec4f41c7425b17bcb4518995baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->