### PR TITLE
refactor(app-service): simplify Shared caller DefaultRules

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.31
+        image: beclab/app-service:0.6.32
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/gateway/meshinagent/decide.go
+++ b/framework/app-service/pkg/gateway/meshinagent/decide.go
@@ -17,10 +17,6 @@ const (
 	DecideSourceEligibility   = "eligibility"
 	DecideSourceSharedDefault = "shared-default"
 	DecideSourceNone          = "none"
-
-	// RuleAllowSharedLLMGateway keeps name-based Shared AI Router Decide for
-	// compatibility. All Shared apps also default to caller via shared-default.
-	RuleAllowSharedLLMGateway = "R-ALLOW-shared-llmgateway"
 )
 
 // Rule maps an application name (or prefix*) to named Shared callees.
@@ -35,15 +31,12 @@ type Rule struct {
 // RuleSet is the phase-1 decide rule table.
 type RuleSet []Rule
 
-// DefaultRules denies platform shells and allow-lists known Shared callers.
+// DefaultRules denies the userspace shell Application (olares-app).
+// Shared callers use shared-default (OPEN-01). Workloads like STS bfl are not
+// matched by name here — admission keys off Application.spec.settings, not Pod name.
 func DefaultRules() RuleSet {
 	return RuleSet{
-		{ID: "R-DENY-middleware", Match: "middleware*", Deny: true},
-		{ID: "R-DENY-os-", Match: "os-", Deny: true},
 		{ID: "R-DENY-olares-app", Match: "olares-app", Deny: true},
-		{ID: "R-DENY-bfl", Match: "bfl", Deny: true},
-		// Shared composite callers (opt-in by platform name). Empty Callees = OPEN-01.
-		{ID: RuleAllowSharedLLMGateway, Match: "llmgateway*", Callees: nil},
 	}
 }
 

--- a/framework/app-service/pkg/gateway/meshinagent/decide_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/decide_test.go
@@ -42,13 +42,13 @@ func TestDecideSharedOptOutBlocksDefault(t *testing.T) {
 	}
 }
 
-func TestDecideSharedPlatformRuleLLMGateway(t *testing.T) {
+func TestDecideSharedLLMGatewayUsesSharedDefault(t *testing.T) {
 	r := Decide("llmgatewayv3", map[string]string{}, DefaultRules(), true)
-	if !r.Inject || r.Source != DecideSourceRule || r.RuleID != RuleAllowSharedLLMGateway {
-		t.Fatalf("Shared llmgateway* must match platform allow: %+v", r)
+	if !r.Inject || r.Source != DecideSourceSharedDefault || r.RuleID != "" {
+		t.Fatalf("Shared llmgateway* must use shared-default (no name allow rule): %+v", r)
 	}
 	if len(r.Callees) != 0 {
-		t.Fatalf("platform Shared caller edges must be empty (OPEN-01): %+v", r)
+		t.Fatalf("shared-default edges must be empty (OPEN-01): %+v", r)
 	}
 }
 
@@ -69,26 +69,25 @@ func TestDecideRuleAllowEmptyCallees(t *testing.T) {
 }
 
 func TestDecideRuleDeny(t *testing.T) {
-	r := Decide("middleware-x", map[string]string{SettingSharedAppDeps: "x"}, DefaultRules(), false)
+	rules := RuleSet{{ID: "R-DENY-demo", Match: "middleware*", Deny: true}}
+	r := Decide("middleware-x", map[string]string{SettingSharedAppDeps: "x"}, rules, false)
 	if r.Inject {
 		t.Fatalf("deny must win over explicit callees: %+v", r)
 	}
-	r2 := Decide("middleware-x", map[string]string{}, DefaultRules(), false)
+	r2 := Decide("middleware-x", map[string]string{}, rules, false)
 	if r2.Inject {
 		t.Fatalf("deny must block: %+v", r2)
 	}
 }
 
 func TestDecidePlatformShellDeny(t *testing.T) {
-	for _, name := range []string{"olares-app", "bfl"} {
-		r := Decide(name, map[string]string{}, DefaultRules(), false)
-		if r.Inject {
-			t.Fatalf("%s must be denied: %+v", name, r)
-		}
-		r2 := Decide(name, map[string]string{SettingAppRef: "ollama"}, DefaultRules(), false)
-		if r2.Inject {
-			t.Fatalf("%s deny must win over appRef: %+v", name, r2)
-		}
+	r := Decide("olares-app", map[string]string{}, DefaultRules(), false)
+	if r.Inject {
+		t.Fatalf("olares-app must be denied: %+v", r)
+	}
+	r2 := Decide("olares-app", map[string]string{SettingAppRef: "ollama"}, DefaultRules(), false)
+	if r2.Inject {
+		t.Fatalf("olares-app deny must win over appRef: %+v", r2)
 	}
 	r3 := Decide("olares-application", map[string]string{}, DefaultRules(), false)
 	if !r3.Inject {
@@ -122,7 +121,7 @@ func TestApplyDecidePreservesExplicit(t *testing.T) {
 		AnnotDecideSource: DecideSourceExplicit,
 		AnnotDecideEdges:  "",
 	}
-	r := ApplyDecide("middleware-x", s, DefaultRules(), true)
+	r := ApplyDecide("middleware-x", s, RuleSet{{ID: "R-DENY-demo", Match: "middleware*", Deny: true}}, true)
 	if !r.Inject || r.Source != DecideSourceExplicit {
 		t.Fatalf("explicit must be preserved even under deny rule: %+v", r)
 	}
@@ -134,14 +133,17 @@ func TestApplyDecidePreservesExplicit(t *testing.T) {
 	}
 }
 
-func TestApplyDecideSharedPlatformRule(t *testing.T) {
+func TestApplyDecideSharedLLMGatewaySharedDefault(t *testing.T) {
 	s := map[string]string{}
 	r := ApplyDecide("llmgatewayv3", s, DefaultRules(), true)
-	if !r.Inject || r.Source != DecideSourceRule || s[AnnotDecide] != "true" {
+	if !r.Inject || r.Source != DecideSourceSharedDefault || s[AnnotDecide] != "true" {
 		t.Fatalf("got %+v settings=%v", r, s)
 	}
-	if s[AnnotDecideRuleID] != RuleAllowSharedLLMGateway {
-		t.Fatalf("rule id: %v", s)
+	if s[AnnotDecideSource] != DecideSourceSharedDefault {
+		t.Fatalf("source: %v", s)
+	}
+	if s[AnnotDecideRuleID] != "" {
+		t.Fatalf("rule id must be empty: %v", s)
 	}
 	if s[AnnotDecideEdges] != "" {
 		t.Fatalf("edges must stay empty: %v", s)

--- a/framework/app-service/pkg/gateway/meshinagent/eligible_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/eligible_test.go
@@ -126,11 +126,11 @@ func TestShouldInjectMeshInAgent(t *testing.T) {
 	if ShouldInject(nil, false) {
 		t.Fatal("nil app must not inject")
 	}
-	denied := &appv1alpha1.Application{
-		Spec: appv1alpha1.ApplicationSpec{Name: "middleware-x", Settings: map[string]string{}},
+	noDecide := &appv1alpha1.Application{
+		Spec: appv1alpha1.ApplicationSpec{Name: "plain", Settings: map[string]string{}},
 	}
-	if ShouldInject(denied, false) {
-		t.Fatal("R-DENY middleware must not inject")
+	if ShouldInject(noDecide, false) {
+		t.Fatal("empty settings without decide must not inject")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Simplify `DefaultRules`: drop the name-based `llmgateway*` allow rule and unused deny entries.
- Bump shipped image pin to `beclab/app-service:0.6.32`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing name-based default denies changes who gets mesh-in injection at install/upgrade for apps that previously matched `middleware*`, `os-`, or `bfl`, which affects gateway admission behavior on a critical control-plane component.
> 
> **Overview**
> **Narrows default mesh-in decide rules** so only the `olares-app` userspace shell is name-denied; the old default denies for `middleware*`, `os-`, and `bfl`, plus the `llmgateway*` allow rule (`RuleAllowSharedLLMGateway`), are removed.
> 
> **Shared callers (including LLM gateway names)** now get mesh injection through the existing **`shared-default`** path with empty callee edges (OPEN-01) instead of a dedicated allow rule and `decide-source=rule` / rule ID annotations.
> 
> **Ships** `beclab/app-service:0.6.32` in the cluster deploy manifest. Tests are updated to match the slimmer `DefaultRules` and the new llmgateway expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5ebc712222af92f3ad43576d0381da92ab414c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->