### PR TITLE
cli: name download create from inspect title and default app to larepass

### DIFF
--- a/cli/cmd/ctl/download/common.go
+++ b/cli/cmd/ctl/download/common.go
@@ -26,9 +26,10 @@ import (
 
 const (
 	minOlaresVersion = "1.12.7"
-	defaultApp       = "wise"
+	defaultApp       = "larepass"
 	// allowedApps is the --app whitelist (kept in sync with validateApp).
-	// Default remains wise; larepass is the TermiPass / LarePass namespace.
+	// larepass is the TermiPass / LarePass namespace and the default;
+	// wise is the Wise app's own namespace.
 	allowedApps = "wise, larepass"
 	// ytdlpQualityValues is the server-accepted --quality enum
 	// (download-server services.IsValidYtdlpQuality). Kept here so the
@@ -68,6 +69,18 @@ const (
 	// waitMaxConsecErrors is the transient-error budget before wait
 	// gives up, mirroring market watch.
 	waitMaxConsecErrors = 5
+	// inspectProbeTimeout bounds create's name probe, which is otherwise
+	// free to decide how long a create takes: an ordinary round trip is
+	// ~0.2s but a yt-dlp inspect measures ~8s, and the manager waits up
+	// to 30s on its yt-dlp daemon before giving up.
+	//
+	// The cap guards the pathological probe (a channel / RSS listing),
+	// not the normal slow one — set below the observed yt-dlp latency it
+	// would throw away the title on every video URL and defeat the whole
+	// point of probing. So it sits above that with headroom and well
+	// under the manager's own ceiling. Callers who would rather have a
+	// fast create than an early name pass --no-inspect.
+	inspectProbeTimeout = 15 * time.Second
 )
 
 // validTaskStatuses mirrors download-server models.validTaskStatuses
@@ -115,11 +128,11 @@ func addOutputFlag(cmd *cobra.Command, target *string) {
 }
 
 func addAppFlag(cmd *cobra.Command, target *string) {
-	cmd.Flags().StringVar(target, "app", defaultApp, "app namespace for the download task (one of: "+allowedApps+"; default: wise)")
+	cmd.Flags().StringVar(target, "app", defaultApp, "app namespace for the download task (one of: "+allowedApps+")")
 }
 
-// validateApp trims --app, defaults empty to wise, and rejects values
-// outside the whitelist. Returns the normalised app name.
+// validateApp trims --app, defaults empty to defaultApp, and rejects
+// values outside the whitelist. Returns the normalised app name.
 func validateApp(raw string) (string, error) {
 	app := strings.TrimSpace(raw)
 	if app == "" {
@@ -617,14 +630,4 @@ func encodeQuery(values url.Values) string {
 		return ""
 	}
 	return "?" + values.Encode()
-}
-
-func displayName(t DownloadTask) string {
-	if strings.TrimSpace(t.FileName) != "" {
-		return t.FileName
-	}
-	if strings.TrimSpace(t.URL) != "" {
-		return t.URL
-	}
-	return "-"
 }

--- a/cli/cmd/ctl/download/common_test.go
+++ b/cli/cmd/ctl/download/common_test.go
@@ -502,20 +502,25 @@ func TestParseTaskID(t *testing.T) {
 }
 
 func TestValidateApp(t *testing.T) {
-	for _, valid := range []string{"", "wise", " larepass ", "larepass"} {
-		got, err := validateApp(valid)
+	// The default app decides which namespace an unqualified create
+	// lands in and which rows an unqualified list returns, so pin the
+	// value itself rather than only "empty resolves to the default".
+	if defaultApp != "larepass" {
+		t.Fatalf("defaultApp = %q, want larepass", defaultApp)
+	}
+	for _, tc := range []struct{ in, want string }{
+		{"", defaultApp},
+		{"   ", defaultApp},
+		{"wise", "wise"},
+		{"larepass", "larepass"},
+		{" larepass ", "larepass"},
+	} {
+		got, err := validateApp(tc.in)
 		if err != nil {
-			t.Fatalf("validateApp(%q) unexpected error: %v", valid, err)
+			t.Fatalf("validateApp(%q) unexpected error: %v", tc.in, err)
 		}
-		switch strings.TrimSpace(valid) {
-		case "", "wise":
-			if got != "wise" {
-				t.Fatalf("validateApp(%q)=%q want wise", valid, got)
-			}
-		default:
-			if got != "larepass" {
-				t.Fatalf("validateApp(%q)=%q want larepass", valid, got)
-			}
+		if got != tc.want {
+			t.Fatalf("validateApp(%q)=%q want %q", tc.in, got, tc.want)
 		}
 	}
 	_, err := validateApp("namespace")

--- a/cli/cmd/ctl/download/create.go
+++ b/cli/cmd/ctl/download/create.go
@@ -320,6 +320,9 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 			lockedBy,
 		)
 	}
+	if err := validateOuttmplSafeName(fileName); err != nil {
+		return err
+	}
 
 	if err := validateYTDLPQuality(quality, false); err != nil {
 		return err

--- a/cli/cmd/ctl/download/create.go
+++ b/cli/cmd/ctl/download/create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -18,17 +19,19 @@ import (
 
 func NewCreateCommand(f *cmdutil.Factory) *cobra.Command {
 	var (
-		app         string
-		path        string
-		name        string
-		quality     string
-		formatID    string
-		extraRaw    string
-		torrentFile string
-		selectFiles string
-		waitDone    bool
-		timeout     time.Duration
-		output      string
+		app            string
+		path           string
+		name           string
+		quality        string
+		formatID       string
+		extraRaw       string
+		torrentFile    string
+		selectFiles    string
+		noInspect      bool
+		inspectTimeout time.Duration
+		waitDone       bool
+		timeout        time.Duration
+		output         string
 	)
 	cmd := &cobra.Command{
 		Use:   "create [url]",
@@ -54,15 +57,37 @@ to download every file.
   and bare Home/… are rejected. The default is ` + defaultDownloadPath + `.
 Pass --path "" when the provider should choose the destination.
 
+Naming:
+  Omit --name and create inspects the URL first, sending the probed
+  title as file_name — the same prefill the LarePass New Task dialog
+  does, so the task reads as the video title from the moment it is
+  created instead of staying nameless until the provider writes the
+  real filename back.
+  The probe is best-effort and capped at ` + inspectProbeTimeout.String() + ` (--inspect-timeout).
+  A probe that fails or runs out of time just omits the field; the
+  create still succeeds and the provider names the file. A yt-dlp
+  inspect measures several seconds, so create is that much slower than
+  a bare POST; --no-inspect skips it when latency matters more than
+  having a name straight away.
+  Do not invent a --name from the URL path: a routing segment such as
+  YouTube's /watch would be pinned to the row for good.
+  Magnet links, --torrent uploads and HuggingFace repos reject --name
+  and are never probed; those providers take the name from torrent
+  metadata or the repo id.
+
 For HuggingFace, set _hf_dest in --extra:
   local (default) downloads under <path>/<repoID>/.
-  cache downloads to the shared HuggingFace cache and ignores --path/--name.
+  cache downloads to the shared HuggingFace cache and ignores --path.
+
+Create is asynchronous: it returns as soon as the row exists, printing
+the task id to poll with "info <id>" (or "list"). --wait is for scripts
+that want one blocking call; it polls until a true terminal status
+(mover phases are not success; see "wait --help").
 
 Re-submitting the same URL always creates a new task (no duplicate 409).
 Each create sends a fresh Idempotency-Key so transport retries of the
 same attempt reuse one key; a second user invoke still inserts a new
-row. Use --wait to poll until a true terminal status (mover phases are
-not success; see "wait --help").`,
+row.`,
 		Example: `  # URL
   olares-cli knowledge download create 'https://host/v?a=1&b=2'
 
@@ -80,18 +105,20 @@ not success; see "wait --help").`,
 			if len(args) > 0 {
 				rawURL = args[0]
 			}
-			return runCreate(c.Context(), f, rawURL, app, path, name, quality, formatID, extraRaw, torrentFile, selectFiles, waitDone, timeout, output)
+			return runCreate(c.Context(), f, rawURL, app, path, name, quality, formatID, extraRaw, torrentFile, selectFiles, noInspect, inspectTimeout, waitDone, timeout, output)
 		},
 	}
 	addAppFlag(cmd, &app)
 	addOutputFlag(cmd, &output)
 	cmd.Flags().StringVar(&path, "path", defaultDownloadPath, "destination: drive/Home|Data/…, Files API URL, or \"\" for HF cache")
-	cmd.Flags().StringVar(&name, "name", "", "suggested file_name (ignored for HuggingFace: repo id / cache layout wins)")
+	cmd.Flags().StringVar(&name, "name", "", "override file_name (default: the inspect title; rejected for magnet / --torrent / HuggingFace)")
 	cmd.Flags().StringVar(&quality, "quality", "", "yt-dlp quality preset (one of: "+ytdlpQualityValues+")")
 	cmd.Flags().StringVar(&formatID, "format-id", "", "yt-dlp format_id override")
 	cmd.Flags().StringVar(&extraRaw, "extra", "", "JSON object merged into extra (string values)")
 	cmd.Flags().StringVar(&torrentFile, "torrent", "", "local .torrent file to upload (base64); the URL argument may be omitted")
 	cmd.Flags().StringVar(&selectFiles, "select-files", "", "comma-separated 1-based file indices for a multi-file torrent (e.g. 1,3,5), or \"all\" (= omit = every file)")
+	cmd.Flags().BoolVar(&noInspect, "no-inspect", false, "skip the name probe and let the provider name the file")
+	cmd.Flags().DurationVar(&inspectTimeout, "inspect-timeout", 0, "max time for the name probe (0 = "+inspectProbeTimeout.String()+"); on expiry the name is left to the provider")
 	cmd.Flags().BoolVar(&waitDone, "wait", false, "after create, poll until a terminal status (same as wait <id>)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "max wait duration when --wait is set (0 = "+waitDefaultTimeout.String()+")")
 	return cmd
@@ -159,7 +186,92 @@ func readTorrentFile(path, flag string) ([]byte, error) {
 	return raw, nil
 }
 
-func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name, quality, formatID, extraRaw, torrentFile, selectFiles string, waitDone bool, timeout time.Duration, outputRaw string) error {
+// renameLockedProvider names the provider that would ignore a
+// caller-supplied file_name, or "" when --name is honoured.
+//
+// aria2 skips its `out` option for magnet / torrent downloads — the
+// name comes from the torrent's own metadata — and `hf download` lays a
+// repo out under its repo id or the shared cache. A --name for those
+// reaches the task row and nothing else, so the list would advertise a
+// filename that does not exist on disk. LarePass disables its rename
+// field for exactly these three (allowRename: false); the CLI rejects
+// the flag rather than dropping it silently, so a caller is told the
+// name will not stick instead of believing it did.
+func renameLockedProvider(rawURL, torrentFile string, extra map[string]string) string {
+	if strings.TrimSpace(torrentFile) != "" {
+		return "torrent upload"
+	}
+	if isMagnetURL(rawURL) {
+		return "magnet link"
+	}
+	if _, ok := extra["_hf_dest"]; ok {
+		return "HuggingFace repo"
+	}
+	if isHuggingFaceURL(rawURL) {
+		return "HuggingFace repo"
+	}
+	return ""
+}
+
+// nameProbe says whether submitCreate may derive file_name from an
+// inspect probe, and how long it may spend doing so.
+type nameProbe struct {
+	url     string
+	enabled bool
+	timeout time.Duration
+}
+
+// inspectedFileName probes the URL and returns its title as a
+// file_name, or "" when there is nothing usable.
+//
+// Every failure is swallowed, and the probe is bounded: the title is a
+// nicety, so an inspect that 505s for want of a cookie must not fail a
+// create that would otherwise succeed, and one that crawls through a
+// channel listing must not decide how long the create takes. Either way
+// the provider writes the real filename back once the download starts.
+// Note this reads the probe's `title`, never its `file_name`: the latter
+// is where an *earlier* task for the same URL landed, not a name for
+// this one.
+func inspectedFileName(ctx context.Context, pc *preparedClient, probe nameProbe) string {
+	if strings.TrimSpace(probe.url) == "" {
+		return ""
+	}
+	timeout := probe.timeout
+	if timeout <= 0 {
+		timeout = inspectProbeTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	q := url.Values{}
+	q.Set("url", probe.url)
+	var data InspectData
+	if err := doGet(ctx, pc.doer, "/api/url/inspect"+encodeQuery(q), &data); err != nil {
+		return ""
+	}
+	return titleToFileName(data.Title)
+}
+
+// submitCreate derives the name the caller did not give and posts the
+// row. Split out of runCreate so the naming contract can be tested on
+// the wire: the whole point of the probe is which file_name reaches the
+// server, and that is invisible to a test of inspectedFileName alone.
+func submitCreate(ctx context.Context, pc *preparedClient, req NewDownloadReq, probe nameProbe) (DownloadTask, error) {
+	if req.FileName == "" && probe.enabled {
+		req.FileName = inspectedFileName(ctx, pc, probe)
+	}
+
+	idemKey := newIdempotencyKey()
+	createCtx := whoami.ContextWithRequestHeaders(ctx, map[string]string{headerIdempotencyKey: idemKey})
+
+	var task DownloadTask
+	if err := doMutate(createCtx, pc.doer, "POST", "/api/download", req, &task); err != nil {
+		return DownloadTask{}, err
+	}
+	return task, nil
+}
+
+func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name, quality, formatID, extraRaw, torrentFile, selectFiles string, noInspect bool, inspectTimeout time.Duration, waitDone bool, timeout time.Duration, outputRaw string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -172,6 +284,12 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 	}
 	if timeout > 0 && !waitDone {
 		return fmt.Errorf("--timeout requires --wait")
+	}
+	if inspectTimeout < 0 {
+		return fmt.Errorf("unsupported --inspect-timeout %s (need >= 0; 0 = %s)", inspectTimeout, inspectProbeTimeout)
+	}
+	if inspectTimeout > 0 && noInspect {
+		return fmt.Errorf("--inspect-timeout cannot be combined with --no-inspect")
 	}
 	rawURL = strings.TrimSpace(rawURL)
 	torrentFile = strings.TrimSpace(torrentFile)
@@ -193,6 +311,16 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 			extra[k] = v
 		}
 	}
+
+	fileName := strings.TrimSpace(name)
+	lockedBy := renameLockedProvider(rawURL, torrentFile, extra)
+	if fileName != "" && lockedBy != "" {
+		return fmt.Errorf(
+			"--name is not supported for a %s: the provider names the download from its own metadata, so a custom name would only be pinned to the task row while the file on disk keeps the original one; drop --name",
+			lockedBy,
+		)
+	}
+
 	if err := validateYTDLPQuality(quality, false); err != nil {
 		return err
 	}
@@ -231,7 +359,7 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 		URL:      rawURL,
 		App:      app,
 		Path:     normalizedPath,
-		FileName: strings.TrimSpace(name),
+		FileName: fileName,
 	}
 	if len(extra) > 0 {
 		req.Extra = extra
@@ -242,11 +370,12 @@ func runCreate(ctx context.Context, f *cmdutil.Factory, rawURL, app, path, name,
 		return err
 	}
 
-	idemKey := newIdempotencyKey()
-	createCtx := whoami.ContextWithRequestHeaders(ctx, map[string]string{headerIdempotencyKey: idemKey})
-
-	var task DownloadTask
-	if err := doMutate(createCtx, pc.doer, "POST", "/api/download", req, &task); err != nil {
+	task, err := submitCreate(ctx, pc, req, nameProbe{
+		url:     rawURL,
+		enabled: lockedBy == "" && !noInspect,
+		timeout: inspectTimeout,
+	})
+	if err != nil {
 		return err
 	}
 

--- a/cli/cmd/ctl/download/create_test.go
+++ b/cli/cmd/ctl/download/create_test.go
@@ -2,9 +2,13 @@ package download
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeSelectFiles(t *testing.T) {
@@ -83,6 +87,8 @@ func TestRunCreateValidatesQualityFromExtra(t *testing.T) {
 		"",
 		false,
 		0,
+		false,
+		0,
 		"table",
 	)
 	if err == nil || !strings.Contains(err.Error(), "unsupported --quality") {
@@ -105,10 +111,370 @@ func TestRunCreateValidatesApp(t *testing.T) {
 		"",
 		false,
 		0,
+		false,
+		0,
 		"table",
 	)
 	if err == nil || !strings.Contains(err.Error(), "unsupported --app") {
 		t.Fatalf("unknown --app should fail locally, got %v", err)
+	}
+}
+
+// recordedCall is one request as it went out, kept whole so a test can
+// assert on the body and not just the path.
+type recordedCall struct {
+	method string
+	path   string
+	body   interface{}
+}
+
+// recordingDoer answers the inspect probe and the create POST with
+// canned envelopes while keeping every call, so a test can check both
+// what was sent and in which order.
+type recordingDoer struct {
+	inspect    []byte
+	inspectErr error
+	create     []byte
+	// onInspect / onCreate observe the context each call was handed, so
+	// a test can assert on deadlines. A non-nil error short-circuits the
+	// canned response.
+	onInspect func(context.Context) error
+	onCreate  func(context.Context) error
+	calls     []recordedCall
+}
+
+func (r *recordingDoer) DoJSON(ctx context.Context, method, path string, body, out interface{}) error {
+	r.calls = append(r.calls, recordedCall{method: method, path: path, body: body})
+	if strings.HasPrefix(path, "/api/url/inspect") {
+		if r.onInspect != nil {
+			if err := r.onInspect(ctx); err != nil {
+				return err
+			}
+		}
+		if r.inspectErr != nil {
+			return r.inspectErr
+		}
+		return json.Unmarshal(r.inspect, out)
+	}
+	if r.onCreate != nil {
+		if err := r.onCreate(ctx); err != nil {
+			return err
+		}
+	}
+	return json.Unmarshal(r.create, out)
+}
+
+func (r *recordingDoer) probed() bool {
+	for _, c := range r.calls {
+		if strings.HasPrefix(c.path, "/api/url/inspect") {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *recordingDoer) createReq(t *testing.T) NewDownloadReq {
+	t.Helper()
+	for _, c := range r.calls {
+		if c.method != "POST" || c.path != "/api/download" {
+			continue
+		}
+		req, ok := c.body.(NewDownloadReq)
+		if !ok {
+			t.Fatalf("create body is %T, want NewDownloadReq", c.body)
+		}
+		return req
+	}
+	t.Fatalf("no create call recorded, calls=%+v", r.calls)
+	return NewDownloadReq{}
+}
+
+func inspectEnvelope(t *testing.T, title string) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]interface{}{
+		"code": 200,
+		"data": map[string]interface{}{"provider": "yt-dlp", "title": title},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// TestSubmitCreateSendsInspectTitleAsFileName is the regression guard
+// for the CLI/LarePass name mismatch: the same YouTube link showed its
+// title in LarePass but landed as the bare URL from the CLI, because
+// only LarePass prefilled file_name from the inspect title. Asserting
+// on the probe result alone would not have caught it — the bug was that
+// nothing carried that title into the create body — so this pins the
+// request actually put on the wire.
+func TestSubmitCreateSendsInspectTitleAsFileName(t *testing.T) {
+	const (
+		youtubeURL = "https://www.youtube.com/watch?v=oi2QgPH61JM"
+		title      = "Black Myth: Zhong Kui – 15 Minutes Gameplay Trailer"
+	)
+	d := &recordingDoer{
+		inspect: inspectEnvelope(t, title),
+		create:  []byte(`{"code":200,"data":{"id":20,"status":"waiting","download_provider":"yt-dlp"}}`),
+	}
+
+	task, err := submitCreate(
+		context.Background(),
+		&preparedClient{doer: d},
+		NewDownloadReq{URL: youtubeURL, App: "wise", Path: "drive/Home/Downloads/"},
+		nameProbe{url: youtubeURL, enabled: true},
+	)
+	if err != nil {
+		t.Fatalf("submitCreate: %v", err)
+	}
+	if task.ID != 20 {
+		t.Fatalf("task id = %d, want 20", task.ID)
+	}
+	if got := d.createReq(t).FileName; got != title {
+		t.Fatalf("file_name = %q, want the probed title %q", got, title)
+	}
+	// The probe has to precede the create or its title cannot land.
+	if len(d.calls) != 2 || !strings.HasPrefix(d.calls[0].path, "/api/url/inspect") {
+		t.Fatalf("expected an inspect then a create, got %+v", d.calls)
+	}
+}
+
+// A slash in a title used to make the daemon mkdir the head of the
+// title and nest the file inside it, so the sanitised form — not the
+// raw title — is what may reach the server.
+func TestSubmitCreateSanitisesTitleBeforeSending(t *testing.T) {
+	d := &recordingDoer{
+		inspect: inspectEnvelope(t, "Foo / Bar"),
+		create:  []byte(`{"code":200,"data":{"id":1,"status":"waiting"}}`),
+	}
+	if _, err := submitCreate(
+		context.Background(),
+		&preparedClient{doer: d},
+		NewDownloadReq{URL: "https://host/v", App: "wise"},
+		nameProbe{url: "https://host/v", enabled: true},
+	); err != nil {
+		t.Fatalf("submitCreate: %v", err)
+	}
+	if got := d.createReq(t).FileName; got != "Foo _ Bar" {
+		t.Fatalf("file_name = %q, want the path separator replaced", got)
+	}
+}
+
+// awaitDeadline blocks until ctx expires, standing in for a probe the
+// server is slow to answer. It gives up on its own after a second so a
+// missing cap fails the assertion instead of hanging the suite until the
+// go test deadline.
+func awaitDeadline(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Second):
+		return errors.New("probe ran unbounded")
+	}
+}
+
+// TestSubmitCreateBoundsTheProbe pins that a slow inspect cannot decide
+// how long a create takes. A yt-dlp probe runs ~10s against a 0.2s
+// ordinary round trip, and a channel URL can outrun even the server's
+// own deadline — so the probe is capped and the create goes out with no
+// name rather than the caller waiting on an optional nicety.
+func TestSubmitCreateBoundsTheProbe(t *testing.T) {
+	probeCtxErr := make(chan error, 1)
+	d := &recordingDoer{
+		create: []byte(`{"code":200,"data":{"id":9,"status":"waiting"}}`),
+		onInspect: func(ctx context.Context) error {
+			err := awaitDeadline(ctx)
+			probeCtxErr <- err
+			return err
+		},
+	}
+
+	start := time.Now()
+	if _, err := submitCreate(
+		context.Background(),
+		&preparedClient{doer: d},
+		NewDownloadReq{URL: "https://host/slow", App: "wise"},
+		nameProbe{url: "https://host/slow", enabled: true, timeout: 20 * time.Millisecond},
+	); err != nil {
+		t.Fatalf("a probe that runs out of time must not fail the create: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("create waited %s on the probe; the cap did not apply", elapsed)
+	}
+	if err := <-probeCtxErr; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("probe ended with %v, want a deadline", err)
+	}
+	if got := d.createReq(t).FileName; got != "" {
+		t.Fatalf("file_name = %q, want empty after a timed-out probe", got)
+	}
+}
+
+// The probe's deadline must not leak into the create request: cancelling
+// the create along with the probe would turn a slow inspect into a
+// failed task.
+func TestSubmitCreateKeepsCreateOutsideTheProbeDeadline(t *testing.T) {
+	d := &recordingDoer{
+		create:    []byte(`{"code":200,"data":{"id":11,"status":"waiting"}}`),
+		onInspect: awaitDeadline,
+		onCreate: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("create context already cancelled: %w", err)
+			}
+			return nil
+		},
+	}
+	if _, err := submitCreate(
+		context.Background(),
+		&preparedClient{doer: d},
+		NewDownloadReq{URL: "https://host/slow", App: "wise"},
+		nameProbe{url: "https://host/slow", enabled: true, timeout: 10 * time.Millisecond},
+	); err != nil {
+		t.Fatalf("submitCreate: %v", err)
+	}
+}
+
+func TestRunCreateValidatesInspectFlags(t *testing.T) {
+	cases := []struct {
+		name           string
+		noInspect      bool
+		inspectTimeout time.Duration
+		wantIn         string
+	}{
+		{
+			name:           "negative timeout",
+			inspectTimeout: -time.Second,
+			wantIn:         "unsupported --inspect-timeout",
+		},
+		{
+			name:           "a cap on a probe that will not run",
+			noInspect:      true,
+			inspectTimeout: time.Second,
+			wantIn:         "--inspect-timeout cannot be combined with --no-inspect",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runCreate(
+				context.Background(),
+				nil,
+				"https://example.com/video",
+				"", "", "", "", "", "", "", "",
+				tc.noInspect,
+				tc.inspectTimeout,
+				false,
+				0,
+				"table",
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("want an error containing %q, got %v", tc.wantIn, err)
+			}
+		})
+	}
+}
+
+func TestSubmitCreateLeavesFileNameAlone(t *testing.T) {
+	cases := []struct {
+		name         string
+		req          NewDownloadReq
+		probe        nameProbe
+		inspectErr   error
+		wantFileName string
+		wantProbed   bool
+	}{
+		{
+			name:         "an explicit --name is never overwritten by the probe",
+			req:          NewDownloadReq{URL: "https://host/v", App: "wise", FileName: "clip.mp4"},
+			probe:        nameProbe{url: "https://host/v", enabled: true},
+			wantFileName: "clip.mp4",
+		},
+		{
+			// A cookie-gated probe must not fail the create: the
+			// provider still writes the real name back later.
+			name:         "a failed probe omits the field and still creates",
+			req:          NewDownloadReq{URL: "https://host/v", App: "wise"},
+			probe:        nameProbe{url: "https://host/v", enabled: true},
+			inspectErr:   errors.New("daemon returned code 505 (network)"),
+			wantFileName: "",
+			wantProbed:   true,
+		},
+		{
+			name:         "a magnet is not probed and stays nameless",
+			req:          NewDownloadReq{URL: "magnet:?xt=urn:btih:abc", App: "wise"},
+			probe:        nameProbe{url: "magnet:?xt=urn:btih:abc"},
+			wantFileName: "",
+		},
+		{
+			name:         "--no-inspect skips the probe",
+			req:          NewDownloadReq{URL: "https://host/v", App: "wise"},
+			probe:        nameProbe{url: "https://host/v"},
+			wantFileName: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &recordingDoer{
+				inspect:    inspectEnvelope(t, "should not be used"),
+				inspectErr: tc.inspectErr,
+				create:     []byte(`{"code":200,"data":{"id":7,"status":"waiting"}}`),
+			}
+			if _, err := submitCreate(context.Background(), &preparedClient{doer: d}, tc.req, tc.probe); err != nil {
+				t.Fatalf("submitCreate: %v", err)
+			}
+			if got := d.createReq(t).FileName; got != tc.wantFileName {
+				t.Fatalf("file_name = %q, want %q", got, tc.wantFileName)
+			}
+			if d.probed() != tc.wantProbed {
+				t.Fatalf("probed = %v, want %v", d.probed(), tc.wantProbed)
+			}
+		})
+	}
+}
+
+// TestRunCreateRejectsNameForRenameLockedProviders pins that the flag
+// fails locally rather than being dropped on the way to the server: for
+// these providers a custom name only ever reaches the task row, so
+// silently accepting it would have the list advertise a filename that
+// does not exist on disk.
+func TestRunCreateRejectsNameForRenameLockedProviders(t *testing.T) {
+	cases := []struct {
+		name        string
+		rawURL      string
+		torrentFile string
+		extra       string
+		wantIn      string
+	}{
+		{name: "magnet", rawURL: "magnet:?xt=urn:btih:abc", wantIn: "magnet link"},
+		{name: "torrent upload", torrentFile: "./x.torrent", wantIn: "torrent upload"},
+		{name: "huggingface", rawURL: "https://huggingface.co/org/repo", wantIn: "HuggingFace repo"},
+		{name: "hf cache via extra", rawURL: "https://host/x", extra: `{"_hf_dest":"cache"}`, wantIn: "HuggingFace repo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runCreate(
+				context.Background(),
+				nil,
+				tc.rawURL,
+				"",
+				"",
+				"my-name.mp4",
+				"",
+				"",
+				tc.extra,
+				tc.torrentFile,
+				"",
+				false,
+				0,
+				false,
+				0,
+				"table",
+			)
+			if err == nil {
+				t.Fatal("--name should be rejected before any HTTP call")
+			}
+			if !strings.Contains(err.Error(), "--name is not supported") || !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("error should name the provider, got %v", err)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/ctl/download/create_test.go
+++ b/cli/cmd/ctl/download/create_test.go
@@ -260,6 +260,61 @@ func TestSubmitCreateSanitisesTitleBeforeSending(t *testing.T) {
 	}
 }
 
+// A "%(" in the inspect title used to be spliced into yt-dlp's outtmpl
+// as a field reference (task 30 failed with err_msg "'백퍼센트'").
+func TestSubmitCreateDefusesOuttmplFieldInTitle(t *testing.T) {
+	d := &recordingDoer{
+		inspect: inspectEnvelope(t, "[MV] 100%(백퍼센트) _ Sketch U(어디 있니)"),
+		create:  []byte(`{"code":200,"data":{"id":1,"status":"waiting"}}`),
+	}
+	if _, err := submitCreate(
+		context.Background(),
+		&preparedClient{doer: d},
+		NewDownloadReq{URL: "https://www.youtube.com/watch?v=iPY_CGYDVAs", App: "larepass"},
+		nameProbe{url: "https://www.youtube.com/watch?v=iPY_CGYDVAs", enabled: true},
+	); err != nil {
+		t.Fatalf("submitCreate: %v", err)
+	}
+	got := d.createReq(t).FileName
+	if strings.Contains(got, "%(") {
+		t.Fatalf("file_name = %q still opens an outtmpl field", got)
+	}
+	if got != "[MV] 100_(백퍼센트) _ Sketch U(어디 있니)" {
+		t.Fatalf("file_name = %q, want the field open defused", got)
+	}
+}
+
+// A caller-chosen name is rejected rather than rewritten, so the caller
+// is told it cannot stick instead of finding the task named something
+// else — the same contract --name already has for a magnet.
+func TestRunCreateRejectsOuttmplFieldInName(t *testing.T) {
+	err := runCreate(
+		context.Background(),
+		nil,
+		"https://example.com/video",
+		"", "", "clip %(title)s", "", "", "", "", "",
+		false, 0, false, 0, "table",
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported --name") {
+		t.Fatalf("a --name opening an outtmpl field must be rejected, got %v", err)
+	}
+}
+
+// A lone "%" is a literal to yt-dlp, so a name carrying one must still
+// be accepted — rejecting it would block a name that downloads fine.
+func TestRunCreateAllowsLonePercentInName(t *testing.T) {
+	err := runCreate(
+		context.Background(),
+		nil,
+		"https://example.com/video",
+		"", "", "100% Real", "", "", "", "", "",
+		false, 0, false, 0, "table",
+	)
+	if err != nil && strings.Contains(err.Error(), "unsupported --name") {
+		t.Fatalf("a lone percent must not be rejected, got %v", err)
+	}
+}
+
 // awaitDeadline blocks until ctx expires, standing in for a probe the
 // server is slow to answer. It gives up on its own after a second so a
 // missing cap fails the assertion instead of hanging the suite until the

--- a/cli/cmd/ctl/download/list.go
+++ b/cli/cmd/ctl/download/list.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 	"time"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
@@ -35,7 +35,7 @@ func NewListCommand(f *cmdutil.Factory) *cobra.Command {
 --all pages through /api/download/list until every matching row is
 collected (distinct from sync --all, which drains the sync cursor).
 --all-apps lists across every app; it cannot be combined with an
-explicit --app. Without --all-apps, --app defaults to wise.
+explicit --app. Without --all-apps, --app defaults to larepass.
 
 --status is validated locally against the server task-status enum;
 illegal values fail before any request.`,
@@ -170,23 +170,82 @@ func renderListTable(w io.Writer, result ListResult) error {
 	return nil
 }
 
+const (
+	taskTableColPad    = 2
+	taskTableNameWidth = 40
+	taskTableURLWidth  = 48
+)
+
 // renderTasksTable prints the shared task table (list / sync / unfinished).
+// Columns are padded by terminal display width, not rune count: a CJK
+// title is two columns per character, and tabwriter treating it as one
+// shoved SOURCE to the right of every ASCII row.
 func renderTasksTable(w io.Writer, tasks []DownloadTask) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tSTATUS\tPROVIDER\tPERCENT\tNAME\tSOURCE\tAPP\tUPDATED")
+	headers := []string{"ID", "STATUS", "PROVIDER", "PERCENT", "NAME", "SOURCE", "APP", "UPDATED"}
+	rows := make([][]string, 0, len(tasks))
 	for _, t := range tasks {
-		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			t.ID,
+		rows = append(rows, []string{
+			strconv.FormatInt(t.ID, 10),
 			orDash(t.Status),
 			orDash(t.DownloadProvider),
 			fmt.Sprintf("%.1f%%", t.Percent),
-			truncate(displayName(t), 40),
-			truncate(orDash(t.URL), 48),
+			clipDisplay(displayName(t), taskTableNameWidth),
+			clipDisplay(orDash(t.URL), taskTableURLWidth),
 			orDash(t.App),
 			formatTime(t.UpdatedAt),
-		)
+		})
 	}
-	return tw.Flush()
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = runewidth.StringWidth(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if n := runewidth.StringWidth(cell); n > widths[i] {
+				widths[i] = n
+			}
+		}
+	}
+	if err := writeDisplayRow(w, headers, widths); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writeDisplayRow(w, row, widths); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDisplayRow(w io.Writer, cells []string, widths []int) error {
+	var b strings.Builder
+	for i, cell := range cells {
+		if i > 0 {
+			b.WriteString(strings.Repeat(" ", taskTableColPad))
+		}
+		b.WriteString(padDisplay(cell, widths[i]))
+	}
+	b.WriteByte('\n')
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func padDisplay(s string, n int) string {
+	w := runewidth.StringWidth(s)
+	if w >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-w)
+}
+
+// clipDisplay clips s to n terminal columns. CJK titles are two
+// columns wide; cutting on runes left NAME visually overflowing the
+// budget and broke the SOURCE column for every other row.
+func clipDisplay(s string, n int) string {
+	if n <= 0 || runewidth.StringWidth(s) <= n {
+		return s
+	}
+	return runewidth.Truncate(s, n, "...")
 }
 
 func orDash(s string) string {
@@ -194,16 +253,6 @@ func orDash(s string) string {
 		return "-"
 	}
 	return s
-}
-
-func truncate(s string, n int) string {
-	if n <= 0 || len(s) <= n {
-		return s
-	}
-	if n <= 3 {
-		return s[:n]
-	}
-	return s[:n-3] + "..."
 }
 
 func formatTime(t time.Time) string {

--- a/cli/cmd/ctl/download/list_table_test.go
+++ b/cli/cmd/ctl/download/list_table_test.go
@@ -1,0 +1,76 @@
+package download
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func TestClipDisplayCountsTerminalColumns(t *testing.T) {
+	cjk := "军训演习：谁不想急头白脸地演一场匪徒！.mp4"
+	if runewidth.StringWidth(cjk) <= taskTableNameWidth {
+		t.Fatalf("fixture too short to clip: width=%d", runewidth.StringWidth(cjk))
+	}
+	got := clipDisplay(cjk, taskTableNameWidth)
+	if w := runewidth.StringWidth(got); w > taskTableNameWidth {
+		t.Fatalf("clipDisplay width %d, want <= %d (%q)", w, taskTableNameWidth, got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("clipped CJK = %q, want trailing ...", got)
+	}
+	ascii := "Black Myth: Zhong Kui – 15 Minutes Gameplay Showcase.mp4"
+	got = clipDisplay(ascii, taskTableNameWidth)
+	if w := runewidth.StringWidth(got); w > taskTableNameWidth {
+		t.Fatalf("ascii clip width %d, want <= %d (%q)", w, taskTableNameWidth, got)
+	}
+}
+
+func TestRenderTasksTableAlignsCJKAgainstASCII(t *testing.T) {
+	var buf strings.Builder
+	err := renderTasksTable(&buf, []DownloadTask{
+		{
+			ID:               24,
+			Status:           "completed",
+			DownloadProvider: "yt-dlp",
+			Percent:          100,
+			FileName:         "军训演习：谁不想急头白脸地演一场匪徒！.mp4",
+			URL:              "https://www.bilibili.com/video/BV1qG8h68ES9/",
+			App:              "wise",
+		},
+		{
+			ID:               23,
+			Status:           "error",
+			DownloadProvider: "yt-dlp",
+			Percent:          0,
+			FileName:         "Black Myth: Zhong Kui – 15 Minutes Gameplay",
+			URL:              "https://www.youtube.com/watch?v=oi2QgPH61JM",
+			App:              "wise",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("lines = %d, want 3 (header + 2 rows):\n%s", len(lines), buf.String())
+	}
+	headerSrc := displayIndex(lines[0], "SOURCE")
+	if headerSrc < 0 {
+		t.Fatalf("header missing SOURCE: %q", lines[0])
+	}
+	for i, line := range lines[1:] {
+		got := displayIndex(line, "https://")
+		if got != headerSrc {
+			t.Fatalf("row %d SOURCE starts at column %d, header at %d\n%s", i, got, headerSrc, buf.String())
+		}
+	}
+}
+
+func displayIndex(line, needle string) int {
+	i := strings.Index(line, needle)
+	if i < 0 {
+		return -1
+	}
+	return runewidth.StringWidth(line[:i])
+}

--- a/cli/cmd/ctl/download/list_wait_test.go
+++ b/cli/cmd/ctl/download/list_wait_test.go
@@ -41,9 +41,9 @@ func TestClassifyWaitStatus(t *testing.T) {
 		{status: "paused", want: "pending"},
 		{status: "waiting", want: "pending"},
 		{status: "preparing", want: "pending"},
-		// The server's retry sweep still owns this row, so calling it a
-		// failure would make a script tear down a task that recovers.
-		{status: "error", autoRet: true, want: "pending"},
+		// will_auto_retry says the sweep may pick the row up again; it
+		// does not make the row any less failed right now.
+		{status: "error", autoRet: true, want: "failure"},
 	}
 	for _, tc := range cases {
 		task := DownloadTask{Status: tc.status, WillAutoRetry: tc.autoRet}
@@ -53,9 +53,11 @@ func TestClassifyWaitStatus(t *testing.T) {
 	}
 }
 
-// TestWaitKeepsPollingAnAutoRetryingError pins the whole loop, not just
-// the classifier: an error row the server will retry must not end wait.
-func TestWaitKeepsPollingAnAutoRetryingError(t *testing.T) {
+// TestWaitStopsOnAnAutoRetryingError pins the whole loop, not just the
+// classifier: an error row ends wait on the first poll even when the
+// server says it will retry. The later responses are there to fail the
+// test loudly if the loop ever starts waiting the sweep out again.
+func TestWaitStopsOnAnAutoRetryingError(t *testing.T) {
 	d := &seqDoer{responses: [][]byte{
 		mustEnvTaskRetry(t, 11, "error", true),
 		mustEnvTaskRetry(t, 11, "downloading", false),
@@ -70,8 +72,11 @@ func TestWaitKeepsPollingAnAutoRetryingError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wait: %v", err)
 	}
-	if task.Status != "completed" {
-		t.Fatalf("status = %q, want completed", task.Status)
+	if task.Status != "error" {
+		t.Fatalf("status = %q, want error", task.Status)
+	}
+	if len(d.paths) != 1 {
+		t.Fatalf("polled %d times, want 1", len(d.paths))
 	}
 }
 

--- a/cli/cmd/ctl/download/name.go
+++ b/cli/cmd/ctl/download/name.go
@@ -1,0 +1,243 @@
+package download
+
+// Naming rules shared by create (which file_name to send) and by the
+// renderers (what to show while the server has not written one yet).
+//
+// Both halves mirror code that already exists on the other side of the
+// wire, so one task reads the same in the CLI, in LarePass and in the
+// Olares Download list: the byte budget comes from the ytdlp daemon's
+// outtmpl sanitiser, the display fallback from download-server's
+// frontend fallbackName / LarePass downloadDisplayName.
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// fileNameMaxChars / fileNameMaxBytes are the ytdlp daemon's
+	// file_name budget (ytdlp/src/core/outtmpl.py): a 255-byte path
+	// component, minus 48 bytes reserved for the transient suffixes
+	// yt-dlp opens while downloading (.f399, .part, .part-Frag12),
+	// minus the 8-byte ".%(ext)s" the daemon splices on. 66 is that
+	// byte budget in CJK characters — the unit a title is counted in;
+	// the byte cap still applies because 4-byte runes fit under 66
+	// yet overrun the daemon, whose open() then fails ENAMETOOLONG.
+	fileNameMaxChars = 66
+	fileNameMaxBytes = 255 - 48 - 8
+
+	extTemplate = ".%(ext)s"
+)
+
+// titleToFileName turns an inspect title into a file_name safe to send
+// on create, or "" when nothing usable is left.
+//
+// Path separators become "_" because the daemon splices file_name into
+// the outtmpl and both os.path.join and yt-dlp's template engine read a
+// slash as a directory boundary — a YouTube title like "Foo / Bar" then
+// lands as a nested Foo_/Bar.webm tree on the user's volume. Everything
+// else, including ":" and non-ASCII, is legal on Linux and kept as is.
+// A bare "." / ".." is dropped: the daemon rejects those as traversal
+// and falls back to its own template, so sending one would only pin a
+// name to the task row that never appears on disk.
+func titleToFileName(title string) string {
+	sanitised := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\':
+			return '_'
+		case 0:
+			return -1
+		}
+		return r
+	}, strings.TrimSpace(title))
+	if sanitised == "." || sanitised == ".." {
+		return ""
+	}
+	return truncateFileNameToBudget(sanitised)
+}
+
+// truncateFileNameToBudget clips a name to both caps at once. When an
+// extension is recognised only the stem is eaten, so the suffix that
+// survives is the one the daemon keeps.
+func truncateFileNameToBudget(name string) string {
+	if utf8.RuneCountInString(name) <= fileNameMaxChars && len(name) <= fileNameMaxBytes {
+		return name
+	}
+	stem, ext := splitOuttmplExt(name)
+	return truncateStem(
+		stem,
+		fileNameMaxChars-utf8.RuneCountInString(ext),
+		fileNameMaxBytes-len(ext),
+	) + ext
+}
+
+// splitOuttmplExt mirrors the daemon's _split_outtmpl_ext: a literal
+// short extension or the ".%(ext)s" template is held back from
+// truncation.
+func splitOuttmplExt(name string) (stem, ext string) {
+	if strings.HasSuffix(name, extTemplate) {
+		return strings.TrimSuffix(name, extTemplate), extTemplate
+	}
+	lastDot := strings.LastIndex(name, ".")
+	if lastDot >= 0 {
+		candidate := name[lastDot+1:]
+		length := utf8.RuneCountInString(candidate)
+		if length >= 1 && length <= 10 && !strings.Contains(candidate, "%") {
+			return name[:lastDot], name[lastDot:]
+		}
+	}
+	return name, ""
+}
+
+func truncateStem(stem string, maxChars, maxBytes int) string {
+	if maxChars <= 0 || maxBytes <= 0 {
+		return ""
+	}
+	chars, bytes := 0, 0
+	var out strings.Builder
+	for _, r := range stem {
+		size := utf8.RuneLen(r)
+		if size < 0 {
+			size = 1
+		}
+		if chars+1 > maxChars || bytes+size > maxBytes {
+			break
+		}
+		chars++
+		bytes += size
+		out.WriteRune(r)
+	}
+	return out.String()
+}
+
+// displayName is the task name for table output. It mirrors
+// download-server's fallbackName and LarePass's downloadDisplayName:
+// file_name, then the torrent metadata name, then the magnet's dn= /
+// info-hash, then a URL basename that actually looks like a file.
+//
+// It stops there rather than falling back to the raw URL. A routing
+// segment such as YouTube's /watch is not a name, and list / info print
+// the URL in their own column anyway — showing it here would only read
+// as a filename the server never wrote.
+func displayName(t DownloadTask) string {
+	if name := strings.TrimRight(strings.TrimSpace(t.FileName), "/"); name != "" {
+		return name
+	}
+	if meta := torrentMetaName(t.Extra); meta != "" {
+		return meta
+	}
+	raw := strings.TrimSpace(t.URL)
+	if raw == "" {
+		return "-"
+	}
+	if isMagnetURL(raw) {
+		if dn := magnetDisplayName(raw); dn != "" {
+			return dn
+		}
+		if hash := magnetInfoHash(raw); hash != "" {
+			if len(hash) > 12 {
+				hash = hash[:12] + "…"
+			}
+			return "magnet:" + hash
+		}
+		return "magnet:…"
+	}
+	if base := urlBasename(raw); base != "" {
+		return base
+	}
+	return "-"
+}
+
+// torrentMetaName reads extra.torrent_meta.name, which the manager
+// persists once aria2 has parsed a magnet's metadata — the first real
+// name a magnet row ever gets.
+func torrentMetaName(extra map[string]interface{}) string {
+	meta, ok := extra["torrent_meta"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := meta["name"].(string)
+	return strings.TrimSpace(name)
+}
+
+func isMagnetURL(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), "magnet:")
+}
+
+// isHuggingFaceURL matches what the manager routes to `hf download`:
+// the huggingface.co / hf.co hosts plus the hf:// and huggingface:
+// pseudo-schemes it still accepts.
+func isHuggingFaceURL(raw string) bool {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "hf://") || strings.HasPrefix(s, "huggingface:") {
+		return true
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	host := strings.TrimPrefix(u.Hostname(), "www.")
+	return host == "huggingface.co" || host == "hf.co"
+}
+
+// magnet: has no authority component, so url.Parse cannot be trusted to
+// find the query — it has to be split off by hand.
+func magnetParams(raw string) url.Values {
+	q := strings.Index(raw, "?")
+	if q < 0 {
+		return nil
+	}
+	// A malformed escape yields the pairs that did parse alongside the
+	// error; those are still the best guess at a display name.
+	values, _ := url.ParseQuery(raw[q+1:])
+	return values
+}
+
+func magnetDisplayName(raw string) string {
+	return strings.TrimSpace(magnetParams(raw).Get("dn"))
+}
+
+func magnetInfoHash(raw string) string {
+	const prefix = "urn:btih:"
+	for _, xt := range magnetParams(raw)["xt"] {
+		if strings.HasPrefix(strings.ToLower(xt), prefix) {
+			return strings.TrimSpace(xt[len(prefix):])
+		}
+	}
+	return ""
+}
+
+// fileNameExtRE is the "looks like a downloadable file" rule: a 1-5
+// character alphanumeric extension. Requiring it is what keeps routing
+// verbs (YouTube /watch, Bilibili /video/BV…) out of a task name.
+var fileNameExtRE = regexp.MustCompile(`\.[A-Za-z0-9]{1,5}$`)
+
+func looksLikeFileName(segment string) bool {
+	return fileNameExtRE.MatchString(segment)
+}
+
+// urlBasename returns the last path segment when it looks like a file,
+// else "". url.Parse has already percent-decoded Path, and the query /
+// fragment are off it, so a signed CDN link still yields a clean guess.
+func urlBasename(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	segments := strings.Split(u.Path, "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i] == "" {
+			continue
+		}
+		if looksLikeFileName(segments[i]) {
+			return segments[i]
+		}
+		return ""
+	}
+	return ""
+}

--- a/cli/cmd/ctl/download/name.go
+++ b/cli/cmd/ctl/download/name.go
@@ -10,6 +10,7 @@ package download
 // frontend fallbackName / LarePass downloadDisplayName.
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -37,11 +38,20 @@ const (
 // Path separators become "_" because the daemon splices file_name into
 // the outtmpl and both os.path.join and yt-dlp's template engine read a
 // slash as a directory boundary — a YouTube title like "Foo / Bar" then
-// lands as a nested Foo_/Bar.webm tree on the user's volume. Everything
-// else, including ":" and non-ASCII, is legal on Linux and kept as is.
-// A bare "." / ".." is dropped: the daemon rejects those as traversal
-// and falls back to its own template, so sending one would only pin a
-// name to the task row that never appears on disk.
+// lands as a nested Foo_/Bar.webm tree on the user's volume.
+// "%(" becomes "_(" for the same reason: it opens an outtmpl field, so
+// a title like "100%(백퍼센트)" made yt-dlp look up a field of that name
+// and fail the task with err_msg "'백퍼센트'" before a byte was written.
+// Only that two-character sequence is neutralised — a lone "%" is a
+// literal to yt-dlp ("100% Real" lands verbatim) and rewriting it would
+// mangle a name that works. Doubling to "%%(" would also parse, but the
+// row would then read "%%(" where the disk reads "%(", so replacing is
+// what keeps the two in step. A trailing ".%(ext)s" is held back, since
+// that one IS the daemon's own extension template.
+// Everything else, including ":" and non-ASCII, is legal on Linux and
+// kept as is. A bare "." / ".." is dropped: the daemon rejects those as
+// traversal and falls back to its own template, so sending one would
+// only pin a name to the task row that never appears on disk.
 func titleToFileName(title string) string {
 	sanitised := strings.Map(func(r rune) rune {
 		switch r {
@@ -52,10 +62,42 @@ func titleToFileName(title string) string {
 		}
 		return r
 	}, strings.TrimSpace(title))
+	sanitised = defuseOuttmplFields(sanitised)
 	if sanitised == "." || sanitised == ".." {
 		return ""
 	}
 	return truncateFileNameToBudget(sanitised)
+}
+
+// outtmplFieldOpen is the only percent form yt-dlp reads as syntax: it
+// starts a "%(field)s" reference, whose lookup either fails the task
+// (unknown field, unterminated key) or silently expands to something
+// other than the name the row advertises.
+const outtmplFieldOpen = "%("
+
+// defuseOuttmplFields neutralises field references in the stem, leaving
+// the extension — literal or the daemon's ".%(ext)s" template — alone.
+// Doing this before truncation also means a clipped stem can never end
+// mid-"%(field)s", which yt-dlp rejects as an incomplete format key.
+func defuseOuttmplFields(name string) string {
+	stem, ext := splitOuttmplExt(name)
+	return strings.ReplaceAll(stem, outtmplFieldOpen, "_(") + ext
+}
+
+// validateOuttmplSafeName refuses a --name that yt-dlp would read as a
+// template. A probed title is rewritten silently (the user did not type
+// it), but a name the caller chose is rejected the same way --name is
+// for a magnet: being told the name cannot stick beats having it
+// changed, or having the task fail with a bare field name for an error.
+func validateOuttmplSafeName(name string) error {
+	stem, _ := splitOuttmplExt(name)
+	if !strings.Contains(stem, outtmplFieldOpen) {
+		return nil
+	}
+	return fmt.Errorf(
+		"unsupported --name %q: %q opens a yt-dlp output-template field, so the download fails with the field name as its error (or silently lands under a different name); use a literal name without %q",
+		name, outtmplFieldOpen, outtmplFieldOpen,
+	)
 }
 
 // truncateFileNameToBudget clips a name to both caps at once. When an

--- a/cli/cmd/ctl/download/name_test.go
+++ b/cli/cmd/ctl/download/name_test.go
@@ -1,0 +1,246 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTitleToFileName(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{name: "plain title kept verbatim", title: "Black Myth: Zhong Kui Trailer", want: "Black Myth: Zhong Kui Trailer"},
+		{name: "surrounding space trimmed", title: "  clip  ", want: "clip"},
+		// A slash in a title made the daemon mkdir the head of the
+		// title and nest the file inside it.
+		{name: "path separators become underscores", title: `Foo / Bar \ Baz`, want: "Foo _ Bar _ Baz"},
+		{name: "nul dropped", title: "a\x00b", want: "ab"},
+		{name: "empty stays empty", title: "   ", want: ""},
+		{name: "traversal segment refused", title: "..", want: ""},
+		{name: "single dot refused", title: ".", want: ""},
+		{name: "dots inside a name are fine", title: "Episode 1..mp4", want: "Episode 1..mp4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := titleToFileName(tc.title); got != tc.want {
+				t.Fatalf("titleToFileName(%q) = %q, want %q", tc.title, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTitleToFileNameFitsDaemonBudget pins the truncation contract: an
+// over-long name makes the daemon's open() fail ENAMETOOLONG, and a CJK
+// title hits the byte cap long before the character one.
+func TestTitleToFileNameFitsDaemonBudget(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+	}{
+		{name: "ascii", title: strings.Repeat("a", 300)},
+		{name: "cjk", title: strings.Repeat("中", 300)},
+		{name: "emoji", title: strings.Repeat("😀", 300)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := titleToFileName(tc.title)
+			if utf8.RuneCountInString(got) > fileNameMaxChars {
+				t.Fatalf("%d chars exceeds the %d-char budget", utf8.RuneCountInString(got), fileNameMaxChars)
+			}
+			if len(got) > fileNameMaxBytes {
+				t.Fatalf("%d bytes exceeds the %d-byte budget", len(got), fileNameMaxBytes)
+			}
+			if got == "" {
+				t.Fatal("truncation must keep a usable stem")
+			}
+		})
+	}
+}
+
+// TestTitleToFileNameKeepsExtension pins that truncation eats the stem,
+// not the suffix — a clipped ".mp4" would leave the file unopenable by
+// extension and defeat the whole point of naming it.
+func TestTitleToFileNameKeepsExtension(t *testing.T) {
+	got := titleToFileName(strings.Repeat("中", 200) + ".mp4")
+	if !strings.HasSuffix(got, ".mp4") {
+		t.Fatalf("truncated name %q lost its extension", got)
+	}
+	if len(got) > fileNameMaxBytes {
+		t.Fatalf("%d bytes exceeds the %d-byte budget", len(got), fileNameMaxBytes)
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		task DownloadTask
+		want string
+	}{
+		{
+			name: "file_name wins",
+			task: DownloadTask{FileName: "clip.mp4", URL: "https://host/x"},
+			want: "clip.mp4",
+		},
+		{
+			name: "folder marker stripped",
+			task: DownloadTask{FileName: "owner/repo/"},
+			want: "owner/repo",
+		},
+		{
+			name: "torrent metadata name once aria2 parsed it",
+			task: DownloadTask{
+				URL:   "magnet:?xt=urn:btih:abc123def4567890",
+				Extra: map[string]interface{}{"torrent_meta": map[string]interface{}{"name": "ubuntu.iso"}},
+			},
+			want: "ubuntu.iso",
+		},
+		{
+			name: "magnet display name",
+			task: DownloadTask{URL: "magnet:?xt=urn:btih:abc&dn=Ubuntu%2024.04"},
+			want: "Ubuntu 24.04",
+		},
+		{
+			name: "magnet info-hash when there is no dn",
+			task: DownloadTask{URL: "magnet:?xt=urn:btih:0123456789abcdef0123"},
+			want: "magnet:0123456789ab…",
+		},
+		{
+			name: "magnet with neither",
+			task: DownloadTask{URL: "magnet:?tr=udp://tracker"},
+			want: "magnet:…",
+		},
+		{
+			name: "url basename when it looks like a file",
+			task: DownloadTask{URL: "https://host/dir/movie.mkv?sig=abc"},
+			want: "movie.mkv",
+		},
+		{
+			name: "percent-encoded basename decoded",
+			task: DownloadTask{URL: "https://host/my%20movie.mkv"},
+			want: "my movie.mkv",
+		},
+		// The regression this whole change is about: /watch is a
+		// routing verb, and showing the URL read as a filename the
+		// server never wrote.
+		{
+			name: "youtube watch url is not a name",
+			task: DownloadTask{URL: "https://www.youtube.com/watch?v=oi2QgPH61JM"},
+			want: "-",
+		},
+		{
+			name: "bilibili video path is not a name",
+			task: DownloadTask{URL: "https://www.bilibili.com/video/BV1xx411c7mD"},
+			want: "-",
+		},
+		{
+			name: "no url at all",
+			task: DownloadTask{},
+			want: "-",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayName(tc.task); got != tc.want {
+				t.Fatalf("displayName(%+v) = %q, want %q", tc.task, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsHuggingFaceURL(t *testing.T) {
+	for _, raw := range []string{
+		"https://huggingface.co/org/repo",
+		"https://HuggingFace.co/org/repo/tree/main",
+		"https://hf.co/org/repo",
+		"hf://datasets/squad",
+		"huggingface:org/repo",
+	} {
+		if !isHuggingFaceURL(raw) {
+			t.Fatalf("%q should route to HuggingFace", raw)
+		}
+	}
+	for _, raw := range []string{
+		"",
+		"https://example.com/huggingface.co/org/repo",
+		"https://www.youtube.com/watch?v=abc",
+		"magnet:?xt=urn:btih:abc",
+	} {
+		if isHuggingFaceURL(raw) {
+			t.Fatalf("%q should not route to HuggingFace", raw)
+		}
+	}
+}
+
+func TestRenameLockedProvider(t *testing.T) {
+	cases := []struct {
+		name        string
+		rawURL      string
+		torrentFile string
+		extra       map[string]string
+		want        string
+	}{
+		{name: "plain url is renameable", rawURL: "https://host/x.mp4"},
+		{name: "youtube is renameable", rawURL: "https://www.youtube.com/watch?v=abc"},
+		{name: "torrent upload", rawURL: "", torrentFile: "./x.torrent", want: "torrent upload"},
+		{name: "magnet", rawURL: "magnet:?xt=urn:btih:abc", want: "magnet link"},
+		{name: "huggingface url", rawURL: "https://huggingface.co/org/repo", want: "HuggingFace repo"},
+		{
+			name:   "hf dest in extra",
+			rawURL: "https://host/x",
+			extra:  map[string]string{"_hf_dest": "cache"},
+			want:   "HuggingFace repo",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renameLockedProvider(tc.rawURL, tc.torrentFile, tc.extra); got != tc.want {
+				t.Fatalf("renameLockedProvider = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInspectedFileName(t *testing.T) {
+	t.Run("title becomes the file name", func(t *testing.T) {
+		d := &fakeDoer{resp: []byte(`{"code":200,"data":{"provider":"yt-dlp","title":"Foo / Bar"}}`)}
+		got := inspectedFileName(context.Background(), &preparedClient{doer: d}, nameProbe{url: "https://www.youtube.com/watch?v=abc"})
+		if got != "Foo _ Bar" {
+			t.Fatalf("file name = %q, want %q", got, "Foo _ Bar")
+		}
+		if !strings.HasPrefix(d.lastPath, "/api/url/inspect?") || !strings.Contains(d.lastPath, "url=") {
+			t.Fatalf("unexpected probe path %q", d.lastPath)
+		}
+	})
+
+	// A probe that fails (a 505 for want of a cookie, a channel URL that
+	// outruns the server deadline) must not stop a create that would
+	// otherwise succeed: the provider writes the real name back anyway.
+	t.Run("probe failure omits the field", func(t *testing.T) {
+		d := &fakeDoer{err: errors.New("daemon returned code 505 (network)")}
+		if got := inspectedFileName(context.Background(), &preparedClient{doer: d}, nameProbe{url: "https://host/x"}); got != "" {
+			t.Fatalf("file name = %q, want empty", got)
+		}
+	})
+
+	t.Run("no title omits the field", func(t *testing.T) {
+		d := &fakeDoer{resp: []byte(`{"code":200,"data":{"provider":"aria2"}}`)}
+		if got := inspectedFileName(context.Background(), &preparedClient{doer: d}, nameProbe{url: "https://host/x.zip"}); got != "" {
+			t.Fatalf("file name = %q, want empty", got)
+		}
+	})
+
+	t.Run("no url means no probe", func(t *testing.T) {
+		d := &fakeDoer{resp: []byte(`{"code":200,"data":{"title":"x"}}`)}
+		if got := inspectedFileName(context.Background(), &preparedClient{doer: d}, nameProbe{url: "  "}); got != "" {
+			t.Fatalf("file name = %q, want empty", got)
+		}
+		if d.lastPath != "" {
+			t.Fatalf("a blank URL must not be probed, got %q", d.lastPath)
+		}
+	})
+}

--- a/cli/cmd/ctl/download/name_test.go
+++ b/cli/cmd/ctl/download/name_test.go
@@ -20,6 +20,18 @@ func TestTitleToFileName(t *testing.T) {
 		// title and nest the file inside it.
 		{name: "path separators become underscores", title: `Foo / Bar \ Baz`, want: "Foo _ Bar _ Baz"},
 		{name: "nul dropped", title: "a\x00b", want: "ab"},
+		// Task 30: this inspect title was sent as file_name and yt-dlp
+		// read %(백퍼센트) as a field, failing with err_msg "'백퍼센트'".
+		{name: "outtmpl field open is defused", title: "[MV] 100%(백퍼센트) _ Sketch U(어디 있니)", want: "[MV] 100_(백퍼센트) _ Sketch U(어디 있니)"},
+		{name: "a known field would silently expand, so it is defused too", title: "clip %(title)s", want: "clip _(title)s"},
+		// An unterminated key is the "incomplete format key" failure.
+		{name: "unterminated field open is defused", title: "clip %(title", want: "clip _(title"},
+		// A lone % is a literal to yt-dlp; rewriting it would mangle a
+		// name that works.
+		{name: "lone percent is kept", title: "100% Real", want: "100% Real"},
+		{name: "lone percent before an extension is kept", title: "100%.mp4", want: "100%.mp4"},
+		{name: "percent conversion chars are literals too", title: "100%s off 100%d", want: "100%s off 100%d"},
+		{name: "the daemon ext template is held back", title: "100%(x) clip.%(ext)s", want: "100_(x) clip.%(ext)s"},
 		{name: "empty stays empty", title: "   ", want: ""},
 		{name: "traversal segment refused", title: "..", want: ""},
 		{name: "single dot refused", title: ".", want: ""},

--- a/cli/cmd/ctl/download/root.go
+++ b/cli/cmd/ctl/download/root.go
@@ -40,7 +40,7 @@ Verb families:
 Universal flags:
 
   -o, --output {table,json}
-      --app <name>     one of: wise, larepass (default wise; create / list / prefs / sync)
+      --app <name>     one of: wise, larepass (default larepass; create / list / prefs / sync)
 
 Run "olares-cli knowledge download <verb> --help" for verb-specific flags.
 `,

--- a/cli/cmd/ctl/download/wait.go
+++ b/cli/cmd/ctl/download/wait.go
@@ -30,8 +30,9 @@ Failure terminals: error, cancelled, removed.
 waiting_to_move and moving are NOT success — the yt-dlp mover is still
 relocating bytes to the destination, so wait keeps polling.
 
-An error the server will retry on its own (will_auto_retry) is not a
-terminal failure; wait keeps polling until the retry sweep settles it.
+Terminality is the status alone. will_auto_retry only reports whether
+the server's sweep may pick a failed row up again; an error row ends
+the wait either way. Poll info afterwards to see if a retry lands.
 
 Polling interval is 2s. On --timeout expiry the command exits non-zero
 and reports the last observed status. This command uses HTTP polling
@@ -158,18 +159,16 @@ func sleepOrCancelWait(ctx context.Context, d time.Duration) {
 }
 
 // classifyWaitStatus returns "success", "failure", or "pending".
-// Mover phases and a will_auto_retry error are pending: the bytes are
-// not on disk yet, and the server's retry sweep still owns that row.
+// Terminality is the status and nothing else: will_auto_retry is a
+// derived presentation flag saying whether the server's sweep may pick
+// a failed row up again, not a state the row is in. Only the mover
+// phases are pending despite reading as done, because the bytes have
+// not reached the destination yet.
 func classifyWaitStatus(task DownloadTask) string {
 	switch task.Status {
 	case "completed", "seeding":
 		return "success"
-	case "error":
-		if task.WillAutoRetry {
-			return "pending"
-		}
-		return "failure"
-	case "cancelled", "removed":
+	case "error", "cancelled", "removed":
 		return "failure"
 	default:
 		return "pending"

--- a/cli/skills/olares-knowledge/SKILL.md
+++ b/cli/skills/olares-knowledge/SKILL.md
@@ -41,7 +41,8 @@ All verbs require Olares 1.12.7+ because the Settings download edge and provider
 
 ## Task and asynchronous semantics
 
-- Create returns a server-side task; command success does not mean bytes have finished downloading or moving. Use `wait` / `create --wait` when scripts need a true terminal status (`waiting_to_move` / `moving` are still in progress, and an `error` row with `will_auto_retry` is still the server's to resolve).
+- Create returns a server-side task id; command success does not mean bytes have finished downloading or moving. Take the id and poll `info <id>` every few seconds rather than blocking a turn on `create --wait`, which is there for scripts that want one call. Either way the status is the only terminality input: `waiting_to_move` / `moving` are still in progress, and `error` is a failure even when `will_auto_retry` says a server sweep may pick the row up again.
+- Create names the task itself, from the URL's inspect title. Leave `--name` off unless the user asked for a specific filename, and never build one out of a URL path — a name sent on create is pinned to the row for good. Magnet links, `--torrent` uploads and HuggingFace repos reject the flag outright: those names come from torrent metadata or the repo id.
 - Re-submitting the same URL always creates a **new** task (no identity dedup). Landing-name collisions are resolved with a `(n)` suffix; they do not reuse or block an existing row. Create sends `Idempotency-Key` only to collapse transport retries of one attempt — not URL dedup.
 - Pause only applies while `waiting` or `downloading` (otherwise 400). Resume, cancel, and remove return **409** while the task is in the yt-dlp mover phase (`waiting_to_move` / `moving`) — wait and retry; do not treat pause the same way.
 - Task ownership follows the active profile. Do not infer another user's task from an id or try alternate identities.
@@ -53,5 +54,5 @@ All verbs require Olares 1.12.7+ because the Settings download edge and provider
 - Confirm create, cancel, remove, seed stop/resume, file remove, preference writes, and global setting writes.
 - Before create, confirm destination/app, provider intent, torrent file selection, and whether an existing equivalent task should be reused. Use `list` / `info` to check; the CLI does **not** detect or block duplicates.
 - `file remove` takes a download-server resource path, not an arbitrary local filesystem path.
-- A URL that fails for a missing login is not a dead end: cookies live in [`olares-settings`](../olares-settings/SKILL.md) under `settings integration cookie`. See [provider/quality inspection](references/olares-knowledge-download-inspect.md) for the signals and the hand-off.
+- A URL that fails for a missing login is not a dead end: cookies live in [`olares-settings`](../olares-settings/SKILL.md) under `settings integration cookie`. The hand-off does need the user, though — the `cookies.txt` is their own browser export, so ask for it rather than hunting for a file. See [provider/quality inspection](references/olares-knowledge-download-inspect.md) for the signals and the full flow.
 - Stop on ambiguous URL/resource path, task owner, duplicate-task intent, torrent selection, or any credential request the cookie hand-off does not cover.

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-inspect.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-inspect.md
@@ -11,6 +11,8 @@ olares-cli knowledge download inspect 'https://example.com/file.zip' -o json
 
 Returns provider (`yt-dlp` / `aria2` / `huggingface` / …), title, and (for yt-dlp) `available_qualities`. Probe failures often still return HTTP 200 with `Error` / `error_category` set — treat as a hint, not a gate before `create`.
 
+Run it to pick a quality or to show the user what a URL resolves to. You do **not** need it to name a task: `create` runs the same probe and sends the title as `file_name` on its own, so there is no reason to inspect first and pass the title back through `--name`. See [task lifecycle](olares-knowledge-download-lifecycle.md) for the naming rules.
+
 If `Available: false` for yt-dlp, the yt-dlp daemon is unreachable (often not installed). Create for yt-dlp URLs will fail until it is available; aria2 / huggingface URLs are unaffected.
 
 ## When the URL needs a login
@@ -23,14 +25,14 @@ These signals mean the URL is downloadable but the server has no session for it 
 | `error_code` 507 / 511 / 512 | inspect data |
 | `error_category` `authorization_failed` / `private_resource` / `bot_detected` | inspect data, or `info` on a failed task |
 
-Do not stop here. Cookies are an [`olares-settings`](../../olares-settings/SKILL.md) concern; import them and retry:
+This is not a dead end, but it is also **not something you can finish on your own**: `cookies.txt` is a Netscape-format export taken from the user's own logged-in browser. No command generates it, and there is no conventional path to guess at — do not go looking for one on disk. Stop and ask the user to export it and tell you where it is. Then import and retry:
 
 ```bash
 olares-cli settings integration cookie import --domain youtube.com --file cookies.txt
 olares-cli knowledge download inspect 'https://www.youtube.com/watch?v=…'
 ```
 
-The CLI prints this command for you, with the domain already filled in from the URL. If the user's `cookies.txt` export turns out to be missing the login, open [`olares-settings`](../../olares-settings/SKILL.md) and use the `header` import path under `settings integration cookie` — that is the fix.
+The CLI prints this command for you, with the domain already filled in from the URL — quote it when you ask, so the user knows exactly what the file is for. If their `cookies.txt` export turns out to be missing the login, open [`olares-settings`](../../olares-settings/SKILL.md) and use the `header` import path under `settings integration cookie` — that is the fix.
 
 ## prefs get / set
 

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-lifecycle.md
@@ -1,12 +1,12 @@
 # knowledge download lifecycle
 
-> **Flags:** `olares-cli knowledge download create|list|info|pause|resume|cancel|remove --help`.
+> **Flags:** `olares-cli knowledge download create|list|info|wait|pause|resume|cancel|remove --help`.
 
 ## create
 
 ```bash
 olares-cli knowledge download create 'https://example.com/video' --app wise
-olares-cli knowledge download create 'https://…' --path drive/Home/Downloads/ --name clip.mp4 --quality 1080p
+olares-cli knowledge download create 'https://…' --path drive/Home/Downloads/ --quality 1080p
 olares-cli knowledge download create 'https://…' --format-id 'bv*+ba/b' -o json
 ```
 
@@ -15,15 +15,38 @@ olares-cli knowledge download create 'https://…' --format-id 'bv*+ba/b' -o jso
 - `--path` is normalized locally to match download-server `CreateFileParam`: bare `drive/Home/...` / `drive/Data/...`, `/api/resources/drive/...`, or a full Files API URL (`https://files.<user>.olares.<tld>/api/resources/drive/Home/...`). `Home` / `Data` are case-sensitive. **Not** accepted: browser Files UI URLs (`.../Files/Home/...`), bare `Home/...`, or other file types (cache/external/…). Defaults to `drive/Home/Downloads/`. Pass `--path ""` for HuggingFace cache mode so the server decides.
 - Re-creating the same URL always inserts a **new** task row (no 409 duplicate). Check `list` / `info` before creating another copy if reuse was intended.
 - Each create sends a fresh `Idempotency-Key`. Transport retries of the **same** CLI attempt reuse that key (server returns the same task). A second user invoke gets a new key and still inserts a new row.
-- `--wait [--timeout <duration>]` polls like `wait <id>` after a successful create (mover phases are not success). The created row is printed even when the wait times out or ends in failure, so a script never loses the id.
 - Success table line: `Created task <id> status=… provider=… name=…`. Use `-o json` for the full task row.
 
-### HuggingFace (`--path` / `--name` behaviour)
+### Naming: leave `--name` off
 
-For HuggingFace URLs the destination is chosen by `extra._hf_dest`, **not** by `--path` / `--name`:
+`create` probes the URL itself and sends the inspect **title** as `file_name` — the same prefill LarePass does in its New Task dialog. That is why the task reads as the video title from the moment it is created instead of sitting nameless until the provider writes the real filename back minutes later.
 
-- **local** (backend default when `_hf_dest` is unset): lands under `<path>/<repoID>/`. `--path` applies; `--name` is unnecessary because the repo id is the folder name (create-time `(n)` de-dup still applies).
-- **cache**: shared `HF_HOME` (Files UI shows `/Common/huggingface/`). `--path` and `--name` are **ignored** — the `huggingface_hub` cache layout (`models--org--repo`) is fixed. Send `--path ""` to match wise.
+- **Do not invent a `--name` from the URL.** A routing segment such as YouTube's `/watch` or Bilibili's `/video/BV…` is not a filename, and a name passed on create is pinned to the row for good — the inspect title never gets a chance to land.
+- Pass `--name` only when the user asked for a specific filename.
+- A failed probe (505, cookie-gated, channel URL past the server deadline) just omits the field; the provider still writes the real name back. Create is not blocked, so do not retry or report failure over it.
+- `inspect` is still worth running on its own when you need the qualities or want to show the user the title first — it is not needed to get the name right.
+
+The probe costs a round trip, and a yt-dlp inspect regularly takes several seconds against a sub-second ordinary call, so create is correspondingly slower than it used to be:
+
+- `--inspect-timeout <duration>` caps it (default 15s, chosen to clear a normal yt-dlp probe while still cutting off a pathological one). On expiry the field is omitted and create carries on.
+- `--no-inspect` skips it entirely — use when create latency matters more than having a name straight away. Cannot be combined with `--inspect-timeout`.
+
+Magnet links, `--torrent` uploads and HuggingFace repos **reject** `--name`:
+
+| Source | `--name` | Where the name comes from |
+|---|---|---|
+| yt-dlp / plain http | optional, usually omit | inspect title, else the provider |
+| magnet / `--torrent` | rejected | torrent metadata (aria2 skips its `out` option) |
+| HuggingFace | rejected | repo id, or the shared-cache layout |
+
+The flag fails locally with the provider named. This mirrors LarePass, which disables its rename field for the same three: a custom name there would only be pinned to the task row while the file on disk keeps the original one.
+
+### HuggingFace (`--path` behaviour)
+
+For HuggingFace URLs the destination is chosen by `extra._hf_dest`, **not** by `--path`:
+
+- **local** (backend default when `_hf_dest` is unset): lands under `<path>/<repoID>/`. `--path` applies; the repo id is the folder name (create-time `(n)` de-dup still applies).
+- **cache**: shared `HF_HOME` (Files UI shows `/Common/huggingface/`). `--path` is **ignored** — the `huggingface_hub` cache layout (`models--org--repo`) is fixed. Send `--path ""` to match wise.
 
 Set HF options through `--extra` (flat string keys map 1:1 to `hf` CLI flags; `_hf_dest` is the only internal key):
 
@@ -40,7 +63,30 @@ olares-cli knowledge download create 'https://huggingface.co/org/repo' \
 
 Recognised HF `--extra` keys: `_hf_dest` (`cache`|`local`), `token`, `revision`, `include`, `exclude`, `max-workers`, `repo-type`. Note wise defaults HF to **cache**; this CLI defaults to **local** unless you pass `_hf_dest`.
 
-## list / info / wait
+## Following a task: `info` polling, not `--wait`
+
+`create` returns as soon as the row exists — the download itself is the server's job and can run for many minutes. **Default path: take the id off create and poll `info <id>` yourself**, every few seconds, so the conversation stays responsive and a slow download does not eat a whole turn.
+
+```bash
+olares-cli knowledge download create 'https://www.youtube.com/watch?v=…' -o json   # → id
+olares-cli knowledge download info 42                                              # → status / percent / file_name
+```
+
+Terminal states are the same however you poll, and the **status is the only input**. **Success:** `completed`, `seeding`. **Failure:** `error`, `cancelled`, `removed`. **Still running:** everything else, including `waiting_to_move` / `moving` — bytes are still being relocated, so neither counts as success.
+
+`will_auto_retry` does not enter that judgement. It is a flag the server derives for the UI (an `error` row whose `err_category` is non-terminal and whose retry budget is not spent), and it means "a background sweep may pick this up again" — not "this row is still running". Report the failure. If the user wants to know whether the retry lands, poll `info` again rather than holding the task open.
+
+`--wait` is the blocking alternative, for scripts that want one call rather than a poll loop:
+
+```bash
+olares-cli knowledge download wait 42
+olares-cli knowledge download wait 42 --timeout 10m
+olares-cli knowledge download create 'https://…' --wait --timeout 30m
+```
+
+`wait <id>` / `create --wait` poll `info` every 2s until a terminal status. `--timeout` defaults to 15m (same as the market / users watch commands); on expiry the exit is non-zero and the current status is printed — `create --wait` still prints the created row, so the id survives. Transient poll errors are retried until 5 of them arrive in a row, then wait aborts; Ctrl-C reports as cancelled by user, not as a timeout. Polling only — no WebSocket watch.
+
+## list / info
 
 ```bash
 olares-cli knowledge download list --app wise
@@ -48,17 +94,15 @@ olares-cli knowledge download list --status downloading --page 1 --page-size 20 
 olares-cli knowledge download list --all
 olares-cli knowledge download list --all-apps
 olares-cli knowledge download info 42
-olares-cli knowledge download wait 42
-olares-cli knowledge download wait 42 --timeout 10m
-olares-cli knowledge download create 'https://…' --wait --timeout 30m
 ```
 
 - `--all` pages through `/api/download/list` until every matching row is collected (distinct from `sync --all`, which drains the sync cursor).
-- `--all-apps` lists across every app and cannot be combined with an explicit `--app` (default `--app wise` is omitted when `--all-apps` is set).
+- `--all-apps` lists across every app and cannot be combined with an explicit `--app` (the default `--app larepass` is omitted when `--all-apps` is set).
 - `--status` is validated locally against the server enum; illegal values fail before any request.
-- `wait <id>` / `create --wait` poll `info` every 2s until a terminal status. **Success:** `completed`, `seeding`. **Failure:** `error` (only when `will_auto_retry` is false), `cancelled`, `removed`. **`waiting_to_move` / `moving` are not success** (still relocating bytes), and an `error` the server will retry on its own keeps polling instead of failing the command. `--timeout` defaults to 15m (same as the market / users watch commands); on expiry the exit is non-zero and the current status is printed — `create --wait` still prints the created row first, so the id survives. Transient poll errors are retried until 5 of them arrive in a row, then wait aborts; Ctrl-C reports as cancelled by user, not as a timeout. Polling only — no WebSocket watch.
 
 Table columns: `ID`, `STATUS`, `PROVIDER`, `PERCENT`, `NAME`, `SOURCE`, `APP`, `UPDATED`. `SOURCE` is the task URL (magnet / http / …). Footer shows `N of total` when the server returns `total`.
+
+`NAME` is `file_name` when the server has one, else the torrent metadata name, the magnet's `dn=` / info-hash, or a URL basename that actually looks like a file. It shows `-` rather than echoing the URL, so a `-` means "no name written yet", not an error — the URL is in `SOURCE` either way.
 
 ## pause / resume / cancel
 

--- a/cli/skills/olares-knowledge/references/olares-knowledge-download-torrent.md
+++ b/cli/skills/olares-knowledge/references/olares-knowledge-download-torrent.md
@@ -62,3 +62,9 @@ omitted. `--select-files` takes 1-based indices, normalised into
 `all` (or omitting the flag) downloads every file, and bad tokens (`0`,
 negatives, non-integers) are rejected locally rather than round-tripping to a
 server 400.
+
+`--name` is rejected for both. aria2 skips its `out` option for magnet and
+torrent downloads, so the file on disk always takes the torrent's own metadata
+name — a custom name would only be pinned to the task row. The row shows the
+magnet's `dn=` (or a short info-hash) until aria2 parses the metadata and the
+real name lands.


### PR DESCRIPTION
## Summary

* **Background**
  `olares-cli knowledge download create` used to POST without `file_name`, so a new task sat nameless (`-` in `list`) until yt-dlp wrote the real filename back. LarePass already prefills the New Task dialog from `/api/url/inspect` title. This change does the same on create: probe the title, sanitize it to the yt-dlp daemon name budget (path separators, `.` / `..`, 66 chars / byte cap), and send it as `file_name`. The probe is best-effort and capped at 15s (`--inspect-timeout`); `--no-inspect` skips it. Magnet, `--torrent`, and HuggingFace still reject `--name` because those names come from torrent metadata or the repo id.
  Unqualified `--app` now defaults to `larepass` (TermiPass) instead of `wise`, so create/list match the LarePass namespace. `list --all-apps` still spans both. `wait` treats `error` as terminal even when `will_auto_retry` is set; poll `info` afterwards if a retry lands.

* **Target Version for Merge**
  1.12.7

* **Related Issues**
  None

* **PRs Involving Sub-Systems**
  None

* **Other information**
  None

## Test plan
- [ ] `go test ./cli/cmd/ctl/download/` passes
- [ ] `olares-cli knowledge download create 'https://www.bilibili.com/video/BV…'` (no `--app`) lands in `larepass` with the video title as `name` from create time
- [ ] `list` without `--app` shows the larepass row; `--app wise` / `--all-apps` still work
- [ ] `--no-inspect` creates without a probe; magnet / `--torrent` / HF still reject `--name`
- [ ] `wait` on a `network_error` row exits as failure even if `will_auto_retry` is true


Made with [Cursor](https://cursor.com)