### PR TITLE
fix: add cm-sidecar github workflow

### DIFF
--- a/.github/workflows/module_cmsidecar_publish_docker.yaml
+++ b/.github/workflows/module_cmsidecar_publish_docker.yaml
@@ -1,0 +1,62 @@
+name: Publish cm-sidecar to Dockerhub
+
+on:
+    workflow_dispatch:
+      inputs:
+        tags:
+          description: 'Release Tags'
+
+jobs:
+  publish_dockerhub_amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+      - name: Build and push amd64 Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: beclab/cm-sidecar:${{ github.event.inputs.tags }}-amd64
+          context: framework/cm-sidecar
+          file: framework/cm-sidecar/Dockerfile
+          platforms: linux/amd64
+  publish_dockerhub_arm64:
+    runs-on: self-hosted
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+      - name: Build and push arm64 Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: beclab/cm-sidecar:${{ github.event.inputs.tags }}-arm64
+          context: framework/cm-sidecar
+          file: framework/cm-sidecar/Dockerfile
+          platforms: linux/arm64
+
+  publish_manifest:
+    needs:
+    - publish_dockerhub_amd64
+    - publish_dockerhub_arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Push manifest
+        run: |
+          docker manifest create beclab/cm-sidecar:${{ github.event.inputs.tags }} --amend beclab/cm-sidecar:${{ github.event.inputs.tags }}-amd64 --amend beclab/cm-sidecar:${{ github.event.inputs.tags }}-arm64
+          docker manifest push beclab/cm-sidecar:${{ github.event.inputs.tags }}


### PR DESCRIPTION

* **Background**
add cm-sidecar github workflow
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that publishes container images using existing Docker Hub secrets; no runtime or application logic is modified.
> 
> **Overview**
> Adds a **manual GitHub Actions workflow** to build and publish the `cm-sidecar` image to Docker Hub as `beclab/cm-sidecar`, matching the existing multi-arch pattern used for other modules.
> 
> On `workflow_dispatch`, it builds **linux/amd64** on `ubuntu-latest` and **linux/arm64** on a **self-hosted** runner from `framework/cm-sidecar`, tags each arch with the input release tag plus `-amd64`/`-arm64`, then creates and pushes a **multi-arch manifest** for the unprefixed tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80c2eafe83347d939f3f1f233876dca17613a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->