### PR TITLE
backup: wise shared host

### DIFF
--- a/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
+++ b/framework/backup-server/.olares/config/cluster/deploy/backup_server.yaml
@@ -1,6 +1,6 @@
 
 
-{{ $backupVersion := "0.3.70" }}
+{{ $backupVersion := "0.3.71" }}
 {{ $backup_server_rootpath := printf "%s%s" .Values.rootPath "/rootfs/backup-server" }}
 
 {{- $backup_nats_secret := (lookup "v1" "Secret" .Release.Namespace "backup-nats-secret") -}}
@@ -168,6 +168,8 @@ spec:
             cpu: 500m
             memory: 512Mi
         env:
+        - name: BACKUP_WISE_HOST
+          value: rss-svc.wisev3-shared:3010
         - name: TERMINUS_IS_CLOUD_VERSION
           value: {{ default "false" .Values.backup.is_cloud_version | quote }}
         - name: ENABLE_MIDDLEWARE_BACKUP
@@ -219,6 +221,8 @@ spec:
             cpu: 2
             memory: 1500Mi
         env:
+        - name: BACKUP_WISE_HOST
+          value: rss-svc.wisev3-shared:3010
         - name: NATS_HOST
           value: nats.os-platform
         - name: NATS_PORT

--- a/framework/backup-server/pkg/modules/backup/v1/handler.go
+++ b/framework/backup-server/pkg/modules/backup/v1/handler.go
@@ -718,7 +718,7 @@ func (h *Handler) addRestore(req *restful.Request, resp *restful.Response) {
 			return
 		}
 	} else {
-		if ok := h.handler.GetBackupHandler().CheckAppInstalled(fmt.Sprintf("wisev3-%s-wisev3", owner)); !ok {
+		if ok := h.handler.GetBackupHandler().CheckAppInstalled("wisev3-shared-wisev3"); !ok {
 			response.HandleError(resp, fmt.Errorf("Wise is not installed. Please go to the Market to install this app."))
 			return
 		}


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
change wise shared url

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Wise connectivity and restore gating; restores can fail if the shared app name or service host does not match the cluster, or if environments still rely on per-user Wise installs.
> 
> **Overview**
> Backup-server is updated to use a **shared Wise v3** service instead of per-user Wise app instances.
> 
> The cluster deploy manifest bumps the image to **v0.3.71** and sets **`BACKUP_WISE_HOST`** to `rss-svc.wisev3-shared:3010` on both the **api** and **controller** containers so runtime calls go to the shared RSS service.
> 
> For non–file restores, the restore API no longer checks `wisev3-{owner}-wisev3`; it requires the cluster application **`wisev3-shared-wisev3`** to be installed before starting a restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad7867477ab4adbf18aef6eb1f81cedf883f416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->