### PR TITLE
olares: bump system-frontend to v1.11.37

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.36
+          image: beclab/system-frontend:v1.11.37
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image so that the v1.12.7 release picks up the latest LarePass/TermiPass desktop and download fixes. It is a chart/manifest-only change: no Olares-side logic is touched, only the image tag.

  Image change:

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.36` | `beclab/system-frontend:v1.11.37` |

  `user-service` stays on its current version.

  **What the new `system-frontend` image contains**

  1. **Desktop windows keep their maximized state, stay inside a shrinking viewport, and animate restore** (TermiPass [#1387](https://github.com/beclab/TermiPass/pull/1387)). Maximized was previously only local to `BasicWindow`, so a refresh wrote an unmaximized snapshot to `expiresStorage`. It is now part of `WindowInfo` and round-trips through `update:modelValue`. Resize used to only nudge `left` and never touched `width`/`height`, so a window opened on a wide screen overflowed after the browser shrank; `clampWindowRectToViewport` now pulls overflowing windows back into the usable area (viewport minus the 108px dock), respecting `min_width`/`min_height`, and the same clamp runs when restoring from storage. Restore had no animation because `transition` lived inside `.animationClass` (maximize only); transitions now live on `.window-animating` for either toggle, and dragging or resizing clears the class immediately so the pointer is not lagged. Geometry updates mutate `WindowInfo` in place so `BasicWindow` is not remounted and the iframe is not reloaded.

  2. **Desktop follows the entrance id that rotates during install** (TermiPass [#1386](https://github.com/beclab/TermiPass/pull/1386)). While an app is deploying, the backend exposes the entrance under the app uuid and later swaps it for the real subdomain (e.g. `f3395cd5` → `router`). Desktop only persisted `/server/myApps` on first load, and later `app_state_change` pushes matched on `entrance.name` and refreshed `state` only, so the stale uuid stayed in `myApps` and Market open intents could not resolve until a desktop refresh. Matching is now by `entrance.id`: a known id still only refreshes `state` / `fatherState`; an unseen id is treated as a rotation, the stale row is replaced in place (icon order unchanged), and omitted `title` / `icon` / `openMethod` are inherited by same-name pairing so multi-entrance apps do not mix siblings. `invisible` omitted is treated as visible, matching `update_my_apps_info`, instead of removing the whole app from the desktop.

  3. **yt-dlp no longer treats file names as output templates** (TermiPass [#1388](https://github.com/beclab/TermiPass/pull/1388)). Prefill rewrites `%( ` in download titles to `_(` so names like `100%(백퍼센트)` are not parsed as yt-dlp outtmpl fields and the task fails. Rename still blocks a user-typed `%( ` for yt-dlp only (aria2 `out` keeps it as a literal); a lone `%` is unchanged. Localized rename-error copy is added for the seven locales.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1387
https://github.com/beclab/TermiPass/pull/1386
https://github.com/beclab/TermiPass/pull/1388

* **Other information**:
None

Made with [Cursor](https://cursor.com)