### PR TITLE
fix(cli): accept a running sidecar when checking pod readiness

### DIFF
--- a/cli/pkg/systemcomponents/check.go
+++ b/cli/pkg/systemcomponents/check.go
@@ -151,6 +151,10 @@ type workload struct {
 	name      string
 	selector  *metav1.LabelSelector
 	assert    func() error
+	// ready is how many replicas the workload's status claims are serving. It is
+	// the claim a node scoped check weighs against the pods that actually exist,
+	// to catch a status that has not caught up with a restart.
+	ready func() int32
 }
 
 type clusterIndex struct {
@@ -283,9 +287,54 @@ func (c *Checker) assertPodsOnNode(ctx context.Context, w workload) error {
 	}
 
 	if live == 0 {
+		if err := c.assertStatusNotStale(ctx, w); err != nil {
+			return fmt.Errorf("no pod running on node %s: %w", c.node, err)
+		}
 		if err := w.assert(); err != nil {
 			return fmt.Errorf("no pod running on node %s: %w", c.node, err)
 		}
+	}
+	return nil
+}
+
+// assertStatusNotStale reports why a workload's status cannot stand in for the
+// pod this node is missing, or nil when the status is consistent with the pods
+// that exist and may be read.
+//
+// The fallback above leans on the status to tell "the replicas run on another
+// node" apart from "the replicas are gone", which only holds while the status
+// describes the present. Callers that restart a node delete its pods in bulk,
+// and until the controllers observe that, the status still counts the pods that
+// were just removed. Reading it then would report a whole node as ready on the
+// strength of a status written before its workloads were taken down.
+//
+// A pod is only counted as backing the claim once it is scheduled and not on its
+// way out: one that is terminating or still unplaced is running nowhere, and a
+// finished one is an execution record. Counting rather than rejecting outright
+// keeps a replica that cannot be placed from blocking a workload that is
+// genuinely serving from somewhere else.
+func (c *Checker) assertStatusNotStale(ctx context.Context, w workload) error {
+	pods, err := c.podsOf(ctx, w, "")
+	if err != nil {
+		// with the pods unreadable the status is the only evidence there is
+		return nil
+	}
+
+	scheduled := int32(0)
+	for _, pod := range pods {
+		switch {
+		case pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed:
+		case pod.DeletionTimestamp != nil:
+		case pod.Spec.NodeName == "":
+		default:
+			scheduled++
+		}
+	}
+
+	if claimed := w.ready(); scheduled < claimed {
+		return fmt.Errorf(
+			"its status still counts %d ready replica(s) while only %d pod(s) are scheduled, so it predates the restart",
+			claimed, scheduled)
 	}
 	return nil
 }
@@ -404,6 +453,7 @@ func deploymentWorkload(d *appsv1.Deployment) workload {
 		name:      d.Name,
 		selector:  d.Spec.Selector,
 		assert:    func() error { return AssertDeploymentReady(d) },
+		ready:     func() int32 { return d.Status.ReadyReplicas },
 	}
 }
 
@@ -413,6 +463,7 @@ func statefulSetWorkload(s *appsv1.StatefulSet) workload {
 		name:      s.Name,
 		selector:  s.Spec.Selector,
 		assert:    func() error { return AssertStatefulSetReady(s) },
+		ready:     func() int32 { return s.Status.ReadyReplicas },
 	}
 }
 
@@ -422,5 +473,6 @@ func daemonSetWorkload(d *appsv1.DaemonSet) workload {
 		name:      d.Name,
 		selector:  d.Spec.Selector,
 		assert:    func() error { return AssertDaemonSetReady(d) },
+		ready:     func() int32 { return d.Status.NumberReady },
 	}
 }

--- a/cli/pkg/systemcomponents/check_node_test.go
+++ b/cli/pkg/systemcomponents/check_node_test.go
@@ -1,0 +1,194 @@
+package systemcomponents
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testNode = "olares-sidecar"
+
+// fakeSource serves a fixed cluster to the checker.
+type fakeSource struct {
+	statefulSets []*appsv1.StatefulSet
+	pods         []*corev1.Pod
+}
+
+func (s *fakeSource) Namespaces(context.Context) ([]string, error) { return nil, nil }
+func (s *fakeSource) Deployments(context.Context) ([]*appsv1.Deployment, error) {
+	return nil, nil
+}
+func (s *fakeSource) StatefulSets(context.Context) ([]*appsv1.StatefulSet, error) {
+	return s.statefulSets, nil
+}
+func (s *fakeSource) DaemonSets(context.Context) ([]*appsv1.DaemonSet, error) { return nil, nil }
+func (s *fakeSource) Pods(context.Context) ([]*corev1.Pod, error)             { return s.pods, nil }
+
+func natsStatefulSet(readyReplicas int32) *appsv1.StatefulSet {
+	one := int32(1)
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "os-platform", Name: "nats", Generation: 1},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "nats"},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			ReadyReplicas:      readyReplicas,
+			UpdatedReplicas:    1,
+			CurrentRevision:    "nats-1",
+			UpdateRevision:     "nats-1",
+		},
+	}
+}
+
+func natsPodOnNode(node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "os-platform",
+			Name:      "nats-0",
+			Labels:    map[string]string{"app.kubernetes.io/name": "nats"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "nats"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "nats",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				Ready: true,
+			}},
+		},
+	}
+}
+
+var natsComponent = []Component{{
+	Namespace: "os-platform",
+	Kind:      StatefulSet,
+	Name:      "nats",
+	Presence:  Required,
+}}
+
+func checkNode(t *testing.T, src *fakeSource) error {
+	t.Helper()
+	return NewChecker(src).OnNode(testNode).Check(context.Background(), natsComponent)
+}
+
+// change-ip deletes every pod on the node and hands straight over to this check.
+// While the controllers have not caught up, the StatefulSet still counts the pod
+// it just lost as ready, and the node scoped pod scan sees nothing to contradict
+// it. Trusting the status there reported a whole node as ready in 20ms, before
+// any workload had come back.
+func TestCheckOnNodeRejectsAStatusThatPredatesARestart(t *testing.T) {
+	tests := []struct {
+		name string
+		pods []*corev1.Pod
+	}{
+		{
+			name: "replacement not created yet",
+			pods: nil,
+		},
+		{
+			name: "replacement created but not scheduled",
+			pods: []*corev1.Pod{natsPodOnNode("")},
+		},
+		{
+			name: "replacement pending while the old pod drains elsewhere",
+			pods: func() []*corev1.Pod {
+				pod := natsPodOnNode("some-other-node")
+				now := metav1.Now()
+				pod.DeletionTimestamp = &now
+				return []*corev1.Pod{pod}
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkNode(t, &fakeSource{
+				statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+				pods:         tt.pods,
+			})
+			if err == nil {
+				t.Fatal("node reported ready while its workload had not come back")
+			}
+			if want := "predates the restart"; !strings.Contains(err.Error(), want) {
+				t.Errorf("got %q, want it to contain %q", err, want)
+			}
+		})
+	}
+}
+
+// The fallback still has to do its job: a workload whose replicas legitimately
+// live on another node has nothing to prove about this one.
+func TestCheckOnNodeAcceptsReplicasServingElsewhere(t *testing.T) {
+	if err := checkNode(t, &fakeSource{
+		statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+		pods:         []*corev1.Pod{natsPodOnNode("some-other-node")},
+	}); err != nil {
+		t.Fatalf("workload serving from another node reported not ready: %v", err)
+	}
+}
+
+// A pod that cannot be placed must not hold back a workload that is serving:
+// only the unplaced pod is discounted, the running one still backs the claim.
+func TestCheckOnNodeAcceptsAnUnschedulableSurgePod(t *testing.T) {
+	surge := natsPodOnNode("")
+	surge.Name = "nats-surge"
+
+	if err := checkNode(t, &fakeSource{
+		statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+		pods:         []*corev1.Pod{natsPodOnNode("some-other-node"), surge},
+	}); err != nil {
+		t.Fatalf("unschedulable surge pod blocked a serving workload: %v", err)
+	}
+}
+
+// A pod that is still draining on the checked node is visible to the node scan,
+// so it is rejected on its own state and the status fallback is never consulted.
+func TestCheckOnNodeRejectsATerminatingPodItCanSee(t *testing.T) {
+	pod := natsPodOnNode(testNode)
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+
+	err := checkNode(t, &fakeSource{
+		statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+		pods:         []*corev1.Pod{pod},
+	})
+	if err == nil {
+		t.Fatal("terminating pod reported ready")
+	}
+	if want := "is terminating"; !strings.Contains(err.Error(), want) {
+		t.Errorf("got %q, want it to contain %q", err, want)
+	}
+}
+
+// A live pod on the checked node is judged on its own state, and never reaches
+// the status fallback at all.
+func TestCheckOnNodeJudgesAPodItCanSee(t *testing.T) {
+	if err := checkNode(t, &fakeSource{
+		statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+		pods:         []*corev1.Pod{natsPodOnNode(testNode)},
+	}); err != nil {
+		t.Fatalf("ready pod on the node reported not ready: %v", err)
+	}
+
+	notReady := natsPodOnNode(testNode)
+	notReady.Status.ContainerStatuses[0].Ready = false
+	err := checkNode(t, &fakeSource{
+		statefulSets: []*appsv1.StatefulSet{natsStatefulSet(1)},
+		pods:         []*corev1.Pod{notReady},
+	})
+	if err == nil {
+		t.Fatal("unready pod on the node reported ready")
+	}
+}

--- a/cli/pkg/systemcomponents/readiness.go
+++ b/cli/pkg/systemcomponents/readiness.go
@@ -101,6 +101,37 @@ func assertRolloutObserved(generation, observed int64) error {
 	return nil
 }
 
+// isSidecar reports whether an init container is one Kubernetes runs alongside
+// the main containers for the life of the pod, rather than to completion.
+func isSidecar(c corev1.Container) bool {
+	return c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+// assertSidecarReady reports why a sidecar is not serving, or nil when it is
+// running and ready. A restart is not held against it: unlike a plain init
+// container it is expected to be restarted, and only its current state decides.
+func assertSidecarReady(s corev1.ContainerStatus, podKey string) error {
+	if w := s.State.Waiting; w != nil {
+		return fmt.Errorf(
+			"sidecar %s in pod %s is waiting (reason=%s, message=%s)",
+			s.Name, podKey, w.Reason, w.Message,
+		)
+	}
+	if t := s.State.Terminated; t != nil {
+		return fmt.Errorf(
+			"sidecar %s in pod %s terminated (exitCode=%d, reason=%s, message=%s)",
+			s.Name, podKey, t.ExitCode, t.Reason, t.Message,
+		)
+	}
+	if s.Started == nil || !*s.Started {
+		return fmt.Errorf("sidecar %s in pod %s has not started", s.Name, podKey)
+	}
+	if !s.Ready {
+		return fmt.Errorf("sidecar %s in pod %s is not ready", s.Name, podKey)
+	}
+	return nil
+}
+
 // AssertPodReady reports why a pod is not serving, or nil when it is running
 // with every container ready.
 //
@@ -133,6 +164,16 @@ func AssertPodReady(pod *corev1.Pod) error {
 			s, ok := initStatusByName[ic.Name]
 			if !ok {
 				return fmt.Errorf("pod %s has not started init container %s yet", podKey, ic.Name)
+			}
+			// A sidecar keeps running for as long as the pod does, so waiting
+			// for it to terminate would never end. Kubelet does not start the
+			// main containers until it is ready, so asserting that much is both
+			// all that is available and all that is needed.
+			if isSidecar(ic) {
+				if err := assertSidecarReady(s, podKey); err != nil {
+					return err
+				}
+				continue
 			}
 			if t := s.State.Terminated; t != nil {
 				if t.ExitCode != 0 {

--- a/cli/pkg/systemcomponents/readiness_test.go
+++ b/cli/pkg/systemcomponents/readiness_test.go
@@ -1,0 +1,133 @@
+package systemcomponents
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// natsPod rebuilds os-platform/nats-0 as it looked while enable-juicefs was
+// waiting on it: cm-sidecar is a sidecar that had already restarted once and is
+// running and ready, and the main containers it gates are serving.
+func natsPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "os-platform", Name: "nats-0"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:          "cm-sidecar",
+				RestartPolicy: ptr(corev1.ContainerRestartPolicyAlways),
+			}},
+			Containers: []corev1.Container{
+				{Name: "nats"},
+				{Name: "reloader"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "cm-sidecar",
+				State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				Ready:        true,
+				Started:      ptr(true),
+				RestartCount: 1,
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "nats", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, Ready: true},
+				{Name: "reloader", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, Ready: true},
+			},
+		},
+	}
+}
+
+// A running sidecar never terminates, so treating it like a plain init
+// container made this pod permanently unready and hung every node scoped wait
+// (enable-juicefs, change-ip, start, staged upgrade) until it ran out of
+// retries.
+func TestAssertPodReadyAcceptsARunningSidecar(t *testing.T) {
+	if err := AssertPodReady(natsPod()); err != nil {
+		t.Fatalf("pod with a ready sidecar reported not ready: %v", err)
+	}
+}
+
+func TestAssertPodReadyRejectsAnUnhealthySidecar(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*corev1.Pod)
+		want   string
+	}{
+		{
+			name: "crash looping",
+			mutate: func(p *corev1.Pod) {
+				p.Status.InitContainerStatuses[0].State = corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+				}
+				p.Status.InitContainerStatuses[0].Ready = false
+				p.Status.InitContainerStatuses[0].Started = ptr(false)
+			},
+			want: "sidecar cm-sidecar in pod os-platform/nats-0 is waiting (reason=CrashLoopBackOff",
+		},
+		{
+			name: "gave up and exited",
+			mutate: func(p *corev1.Pod) {
+				p.Status.InitContainerStatuses[0].State = corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+				}
+				p.Status.InitContainerStatuses[0].Ready = false
+			},
+			want: "sidecar cm-sidecar in pod os-platform/nats-0 terminated (exitCode=1",
+		},
+		{
+			name: "running but failing its probe",
+			mutate: func(p *corev1.Pod) {
+				p.Status.InitContainerStatuses[0].Ready = false
+			},
+			want: "sidecar cm-sidecar in pod os-platform/nats-0 is not ready",
+		},
+		{
+			name: "not started yet",
+			mutate: func(p *corev1.Pod) {
+				p.Status.InitContainerStatuses[0].Started = ptr(false)
+			},
+			want: "sidecar cm-sidecar in pod os-platform/nats-0 has not started",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := natsPod()
+			tt.mutate(pod)
+			err := AssertPodReady(pod)
+			if err == nil {
+				t.Fatalf("unhealthy sidecar reported ready")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("got %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// A plain init container still has to run to completion, so the sidecar
+// handling must not weaken the ordinary case.
+func TestAssertPodReadyStillWaitsForAPlainInitContainer(t *testing.T) {
+	pod := natsPod()
+	pod.Spec.InitContainers[0].RestartPolicy = nil
+	pod.Status.InitContainerStatuses[0].RestartCount = 0
+
+	err := AssertPodReady(pod)
+	if err == nil {
+		t.Fatal("running init container reported ready")
+	}
+	if want := "init container cm-sidecar is still running"; !strings.Contains(err.Error(), want) {
+		t.Errorf("got %q, want it to contain %q", err, want)
+	}
+}


### PR DESCRIPTION
* **Background**
Since https://github.com/beclab/Olares/pull/4029, there're system pods shipped with a long-running init container, these containers are checked separately from normal init containers.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes readiness gates used during node operations and upgrades; incorrect logic could block or prematurely allow cluster steps, but scope is limited to CLI health checks rather than cluster mutation.
> 
> **Overview**
> Fixes **system component readiness** in `cli/pkg/systemcomponents` so node-scoped waits (change-ip, enable-juicefs, start, staged upgrade) stop hanging or falsely succeeding.
> 
> **Pod readiness** now treats init containers with `RestartPolicy: Always` as **sidecars**: `AssertPodReady` checks that they are started, running, and ready instead of waiting for termination. Plain init containers still must complete. Unhealthy sidecars (crash loop, terminated, not ready) are rejected with explicit errors.
> 
> **Node-scoped checks** when no live pod is on the node still fall back to workload status, but **`assertStatusNotStale`** compares claimed ready replicas to cluster-wide **scheduled** pods (excluding terminating, unplaced, and finished). If status still reports more ready replicas than exist, the check fails with a message that status **predates the restart**, avoiding a false “node ready” right after bulk pod deletion. Workloads legitimately serving on another node still pass; unschedulable surge pods do not block that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a420bc076e851fc028d5290afe6aaf7b3592938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->