### PR TITLE
fix(cli): extract olaresd and etcd archives outside the invocation CWD

### DIFF
--- a/cli/pkg/daemon/task.go
+++ b/cli/pkg/daemon/task.go
@@ -37,7 +37,9 @@ func (g *InstallTerminusdBinary) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "sync olaresd tar.gz failed")
 	}
 
-	installCmd := fmt.Sprintf("tar -zxf %s && cp -f olaresd /usr/local/bin/ && chmod +x /usr/local/bin/olaresd && rm -rf olaresd*", dst)
+	extracted := filepath.Join(common.TmpDir, "olaresd")
+	installCmd := fmt.Sprintf("tar -zxf %s -C %s && install -m 0755 %s /usr/local/bin/olaresd && rm -f %s",
+		dst, common.TmpDir, extracted, extracted)
 	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install olaresd binaries failed")
 	}

--- a/cli/pkg/etcd/tasks.go
+++ b/cli/pkg/etcd/tasks.go
@@ -153,8 +153,9 @@ func (g *InstallETCDBinary) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "sync etcd tar.gz failed")
 	}
 
-	etcdDir := strings.TrimSuffix(binary.Filename, ".tar.gz")
-	installCmd := fmt.Sprintf("tar -zxf %s && cp -f %s-*/etcd* /usr/local/bin/ && chmod +x /usr/local/bin/etcd* && rm -rf %s-*", dst, etcdDir, etcdDir)
+	etcdDir := filepath.Join(common.TmpDir, strings.TrimSuffix(binary.Filename, ".tar.gz"))
+	installCmd := fmt.Sprintf("tar -zxf %s -C %s && cp -f %s-*/etcd* /usr/local/bin/ && chmod +x /usr/local/bin/etcd* && rm -rf %s-*",
+		dst, common.TmpDir, etcdDir, etcdDir)
 	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install etcd binaries failed")
 	}


### PR DESCRIPTION
* **Background**
Currently, some installation tasks extract package archives into the current working directory and may result in a conflict, they re changed to a temp dir

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped install-script changes for olaresd/etcd only; behavior is safer and does not touch auth or cluster data paths.
> 
> **Overview**
> **olaresd** and **etcd** binary install tasks no longer unpack tarballs in the shell’s current working directory, which could collide with unrelated files in that directory.
> 
> Both flows now extract with `tar -zxf … -C` into `common.TmpDir` (`/tmp/kubekey`), after the existing `ResetTmpDir` step. **olaresd** installs via `install -m 0755` from a known path under TmpDir and removes only that extracted artifact; **etcd** still copies versioned `etcd-*` binaries into `/usr/local/bin` but resolves the extract folder under TmpDir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef59d957969b62b9814d5aeb56199898c0f2336a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->