### PR TITLE
feat(cli): cover the whole Settings Appearance page, in the words the page uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ apps/packages/app/.quasar/*
 cli/cmd/ctl/settings/scripts/*
 cli/cmd/ctl/settings/KNOWN_ISSUES.md
 cli/cmd/ctl/settings/NOTES.md
+cli/cmd/ctl/settings/REPORT.md
+cli/cmd/ctl/settings/VERIFICATION.md
 cli/cmd/ctl/files/scripts/*
 
 # Trellis task-management scaffolding (local workflow state; not product code).

--- a/cli/cmd/ctl/router/discovery.go
+++ b/cli/cmd/ctl/router/discovery.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
@@ -65,18 +66,14 @@ type myApp struct {
 // is the authority on what is installed — Router hides the provider of an
 // application that is not running.
 func listMyApps(ctx context.Context, doer *whoami.HTTPClient) ([]myApp, error) {
-	var env struct {
-		Code    int             `json:"code"`
-		Message string          `json:"message"`
-		Data    json.RawMessage `json:"data"`
-	}
+	var env bflenvelope.Envelope
 	if err := doer.DoJSON(ctx, "GET", "/api/myapps", nil, &env); err != nil {
 		return nil, fmt.Errorf("list installed apps: %w", err)
 	}
 	switch env.Code {
 	case 0, 200:
 	default:
-		msg := strings.TrimSpace(env.Message)
+		msg := strings.TrimSpace(env.Message.Text)
 		if msg == "" {
 			msg = fmt.Sprintf("code %d", env.Code)
 		}

--- a/cli/cmd/ctl/search/app.go
+++ b/cli/cmd/ctl/search/app.go
@@ -11,17 +11,18 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
 
 var uninstalledAppStates = map[string]struct{}{
-	"pendingCanceled":      {},
-	"downloadingCanceled":  {},
-	"downloadFailed":       {},
-	"installingCanceled":   {},
-	"installFailed":        {},
-	"uninstalled":          {},
+	"pendingCanceled":     {},
+	"downloadingCanceled": {},
+	"downloadFailed":      {},
+	"installingCanceled":  {},
+	"installFailed":       {},
+	"uninstalled":         {},
 }
 
 type appOptions struct {
@@ -143,25 +144,13 @@ func decodeMyAppsResponse(method, path string, raw json.RawMessage) ([]appRaw, e
 		return apps, nil
 	}
 
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := json.Unmarshal(trimmed, &env); err != nil {
 		return nil, fmt.Errorf("%s %s: decode response: %w", method, path, err)
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return nil, fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return nil, fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if len(env.Data) == 0 {
-		return nil, nil
-	}
 	var apps []appRaw
-	if err := json.Unmarshal(env.Data, &apps); err != nil {
-		return nil, fmt.Errorf("%s %s: decode data: %w", method, path, err)
+	if err := bflenvelope.Data(method, path, env, &apps); err != nil {
+		return nil, err
 	}
 	return apps, nil
 }

--- a/cli/cmd/ctl/search/common.go
+++ b/cli/cmd/ctl/search/common.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
@@ -130,14 +131,6 @@ func newDoer(ctx context.Context, f *cmdutil.Factory) (*whoami.HTTPClient, error
 	return whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID), nil
 }
 
-// bflEnvelope is search3's (and BFL's) shared response shape. code 0/200
-// mean success; data carries the typed payload.
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 // doEnvelope issues an authenticated request and unwraps the {code,
 // message, data} envelope into out. out may be nil for fire-and-forget
 // calls (e.g. cancel).
@@ -149,31 +142,11 @@ func doEnvelope(ctx context.Context, d *whoami.HTTPClient, method, path string, 
 // soft codes as success, decoding whatever data they carry. This lets callers
 // tolerate non-fatal upstream codes (e.g. /search/more's "no more results").
 func doEnvelopeAllowing(ctx context.Context, d *whoami.HTTPClient, method, path string, body, out interface{}, softCodes ...int) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	ok := env.Code == 0 || env.Code == 200
-	for _, c := range softCodes {
-		if env.Code == c {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out, softCodes...)
 }
 
 // resultItem captures the fields the desktop SPA reads off each result

--- a/cli/cmd/ctl/settings/advanced/common.go
+++ b/cli/cmd/ctl/settings/advanced/common.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/containerdimages"
 	"github.com/beclab/Olares/cli/pkg/credential"
@@ -81,37 +82,16 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/advanced/env.go
+++ b/cli/cmd/ctl/settings/advanced/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/userenv"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
@@ -24,12 +25,12 @@ import (
 //	system  /api/env/systemenvs
 //	user    /api/env/userenvs
 //
-// Both are GET (list) + PUT (replace-with-merged-vector). Per the SPA's
-// SystemEnvironmentPage.vue rules, system entries that the upstream has
-// flagged with editable: false are read-only; the upstream rejects PUTs
-// that try to change them. We don't pre-validate that locally because
-// the editable flag isn't always populated and we'd rather surface the
-// upstream error than block a legitimate write.
+// Both are GET (list) + PUT (upsert of the entries in the body). Per the
+// SPA's SystemEnvironmentPage.vue rules, system entries that the upstream
+// has flagged with editable: false are read-only; the upstream rejects
+// PUTs that try to change them. We don't pre-validate that locally
+// because the editable flag isn't always populated and we'd rather
+// surface the upstream error than block a legitimate write.
 //
 // Per-app env is at `settings apps env get|set <name>` — this command
 // is the *system-wide* surface, not the per-app one.
@@ -48,8 +49,8 @@ Subcommands:
 `,
 	}
 	cmd.SilenceUsage = true
-	cmd.AddCommand(newEnvScopeCommand(f, "system", "/api/env/systemenvs"))
-	cmd.AddCommand(newEnvScopeCommand(f, "user", "/api/env/userenvs"))
+	cmd.AddCommand(newEnvScopeCommand(f, "system", userenv.SystemEnvsPath))
+	cmd.AddCommand(newEnvScopeCommand(f, "user", userenv.UserEnvsPath))
 	return cmd
 }
 
@@ -61,20 +62,6 @@ func newEnvScopeCommand(f *cmdutil.Factory, scope, basePath string) *cobra.Comma
 	cmd.AddCommand(newEnvListCommand(f, scope, basePath))
 	cmd.AddCommand(newEnvSetCommand(f, scope, basePath))
 	return cmd
-}
-
-// baseEnv mirrors apps/.../constant/index.ts:1028 BaseEnv. We share
-// only the subset we render in the table; --output json marshalls the
-// full BFL inner shape verbatim via the json.RawMessage path in
-// runEnvList.
-type baseEnv struct {
-	EnvName     string `json:"envName"`
-	Value       string `json:"value,omitempty"`
-	Default     string `json:"default,omitempty"`
-	Editable    *bool  `json:"editable,omitempty"`
-	Type        string `json:"type,omitempty"`
-	Required    *bool  `json:"required,omitempty"`
-	Description string `json:"description,omitempty"`
 }
 
 // newEnvListCommand returns the read verb for either scope. The SPA's
@@ -110,7 +97,7 @@ func runEnvList(ctx context.Context, f *cmdutil.Factory, path, outputRaw string)
 	if err != nil {
 		return err
 	}
-	envs, err := fetchEnv(ctx, pc.doer, path)
+	envs, err := userenv.List(ctx, pc.doer, path)
 	if err != nil {
 		return err
 	}
@@ -120,15 +107,7 @@ func runEnvList(ctx context.Context, f *cmdutil.Factory, path, outputRaw string)
 	return renderEnvTable(os.Stdout, envs)
 }
 
-func fetchEnv(ctx context.Context, d Doer, path string) ([]baseEnv, error) {
-	var envs []baseEnv
-	if err := doGetEnvelope(ctx, d, path, &envs); err != nil {
-		return nil, err
-	}
-	return envs, nil
-}
-
-func renderEnvTable(w io.Writer, envs []baseEnv) error {
+func renderEnvTable(w io.Writer, envs []userenv.Entry) error {
 	if len(envs) == 0 {
 		fmt.Fprintln(w, "no environment variables defined")
 		return nil
@@ -161,10 +140,10 @@ Argument shape: pass each variable as --var KEY=VALUE (repeatable);
 the bare form "set KEY=VALUE" is NOT accepted — Cobra would treat the
 first positional token as a sub-verb and reject it as "unknown command".
 
-The CLI does a read-modify-write to avoid clobbering values it doesn't
-know about: it fetches the current vector, overlays the --var pairs
-you pass, and PUTs the merged result back. The upstream rejects writes
-to system fields the SPA flags as editable: false.
+Only the variables you name are sent; the upstream leaves every other
+one untouched. It rejects the whole batch if any named variable is one
+the SPA flags as editable: false, or if it does not exist yet — this
+verb updates existing variables and does not create them.
 
 Examples:
   olares-cli settings advanced env user   set --var FOO=bar
@@ -212,16 +191,7 @@ func runEnvSet(ctx context.Context, f *cmdutil.Factory, path, scope string, vars
 	if err != nil {
 		return err
 	}
-	current, err := fetchEnv(ctx, pc.doer, path)
-	if err != nil {
-		return err
-	}
-	merged := mergeEnvUpdates(current, updates)
-	body := make([]map[string]string, 0, len(merged))
-	for _, e := range merged {
-		body = append(body, map[string]string{"envName": e.envName, "value": e.value})
-	}
-	if err := doMutateEnvelope(ctx, pc.doer, "PUT", path, body, nil); err != nil {
+	if err := userenv.SetValues(ctx, pc.doer, path, updates); err != nil {
 		return err
 	}
 	keys := make([]string, 0, len(updates))
@@ -230,11 +200,6 @@ func runEnvSet(ctx context.Context, f *cmdutil.Factory, path, scope string, vars
 	}
 	fmt.Printf("Updated %d %s environment variable(s): %s\n", len(updates), scope, strings.Join(keys, ", "))
 	return nil
-}
-
-type envPair struct {
-	envName string
-	value   string
 }
 
 func parseVarFlags(raw []string) (map[string]string, error) {
@@ -252,23 +217,4 @@ func parseVarFlags(raw []string) (map[string]string, error) {
 		out[key] = val
 	}
 	return out, nil
-}
-
-func mergeEnvUpdates(current []baseEnv, updates map[string]string) []envPair {
-	out := make([]envPair, 0, len(current)+len(updates))
-	seen := make(map[string]bool, len(current))
-	for _, e := range current {
-		v := e.Value
-		if up, ok := updates[e.EnvName]; ok {
-			v = up
-		}
-		out = append(out, envPair{envName: e.EnvName, value: v})
-		seen[e.EnvName] = true
-	}
-	for k, v := range updates {
-		if !seen[k] {
-			out = append(out, envPair{envName: k, value: v})
-		}
-	}
-	return out
 }

--- a/cli/cmd/ctl/settings/appearance/common.go
+++ b/cli/cmd/ctl/settings/appearance/common.go
@@ -1,9 +1,16 @@
 // Package appearance hosts `olares-cli settings appearance`. Mirrors the
-// SPA's Settings -> Appearance page (language + locale). Backed by
-// user-service's wallpaper.controller.ts /api/wallpaper/config/system,
-// which forwards /bfl/settings/v1alpha1/config-system. user-service
-// re-wraps the BFL response with returnSucceed(response.data.data), so
-// the CLI sees a uniform BFL envelope around the inner config body.
+// SPA's Settings -> Appearance page: locale, theme, widget preferences,
+// wallpaper, and the desktop layout reset.
+//
+// Most of it is backed by user-service (wallpaper.controller.ts,
+// widget.controller.ts, desktop-layout.controller.ts) on the /api/*
+// prefix, which re-wraps its upstream with returnSucceed(...) so the CLI
+// sees a uniform BFL envelope. Two calls step outside that:
+//
+//   - the theme write goes to /api/env/userenvs, because the theme lives
+//     in the OLARES_USER_THEME UserEnv (see theme.go);
+//   - the wallpaper image upload goes to the settings ingress, because
+//     /images is not proxied on the desktop host (see imageClient below).
 //
 // Same per-area common.go pattern as settings/me / users / apps / vpn /
 // network — each subpackage owns its own decoder so per-endpoint quirks
@@ -15,15 +22,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
+
+// appearanceMinOlaresVersion is the first Olares line carrying the three
+// Appearance surfaces that 1.12.5 does not have: the widget preferences
+// API (/api/widget), the desktop layout reset route, and the
+// OLARES_USER_THEME user env the theme is stored in. The rest of the
+// subtree (locale, wallpaper) works on 1.12.5, so the gate is per-verb
+// rather than on the whole area.
+const appearanceMinOlaresVersion = "1.12.6"
 
 type Format string
 
@@ -55,6 +75,7 @@ type Doer interface {
 type preparedClient struct {
 	profile *credential.ResolvedProfile
 	doer    Doer
+	images  *imageClient
 }
 
 func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
@@ -69,20 +90,38 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	uploadHC, err := f.HTTPClientWithoutTimeout(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &preparedClient{
 		profile: rp,
 		doer:    whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID),
+		images: &imageClient{
+			hc:       uploadHC,
+			baseURL:  strings.TrimRight(rp.SettingsURL, "/"),
+			olaresID: rp.OlaresID,
+		},
 	}, nil
-}
-
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
 }
 
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
+}
+
+// requireAppearanceBackendVersion is the client-side version preflight for
+// the Appearance verbs whose upstream landed in 1.12.6, so an older backend
+// gets the canonical upgrade message instead of an opaque 404 (widget,
+// layout) or a missing-CR message (theme). Thin wrapper supplying this
+// area's gate copy to the shared helper, like `settings compute`'s
+// requireComputeBackendVersion.
+func requireAppearanceBackendVersion(ctx context.Context, f *cmdutil.Factory, verb, reason string) error {
+	return preflight.RequireMinVersion(ctx, f, preflight.MinVersionGate{
+		Verb:       verb,
+		MinVersion: appearanceMinOlaresVersion,
+		Reason:     reason,
+		Fallback:   "upgrade the Olares system to >= " + appearanceMinOlaresVersion,
+	})
 }
 
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of doGetEnvelope:
@@ -92,24 +131,102 @@ func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) er
 // returnSucceed(response.data.data), so the same envelope contract holds
 // for writes.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
+	return bflenvelope.Data(method, path, env, out)
+}
+
+// imageClient posts images to tapr's images-uploader.
+//
+// It rides SettingsURL, not DesktopURL: /images is proxied only by the
+// settings and profile-editor ingresses (apps/docker/system-frontend/
+// nginx/settings.conf), so this cannot share the base URL every /api/*
+// call in this package uses.
+type imageClient struct {
+	hc       *http.Client
+	baseURL  string
+	olaresID string
+}
+
+// upload streams filePath as the multipart `image` part and decodes the
+// envelope the uploader replies with. The client has no overall timeout;
+// the request context stays the cancellation boundary.
+func (c *imageClient) upload(ctx context.Context, path, filePath string, fields map[string]string, out interface{}) error {
+	body, contentType, err := multipartImage(filePath, fields)
+	if err != nil {
+		return err
+	}
+	target := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("POST %s: read response body: %w", target, err)
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized,
+		resp.StatusCode == http.StatusForbidden,
+		resp.StatusCode == 459:
+		return credential.FormatHTTPAuthError(resp.StatusCode, respBody, c.olaresID)
+	case resp.StatusCode/100 != 2:
+		return fmt.Errorf("POST %s: HTTP %d: %s", target, resp.StatusCode, truncate(string(respBody), 500))
+	}
+	var env bflenvelope.Envelope
+	if err := json.Unmarshal(respBody, &env); err != nil {
+		return fmt.Errorf("POST %s: decode response: %w (body=%s)", target, err, truncate(string(respBody), 200))
+	}
+	return bflenvelope.Data(http.MethodPost, path, env, out)
+}
+
+// multipartImage streams the file rather than buffering it, with the text
+// fields written first so the receiver sees them before the image bytes.
+// Only opening the file fails here; a read that fails mid-upload travels
+// down the pipe and fails the request.
+func multipartImage(filePath string, fields map[string]string) (io.Reader, string, error) {
+	fh, err := os.Open(filePath)
+	if err != nil {
+		// os.Open's error already names the operation and the path.
+		return nil, "", err
+	}
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		defer fh.Close()
+		_ = pw.CloseWithError(writeImageParts(mw, fh, filePath, fields))
+	}()
+	return pr, mw.FormDataContentType(), nil
+}
+
+func writeImageParts(mw *multipart.Writer, file io.Reader, filePath string, fields map[string]string) error {
+	for k, v := range fields {
+		if strings.TrimSpace(v) == "" {
+			continue
 		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
+		if err := mw.WriteField(k, v); err != nil {
+			return fmt.Errorf("write field %s: %w", k, err)
+		}
 	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
+	part, err := mw.CreateFormFile("image", filepath.Base(filePath))
+	if err != nil {
+		return fmt.Errorf("create the image part: %w", err)
 	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
+	if _, err := io.Copy(part, file); err != nil {
+		return fmt.Errorf("read %s: %w", filePath, err)
+	}
+	if err := mw.Close(); err != nil {
+		return fmt.Errorf("finish the upload: %w", err)
 	}
 	return nil
 }
@@ -128,4 +245,18 @@ func nonEmpty(s string) string {
 		return "-"
 	}
 	return s
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
 }

--- a/cli/cmd/ctl/settings/appearance/get.go
+++ b/cli/cmd/ctl/settings/appearance/get.go
@@ -28,10 +28,13 @@ func NewGetCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "show locale, theme, widget preferences and wallpaper",
-		Long: `Show every value the Settings -> Appearance page reads: the
-localization fields (language, location, timezone, theme), the desktop
-widget preferences, and the wallpaper selection.
+		Short: "show locale, widget preferences and wallpaper",
+		Long: `Show the values the Settings -> Appearance page reads: the
+localization fields (language, location, timezone), the desktop widget
+preferences, and the wallpaper selection.
+
+The theme is left out: it is a browser cookie the SPA never sends
+upstream, so the value this backend holds is not what anything displays.
 
 This is the only read verb in the subtree — there is no separate
 "widget get" or "wallpaper get".
@@ -48,14 +51,14 @@ With --output json the sections arrive as the top-level keys "locale",
 	return cmd
 }
 
-// localeConfig mirrors BFL's PostLocale. Theme and timezone are read from
-// the per-user UserEnv CRs by BFL's HandleGetSysConfig; location still
-// lives on a user annotation.
+// localeConfig mirrors the part of BFL's PostLocale this page shows.
+// Timezone is read from the per-user UserEnv CRs by BFL's
+// HandleGetSysConfig; location still lives on a user annotation. The
+// upstream also carries a theme, left out for the reason in theme.go.
 type localeConfig struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
 	Timezone string `json:"timezone"`
-	Theme    string `json:"theme"`
 }
 
 // appearanceView holds a nil section for one this backend is too old to
@@ -134,7 +137,6 @@ func renderAppearance(w io.Writer, v appearanceView) error {
 			{"Language", nonEmpty(v.Locale.Language)},
 			{"Location", nonEmpty(v.Locale.Location)},
 			{"Timezone", nonEmpty(v.Locale.Timezone)},
-			{"Theme", nonEmpty(v.Locale.Theme)},
 		}
 	}
 	if v.Widget != nil {

--- a/cli/cmd/ctl/settings/appearance/get.go
+++ b/cli/cmd/ctl/settings/appearance/get.go
@@ -5,31 +5,39 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
+// localeConfigPath is user-service's /api/wallpaper/config/system, which
+// forwards /bfl/settings/v1alpha1/config-system. The body is BFL's
+// PostLocale (the same struct serves GET and POST):
+//
+//	{ "language": "en-US", "location": "...", "timezone": "UTC", "theme": "light" }
+const localeConfigPath = "/api/wallpaper/config/system"
+
 // `olares-cli settings appearance get`
 //
-// Backed by user-service's /api/wallpaper/config/system, which forwards
-// /bfl/settings/v1alpha1/config-system. The body is BFL's PostLocale
-// (it's the same struct used for both GET and POST):
-//
-//   { "language": "en-US", "location": "..." }
-//
-// Other appearance bits (login background, desktop style, theme picker,
-// wallpaper image upload) are intentionally browser-bound and stay out
-// of CLI scope — they're either visual blob workflows or only meaningful
-// inside an active SPA session.
+// The whole Appearance page in one read, which costs three upstream calls
+// because user-service keeps locale, widget preferences and wallpaper in
+// three separate endpoints.
 func NewGetCommand(f *cmdutil.Factory) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "show language + locale",
-		Long: `Show the language + location values used for Olares localization
-(the same fields the Settings -> Appearance > Language picker writes).
+		Short: "show locale, theme, widget preferences and wallpaper",
+		Long: `Show every value the Settings -> Appearance page reads: the
+localization fields (language, location, timezone, theme), the desktop
+widget preferences, and the wallpaper selection.
+
+This is the only read verb in the subtree — there is no separate
+"widget get" or "wallpaper get".
+
+With --output json the sections arrive as the top-level keys "locale",
+"widget" and "wallpaper", each holding the upstream field names verbatim.
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
@@ -40,9 +48,31 @@ func NewGetCommand(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-type appearanceConfig struct {
+// localeConfig mirrors BFL's PostLocale. Theme and timezone are read from
+// the per-user UserEnv CRs by BFL's HandleGetSysConfig; location still
+// lives on a user annotation.
+type localeConfig struct {
 	Language string `json:"language"`
 	Location string `json:"location"`
+	Timezone string `json:"timezone"`
+	Theme    string `json:"theme"`
+}
+
+// appearanceView holds a nil section for one this backend is too old to
+// serve, so a 1.12.5 reader gets locale and wallpaper instead of an error
+// about the widget API it does not have.
+type appearanceView struct {
+	Locale    *localeConfig      `json:"locale"`
+	Widget    *widgetPreferences `json:"widget"`
+	Wallpaper *wallpaperConfig   `json:"wallpaper"`
+}
+
+// appearanceSection is one upstream read feeding one rendered section.
+type appearanceSection struct {
+	name  string
+	path  string
+	out   interface{}
+	apply func()
 }
 
 func runGet(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
@@ -59,28 +89,128 @@ func runGet(ctx context.Context, f *cmdutil.Factory, outputRaw string) error {
 		return err
 	}
 
-	var cfg appearanceConfig
-	if err := doGetEnvelope(ctx, pc.doer, "/api/wallpaper/config/system", &cfg); err != nil {
+	// Locale and wallpaper exist on every supported backend; the widget
+	// section is 1.12.6+, so on an older one it is reported as gated
+	// rather than failing the whole page.
+	widgetSupported, err := f.OlaresBackendAtLeast(ctx, appearanceMinOlaresVersion)
+	if err != nil {
 		return err
 	}
 
-	switch format {
-	case FormatJSON:
-		return printJSON(os.Stdout, cfg)
-	default:
-		return renderAppearance(os.Stdout, cfg)
+	var view appearanceView
+	locale, widget, wallpaper := new(localeConfig), new(widgetPreferences), new(wallpaperConfig)
+	sections := []appearanceSection{
+		{"locale", localeConfigPath, locale, func() { view.Locale = locale }},
+		{"wallpaper", wallpaperPath, wallpaper, func() { view.Wallpaper = wallpaper }},
 	}
+	if widgetSupported {
+		sections = append(sections,
+			appearanceSection{"widget preferences", widgetPath, widget, func() { view.Widget = widget }})
+	}
+	for _, s := range sections {
+		if err := doGetEnvelope(ctx, pc.doer, s.path, s.out); err != nil {
+			return fmt.Errorf("read %s: %w", s.name, err)
+		}
+		s.apply()
+	}
+
+	if format == FormatJSON {
+		return printJSON(os.Stdout, view)
+	}
+	return renderAppearance(os.Stdout, view)
 }
 
-func renderAppearance(w io.Writer, c appearanceConfig) error {
-	rows := [][2]string{
-		{"Language", nonEmpty(c.Language)},
-		{"Location", nonEmpty(c.Location)},
+func renderAppearance(w io.Writer, v appearanceView) error {
+	sections := []struct {
+		title string
+		rows  [][2]string
+	}{
+		{"Locale", nil},
+		{"Widget", nil},
+		{"Wallpaper", nil},
 	}
-	for _, r := range rows {
-		if _, err := fmt.Fprintf(w, "%-10s %s\n", r[0]+":", r[1]); err != nil {
+	if v.Locale != nil {
+		sections[0].rows = [][2]string{
+			{"Language", nonEmpty(v.Locale.Language)},
+			{"Location", nonEmpty(v.Locale.Location)},
+			{"Timezone", nonEmpty(v.Locale.Timezone)},
+			{"Theme", nonEmpty(v.Locale.Theme)},
+		}
+	}
+	if v.Widget != nil {
+		sections[1].rows = [][2]string{
+			{"Show widgets", boolStr(v.Widget.ShowWidgets)},
+			{"24-hour format", boolStr(v.Widget.Is24HourFormat)},
+			{"Date format", nonEmpty(v.Widget.DateFormat)},
+			{"Show dashboard", boolStr(v.Widget.ShowDashboard)},
+		}
+	}
+	if v.Wallpaper != nil {
+		// Named as the user selects them: a built-in by the number
+		// `wallpaper set` takes, a fill mode by its Settings label.
+		sections[2].rows = [][2]string{
+			{"Desktop", describeWallpaperValue(v.Wallpaper.Desktop)},
+			{"Desktop style", contentModeLabel(nonEmpty(v.Wallpaper.DesktopStyle))},
+			{"Login", describeWallpaperValue(v.Wallpaper.Login)},
+			{"Login style", contentModeLabel(nonEmpty(v.Wallpaper.LoginStyle))},
+		}
+	}
+	for i, s := range sections {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if s.rows == nil {
+			if _, err := fmt.Fprintf(w, "%s\n  requires Olares >= %s\n", s.title, appearanceMinOlaresVersion); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := renderSection(w, s.title, s.rows); err != nil {
 			return err
 		}
 	}
+
+	if v.Wallpaper == nil {
+		return nil
+	}
+	// The uploaded lists are what `wallpaper delete` takes as its <bg>
+	// argument, so print them in full rather than as a count.
+	for _, l := range []struct {
+		title string
+		items []string
+	}{
+		{"Uploaded desktop backgrounds", v.Wallpaper.UploadDesktopBackgrounds},
+		{"Uploaded login backgrounds", v.Wallpaper.UploadLoginBackgrounds},
+	} {
+		if _, err := fmt.Fprintf(w, "\n%s\n", l.title); err != nil {
+			return err
+		}
+		if len(l.items) == 0 {
+			if _, err := fmt.Fprintln(w, "  none"); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, item := range l.items {
+			if _, err := fmt.Fprintf(w, "  %s\n", item); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
+}
+
+func renderSection(w io.Writer, title string, rows [][2]string) error {
+	if _, err := fmt.Fprintf(w, "%s\n", title); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(tw, "  %s\t%s\n", r[0]+":", r[1]); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
 }

--- a/cli/cmd/ctl/settings/appearance/get_test.go
+++ b/cli/cmd/ctl/settings/appearance/get_test.go
@@ -12,7 +12,6 @@ func sampleView() appearanceView {
 		Locale: &localeConfig{
 			Language: "zh-CN",
 			Timezone: "Asia/Shanghai",
-			Theme:    "dark",
 		},
 		Widget: &widgetPreferences{
 			ShowWidgets:    true,
@@ -38,7 +37,7 @@ func TestRenderAppearanceCoversAllThreeSections(t *testing.T) {
 	out := buf.String()
 
 	for _, want := range []string{
-		"Locale", "Language:", "zh-CN", "Asia/Shanghai", "Theme:", "dark",
+		"Locale", "Language:", "zh-CN", "Asia/Shanghai",
 		"Widget", "Show widgets:", "24-hour format:", "Date format:", "M/D/YY",
 		// The wallpaper rows are named as `wallpaper set` and Settings
 		// name them: a built-in by number, a fill mode by its label.
@@ -152,6 +151,17 @@ func TestAppearanceViewJSONShape(t *testing.T) {
 		if _, ok := decoded[key]; !ok {
 			t.Errorf("missing top-level key %q: %s", key, raw)
 		}
+	}
+
+	// The upstream locale payload carries a theme this page leaves out
+	// (see theme.go); emitting it would advertise a setting no interface
+	// reads.
+	var locale map[string]interface{}
+	if err := json.Unmarshal(decoded["locale"], &locale); err != nil {
+		t.Fatalf("unmarshal locale: %v", err)
+	}
+	if _, ok := locale["theme"]; ok {
+		t.Errorf("locale still carries a theme key: %s", raw)
 	}
 
 	var widget map[string]interface{}

--- a/cli/cmd/ctl/settings/appearance/get_test.go
+++ b/cli/cmd/ctl/settings/appearance/get_test.go
@@ -1,0 +1,180 @@
+package appearance
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func sampleView() appearanceView {
+	return appearanceView{
+		Locale: &localeConfig{
+			Language: "zh-CN",
+			Timezone: "Asia/Shanghai",
+			Theme:    "dark",
+		},
+		Widget: &widgetPreferences{
+			ShowWidgets:    true,
+			Is24HourFormat: false,
+			DateFormat:     "M/D/YY",
+			ShowDashboard:  false,
+		},
+		Wallpaper: &wallpaperConfig{
+			Desktop:                  "/bg/3.jpg",
+			DesktopStyle:             "cover",
+			Login:                    "https://files.example/greeter.jpg",
+			LoginStyle:               "fill",
+			UploadDesktopBackgrounds: []string{"https://files.example/a.jpg"},
+		},
+	}
+}
+
+func TestRenderAppearanceCoversAllThreeSections(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderAppearance(&buf, sampleView()); err != nil {
+		t.Fatalf("renderAppearance errored: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"Locale", "Language:", "zh-CN", "Asia/Shanghai", "Theme:", "dark",
+		"Widget", "Show widgets:", "24-hour format:", "Date format:", "M/D/YY",
+		// The wallpaper rows are named as `wallpaper set` and Settings
+		// name them: a built-in by number, a fill mode by its label.
+		"Wallpaper", "Desktop:", "built-in 3", "Desktop style:", "Stretch",
+		"Login:", "https://files.example/greeter.jpg", "Login style:", "Fill",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output is missing %q:\n%s", want, out)
+		}
+	}
+
+	// The stored /bg/<n>.jpg token is an upstream detail; only -o json
+	// carries it.
+	if strings.Contains(out, "/bg/3.jpg") {
+		t.Errorf("table leaked the stored wallpaper token:\n%s", out)
+	}
+
+	// Location is empty upstream; a blank line would read as a missing
+	// row rather than an unset value.
+	if !strings.Contains(out, "Location:  -") {
+		t.Errorf("empty Location is not rendered as \"-\":\n%s", out)
+	}
+
+	// The uploaded lists are what `wallpaper delete` takes, so they are
+	// printed in full rather than counted.
+	if !strings.Contains(out, "https://files.example/a.jpg") {
+		t.Errorf("uploaded desktop background is not listed:\n%s", out)
+	}
+	if !strings.Contains(out, "Uploaded login backgrounds\n  none") {
+		t.Errorf("an empty uploaded list is not rendered as \"none\":\n%s", out)
+	}
+}
+
+// 1.12.5 has no widget API, so that section arrives nil and the rest of
+// the page still has to render.
+func TestRenderAppearanceMarksAGatedSection(t *testing.T) {
+	view := sampleView()
+	view.Widget = nil
+
+	var buf bytes.Buffer
+	if err := renderAppearance(&buf, view); err != nil {
+		t.Fatalf("renderAppearance errored on a nil section: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "Widget\n  requires Olares >= "+appearanceMinOlaresVersion) {
+		t.Errorf("gated widget section is not called out with its minimum version:\n%s", out)
+	}
+	for _, want := range []string{"zh-CN", "built-in 3", "https://files.example/a.jpg"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("section that does exist lost %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Date format:") {
+		t.Errorf("absent section rendered zeroed rows:\n%s", out)
+	}
+}
+
+// A nil wallpaper section must not print the uploaded-gallery lists,
+// which would read as "the galleries are empty".
+func TestRenderAppearanceSkipsGalleriesWhenWallpaperIsAbsent(t *testing.T) {
+	view := sampleView()
+	view.Wallpaper = nil
+
+	var buf bytes.Buffer
+	if err := renderAppearance(&buf, view); err != nil {
+		t.Fatalf("renderAppearance errored: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "Uploaded desktop backgrounds") {
+		t.Errorf("gallery list printed for an absent wallpaper section:\n%s", out)
+	}
+}
+
+func TestAppearanceViewJSONEmitsNullForAGatedSection(t *testing.T) {
+	view := sampleView()
+	view.Widget = nil
+	raw, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The key stays present so a scripted caller can tell "gated" from
+	// "this CLI does not know about the section".
+	got, ok := decoded["widget"]
+	if !ok {
+		t.Fatalf("widget key dropped entirely: %s", raw)
+	}
+	if string(got) != "null" {
+		t.Errorf("widget = %s; want null", got)
+	}
+}
+
+// The JSON view is a scripted-caller contract: three section keys, each
+// holding the upstream field names verbatim.
+func TestAppearanceViewJSONShape(t *testing.T) {
+	raw, err := json.Marshal(sampleView())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded) != 3 {
+		t.Errorf("top-level keys = %d; want exactly locale, widget, wallpaper: %s", len(decoded), raw)
+	}
+	for _, key := range []string{"locale", "widget", "wallpaper"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("missing top-level key %q: %s", key, raw)
+		}
+	}
+
+	var widget map[string]interface{}
+	if err := json.Unmarshal(decoded["widget"], &widget); err != nil {
+		t.Fatalf("unmarshal widget: %v", err)
+	}
+	// showWeight is the upstream name of the widget master switch.
+	if got, ok := widget["showWeight"]; !ok || got != true {
+		t.Errorf("widget.showWeight = %v (present=%v); want true", got, ok)
+	}
+
+	// The table renames values for the reader; JSON must keep the stored
+	// ones, or a script round-tripping them would write nonsense.
+	var wallpaper map[string]interface{}
+	if err := json.Unmarshal(decoded["wallpaper"], &wallpaper); err != nil {
+		t.Fatalf("unmarshal wallpaper: %v", err)
+	}
+	for key, want := range map[string]interface{}{"desktop": "/bg/3.jpg", "desktopStyle": "cover"} {
+		if got := wallpaper[key]; got != want {
+			t.Errorf("wallpaper.%s = %v; want the stored %v", key, got, want)
+		}
+	}
+	if _, ok := wallpaper["upload_desktop_backgrounds"]; !ok {
+		t.Errorf("wallpaper is missing upload_desktop_backgrounds: %s", decoded["wallpaper"])
+	}
+}

--- a/cli/cmd/ctl/settings/appearance/layout.go
+++ b/cli/cmd/ctl/settings/appearance/layout.go
@@ -1,0 +1,96 @@
+package appearance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// `olares-cli settings appearance layout reset`
+//
+// Backed by user-service's desktop-layout.controller.ts, which drops the
+// launchpad and dock layouts and broadcasts desktop_layout_updated to any
+// open session. The arrangement is not recoverable afterwards.
+const layoutResetPath = "/api/desktop/layout/reset"
+
+// layoutResetResult names the surfaces the upstream actually cleared.
+type layoutResetResult struct {
+	ChangedSurfaces []string `json:"changedSurfaces"`
+}
+
+func NewLayoutCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "layout",
+		Short: "desktop layout",
+		Long: `Manage the desktop layout (Settings -> Appearance > Reset desktop
+layout).
+
+Subcommands:
+  reset                 restore the default launchpad and dock arrangement
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newLayoutResetCommand(f))
+	return cmd
+}
+
+func newLayoutResetCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "reset the desktop layout to its defaults",
+		Long: `Reset the desktop layout to its defaults.
+
+This discards the launchpad ordering, folders and dock arrangement for
+the current user. There is no undo, and any open Olares desktop session
+re-renders immediately.
+
+Examples:
+  olares-cli settings appearance layout reset
+  olares-cli settings appearance layout reset --yes
+`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return runLayoutReset(c.Context(), f, assumeYes)
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the y/N prompt (required for non-TTY stdin)")
+	return cmd
+}
+
+func runLayoutReset(ctx context.Context, f *cmdutil.Factory, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Gate before the prompt: never ask the user to confirm something
+	// this backend cannot carry out.
+	if err := requireAppearanceBackendVersion(ctx, f,
+		"settings appearance layout reset", "the desktop layout reset route"); err != nil {
+		return err
+	}
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		"Reset the desktop layout, discarding the current launchpad and dock arrangement?",
+		assumeYes); err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	var result layoutResetResult
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", layoutResetPath, map[string]string{}, &result); err != nil {
+		return err
+	}
+	if len(result.ChangedSurfaces) == 0 {
+		fmt.Println("Desktop layout reset.")
+		return nil
+	}
+	fmt.Printf("Desktop layout reset (%s).\n", strings.Join(result.ChangedSurfaces, ", "))
+	return nil
+}

--- a/cli/cmd/ctl/settings/appearance/root.go
+++ b/cli/cmd/ctl/settings/appearance/root.go
@@ -1,7 +1,8 @@
-// Package appearance implements the `olares-cli settings appearance` subtree
-// (Settings -> Appearance). Backed by user-service's wallpaper.controller.ts
-// — only the language/theme JSON read + language set fall in CLI scope; the
-// wallpaper image picker is intentionally browser-bound and out of scope.
+// Package appearance implements the `olares-cli settings appearance`
+// subtree (Settings -> Appearance): locale, theme, desktop widget
+// preferences, wallpaper, and the desktop layout reset.
+//
+// See common.go for how the three backing services are reached.
 package appearance
 
 import (
@@ -10,25 +11,38 @@ import (
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
-// NewAppearanceCommand returns the `settings appearance` parent: read
-// the language / locale and update the system language. Wallpaper +
-// theme picker stay in the SPA (browser blob/picker flows).
+// NewAppearanceCommand returns the `settings appearance` parent.
 func NewAppearanceCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "appearance",
-		Short: "Appearance settings (language, locale)",
+		Short: "Appearance settings (locale, theme, widgets, wallpaper, layout)",
 		Long: `Read and update appearance preferences (Settings -> Appearance).
 
 Subcommands:
-  get                              show language + locale
-  language set --value <code>      update the system language
+  get                                   show the whole page in one read
+  language set <locale>                 update the system language
+  theme set <light|dark>                update the theme preference
+  widget set [flags]                    update the desktop widget preferences
+  wallpaper set <surface> <bg>          select a wallpaper
+  wallpaper style set <surface> <mode>  set the wallpaper fill mode
+  wallpaper upload <surface> --file     upload a local image and select it
+  wallpaper delete <surface> <bg>       remove an uploaded image
+  layout reset                          restore the default desktop layout
 
-Wallpaper image upload + theme picker stay in the SPA — they are browser
-blob/picker flows with no useful CLI surface.
+"get" is the only read verb: the write subtrees have no "get" of their
+own, because reading Appearance means reading the page.
+
+A theme written here is what apps and the login flow observe. It does not
+change an Olares desktop already open in a browser, whose light/dark state
+comes from a cookie the SPA never sends to the backend.
 `,
 	}
 	cmd.SilenceUsage = true
 	cmd.AddCommand(NewGetCommand(f))
 	cmd.AddCommand(NewLanguageCommand(f))
+	cmd.AddCommand(NewThemeCommand(f))
+	cmd.AddCommand(NewWidgetCommand(f))
+	cmd.AddCommand(NewWallpaperCommand(f))
+	cmd.AddCommand(NewLayoutCommand(f))
 	return cmd
 }

--- a/cli/cmd/ctl/settings/appearance/root.go
+++ b/cli/cmd/ctl/settings/appearance/root.go
@@ -1,6 +1,8 @@
 // Package appearance implements the `olares-cli settings appearance`
-// subtree (Settings -> Appearance): locale, theme, desktop widget
-// preferences, wallpaper, and the desktop layout reset.
+// subtree (Settings -> Appearance): locale, desktop widget preferences,
+// wallpaper, and the desktop layout reset.
+//
+// Theme is absent on purpose: see theme.go.
 //
 // See common.go for how the three backing services are reached.
 package appearance
@@ -15,13 +17,12 @@ import (
 func NewAppearanceCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "appearance",
-		Short: "Appearance settings (locale, theme, widgets, wallpaper, layout)",
+		Short: "Appearance settings (locale, widgets, wallpaper, layout)",
 		Long: `Read and update appearance preferences (Settings -> Appearance).
 
 Subcommands:
   get                                   show the whole page in one read
   language set <locale>                 update the system language
-  theme set <light|dark>                update the theme preference
   widget set [flags]                    update the desktop widget preferences
   wallpaper set <surface> <bg>          select a wallpaper
   wallpaper style set <surface> <mode>  set the wallpaper fill mode
@@ -31,16 +32,11 @@ Subcommands:
 
 "get" is the only read verb: the write subtrees have no "get" of their
 own, because reading Appearance means reading the page.
-
-A theme written here is what apps and the login flow observe. It does not
-change an Olares desktop already open in a browser, whose light/dark state
-comes from a cookie the SPA never sends to the backend.
 `,
 	}
 	cmd.SilenceUsage = true
 	cmd.AddCommand(NewGetCommand(f))
 	cmd.AddCommand(NewLanguageCommand(f))
-	cmd.AddCommand(NewThemeCommand(f))
 	cmd.AddCommand(NewWidgetCommand(f))
 	cmd.AddCommand(NewWallpaperCommand(f))
 	cmd.AddCommand(NewLayoutCommand(f))

--- a/cli/cmd/ctl/settings/appearance/theme.go
+++ b/cli/cmd/ctl/settings/appearance/theme.go
@@ -13,18 +13,17 @@ import (
 
 // `olares-cli settings appearance theme set ...`
 //
-// The theme is stored in the OLARES_USER_THEME UserEnv, which
-// build/user-env.yaml declares the single source of truth: BFL's
-// config-system endpoint and the env settings page both read and write
-// it, and app-service injects it into apps. We write it through
-// /api/env/userenvs — the same vector `settings advanced env user`
-// drives — because that is the only route to it that does not need a
-// JWS-signed activation payload.
+// NOT REGISTERED in root.go, and deliberately kept: the live theme is a
+// browser cookie (theme_name, written and read only by the SPA, never
+// sent upstream), which a CLI cannot set. The OLARES_USER_THEME UserEnv
+// this writes has no shipped reader — nothing under apps/ references it,
+// the greeter reads only the login wallpaper, and no app manifest binds
+// it through valueFrom — so exposing the verb would report success on a
+// write nobody observes. Re-register it once that UserEnv drives the UI.
 //
-// The Settings SPA's own light/dark toggle only writes a browser cookie
-// and never calls the backend, so a value set here is what apps and the
-// login flow observe, not what an already-open browser session looks
-// like. That asymmetry is a frontend gap, not a CLI limitation.
+// The write itself goes through /api/env/userenvs — the same vector
+// `settings advanced env user` drives — because that is the only route
+// to it that does not need a JWS-signed activation payload.
 //
 // Role: Appearance is in the normal-user menu (admin.ts:101-103), and
 // a UserEnv is per-user. No PreflightRole check.
@@ -59,13 +58,11 @@ func newThemeSetCommand(f *cmdutil.Factory) *cobra.Command {
 		Short: "update the system theme preference",
 		Long: `Update the system theme preference.
 
-The value is written to the OLARES_USER_THEME user environment variable,
-which the platform treats as the source of truth for the theme: apps
-receive it, and the login flow honors it.
+The value is written to the OLARES_USER_THEME user environment variable.
 
-An Olares desktop already open in a browser will not change appearance:
-its light/dark state comes from a cookie the SPA sets locally and never
-sends to the backend.
+No Olares interface reads it yet: a desktop's light/dark state comes from
+a cookie the SPA sets locally and never sends to the backend, so this
+does not change how anything looks.
 
 Allowed values:
   light

--- a/cli/cmd/ctl/settings/appearance/theme.go
+++ b/cli/cmd/ctl/settings/appearance/theme.go
@@ -1,0 +1,123 @@
+package appearance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/userenv"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// `olares-cli settings appearance theme set ...`
+//
+// The theme is stored in the OLARES_USER_THEME UserEnv, which
+// build/user-env.yaml declares the single source of truth: BFL's
+// config-system endpoint and the env settings page both read and write
+// it, and app-service injects it into apps. We write it through
+// /api/env/userenvs — the same vector `settings advanced env user`
+// drives — because that is the only route to it that does not need a
+// JWS-signed activation payload.
+//
+// The Settings SPA's own light/dark toggle only writes a browser cookie
+// and never calls the backend, so a value set here is what apps and the
+// login flow observe, not what an already-open browser session looks
+// like. That asymmetry is a frontend gap, not a CLI limitation.
+//
+// Role: Appearance is in the normal-user menu (admin.ts:101-103), and
+// a UserEnv is per-user. No PreflightRole check.
+
+// themeValues mirrors the options declared for OLARES_USER_THEME in
+// build/user-env.yaml. app-service validates the value against that same
+// declaration (EnvVarSpec.ValidateValue -> "value not in options"), so
+// this check only moves the rejection earlier — there is no route that
+// writes a value the declaration does not list.
+var themeValues = []string{"light", "dark"}
+
+func NewThemeCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "theme",
+		Short: "system theme preference",
+		Long: `Update the system theme preference (Settings -> Appearance > Theme).
+
+The current value is shown by "settings appearance get".
+
+Subcommands:
+  set <light|dark>      update the theme preference
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newThemeSetCommand(f))
+	return cmd
+}
+
+func newThemeSetCommand(f *cmdutil.Factory) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <light|dark>",
+		Short: "update the system theme preference",
+		Long: `Update the system theme preference.
+
+The value is written to the OLARES_USER_THEME user environment variable,
+which the platform treats as the source of truth for the theme: apps
+receive it, and the login flow honors it.
+
+An Olares desktop already open in a browser will not change appearance:
+its light/dark state comes from a cookie the SPA sets locally and never
+sends to the backend.
+
+Allowed values:
+  light
+  dark
+
+The platform declares these two and rejects anything else, so a value a
+newer release adds needs a newer CLI rather than a flag to bypass this.
+
+Examples:
+  olares-cli settings appearance theme set dark
+  olares-cli settings appearance theme set light
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			value, err := resolveThemeValue(args[0])
+			if err != nil {
+				return err
+			}
+			return runThemeSet(c.Context(), f, value)
+		},
+	}
+}
+
+func resolveThemeValue(raw string) (string, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", fmt.Errorf("a theme value is required (allowed: %s)", strings.Join(themeValues, ", "))
+	}
+	for _, v := range themeValues {
+		if value == v {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported theme %q (allowed: %s)", raw, strings.Join(themeValues, ", "))
+}
+
+func runThemeSet(ctx context.Context, f *cmdutil.Factory, value string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := requireAppearanceBackendVersion(ctx, f,
+		"settings appearance theme set", "the "+userenv.ThemeEnvName+" user env"); err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	updates := map[string]string{userenv.ThemeEnvName: value}
+	if err := userenv.SetValues(ctx, pc.doer, userenv.UserEnvsPath, updates); err != nil {
+		return err
+	}
+	fmt.Printf("System theme updated to %q.\n", value)
+	return nil
+}

--- a/cli/cmd/ctl/settings/appearance/theme_test.go
+++ b/cli/cmd/ctl/settings/appearance/theme_test.go
@@ -1,0 +1,55 @@
+package appearance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveThemeValue(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		want     string
+		wantErr  bool
+		wantSubs []string
+	}{
+		{name: "light", raw: "light", want: "light"},
+		{name: "dark", raw: "dark", want: "dark"},
+		{name: "trimmed_and_lowercased", raw: "  Dark  ", want: "dark"},
+		{
+			name:     "unknown_rejected",
+			raw:      "auto",
+			wantErr:  true,
+			wantSubs: []string{`"auto"`, "allowed: light, dark"},
+		},
+		{
+			name:     "empty_rejected",
+			raw:      "   ",
+			wantErr:  true,
+			wantSubs: []string{"theme value is required"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveThemeValue(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveThemeValue(%q) = %q, nil; want error", tc.raw, got)
+				}
+				for _, sub := range tc.wantSubs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not contain %q", err, sub)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveThemeValue(%q) errored: %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveThemeValue(%q) = %q; want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/ctl/settings/appearance/version_gate_test.go
+++ b/cli/cmd/ctl/settings/appearance/version_gate_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
-// The three verbs whose upstream landed in 1.12.6 share one gate; each
-// passes its own verb name and reason so the message names the command
-// the user actually typed.
+// The verbs whose upstream landed in 1.12.6 share one gate; each passes
+// its own verb name and reason so the message names the command the user
+// actually typed.
 func TestRequireAppearanceBackendVersion(t *testing.T) {
 	previous := viper.GetString(cmdutil.FlagOlaresVersion)
 	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, previous) })
@@ -21,7 +21,6 @@ func TestRequireAppearanceBackendVersion(t *testing.T) {
 		verb   string
 		reason string
 	}{
-		{"settings appearance theme set", "the OLARES_USER_THEME user env"},
 		{"settings appearance widget set", "the widget preferences API"},
 		{"settings appearance layout reset", "the desktop layout reset route"},
 	}
@@ -51,7 +50,7 @@ func TestRequireAppearanceBackendVersion(t *testing.T) {
 	// refresh hint rather than letting the call 404.
 	viper.Set(cmdutil.FlagOlaresVersion, "not-a-version")
 	err := requireAppearanceBackendVersion(context.Background(), cmdutil.NewFactory(),
-		"settings appearance theme set", "the theme user env")
+		"settings appearance widget set", "the widget preferences API")
 	if err == nil || !strings.Contains(err.Error(), "profile list --refresh-version") {
 		t.Fatalf("expected fail-closed refresh hint, got %v", err)
 	}

--- a/cli/cmd/ctl/settings/appearance/version_gate_test.go
+++ b/cli/cmd/ctl/settings/appearance/version_gate_test.go
@@ -1,0 +1,66 @@
+package appearance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// The three verbs whose upstream landed in 1.12.6 share one gate; each
+// passes its own verb name and reason so the message names the command
+// the user actually typed.
+func TestRequireAppearanceBackendVersion(t *testing.T) {
+	previous := viper.GetString(cmdutil.FlagOlaresVersion)
+	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, previous) })
+
+	gated := []struct {
+		verb   string
+		reason string
+	}{
+		{"settings appearance theme set", "the OLARES_USER_THEME user env"},
+		{"settings appearance widget set", "the widget preferences API"},
+		{"settings appearance layout reset", "the desktop layout reset route"},
+	}
+
+	viper.Set(cmdutil.FlagOlaresVersion, "1.12.5")
+	for _, g := range gated {
+		err := requireAppearanceBackendVersion(context.Background(), cmdutil.NewFactory(), g.verb, g.reason)
+		if err == nil {
+			t.Fatalf("%s: expected a version gate error on 1.12.5", g.verb)
+		}
+		for _, want := range []string{g.verb, "requires Olares >= 1.12.6", g.reason, "1.12.5"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("%s: error %q missing %q", g.verb, err, want)
+			}
+		}
+	}
+
+	// A dated 1.12.6 build is the 1.12.6 line and must pass.
+	viper.Set(cmdutil.FlagOlaresVersion, "1.12.6-20260203")
+	for _, g := range gated {
+		if err := requireAppearanceBackendVersion(context.Background(), cmdutil.NewFactory(), g.verb, g.reason); err != nil {
+			t.Fatalf("%s: daily 1.12.6 build should pass: %v", g.verb, err)
+		}
+	}
+
+	// Fail-closed: an undetectable version is rejected with the shared
+	// refresh hint rather than letting the call 404.
+	viper.Set(cmdutil.FlagOlaresVersion, "not-a-version")
+	err := requireAppearanceBackendVersion(context.Background(), cmdutil.NewFactory(),
+		"settings appearance theme set", "the theme user env")
+	if err == nil || !strings.Contains(err.Error(), "profile list --refresh-version") {
+		t.Fatalf("expected fail-closed refresh hint, got %v", err)
+	}
+}
+
+// The locale and wallpaper sections predate the gate, so the minimum must
+// not be raised to a version that would gate the whole page.
+func TestAppearanceMinVersionCoversOnlyTheNewSurfaces(t *testing.T) {
+	if appearanceMinOlaresVersion != "1.12.6" {
+		t.Fatalf("appearanceMinOlaresVersion = %q, want 1.12.6", appearanceMinOlaresVersion)
+	}
+}

--- a/cli/cmd/ctl/settings/appearance/wallpaper.go
+++ b/cli/cmd/ctl/settings/appearance/wallpaper.go
@@ -143,24 +143,36 @@ func (s surface) builtinWallpapers() []string {
 // verbatim and never checks it: an out-of-range number would leave a
 // broken background behind with no error. Uploaded URLs are judged on
 // their shape rather than looked up, to keep this offline.
-func resolveWallpaperValue(s surface, raw string) (string, error) {
+//
+// force drops the range and shape checks, never the number vocabulary:
+// a built-in a newer release adds still has to be stored as /bg/<n>.jpg,
+// since the bare number is not a value the backend can resolve.
+func resolveWallpaperValue(s surface, raw string, force bool) (string, error) {
 	if isUploadedWallpaperURL(raw) {
 		return raw, nil
 	}
+	n, ok := builtinWallpaperNumber(raw)
+	if !ok {
+		if force {
+			return raw, nil
+		}
+		return "", fmt.Errorf("%q is not a %s wallpaper: pass a built-in number (%s) or an https:// URL from `wallpaper upload`; run `olares-cli settings appearance wallpaper list %s` to see the choices (--force sends it anyway)",
+			raw, s.name, builtinWallpaperRange(s), s.name)
+	}
+	if n >= s.builtinCount && !force {
+		return "", fmt.Errorf("%s has no built-in wallpaper %d: %s", s.name, n, builtinWallpaperRange(s))
+	}
+	return builtinWallpaperValue(n), nil
+}
+
+// builtinWallpaperNumber reads a built-in's number from either spelling a
+// user may type: the bare number the Settings grid shows, or the
+// /bg/<n>.jpg value `get -o json` reports.
+func builtinWallpaperNumber(raw string) (int, bool) {
 	if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
-		if n >= s.builtinCount {
-			return "", fmt.Errorf("%s has no built-in wallpaper %d: %s", s.name, n, builtinWallpaperRange(s))
-		}
-		return builtinWallpaperValue(n), nil
+		return n, true
 	}
-	if n, ok := builtinWallpaperIndex(raw); ok {
-		if n >= s.builtinCount {
-			return "", fmt.Errorf("%s has no built-in wallpaper %d: %s", s.name, n, builtinWallpaperRange(s))
-		}
-		return raw, nil
-	}
-	return "", fmt.Errorf("%q is not a %s wallpaper: pass a built-in number (%s) or an https:// URL from `wallpaper upload`; run `olares-cli settings appearance wallpaper list %s` to see the choices (--force sends it anyway)",
-		raw, s.name, builtinWallpaperRange(s), s.name)
+	return builtinWallpaperIndex(raw)
 }
 
 func isUploadedWallpaperURL(raw string) bool {
@@ -374,8 +386,8 @@ Two kinds of value work:
 
 The upstream stores the value verbatim and never checks it, so an
 out-of-range number would leave a broken background behind with no error.
-This command therefore validates first; --force skips that for a value a
-newer release adds.
+This command therefore validates first; --force skips that for a built-in
+a newer release adds, and still stores a number as /bg/<n>.jpg.
 
 Examples:
   olares-cli settings appearance wallpaper set desktop 3
@@ -391,16 +403,14 @@ Examples:
 			if raw == "" {
 				return fmt.Errorf("set requires a built-in number or an uploaded URL")
 			}
-			bg := raw
-			if !force {
-				if bg, err = resolveWallpaperValue(s, raw); err != nil {
-					return err
-				}
+			bg, err := resolveWallpaperValue(s, raw, force)
+			if err != nil {
+				return err
 			}
 			return runWallpaperSet(c.Context(), f, s, bg)
 		},
 	}
-	cmd.Flags().BoolVar(&force, "force", false, "store the value as given, skipping validation (forward compatibility)")
+	cmd.Flags().BoolVar(&force, "force", false, "skip the range and shape checks, still resolving a number to /bg/<n>.jpg (forward compatibility)")
 	return cmd
 }
 

--- a/cli/cmd/ctl/settings/appearance/wallpaper.go
+++ b/cli/cmd/ctl/settings/appearance/wallpaper.go
@@ -1,0 +1,628 @@
+package appearance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cliutil"
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// `olares-cli settings appearance wallpaper ...`
+//
+// Backed by user-service's wallpaper.controller.ts. The desktop and login
+// surfaces have separate endpoints throughout, and the login ones fan out
+// to BFL's /bfl/settings/v1alpha1/set-login-background so the greeter
+// picks the change up.
+//
+// Current values are shown by `appearance get`.
+const wallpaperPath = "/api/wallpaper"
+
+// imageUploadPath is served by tapr's images-uploader, not user-service,
+// and is reachable only on the settings ingress — see imageClient.
+const imageUploadPath = "/images/upload/v1"
+
+// wallpaperConfig mirrors user-service's Wallpaper type.
+type wallpaperConfig struct {
+	Desktop                  string   `json:"desktop"`
+	Login                    string   `json:"login"`
+	DesktopStyle             string   `json:"desktopStyle"`
+	LoginStyle               string   `json:"loginStyle"`
+	UploadDesktopBackgrounds []string `json:"upload_desktop_backgrounds"`
+	UploadLoginBackgrounds   []string `json:"upload_login_backgrounds"`
+}
+
+// contentModes mirrors IMG_CONTENT_MODE in apps/.../constant/index.ts:
+// the label is what Settings -> Appearance shows, the wire value is what
+// user-service stores and validates. Users read the label, so the CLI
+// takes either and always prints the label.
+var contentModes = []struct {
+	label string
+	wire  string
+}{
+	{"Fill", "fill"},
+	{"Stretch", "cover"},
+	{"Tile", "repeat"},
+}
+
+// contentModeLabel maps a stored value back to the label the UI shows,
+// so `get` and the CLI's own confirmations read like the page. Unknown
+// values pass through: a newer release may add one.
+func contentModeLabel(wire string) string {
+	for _, m := range contentModes {
+		if wire == m.wire {
+			return m.label
+		}
+	}
+	return wire
+}
+
+func contentModeLabels() []string {
+	out := make([]string, 0, len(contentModes))
+	for _, m := range contentModes {
+		out = append(out, m.label)
+	}
+	return out
+}
+
+// surface holds the per-surface endpoint spellings. The desktop/login
+// split is irregular enough (camelCase style routes, a login-only upload
+// policy) that keeping it in one table beats branching at each call site.
+type surface struct {
+	name string
+	// set selects an existing image as the active wallpaper.
+	set string
+	// style sets the fill mode.
+	style string
+	// register records an uploaded image in the surface's gallery.
+	register string
+	// remove drops an uploaded image from the gallery.
+	remove string
+	// uploadPolicy is the `policy` form field the images-uploader needs.
+	// Login backgrounds must be public: the greeter fetches them before
+	// the user is authenticated.
+	uploadPolicy string
+	// builtinCount is how many built-in images this surface offers,
+	// numbered 0..builtinCount-1. It mirrors picturesCount in the SPA's
+	// Appearance page: nothing upstream enumerates them, and the two
+	// surfaces ship a different number of images.
+	builtinCount int
+}
+
+var surfaces = map[string]surface{
+	"desktop": {
+		name:         "desktop",
+		set:          "/api/wallpaper/desktop",
+		style:        "/api/wallpaper/desktopStyle",
+		register:     "/api/wallpaper/upload/desktop",
+		remove:       "/api/wallpaper/delete/desktop",
+		builtinCount: 28,
+	},
+	"login": {
+		name:         "login",
+		set:          "/api/wallpaper/login",
+		style:        "/api/wallpaper/loginStyle",
+		register:     "/api/wallpaper/upload/login",
+		remove:       "/api/wallpaper/delete/login",
+		uploadPolicy: "public",
+		builtinCount: 29,
+	},
+}
+
+// builtinWallpaperPrefix is the token both surfaces store for a built-in
+// image. The login surface stores it too: the greeter resolves the value
+// under its own asset root (LoginPage.vue renders "auth/" + value), and
+// the Settings preview swaps the prefix to /login/ only for display. A
+// stored /login/<n>.jpg therefore resolves nowhere.
+const builtinWallpaperPrefix = "/bg/"
+
+// builtinWallpapers lists every value `wallpaper set` accepts for s
+// without an upload.
+func (s surface) builtinWallpapers() []string {
+	out := make([]string, 0, s.builtinCount)
+	for i := 0; i < s.builtinCount; i++ {
+		out = append(out, builtinWallpaperValue(i))
+	}
+	return out
+}
+
+// resolveWallpaperValue turns what the user types into the value to store.
+//
+// A built-in is addressed by its number, because that is all the Settings
+// page offers too — a grid of unnamed thumbnails. The stored /bg/<n>.jpg
+// spelling is accepted as well, so a value read back from `get` can be
+// fed straight back in.
+//
+// Validation is on this side because the upstream stores the value
+// verbatim and never checks it: an out-of-range number would leave a
+// broken background behind with no error. Uploaded URLs are judged on
+// their shape rather than looked up, to keep this offline.
+func resolveWallpaperValue(s surface, raw string) (string, error) {
+	if isUploadedWallpaperURL(raw) {
+		return raw, nil
+	}
+	if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
+		if n >= s.builtinCount {
+			return "", fmt.Errorf("%s has no built-in wallpaper %d: %s", s.name, n, builtinWallpaperRange(s))
+		}
+		return builtinWallpaperValue(n), nil
+	}
+	if n, ok := builtinWallpaperIndex(raw); ok {
+		if n >= s.builtinCount {
+			return "", fmt.Errorf("%s has no built-in wallpaper %d: %s", s.name, n, builtinWallpaperRange(s))
+		}
+		return raw, nil
+	}
+	return "", fmt.Errorf("%q is not a %s wallpaper: pass a built-in number (%s) or an https:// URL from `wallpaper upload`; run `olares-cli settings appearance wallpaper list %s` to see the choices (--force sends it anyway)",
+		raw, s.name, builtinWallpaperRange(s), s.name)
+}
+
+func isUploadedWallpaperURL(raw string) bool {
+	return strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://")
+}
+
+func builtinWallpaperValue(n int) string {
+	return fmt.Sprintf("%s%d.jpg", builtinWallpaperPrefix, n)
+}
+
+func builtinWallpaperRange(s surface) string {
+	return fmt.Sprintf("0-%d", s.builtinCount-1)
+}
+
+// describeWallpaperValue names a stored value the way the user selects
+// it, so output and input use one vocabulary instead of exposing the
+// /bg/<n>.jpg token that only the backend cares about.
+func describeWallpaperValue(bg string) string {
+	if n, ok := builtinWallpaperIndex(bg); ok {
+		return fmt.Sprintf("built-in %d", n)
+	}
+	return nonEmpty(bg)
+}
+
+// builtinWallpaperIndex parses "/bg/<n>.jpg" into n.
+func builtinWallpaperIndex(bg string) (int, bool) {
+	rest, ok := strings.CutPrefix(bg, builtinWallpaperPrefix)
+	if !ok {
+		return 0, false
+	}
+	rest, ok = strings.CutSuffix(rest, ".jpg")
+	if !ok || rest == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func resolveSurface(raw string) (surface, error) {
+	s, ok := surfaces[strings.ToLower(strings.TrimSpace(raw))]
+	if !ok {
+		return surface{}, fmt.Errorf("unknown surface %q (allowed: desktop, login)", raw)
+	}
+	return s, nil
+}
+
+func NewWallpaperCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wallpaper",
+		Short: "desktop and login wallpaper",
+		Long: `Change the desktop or login wallpaper (Settings -> Appearance >
+Wallpaper).
+
+Current values are shown by "settings appearance get"; the values you can
+select are listed by "wallpaper list <surface>".
+
+Subcommands:
+  list <desktop|login>                  list the selectable images
+  set <desktop|login> <bg>              select an image
+  style set <desktop|login> <mode>      set the fill mode
+  upload <desktop|login> --file <path>  upload a local image and select it
+  delete <desktop|login> <bg>           remove an uploaded image
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newWallpaperListCommand(f))
+	cmd.AddCommand(newWallpaperSetCommand(f))
+	cmd.AddCommand(newWallpaperStyleCommand(f))
+	cmd.AddCommand(newWallpaperUploadCommand(f))
+	cmd.AddCommand(newWallpaperDeleteCommand(f))
+	return cmd
+}
+
+// `olares-cli settings appearance wallpaper list <surface>`
+//
+// Exists because nothing upstream enumerates the built-in images: their
+// count lives only in the SPA, and `get` shows the active value plus the
+// uploaded gallery. Without this, picking a wallpaper from the CLI means
+// guessing a number at which a wrong guess is accepted silently.
+func newWallpaperListCommand(f *cmdutil.Factory) *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "list <desktop|login>",
+		Short: "show what this surface can be set to",
+		Long: `Show what "wallpaper set <surface>" accepts: the range of built-in
+image numbers, and the images uploaded to this surface's gallery.
+
+The built-in range differs per surface, so pass the one you mean. The
+range is known locally and costs no request; the uploaded images are read
+from the backend.
+
+Examples:
+  olares-cli settings appearance wallpaper list desktop
+  olares-cli settings appearance wallpaper list login -o json
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, err := resolveSurface(args[0])
+			if err != nil {
+				return err
+			}
+			return runWallpaperList(c.Context(), f, s, output)
+		},
+	}
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+// wallpaperChoices is the --output json contract for `wallpaper list`.
+type wallpaperChoices struct {
+	Surface  string   `json:"surface"`
+	Builtin  []string `json:"builtin"`
+	Uploaded []string `json:"uploaded"`
+	Active   string   `json:"active"`
+}
+
+func runWallpaperList(ctx context.Context, f *cmdutil.Factory, s surface, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	var cfg wallpaperConfig
+	if err := doGetEnvelope(ctx, pc.doer, wallpaperPath, &cfg); err != nil {
+		return err
+	}
+
+	choices := wallpaperChoices{
+		Surface:  s.name,
+		Builtin:  s.builtinWallpapers(),
+		Uploaded: cfg.UploadDesktopBackgrounds,
+		Active:   cfg.Desktop,
+	}
+	if s.name == "login" {
+		choices.Uploaded, choices.Active = cfg.UploadLoginBackgrounds, cfg.Login
+	}
+	if choices.Uploaded == nil {
+		choices.Uploaded = []string{}
+	}
+
+	if format == FormatJSON {
+		return printJSON(os.Stdout, choices)
+	}
+	return renderWallpaperChoices(os.Stdout, choices)
+}
+
+// renderWallpaperChoices prints the built-ins as a range rather than one
+// line per image: a terminal cannot show the thumbnails that make the
+// Settings grid meaningful, so 28 near-identical lines would not help
+// anyone choose. The uploaded URLs are listed, since those are distinct.
+func renderWallpaperChoices(w io.Writer, c wallpaperChoices) error {
+	var active string
+	if n, ok := builtinWallpaperIndex(c.Active); ok {
+		active = fmt.Sprintf(", currently %d", n)
+	}
+	if _, err := fmt.Fprintf(w, "Built-in %s wallpapers\n  %s%s\n\n",
+		c.Surface, builtinWallpaperNumbers(c), active); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Uploaded %s wallpapers\n", c.Surface); err != nil {
+		return err
+	}
+	if len(c.Uploaded) == 0 {
+		if _, err := fmt.Fprintln(w, "  none"); err != nil {
+			return err
+		}
+	}
+	for _, url := range c.Uploaded {
+		marker := "  "
+		if url == c.Active {
+			marker = "* "
+		}
+		if _, err := fmt.Fprintf(w, "%s%s\n", marker, url); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintf(w, "\nSelect one with `settings appearance wallpaper set %s <number|url>`.\n", c.Surface)
+	return err
+}
+
+func builtinWallpaperNumbers(c wallpaperChoices) string {
+	if len(c.Builtin) == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("0-%d", len(c.Builtin)-1)
+}
+
+func newWallpaperSetCommand(f *cmdutil.Factory) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "set <desktop|login> <number|url>",
+		Short: "select an existing image as the wallpaper",
+		Long: `Select an image as the desktop or login wallpaper.
+
+Two kinds of value work:
+
+  <number>      a built-in image, numbered as in "wallpaper list
+                <surface>"; the range differs between desktop and login
+  https://...   an image previously uploaded (see "wallpaper upload")
+
+The upstream stores the value verbatim and never checks it, so an
+out-of-range number would leave a broken background behind with no error.
+This command therefore validates first; --force skips that for a value a
+newer release adds.
+
+Examples:
+  olares-cli settings appearance wallpaper set desktop 3
+  olares-cli settings appearance wallpaper set login 5
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, err := resolveSurface(args[0])
+			if err != nil {
+				return err
+			}
+			raw := strings.TrimSpace(args[1])
+			if raw == "" {
+				return fmt.Errorf("set requires a built-in number or an uploaded URL")
+			}
+			bg := raw
+			if !force {
+				if bg, err = resolveWallpaperValue(s, raw); err != nil {
+					return err
+				}
+			}
+			return runWallpaperSet(c.Context(), f, s, bg)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "store the value as given, skipping validation (forward compatibility)")
+	return cmd
+}
+
+func runWallpaperSet(ctx context.Context, f *cmdutil.Factory, s surface, bg string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", s.set, map[string]string{"bg": bg}, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Set the %s wallpaper to %s.\n", s.name, describeWallpaperValue(bg))
+	return nil
+}
+
+func newWallpaperStyleCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "style",
+		Short: "wallpaper fill mode",
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "set <desktop|login> <Fill|Stretch|Tile>",
+		Short: "set how the wallpaper fills the screen",
+		Long: `Set how the wallpaper fills the screen.
+
+Modes are the ones in Settings -> Appearance: Fill, Stretch, Tile. The
+stored values (fill, cover, repeat) are accepted too.
+
+Examples:
+  olares-cli settings appearance wallpaper style set desktop Stretch
+  olares-cli settings appearance wallpaper style set login Fill
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, err := resolveSurface(args[0])
+			if err != nil {
+				return err
+			}
+			mode, err := resolveContentMode(args[1])
+			if err != nil {
+				return err
+			}
+			return runWallpaperStyleSet(c.Context(), f, s, mode)
+		},
+	})
+	return cmd
+}
+
+// resolveContentMode takes what the user saw in Settings (Fill, Stretch,
+// Tile) or the stored value (fill, cover, repeat) and returns the stored
+// value.
+func resolveContentMode(raw string) (string, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	for _, m := range contentModes {
+		if value == strings.ToLower(m.label) || value == m.wire {
+			return m.wire, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported fill mode %q (allowed: %s)", raw, strings.Join(contentModeLabels(), ", "))
+}
+
+func runWallpaperStyleSet(ctx context.Context, f *cmdutil.Factory, s surface, mode string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", s.style, map[string]string{"style": mode}, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Set the %s wallpaper fill mode to %s.\n", s.name, contentModeLabel(mode))
+	return nil
+}
+
+// uploadedImage is the images-uploader's response payload.
+type uploadedImage struct {
+	ImageURL string `json:"imageUrl"`
+	Size     int64  `json:"size"`
+}
+
+func newWallpaperUploadCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		file   string
+		noSet  bool
+		output string
+	)
+	cmd := &cobra.Command{
+		Use:   "upload <desktop|login> --file <path>",
+		Short: "upload a local image and make it the wallpaper",
+		Long: `Upload a local image, add it to the surface's gallery, and select it
+as the wallpaper. Pass --no-set to only upload and register it.
+
+The upload goes to the settings ingress rather than the desktop one,
+because the image service is only proxied there. Login backgrounds are
+uploaded with a public access policy, which the greeter needs to fetch
+them before anyone is signed in.
+
+Accepted image types: png, jpeg, jpg, gif.
+
+Examples:
+  olares-cli settings appearance wallpaper upload desktop --file ~/Pictures/bg.jpg
+  olares-cli settings appearance wallpaper upload login --file ./greeter.png --no-set
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, err := resolveSurface(args[0])
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(file) == "" {
+				return fmt.Errorf("upload requires --file <path>")
+			}
+			return runWallpaperUpload(c.Context(), f, s, file, noSet, output)
+		},
+	}
+	cmd.Flags().StringVar(&file, "file", "", "path to the local image to upload (required)")
+	cmd.Flags().BoolVar(&noSet, "no-set", false, "upload and register the image without selecting it")
+	addOutputFlag(cmd, &output)
+	return cmd
+}
+
+func runWallpaperUpload(ctx context.Context, f *cmdutil.Factory, s surface, file string, noSet bool, outputRaw string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	format, err := parseFormat(outputRaw)
+	if err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	fields := map[string]string{}
+	if s.uploadPolicy != "" {
+		fields["policy"] = s.uploadPolicy
+	}
+	var uploaded uploadedImage
+	if err := pc.images.upload(ctx, imageUploadPath, file, fields, &uploaded); err != nil {
+		return err
+	}
+	if strings.TrimSpace(uploaded.ImageURL) == "" {
+		return fmt.Errorf("upload succeeded but the image service returned no imageUrl")
+	}
+
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", s.register,
+		map[string]string{"bg": uploaded.ImageURL}, nil); err != nil {
+		return fmt.Errorf("register the uploaded image: %w", err)
+	}
+	if !noSet {
+		if err := doMutateEnvelope(ctx, pc.doer, "POST", s.set,
+			map[string]string{"bg": uploaded.ImageURL}, nil); err != nil {
+			return fmt.Errorf("select the uploaded image: %w", err)
+		}
+	}
+
+	if format == FormatJSON {
+		return printJSON(os.Stdout, uploaded)
+	}
+	if noSet {
+		fmt.Printf("Uploaded %s to the %s gallery: %s\n", file, s.name, uploaded.ImageURL)
+		return nil
+	}
+	fmt.Printf("Uploaded %s and set it as the %s wallpaper: %s\n", file, s.name, uploaded.ImageURL)
+	return nil
+}
+
+func newWallpaperDeleteCommand(f *cmdutil.Factory) *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:     "delete <desktop|login> <url>",
+		Aliases: []string{"rm"},
+		Short:   "remove an uploaded image from a wallpaper gallery",
+		Long: `Remove an uploaded image from the desktop or login gallery.
+
+Only uploaded images can be removed, so the value is one of the URLs
+listed by "wallpaper list <surface>". If the image being removed is the
+active wallpaper, the upstream falls back to a built-in default.
+
+Examples:
+  olares-cli settings appearance wallpaper delete desktop https://files.example/bg.jpg
+  olares-cli settings appearance wallpaper delete login https://files.example/greeter.png --yes
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, err := resolveSurface(args[0])
+			if err != nil {
+				return err
+			}
+			bg := strings.TrimSpace(args[1])
+			if bg == "" {
+				return fmt.Errorf("delete requires the URL of an uploaded image")
+			}
+			return runWallpaperDelete(c.Context(), f, s, bg, assumeYes)
+		},
+	}
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the y/N prompt (required for non-TTY stdin)")
+	return cmd
+}
+
+func runWallpaperDelete(ctx context.Context, f *cmdutil.Factory, s surface, bg string, assumeYes bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := cliutil.ConfirmDestructive(os.Stderr, os.Stdin,
+		fmt.Sprintf("Remove %q from the %s wallpaper gallery?", bg, s.name),
+		assumeYes); err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", s.remove, map[string]string{"bg": bg}, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Removed %q from the %s wallpaper gallery.\n", bg, s.name)
+	return nil
+}

--- a/cli/cmd/ctl/settings/appearance/wallpaper_test.go
+++ b/cli/cmd/ctl/settings/appearance/wallpaper_test.go
@@ -1,0 +1,357 @@
+package appearance
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSurface(t *testing.T) {
+	desktop, err := resolveSurface("Desktop")
+	if err != nil {
+		t.Fatalf("resolveSurface(\"Desktop\") errored: %v", err)
+	}
+	if desktop.name != "desktop" || desktop.uploadPolicy != "" {
+		t.Errorf("desktop surface = %+v; want name=desktop and no upload policy", desktop)
+	}
+
+	login, err := resolveSurface("  login ")
+	if err != nil {
+		t.Fatalf("resolveSurface(\" login \") errored: %v", err)
+	}
+	// The greeter fetches the login background before the user is
+	// authenticated, so it has to be uploaded as public.
+	if login.uploadPolicy != "public" {
+		t.Errorf("login upload policy = %q; want %q", login.uploadPolicy, "public")
+	}
+
+	// Every surface needs all four routes; a missing one would send a
+	// write to the empty path.
+	for name, s := range surfaces {
+		for field, path := range map[string]string{
+			"set": s.set, "style": s.style, "register": s.register, "remove": s.remove,
+		} {
+			if !strings.HasPrefix(path, "/api/wallpaper/") {
+				t.Errorf("surface %s %s path = %q; want an /api/wallpaper/ route", name, field, path)
+			}
+		}
+	}
+
+	if _, err := resolveSurface("greeter"); err == nil {
+		t.Error("resolveSurface accepted an unknown surface")
+	}
+}
+
+// A built-in is selected by number, as in the Settings grid, and stored
+// as /bg/<n>.jpg on both surfaces: the greeter resolves the value under
+// its own asset root, so /login/<n>.jpg — the path the Settings page
+// builds for its preview — is not a storable value.
+func TestResolveWallpaperValue(t *testing.T) {
+	desktop, login := surfaces["desktop"], surfaces["login"]
+
+	for _, s := range []surface{desktop, login} {
+		// A number is the documented spelling; the stored path is
+		// accepted so `get` output can be fed back in.
+		for raw, want := range map[string]string{
+			"0":                            "/bg/0.jpg",
+			"3":                            "/bg/3.jpg",
+			fmt.Sprint(s.builtinCount - 1): builtinWallpaperValue(s.builtinCount - 1),
+			"/bg/0.jpg":                    "/bg/0.jpg",
+			"https://files.example/a.png":  "https://files.example/a.png",
+			"http://files.example/a.png":   "http://files.example/a.png",
+		} {
+			got, err := resolveWallpaperValue(s, raw)
+			if err != nil {
+				t.Errorf("%s rejected valid %q: %v", s.name, raw, err)
+				continue
+			}
+			if got != want {
+				t.Errorf("%s resolveWallpaperValue(%q) = %q; want %q", s.name, raw, got, want)
+			}
+		}
+
+		for _, bad := range []string{
+			fmt.Sprint(s.builtinCount),                // one past the end
+			fmt.Sprintf("/bg/%d.jpg", s.builtinCount), // same, spelled as a path
+			"999",
+			"/login/5.jpg", // a preview path, never stored
+			"/bg/3.png",
+			"/bg/.jpg",
+			"-1",
+			"bg/3.jpg",
+			"",
+		} {
+			if _, err := resolveWallpaperValue(s, bad); err == nil {
+				t.Errorf("%s accepted invalid %q", s.name, bad)
+			}
+		}
+	}
+
+	// The surfaces ship a different number of images, so the boundary
+	// must be per-surface rather than shared.
+	if desktop.builtinCount == login.builtinCount {
+		t.Fatal("test assumes the two surfaces differ in built-in count")
+	}
+	edge := fmt.Sprint(desktop.builtinCount)
+	if _, err := resolveWallpaperValue(desktop, edge); err == nil {
+		t.Errorf("desktop accepted %q, which is past its own range", edge)
+	}
+	if _, err := resolveWallpaperValue(login, edge); err != nil {
+		t.Errorf("login rejected %q, which is inside its range: %v", edge, err)
+	}
+
+	// An out-of-range number is a near miss, so the message only needs
+	// the range; an unparseable value needs the whole how-to.
+	_, err := resolveWallpaperValue(desktop, "999")
+	if want := builtinWallpaperRange(desktop); !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q missing the range %q", err, want)
+	}
+	_, err = resolveWallpaperValue(desktop, "/bg/3.png")
+	for _, want := range []string{"wallpaper list desktop", "--force", builtinWallpaperRange(desktop)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// The table renames values for the reader; the JSON output is a scripted
+// caller's contract and must keep the stored spellings, which are also
+// what `set` accepts.
+func TestWallpaperChoicesJSONKeepsStoredValues(t *testing.T) {
+	s := surfaces["desktop"]
+	raw, err := json.Marshal(wallpaperChoices{
+		Surface:  s.name,
+		Builtin:  s.builtinWallpapers(),
+		Uploaded: []string{},
+		Active:   "/bg/3.jpg",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Surface  string   `json:"surface"`
+		Builtin  []string `json:"builtin"`
+		Uploaded []string `json:"uploaded"`
+		Active   string   `json:"active"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Active != "/bg/3.jpg" {
+		t.Errorf("active = %q; want the stored /bg/3.jpg, not a display name", decoded.Active)
+	}
+	if len(decoded.Builtin) != s.builtinCount || decoded.Builtin[0] != "/bg/0.jpg" {
+		t.Errorf("builtin = %v; want the %d stored values", decoded.Builtin, s.builtinCount)
+	}
+	// An absent gallery must marshal as [] rather than null, so a caller
+	// can iterate it unconditionally.
+	if !strings.Contains(string(raw), `"uploaded":[]`) {
+		t.Errorf("empty gallery is not an empty array: %s", raw)
+	}
+}
+
+// Output names a value the same way input takes it, so `get` and `set`
+// share one vocabulary.
+func TestDescribeWallpaperValue(t *testing.T) {
+	for raw, want := range map[string]string{
+		"/bg/0.jpg":                   "built-in 0",
+		"/bg/27.jpg":                  "built-in 27",
+		"https://files.example/a.png": "https://files.example/a.png",
+		"":                            "-",
+	} {
+		if got := describeWallpaperValue(raw); got != want {
+			t.Errorf("describeWallpaperValue(%q) = %q; want %q", raw, got, want)
+		}
+	}
+}
+
+func TestBuiltinWallpapersEnumeratesTheWholeRange(t *testing.T) {
+	s := surfaces["desktop"]
+	got := s.builtinWallpapers()
+	if len(got) != s.builtinCount {
+		t.Fatalf("builtinWallpapers() = %d entries; want %d", len(got), s.builtinCount)
+	}
+	if got[0] != "/bg/0.jpg" {
+		t.Errorf("first entry = %q; want /bg/0.jpg", got[0])
+	}
+	if last, want := got[len(got)-1], fmt.Sprintf("/bg/%d.jpg", s.builtinCount-1); last != want {
+		t.Errorf("last entry = %q; want %q", last, want)
+	}
+	// Every generated value must be accepted by set, or `list` would be
+	// advertising values `set` refuses.
+	for _, v := range got {
+		if _, err := resolveWallpaperValue(s, v); err != nil {
+			t.Fatalf("listed value %q is rejected by set: %v", v, err)
+		}
+	}
+}
+
+// The built-ins are printed as a range: a terminal cannot show the
+// thumbnails that make the Settings grid meaningful, so one line per
+// image would be noise.
+func TestRenderWallpaperChoicesShowsTheRangeAndTheActiveOne(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderWallpaperChoices(&buf, wallpaperChoices{
+		Surface:  "desktop",
+		Builtin:  []string{"/bg/0.jpg", "/bg/1.jpg", "/bg/2.jpg"},
+		Uploaded: []string{"https://files.example/a.png"},
+		Active:   "/bg/1.jpg",
+	})
+	if err != nil {
+		t.Fatalf("renderWallpaperChoices errored: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "0-2, currently 1") {
+		t.Errorf("built-in range or active number missing:\n%s", out)
+	}
+	if strings.Contains(out, "/bg/0.jpg") {
+		t.Errorf("built-ins are enumerated as paths:\n%s", out)
+	}
+	if !strings.Contains(out, "  https://files.example/a.png") {
+		t.Errorf("uploaded wallpaper missing:\n%s", out)
+	}
+	// The reader must not have to guess the verb that consumes this.
+	if !strings.Contains(out, "wallpaper set desktop <number|url>") {
+		t.Errorf("output does not say how to select:\n%s", out)
+	}
+}
+
+func TestRenderWallpaperChoicesMarksAnActiveUpload(t *testing.T) {
+	var buf bytes.Buffer
+	const url = "https://files.example/a.png"
+	if err := renderWallpaperChoices(&buf, wallpaperChoices{
+		Surface:  "desktop",
+		Builtin:  []string{"/bg/0.jpg"},
+		Uploaded: []string{url, "https://files.example/b.png"},
+		Active:   url,
+	}); err != nil {
+		t.Fatalf("renderWallpaperChoices errored: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "* "+url) {
+		t.Errorf("active upload is not marked:\n%s", out)
+	}
+	// No built-in is active, so no "currently" claim may appear.
+	if strings.Contains(out, "currently") {
+		t.Errorf("a built-in is reported active while an upload is:\n%s", out)
+	}
+}
+
+func TestRenderWallpaperChoicesEmptyGallery(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderWallpaperChoices(&buf, wallpaperChoices{
+		Surface: "login",
+		Builtin: []string{"/bg/0.jpg"},
+		Active:  "/bg/0.jpg",
+	}); err != nil {
+		t.Fatalf("renderWallpaperChoices errored: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Uploaded login wallpapers\n  none") {
+		t.Errorf("empty gallery is not rendered as \"none\":\n%s", buf.String())
+	}
+}
+
+// The fill modes are named in the CLI the way Settings names them, so a
+// user typing what they read gets what they expect. The stored values
+// stay accepted for scripts.
+func TestResolveContentMode(t *testing.T) {
+	for _, m := range contentModes {
+		for _, raw := range []string{m.label, strings.ToLower(m.label), strings.ToUpper(m.label), m.wire} {
+			got, err := resolveContentMode(raw)
+			if err != nil {
+				t.Errorf("resolveContentMode(%q) errored: %v", raw, err)
+				continue
+			}
+			if got != m.wire {
+				t.Errorf("resolveContentMode(%q) = %q; want %q", raw, got, m.wire)
+			}
+		}
+		if got := contentModeLabel(m.wire); got != m.label {
+			t.Errorf("contentModeLabel(%q) = %q; want %q", m.wire, got, m.label)
+		}
+	}
+
+	// An unknown mode is listed by label, since that is what the user saw.
+	_, err := resolveContentMode("scaled")
+	if err == nil {
+		t.Fatal("resolveContentMode accepted an unknown mode")
+	}
+	if !strings.Contains(err.Error(), "allowed: Fill, Stretch, Tile") {
+		t.Errorf("error %q does not list the allowed modes by label", err)
+	}
+
+	// A value a newer release adds must still print rather than vanish.
+	if got := contentModeLabel("scaled"); got != "scaled" {
+		t.Errorf("contentModeLabel passed over an unknown value: %q", got)
+	}
+}
+
+func TestMultipartImageSendsFieldsThenFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "greeter.png")
+	const payload = "not-really-a-png"
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	body, contentType, err := multipartImage(path, map[string]string{"policy": "public", "skipped": "  "})
+	if err != nil {
+		t.Fatalf("multipartImage errored: %v", err)
+	}
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse content type %q: %v", contentType, err)
+	}
+
+	fields := map[string]string{}
+	files := map[string]string{}
+	filenames := map[string]string{}
+	mr := multipart.NewReader(body, params["boundary"])
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part body: %v", err)
+		}
+		if part.FileName() == "" {
+			fields[part.FormName()] = string(content)
+			continue
+		}
+		files[part.FormName()] = string(content)
+		filenames[part.FormName()] = part.FileName()
+	}
+
+	if fields["policy"] != "public" {
+		t.Errorf("policy field = %q; want %q", fields["policy"], "public")
+	}
+	if _, ok := fields["skipped"]; ok {
+		t.Error("a blank field was written; blank fields must be dropped")
+	}
+	// The uploader reads the file from the `image` part.
+	if files["image"] != payload {
+		t.Errorf("image part = %q; want %q", files["image"], payload)
+	}
+	if filenames["image"] != "greeter.png" {
+		t.Errorf("image filename = %q; want the basename %q", filenames["image"], "greeter.png")
+	}
+}
+
+func TestMultipartImageMissingFile(t *testing.T) {
+	if _, _, err := multipartImage(filepath.Join(t.TempDir(), "absent.png"), nil); err == nil {
+		t.Error("multipartImage accepted a path that does not exist")
+	}
+}

--- a/cli/cmd/ctl/settings/appearance/wallpaper_test.go
+++ b/cli/cmd/ctl/settings/appearance/wallpaper_test.go
@@ -67,7 +67,7 @@ func TestResolveWallpaperValue(t *testing.T) {
 			"https://files.example/a.png":  "https://files.example/a.png",
 			"http://files.example/a.png":   "http://files.example/a.png",
 		} {
-			got, err := resolveWallpaperValue(s, raw)
+			got, err := resolveWallpaperValue(s, raw, false)
 			if err != nil {
 				t.Errorf("%s rejected valid %q: %v", s.name, raw, err)
 				continue
@@ -88,7 +88,7 @@ func TestResolveWallpaperValue(t *testing.T) {
 			"bg/3.jpg",
 			"",
 		} {
-			if _, err := resolveWallpaperValue(s, bad); err == nil {
+			if _, err := resolveWallpaperValue(s, bad, false); err == nil {
 				t.Errorf("%s accepted invalid %q", s.name, bad)
 			}
 		}
@@ -100,24 +100,80 @@ func TestResolveWallpaperValue(t *testing.T) {
 		t.Fatal("test assumes the two surfaces differ in built-in count")
 	}
 	edge := fmt.Sprint(desktop.builtinCount)
-	if _, err := resolveWallpaperValue(desktop, edge); err == nil {
+	if _, err := resolveWallpaperValue(desktop, edge, false); err == nil {
 		t.Errorf("desktop accepted %q, which is past its own range", edge)
 	}
-	if _, err := resolveWallpaperValue(login, edge); err != nil {
+	if _, err := resolveWallpaperValue(login, edge, false); err != nil {
 		t.Errorf("login rejected %q, which is inside its range: %v", edge, err)
 	}
 
 	// An out-of-range number is a near miss, so the message only needs
 	// the range; an unparseable value needs the whole how-to.
-	_, err := resolveWallpaperValue(desktop, "999")
+	_, err := resolveWallpaperValue(desktop, "999", false)
 	if want := builtinWallpaperRange(desktop); !strings.Contains(err.Error(), want) {
 		t.Errorf("error %q missing the range %q", err, want)
 	}
-	_, err = resolveWallpaperValue(desktop, "/bg/3.png")
+	_, err = resolveWallpaperValue(desktop, "/bg/3.png", false)
 	for _, want := range []string{"wallpaper list desktop", "--force", builtinWallpaperRange(desktop)} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q", err, want)
 		}
+	}
+}
+
+// --force relaxes the checks, not the vocabulary. The bare number is not
+// a value the backend can resolve, so forcing one has to store
+// /bg/<n>.jpg -- otherwise the escape hatch offered by the out-of-range
+// message silently writes a broken background.
+func TestResolveWallpaperValueForceKeepsTheNumberVocabulary(t *testing.T) {
+	s := surfaces["desktop"]
+
+	// The exact path the out-of-range error invites: a built-in a newer
+	// release added, past the count this CLI was built with.
+	beyond := s.builtinCount
+	got, err := resolveWallpaperValue(s, fmt.Sprint(beyond), true)
+	if err != nil {
+		t.Fatalf("force rejected %d: %v", beyond, err)
+	}
+	if want := builtinWallpaperValue(beyond); got != want {
+		t.Errorf("force resolveWallpaperValue(%d) = %q; want %q", beyond, got, want)
+	}
+
+	// In-range numbers resolve the same with or without the flag.
+	for _, raw := range []string{"0", "3"} {
+		forced, err := resolveWallpaperValue(s, raw, true)
+		if err != nil {
+			t.Fatalf("force rejected %q: %v", raw, err)
+		}
+		plain, err := resolveWallpaperValue(s, raw, false)
+		if err != nil {
+			t.Fatalf("%q rejected without force: %v", raw, err)
+		}
+		if forced != plain {
+			t.Errorf("--force changed %q from %q to %q", raw, plain, forced)
+		}
+	}
+
+	// A shape this CLI cannot read is the one case force sends verbatim,
+	// since there is nothing to resolve it to.
+	for _, raw := range []string{"/bg/3.png", "/login/5.jpg"} {
+		got, err := resolveWallpaperValue(s, raw, true)
+		if err != nil {
+			t.Fatalf("force rejected %q: %v", raw, err)
+		}
+		if got != raw {
+			t.Errorf("force resolveWallpaperValue(%q) = %q; want it verbatim", raw, got)
+		}
+	}
+
+	// Whatever force stores, `get` and the confirmation line must be able
+	// to name it the way the user selected it.
+	forced, err := resolveWallpaperValue(s, fmt.Sprint(beyond), true)
+	if err != nil {
+		t.Fatalf("force rejected %d: %v", beyond, err)
+	}
+	if want := fmt.Sprintf("built-in %d", beyond); describeWallpaperValue(forced) != want {
+		t.Errorf("describeWallpaperValue(%q) = %q; want %q", forced, describeWallpaperValue(forced), want)
 	}
 }
 
@@ -187,7 +243,7 @@ func TestBuiltinWallpapersEnumeratesTheWholeRange(t *testing.T) {
 	// Every generated value must be accepted by set, or `list` would be
 	// advertising values `set` refuses.
 	for _, v := range got {
-		if _, err := resolveWallpaperValue(s, v); err != nil {
+		if _, err := resolveWallpaperValue(s, v, false); err != nil {
 			t.Fatalf("listed value %q is rejected by set: %v", v, err)
 		}
 	}

--- a/cli/cmd/ctl/settings/appearance/widget.go
+++ b/cli/cmd/ctl/settings/appearance/widget.go
@@ -1,0 +1,191 @@
+package appearance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
+)
+
+// `olares-cli settings appearance widget set ...`
+//
+// Backed by user-service's widget.controller.ts:
+//
+//	GET  /api/widget  -> WidgetPreferences
+//	POST /api/widget  <- { "widget": WidgetPreferences }
+//
+// The POST replaces the whole preferences object, so a partial change is
+// a read-modify-write. Current values are shown by `appearance get`.
+const widgetPath = "/api/widget"
+
+// widgetPreferences mirrors the SPA's WidgetPreferences
+// (apps/.../stores/settings/widgetPreferences.ts:19-24). The JSON tags
+// keep the upstream spelling — "showWeight" is the wire name for the
+// widget master switch, despite what it reads like.
+type widgetPreferences struct {
+	ShowWidgets    bool   `json:"showWeight"`
+	Is24HourFormat bool   `json:"is24HourFormat"`
+	DateFormat     string `json:"dateFormat"`
+	ShowDashboard  bool   `json:"showDashboard"`
+}
+
+// dateFormats mirrors the DateFormat union in
+// apps/.../stores/settings/widgetPreferences.ts:6-17. The upstream stores
+// whatever string it is handed, so an unlisted value would be accepted
+// and then fail to render in the desktop clock.
+var dateFormats = []string{
+	"YYYY/MM/DD",
+	"D/M/YY",
+	"M/D/YY",
+	"DD/MM/YYYY",
+	"DD.MM.YYYY",
+	"DD-MM-YYYY",
+	"YYYY.MM.DD",
+	"YYYY-MM-DD",
+	"YY/MM/DD",
+	"YY-M-D",
+	"YY.M.D",
+}
+
+func NewWidgetCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "widget",
+		Short: "desktop widget preferences",
+		Long: `Update the desktop widget preferences (Settings -> Appearance >
+Widgets and Date & Time).
+
+Current values are shown by "settings appearance get".
+
+Subcommands:
+  set [flags]           update one or more preferences
+`,
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(newWidgetSetCommand(f))
+	return cmd
+}
+
+// widgetPatch carries only the preferences the caller actually named.
+// The upstream POST replaces the whole object, so anything left nil has
+// to be sent back exactly as it was read.
+type widgetPatch struct {
+	showWidgets    *bool
+	is24HourFormat *bool
+	dateFormat     *string
+	showDashboard  *bool
+}
+
+func (p widgetPatch) empty() bool {
+	return p.showWidgets == nil && p.is24HourFormat == nil &&
+		p.dateFormat == nil && p.showDashboard == nil
+}
+
+func (p widgetPatch) apply(cur widgetPreferences) widgetPreferences {
+	if p.showWidgets != nil {
+		cur.ShowWidgets = *p.showWidgets
+	}
+	if p.is24HourFormat != nil {
+		cur.Is24HourFormat = *p.is24HourFormat
+	}
+	if p.dateFormat != nil {
+		cur.DateFormat = *p.dateFormat
+	}
+	if p.showDashboard != nil {
+		cur.ShowDashboard = *p.showDashboard
+	}
+	return cur
+}
+
+func newWidgetSetCommand(f *cmdutil.Factory) *cobra.Command {
+	var (
+		showWidgets    bool
+		is24HourFormat bool
+		dateFormat     string
+		showDashboard  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "set [flags]",
+		Short: "update one or more desktop widget preferences",
+		Long: fmt.Sprintf(`Update one or more desktop widget preferences. Only the flags you
+pass are changed; the rest are read from the upstream and sent back
+unchanged, because the endpoint replaces the whole object.
+
+Allowed --date-format values:
+  %s
+
+Examples:
+  olares-cli settings appearance widget set --show-widgets=false
+  olares-cli settings appearance widget set --24-hour=false --date-format M/D/YY
+  olares-cli settings appearance widget set --show-dashboard=true
+`, strings.Join(dateFormats, "\n  ")),
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			patch := widgetPatch{}
+			if c.Flags().Changed("show-widgets") {
+				patch.showWidgets = &showWidgets
+			}
+			if c.Flags().Changed("24-hour") {
+				patch.is24HourFormat = &is24HourFormat
+			}
+			if c.Flags().Changed("show-dashboard") {
+				patch.showDashboard = &showDashboard
+			}
+			if c.Flags().Changed("date-format") {
+				resolved, err := resolveDateFormat(dateFormat)
+				if err != nil {
+					return err
+				}
+				patch.dateFormat = &resolved
+			}
+			return runWidgetSet(c.Context(), f, patch)
+		},
+	}
+	cmd.Flags().BoolVar(&showWidgets, "show-widgets", true, "show the desktop widgets")
+	cmd.Flags().BoolVar(&is24HourFormat, "24-hour", true, "use 24-hour time in the clock widget")
+	cmd.Flags().StringVar(&dateFormat, "date-format", "", "date format used by the clock widget")
+	cmd.Flags().BoolVar(&showDashboard, "show-dashboard", true, "show the dashboard widget")
+	return cmd
+}
+
+func resolveDateFormat(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("--date-format requires a value (allowed: %s)", strings.Join(dateFormats, ", "))
+	}
+	for _, f := range dateFormats {
+		if value == f {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported --date-format %q (allowed: %s)", raw, strings.Join(dateFormats, ", "))
+}
+
+func runWidgetSet(ctx context.Context, f *cmdutil.Factory, patch widgetPatch) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if patch.empty() {
+		return fmt.Errorf("widget set requires at least one of --show-widgets, --24-hour, --date-format, --show-dashboard")
+	}
+	if err := requireAppearanceBackendVersion(ctx, f,
+		"settings appearance widget set", "the widget preferences API"); err != nil {
+		return err
+	}
+	pc, err := prepare(ctx, f)
+	if err != nil {
+		return err
+	}
+	var current widgetPreferences
+	if err := doGetEnvelope(ctx, pc.doer, widgetPath, &current); err != nil {
+		return err
+	}
+	body := map[string]widgetPreferences{"widget": patch.apply(current)}
+	if err := doMutateEnvelope(ctx, pc.doer, "POST", widgetPath, body, nil); err != nil {
+		return err
+	}
+	fmt.Println("Widget preferences updated.")
+	return nil
+}

--- a/cli/cmd/ctl/settings/appearance/widget_test.go
+++ b/cli/cmd/ctl/settings/appearance/widget_test.go
@@ -1,0 +1,90 @@
+package appearance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveDateFormat(t *testing.T) {
+	for _, allowed := range dateFormats {
+		got, err := resolveDateFormat("  " + allowed + "  ")
+		if err != nil {
+			t.Fatalf("resolveDateFormat(%q) errored: %v", allowed, err)
+		}
+		if got != allowed {
+			t.Errorf("resolveDateFormat(%q) = %q; want %q", allowed, got, allowed)
+		}
+	}
+
+	if _, err := resolveDateFormat("yyyy/mm/dd"); err == nil {
+		t.Error("resolveDateFormat accepted a lowercased format; the upstream is case-sensitive")
+	}
+	_, err := resolveDateFormat("")
+	if err == nil || !strings.Contains(err.Error(), "requires a value") {
+		t.Errorf("empty --date-format error = %v; want it to mention a required value", err)
+	}
+}
+
+// The upstream POST replaces the whole preferences object, so a patch has
+// to leave every field the caller did not name exactly as it was read.
+func TestWidgetPatchApplyOnlyTouchesNamedFields(t *testing.T) {
+	current := widgetPreferences{
+		ShowWidgets:    true,
+		Is24HourFormat: true,
+		DateFormat:     "YYYY/MM/DD",
+		ShowDashboard:  true,
+	}
+	no := false
+	format := "M/D/YY"
+
+	t.Run("single_bool", func(t *testing.T) {
+		got := widgetPatch{showWidgets: &no}.apply(current)
+		want := current
+		want.ShowWidgets = false
+		if got != want {
+			t.Errorf("apply() = %+v; want %+v", got, want)
+		}
+	})
+
+	t.Run("date_format_only", func(t *testing.T) {
+		got := widgetPatch{dateFormat: &format}.apply(current)
+		want := current
+		want.DateFormat = format
+		if got != want {
+			t.Errorf("apply() = %+v; want %+v", got, want)
+		}
+	})
+
+	t.Run("empty_patch_is_identity", func(t *testing.T) {
+		if got := (widgetPatch{}).apply(current); got != current {
+			t.Errorf("apply() = %+v; want the input unchanged %+v", got, current)
+		}
+	})
+
+	t.Run("false_is_not_mistaken_for_unset", func(t *testing.T) {
+		zeroed := widgetPreferences{DateFormat: "YY-M-D"}
+		yes := true
+		got := widgetPatch{showDashboard: &yes}.apply(zeroed)
+		if !got.ShowDashboard || got.DateFormat != "YY-M-D" {
+			t.Errorf("apply() = %+v; want ShowDashboard set and DateFormat preserved", got)
+		}
+	})
+}
+
+func TestWidgetPatchEmpty(t *testing.T) {
+	if !(widgetPatch{}).empty() {
+		t.Error("a patch with no fields set reports non-empty")
+	}
+	flag := false
+	format := "YY-M-D"
+	for name, p := range map[string]widgetPatch{
+		"show_widgets":   {showWidgets: &flag},
+		"is_24_hour":     {is24HourFormat: &flag},
+		"show_dashboard": {showDashboard: &flag},
+		"date_format":    {dateFormat: &format},
+	} {
+		if p.empty() {
+			t.Errorf("patch %s reports empty", name)
+		}
+	}
+}

--- a/cli/cmd/ctl/settings/apps/common.go
+++ b/cli/cmd/ctl/settings/apps/common.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -76,45 +77,17 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-// bflEnvelope is the BFL response wrapper. /api/myapps and the
-// /api/applications/* endpoints all return this shape:
-//
-//	{ "code": 0, "message": "ok", "data": <typed payload> }
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of doGetEnvelope.
-// user-service routes return BFL `{code: 0}` (the most common shape —
-// returnSucceed wraps everything) or, for endpoints that proxy through
-// additional layers, `{code: 200}`. Both are treated as success.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			msg = fmt.Sprintf("server returned code=%d", env.Code)
-		}
-		return fmt.Errorf("%s %s: %s", method, path, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/apps/env.go
+++ b/cli/cmd/ctl/settings/apps/env.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -22,17 +23,12 @@ import (
 //	GET /api/env/apps/{appName}/env             -> BaseEnv[] (BFL envelope)
 //	PUT /api/env/apps/{appName}/env  body: UpdateEnvItem[]
 //
-// UpdateEnvItem is just `{envName, value}` — the SPA strips the
-// definition fields and sends back only the changed values, all in one
-// PUT (the upstream replaces the entire vector each call). To match
-// that semantic safely from the CLI we:
-//
-//   - fetch the current env first with the same GET,
-//   - merge user-supplied --var KEY=VALUE pairs on top, and
-//   - PUT the merged set.
-//
-// Without the read-modify-write merge, a CLI user setting one variable
-// would clobber every other variable the SPA had set previously.
+// UpdateEnvItem is just `{envName, value}`. The upstream patches the
+// entries it finds by name and leaves the rest of the vector untouched,
+// so the PUT carries only what the caller asked to change. Sending the
+// whole vector back is worse than redundant: the handler rejects the
+// entire request if any named variable is not editable, so a full-vector
+// PUT fails on every app that declares a read-only variable.
 
 func NewEnvCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -152,11 +148,15 @@ func newEnvSetCommand(f *cmdutil.Factory) *cobra.Command {
 		Short: "update one or more environment variables on an installed app",
 		Long: `Update one or more environment variables on an installed app.
 
-The CLI does a read-modify-write to avoid clobbering values it doesn't
-know about: it fetches the current vector, overlays the --var pairs you
-pass, and PUTs the merged result back. Only variables the SPA flagged
-as editable: true can be updated; the upstream rejects writes to system
-fields with a 400.
+Only the variables you name are sent. The upstream patches the matching
+entries and leaves the rest of the vector alone, so there is nothing to
+merge client-side.
+
+Two upstream rules to know:
+  - only variables the app declares as editable can be written; naming a
+    read-only one fails the whole request with a 400
+  - a name the app does not declare is ignored rather than created, so
+    this command reports which of your keys actually landed
 
 Examples:
   olares-cli settings apps env set my-app \
@@ -194,32 +194,69 @@ func runAppEnvSet(ctx context.Context, f *cmdutil.Factory, appName string, vars 
 	if err != nil {
 		return err
 	}
-	current, err := fetchAppEnv(ctx, pc.doer, appName)
-	if err != nil {
-		return err
-	}
-	merged := mergeEnvUpdates(current, updates)
-	body := make([]map[string]string, 0, len(merged))
-	for _, e := range merged {
-		body = append(body, map[string]string{"envName": e.envName, "value": e.value})
-	}
+	return runAppEnvSetWithDoer(ctx, pc.doer, appName, updates)
+}
+
+// runAppEnvSetWithDoer is the wire-level core of `apps env set`, split
+// out so tests can assert the request shape without a live cluster.
+func runAppEnvSetWithDoer(ctx context.Context, d Doer, appName string, updates map[string]string) error {
+	body := envUpdateBody(updates)
 	path := "/api/env/apps/" + url.PathEscape(appName) + "/env"
-	if err := doMutateEnvelope(ctx, pc.doer, "PUT", path, body, nil); err != nil {
+	var after []baseEnv
+	if err := doMutateEnvelope(ctx, d, "PUT", path, body, &after); err != nil {
 		return err
 	}
-	keys := make([]string, 0, len(updates))
-	for k := range updates {
-		keys = append(keys, k)
+	applied, ignored := splitAppliedEnvKeys(updates, after)
+	if len(applied) > 0 {
+		fmt.Printf("Updated %d environment variable(s) on %q: %s\n", len(applied), appName, strings.Join(applied, ", "))
 	}
-	fmt.Printf("Updated %d environment variable(s) on %q: %s\n", len(updates), appName, strings.Join(keys, ", "))
+	if len(ignored) > 0 {
+		return fmt.Errorf("%q does not declare %s, so %s ignored (this app's variables come from its chart, they cannot be created here)",
+			appName, strings.Join(ignored, ", "), plural(len(ignored), "it was", "they were"))
+	}
 	return nil
 }
 
-// envPair is the wire shape we emit on PUT — matches UpdateEnvItem in
-// constant/index.ts.
-type envPair struct {
-	envName string
-	value   string
+// envUpdateBody emits UpdateEnvItem[] (constant/index.ts) sorted by name
+// so a given set of updates always produces the same request.
+func envUpdateBody(updates map[string]string) []map[string]string {
+	names := make([]string, 0, len(updates))
+	for name := range updates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	body := make([]map[string]string, 0, len(names))
+	for _, name := range names {
+		body = append(body, map[string]string{"envName": name, "value": updates[name]})
+	}
+	return body
+}
+
+// splitAppliedEnvKeys sorts the requested names into those the app
+// declares (the upstream echoes its full vector back) and those it does
+// not, which the upstream drops without saying so.
+func splitAppliedEnvKeys(updates map[string]string, after []baseEnv) (applied, ignored []string) {
+	declared := make(map[string]bool, len(after))
+	for _, e := range after {
+		declared[e.EnvName] = true
+	}
+	for name := range updates {
+		if declared[name] {
+			applied = append(applied, name)
+		} else {
+			ignored = append(ignored, name)
+		}
+	}
+	sort.Strings(applied)
+	sort.Strings(ignored)
+	return applied, ignored
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 // parseVarFlags splits "KEY=VALUE" inputs into a map. Values may contain
@@ -239,27 +276,4 @@ func parseVarFlags(raw []string) (map[string]string, error) {
 		out[key] = val
 	}
 	return out, nil
-}
-
-// mergeEnvUpdates takes the upstream's current BaseEnv vector, overlays
-// the user's KEY=VALUE updates, and returns the full vector to PUT.
-// New keys (not in `current`) are appended at the end so the SPA's
-// stable order survives a CLI mutation.
-func mergeEnvUpdates(current []baseEnv, updates map[string]string) []envPair {
-	out := make([]envPair, 0, len(current)+len(updates))
-	seen := make(map[string]bool, len(current))
-	for _, e := range current {
-		v := e.Value
-		if up, ok := updates[e.EnvName]; ok {
-			v = up
-		}
-		out = append(out, envPair{envName: e.EnvName, value: v})
-		seen[e.EnvName] = true
-	}
-	for k, v := range updates {
-		if !seen[k] {
-			out = append(out, envPair{envName: k, value: v})
-		}
-	}
-	return out
 }

--- a/cli/cmd/ctl/settings/apps/env_test.go
+++ b/cli/cmd/ctl/settings/apps/env_test.go
@@ -1,0 +1,137 @@
+package apps
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseVarFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		want    map[string]string
+		wantErr string
+	}{
+		{
+			name: "splits_on_first_equals_only",
+			in:   []string{"GREETING=hi=there"},
+			want: map[string]string{"GREETING": "hi=there"},
+		},
+		{
+			name: "empty_value_is_allowed",
+			in:   []string{"LOG_LEVEL="},
+			want: map[string]string{"LOG_LEVEL": ""},
+		},
+		{
+			name: "trims_the_key_but_not_the_value",
+			in:   []string{"  API_URL  = https://x "},
+			want: map[string]string{"API_URL": " https://x "},
+		},
+		{
+			name: "last_wins_on_a_repeated_key",
+			in:   []string{"A=1", "A=2"},
+			want: map[string]string{"A": "2"},
+		},
+		{name: "missing_equals", in: []string{"NOPE"}, wantErr: "expected KEY=VALUE"},
+		{name: "empty_key", in: []string{"=1"}, wantErr: "expected KEY=VALUE"},
+		{name: "blank_key", in: []string{"   =1"}, wantErr: "empty key"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseVarFlags(tc.in)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v; want it to mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v; want %v", got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q = %q; want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvUpdateBodyCarriesOnlyTheRequestedNames(t *testing.T) {
+	body := envUpdateBody(map[string]string{"ZED": "3", "ALPHA": "1"})
+	if len(body) != 2 {
+		t.Fatalf("body has %d entries; want only the 2 requested", len(body))
+	}
+	if body[0]["envName"] != "ALPHA" || body[1]["envName"] != "ZED" {
+		t.Errorf("body is not sorted by name: %v", body)
+	}
+	if body[0]["value"] != "1" || body[1]["value"] != "3" {
+		t.Errorf("values do not match the request: %v", body)
+	}
+}
+
+func TestSplitAppliedEnvKeys(t *testing.T) {
+	// The upstream echoes the app's full vector, so a requested name
+	// missing from it was silently dropped rather than created.
+	after := []baseEnv{{EnvName: "API_URL"}, {EnvName: "LOG_LEVEL"}}
+	applied, ignored := splitAppliedEnvKeys(
+		map[string]string{"LOG_LEVEL": "debug", "TYPO": "x", "API_URL": "y"},
+		after,
+	)
+	if strings.Join(applied, ",") != "API_URL,LOG_LEVEL" {
+		t.Errorf("applied = %v; want the two declared names, sorted", applied)
+	}
+	if strings.Join(ignored, ",") != "TYPO" {
+		t.Errorf("ignored = %v; want only the undeclared name", ignored)
+	}
+}
+
+func TestRunAppEnvSetSendsOnlyTheNamedVariables(t *testing.T) {
+	d := &fakeDoer{}
+	// A read-only variable in the app's vector must not end up in the
+	// request: the upstream 400s the whole call if it is named.
+	d.enqueueEnvelope([]baseEnv{
+		{EnvName: "API_URL"},
+		{EnvName: "OLARES_SECRET"},
+	})
+
+	if err := runAppEnvSetWithDoer(context.Background(), d, "my-app", map[string]string{"API_URL": "https://x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(d.calls) != 1 {
+		t.Fatalf("made %d wire calls; want a single PUT with no preparatory GET", len(d.calls))
+	}
+	call := d.lastCall()
+	if call.method != "PUT" || call.path != "/api/env/apps/my-app/env" {
+		t.Errorf("call = %s %s; want PUT /api/env/apps/my-app/env", call.method, call.path)
+	}
+	raw, err := json.Marshal(call.body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if got := string(raw); got != `[{"envName":"API_URL","value":"https://x"}]` {
+		t.Errorf("body = %s; want only the named variable", got)
+	}
+}
+
+func TestRunAppEnvSetReportsAnUndeclaredName(t *testing.T) {
+	d := &fakeDoer{}
+	d.enqueueEnvelope([]baseEnv{{EnvName: "API_URL"}})
+
+	err := runAppEnvSetWithDoer(context.Background(), d, "my-app", map[string]string{"TYPO": "x"})
+	if err == nil {
+		t.Fatal("setting an undeclared variable reported success")
+	}
+	for _, sub := range []string{"TYPO", "does not declare"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not mention %q", err, sub)
+		}
+	}
+}

--- a/cli/cmd/ctl/settings/apps/fake_doer_test.go
+++ b/cli/cmd/ctl/settings/apps/fake_doer_test.go
@@ -16,8 +16,8 @@ import (
 //   - leave responses empty and let the doer return nil for every call
 //     (the body assertion path),
 //
-//   - queue typed responses with `enqueueRespond([]byte)` to drive
-//     reads back through bflEnvelope unwrapping, or
+//   - queue typed responses with `enqueueEnvelope` to drive reads back
+//     through envelope unwrapping, or
 //
 //   - set wantErr to fail the next call.
 type fakeDoer struct {

--- a/cli/cmd/ctl/settings/backup/common.go
+++ b/cli/cmd/ctl/settings/backup/common.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -88,41 +89,18 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-// bflEnvelope mirrors the {code, message, data} BFL backup-server
-// returns under /apis/backup/v1/... Some handlers use code 0 for
-// success and others (occasionally) code 200; we tolerate both, as
-// settings/network does.
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
+// The backup-server routes under /apis/backup/v1/... use code 0 for
+// success on some handlers and 200 on others; bflenvelope tolerates both.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {
@@ -172,4 +150,3 @@ func fmtUnix(sec int64) string {
 	}
 	return time.Unix(sec, 0).Format(time.RFC3339)
 }
-

--- a/cli/cmd/ctl/settings/compute/common.go
+++ b/cli/cmd/ctl/settings/compute/common.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -104,56 +105,16 @@ func requireComputeBackendVersion(ctx context.Context, f *cmdutil.Factory) error
 	})
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
-	var env bflEnvelope
-	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
-		return err
-	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
-		}
-		return fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("GET %s: decode data: %w", path, err)
-	}
-	return nil
+	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/gpu/common.go
+++ b/cli/cmd/ctl/settings/gpu/common.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -73,33 +74,12 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
-		}
-		return fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("GET %s: decode data: %w", path, err)
-	}
-	return nil
+	return bflenvelope.Data("GET", path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/integration/common.go
+++ b/cli/cmd/ctl/settings/integration/common.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -93,12 +94,6 @@ func prepareSettings(ctx context.Context, f *cmdutil.Factory) (*preparedClient, 
 	})
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
@@ -107,26 +102,11 @@ func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) er
 // account.controller.ts wraps every route in returnSucceed/returnError,
 // so reads and writes share the same {code, message, data} envelope.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/internal/userenv/userenv.go
+++ b/cli/cmd/ctl/settings/internal/userenv/userenv.go
@@ -1,0 +1,98 @@
+// Package userenv is the client for user-service's env vectors
+// (/api/env/systemenvs, /api/env/userenvs), shared by `settings advanced
+// env` and `settings appearance theme`.
+//
+// The PUT upserts exactly the entries in the body and leaves every other
+// one untouched (app-service's batchUpdateUserEnvs), so a write sends
+// only the variables it means to change. Sending the whole vector back
+// is not just redundant: the handler rejects the entire batch with a 400
+// if any entry in it is non-editable, so resending unrelated variables
+// turns an unrelated read-only entry into a failed write.
+package userenv
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
+)
+
+// The two vectors user-service exposes.
+const (
+	SystemEnvsPath = "/api/env/systemenvs"
+	UserEnvsPath   = "/api/env/userenvs"
+)
+
+// ThemeEnvName is the per-user theme preference. build/user-env.yaml
+// declares this UserEnv the single source of truth for the theme, read
+// and written by both the env settings page and BFL's config-system
+// endpoint.
+const ThemeEnvName = "OLARES_USER_THEME"
+
+type Doer interface {
+	DoJSON(ctx context.Context, method, path string, body, out interface{}) error
+}
+
+// Entry mirrors apps/.../constant/index.ts BaseEnv. Callers render a
+// subset in tables and marshal the whole struct for --output json, so
+// the optional fields stay omitempty to keep that output identical to
+// what the upstream sent.
+type Entry struct {
+	EnvName     string `json:"envName"`
+	Value       string `json:"value,omitempty"`
+	Default     string `json:"default,omitempty"`
+	Editable    *bool  `json:"editable,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Required    *bool  `json:"required,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Pair is one element of the PUT body — matches UpdateEnvItem in
+// constant/index.ts.
+type Pair struct {
+	EnvName string `json:"envName"`
+	Value   string `json:"value"`
+}
+
+// List reads the current vector at path.
+func List(ctx context.Context, d Doer, path string) ([]Entry, error) {
+	var entries []Entry
+	if err := doEnvelope(ctx, d, "GET", path, nil, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// SetValues writes the named variables. The upstream rejects the whole
+// batch when any entry in it is flagged editable: false, or when a
+// required entry would end up empty.
+func SetValues(ctx context.Context, d Doer, path string, updates map[string]string) error {
+	if len(updates) == 0 {
+		return fmt.Errorf("no environment variable updates supplied")
+	}
+	return doEnvelope(ctx, d, "PUT", path, Body(updates), nil)
+}
+
+// Body renders updates as the PUT payload, sorted by name so a
+// multi-variable write does not depend on Go's map iteration order.
+func Body(updates map[string]string) []Pair {
+	names := make([]string, 0, len(updates))
+	for name := range updates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]Pair, 0, len(names))
+	for _, name := range names {
+		out = append(out, Pair{EnvName: name, Value: updates[name]})
+	}
+	return out
+}
+
+func doEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
+	var env bflenvelope.Envelope
+	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
+		return err
+	}
+	return bflenvelope.Data(method, path, env, out)
+}

--- a/cli/cmd/ctl/settings/internal/userenv/userenv_test.go
+++ b/cli/cmd/ctl/settings/internal/userenv/userenv_test.go
@@ -1,0 +1,141 @@
+package userenv
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
+)
+
+func TestBodySortsByName(t *testing.T) {
+	got := Body(map[string]string{"ZED": "3", "ALPHA": "1", "MID": "2"})
+
+	wantOrder := []string{"ALPHA", "MID", "ZED"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("body has %d entries; want %d: %+v", len(got), len(wantOrder), got)
+	}
+	for i, name := range wantOrder {
+		if got[i].EnvName != name {
+			t.Errorf("entry %d = %q; want %q", i, got[i].EnvName, name)
+		}
+	}
+}
+
+// An empty value is a legitimate write (clearing a variable), so it must
+// survive into the body rather than being dropped as "unset".
+func TestBodyKeepsEmptyValues(t *testing.T) {
+	got := Body(map[string]string{"FOO": ""})
+	if len(got) != 1 || got[0].EnvName != "FOO" || got[0].Value != "" {
+		t.Errorf("body = %+v; want a single cleared FOO", got)
+	}
+}
+
+type recordedCall struct {
+	method string
+	path   string
+	body   interface{}
+}
+
+type fakeDoer struct {
+	list  []Entry
+	calls []recordedCall
+}
+
+func (d *fakeDoer) DoJSON(_ context.Context, method, path string, body, out interface{}) error {
+	d.calls = append(d.calls, recordedCall{method: method, path: path, body: body})
+	env, ok := out.(*bflenvelope.Envelope)
+	if !ok {
+		return nil
+	}
+	env.Code = 200
+	if method == "GET" {
+		data, err := json.Marshal(d.list)
+		if err != nil {
+			return err
+		}
+		env.Data = data
+	}
+	return nil
+}
+
+// The upstream upserts what it is given, and 400s the whole batch if any
+// entry in the body is non-editable. Sending the untouched variables back
+// would turn an unrelated read-only entry into a failed write, so the
+// write must be a single PUT carrying only the named variables.
+func TestSetValuesSendsOnlyTheNamedVariables(t *testing.T) {
+	d := &fakeDoer{list: []Entry{
+		{EnvName: "OLARES_USER_LANGUAGE", Value: "en-US"},
+		{EnvName: ThemeEnvName, Value: "light"},
+		{EnvName: "OLARES_USER_PASSWORD", Value: "secret"},
+	}}
+
+	if err := SetValues(context.Background(), d, UserEnvsPath, map[string]string{ThemeEnvName: "dark"}); err != nil {
+		t.Fatalf("SetValues errored: %v", err)
+	}
+
+	if len(d.calls) != 1 {
+		t.Fatalf("made %d calls; want a single PUT with no preceding read: %+v", len(d.calls), d.calls)
+	}
+	if d.calls[0].method != "PUT" || d.calls[0].path != UserEnvsPath {
+		t.Errorf("call = %s %s; want PUT %s", d.calls[0].method, d.calls[0].path, UserEnvsPath)
+	}
+
+	raw, err := json.Marshal(d.calls[0].body)
+	if err != nil {
+		t.Fatalf("marshal PUT body: %v", err)
+	}
+	want := `[{"envName":"OLARES_USER_THEME","value":"dark"}]`
+	if string(raw) != want {
+		t.Errorf("PUT body = %s; want %s", raw, want)
+	}
+}
+
+func TestSetValuesRefusesAnEmptyUpdateSet(t *testing.T) {
+	d := &fakeDoer{}
+	err := SetValues(context.Background(), d, UserEnvsPath, nil)
+	if err == nil || !strings.Contains(err.Error(), "no environment variable updates") {
+		t.Fatalf("SetValues(nil) = %v; want a refusal before any request", err)
+	}
+	if len(d.calls) != 0 {
+		t.Errorf("made %d calls; want none", len(d.calls))
+	}
+}
+
+func TestListDecodesTheVector(t *testing.T) {
+	d := &fakeDoer{list: []Entry{{EnvName: "A", Value: "1"}, {EnvName: "B", Value: "2"}}}
+	got, err := List(context.Background(), d, UserEnvsPath)
+	if err != nil {
+		t.Fatalf("List errored: %v", err)
+	}
+	if len(got) != 2 || got[0].EnvName != "A" || got[1].Value != "2" {
+		t.Errorf("List = %+v; want the upstream vector verbatim", got)
+	}
+}
+
+func TestListSurfacesAnUpstreamErrorCode(t *testing.T) {
+	d := &failingDoer{code: 500, message: "boom"}
+	_, err := List(context.Background(), d, UserEnvsPath)
+	if err == nil {
+		t.Fatal("List returned no error on upstream code 500")
+	}
+	for _, sub := range []string{"GET " + UserEnvsPath, "500", "boom"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err, sub)
+		}
+	}
+}
+
+type failingDoer struct {
+	code    int
+	message string
+}
+
+func (d *failingDoer) DoJSON(_ context.Context, _, _ string, _, out interface{}) error {
+	if env, ok := out.(*bflenvelope.Envelope); ok {
+		env.Code = d.code
+		env.Message = bflenvelope.Message{Text: d.message}
+	}
+	return nil
+}

--- a/cli/cmd/ctl/settings/me/common.go
+++ b/cli/cmd/ctl/settings/me/common.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -103,60 +104,26 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-// bflEnvelope is the universal user-service / BFL response wrapper. Every
-// /api/* and /bfl/backend/* endpoint we hit in `me` returns this shape:
-//
-//	{ "code": 0, "message": "ok", "data": <typed payload> }
-//
-// We unmarshal data lazily via json.RawMessage so each verb can decode
-// into its own typed struct without re-reading the response.
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 // doGetEnvelope sends a GET, validates the BFL envelope, and decodes
-// data into out. Verbs that only care about the unwrapped payload should
-// call this; verbs that need code/message visibility (none yet) can call
-// d.DoJSON directly with their own envelope type.
+// data into out.
 //
 // Errors fall into three buckets:
 //   - HTTP / network → wrapped by the underlying Doer (already
 //     CTA-formatted for 401/403).
-//   - Envelope code != 0 → wrapped here so the user sees the server's
-//     own message rather than a generic "decode failure".
-//   - JSON decode of data → wrapped here.
+//   - Envelope code outside 0/200 → wrapped by bflenvelope so the user
+//     sees the server's own message rather than a decode failure.
+//   - JSON decode of data → wrapped by bflenvelope.
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of doGetEnvelope.
-// user-service routes either return BFL `{code: 0}` (the most common
-// shape — returnSucceed wraps everything) or, for endpoints that proxy
-// through additional layers, `{code: 200}`. Both are treated as success
-// here.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			msg = fmt.Sprintf("server returned code=%d", env.Code)
-		}
-		return fmt.Errorf("%s %s: %s", method, path, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 // printJSON pretty-prints v to stdout — used by every `me` verb when the

--- a/cli/cmd/ctl/settings/network/common.go
+++ b/cli/cmd/ctl/settings/network/common.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -88,17 +89,8 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-// bflEnvelope mirrors what user-service forwards from BFL or wraps
-// itself via returnSucceed.
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 // doGetEnvelope GETs a path that returns a BFL-shaped envelope and
-// decodes the inner data into `out`. A code of 0 (or 200, which a
-// handful of olaresd-backed handlers use) is treated as success.
+// decodes the inner data into `out`.
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
@@ -106,28 +98,13 @@ func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) er
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of doGetEnvelope.
 // user-service routes return BFL `{code: 0}` (the most common shape —
 // returnSucceed wraps everything) or `{code: 200}` for a few
-// olaresd-proxied handlers. Both are treated as success here.
+// olaresd-proxied handlers; bflenvelope treats both as success.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/restore/common.go
+++ b/cli/cmd/ctl/settings/restore/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -78,37 +79,16 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
 
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 // readPasswordOnce returns the password either from --password (literal),

--- a/cli/cmd/ctl/settings/search/common.go
+++ b/cli/cmd/ctl/settings/search/common.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -73,12 +74,6 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) error {
 	return doMutateEnvelope(ctx, d, "GET", path, nil, out)
 }
@@ -86,28 +81,13 @@ func doGetEnvelope(ctx context.Context, d Doer, path string, out interface{}) er
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of doGetEnvelope.
 // search.controller.ts proxies all methods (`@All`) so the response
 // envelope is the same on writes as on reads — search3's own
-// {code, message, data} body, where code 0/200 mean success.
+// {code, message, data} body.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
-		}
-		return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func printJSON(w io.Writer, v interface{}) error {

--- a/cli/cmd/ctl/settings/video/common.go
+++ b/cli/cmd/ctl/settings/video/common.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -71,29 +72,17 @@ func prepare(ctx context.Context, f *cmdutil.Factory) (*preparedClient, error) {
 	}, nil
 }
 
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
-// doGetEnvelopeRaw decodes the inner data into a json.RawMessage so the
-// caller can either pretty-print it as-is or further process. The video
-// config struct is large and provider-versioned, so we deliberately
-// don't model it field-by-field at the CLI layer.
+// doGetEnvelopeRaw returns the inner data as a json.RawMessage so the
+// caller can either pretty-print it as-is or further process it. The
+// video config struct is large and provider-versioned, so it is not
+// modeled field-by-field at the CLI layer.
 func doGetEnvelopeRaw(ctx context.Context, d Doer, path string) (json.RawMessage, error) {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
 		return nil, err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			return nil, fmt.Errorf("GET %s: upstream returned code %d", path, env.Code)
-		}
-		return nil, fmt.Errorf("GET %s: upstream returned code %d: %s", path, env.Code, msg)
+	if err := bflenvelope.Data("GET", path, env, nil); err != nil {
+		return nil, err
 	}
 	return env.Data, nil
 }

--- a/cli/cmd/ctl/settings/vpn/acl.go
+++ b/cli/cmd/ctl/settings/vpn/acl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cliutil"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -229,7 +230,7 @@ type aclAllRow struct {
 // All three resolve to the same map[string][]AclInfo so callers and
 // tests can stay shape-agnostic.
 func getAllACLViaDoer(ctx context.Context, d Doer) (map[string][]AclInfo, error) {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, "GET", "/api/acl/all", nil, &env); err != nil {
 		return nil, err
 	}
@@ -420,7 +421,7 @@ func runACLGet(ctx context.Context, f *cmdutil.Factory, app, outputRaw string) e
 // envelope back.
 func getAppACLViaDoer(ctx context.Context, d Doer, app string) ([]AclInfo, error) {
 	path := "/api/acl/app/status?name=" + url.QueryEscape(app)
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, "GET", path, nil, &env); err != nil {
 		return nil, err
 	}

--- a/cli/cmd/ctl/settings/vpn/common.go
+++ b/cli/cmd/ctl/settings/vpn/common.go
@@ -2,35 +2,35 @@
 // Settings -> VPN page. Four flavors of endpoints ride here:
 //
 //  1. Headscale proxy at /headscale/...                  (raw upstream JSON;
-//                                                        no BFL envelope)
+//     no BFL envelope)
 //  2. public-domain-policy at /api/launcher-public-...   (the one path
-//                                                        user-service
-//                                                        actually unwraps
-//                                                        — body is the
-//                                                        inner data)
+//     user-service
+//     actually unwraps
+//     — body is the
+//     inner data)
 //  3. Subroutes / SSH toggles at /api/acl/{ssh,subroutes}
-//                                                        (BFL envelope on
-//                                                        the read; the
-//                                                        SPA only "sees"
-//                                                        the inner shape
-//                                                        because of its
-//                                                        global axios
-//                                                        response
-//                                                        interceptor.
-//                                                        CLI callers must
-//                                                        unwrap manually
-//                                                        — see ssh.go's
-//                                                        decodeSSHStatus.
-//                                                        POST returns an
-//                                                        opaque success
-//                                                        body we don't
-//                                                        consume.)
+//     (BFL envelope on
+//     the read; the
+//     SPA only "sees"
+//     the inner shape
+//     because of its
+//     global axios
+//     response
+//     interceptor.
+//     CLI callers must
+//     unwrap manually
+//     — see ssh.go's
+//     decodeSSHStatus.
+//     POST returns an
+//     opaque success
+//     body we don't
+//     consume.)
 //  4. Per-app ACL at /api/acl/app/status                 (BFL envelope on
-//                                                        both ends; GET
-//                                                        treats code!=0
-//                                                        as "no ACL
-//                                                        configured" not
-//                                                        a hard error)
+//     both ends; GET
+//     treats code!=0
+//     as "no ACL
+//     configured" not
+//     a hard error)
 //
 // common.go centralizes the per-area Doer + output plumbing in the same
 // shape as the other settings subpackages. We deliberately don't reach
@@ -49,6 +49,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/credential"
 	"github.com/beclab/Olares/cli/pkg/whoami"
@@ -115,46 +116,18 @@ func printJSON(w io.Writer, v interface{}) error {
 	return enc.Encode(v)
 }
 
-// bflEnvelope is the BFL response wrapper that comes back on the per-app
-// ACL endpoints. Most other vpn paths either hit Headscale directly (raw
-// JSON, no envelope) or a user-service route that already unwraps the
-// envelope before responding (public-domain-policy, ssh status). The
-// per-app ACL editor is the odd one out — both the GET and the POST
-// round-trip the envelope verbatim.
-type bflEnvelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data"`
-}
-
 // doMutateEnvelope is the POST/PUT/DELETE counterpart of plain DoJSON
-// for routes that surface a BFL envelope on the response. Treats
-// `code: 0` and `code: 200` as success; anything else surfaces the
-// upstream message verbatim. Used today only by the per-app ACL editor;
-// the existing ssh/subroutes/public-domain-policy writes pass nil out
-// because user-service unwraps the envelope server-side for those
-// paths.
+// for routes that surface a BFL envelope on the response. Most other vpn
+// paths either hit Headscale directly (raw JSON, no envelope) or a
+// user-service route that unwraps the envelope before responding
+// (public-domain-policy, ssh status), which is why the ssh / subroutes /
+// public-domain-policy writes pass a nil out.
 func doMutateEnvelope(ctx context.Context, d Doer, method, path string, body, out interface{}) error {
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := d.DoJSON(ctx, method, path, body, &env); err != nil {
 		return err
 	}
-	switch env.Code {
-	case 0, 200:
-	default:
-		msg := strings.TrimSpace(env.Message)
-		if msg == "" {
-			msg = fmt.Sprintf("server returned code=%d", env.Code)
-		}
-		return fmt.Errorf("%s %s: %s", method, path, msg)
-	}
-	if out == nil || len(env.Data) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(env.Data, out); err != nil {
-		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
-	}
-	return nil
+	return bflenvelope.Data(method, path, env, out)
 }
 
 func nonEmpty(s string) string {
@@ -184,4 +157,3 @@ func joinNonEmpty(ss []string, sep string) string {
 	}
 	return out
 }
-

--- a/cli/cmd/ctl/settings/vpn/ssh.go
+++ b/cli/cmd/ctl/settings/vpn/ssh.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
@@ -143,12 +144,12 @@ func decodeSSHStatus(raw json.RawMessage) (sshStatus, error) {
 	if len(trimmed) == 0 || string(trimmed) == "null" {
 		return out, nil
 	}
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := json.Unmarshal(trimmed, &env); err == nil && envelopeLooksWrapped(trimmed, env) {
 		switch env.Code {
 		case 0, 200:
 		default:
-			msg := strings.TrimSpace(env.Message)
+			msg := strings.TrimSpace(env.Message.Text)
 			if msg == "" {
 				msg = fmt.Sprintf("server returned code=%d", env.Code)
 			}
@@ -192,15 +193,15 @@ func decodeFlatSSHStatus(body []byte) (sshStatus, bool, error) {
 
 // envelopeLooksWrapped reports whether `body` matches the BFL envelope
 // shape `{code, message, data}` rather than the inner sshStatus shape
-// `{state, allow_ssh}`. Both targets json.Unmarshal cleanly into a
-// bflEnvelope (extra keys are ignored, missing keys default to zero),
+// `{state, allow_ssh}`. Both targets json.Unmarshal cleanly into an
+// envelope (extra keys are ignored, missing keys default to zero),
 // so we look at the body itself: the envelope always carries a
 // top-level `code` key (response.Success / response.HandleError both
 // emit it unconditionally), while the inner shape never does. Treat
 // the presence of either `code` or `data` as proof of an envelope so
 // we still surface non-success codes on error responses where the
 // upstream omits `data`.
-func envelopeLooksWrapped(body []byte, env bflEnvelope) bool {
+func envelopeLooksWrapped(body []byte, env bflenvelope.Envelope) bool {
 	if len(env.Data) > 0 {
 		return true
 	}

--- a/cli/cmd/ctl/settings/vpn/ssh_test.go
+++ b/cli/cmd/ctl/settings/vpn/ssh_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 )
 
 func TestDecodeSSHStatus(t *testing.T) {
@@ -136,7 +138,7 @@ func TestEnvelopeLooksWrapped(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var env bflEnvelope
+			var env bflenvelope.Envelope
 			_ = json.Unmarshal([]byte(c.body), &env)
 			got := envelopeLooksWrapped([]byte(c.body), env)
 			if got != c.want {

--- a/cli/cmd/ctl/settings/vpn/subroutes.go
+++ b/cli/cmd/ctl/settings/vpn/subroutes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/beclab/Olares/cli/cmd/ctl/settings/internal/preflight"
+	"github.com/beclab/Olares/cli/pkg/bflenvelope"
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 	"github.com/beclab/Olares/cli/pkg/whoami"
 )
@@ -144,12 +145,12 @@ func decodeSubroutesStatus(raw json.RawMessage) ([]string, error) {
 	if len(trimmed) == 0 || string(trimmed) == "null" {
 		return nil, nil
 	}
-	var env bflEnvelope
+	var env bflenvelope.Envelope
 	if err := json.Unmarshal(trimmed, &env); err == nil && envelopeLooksWrapped(trimmed, env) {
 		switch env.Code {
 		case 0, 200:
 		default:
-			msg := strings.TrimSpace(env.Message)
+			msg := strings.TrimSpace(env.Message.Text)
 			if msg == "" {
 				msg = fmt.Sprintf("server returned code=%d", env.Code)
 			}

--- a/cli/cmd/ctl/skills_commands_test.go
+++ b/cli/cmd/ctl/skills_commands_test.go
@@ -88,7 +88,6 @@ func skillCommandPaths() []string {
 		"settings appearance",
 		"settings appearance get",
 		"settings appearance language set",
-		"settings appearance theme set",
 		"settings appearance widget set",
 		"settings appearance wallpaper list",
 		"settings appearance wallpaper set",
@@ -269,8 +268,8 @@ func TestEveryAppearanceVerbIsListed(t *testing.T) {
 
 	// Guard against the walk silently finding nothing, which would make
 	// the check above vacuous.
-	if found < 10 {
-		t.Fatalf("walked only %d runnable appearance verbs; the subtree has at least 10", found)
+	if found < 9 {
+		t.Fatalf("walked only %d runnable appearance verbs; the subtree has at least 9", found)
 	}
 }
 

--- a/cli/cmd/ctl/skills_commands_test.go
+++ b/cli/cmd/ctl/skills_commands_test.go
@@ -5,10 +5,14 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
-func TestSkillCommandPathsExist(t *testing.T) {
-	paths := []string{
+// skillCommandPaths is every command path the skill docs spell out, so
+// renaming or removing one fails here rather than in a user's session.
+func skillCommandPaths() []string {
+	return []string{
 		"profile",
 		"profile login",
 		"profile import",
@@ -82,6 +86,16 @@ func TestSkillCommandPathsExist(t *testing.T) {
 		"settings backup",
 		"settings integration",
 		"settings appearance",
+		"settings appearance get",
+		"settings appearance language set",
+		"settings appearance theme set",
+		"settings appearance widget set",
+		"settings appearance wallpaper list",
+		"settings appearance wallpaper set",
+		"settings appearance wallpaper style set",
+		"settings appearance wallpaper upload",
+		"settings appearance wallpaper delete",
+		"settings appearance layout reset",
 		"settings network",
 		"settings gpu",
 		"settings compute",
@@ -201,9 +215,11 @@ func TestSkillCommandPathsExist(t *testing.T) {
 		"router audit list",
 		"router audit get",
 	}
+}
 
+func TestSkillCommandPathsExist(t *testing.T) {
 	root := NewDefaultCommand()
-	for _, path := range paths {
+	for _, path := range skillCommandPaths() {
 		t.Run(path, func(t *testing.T) {
 			cmd, args, err := root.Find(strings.Fields(path))
 			if err != nil {
@@ -216,6 +232,45 @@ func TestSkillCommandPathsExist(t *testing.T) {
 				t.Fatalf("resolved %q to %q", path, got)
 			}
 		})
+	}
+}
+
+// TestSkillCommandPathsExist only proves the listed paths resolve, so a
+// newly added verb can ship unlisted. This is the reverse check for the
+// area under active change: every runnable verb under `settings
+// appearance` must be listed above, and therefore documented.
+func TestEveryAppearanceVerbIsListed(t *testing.T) {
+	listed := map[string]bool{}
+	for _, path := range skillCommandPaths() {
+		listed[path] = true
+	}
+
+	root := NewDefaultCommand()
+	appearance, _, err := root.Find(strings.Fields("settings appearance"))
+	if err != nil {
+		t.Fatalf("find settings appearance: %v", err)
+	}
+
+	var found int
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		if cmd.Runnable() {
+			found++
+			path := strings.TrimPrefix(cmd.CommandPath(), "olares-cli ")
+			if !listed[path] {
+				t.Errorf("verb %q is not in skillCommandPaths; add it there and document it in the skill reference", path)
+			}
+		}
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(appearance)
+
+	// Guard against the walk silently finding nothing, which would make
+	// the check above vacuous.
+	if found < 10 {
+		t.Fatalf("walked only %d runnable appearance verbs; the subtree has at least 10", found)
 	}
 }
 

--- a/cli/pkg/bflenvelope/bflenvelope.go
+++ b/cli/pkg/bflenvelope/bflenvelope.go
@@ -1,0 +1,89 @@
+// Package bflenvelope decodes the response envelope every `olares-cli
+// settings` route replies with: {code, message, data}.
+//
+// It exists because `message` is not always a string. user-service
+// re-wraps an upstream failure verbatim, so an app-service 400 arrives
+// nested inside a 500:
+//
+//	{"code":500,"message":{"code":400,"message":"value not in options"},"data":null}
+//
+// Decoding that field as a string fails the whole unmarshal, and the
+// caller gets a Go type error instead of the reason the write was
+// rejected.
+package bflenvelope
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Envelope is the outer response shape. Data stays raw so callers decode
+// only the payload they expect.
+type Envelope struct {
+	Code    int             `json:"code"`
+	Message Message         `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// Message is an error text that may arrive as a string or as a nested
+// envelope. Unmarshalling never fails: an unrecognized shape is kept as
+// its raw JSON, which is more useful to a reader than a decode error.
+type Message struct {
+	Text string
+}
+
+func (m *Message) UnmarshalJSON(raw []byte) error {
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		m.Text = text
+		return nil
+	}
+	var nested struct {
+		Message json.RawMessage `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &nested); err == nil && len(nested.Message) > 0 {
+		var inner Message
+		if inner.UnmarshalJSON(nested.Message) == nil && inner.Text != "" {
+			m.Text = inner.Text
+			return nil
+		}
+	}
+	m.Text = strings.TrimSpace(string(raw))
+	return nil
+}
+
+// Data applies the envelope contract: a code outside {0, 200} is an
+// error, otherwise the payload is decoded into out. Pass a nil out for
+// calls with no useful response body.
+//
+// softCodes are extra codes to accept, for routes where a non-success
+// code is still informative rather than fatal (e.g. search's "no more
+// results").
+func Data(method, path string, env Envelope, out interface{}, softCodes ...int) error {
+	if !accepts(env.Code, softCodes) {
+		if msg := strings.TrimSpace(env.Message.Text); msg != "" {
+			return fmt.Errorf("%s %s: upstream returned code %d: %s", method, path, env.Code, msg)
+		}
+		return fmt.Errorf("%s %s: upstream returned code %d", method, path, env.Code)
+	}
+	if out == nil || len(env.Data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Data, out); err != nil {
+		return fmt.Errorf("%s %s: decode data: %w", method, path, err)
+	}
+	return nil
+}
+
+func accepts(code int, softCodes []int) bool {
+	if code == 0 || code == 200 {
+		return true
+	}
+	for _, soft := range softCodes {
+		if code == soft {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/bflenvelope/bflenvelope_test.go
+++ b/cli/pkg/bflenvelope/bflenvelope_test.go
@@ -1,0 +1,107 @@
+package bflenvelope
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDecodeMessageShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "plain_string",
+			body: `{"code":400,"message":"bad request","data":null}`,
+			want: "bad request",
+		},
+		{
+			// user-service re-wraps an app-service failure verbatim, so
+			// the real reason arrives nested inside an outer 500.
+			name: "nested_envelope",
+			body: `{"code":500,"message":{"code":400,"message":"value not in options"},"data":null}`,
+			want: "value not in options",
+		},
+		{
+			name: "doubly_nested",
+			body: `{"code":500,"message":{"code":500,"message":{"code":400,"message":"deep"}},"data":null}`,
+			want: "deep",
+		},
+		{
+			name: "empty_string",
+			body: `{"code":400,"message":"","data":null}`,
+			want: "",
+		},
+		{
+			// An unrecognized shape is kept verbatim: a reader can act on
+			// the raw JSON, but not on a decode error.
+			name: "unexpected_shape_kept_raw",
+			body: `{"code":400,"message":[1,2],"data":null}`,
+			want: "[1,2]",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var env Envelope
+			if err := json.Unmarshal([]byte(tc.body), &env); err != nil {
+				t.Fatalf("unmarshal must not fail on any message shape: %v", err)
+			}
+			if env.Message.Text != tc.want {
+				t.Errorf("message = %q; want %q", env.Message.Text, tc.want)
+			}
+		})
+	}
+}
+
+func TestDataSurfacesTheNestedReason(t *testing.T) {
+	var env Envelope
+	body := `{"code":500,"message":{"code":400,"message":"value not in options"},"data":null}`
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := Data("PUT", "/api/env/userenvs", env, nil)
+	if err == nil {
+		t.Fatal("Data returned nil on a non-2xx envelope code")
+	}
+	for _, sub := range []string{"PUT /api/env/userenvs", "500", "value not in options"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err, sub)
+		}
+	}
+}
+
+func TestDataAcceptsBothSuccessCodes(t *testing.T) {
+	for _, code := range []int{0, 200} {
+		var out struct {
+			Name string `json:"name"`
+		}
+		env := Envelope{Code: code, Data: json.RawMessage(`{"name":"ok"}`)}
+		if err := Data("GET", "/api/thing", env, &out); err != nil {
+			t.Fatalf("code %d treated as failure: %v", code, err)
+		}
+		if out.Name != "ok" {
+			t.Errorf("code %d: payload = %q; want %q", code, out.Name, "ok")
+		}
+	}
+}
+
+func TestDataIgnoresPayloadWhenCallerWantsNone(t *testing.T) {
+	env := Envelope{Code: 200, Data: json.RawMessage(`{"anything":true}`)}
+	if err := Data("POST", "/api/thing", env, nil); err != nil {
+		t.Errorf("Data with a nil out errored: %v", err)
+	}
+}
+
+func TestDataReportsAnUndecodablePayload(t *testing.T) {
+	var out struct {
+		N int `json:"n"`
+	}
+	env := Envelope{Code: 200, Data: json.RawMessage(`{"n":"not-a-number"}`)}
+	err := Data("GET", "/api/thing", env, &out)
+	if err == nil || !strings.Contains(err.Error(), "decode data") {
+		t.Errorf("error = %v; want it to name the payload decode failure", err)
+	}
+}

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -34,7 +34,7 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 | `vpn` | devices, hidden `routes enable/disable`, SSH, subroutes (hidden enable/disable), ACL, public-domain-policy | [VPN and ACL decisions](references/olares-settings-vpn.md) |
 | `integration` | account list/get/add/delete, `cookie import/list/rm/validate` | [integration accounts](references/olares-settings-integration.md); [cookie store](references/olares-settings-cookies.md) |
 | `backup` | plans, snapshots, password | [backup decisions](references/olares-settings-backup.md) |
-| `appearance` | `get` (whole page), `language set`, `theme set`, `widget set`, `wallpaper set/style/upload/delete`, `layout reset` | [appearance, theme and wallpaper](references/olares-settings-appearance.md) |
+| `appearance` | `get` (whole page), `language set`, `widget set`, `wallpaper list/set/style/upload/delete`, `layout reset` | [appearance and wallpaper](references/olares-settings-appearance.md) |
 | `network` | reverse-proxy, FRP, hosts-file, overlay gateway/app | `settings network --help` |
 | `gpu` / `compute` | legacy GPU list / accelerator list, unbind, set-type | `settings gpu --help`; `settings compute --help` |
 | `video` | `config get` | `settings video --help` |
@@ -63,5 +63,5 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 - Confirm destructive or wider consequences separately: user deletion, ACL replacement, accelerator unbind/type changes, app restart/stop, index rebuild, and gateway-wide overlay changes.
 - Treat app lifecycle requests as [`olares-market`](../olares-market/SKILL.md), not settings configuration.
 - A download or collection that fails for a missing login is a cookie import here (`settings integration cookie`), not an [`olares-knowledge`](../olares-knowledge/SKILL.md) problem — see [cookie store](references/olares-settings-cookies.md).
-- A theme set through `settings appearance theme set` does not repaint a browser desktop that is already open: that state is a cookie the SPA never sends upstream. Report it rather than retrying or hunting for another verb.
+- There is no theme verb: a desktop's light/dark state is a cookie the SPA never sends upstream, so no CLI can change it. Report that rather than hunting for a verb or writing `OLARES_USER_THEME`, which nothing reads.
 - Stop when the requested verb is not registered, the role is insufficient, the target user/app/device is ambiguous, or the action requires a JWS/device interaction the CLI cannot perform.

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -34,7 +34,7 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 | `vpn` | devices, hidden `routes enable/disable`, SSH, subroutes (hidden enable/disable), ACL, public-domain-policy | [VPN and ACL decisions](references/olares-settings-vpn.md) |
 | `integration` | account list/get/add/delete, `cookie import/list/rm/validate` | [integration accounts](references/olares-settings-integration.md); [cookie store](references/olares-settings-cookies.md) |
 | `backup` | plans, snapshots, password | [backup decisions](references/olares-settings-backup.md) |
-| `appearance` | `get`, `language set` | `settings appearance --help` |
+| `appearance` | `get` (whole page), `language set`, `theme set`, `widget set`, `wallpaper set/style/upload/delete`, `layout reset` | [appearance, theme and wallpaper](references/olares-settings-appearance.md) |
 | `network` | reverse-proxy, FRP, hosts-file, overlay gateway/app | `settings network --help` |
 | `gpu` / `compute` | legacy GPU list / accelerator list, unbind, set-type | `settings gpu --help`; `settings compute --help` |
 | `video` | `config get` | `settings video --help` |
@@ -63,4 +63,5 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 - Confirm destructive or wider consequences separately: user deletion, ACL replacement, accelerator unbind/type changes, app restart/stop, index rebuild, and gateway-wide overlay changes.
 - Treat app lifecycle requests as [`olares-market`](../olares-market/SKILL.md), not settings configuration.
 - A download or collection that fails for a missing login is a cookie import here (`settings integration cookie`), not an [`olares-knowledge`](../olares-knowledge/SKILL.md) problem — see [cookie store](references/olares-settings-cookies.md).
+- A theme set through `settings appearance theme set` does not repaint a browser desktop that is already open: that state is a cookie the SPA never sends upstream. Report it rather than retrying or hunting for another verb.
 - Stop when the requested verb is not registered, the role is insufficient, the target user/app/device is ambiguous, or the action requires a JWS/device interaction the CLI cannot perform.

--- a/cli/skills/olares-settings/references/olares-settings-appearance.md
+++ b/cli/skills/olares-settings/references/olares-settings-appearance.md
@@ -3,7 +3,9 @@
 > **Prerequisite:** Read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
 > **Flags & examples:** `olares-cli settings appearance --help` and `olares-cli settings appearance <noun> <verb> --help`.
 
-Mirror the Settings → Appearance page: locale, theme, desktop widget preferences, wallpaper, and the desktop layout reset. Every verb is per-user; none of them require admin or owner.
+Mirror the Settings → Appearance page: locale, desktop widget preferences, wallpaper, and the desktop layout reset. Every verb is per-user; none of them require admin or owner.
+
+**There is no theme verb.** A desktop's light/dark state is a browser cookie the SPA never sends upstream, so no CLI can change it. Say that plainly instead of reaching for `settings advanced env user set --var OLARES_USER_THEME=...`, which writes a variable no Olares interface reads.
 
 ## Sub-tree
 
@@ -11,7 +13,6 @@ Mirror the Settings → Appearance page: locale, theme, desktop widget preferenc
 |---|---|---|---|---|
 | `get` | normal | any | VERIFIED | Read the whole page: locale + widget + wallpaper |
 | `language set <locale>` | normal | any | VERIFIED | Set the system language |
-| `theme set <light\|dark>` | normal | >= 1.12.6 | VERIFIED | Set the theme preference |
 | `widget set [flags]` | normal | >= 1.12.6 | VERIFIED | Set desktop widget preferences |
 | `wallpaper list <surface>` | normal | any | VERIFIED | Show the built-in range and uploaded images |
 | `wallpaper set <surface> <number\|url>` | normal | any | VERIFIED | Select a wallpaper |
@@ -24,9 +25,9 @@ Mirror the Settings → Appearance page: locale, theme, desktop widget preferenc
 
 ## Version gate (Olares >= 1.12.6)
 
-Three verbs need Olares 1.12.6+, where their upstream arrived: `theme set` (the `OLARES_USER_THEME` user env), `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). `get`, `language set` and every `wallpaper` verb work on any supported backend.
+Two verbs need Olares 1.12.6+, where their upstream arrived: `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). `get`, `language set` and every `wallpaper` verb work on any supported backend.
 
-On an older backend the three fail up front with the shared message naming the verb and the detected version (see [Common errors](#common-errors)); nothing is sent. `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
+On an older backend the two fail up front with the shared message naming the verb and the detected version (see [Common errors](#common-errors)); nothing is sent. `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
 
 `get` is the one verb that degrades instead of failing: below 1.12.6 it reads locale and wallpaper — which exist everywhere — and renders the widget section as `requires Olares >= 1.12.6`. With `-o json` that section is `null`, the key still present so a caller can tell a gated section from one this CLI does not know about. On 1.12.5 the locale section also returns an empty `timezone`, which renders as `-`.
 
@@ -45,7 +46,7 @@ A section that fails for any other reason — auth, 500, a malformed body — fa
 
 ```json
 {
-  "locale":    { "language": "en-US", "location": "", "timezone": "UTC", "theme": "light" },
+  "locale":    { "language": "en-US", "location": "", "timezone": "UTC" },
   "widget":    { "showWeight": true, "is24HourFormat": true, "dateFormat": "YYYY/MM/DD", "showDashboard": true },
   "wallpaper": { "desktop": "/bg/0.jpg", "desktopStyle": "fill", "login": "/bg/0.jpg", "loginStyle": "fill",
                  "upload_desktop_backgrounds": [], "upload_login_backgrounds": [] }
@@ -55,18 +56,6 @@ A section that fails for any other reason — auth, 500, a malformed body — fa
 Read the language from `.locale.language`, not `.language`. `showWeight` is the upstream name of the widget master switch despite what it reads like.
 
 **JSON carries the stored values; the table renames them for the reader** — `"desktop": "/bg/3.jpg"` prints as `built-in 3` and `"desktopStyle": "cover"` as `Stretch`, matching how `wallpaper set` and Settings name them. Script against `-o json`.
-
-## `theme set` writes a different place than the SPA toggle
-
-```bash
-olares-cli settings appearance theme set dark
-```
-
-The theme lives in the `OLARES_USER_THEME` user env, which the platform declares the source of truth: apps receive it and the login flow honors it. This verb writes it through `/api/env/userenvs`, so `settings advanced env user list` shows the same value. The variable itself arrived in 1.12.6 — see the [version gate](#version-gate-olares--1126).
-
-**An Olares desktop already open in a browser will not change appearance.** The SPA's own light/dark toggle only sets a local cookie and never calls the backend, so the two are not connected. Tell the user this rather than letting them conclude the command did nothing.
-
-Only `light` and `dark` are accepted, and **there is no bypass**: app-service validates the value against the same declaration and answers `value not in options`. Going around the CLI with `settings advanced env user set --var OLARES_USER_THEME=auto` is rejected too (verified). A value a newer release adds needs a newer CLI.
 
 ## `widget set` changes only the flags you pass
 
@@ -125,9 +114,9 @@ Drops the launchpad ordering, folders and dock arrangement for the current user 
 
 ## Agent best practices
 
-- **For "switch to dark mode"** → `theme set dark`, then state that an open browser desktop keeps its cookie-driven appearance. Do not retry or look for another verb when the browser does not change.
+- **For "switch to dark mode"** → report that it can only be changed in Settings → Appearance in the browser, because the value is a local cookie. Do not hunt for a verb or write the user env instead.
 - **For "change my wallpaper"** → ask which surface, since `desktop` and `login` are separate settings and users rarely mean both, then run `wallpaper list <surface>` rather than guessing a number. Refer to built-ins by number, never as `/login/<n>.jpg`.
-- **Confirm separately for `layout reset` and `wallpaper delete`.** Both are irreversible for the user's arrangement or gallery, and neither is implied by a request to change the wallpaper or theme.
+- **Confirm separately for `layout reset` and `wallpaper delete`.** Both are irreversible for the user's arrangement or gallery, and neither is implied by a request to change the wallpaper.
 - **Do not use this subtree for per-app icons or entrance titles** — those are [post-install app configuration](olares-settings-apps.md).
 
 ## Common errors
@@ -138,11 +127,10 @@ Drops the launchpad ordering, folders and dock arrangement for the current user 
 | `<surface> has no built-in wallpaper <n>` | Number past this surface's range | Run `wallpaper list <surface>`; desktop stops at 27, login at 28 |
 | `"..." is not a <surface> wallpaper` | Neither a number, an `http(s)://` URL, nor a `/bg/<n>.jpg` value — e.g. a `/login/<n>.jpg` path | Pass a number from `wallpaper list <surface>`; `--force` only for a value a newer release adds |
 | `unsupported fill mode "..."` | Mode outside `Fill` / `Stretch` / `Tile` | Use one of the three, as spelled in Settings |
-| `unsupported theme "..."` | Value outside `light` / `dark` | Use one of the two; the backend rejects anything else as well |
 | `unsupported --date-format "..."` | Format not in the SPA's list | Pick from the list above |
 | `widget set requires at least one of ...` | Called with no flags | Name the preference to change |
 | `read locale: ...` / `read wallpaper: ...` | One section of `get` failed | Retry, then check `settings advanced status` |
-| `requires Olares >= 1.12.6 ...` on `theme set` / `widget set` / `layout reset` | Backend predates the verb's upstream | Upgrade Olares; nothing was sent, and no layout was reset |
+| `requires Olares >= 1.12.6 ...` on `widget set` / `layout reset` | Backend predates the verb's upstream | Upgrade Olares; nothing was sent, and no layout was reset |
 | `requires Olares >= 1.12.6 ..., but the backend version could not be determined` | Version undetectable | Log in, then `olares-cli profile list --refresh-version` |
 | `upload succeeded but the image service returned no imageUrl` | Image service accepted the file but returned an unexpected body | Retry; if it persists the image service is misconfigured |
 | `stdin is not a terminal — pass --yes to confirm` | Destructive verb in a script | Pass `--yes` after confirming with the user |

--- a/cli/skills/olares-settings/references/olares-settings-appearance.md
+++ b/cli/skills/olares-settings/references/olares-settings-appearance.md
@@ -104,7 +104,7 @@ When an uploaded image is active, the built-in line drops `currently` and that U
 
 Ranges (mirroring the SPA's `picturesCount`, the only place they exist): desktop `0-27`, login `0-28` — `28` is valid for login and invalid for desktop. `set` also takes an uploaded `https://` URL, and the stored `/bg/<n>.jpg` spelling so a value read from `get -o json` can be fed back in.
 
-The value is stored verbatim and **not validated upstream** — a bad one is accepted and leaves a broken background with no error. The CLI therefore validates first; `--force` stores the value as given, for one a newer release adds. Uploaded URLs are judged by shape, not looked up, so `set` stays a single request.
+The value is stored verbatim and **not validated upstream** — a bad one is accepted and leaves a broken background with no error. The CLI therefore validates first; `--force` drops the range check for a built-in a newer release adds, still storing a number as `/bg/<n>.jpg`. Uploaded URLs are judged by shape, not looked up, so `set` stays a single request.
 
 **Never offer `/login/<n>.jpg`.** Both surfaces store `/bg/<n>.jpg`: the greeter resolves the stored value under its own asset root (`LoginPage.vue` renders `"auth/" + value`), and the Settings page swaps the prefix to `/login/` only to preview the login variant. A stored `/login/<n>.jpg` resolves nowhere.
 

--- a/cli/skills/olares-settings/references/olares-settings-appearance.md
+++ b/cli/skills/olares-settings/references/olares-settings-appearance.md
@@ -5,8 +5,6 @@
 
 Mirror the Settings → Appearance page: locale, theme, desktop widget preferences, wallpaper, and the desktop layout reset. Every verb is per-user; none of them require admin or owner.
 
-Every verb below is VERIFIED against a live 1.12.7 and a live 1.12.5 backend.
-
 ## Sub-tree
 
 | Verb | Floor | Needs | Status | Purpose |
@@ -28,23 +26,9 @@ Every verb below is VERIFIED against a live 1.12.7 and a live 1.12.5 backend.
 
 Three verbs need Olares 1.12.6+, where their upstream arrived: `theme set` (the `OLARES_USER_THEME` user env), `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). `get`, `language set` and every `wallpaper` verb work on any supported backend.
 
-On an older backend the three fail up front with the shared message, naming the verb and the detected version:
+On an older backend the three fail up front with the shared message naming the verb and the detected version (see [Common errors](#common-errors)); nothing is sent. `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
 
-```
-`settings appearance theme set` requires Olares >= 1.12.6 (the OLARES_USER_THEME user env),
-but this backend is 1.12.5; upgrade the Olares system to >= 1.12.6
-```
-
-Nothing is sent when the gate trips, and `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
-
-`get` is the one verb that degrades instead of failing: below 1.12.6 it reads locale and wallpaper and reports the widget section as gated, since those two exist everywhere.
-
-```
-Widget
-  requires Olares >= 1.12.6
-```
-
-With `-o json` that section is `null` — the key stays present so a caller can tell a gated section from one this CLI does not know about. On 1.12.5 the locale section also returns an empty `timezone`, which renders as `-`.
+`get` is the one verb that degrades instead of failing: below 1.12.6 it reads locale and wallpaper — which exist everywhere — and renders the widget section as `requires Olares >= 1.12.6`. With `-o json` that section is `null`, the key still present so a caller can tell a gated section from one this CLI does not know about. On 1.12.5 the locale section also returns an empty `timezone`, which renders as `-`.
 
 ## `get` is the only read verb
 
@@ -70,13 +54,12 @@ A section that fails for any other reason — auth, 500, a malformed body — fa
 
 Read the language from `.locale.language`, not `.language`. `showWeight` is the upstream name of the widget master switch despite what it reads like.
 
-**JSON carries the stored values; the table renames them for the reader.** `"desktop": "/bg/3.jpg"` prints as `built-in 3` and `"desktopStyle": "cover"` as `Stretch`, matching how `wallpaper set` and Settings name them. Script against `-o json`.
+**JSON carries the stored values; the table renames them for the reader** — `"desktop": "/bg/3.jpg"` prints as `built-in 3` and `"desktopStyle": "cover"` as `Stretch`, matching how `wallpaper set` and Settings name them. Script against `-o json`.
 
 ## `theme set` writes a different place than the SPA toggle
 
 ```bash
 olares-cli settings appearance theme set dark
-olares-cli settings appearance theme set light
 ```
 
 The theme lives in the `OLARES_USER_THEME` user env, which the platform declares the source of truth: apps receive it and the login flow honors it. This verb writes it through `/api/env/userenvs`, so `settings advanced env user list` shows the same value. The variable itself arrived in 1.12.6 — see the [version gate](#version-gate-olares--1126).
@@ -102,13 +85,12 @@ The upstream POST replaces the whole preferences object, so the CLI reads the cu
 ```bash
 olares-cli settings appearance wallpaper list desktop
 olares-cli settings appearance wallpaper set desktop 3
-olares-cli settings appearance wallpaper set login 5
 olares-cli settings appearance wallpaper style set desktop Stretch
 olares-cli settings appearance wallpaper upload desktop --file ./bg.jpg
 olares-cli settings appearance wallpaper delete desktop https://files.example/bg.jpg --yes
 ```
 
-**A built-in is selected by number**, as in the Settings grid — that grid is unnamed thumbnails, so a number is the only handle either side has. `wallpaper list <surface>` shows the range and which one is active; the surfaces ship a different number of images, so it needs the surface.
+**A built-in is selected by number**, as in the Settings grid — that grid is unnamed thumbnails, so a number is the only handle either side has. `wallpaper list <surface>` prints the range and the active value; it needs the surface because the two ship a different number of images.
 
 ```
 Built-in desktop wallpapers
@@ -116,15 +98,11 @@ Built-in desktop wallpapers
 
 Uploaded desktop wallpapers
   none
-
-Select one with `settings appearance wallpaper set desktop <number|url>`.
 ```
 
-When the active wallpaper is an uploaded image, the built-in line drops the `currently` note and the uploaded URL is marked `*` instead, so no built-in is ever reported as active when it is not.
+When an uploaded image is active, the built-in line drops `currently` and that URL is marked `*` instead, so no built-in is ever reported as active when it is not.
 
-Ranges (mirroring the SPA's `picturesCount`, which is the only place they exist): desktop `0-27`, login `0-28`. `28` is valid for login and invalid for desktop.
-
-`set` also takes an uploaded `https://` URL, and the stored `/bg/<n>.jpg` spelling so a value read from `get -o json` can be fed back in.
+Ranges (mirroring the SPA's `picturesCount`, the only place they exist): desktop `0-27`, login `0-28` — `28` is valid for login and invalid for desktop. `set` also takes an uploaded `https://` URL, and the stored `/bg/<n>.jpg` spelling so a value read from `get -o json` can be fed back in.
 
 The value is stored verbatim and **not validated upstream** — a bad one is accepted and leaves a broken background with no error. The CLI therefore validates first; `--force` stores the value as given, for one a newer release adds. Uploaded URLs are judged by shape, not looked up, so `set` stays a single request.
 
@@ -132,7 +110,7 @@ The value is stored verbatim and **not validated upstream** — a bad one is acc
 
 Fill modes are named as Settings names them: `Fill`, `Stretch`, `Tile` (case-insensitive). The stored values `fill`, `cover`, `repeat` are accepted too, and `get` prints the label.
 
-`upload` is three calls: it posts the image, registers the returned URL in the surface's gallery, then selects it. `--no-set` stops after registering. **The upload goes to `<SettingsURL>/images/upload/v1`, not the desktop ingress** — `/images` is only proxied on the settings host, so an error mentioning that origin is expected rather than a misrouted request. Login uploads are sent with a public access policy because the greeter fetches them before anyone is signed in. Accepted types: png, jpeg, jpg, gif.
+`upload` posts the image, registers the returned URL in the surface's gallery, then selects it; `--no-set` stops after registering. **The upload goes to `<SettingsURL>/images/upload/v1`, not the desktop ingress** — `/images` is only proxied on the settings host, so an error naming that origin is expected rather than a misrouted request. Login uploads carry a public access policy because the greeter fetches them before anyone is signed in. Accepted types: png, jpeg, jpg, gif.
 
 `delete` takes an uploaded URL, prompts for confirmation, and if the image being removed is the active wallpaper the upstream falls back to a built-in default. **It only removes the image from the gallery — the file stays in the user's Drive** (`Home/Pictures/Upload`), same as the SPA's delete button. Do not tell the user it freed disk space; removing the file is a separate `files rm`.
 
@@ -143,15 +121,12 @@ olares-cli settings appearance layout reset
 olares-cli settings appearance layout reset --yes
 ```
 
-Drops the launchpad ordering, folders and dock arrangement for the current user and broadcasts the change to open sessions. **There is no undo.** The output names the surfaces the upstream reset — observed to be `launchpad, dock` every time, including on a layout that was already default, so it is not a signal that anything had been customized.
-
-Needs Olares >= 1.12.6, checked before the prompt — see the [version gate](#version-gate-olares--1126).
+Drops the launchpad ordering, folders and dock arrangement for the current user and broadcasts the change to open sessions. **There is no undo.** Needs Olares >= 1.12.6, checked before the prompt. The output names the surfaces the upstream reset — observed to be `launchpad, dock` every time, including on a layout that was already default, so it is not a signal that anything had been customized.
 
 ## Agent best practices
 
 - **For "switch to dark mode"** → `theme set dark`, then state that an open browser desktop keeps its cookie-driven appearance. Do not retry or look for another verb when the browser does not change.
-- **For "change my wallpaper"** → ask which surface. `desktop` and `login` are separate settings and users rarely mean both.
-- **Run `wallpaper list <surface>` before `wallpaper set`** rather than guessing a number, since the two surfaces have different ranges. Refer to built-ins by number, never as `/login/<n>.jpg`.
+- **For "change my wallpaper"** → ask which surface, since `desktop` and `login` are separate settings and users rarely mean both, then run `wallpaper list <surface>` rather than guessing a number. Refer to built-ins by number, never as `/login/<n>.jpg`.
 - **Confirm separately for `layout reset` and `wallpaper delete`.** Both are irreversible for the user's arrangement or gallery, and neither is implied by a request to change the wallpaper or theme.
 - **Do not use this subtree for per-app icons or entrance titles** — those are [post-install app configuration](olares-settings-apps.md).
 

--- a/cli/skills/olares-settings/references/olares-settings-appearance.md
+++ b/cli/skills/olares-settings/references/olares-settings-appearance.md
@@ -1,0 +1,173 @@
+# settings appearance
+
+> **Prerequisite:** Read [`../../olares-shared/SKILL.md`](../../olares-shared/SKILL.md) and the parent [`../SKILL.md`](../SKILL.md) first.
+> **Flags & examples:** `olares-cli settings appearance --help` and `olares-cli settings appearance <noun> <verb> --help`.
+
+Mirror the Settings → Appearance page: locale, theme, desktop widget preferences, wallpaper, and the desktop layout reset. Every verb is per-user; none of them require admin or owner.
+
+Every verb below is VERIFIED against a live 1.12.7 and a live 1.12.5 backend.
+
+## Sub-tree
+
+| Verb | Floor | Needs | Status | Purpose |
+|---|---|---|---|---|
+| `get` | normal | any | VERIFIED | Read the whole page: locale + widget + wallpaper |
+| `language set <locale>` | normal | any | VERIFIED | Set the system language |
+| `theme set <light\|dark>` | normal | >= 1.12.6 | VERIFIED | Set the theme preference |
+| `widget set [flags]` | normal | >= 1.12.6 | VERIFIED | Set desktop widget preferences |
+| `wallpaper list <surface>` | normal | any | VERIFIED | Show the built-in range and uploaded images |
+| `wallpaper set <surface> <number\|url>` | normal | any | VERIFIED | Select a wallpaper |
+| `wallpaper style set <surface> <Fill\|Stretch\|Tile>` | normal | any | VERIFIED | Set the wallpaper fill mode |
+| `wallpaper upload <surface> --file` | normal | any | VERIFIED | Upload a local image and select it |
+| `wallpaper delete <surface> <url>` | normal | any | VERIFIED | Remove an uploaded image |
+| `layout reset` | normal | >= 1.12.6 | VERIFIED | Restore the default desktop layout |
+
+`<surface>` is always `desktop` or `login`.
+
+## Version gate (Olares >= 1.12.6)
+
+Three verbs need Olares 1.12.6+, where their upstream arrived: `theme set` (the `OLARES_USER_THEME` user env), `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). `get`, `language set` and every `wallpaper` verb work on any supported backend.
+
+On an older backend the three fail up front with the shared message, naming the verb and the detected version:
+
+```
+`settings appearance theme set` requires Olares >= 1.12.6 (the OLARES_USER_THEME user env),
+but this backend is 1.12.5; upgrade the Olares system to >= 1.12.6
+```
+
+Nothing is sent when the gate trips, and `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
+
+`get` is the one verb that degrades instead of failing: below 1.12.6 it reads locale and wallpaper and reports the widget section as gated, since those two exist everywhere.
+
+```
+Widget
+  requires Olares >= 1.12.6
+```
+
+With `-o json` that section is `null` — the key stays present so a caller can tell a gated section from one this CLI does not know about. On 1.12.5 the locale section also returns an empty `timezone`, which renders as `-`.
+
+## `get` is the only read verb
+
+```bash
+olares-cli settings appearance get
+olares-cli settings appearance get -o json
+```
+
+There is no `widget get` or `wallpaper get`. One `get` reads all three upstream endpoints (`/api/wallpaper/config/system`, `/api/widget`, `/api/wallpaper`) — the widget one only on 1.12.6+, see the [version gate](#version-gate-olares--1126).
+
+A section that fails for any other reason — auth, 500, a malformed body — fails the whole command, because a zeroed section would be read as real configuration.
+
+`-o json` is three sections, each holding the upstream field names verbatim:
+
+```json
+{
+  "locale":    { "language": "en-US", "location": "", "timezone": "UTC", "theme": "light" },
+  "widget":    { "showWeight": true, "is24HourFormat": true, "dateFormat": "YYYY/MM/DD", "showDashboard": true },
+  "wallpaper": { "desktop": "/bg/0.jpg", "desktopStyle": "fill", "login": "/bg/0.jpg", "loginStyle": "fill",
+                 "upload_desktop_backgrounds": [], "upload_login_backgrounds": [] }
+}
+```
+
+Read the language from `.locale.language`, not `.language`. `showWeight` is the upstream name of the widget master switch despite what it reads like.
+
+**JSON carries the stored values; the table renames them for the reader.** `"desktop": "/bg/3.jpg"` prints as `built-in 3` and `"desktopStyle": "cover"` as `Stretch`, matching how `wallpaper set` and Settings name them. Script against `-o json`.
+
+## `theme set` writes a different place than the SPA toggle
+
+```bash
+olares-cli settings appearance theme set dark
+olares-cli settings appearance theme set light
+```
+
+The theme lives in the `OLARES_USER_THEME` user env, which the platform declares the source of truth: apps receive it and the login flow honors it. This verb writes it through `/api/env/userenvs`, so `settings advanced env user list` shows the same value. The variable itself arrived in 1.12.6 — see the [version gate](#version-gate-olares--1126).
+
+**An Olares desktop already open in a browser will not change appearance.** The SPA's own light/dark toggle only sets a local cookie and never calls the backend, so the two are not connected. Tell the user this rather than letting them conclude the command did nothing.
+
+Only `light` and `dark` are accepted, and **there is no bypass**: app-service validates the value against the same declaration and answers `value not in options`. Going around the CLI with `settings advanced env user set --var OLARES_USER_THEME=auto` is rejected too (verified). A value a newer release adds needs a newer CLI.
+
+## `widget set` changes only the flags you pass
+
+```bash
+olares-cli settings appearance widget set --show-widgets=false
+olares-cli settings appearance widget set --24-hour=false --date-format M/D/YY
+olares-cli settings appearance widget set --show-dashboard=true
+```
+
+The upstream POST replaces the whole preferences object, so the CLI reads the current values first and sends the unnamed ones back untouched. Passing no flag at all is an error rather than a no-op write.
+
+`--date-format` is checked against the SPA's list (`YYYY/MM/DD`, `D/M/YY`, `M/D/YY`, `DD/MM/YYYY`, `DD.MM.YYYY`, `DD-MM-YYYY`, `YYYY.MM.DD`, `YYYY-MM-DD`, `YY/MM/DD`, `YY-M-D`, `YY.M.D`) because the upstream stores any string it is handed and an unlisted one silently fails to render in the desktop clock.
+
+## `wallpaper`
+
+```bash
+olares-cli settings appearance wallpaper list desktop
+olares-cli settings appearance wallpaper set desktop 3
+olares-cli settings appearance wallpaper set login 5
+olares-cli settings appearance wallpaper style set desktop Stretch
+olares-cli settings appearance wallpaper upload desktop --file ./bg.jpg
+olares-cli settings appearance wallpaper delete desktop https://files.example/bg.jpg --yes
+```
+
+**A built-in is selected by number**, as in the Settings grid — that grid is unnamed thumbnails, so a number is the only handle either side has. `wallpaper list <surface>` shows the range and which one is active; the surfaces ship a different number of images, so it needs the surface.
+
+```
+Built-in desktop wallpapers
+  0-27, currently 3
+
+Uploaded desktop wallpapers
+  none
+
+Select one with `settings appearance wallpaper set desktop <number|url>`.
+```
+
+When the active wallpaper is an uploaded image, the built-in line drops the `currently` note and the uploaded URL is marked `*` instead, so no built-in is ever reported as active when it is not.
+
+Ranges (mirroring the SPA's `picturesCount`, which is the only place they exist): desktop `0-27`, login `0-28`. `28` is valid for login and invalid for desktop.
+
+`set` also takes an uploaded `https://` URL, and the stored `/bg/<n>.jpg` spelling so a value read from `get -o json` can be fed back in.
+
+The value is stored verbatim and **not validated upstream** — a bad one is accepted and leaves a broken background with no error. The CLI therefore validates first; `--force` stores the value as given, for one a newer release adds. Uploaded URLs are judged by shape, not looked up, so `set` stays a single request.
+
+**Never offer `/login/<n>.jpg`.** Both surfaces store `/bg/<n>.jpg`: the greeter resolves the stored value under its own asset root (`LoginPage.vue` renders `"auth/" + value`), and the Settings page swaps the prefix to `/login/` only to preview the login variant. A stored `/login/<n>.jpg` resolves nowhere.
+
+Fill modes are named as Settings names them: `Fill`, `Stretch`, `Tile` (case-insensitive). The stored values `fill`, `cover`, `repeat` are accepted too, and `get` prints the label.
+
+`upload` is three calls: it posts the image, registers the returned URL in the surface's gallery, then selects it. `--no-set` stops after registering. **The upload goes to `<SettingsURL>/images/upload/v1`, not the desktop ingress** — `/images` is only proxied on the settings host, so an error mentioning that origin is expected rather than a misrouted request. Login uploads are sent with a public access policy because the greeter fetches them before anyone is signed in. Accepted types: png, jpeg, jpg, gif.
+
+`delete` takes an uploaded URL, prompts for confirmation, and if the image being removed is the active wallpaper the upstream falls back to a built-in default. **It only removes the image from the gallery — the file stays in the user's Drive** (`Home/Pictures/Upload`), same as the SPA's delete button. Do not tell the user it freed disk space; removing the file is a separate `files rm`.
+
+## `layout reset`
+
+```bash
+olares-cli settings appearance layout reset
+olares-cli settings appearance layout reset --yes
+```
+
+Drops the launchpad ordering, folders and dock arrangement for the current user and broadcasts the change to open sessions. **There is no undo.** The output names the surfaces the upstream reset — observed to be `launchpad, dock` every time, including on a layout that was already default, so it is not a signal that anything had been customized.
+
+Needs Olares >= 1.12.6, checked before the prompt — see the [version gate](#version-gate-olares--1126).
+
+## Agent best practices
+
+- **For "switch to dark mode"** → `theme set dark`, then state that an open browser desktop keeps its cookie-driven appearance. Do not retry or look for another verb when the browser does not change.
+- **For "change my wallpaper"** → ask which surface. `desktop` and `login` are separate settings and users rarely mean both.
+- **Run `wallpaper list <surface>` before `wallpaper set`** rather than guessing a number, since the two surfaces have different ranges. Refer to built-ins by number, never as `/login/<n>.jpg`.
+- **Confirm separately for `layout reset` and `wallpaper delete`.** Both are irreversible for the user's arrangement or gallery, and neither is implied by a request to change the wallpaper or theme.
+- **Do not use this subtree for per-app icons or entrance titles** — those are [post-install app configuration](olares-settings-apps.md).
+
+## Common errors
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `unknown surface "..."` | First positional is not `desktop` / `login` | Pass one of the two |
+| `<surface> has no built-in wallpaper <n>` | Number past this surface's range | Run `wallpaper list <surface>`; desktop stops at 27, login at 28 |
+| `"..." is not a <surface> wallpaper` | Neither a number, an `http(s)://` URL, nor a `/bg/<n>.jpg` value — e.g. a `/login/<n>.jpg` path | Pass a number from `wallpaper list <surface>`; `--force` only for a value a newer release adds |
+| `unsupported fill mode "..."` | Mode outside `Fill` / `Stretch` / `Tile` | Use one of the three, as spelled in Settings |
+| `unsupported theme "..."` | Value outside `light` / `dark` | Use one of the two; the backend rejects anything else as well |
+| `unsupported --date-format "..."` | Format not in the SPA's list | Pick from the list above |
+| `widget set requires at least one of ...` | Called with no flags | Name the preference to change |
+| `read locale: ...` / `read wallpaper: ...` | One section of `get` failed | Retry, then check `settings advanced status` |
+| `requires Olares >= 1.12.6 ...` on `theme set` / `widget set` / `layout reset` | Backend predates the verb's upstream | Upgrade Olares; nothing was sent, and no layout was reset |
+| `requires Olares >= 1.12.6 ..., but the backend version could not be determined` | Version undetectable | Log in, then `olares-cli profile list --refresh-version` |
+| `upload succeeded but the image service returned no imageUrl` | Image service accepted the file but returned an unexpected body | Retry; if it persists the image service is misconfigured |
+| `stdin is not a terminal — pass --yes to confirm` | Destructive verb in a script | Pass `--yes` after confirming with the user |

--- a/cli/skills/olares-settings/references/olares-settings-apps.md
+++ b/cli/skills/olares-settings/references/olares-settings-apps.md
@@ -15,7 +15,7 @@ The **post-install** surface for an Olares app. Inspect the app, list its entran
 | `get <app>` | normal | VERIFIED | Detail view (filtered client-side; no per-app endpoint) |
 | `entrances list <app>` | normal | VERIFIED | Entrance names, auth levels, visibility. Its `STATE` and `URL` columns read `-`; for the app's host use `list` / `get` |
 | `env get <app>` | normal | VERIFIED | Current per-app env vector |
-| `env set <app> KEY=VALUE [KEY=VALUE...]` | normal | UNVERIFIED | Replace the env vector |
+| `env set <app> --var KEY=VALUE [--var ...]` | normal | VERIFIED | Patch the named variables only |
 | `domain get <app> <entrance>` | normal | VERIFIED | Per-entrance custom-domain setup |
 | `domain list <app>` | normal | VERIFIED | Every entrance's domain setup |
 | `domain set <app> <entrance> [flags]` | normal | UNVERIFIED | RMW update |
@@ -115,10 +115,14 @@ olares-cli settings apps auth-level set firefox www --level public
 
 ```bash
 olares-cli settings apps env get gitea
-olares-cli settings apps env set gitea GITEA_TOKEN=abc DB_PASS=xyz
+olares-cli settings apps env set gitea --var GITEA_TOKEN=abc --var DB_PASS=xyz
 ```
 
-- `env set` REPLACES the full env vector. Read current env first if you only want to add a single var.
+- **Values go through `--var KEY=VALUE`, repeated per variable** — positional `KEY=VALUE` pairs are not accepted.
+- `env set` sends only the variables you name; the upstream patches those entries and leaves the rest of the vector alone, so there is no need to read the current env first.
+- **An app's variables come from its chart and cannot be created here.** A name the app does not declare is dropped by the upstream, so `env set` checks the response and fails naming the keys that were ignored.
+- **Naming a read-only variable fails the whole request** with `app env '<name>' is not editable` — `env get` shows which are editable under `--output json`.
+- Only the first `=` splits, so a value may contain `=`: `--var "GREETING=hi=there"`.
 - For secrets, pipe via env var or stdin redirection. Don't paste the value into chat.
 
 ## `list` filters
@@ -136,7 +140,7 @@ olares-cli settings apps list --all            # also include uninstalled / pend
 - **Always run `entrances list <app>` before any per-entrance edit.** User-facing names (e.g. `www`) often differ from the chart-defined service names.
 - **For `policy set`**, surface `policy get` output to the user BEFORE applying — the replacement semantics are easy to misuse.
 - **For `domain set --third-party`**, run `domain get` first and act on that one stage only (table above). Hand over the CNAME name/value split verbatim, wait for them to confirm the record, then `finish` — a full command list given up front reliably ends with `finish` run against a record nobody added yet.
-- **For UNVERIFIED verbs** (`env set`, `domain set/finish`, `policy set`, `auth-level set`), the result is provisional — confirm the outcome after running.
+- **For UNVERIFIED verbs** (`domain set/finish`, `policy set`, `auth-level set`), the result is provisional — confirm the outcome after running.
 
 ## Common errors
 

--- a/cli/skills/olares-settings/references/olares-settings-apps.md
+++ b/cli/skills/olares-settings/references/olares-settings-apps.md
@@ -59,8 +59,7 @@ olares-cli settings apps domain set firefox www \
   --key-file /etc/letsencrypt/live/firefox.example.com/privkey.pem
 
 # Explicitly drop a domain dimension (RMW would otherwise preserve it).
-olares-cli settings apps domain set firefox www --clear-third-party
-olares-cli settings apps domain set firefox www --clear-third-level
+olares-cli settings apps domain set firefox www --clear-third-party   # or --clear-third-level
 ```
 
 - **Unspecified flags survive** — RMW under the hood. Pass `--clear-*` to drop a dimension.
@@ -89,13 +88,10 @@ Adding or changing the third-party domain resets both status fields to empty / `
 olares-cli settings apps policy set firefox www \
   --sub-policy "uri=/admin,policy=two_factor" \
   --sub-policy "uri=/api,policy=public"
-
-# Drop the set without adding new entries.
-olares-cli settings apps policy set firefox www --clear-sub-policies
 ```
 
 - `--default-policy` values: `system` | `one_factor` | `two_factor` | `public`. That flag, `--one-time` and `--valid-duration` follow RMW semantics.
-- **Sub-policy entries are REPLACED in full whenever any sub-policy flag is passed** — partial sub-policy edits don't compose safely, so this is intentional.
+- **Sub-policy entries are REPLACED in full whenever any sub-policy flag is passed** — partial sub-policy edits don't compose safely, so this is intentional. `--clear-sub-policies` drops the set without adding new entries.
 
 ## `auth-level set` — no GET endpoint upstream
 
@@ -118,11 +114,9 @@ olares-cli settings apps env get gitea
 olares-cli settings apps env set gitea --var GITEA_TOKEN=abc --var DB_PASS=xyz
 ```
 
-- **Values go through `--var KEY=VALUE`, repeated per variable** — positional `KEY=VALUE` pairs are not accepted.
+- **Values go through `--var KEY=VALUE`, repeated per variable** — positional pairs are not accepted. Only the first `=` splits, so a value may contain one: `--var "GREETING=hi=there"`.
 - `env set` sends only the variables you name; the upstream patches those entries and leaves the rest of the vector alone, so there is no need to read the current env first.
-- **An app's variables come from its chart and cannot be created here.** A name the app does not declare is dropped by the upstream, so `env set` checks the response and fails naming the keys that were ignored.
-- **Naming a read-only variable fails the whole request** with `app env '<name>' is not editable` — `env get` shows which are editable under `--output json`.
-- Only the first `=` splits, so a value may contain `=`: `--var "GREETING=hi=there"`.
+- **Only the variables the app's chart declares can be set, and only the editable ones** — `env get --output json` shows both. An undeclared name is dropped by the upstream, so `env set` checks the response and fails naming the ignored keys; a read-only one fails the whole request with `app env '<name>' is not editable`.
 - For secrets, pipe via env var or stdin redirection. Don't paste the value into chat.
 
 ## `list` filters


### PR DESCRIPTION
## Why

`settings appearance` only exposed language, so an agent asked to change the desktop widgets, the wallpaper or the desktop layout had no verb to call.

## What

**7 new verbs**, all under `olares-cli settings appearance`:

| Verb | Purpose | Needs |
|---|---|---|
| `widget set [flags]` | desktop widget preferences (visibility, 24-hour clock, date format, dashboard) | >= 1.12.6 |
| `layout reset` | restore the default launchpad/dock arrangement, confirmed | >= 1.12.6 |
| `wallpaper list <surface>` | show the selectable built-in range and uploaded images | any |
| `wallpaper set <surface> <number\|url>` | select a wallpaper | any |
| `wallpaper style set <surface> <Fill\|Stretch\|Tile>` | fill mode | any |
| `wallpaper upload <surface> --file <path>` | upload a local image and select it | any |
| `wallpaper delete <surface> <url>` | remove an uploaded image, confirmed | any |

`get` reads the whole page (locale + widget + wallpaper) instead of one field, and is still the only read verb.

## Theme is deliberately not exposed

A desktop's light/dark state is a browser cookie the SPA writes and reads without ever calling the backend, so no CLI can change it. The `OLARES_USER_THEME` user env has no shipped reader: nothing under `apps/` references it, the greeter reads only the login wallpaper, and no manifest binds it through `valueFrom`. Writing it therefore succeeds while nothing on screen changes, so the verb is not registered and `get` does not report the value. `theme.go` is kept, unregistered, to be restored once that user env drives the UI.

## Vocabulary matches the page, not the wire

Users read the Settings page, so the CLI takes what the page shows. The stored spellings stay accepted, and `-o json` keeps the stored values, so scripts are unaffected — there are tests pinning both directions.

| Shown in Settings | Stored | CLI takes |
|---|---|---|
| an unnamed thumbnail in the grid | `/bg/3.jpg` | `3` (or `/bg/3.jpg`) |
| `Stretch` | `cover` | `Stretch` (or `cover`) |

The wallpaper value is stored verbatim and **never validated upstream**, so a wrong one leaves a broken background behind with no error. It is validated client-side, and `wallpaper list` exists for discovery because the built-in count lives only in the SPA — nothing upstream enumerates it. `--force` relaxes the range and shape checks for a built-in a newer release adds; it still resolves a number to `/bg/<n>.jpg`, since the bare number is not a value the backend can resolve.

## Version gating

The two 1.12.6 verbs use the shared `preflight.RequireMinVersion`, so an older backend gets the canonical upgrade message rather than an opaque 404. `layout reset` gates *before* its confirmation prompt, so a user is never asked to confirm something the backend cannot do. `appearance get` degrades on an older backend — it returns locale and wallpaper and marks the widget section as gated — instead of failing the whole page.

## Also in this branch

- **Readable upstream errors.** user-service sometimes answers with a nested error envelope, which the per-package decoders could not unmarshal, so the user saw a Go type error instead of the reason. `pkg/bflenvelope` now owns that contract and all 16 packages use it (every `settings` subtree plus `search` and `router`).
- **`advanced env user set` and `apps env set` send only the named variables.** The upstream upserts, and rejects the request outright when the vector carries a non-editable entry, so returning the whole vector was both unnecessary and a way to fail a valid edit. `apps env set` also reports which keys the upstream silently ignored.
- **`skills_commands_test.go` guards both directions.** The command-path check only proved listed paths resolve, so a new verb could ship undocumented; a reverse guard now walks the `settings appearance` subtree and requires every runnable verb to be listed.

## Breaking change

`settings appearance get -o json` goes from a flat `{language, location}` object to three sections (`locale`, `widget`, `wallpaper`), each holding the upstream field names verbatim. Read the language from `.locale.language`. `locale` carries no `theme`. A section the backend is too old to serve is `null` rather than absent, so a caller can tell "gated" from "unknown to this CLI".

## Test plan

- [x] `go test ./cmd/... ./pkg/bflenvelope/...` green; 41 new unit tests
- [x] `python3 cli/skills/validate.py` green
- [x] Live-verified on three backends: 1.12.5, 1.12.6, 1.12.7 — reads, writes, every rejection path, upload/delete round-trip; all machines restored afterwards
- [x] 1.12.6 confirmed empirically as the floor for `widget set` / `layout reset`
- [x] `appearance get` confirmed to degrade rather than fail on 1.12.5
- [x] `wallpaper set --force` confirmed on 1.12.7 to store `/bg/<n>.jpg` for a number past the known range

Made with [Cursor](https://cursor.com)
