### PR TITLE
feat: anydoc extraction, OCR for scanned PDFs, and better text indexing

### DIFF
--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -245,7 +245,7 @@ spec:
             value: os_framework_search3
       containers:
       - name: search3
-        image: beclab/search3:v0.3.14
+        image: beclab/search3:v0.4.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -312,7 +312,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: search3monitor
-        image: beclab/search3monitor:v0.3.14
+        image: beclab/search3monitor:v0.4.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_validation.yaml
@@ -64,7 +64,7 @@ spec:
                     operator: Exists
       containers:
       - name: search3-validation
-        image: beclab/search3validation:v0.3.14
+        image: beclab/search3validation:v0.4.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Title: search3: anydoc extraction, OCR for scanned PDFs, and better text indexing
<!-- If the changes affect two subsystems, use a comma (and a whitespace) to separate them like util/codec, util/types:. -->

* **Background**
1. **Extract text with `anydoc`** instead of older tools (pdftotext / heavy Tika-style paths) for PDF, Word, Excel, PPT, RTF, ODT, and EPUB.
2. **Handle scanned PDFs** — mark them as `PENDING_OCR` instead of a hard failure, then let **search3monitor** run OCR and finish indexing.
3. **Improve search recall** — clean up text before indexing, fix how filename vs body keywords are handled, and fix a bug where some PDFs never got indexed at all.
4. **fix nats reconnect err**
* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
daily build, 1.12.7
* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->

*  https://github.com/Above-Os/search3/pull/213

<!-- CURSOR_SUMMARY -->
---