### PR TITLE
feat(cli): show the appearance value domains, and add the 1.12.7 locales

### DIFF
--- a/cli/cmd/ctl/settings/appearance/get.go
+++ b/cli/cmd/ctl/settings/appearance/get.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -134,7 +135,7 @@ func renderAppearance(w io.Writer, v appearanceView) error {
 	}
 	if v.Locale != nil {
 		sections[0].rows = [][2]string{
-			{"Language", nonEmpty(v.Locale.Language)},
+			{"Language", describeLocale(v.Locale.Language)},
 			{"Location", nonEmpty(v.Locale.Location)},
 			{"Timezone", nonEmpty(v.Locale.Timezone)},
 		}
@@ -143,7 +144,7 @@ func renderAppearance(w io.Writer, v appearanceView) error {
 		sections[1].rows = [][2]string{
 			{"Show widgets", boolStr(v.Widget.ShowWidgets)},
 			{"24-hour format", boolStr(v.Widget.Is24HourFormat)},
-			{"Date format", nonEmpty(v.Widget.DateFormat)},
+			{"Date format", describeDateFormat(v.Widget.DateFormat, time.Now())},
 			{"Show dashboard", boolStr(v.Widget.ShowDashboard)},
 		}
 	}

--- a/cli/cmd/ctl/settings/appearance/get_test.go
+++ b/cli/cmd/ctl/settings/appearance/get_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func sampleView() appearanceView {
@@ -37,8 +38,13 @@ func TestRenderAppearanceCoversAllThreeSections(t *testing.T) {
 	out := buf.String()
 
 	for _, want := range []string{
-		"Locale", "Language:", "zh-CN", "Asia/Shanghai",
+		// The code plus the name the picker shows for it, so an unfamiliar
+		// locale does not have to be looked up elsewhere.
+		"Locale", "Language:", "zh-CN (简体中文)", "Asia/Shanghai",
 		"Widget", "Show widgets:", "24-hour format:", "Date format:", "M/D/YY",
+		// The pattern alone does not say what the clock reads, which is
+		// how Settings shows it: picker plus a live preview.
+		"(" + renderDateFormat("M/D/YY", time.Now()) + ")",
 		// The wallpaper rows are named as `wallpaper set` and Settings
 		// name them: a built-in by number, a fill mode by its label.
 		"Wallpaper", "Desktop:", "built-in 3", "Desktop style:", "Stretch",
@@ -163,6 +169,10 @@ func TestAppearanceViewJSONShape(t *testing.T) {
 	if _, ok := locale["theme"]; ok {
 		t.Errorf("locale still carries a theme key: %s", raw)
 	}
+	// The picker's name for the locale belongs to the table only.
+	if got := locale["language"]; got != "zh-CN" {
+		t.Errorf("locale.language = %v; want the stored zh-CN", got)
+	}
 
 	var widget map[string]interface{}
 	if err := json.Unmarshal(decoded["widget"], &widget); err != nil {
@@ -171,6 +181,11 @@ func TestAppearanceViewJSONShape(t *testing.T) {
 	// showWeight is the upstream name of the widget master switch.
 	if got, ok := widget["showWeight"]; !ok || got != true {
 		t.Errorf("widget.showWeight = %v (present=%v); want true", got, ok)
+	}
+	// The preview belongs to the table only: a script reading this back
+	// has to get the pattern the upstream stores.
+	if got := widget["dateFormat"]; got != "M/D/YY" {
+		t.Errorf("widget.dateFormat = %v; want the stored M/D/YY", got)
 	}
 
 	// The table renames values for the reader; JSON must keep the stored

--- a/cli/cmd/ctl/settings/appearance/language.go
+++ b/cli/cmd/ctl/settings/appearance/language.go
@@ -19,19 +19,20 @@ import (
 //   updateLanguage(language) -> axios.post('/api/wallpaper/update/language',
 //                                          { language })
 //
-// We mirror the SPA's supportLanguages whitelist client-side
-// (apps/.../i18n/index.ts:12 — currently `en-US` and `zh-CN`) because
-// neither user-service nor BFL validate the value today: an unknown
-// code would land in the config-system CRD verbatim and the SPA's
-// i18n loader would silently fall back to defaultLanguage on the next
-// session — i.e. the call "succeeds" but nothing changes. The CLI
-// catches that early so callers get a real error instead of a
-// false-positive.
+// Termipass writes the same field from the same route
+// (packages/app/src/stores/settings/background.ts requestUpdateLanguage),
+// so its picker is the reference for what this endpoint accepts — see
+// supportedLocales below.
 //
-// `--force` is the escape hatch for the unusual case where the SPA
-// has shipped a new locale before this CLI build catches up. It
-// bypasses the local whitelist and PUTs the value through; the
-// upstream remains the final authority.
+// The two SPAs reading this field do not carry the same bundles: the
+// Olares desktop ships en-US and zh-CN only, so one of the locales
+// added in 1.12.7 renders in LarePass while the browser desktop falls
+// back to English.
+//
+// `--force` is the escape hatch for the unusual case where a SPA has
+// shipped a locale before this CLI build catches up. It bypasses both
+// the whitelist and the version requirement; the upstream remains the
+// final authority.
 //
 // Role: Appearance is in the normal-user menu (admin.ts:101-103). No
 // PreflightRole check.
@@ -47,7 +48,7 @@ The current value can be inspected via "settings appearance get".
 
 Subcommands:
   set <locale>          update the system language
-                        (e.g. "set en-US"; --value also accepted)
+                        (` + localeSummary() + `)
 `,
 	}
 	cmd.SilenceUsage = true
@@ -55,11 +56,94 @@ Subcommands:
 	return cmd
 }
 
-// supportedLocales is the client-side whitelist mirrored from the
-// SPA's apps/.../i18n/index.ts supportLanguages list. Keep in sync
-// when SPA adds a locale; until then, callers can use --force to
-// bypass the check.
-var supportedLocales = []string{"en-US", "zh-CN"}
+// localeOption is a locale code with the name the picker shows for it,
+// and the Olares release whose SPA carries its translation.
+type localeOption struct {
+	code  string
+	label string
+	since string
+}
+
+// localeMinVersionExtended is the release that added five locales.
+// Settings gates its own picker on the same boundary, treating any
+// 1.12.7 prerelease as in (Termipass ActiveOlaresReminderDialog.vue:
+// compareOlaresVersion(version, "1.12.7-0") >= 0), which is also what
+// OlaresBackendAtLeast does with a prerelease.
+const localeMinVersionExtended = "1.12.7"
+
+// supportedLocales mirrors the SPA's supportLanguages picker
+// (Termipass packages/app/src/i18n/index.ts). It stays a client-side
+// whitelist because neither user-service nor BFL validate the value:
+// an unknown code lands in the config-system CRD verbatim and the SPA
+// falls back to its default on the next session, so the call
+// "succeeds" while nothing changes.
+//
+// Add a locale here when the SPA ships its bundle, with the release
+// that ships it; until then callers can use --force.
+var supportedLocales = []localeOption{
+	{code: "en-US", label: "English"},
+	{code: "zh-CN", label: "简体中文"},
+	{code: "de-DE", label: "Deutsch", since: localeMinVersionExtended},
+	{code: "es-ES", label: "Español", since: localeMinVersionExtended},
+	{code: "it-IT", label: "Italiano", since: localeMinVersionExtended},
+	{code: "fr-FR", label: "Français", since: localeMinVersionExtended},
+	{code: "ja-JP", label: "日本語", since: localeMinVersionExtended},
+}
+
+// localeSummary is the one-line form for the parent help, kept in step
+// with supportedLocales so adding a locale cannot leave a stale count
+// behind. It assumes the gated ones share a single release, which is
+// what the list holds today.
+func localeSummary() string {
+	var always []string
+	gated := 0
+	for _, l := range supportedLocales {
+		if l.since == "" {
+			always = append(always, l.code)
+			continue
+		}
+		gated++
+	}
+	summary := strings.Join(always, ", ")
+	if gated > 0 {
+		summary += fmt.Sprintf(", and %d more on Olares >= %s", gated, localeMinVersionExtended)
+	}
+	return summary
+}
+
+// localeChoices lists the locales the way the picker labels them,
+// grouped so the ones needing a newer Olares are named as such. CJK
+// labels make column alignment unreliable, hence the inline shape.
+func localeChoices() string {
+	var always, gated []string
+	for _, l := range supportedLocales {
+		entry := fmt.Sprintf("%s (%s)", l.code, l.label)
+		if l.since == "" {
+			always = append(always, entry)
+			continue
+		}
+		gated = append(gated, entry)
+	}
+	out := "  " + strings.Join(always, ", ")
+	if len(gated) > 0 {
+		out += fmt.Sprintf("\n  Olares >= %s also has: %s", localeMinVersionExtended, strings.Join(gated, ", "))
+	}
+	return out
+}
+
+// describeLocale is how a stored code reads in the table: the code the
+// page shows, plus the name it shows beside it. A code this CLI does
+// not carry — one --force wrote, or one a newer SPA added — is printed
+// as stored rather than guessed at.
+func describeLocale(code string) string {
+	code = strings.TrimSpace(code)
+	for _, l := range supportedLocales {
+		if strings.EqualFold(code, l.code) {
+			return fmt.Sprintf("%s (%s)", l.code, l.label)
+		}
+	}
+	return nonEmpty(code)
+}
 
 // newLanguageSetCommand registers `appearance language set [<locale>]`.
 //
@@ -78,63 +162,86 @@ func newLanguageSetCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <locale>",
 		Short: "update the system language preference (e.g. set en-US)",
-		Long: `Update the system language preference. The value is a locale code
+		Long: fmt.Sprintf(`Update the system language preference. The value is a locale code
 the SPA's language picker emits.
 
-Allowed locales (matches SPA's i18n bundle list):
-  en-US
-  zh-CN
+Allowed locales (matches the SPA's i18n bundle list):
+%s
+
+Case does not matter: "en-us" sets en-US.
 
 The locale can be passed as a positional argument or as --value. Pass
 exactly one of the two; passing both with conflicting values is an
 error.
 
-Pass --force to bypass the client-side whitelist. Use only when the
-SPA has shipped a new locale ahead of this CLI build — the upstream
-will accept any string today, so a typo with --force will silently
-land in the config-system CRD and the SPA will fall back to the
-default locale on the next session.
+Pass --force to bypass both the list and the version requirement. Use
+only when the SPA has shipped a locale ahead of this CLI build — the
+upstream will accept any string today, so a forced typo lands in the
+config-system CRD and the SPA falls back to its default locale on the
+next session, i.e. the write "succeeds" and nothing changes.
 
 Examples:
   olares-cli settings appearance language set en-US
   olares-cli settings appearance language set zh-CN
+  olares-cli settings appearance language set de-DE
   olares-cli settings appearance language set --value en-US
-  olares-cli settings appearance language set ja-JP --force
-`,
+  olares-cli settings appearance language set ko-KR --force
+`, localeChoices()),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			resolved, err := resolveLanguageValue(args, value)
 			if err != nil {
 				return err
 			}
-			if err := validateLocale(resolved, force); err != nil {
+			canonical, err := resolveLocale(c.Context(), f, resolved, force)
+			if err != nil {
 				return err
 			}
-			return runLanguageSet(c.Context(), f, resolved)
+			return runLanguageSet(c.Context(), f, canonical)
 		},
 	}
-	cmd.Flags().StringVar(&value, "value", "", "locale code to set (e.g. en-US, zh-CN); same as the positional <locale>")
-	cmd.Flags().BoolVar(&force, "force", false, "bypass the client-side whitelist (use only when the SPA has shipped a new locale ahead of this CLI build)")
+	cmd.Flags().StringVar(&value, "value", "", "locale code to set (e.g. en-US); same as the positional <locale>")
+	cmd.Flags().BoolVar(&force, "force", false, "bypass the whitelist and the version requirement (use only when a SPA has shipped a locale ahead of this CLI build)")
 	return cmd
 }
 
-// validateLocale enforces the client-side supportedLocales whitelist.
-// `force=true` short-circuits to nil so callers can opt into writing
-// a locale the CLI doesn't yet know about. The trim is symmetric with
-// resolveLanguageValue's trim so callers that bypass that helper still
-// get the same forgiving behavior.
-func validateLocale(value string, force bool) error {
+// resolveLocale enforces the client-side whitelist and returns the
+// canonical spelling, because the SPA's i18n bundle is keyed by it:
+// "en-us" has to be stored as "en-US" to load anything. Matching
+// case-insensitively is what this subtree does with surfaces, fill modes
+// and date formats.
+//
+// The backend version is only consulted for a locale that needs one, so
+// setting en-US or zh-CN still works when the version cannot be
+// established.
+//
+// `force=true` passes the value through untouched — the CLI cannot know
+// the canonical spelling of a locale it does not carry, and the upstream
+// is the authority there.
+func resolveLocale(ctx context.Context, f *cmdutil.Factory, value string, force bool) (string, error) {
 	value = strings.TrimSpace(value)
 	if force {
-		return nil
+		return value, nil
 	}
 	for _, l := range supportedLocales {
-		if value == l {
-			return nil
+		if !strings.EqualFold(value, l.code) {
+			continue
 		}
+		if l.since == "" {
+			return l.code, nil
+		}
+		ok, err := f.OlaresBackendAtLeast(ctx, l.since)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("locale %s (%s) needs Olares >= %s, where its translation shipped; pass --force to write it anyway",
+				l.code, l.label, l.since)
+		}
+		return l.code, nil
 	}
-	return fmt.Errorf("unsupported locale %q (allowed: %s; pass --force to bypass for forward compatibility)",
-		value, strings.Join(supportedLocales, ", "))
+	return "", fmt.Errorf("unsupported locale %q; allowed locales:\n%s\npass --force to write a locale this CLI does not carry",
+		value, localeChoices())
 }
 
 // resolveLanguageValue picks the locale from <args> or --value. Empty

--- a/cli/cmd/ctl/settings/appearance/language_test.go
+++ b/cli/cmd/ctl/settings/appearance/language_test.go
@@ -1,26 +1,63 @@
 package appearance
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
 
-func TestValidateLocale(t *testing.T) {
+// backendVersion pins what OlaresBackendAtLeast resolves against, the
+// way version_gate_test.go does, so the gated locales can be exercised
+// without a cluster.
+func backendVersion(t *testing.T, version string) *cmdutil.Factory {
+	t.Helper()
+	previous := viper.GetString(cmdutil.FlagOlaresVersion)
+	t.Cleanup(func() { viper.Set(cmdutil.FlagOlaresVersion, previous) })
+	viper.Set(cmdutil.FlagOlaresVersion, version)
+	return cmdutil.NewFactory()
+}
+
+func TestResolveLocale(t *testing.T) {
 	cases := []struct {
 		name     string
 		value    string
+		version  string
 		force    bool
+		want     string
 		wantErr  bool
 		wantSubs []string
 	}{
-		{name: "allowed_en", value: "en-US"},
-		{name: "allowed_zh", value: "zh-CN"},
-		{name: "trim_then_match", value: "  en-US  "},
+		{name: "allowed_en", value: "en-US", want: "en-US"},
+		{name: "allowed_zh", value: "zh-CN", want: "zh-CN"},
+		{name: "trim_then_match", value: "  en-US  ", want: "en-US"},
+		// The SPA's i18n bundle is keyed by the canonical spelling, so a
+		// case-insensitive match has to store that rather than the input.
+		{name: "lowercased_is_canonicalized", value: "en-us", want: "en-US"},
+		{name: "mixed_case_is_canonicalized", value: "ZH-cn", want: "zh-CN"},
+		// The five locales that shipped in 1.12.7.
+		{name: "added_locale_on_1_12_7", value: "de-DE", version: "1.12.7", want: "de-DE"},
+		{name: "added_locale_canonicalized", value: "ja-jp", version: "1.12.7", want: "ja-JP"},
+		// A dated build is its own line, and so is a prerelease: Settings
+		// compares against 1.12.7-0 for the same reason.
+		{name: "added_locale_on_daily", value: "fr-FR", version: "1.12.7-20260819", want: "fr-FR"},
+		{name: "added_locale_on_prerelease", value: "es-ES", version: "1.12.7-alpha.4", want: "es-ES"},
+		{
+			name:     "added_locale_below_gate",
+			value:    "de-DE",
+			version:  "1.12.6",
+			wantErr:  true,
+			wantSubs: []string{"de-DE", "Deutsch", "Olares >= 1.12.7", "--force"},
+		},
 		{
 			name:     "unknown_rejected",
 			value:    "xx",
 			wantErr:  true,
-			wantSubs: []string{`"xx"`, "allowed: en-US, zh-CN", "--force"},
+			wantSubs: []string{`"xx"`, "en-US (English)", "zh-CN (简体中文)", "de-DE (Deutsch)", "--force"},
 		},
 		{
 			name:     "empty_rejected",
@@ -28,16 +65,27 @@ func TestValidateLocale(t *testing.T) {
 			wantErr:  true,
 			wantSubs: []string{"--force"},
 		},
-		{name: "force_overrides_unknown", value: "xx", force: true},
+		// Forced values pass through untouched: the CLI cannot know the
+		// canonical spelling of a locale it does not carry.
+		{name: "force_overrides_unknown", value: "xx", force: true, want: "xx"},
+		{name: "force_keeps_case", value: "ko-kr", force: true, want: "ko-kr"},
+		{name: "force_overrides_the_gate", value: "de-DE", version: "1.12.5", force: true, want: "de-DE"},
 		{name: "force_overrides_empty", value: "", force: true},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateLocale(tc.value, tc.force)
+			// An ungated locale must not need a version at all, so those
+			// cases run against a version that cannot be resolved.
+			version := tc.version
+			if version == "" {
+				version = "not-a-version"
+			}
+			f := backendVersion(t, version)
+			got, err := resolveLocale(context.Background(), f, tc.value, tc.force)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("validateLocale(%q, %v) returned nil; want error", tc.value, tc.force)
+					t.Fatalf("resolveLocale(%q, %v) returned nil; want error", tc.value, tc.force)
 				}
 				msg := err.Error()
 				for _, sub := range tc.wantSubs {
@@ -48,9 +96,84 @@ func TestValidateLocale(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Fatalf("validateLocale(%q, %v) returned error %v; want nil", tc.value, tc.force, err)
+				t.Fatalf("resolveLocale(%q, %v) returned error %v; want nil", tc.value, tc.force, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveLocale(%q, %v) = %q; want %q", tc.value, tc.force, got, tc.want)
 			}
 		})
+	}
+}
+
+// A gated locale on an undetectable backend has to say so rather than
+// read as an unknown code.
+func TestResolveLocaleReportsAnUnknownBackendVersion(t *testing.T) {
+	f := backendVersion(t, "not-a-version")
+	_, err := resolveLocale(context.Background(), f, "de-DE", false)
+	if err == nil || !strings.Contains(err.Error(), "profile list --refresh-version") {
+		t.Fatalf("expected the shared refresh hint, got %v", err)
+	}
+}
+
+func TestDescribeLocale(t *testing.T) {
+	for value, want := range map[string]string{
+		"zh-CN": "zh-CN (简体中文)",
+		"de-DE": "de-DE (Deutsch)",
+		// Case-insensitive, and canonicalized on the way out.
+		"en-us": "en-US (English)",
+		// A code this CLI does not carry is shown as stored.
+		"ko-KR": "ko-KR",
+		"":      nonEmpty(""),
+	} {
+		if got := describeLocale(value); got != want {
+			t.Errorf("describeLocale(%q) = %q; want %q", value, got, want)
+		}
+	}
+}
+
+// The parent help is where a reader learns the value domain, so it has
+// to follow supportedLocales rather than restate a count by hand.
+func TestLanguageHelpFollowsTheLocaleList(t *testing.T) {
+	var gated []string
+	for _, l := range supportedLocales {
+		if l.since != "" {
+			gated = append(gated, l.code)
+		}
+	}
+	long := NewLanguageCommand(cmdutil.NewFactory()).Long
+	want := fmt.Sprintf("en-US, zh-CN, and %d more on Olares >= %s", len(gated), localeMinVersionExtended)
+	if !strings.Contains(long, want) {
+		t.Errorf("parent help does not carry %q:\n%s", want, long)
+	}
+	// Help is offline text: no help line may run past a narrow terminal.
+	for _, line := range strings.Split(long, "\n") {
+		if len(line) > 72 {
+			t.Errorf("help line is %d chars: %q", len(line), line)
+		}
+	}
+}
+
+// The gate exists because the desktop and LarePass ship different
+// bundles; moving it silently would change which locales are accepted.
+func TestLocaleChoicesNamesTheGate(t *testing.T) {
+	if localeMinVersionExtended != "1.12.7" {
+		t.Fatalf("localeMinVersionExtended = %q, want 1.12.7", localeMinVersionExtended)
+	}
+	choices := localeChoices()
+	for _, want := range []string{
+		"en-US (English)", "zh-CN (简体中文)",
+		"Olares >= 1.12.7 also has:",
+		"de-DE (Deutsch)", "es-ES (Español)", "it-IT (Italiano)",
+		"fr-FR (Français)", "ja-JP (日本語)",
+	} {
+		if !strings.Contains(choices, want) {
+			t.Errorf("choices missing %q:\n%s", want, choices)
+		}
+	}
+	// The ungated pair leads; a reader should not have to work out which
+	// half applies to their backend.
+	if strings.Index(choices, "en-US") > strings.Index(choices, "de-DE") {
+		t.Errorf("gated locales are listed before the ungated ones:\n%s", choices)
 	}
 }
 

--- a/cli/cmd/ctl/settings/appearance/widget.go
+++ b/cli/cmd/ctl/settings/appearance/widget.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
@@ -50,17 +52,63 @@ var dateFormats = []string{
 	"YY.M.D",
 }
 
+// dateFormatLayout translates the SPA's pattern vocabulary into a Go
+// layout. The replacer is single-pass and tries these in order, so YYYY
+// is never read as two YY and no substitution rewrites another's output.
+var dateFormatLayout = strings.NewReplacer(
+	"YYYY", "2006", "YY", "06", "MM", "01", "DD", "02", "M", "1", "D", "2",
+)
+
+// renderDateFormat shows what a pattern produces. Settings pairs its
+// picker with a live preview of the current date, and without one
+// YY-M-D and YY.M.D can only be told apart by setting both.
+func renderDateFormat(pattern string, at time.Time) string {
+	return at.Format(dateFormatLayout.Replace(pattern))
+}
+
+// describeDateFormat is how a stored pattern reads in the table: the
+// pattern the page shows, plus what the clock currently makes of it.
+func describeDateFormat(pattern string, at time.Time) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return nonEmpty(pattern)
+	}
+	return fmt.Sprintf("%s (%s)", pattern, renderDateFormat(pattern, at))
+}
+
+// dateFormatChoices lists every pattern beside that preview, two per
+// line to keep the help short enough to read.
+func dateFormatChoices(at time.Time) string {
+	var b strings.Builder
+	for i := 0; i < len(dateFormats); i += 2 {
+		b.WriteString(fmt.Sprintf("  %-11s %-11s", dateFormats[i], renderDateFormat(dateFormats[i], at)))
+		if i+1 < len(dateFormats) {
+			b.WriteString(fmt.Sprintf("  %-11s %s", dateFormats[i+1], renderDateFormat(dateFormats[i+1], at)))
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), " \n")
+}
+
 func NewWidgetCommand(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "widget",
 		Short: "desktop widget preferences",
 		Long: `Update the desktop widget preferences (Settings -> Appearance >
-Widgets and Date & Time).
+Widget and Date & Time).
 
 Current values are shown by "settings appearance get".
 
 Subcommands:
-  set [flags]           update one or more preferences
+  set --show-widgets=<true|false>    show the desktop widgets
+  set --24-hour=<true|false>         24-hour time in the clock widget
+  set --date-format YYYY/MM/DD       date format in the clock widget,
+                                     one of 11 patterns ("set --help")
+  set --show-dashboard=<true|false>  show the dashboard widget
+
+One "set" takes any combination of these, and a preference you leave
+out keeps its current value. The desktop shows the last three only
+while --show-widgets is true.
 `,
 	}
 	cmd.SilenceUsage = true
@@ -113,15 +161,25 @@ func newWidgetSetCommand(f *cmdutil.Factory) *cobra.Command {
 pass are changed; the rest are read from the upstream and sent back
 unchanged, because the endpoint replaces the whole object.
 
-Allowed --date-format values:
-  %s
+The boolean flags need the equals sign: "--24-hour=false" turns the
+setting off, while "--24-hour false" turns it on and then fails on the
+leftover word.
+
+--date-format patterns, each shown as today's date:
+%s
+
+Case does not matter: "yyyy/mm/dd" sets YYYY/MM/DD.
+
+The desktop shows the clock and the dashboard only while
+--show-widgets is true, though the other preferences are still stored
+while it is false.
 
 Examples:
   olares-cli settings appearance widget set --show-widgets=false
   olares-cli settings appearance widget set --24-hour=false --date-format M/D/YY
   olares-cli settings appearance widget set --show-dashboard=true
-`, strings.Join(dateFormats, "\n  ")),
-		Args: cobra.NoArgs,
+`, dateFormatChoices(time.Now())),
+		Args: rejectBooleanAsArgument,
 		RunE: func(c *cobra.Command, _ []string) error {
 			patch := widgetPatch{}
 			if c.Flags().Changed("show-widgets") {
@@ -143,24 +201,61 @@ Examples:
 			return runWidgetSet(c.Context(), f, patch)
 		},
 	}
-	cmd.Flags().BoolVar(&showWidgets, "show-widgets", true, "show the desktop widgets")
-	cmd.Flags().BoolVar(&is24HourFormat, "24-hour", true, "use 24-hour time in the clock widget")
-	cmd.Flags().StringVar(&dateFormat, "date-format", "", "date format used by the clock widget")
-	cmd.Flags().BoolVar(&showDashboard, "show-dashboard", true, "show the dashboard widget")
+	// Declared false so the help does not print "(default true)": omitting
+	// a flag keeps the current value rather than setting it to anything.
+	cmd.Flags().BoolVar(&showWidgets, "show-widgets", false, "show the desktop widgets (unchanged if omitted)")
+	cmd.Flags().BoolVar(&is24HourFormat, "24-hour", false, "use 24-hour time in the clock widget (unchanged if omitted)")
+	cmd.Flags().StringVar(&dateFormat, "date-format", "",
+		"one of the 11 `YYYY/MM/DD`-style patterns listed above (unchanged if omitted)")
+	cmd.Flags().BoolVar(&showDashboard, "show-dashboard", false, "show the dashboard widget (unchanged if omitted)")
 	return cmd
 }
 
+// A boolean flag consumes no following word, so "--24-hour false" sets the
+// preference to true and leaves "false" as a positional, which NoArgs alone
+// would report as an unknown command.
+func rejectBooleanAsArgument(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		if value := strings.ToLower(args[0]); value == "true" || value == "false" {
+			return fmt.Errorf("%q was read as an argument, not as a flag value: a boolean flag needs the equals sign, as in --%s=%s",
+				args[0], exampleBooleanFlag(cmd), value)
+		}
+	}
+	return cobra.NoArgs(cmd, args)
+}
+
+// The flag to put in that example: the boolean the caller just passed, when
+// there is only one, so the suggestion is the line they meant to type.
+func exampleBooleanFlag(cmd *cobra.Command) string {
+	var passed []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if f.Value.Type() == "bool" {
+			passed = append(passed, f.Name)
+		}
+	})
+	if len(passed) == 1 {
+		return passed[0]
+	}
+	return "show-widgets"
+}
+
+// resolveDateFormat accepts a pattern in any case and returns the spelling
+// the desktop clock renders, matching how this subtree reads surfaces and
+// fill modes. A pattern a newer Settings adds needs a newer CLI to preview
+// it, so there is no flag to bypass the list.
 func resolveDateFormat(raw string) (string, error) {
-	value := strings.TrimSpace(raw)
+	value := strings.ToUpper(strings.TrimSpace(raw))
 	if value == "" {
-		return "", fmt.Errorf("--date-format requires a value (allowed: %s)", strings.Join(dateFormats, ", "))
+		return "", fmt.Errorf("--date-format requires one of these patterns (shown as today's date):\n%s",
+			dateFormatChoices(time.Now()))
 	}
 	for _, f := range dateFormats {
 		if value == f {
-			return value, nil
+			return f, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported --date-format %q (allowed: %s)", raw, strings.Join(dateFormats, ", "))
+	return "", fmt.Errorf("unsupported --date-format %q; allowed patterns (shown as today's date):\n%s",
+		raw, dateFormatChoices(time.Now()))
 }
 
 func runWidgetSet(ctx context.Context, f *cmdutil.Factory, patch widgetPatch) error {

--- a/cli/cmd/ctl/settings/appearance/widget_test.go
+++ b/cli/cmd/ctl/settings/appearance/widget_test.go
@@ -3,6 +3,9 @@ package appearance
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
 )
 
 func TestResolveDateFormat(t *testing.T) {
@@ -16,12 +19,88 @@ func TestResolveDateFormat(t *testing.T) {
 		}
 	}
 
-	if _, err := resolveDateFormat("yyyy/mm/dd"); err == nil {
-		t.Error("resolveDateFormat accepted a lowercased format; the upstream is case-sensitive")
+	// Case-insensitive like this subtree's surfaces and fill modes, and
+	// canonicalized because the clock renders the stored spelling.
+	for _, raw := range []string{"yyyy/mm/dd", "Yyyy/Mm/Dd"} {
+		got, err := resolveDateFormat(raw)
+		if err != nil {
+			t.Fatalf("resolveDateFormat(%q) errored: %v", raw, err)
+		}
+		if got != "YYYY/MM/DD" {
+			t.Errorf("resolveDateFormat(%q) = %q; want YYYY/MM/DD", raw, got)
+		}
 	}
-	_, err := resolveDateFormat("")
-	if err == nil || !strings.Contains(err.Error(), "requires a value") {
-		t.Errorf("empty --date-format error = %v; want it to mention a required value", err)
+
+	// Both rejections have to carry the list: it is the whole fix, and
+	// the patterns are otherwise two levels deep in the help.
+	for _, raw := range []string{"", "m/d/y"} {
+		_, err := resolveDateFormat(raw)
+		if err == nil {
+			t.Fatalf("resolveDateFormat(%q) was accepted", raw)
+		}
+		for _, want := range []string{"YYYY/MM/DD", "YY.M.D", "today's date"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error for %q missing %q:\n%v", raw, want, err)
+			}
+		}
+	}
+}
+
+func TestRenderDateFormat(t *testing.T) {
+	// A two-digit day and month, then a one-digit pair: the patterns
+	// differ in whether they pad, so both cases have to be right.
+	padded := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	for pattern, want := range map[string]string{
+		"YYYY/MM/DD": "2026/08/27",
+		"D/M/YY":     "27/8/26",
+		"M/D/YY":     "8/27/26",
+		"DD.MM.YYYY": "27.08.2026",
+		"YY-M-D":     "26-8-27",
+		"YY.M.D":     "26.8.27",
+	} {
+		if got := renderDateFormat(pattern, padded); got != want {
+			t.Errorf("renderDateFormat(%q) = %q; want %q", pattern, got, want)
+		}
+	}
+
+	single := time.Date(2026, 11, 5, 0, 0, 0, 0, time.UTC)
+	for pattern, want := range map[string]string{
+		"YY-M-D":     "26-11-5",
+		"D/M/YY":     "5/11/26",
+		"DD/MM/YYYY": "05/11/2026",
+	} {
+		if got := renderDateFormat(pattern, single); got != want {
+			t.Errorf("renderDateFormat(%q) = %q; want %q", pattern, got, want)
+		}
+	}
+}
+
+// Every allowed pattern has to survive the layout translation, or the
+// help would preview one of them as literal Y/M/D characters.
+func TestDateFormatChoicesPreviewsEveryPattern(t *testing.T) {
+	at := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	choices := dateFormatChoices(at)
+	for _, pattern := range dateFormats {
+		rendered := renderDateFormat(pattern, at)
+		if strings.ContainsAny(rendered, "YMD") {
+			t.Errorf("pattern %q rendered as %q; a token was left untranslated", pattern, rendered)
+		}
+		if !strings.Contains(choices, pattern) || !strings.Contains(choices, rendered) {
+			t.Errorf("choices omit %q or its preview %q:\n%s", pattern, rendered, choices)
+		}
+	}
+	if lines := strings.Count(choices, "\n") + 1; lines != 6 {
+		t.Errorf("choices span %d lines; want 6 (two patterns per line)", lines)
+	}
+}
+
+func TestDescribeDateFormat(t *testing.T) {
+	at := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	if got, want := describeDateFormat("DD.MM.YYYY", at), "DD.MM.YYYY (27.08.2026)"; got != want {
+		t.Errorf("describeDateFormat() = %q; want %q", got, want)
+	}
+	if got := describeDateFormat("", at); got != nonEmpty("") {
+		t.Errorf("describeDateFormat(\"\") = %q; want the placeholder %q", got, nonEmpty(""))
 	}
 }
 
@@ -69,6 +148,76 @@ func TestWidgetPatchApplyOnlyTouchesNamedFields(t *testing.T) {
 			t.Errorf("apply() = %+v; want ShowDashboard set and DateFormat preserved", got)
 		}
 	})
+}
+
+// "set" is the only verb here, so the preferences live in its flags. The
+// parent help has to name them or the subtree reads as if it did nothing.
+func TestWidgetParentHelpNamesEveryPreference(t *testing.T) {
+	long := NewWidgetCommand(nil).Long
+	newWidgetSetCommand(nil).Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" {
+			return
+		}
+		if !strings.Contains(long, "--"+f.Name) {
+			t.Errorf("widget help does not mention --%s", f.Name)
+		}
+	})
+}
+
+// Omitting a flag keeps the current value, so a "(default true)" in the
+// help — which pflag prints for any non-zero default — would be a lie.
+func TestWidgetSetFlagsAdvertiseNoDefault(t *testing.T) {
+	usage := newWidgetSetCommand(nil).Flags().FlagUsages()
+	if strings.Contains(usage, "default") {
+		t.Errorf("flag help implies a default value:\n%s", usage)
+	}
+}
+
+func TestRejectBooleanAsArgument(t *testing.T) {
+	cmd := newWidgetSetCommand(nil)
+
+	for _, arg := range []string{"false", "TRUE"} {
+		err := rejectBooleanAsArgument(cmd, []string{arg})
+		if err == nil {
+			t.Fatalf("bare %q accepted as an argument", arg)
+		}
+		for _, want := range []string{"equals sign", strings.ToLower(arg)} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing %q", err, want)
+			}
+		}
+	}
+
+	if err := rejectBooleanAsArgument(cmd, nil); err != nil {
+		t.Errorf("no arguments rejected: %v", err)
+	}
+	if err := rejectBooleanAsArgument(cmd, []string{"widgets"}); err == nil {
+		t.Error("an unrelated argument was accepted")
+	}
+}
+
+// The example has to name the flag the caller passed, or "--24-hour false"
+// is answered with a line about a flag they never typed.
+func TestRejectBooleanAsArgumentNamesTheFlagPassed(t *testing.T) {
+	cmd := newWidgetSetCommand(nil)
+	if err := cmd.Flags().Parse([]string{"--24-hour"}); err != nil {
+		t.Fatalf("parsing --24-hour: %v", err)
+	}
+	err := rejectBooleanAsArgument(cmd, []string{"false"})
+	if err == nil || !strings.Contains(err.Error(), "--24-hour=false") {
+		t.Errorf("error = %v; want it to suggest --24-hour=false", err)
+	}
+
+	// Ambiguous: two booleans passed, so the example falls back rather
+	// than guessing which one was missing its value.
+	both := newWidgetSetCommand(nil)
+	if err := both.Flags().Parse([]string{"--24-hour", "--show-dashboard"}); err != nil {
+		t.Fatalf("parsing two booleans: %v", err)
+	}
+	if err := rejectBooleanAsArgument(both, []string{"false"}); err == nil ||
+		!strings.Contains(err.Error(), "--show-widgets=false") {
+		t.Errorf("error = %v; want the fallback example", err)
+	}
 }
 
 func TestWidgetPatchEmpty(t *testing.T) {

--- a/cli/skills/olares-settings/SKILL.md
+++ b/cli/skills/olares-settings/SKILL.md
@@ -52,6 +52,7 @@ Load the shared [platform model](../olares-shared/references/olares-platform.md)
 
 - Olares 1.12.5 uses legacy `gpu list`; 1.12.6+ uses `compute`.
 - Overlay gateway and per-app overlay operations require 1.12.6+.
+- `appearance widget set` and `appearance layout reset` require 1.12.6+; `appearance get` degrades instead, reporting the widget section as gated. Five of the seven locales `appearance language set` accepts require 1.12.7+.
 - Overlay writes are asynchronous. `--watch` observes the gateway/app state settling; per-app overlay changes may restart a running app through Market.
 - Search indexing and rebuild are asynchronous. A successful request does not mean newly indexed content is immediately searchable.
 

--- a/cli/skills/olares-settings/references/olares-settings-appearance.md
+++ b/cli/skills/olares-settings/references/olares-settings-appearance.md
@@ -12,7 +12,7 @@ Mirror the Settings → Appearance page: locale, desktop widget preferences, wal
 | Verb | Floor | Needs | Status | Purpose |
 |---|---|---|---|---|
 | `get` | normal | any | VERIFIED | Read the whole page: locale + widget + wallpaper |
-| `language set <locale>` | normal | any | VERIFIED | Set the system language |
+| `language set <locale>` | normal | any (5 of 7 locales >= 1.12.7) | VERIFIED | Set the system language |
 | `widget set [flags]` | normal | >= 1.12.6 | VERIFIED | Set desktop widget preferences |
 | `wallpaper list <surface>` | normal | any | VERIFIED | Show the built-in range and uploaded images |
 | `wallpaper set <surface> <number\|url>` | normal | any | VERIFIED | Select a wallpaper |
@@ -21,13 +21,15 @@ Mirror the Settings → Appearance page: locale, desktop widget preferences, wal
 | `wallpaper delete <surface> <url>` | normal | any | VERIFIED | Remove an uploaded image |
 | `layout reset` | normal | >= 1.12.6 | VERIFIED | Restore the default desktop layout |
 
-`<surface>` is always `desktop` or `login`.
+`<surface>` is always `desktop` or `login`. Every fixed value in this sub-tree — surfaces, fill modes, date patterns, locales — is matched without regard to case and stored in its canonical spelling, so `Desktop`, `stretch`, `yy.m.d` and `en-us` all work. `language set` keeps a `--force` for a locale shipped ahead of this CLI, and a forced value is passed through as typed.
 
-## Version gate (Olares >= 1.12.6)
+## Version gates
 
-Two verbs need Olares 1.12.6+, where their upstream arrived: `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). `get`, `language set` and every `wallpaper` verb work on any supported backend.
+Two verbs need Olares 1.12.6+, where their upstream arrived: `widget set` (the widget preferences API) and `layout reset` (the desktop layout reset route). Every `wallpaper` verb works on any supported backend, and so does `get`.
 
-On an older backend the two fail up front with the shared message naming the verb and the detected version (see [Common errors](#common-errors)); nothing is sent. `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
+`language set` has a gate of its own on the value rather than the verb: `en-US` and `zh-CN` work everywhere, while `de-DE`, `es-ES`, `it-IT`, `fr-FR` and `ja-JP` need Olares >= 1.12.7, which is where their translations shipped. The version is only resolved when one of those five is asked for, so the two universal locales still work on a backend whose version cannot be established. Warn the user that those five change LarePass only: the browser desktop still ships `en-US` and `zh-CN` bundles alone and falls back to English for the others, and both read this one field.
+
+On an older backend the gated verbs and locales fail up front with a message naming the requirement and the detected version (see [Common errors](#common-errors)); nothing is sent. `layout reset` is gated **before** its confirmation prompt, so an older backend never asks the user to confirm a reset it cannot perform. Treat daily builds by their `major.minor.patch` base (`1.12.6-20260203` is the 1.12.6 line). Follow the shared auth/version gate when the version cannot be established.
 
 `get` is the one verb that degrades instead of failing: below 1.12.6 it reads locale and wallpaper — which exist everywhere — and renders the widget section as `requires Olares >= 1.12.6`. With `-o json` that section is `null`, the key still present so a caller can tell a gated section from one this CLI does not know about. On 1.12.5 the locale section also returns an empty `timezone`, which renders as `-`.
 
@@ -38,7 +40,7 @@ olares-cli settings appearance get
 olares-cli settings appearance get -o json
 ```
 
-There is no `widget get` or `wallpaper get`. One `get` reads all three upstream endpoints (`/api/wallpaper/config/system`, `/api/widget`, `/api/wallpaper`) — the widget one only on 1.12.6+, see the [version gate](#version-gate-olares--1126).
+There is no `widget get` or `wallpaper get`. One `get` reads all three upstream endpoints (`/api/wallpaper/config/system`, `/api/widget`, `/api/wallpaper`) — the widget one only on 1.12.6+, see the [version gates](#version-gates).
 
 A section that fails for any other reason — auth, 500, a malformed body — fails the whole command, because a zeroed section would be read as real configuration.
 
@@ -55,7 +57,7 @@ A section that fails for any other reason — auth, 500, a malformed body — fa
 
 Read the language from `.locale.language`, not `.language`. `showWeight` is the upstream name of the widget master switch despite what it reads like.
 
-**JSON carries the stored values; the table renames them for the reader** — `"desktop": "/bg/3.jpg"` prints as `built-in 3` and `"desktopStyle": "cover"` as `Stretch`, matching how `wallpaper set` and Settings name them. Script against `-o json`.
+**JSON carries the stored values; the table renames them for the reader** — `"desktop": "/bg/3.jpg"` prints as `built-in 3`, `"desktopStyle": "cover"` as `Stretch`, `"dateFormat": "M/D/YY"` as `M/D/YY (8/27/26)`, and `"language": "zh-CN"` as `zh-CN (简体中文)`, matching how the verbs and Settings name them. Script against `-o json`.
 
 ## `widget set` changes only the flags you pass
 
@@ -67,7 +69,11 @@ olares-cli settings appearance widget set --show-dashboard=true
 
 The upstream POST replaces the whole preferences object, so the CLI reads the current values first and sends the unnamed ones back untouched. Passing no flag at all is an error rather than a no-op write.
 
-`--date-format` is checked against the SPA's list (`YYYY/MM/DD`, `D/M/YY`, `M/D/YY`, `DD/MM/YYYY`, `DD.MM.YYYY`, `DD-MM-YYYY`, `YYYY.MM.DD`, `YYYY-MM-DD`, `YY/MM/DD`, `YY-M-D`, `YY.M.D`) because the upstream stores any string it is handed and an unlisted one silently fails to render in the desktop clock.
+The four preferences are the whole Widget section of the page: `--show-widgets` is the master switch, and `--24-hour` / `--date-format` / `--show-dashboard` are the ones the desktop displays only while it is on (their values are still stored while it is off). Boolean flags need the equals sign — `--24-hour false` sets it to true and then rejects the leftover word, naming the correct form.
+
+What the user sees: the widget is the clock block on the desktop — time, date, and CPU/memory rings beneath them. `--show-widgets=false` hides the whole block; `--show-dashboard=false` hides only the rings and keeps the clock. So a request to hide resource or usage readings is `--show-dashboard`, not the master switch.
+
+`--date-format` is checked against the SPA's list (`YYYY/MM/DD`, `D/M/YY`, `M/D/YY`, `DD/MM/YYYY`, `DD.MM.YYYY`, `DD-MM-YYYY`, `YYYY.MM.DD`, `YYYY-MM-DD`, `YY/MM/DD`, `YY-M-D`, `YY.M.D`) because the upstream stores any string it is handed and an unlisted one silently fails to render in the desktop clock. Case does not matter and the canonical spelling is what gets stored, so `--date-format yy.m.d` sets `YY.M.D`. Rejections print the whole list with each pattern rendered as today's date, which is how Settings shows it — `YY-M-D` and `YY.M.D` are otherwise indistinguishable. There is no `--force`: a pattern a newer Settings adds needs a newer CLI to render it.
 
 ## `wallpaper`
 
@@ -127,7 +133,9 @@ Drops the launchpad ordering, folders and dock arrangement for the current user 
 | `<surface> has no built-in wallpaper <n>` | Number past this surface's range | Run `wallpaper list <surface>`; desktop stops at 27, login at 28 |
 | `"..." is not a <surface> wallpaper` | Neither a number, an `http(s)://` URL, nor a `/bg/<n>.jpg` value — e.g. a `/login/<n>.jpg` path | Pass a number from `wallpaper list <surface>`; `--force` only for a value a newer release adds |
 | `unsupported fill mode "..."` | Mode outside `Fill` / `Stretch` / `Tile` | Use one of the three, as spelled in Settings |
-| `unsupported --date-format "..."` | Format not in the SPA's list | Pick from the list above |
+| `unsupported locale "..."` | Not one of the seven the SPA carries | Pick from the list the error prints; `--force` only for a locale a newer release adds |
+| `locale de-DE (Deutsch) needs Olares >= 1.12.7` | One of the five 1.12.7 locales on an older backend | Upgrade Olares, or stay on `en-US` / `zh-CN`; nothing was sent |
+| `unsupported --date-format "..."` | Pattern not in the SPA's list | Pick from the list the error prints, each shown as today's date |
 | `widget set requires at least one of ...` | Called with no flags | Name the preference to change |
 | `read locale: ...` / `read wallpaper: ...` | One section of `get` failed | Retry, then check `settings advanced status` |
 | `requires Olares >= 1.12.6 ...` on `widget set` / `layout reset` | Backend predates the verb's upstream | Upgrade Olares; nothing was sent, and no layout was reset |

--- a/cli/skills/olares-settings/references/olares-settings-vpn.md
+++ b/cli/skills/olares-settings/references/olares-settings-vpn.md
@@ -57,7 +57,7 @@ olares-cli settings vpn subroutes enable
 olares-cli settings vpn subroutes disable
 ```
 
-`status` returns the `allow_subroutes` flag plus the current sub-route list. `-o json` emits the unwrapped `[]string` the SPA reads. The enable/disable verbs are hidden for compatibility and toggle sub-domain access across the mesh.
+`status` returns the `allow_subroutes` flag plus the current sub-route list. `-o json` emits the unwrapped `[]string` the SPA reads. The enable/disable verbs are hidden for compatibility and toggle Settings → VPN → "Subnet routes": whether VPN clients may reach other devices on the local network, such as printers and file servers.
 
 ## `acl` — per-app ACL (RMW under the hood)
 


### PR DESCRIPTION
Follow-up to #4034, on the same subtree.

## What changed

### `language set` takes the seven locales Settings carries

`de-DE`, `es-ES`, `it-IT`, `fr-FR` and `ja-JP` join `en-US` and `zh-CN`. Settings writes them through the same `/api/wallpaper/update/language` route the CLI uses, so its picker is the reference for what this endpoint accepts.

The gate is on the value rather than the verb: `en-US` and `zh-CN` work on any backend, the five added in 1.12.7 are refused below it, and the backend version is only resolved when one of those five is asked for — so the universal pair still works when the version cannot be established. The boundary matches the SPA's own (`compareOlaresVersion(version, '1.12.7-0') >= 0`), which counts a 1.12.7 prerelease as in.

The two SPAs reading this field carry different bundles: the browser desktop ships `en-US` and `zh-CN` alone at 1.12.7 and falls back to English for the rest, while LarePass renders all seven. The skill reference tells the reader to say so before setting one of the five.

### The value domain is in the help

- **`widget -h` lists the four switches.** Cobra does not expand a subcommand's flags in the parent help and `widget` has a single verb, so the command read as though it could only set a date format. A test walks the flag set, so a new flag cannot skip the listing.
- **The bool flags declare `false`.** Declaring `true` made help print `(default true)`, which reads as "omitting this turns it on" when the real semantics is "keep the stored value". A bare `--show-widgets` is still true.
- **`--24-hour false` names the equals form.** It used to set the flag and leave `false` as an argument, reported as `unknown command "false"`.
- **The eleven date patterns render as today's date** in help and in rejections, because `YY-M-D` and `YY.M.D` are otherwise indistinguishable — Settings solves the same problem with a live preview.
- **Locale rejections print the seven** with the names Settings shows beside them.
- **The parent help's locale line is generated from the list**, so adding a locale cannot leave a stale count behind. A test pins that, and the help line width.

### Fixed values are case-insensitive across the subtree

Surfaces and fill modes already matched without regard to case; date patterns and locales did not, and now do, storing the canonical spelling. Locales must be canonical on the wire: the SPA's i18n bundle is keyed by `en-US`, so `en-us` would load nothing and fall back silently.

### `get`'s table names values the way the page does

| Stored | Table prints |
|---|---|
| `"language": "zh-CN"` | `zh-CN (简体中文)` |
| `"dateFormat": "M/D/YY"` | `M/D/YY (8/27/26)` |

`-o json` keeps the stored values, with tests pinning both directions.

### Two documentation fixes

- **The widget switches now say what they hide on screen.** A request to hide resource readings is `--show-dashboard`, not the master switch; the old text named the flags without ever saying that the widget is the desktop clock block and that the dashboard is the CPU/memory rings under it.
- **The vpn reference described subnet routes wrong.** It called `subroutes enable/disable` a toggle for "sub-domain access across the mesh"; Settings labels that switch "Subnet routes" and describes it as letting VPN clients reach devices on the local network, printers and file servers among them. Sub-domains are not involved.

## Test plan

- [x] `go test ./cmd/...` green on top of current `main`
- [x] `python3 cli/skills/validate.py` green, every reference under the 150-line cap
- [x] 1.12.7 confirmed as the floor for the five added locales: `de-DE` and `ja-jp` written, canonicalized and read back there, refused on 1.12.6 and 1.12.5 with the same message
- [x] `en-US` / `zh-CN` confirmed to still write on all three backends, and `zh-cn` to canonicalize
- [x] `widget set` help, rejections and `NoOptDefVal` behaviour checked on 1.12.5, 1.12.6 and 1.12.7; validation confirmed to run before the version gate
- [x] All three machines restored to their initial state afterwards

Made with [Cursor](https://cursor.com)
