### PR TITLE
fix(app-service): mint olares-cli credential on upgrade

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -1121,8 +1121,8 @@ func (h *Handler) cliCredentialInject(pod *corev1.Pod, namespace string) (*corev
 		return pod, nil
 	}
 
-	// The Secret is provisioned before the chart is installed, so a pod
-	// reaching admission for an app that asked for the credential should
+	// The Secret is provisioned before the chart is installed or upgraded, so
+	// a pod reaching admission for an app that asked for the credential should
 	// always find it. Mounting it unconditionally (rather than checking the
 	// Secret first) keeps the pod from silently coming up logged out: without
 	// the Secret kubelet holds the pod in ContainerCreating, which is visible,

--- a/framework/app-service/pkg/appinstaller/helm_ops_olarescli.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_olarescli.go
@@ -18,13 +18,16 @@ import (
 // credential for an app that declares permission.loginOlaresCLI, and writes
 // it into the app's namespace for the pod webhook to pick up.
 //
-// It runs before the chart is installed so the Secret exists by the time the
-// first pod is admitted; a pod that starts without it would come up logged
-// out and stay that way until it restarted.
+// It runs before the chart is installed or upgraded so the Secret exists by
+// the time the first (or newly rolled) pod is admitted. An upgrade that newly
+// sets the permission updates ApplicationManager config, which is what the
+// mutating webhook reads; without a Secret the webhook still mounts
+// olares-cli-credential and kubelet holds the pod in ContainerCreating.
 //
-// Failures are fatal to the install: an app that asked for a credential and
-// silently came up without one is worse than an install that says why it
-// stopped.
+// Failures are fatal: an app that asked for a credential and silently came
+// up without one is worse than an install or upgrade that says why it
+// stopped. EnsureCredential itself is idempotent, so an upgrade of an app
+// that already had the grant is a no-op.
 func (h *HelmOps) EnsureOlaresCLICredential() error {
 	if !h.app.LoginOlaresCLI {
 		return nil

--- a/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
@@ -35,6 +35,11 @@ func (h *HelmOps) upgrade() error {
 		return err
 	}
 
+	if err = h.EnsureOlaresCLICredential(); err != nil {
+		klog.Errorf("Failed to provision olares-cli credential err=%v", err)
+		return err
+	}
+
 	// ResetThenReuseValues: absorb new chart defaults (image/template) while
 	// keeping prior user overrides that SetValues does not re-emit.
 	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, helm.ResetThenReuseValues)


### PR DESCRIPTION



* **Background**
An already-installed app that newly sets permission.loginOlaresCLI updates config so the webhook mounts olares-cli-credential, but the Secret was never created and new pods stuck in ContainerCreating.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app upgrade and long-lived credential provisioning; failures block upgrades but align with existing install semantics and reduce silent broken pod states.
> 
> **Overview**
> Fixes pods stuck in **ContainerCreating** when an existing app **gains** `permission.loginOlaresCLI` on upgrade: the mutating webhook starts mounting `olares-cli-credential`, but the Secret was only created on **install**.
> 
> The upgrade path now calls **`EnsureOlaresCLICredential()`** before `helm.UpgradeCharts`, matching install behavior. Provisioning failures **fail the upgrade** (same as install). Comments in the webhook and `helm_ops_olarescli.go` are updated to describe install **and** upgrade, and note that credential ensure is **idempotent** for apps that already had the grant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8679e6403dcdfeadc10b7bd994c8f20d6042132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->