### PR TITLE
oac: require rendered spec.replicas to track workloads.<name>.replicaCount

### DIFF
--- a/framework/oac/chart.go
+++ b/framework/oac/chart.go
@@ -28,9 +28,10 @@ import (
 //  4. Custom validators registered via WithCustomValidator (none by default)
 //  5. Helm dry-run and mandatory workload-integrity checks (upload mount
 //     path, `type=app` workload naming, workloadReplicas <-> rendered
-//     workload exact match plus values.yaml replicaCount coverage, and
-//     overlayGateway entrance workload existence) - ALWAYS run; not
-//     governed by any Skip* option
+//     workload exact match plus values.yaml replicaCount coverage,
+//     rendered spec.replicas actually tracking workloads.<name>.replicaCount
+//     so the platform can scale the app to zero, and overlayGateway entrance
+//     workload existence) - ALWAYS run; not governed by any Skip* option
 //  6. HostPath + rolling-update incompatibility check - ON by default,
 //     turn off with SkipHostPathCheck()
 //  7. Rendered-resource namespace check (workloads in app-namespace;
@@ -153,6 +154,10 @@ func (c *OAC) lintRenderedScenario(oacPath string, m Manifest, sc ownerScenario)
 	}
 
 	if err := c.checkManifestWorkloadRefs(oacPath, m, list); err != nil {
+		return err
+	}
+
+	if err := c.checkWorkloadScaleToZero(oacPath, m, sc); err != nil {
 		return err
 	}
 
@@ -537,6 +542,54 @@ func (c *OAC) checkManifestWorkloadRefs(oacPath string, m Manifest, list kube.Re
 			workloads[i] = e.Workload
 		}
 		if err := resources.CheckOverlayGatewayWorkloads(list, workloads); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// checkWorkloadScaleToZero renders the chart twice with every declared
+// workloads.<name>.replicaCount forced to 0 and then to 1, and requires the
+// rendered spec.replicas to follow. It reproduces exactly what app-service does
+// to stop and start an app (HelmOps.Scale), so a chart that passes here is one
+// the platform can actually control.
+//
+// The zero render is the one that matters. Stopping an app is a helm upgrade with
+// that value set to 0; if spec.replicas does not move, the upgrade is a no-op, no
+// pod terminates, and the operation sits in Stopping until a 30-minute TTL turns
+// it into StopFailed -- with no error anywhere to say why. The one render guards
+// the opposite mistake, a chart pinned at 0 that can never come up.
+//
+// This complements the static scan in checkWorkloadReplicaTemplates rather than
+// replacing it: that one names the offending line, which is the more useful
+// message when it fires, while this one cannot be talked around.
+//
+// v2 is out of scope on both ends -- the manifest validator does not require
+// workloadReplicas for it and HelmOpsV2.Scale is a no-op -- and a chart that
+// declares nothing has nothing to check.
+func (c *OAC) checkWorkloadScaleToZero(oacPath string, m Manifest, sc ownerScenario) error {
+	if isV2Manifest(m) {
+		return nil
+	}
+	cfg, ok := m.Raw().(*manifest.AppConfiguration)
+	if !ok || cfg.WorkloadReplicas == nil || len(*cfg.WorkloadReplicas) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(*cfg.WorkloadReplicas))
+	for name := range *cfg.WorkloadReplicas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var errs []error
+	for _, want := range []int32{0, 1} {
+		values := c.buildRenderValues(m, sc)
+		helmrender.SetWorkloadReplicas(values, names, want)
+		list, err := helmrender.Render(oacPath, values, m.AppName(), "")
+		if err != nil {
+			return fmt.Errorf("helm render (replicaCount=%d probe): %w", want, err)
+		}
+		if err := resources.CheckWorkloadReplicasRendered(list, want); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/framework/oac/internal/helmrender/values.go
+++ b/framework/oac/internal/helmrender/values.go
@@ -93,6 +93,27 @@ func SetGPUType(values map[string]interface{}, mode string) {
 	gpu["Type"] = mode
 }
 
+// SetWorkloadReplicas mutates values so that `.Values.workloads.<name>.replicaCount`
+// renders as replicas for every name in names, replacing whatever the chart's own
+// values.yaml declares.
+//
+// The emitted shape mirrors app-service's buildWorkloadsValues
+// (pkg/appinstaller/helm_utils.go), which is what the platform actually passes to
+// helm when it scales an app: a map of workload name to a single-key map holding
+// replicaCount. Keeping the two identical is the point -- a lint render that
+// disagreed with the production render would prove nothing.
+//
+// Names come from the manifest's workloadReplicas keys. BuildValues deliberately
+// leaves `workloads` unset so charts render against their own defaults, so a
+// caller that wants to drive the replica count has to inject it here.
+func SetWorkloadReplicas(values map[string]interface{}, names []string, replicas int32) {
+	workloads := make(map[string]interface{}, len(names))
+	for _, name := range names {
+		workloads[name] = map[string]interface{}{"replicaCount": replicas}
+	}
+	values["workloads"] = workloads
+}
+
 // MergeValues recursively deep-merges src into dst in place. On conflicts
 // src wins -- when both dst[k] and src[k] are themselves maps the merge
 // recurses, otherwise dst[k] is replaced wholesale by src[k]. Map values

--- a/framework/oac/internal/resources/workloads.go
+++ b/framework/oac/internal/resources/workloads.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // CollectWorkloadNames returns the set of Deployment and StatefulSet names
@@ -64,6 +67,75 @@ func CheckWorkloadReplicas(list kube.ResourceList, replicas map[string]int32) er
 		))
 	}
 
+	return errors.Join(errs...)
+}
+
+// CheckWorkloadReplicasRendered asserts that every rendered Deployment and
+// StatefulSet in list carries spec.replicas == want. list must be a helm render
+// performed with `.Values.workloads.<name>.replicaCount` set to want for every
+// declared workload.
+//
+// This is how the platform starts and stops an app: app-service does not patch
+// workloads, it re-runs helm with that value overridden (HelmOps.Scale). A chart
+// whose spec.replicas does not track the value therefore cannot be stopped at
+// all -- the upgrade produces an identical manifest, nothing is written, the pods
+// stay up, and the stop sits in Stopping until its 30-minute TTL turns into
+// StopFailed. The same override drives the replicas=0 first phase of a two-phase
+// install, so a chart that ignores it also runs its pods before the resource and
+// GPU admission checks have passed.
+//
+// Static inspection of the template cannot decide this. `| default 1` neutralises
+// a correct-looking reference because helm's default treats 0 as empty; a
+// template that omits spec.replicas entirely takes the Kubernetes default of 1
+// while naming no value at all; and a count reached through _helpers.tpl, an if
+// block or a subchart is not visible on the replicas line. Comparing two real
+// renders is immune to all of them.
+//
+// A workload with spec.replicas unset counts as 1, matching Kubernetes' own
+// default rather than being skipped: "no value" is precisely the failure this
+// check exists to catch.
+func CheckWorkloadReplicasRendered(list kube.ResourceList, want int32) error {
+	var errs []error
+	for _, r := range list {
+		kind := r.Object.GetObjectKind().GroupVersionKind().Kind
+		var (
+			name string
+			got  *int32
+		)
+		switch kind {
+		case KindDeployment:
+			var dep appsv1.Deployment
+			if err := scheme.Scheme.Convert(r.Object, &dep, nil); err != nil {
+				return err
+			}
+			name, got = dep.Name, dep.Spec.Replicas
+		case KindStatefulSet:
+			var sts appsv1.StatefulSet
+			if err := scheme.Scheme.Convert(r.Object, &sts, nil); err != nil {
+				return err
+			}
+			name, got = sts.Name, sts.Spec.Replicas
+		default:
+			continue
+		}
+		effective := int32(1)
+		if got != nil {
+			effective = *got
+		}
+		if effective == want {
+			continue
+		}
+		detail := fmt.Sprintf("%d", effective)
+		if got == nil {
+			detail = "unset (Kubernetes defaults it to 1)"
+		}
+		errs = append(errs, fmt.Errorf(
+			"%s %q: spec.replicas rendered as %s while workloads.%s.replicaCount was %d; "+
+				"the platform starts and stops an app by overriding that value, so spec.replicas must "+
+				"reference it directly, without `default` or any other filter that discards a zero",
+			strings.ToLower(kind), name, detail, name, want,
+		))
+	}
 	return errors.Join(errs...)
 }
 

--- a/framework/oac/internal/resources/workloads_test.go
+++ b/framework/oac/internal/resources/workloads_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"helm.sh/helm/v3/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
+	cliresource "k8s.io/cli-runtime/pkg/resource"
 )
 
 func TestCollectWorkloadNames(t *testing.T) {
@@ -62,6 +64,70 @@ func TestCheckWorkloadReplicas_UnknownEntry(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `entry "ghost" does not match`) {
 		t.Fatalf("error should flag unknown 'ghost', got: %v", err)
+	}
+}
+
+// deploymentWithReplicas builds a Deployment whose spec.replicas is set, which
+// the shared newDeployment helper deliberately leaves nil.
+func deploymentWithReplicas(name string, replicas int32) *cliresource.Info {
+	info := newDeployment(name)
+	info.Object.(*appsv1.Deployment).Spec.Replicas = &replicas
+	return info
+}
+
+func statefulSetWithReplicas(name string, replicas int32) *cliresource.Info {
+	info := newStatefulSet(name)
+	info.Object.(*appsv1.StatefulSet).Spec.Replicas = &replicas
+	return info
+}
+
+func TestCheckWorkloadReplicasRendered_Follows(t *testing.T) {
+	list := kube.ResourceList{
+		deploymentWithReplicas("web", 0),
+		statefulSetWithReplicas("db", 0),
+		newDaemonSet("node-agent"), // no replicas to track
+	}
+	if err := CheckWorkloadReplicasRendered(list, 0); err != nil {
+		t.Fatalf("workloads that track the injected value must pass: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicasRendered_Pinned(t *testing.T) {
+	// What `| default 1` produces: the injected 0 is discarded and the
+	// workload renders at 1, so the app cannot be stopped.
+	list := kube.ResourceList{deploymentWithReplicas("web", 1)}
+	err := CheckWorkloadReplicasRendered(list, 0)
+	if err == nil {
+		t.Fatal("expected error when spec.replicas ignores the injected 0")
+	}
+	if !strings.Contains(err.Error(), "rendered as 1") {
+		t.Fatalf("error should report the rendered value, got: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicasRendered_Unset(t *testing.T) {
+	// A template with no spec.replicas at all. Kubernetes defaults it to 1,
+	// so it is a failure and not something to skip.
+	list := kube.ResourceList{newDeployment("web")}
+	err := CheckWorkloadReplicasRendered(list, 0)
+	if err == nil {
+		t.Fatal("expected error when spec.replicas is absent")
+	}
+	if !strings.Contains(err.Error(), "unset") {
+		t.Fatalf("error should say the field is unset, got: %v", err)
+	}
+}
+
+func TestCheckWorkloadReplicasRendered_StuckAtZero(t *testing.T) {
+	// The opposite mistake: a chart hardcoded to 0 renders correctly for a
+	// stop and can never be started.
+	list := kube.ResourceList{deploymentWithReplicas("web", 0)}
+	err := CheckWorkloadReplicasRendered(list, 1)
+	if err == nil {
+		t.Fatal("expected error when spec.replicas cannot be raised above 0")
+	}
+	if !strings.Contains(err.Error(), "rendered as 0") {
+		t.Fatalf("error should report the rendered value, got: %v", err)
 	}
 }
 

--- a/framework/oac/oac_test.go
+++ b/framework/oac/oac_test.go
@@ -232,6 +232,41 @@ func TestLint_WorkloadReplicas_OK(t *testing.T) {
 	}
 }
 
+// TestLint_WorkloadScaleToZero_DefaultFilter is the regression this check was
+// written for. The chart's replicas line references
+// workloads.<name>.replicaCount, so the static template scan is satisfied, but
+// `| default 1` discards the platform's scale-to-zero because helm's default
+// treats 0 as empty. Installed, such an app hangs in Stopping until its TTL
+// expires, and nothing in the failure names the chart.
+func TestLint_WorkloadScaleToZero_DefaultFilter(t *testing.T) {
+	err := oac.Lint("testdata/wlrdefault",
+		oac.WithOwnerAdmin("alice"),
+		oac.SkipResourceCheck(),
+	)
+	if err == nil {
+		t.Fatal("expected Lint to fail: `| default 1` discards replicaCount=0")
+	}
+	if !strings.Contains(err.Error(), "spec.replicas") {
+		t.Fatalf("error should name spec.replicas, got: %v", err)
+	}
+}
+
+// TestLint_WorkloadScaleToZero_Absent covers the other shape of the same bug: a
+// template that omits spec.replicas entirely. The static scan has no line to
+// object to, and Kubernetes silently defaults the field to 1.
+func TestLint_WorkloadScaleToZero_Absent(t *testing.T) {
+	err := oac.Lint("testdata/wlrnoreplicas",
+		oac.WithOwnerAdmin("alice"),
+		oac.SkipResourceCheck(),
+	)
+	if err == nil {
+		t.Fatal("expected Lint to fail: the Deployment declares no spec.replicas")
+	}
+	if !strings.Contains(err.Error(), "unset") {
+		t.Fatalf("error should say the field is unset, got: %v", err)
+	}
+}
+
 // TestLint_OverlayGatewayWorkloadMissing confirms the rendered check fires
 // through Lint when an overlayGateway entrance references a workload that no
 // rendered Deployment/StatefulSet provides.

--- a/framework/oac/testdata/wlrdefault/Chart.yaml
+++ b/framework/oac/testdata/wlrdefault/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: wlrdefault
+description: fixture whose replicas reference is neutralised by `| default 1`
+type: application
+version: 1.0.0
+appVersion: "1"

--- a/framework/oac/testdata/wlrdefault/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlrdefault/OlaresManifest.yaml
@@ -1,0 +1,36 @@
+olaresManifest.version: "0.12.0"
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: wlrdefault
+  icon: https://example.com/icon.png
+  description: fixture
+  title: Fixture
+  version: 1.0.0
+entrances:
+  - name: main
+    host: wlrdefault
+    port: 8080
+    title: Main
+    icon: https://example.com/e.png
+    authLevel: public
+    openMethod: default
+spec:
+  versionName: v1
+  requiredCpu: 100m
+  limitedCpu: 200m
+  requiredMemory: 128Mi
+  limitedMemory: 256Mi
+  requiredDisk: 1Gi
+  supportArch: [amd64, arm64]
+permission:
+  appData: false
+workloadReplicas:
+  wlrdefault: 1
+options:
+  policies: []
+  resetCookie: { enabled: false }
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/wlrdefault/templates/deployment.yaml
+++ b/framework/oac/testdata/wlrdefault/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  # `default` treats 0 as empty, so the platform's scale-to-zero is discarded
+  # here even though the reference itself looks correct.
+  replicas: {{ .Values.workloads.wlrdefault.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: main
+          image: nginx:1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/framework/oac/testdata/wlrdefault/values.yaml
+++ b/framework/oac/testdata/wlrdefault/values.yaml
@@ -1,0 +1,3 @@
+workloads:
+  wlrdefault:
+    replicaCount: 1

--- a/framework/oac/testdata/wlrnoreplicas/Chart.yaml
+++ b/framework/oac/testdata/wlrnoreplicas/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: wlrnoreplicas
+description: fixture whose Deployment omits spec.replicas entirely
+type: application
+version: 1.0.0
+appVersion: "1"

--- a/framework/oac/testdata/wlrnoreplicas/OlaresManifest.yaml
+++ b/framework/oac/testdata/wlrnoreplicas/OlaresManifest.yaml
@@ -1,0 +1,36 @@
+olaresManifest.version: "0.12.0"
+olaresManifest.type: app
+apiVersion: v1
+metadata:
+  name: wlrnoreplicas
+  icon: https://example.com/icon.png
+  description: fixture
+  title: Fixture
+  version: 1.0.0
+entrances:
+  - name: main
+    host: wlrnoreplicas
+    port: 8080
+    title: Main
+    icon: https://example.com/e.png
+    authLevel: public
+    openMethod: default
+spec:
+  versionName: v1
+  requiredCpu: 100m
+  limitedCpu: 200m
+  requiredMemory: 128Mi
+  limitedMemory: 256Mi
+  requiredDisk: 1Gi
+  supportArch: [amd64, arm64]
+permission:
+  appData: false
+workloadReplicas:
+  wlrnoreplicas: 1
+options:
+  policies: []
+  resetCookie: { enabled: false }
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.3-0,<1.12.6"

--- a/framework/oac/testdata/wlrnoreplicas/templates/deployment.yaml
+++ b/framework/oac/testdata/wlrnoreplicas/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  # No spec.replicas at all: Kubernetes defaults it to 1 and the platform has
+  # nothing to override, so this app can never be scaled to zero.
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: main
+          image: nginx:1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/framework/oac/testdata/wlrnoreplicas/values.yaml
+++ b/framework/oac/testdata/wlrnoreplicas/values.yaml
@@ -1,0 +1,3 @@
+workloads:
+  wlrnoreplicas:
+    replicaCount: 1


### PR DESCRIPTION
## Background

Voice Studio V3 on yaotest004 hung in "Stopping" and never left it. The root cause turned out to be the chart, not app-service.

Stopping an app is a helm upgrade with `workloads.<name>.replicaCount` set to 0 (`HelmOps.Scale`); app-service does not patch the workload. But `audiovoicestudiov3` renders its replicas like this:

```yaml
replicas: {{ .Values.workloads.audiovoicestudiov3.replicaCount | default 1 }}
```

Helm's `default` treats 0 as empty, so the injected 0 is discarded and the field still renders as 1. The upgrade produces a manifest identical to what is already deployed, nothing is written, no pod terminates, `waitForPodsGone` polls forever, and the app sits in `Stopping` until its 30-minute TTL turns it into `StopFailed` — with nothing anywhere in the failure pointing at the chart.

The same override drives the `replicas=0` first phase of a two-phase install, so a chart like this also runs its pods before the resource and GPU admission checks have passed.

The existing static template scan (`checkWorkloadReplicaTemplates`) cannot see any of this, and misses it three different ways:

1. `| default 1` — the reference itself looks entirely correct and the regex matches it;
2. the template omits `spec.replicas` altogether — there is no line to match, and Kubernetes defaults the field to 1;
3. the count is reached through `_helpers.tpl`, an `if` block or a subchart — it never appears on the replicas line.

## Approach

Stop reading the template and render it instead — twice, forcing every declared workload's `replicaCount` to 0 and then to 1 (the injected shape is identical to app-service's `buildWorkloadsValues`) — then assert that the rendered `spec.replicas` follows. The zero render is the point; the one render guards the opposite mistake, a chart pinned at 0 that can never come up.

- `helmrender.SetWorkloadReplicas` injects `.Values.workloads.<name>.replicaCount`.
- `resources.CheckWorkloadReplicasRendered` asserts the rendered result. An unset `spec.replicas` counts as 1 rather than being skipped — "no value" is precisely the failure being caught.
- `chart.go` hooks it into `lintRenderedScenario` as a mandatory check, not governed by any `Skip*` option.

The static scan stays as it is: when it does fire it names the offending line, which is the more useful message. The value of this check is that it cannot be talked around. v2 is out of scope on both ends — the manifest validator does not require `workloadReplicas` for it, and `HelmOpsV2.Scale` is a no-op.

## Blast radius (measured against both fleets before landing)

| Fleet | Total | Newly rejected |
|---|---|---|
| `terminus-apps` | 352 | 3: `audiovoicestudiov3`, `gitlab`, `grafana` |
| `apps` | 342 | 2: `gitlab`, `grafana` |

All three are genuine, not false positives:

- `audiovoicestudiov3` — the `| default 1` above.
- `gitlab` — the `gitlab-gitlab-runner` and `gitlab-minio` Deployments carry no `spec.replicas` at all.
- `grafana` — both `values.yaml` and the manifest declare `workloads.grafana.replicaCount`, yet the Deployment template references neither it nor `spec.replicas`. So grafana in the public marketplace cannot be stopped either.

Fixing those three charts goes through their own OAC repositories and is out of scope here.

## Tests

- Four unit tests over `CheckWorkloadReplicasRendered`: tracking correctly, pinned at 1 by `default`, field absent, stuck at 0.
- Two Lint-level fixtures, one per shape of the bug (`testdata/wlrdefault`, `testdata/wlrnoreplicas`). Both pass the existing static scan and are caught only by the new check.
- `go build`, `go vet` and `gofmt` clean on the touched files; package tests pass. `internal/manifest`'s `TestValidateMetadataAppID_ReservedRejected` already fails on main and is unrelated to this change (verified against a clean checkout).
