### PR TITLE
fix(app-service): mint olares-cli credential on upgrade

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.32
+        image: beclab/app-service:0.6.33
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
-	github.com/beclab/Olares/framework/oac v0.0.0-20260820131126-7c6e29f28ef3
+	github.com/beclab/Olares/framework/oac v0.0.0-20260827142328-d8439d0b8dee
 	github.com/beclab/api v0.0.26
 	github.com/beclab/lldap-client v0.0.11
 	github.com/containerd/containerd v1.7.29

--- a/framework/app-service/go.sum
+++ b/framework/app-service/go.sum
@@ -110,10 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.20 h1:oIaQ1e17CSKaWmUTu62MtraRWVI
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.20/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/beclab/Olares/framework/oac v0.0.0-20260820131126-7c6e29f28ef3 h1:3WNQPURVTNcvLQQXj5Re15LrqWxN/RsivY8E6oA3Oks=
-github.com/beclab/Olares/framework/oac v0.0.0-20260820131126-7c6e29f28ef3/go.mod h1:MZco7qqMAzDYJQbrnfmZlym3qN0R+RDhkkn+nEH9JWA=
-github.com/beclab/api v0.0.26-0.20260821121635-360c809da1ec h1:rvdJfsvfWKJApGJFnWa1e/6UaSi8ixmMEZNiHUEciw8=
-github.com/beclab/api v0.0.26-0.20260821121635-360c809da1ec/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
+github.com/beclab/Olares/framework/oac v0.0.0-20260827142328-d8439d0b8dee h1:DLczREiMVf0Pt1Q9iiPpyBZesWPOZtIjUzOVjVL1TKs=
+github.com/beclab/Olares/framework/oac v0.0.0-20260827142328-d8439d0b8dee/go.mod h1:MZco7qqMAzDYJQbrnfmZlym3qN0R+RDhkkn+nEH9JWA=
 github.com/beclab/api v0.0.26 h1:+865PJalukiFPA4rK/mUwN+wb786mjPUhIg6pSQW4RI=
 github.com/beclab/api v0.0.26/go.mod h1:okd0RExsvSsuW5MsRh7v56Xex3vi5B26xHOGH3LT6yQ=
 github.com/beclab/lldap-client v0.0.11 h1:/XWzEd2pAFS7nwOtapyr7ClQViyGIUsMiyQ2d8t8sEo=

--- a/framework/app-service/pkg/apiserver/handler_webhook.go
+++ b/framework/app-service/pkg/apiserver/handler_webhook.go
@@ -1121,8 +1121,8 @@ func (h *Handler) cliCredentialInject(pod *corev1.Pod, namespace string) (*corev
 		return pod, nil
 	}
 
-	// The Secret is provisioned before the chart is installed, so a pod
-	// reaching admission for an app that asked for the credential should
+	// The Secret is provisioned before the chart is installed or upgraded, so
+	// a pod reaching admission for an app that asked for the credential should
 	// always find it. Mounting it unconditionally (rather than checking the
 	// Secret first) keeps the pod from silently coming up logged out: without
 	// the Secret kubelet holds the pod in ContainerCreating, which is visible,

--- a/framework/app-service/pkg/appinstaller/helm_ops_olarescli.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_olarescli.go
@@ -18,13 +18,16 @@ import (
 // credential for an app that declares permission.loginOlaresCLI, and writes
 // it into the app's namespace for the pod webhook to pick up.
 //
-// It runs before the chart is installed so the Secret exists by the time the
-// first pod is admitted; a pod that starts without it would come up logged
-// out and stay that way until it restarted.
+// It runs before the chart is installed or upgraded so the Secret exists by
+// the time the first (or newly rolled) pod is admitted. An upgrade that newly
+// sets the permission updates ApplicationManager config, which is what the
+// mutating webhook reads; without a Secret the webhook still mounts
+// olares-cli-credential and kubelet holds the pod in ContainerCreating.
 //
-// Failures are fatal to the install: an app that asked for a credential and
-// silently came up without one is worse than an install that says why it
-// stopped.
+// Failures are fatal: an app that asked for a credential and silently came
+// up without one is worse than an install or upgrade that says why it
+// stopped. EnsureCredential itself is idempotent, so an upgrade of an app
+// that already had the grant is a no-op.
 func (h *HelmOps) EnsureOlaresCLICredential() error {
 	if !h.app.LoginOlaresCLI {
 		return nil

--- a/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_upgrade.go
@@ -35,6 +35,11 @@ func (h *HelmOps) upgrade() error {
 		return err
 	}
 
+	if err = h.EnsureOlaresCLICredential(); err != nil {
+		klog.Errorf("Failed to provision olares-cli credential err=%v", err)
+		return err
+	}
+
 	// ResetThenReuseValues: absorb new chart defaults (image/template) while
 	// keeping prior user overrides that SetValues does not re-emit.
 	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, helm.ResetThenReuseValues)


### PR DESCRIPTION
* **Background**
An already-installed app that newly sets permission.loginOlaresCLI updates config so the webhook mounts olares-cli-credential, but the Secret was never created and new pods stuck in ContainerCreating.

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app upgrade and credential provisioning for Olares CLI login; failures block upgrades, but the path is idempotent and aligns with existing install behavior.
> 
> **Overview**
> Fixes apps that **newly enable** `permission.loginOlaresCLI` on upgrade: the mutating webhook would mount `olares-cli-credential`, but the Secret was only created on install, so rolled pods could stay in **ContainerCreating**.
> 
> The upgrade path now calls **`EnsureOlaresCLICredential()`** before `helm.UpgradeCharts` (same idea as install). Provisioning stays **idempotent**; failures still abort the upgrade with a clear error.
> 
> Comments in the webhook and Olares CLI helm helpers are updated to describe install **and** upgrade. Release bits: **app-service image `0.6.33`** and a bumped **`framework/oac`** module pin in `go.mod`/`go.sum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e85ab0cbf200181ed44f749d4448d921e3d8f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->