### PR TITLE
market: oac up to 0.0.39

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -148,7 +148,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.104
+        image: beclab/market-backend:v0.6.105
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
oac up to 0.0.39

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/436


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image version bump in the market deployment; typical release rollout with no config or security surface changes in this diff.
> 
> **Overview**
> Bumps the **market** appstore deployment to **`beclab/market-backend:v0.6.105`** (from `v0.6.104`) in `market_deploy.yaml`, aligning the cluster chart with **OAC 0.0.39** and the related market changes (beclab/market#436).
> 
> No other manifest, env, or RBAC changes in this PR—only the container image tag on `appstore-backend`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89cb5e668cc89b61cfe90784942575114c98bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->