### PR TITLE
fix(download-server): stop non-terminating sources (playlists/channels & live streams)

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.13"
+        image: "beclab/download-server:v1.0.14"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Two classes of URL sailed through inspect and got offered as normal downloads, but either balloon into unbounded work or never terminate.
Playlist / channel URLs — a bare /@handle/shorts, playlist?list=... etc. ignores noplaylist; yt-dlp would walk every entry in a single process .
Live broadcasts  — yt-dlp hands the live edge to ffmpeg, which records until the broadcast stops: the task pins a parallel slot in downloading with no percent (no duration/filesize), and — the ffmpeg child bypassing our progress_hooks — the cooperative cancel_event is never observed, so pause/cancel don't stop it and the ffmpeg child can outlive its parent.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field image version bump in Helm/deploy config; runtime behavior change is confined to the patched download-server image rollout.
> 
> **Overview**
> This PR **only updates the cluster deploy** so the `download-server` container runs **`beclab/download-server:v1.0.14`** instead of `v1.0.13`.
> 
> That image carries the fix described for the target merge (**v1.12.7**): blocking playlist/channel URLs that would ignore `noplaylist` and expand into unbounded yt-dlp work, and rejecting or handling **live** / **upcoming** broadcasts so ffmpeg-backed tasks do not pin download slots forever or ignore pause/cancel via `cancel_event`.
> 
> No application source changes appear in this diff—release is delivered by the image pin in `download_deploy.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fad721591fb6b782341662c3972eb451d694ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->