### PR TITLE
fix(app-service,cli): cap upgrade history at 10 revisions

### DIFF
--- a/cli/pkg/utils/helm.go
+++ b/cli/pkg/utils/helm.go
@@ -91,6 +91,7 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = namespace
 	client.Timeout = 300 * time.Second
+	client.MaxHistory = 10
 	if reuseValue {
 		client.ReuseValues = true
 	}

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -106,6 +106,7 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = namespace
 	client.Timeout = 300 * time.Second
+	client.MaxHistory = 10
 	client.Recreate = false
 	// Do not use Atomic, this could cause helm wait all resource ready.
 	//client.Atomic = true


### PR DESCRIPTION
* **Background**
Helm SDK leaves MaxHistory at 0 (unlimited). Match the helm CLI default so helm.sh/release.v1 secrets stop growing without bound.
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:
