### PR TITLE
app-service: tell a stop that cannot finish from one that is still working

### DIFF
--- a/framework/app-service/pkg/appstate/suspend_resume_test.go
+++ b/framework/app-service/pkg/appstate/suspend_resume_test.go
@@ -3,13 +3,19 @@ package appstate
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/testutil"
+	appv1alpha1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 
 	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestSuspendThenResumeViaPatch(t *testing.T) {
@@ -108,5 +114,87 @@ func TestScaleOrPatchResumePropagatesScaleError(t *testing.T) {
 
 	if err := p.scaleOrPatchResume(context.TODO(), false); err == nil {
 		t.Fatal("expected scale error to propagate")
+	}
+}
+
+func newPodForStop(name string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "nginx-alice"},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+}
+
+func suspendingAppFor(am *appv1alpha1.ApplicationManager, c client.Client) *SuspendingApp {
+	return &SuspendingApp{&baseOperationApp{baseStatefulApp: &baseStatefulApp{manager: am, client: c}}}
+}
+
+// A chart leaves completed hook and job pods behind on purpose, and counting
+// them as live made every stop of such an app burn the whole Stopping TTL
+// before reporting a timeout.
+func TestStopWaitIgnoresPodsThatAlreadyFinished(t *testing.T) {
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	done := newPodForStop("nginx-predelete", corev1.PodSucceeded)
+	failed := newPodForStop("nginx-migrate", corev1.PodFailed)
+	p := suspendingAppFor(am, testutil.NewFakeClient(am, done, failed))
+
+	if err := p.waitForPodsGone(context.TODO()); err != nil {
+		t.Fatalf("waitForPodsGone: %v", err)
+	}
+}
+
+// Waiting out the TTL told an operator only that something timed out. The pod
+// is the symptom and its owner is what has to change, so both are named.
+func TestStopWaitNamesThePodItCannotRemove(t *testing.T) {
+	restore := podStopGrace
+	podStopGrace = 0
+	t.Cleanup(func() { podStopGrace = restore })
+
+	am := testutil.NewAppManager("nginx", testutil.WithNamespace("nginx-alice"))
+	engine := newPodForStop("fs-eng-abc", corev1.PodRunning)
+	engine.OwnerReferences = []metav1.OwnerReference{
+		{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "fs-eng-abc-7d9", UID: "u", Controller: ptr.To(true)},
+	}
+	p := suspendingAppFor(am, testutil.NewFakeClient(am, engine))
+
+	err := p.waitForPodsGone(context.TODO())
+	if err == nil {
+		t.Fatal("expected a pod nobody asked to terminate to fail the stop")
+	}
+	for _, want := range []string{"fs-eng-abc", "ReplicaSet/fs-eng-abc-7d9", "nginx-alice"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// A pod carrying a DeletionTimestamp is terminating legitimately and must keep
+// the stop waiting; only a pod nobody asked to stop is a blocker.
+func TestClassifyPodsForStopSeparatesTerminatingFromStuck(t *testing.T) {
+	now := metav1.Now()
+	terminating := *newPodForStop("nginx-1", corev1.PodRunning)
+	terminating.DeletionTimestamp = &now
+	stuck := *newPodForStop("nginx-2", corev1.PodRunning)
+
+	count, blockers := classifyPodsForStop([]corev1.Pod{terminating, stuck})
+	if count != 1 {
+		t.Errorf("terminating=%d want 1", count)
+	}
+	if len(blockers) != 1 || blockers[0].name != "nginx-2" {
+		t.Errorf("blockers=%v want only nginx-2", blockers)
+	}
+}
+
+func TestDescribePodOwnerPrefersTheController(t *testing.T) {
+	pod := newPodForStop("p", corev1.PodRunning)
+	pod.OwnerReferences = []metav1.OwnerReference{
+		{Kind: "Deployment", Name: "not-the-controller"},
+		{Kind: "ReplicaSet", Name: "the-controller", Controller: ptr.To(true)},
+	}
+	if got := describePodOwner(pod); got != "ReplicaSet/the-controller" {
+		t.Errorf("owner=%q want ReplicaSet/the-controller", got)
+	}
+	// An unowned pod is the case where scaling a workload down cannot help.
+	if got := describePodOwner(newPodForStop("p", corev1.PodRunning)); got != "no owner" {
+		t.Errorf("owner=%q want %q", got, "no owner")
 	}
 }

--- a/framework/app-service/pkg/appstate/suspending_app.go
+++ b/framework/app-service/pkg/appstate/suspending_app.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/apiserver/api"
@@ -19,6 +20,7 @@ import (
 
 	kbopv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -103,10 +105,25 @@ func (p *SuspendingApp) Exec(ctx context.Context) (StatefulInProgressApp, error)
 		})
 }
 
+// podStopGrace is how long a running pod that nobody has asked to terminate may
+// hold up a stop. Scale(0) and the patch path only request termination, so there
+// is a short window in which a pod is still running with no DeletionTimestamp;
+// past that window the pod answers to something the chart does not own and
+// waiting cannot remove it. A var so tests can reach the fast-fail branch.
+var podStopGrace = 2 * time.Minute
+
+// podStopBlocker names a pod keeping a stop from completing, plus whatever
+// created it. The pod is the symptom; its owner is what has to change.
+type podStopBlocker struct {
+	name  string
+	owner string
+}
+
 func (p *SuspendingApp) waitForPodsGone(ctx context.Context) error {
 	// Scale(0)/patch only requests termination; do not claim Stopped while
 	// pods remain or upgrade resource checks that treat Stopped as "full"
 	// would under-count live requests. Cancel interrupts via ctx.
+	start := time.Now()
 	return utilwait.PollImmediate(time.Second, 30*time.Minute, func() (bool, error) {
 		if err := ctx.Err(); err != nil {
 			return false, err
@@ -116,13 +133,65 @@ func (p *SuspendingApp) waitForPodsGone(ctx context.Context) error {
 			klog.Errorf("list pods while suspending app %s failed %v", p.manager.Spec.AppName, err)
 			return false, err
 		}
-		if len(pods) == 0 {
+		terminating, blockers := classifyPodsForStop(pods)
+		if terminating == 0 && len(blockers) == 0 {
 			return true, nil
 		}
-		klog.Infof("suspend app %s waiting for %d pod(s) to terminate in namespace %s",
-			p.manager.Spec.AppName, len(pods), p.manager.Spec.AppNamespace)
+		if len(blockers) > 0 && time.Since(start) >= podStopGrace {
+			// Burning the whole Stopping TTL told an operator only that
+			// something timed out, so name what is still running and what
+			// made it.
+			return false, fmt.Errorf("suspend app %s blocked by pod(s) that are not terminating in namespace %s: %s",
+				p.manager.Spec.AppName, p.manager.Spec.AppNamespace, formatPodStopBlockers(blockers))
+		}
+		klog.Infof("suspend app %s waiting for %d terminating and %d running pod(s) in namespace %s",
+			p.manager.Spec.AppName, terminating, len(blockers), p.manager.Spec.AppNamespace)
 		return false, nil
 	})
+}
+
+// classifyPodsForStop splits an app namespace's pods into the ones a stop must
+// still wait for and the ones that will not leave on their own.
+//
+// A pod in a terminal phase is not waited on: it holds no compute, and charts
+// leave completed hook and job pods behind, which made every stop of such an
+// app burn the full Stopping TTL before reporting a timeout.
+func classifyPodsForStop(pods []corev1.Pod) (terminating int, blockers []podStopBlocker) {
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		if pod.DeletionTimestamp != nil {
+			terminating++
+			continue
+		}
+		blockers = append(blockers, podStopBlocker{name: pod.Name, owner: describePodOwner(pod)})
+	}
+	return terminating, blockers
+}
+
+// describePodOwner renders a pod's controller as kind/name. An unowned pod is
+// worth spelling out rather than omitting: it is the case where scaling a
+// workload down cannot help, because no workload created the pod.
+func describePodOwner(pod *corev1.Pod) string {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return ref.Kind + "/" + ref.Name
+		}
+	}
+	if len(pod.OwnerReferences) > 0 {
+		return pod.OwnerReferences[0].Kind + "/" + pod.OwnerReferences[0].Name
+	}
+	return "no owner"
+}
+
+func formatPodStopBlockers(blockers []podStopBlocker) string {
+	parts := make([]string, 0, len(blockers))
+	for _, b := range blockers {
+		parts = append(parts, fmt.Sprintf("%s (owned by %s)", b.name, b.owner))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (p *SuspendingApp) exec(ctx context.Context) error {


### PR DESCRIPTION
* **Background**

`SuspendingApp.waitForPodsGone` waited for the app namespace to hold zero pods,
polling for thirty minutes. Two kinds of pod it could never remove were treated
as work in progress.

A pod in a terminal phase (`Succeeded` / `Failed`) holds no compute, and charts
leave completed hook and job pods behind on purpose. Every stop of such an app
burned the whole Stopping TTL and then reported a timeout.

A pod with no `DeletionTimestamp` is one nobody has asked to terminate. Stopping
only scales the chart's own workloads, so a pod the application created at
runtime — a GPU engine, an operator's deployment — answers to nothing the stop
can reach, and waiting cannot remove it. This is what parked flowstudio in
`stopping` for thirty minutes and then in `stopFailed`: its GPU engine pods
(`fs-eng-*`) live outside the chart.

The error the operator got was one line saying something timed out, with no
indication of what was still running.

* **What changed**

`classifyPodsForStop` splits the namespace three ways:

| pod | handling |
| --- | --- |
| `Succeeded` / `Failed` | ignored — holds no compute, and charts leave these behind |
| has `DeletionTimestamp` | counted as terminating, keep waiting |
| still running, nobody asked it to stop | counted as a blocker |

A blocker that persists past `podStopGrace` (2 minutes) fails the stop, naming
the pod and its owner via `describePodOwner`. The grace period is not
conservatism: `Scale(0)` and the patch path only *request* termination, so a pod
is briefly running with no `DeletionTimestamp`; past that window the pod is not
the chart's to remove and waiting is pointless. An unowned pod is spelled out as
`no owner` rather than omitted — that is precisely the case where scaling a
workload down cannot help.

`podStopGrace` is a `var` so a test can reach the fast-fail branch.

* **Target Version for Merge**

main

* **Related Issues**

None filed. Reproduced on yaotest004 with flowstudio.

* **PRs Involving Sub-Systems**

Two sibling changes outside this repository fix the other layers of the same
incident:

- `beclab/market`: `stopApp` resolved through `operationStatesRunning`, so an app
  parked at `stopFailed` 404'd on the retry even though
  `OperationAllowedInState[StopFailed]` accepts `StopOp`. With resume also
  disallowed from that state, uninstall was the only way out of a transient stop
  failure.
- `beclab/flowstudio`: the application now reaps its engines in a `preStop` hook,
  and its Helm pre-delete Job declines both sidecar injectors.

* **Other information**

The fourth layer of the same incident is **not** addressed here and is worth a
platform decision. A Job pod must reach `Succeeded`, which requires every
container to exit, and neither `linkerd-proxy` nor `olares-mesh-in-agent` ever
does. flowstudio's pre-delete hook exited 0 (`predelete done deploys=0
services=0 gpubindings=0`), the pod stayed `Running` at `2/3 Completed`, and the
Job died of `activeDeadlineSeconds` — failing the uninstall over work that was
already done. Any application running a one-shot Job in its own namespace hits
this.

The chart-side workaround (a `linkerd.io/inject: disabled` annotation plus
`gateway.olares.io/shared-caller-outbound: "false"`) has to be remembered by
every application author. Skipping injection for pods whose `RestartPolicy` is
not `Always` looks like the right platform answer, but two things need
confirming first:

1. `MustInject` in `pkg/webhook/webhook.go` decides only app-service's own
   injection. Linkerd's injector is a separate webhook, and shared namespaces
   carry `linkerd.io/inject=enabled`. If linkerd runs first, writing the
   annotation from here is too late.
2. The alternative — `UninstallCharts` retrying with hooks disabled once it can
   prove the work container exited 0 — races the hook pod's
   `hook-delete-policy`, which may already have removed the evidence.

Verification: `go build ./...`, `go vet ./pkg/appstate/`, `gofmt -l`, and
`go test ./pkg/appstate/` all clean, including four new tests —
`TestStopWaitIgnoresPodsThatAlreadyFinished`,
`TestStopWaitNamesThePodItCannotRemove`,
`TestClassifyPodsForStopSeparatesTerminatingFromStuck` and
`TestDescribePodOwnerPrefersTheController`.

Made with [Cursor](https://cursor.com)