### PR TITLE
fix(daemon): allow reboot and shutdown while restarting

### DIFF
--- a/daemon/pkg/cluster/state/terminus.go
+++ b/daemon/pkg/cluster/state/terminus.go
@@ -328,6 +328,11 @@ func (i DiskModifingValidator) ValidateOp(op commands.Interface) error {
 type RestartingValidator struct{}
 
 func (i RestartingValidator) ValidateOp(op commands.Interface) error {
+	switch op.OperationName() {
+	case commands.Reboot, commands.Shutdown:
+		return nil
+	}
+
 	return errors.New("olares is restaring, cannot perform the operation")
 }
 


### PR DESCRIPTION
## Summary
- Allow `Reboot` and `Shutdown` while Olares is in the `Restarting` state (post-boot stabilization, not an in-flight power-off).
- Restores the same power operations that `SystemError` already permits when that state is overlaid as `Restarting` for the short uptime window.

## Test plan
- [ ] After a reboot, while status is `restarting`, trigger reboot again and confirm it is accepted (not 403).
- [ ] After a reboot, while status is `restarting`, trigger shutdown and confirm it is accepted.
- [ ] While `restarting`, confirm a non-power operation (e.g. uninstall / change-ip) is still refused.
- [ ] Confirm `AddingNode` / `Uninstalling` still refuse reboot and shutdown.


Made with [Cursor](https://cursor.com)