### PR TITLE
fix(files): stop browsers caching the media play redirect

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -212,7 +212,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.192
+          image: beclab/files-server:v0.2.193
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
## Summary
- Bump files-server to v0.2.193 so the media play redirect is 302 + no-store.
- Stops browsers caching PlaySessionId, so encoding settings (e.g. Allow HEVC) take effect on the next play.
## Test plan
- [x] Play the same video twice; Location PlaySessionId changes
- [x] Toggle Allow HEVC encoding and replay; new

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in cluster deploy; behavior change is limited to media redirect caching with no auth or data-model changes in this diff.
> 
> **Overview**
> Deploys **files-server v0.2.193** on the `files` DaemonSet container (was v0.2.192) in `files_deploy.yaml`.
> 
> That release changes the media play redirect to **302** with **no-store** caching headers so browsers do not reuse a cached `PlaySessionId`. Replay and encoding toggles (e.g. **Allow HEVC**) therefore pick up fresh session behavior on the next play.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff27926e706914e1f37c8c3bf41725704052cd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->