### PR TITLE
fix(cli): return the whole federated search result set, and render it correctly

### DIFF
--- a/cli/cmd/ctl/search/async.go
+++ b/cli/cmd/ctl/search/async.go
@@ -6,10 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,8 +26,18 @@ import (
 
 const (
 	asyncSearchMinOlaresVersion = "1.12.7"
+	// The Desktop WebSocket is normally reached over the public internet
+	// through the Olares reverse proxy, where TCP connect plus TLS can take
+	// noticeably longer than the login round trip that follows it. The two
+	// therefore get separate budgets, and the handshake matches the 30s the
+	// CLI's other WebSocket dials allow.
+	asyncSearchHandshakeTimeout = 30 * time.Second
 	asyncSearchLoginTimeout     = 15 * time.Second
-	asyncSearchHeartbeat        = 25 * time.Second
+	// A dropped or timed-out dial against that relay is common enough that a
+	// single attempt makes the command flaky rather than the network.
+	asyncSearchDialAttempts = 3
+	asyncSearchDialBackoff  = time.Second
+	asyncSearchHeartbeat    = 25 * time.Second
 	// user-service publishes its own timeout job_finished at ten minutes.
 	// Leave enough time for that terminal frame to cross the WebSocket.
 	asyncSearchJobTimeout = 10*time.Minute + 30*time.Second
@@ -126,50 +140,47 @@ func (c *asyncHitCollector) rows(sources []string) []json.RawMessage {
 	return rows
 }
 
-func runVersionedFileSearch(ctx context.Context, f *cmdutil.Factory, keyword, searchType string, o *pagingOptions, onHit func(asyncIndexedHit) error) ([]resultItem, bool, error) {
+func runVersionedFileSearch(ctx context.Context, f *cmdutil.Factory, keyword, searchType string, o *pagingOptions, onHit func(asyncIndexedHit) error) (searchPage, bool, error) {
 	useAsync, err := f.OlaresBackendAtLeast(ctx, asyncSearchMinOlaresVersion)
 	if err != nil {
-		return nil, false, err
+		return searchPage{}, false, err
 	}
 	if !useAsync {
-		items, err := runSessionSearch(ctx, f, keyword, appFilesV2, searchType, o)
-		return items, false, err
+		paging := o.sessionPaging()
+		items, err := runSessionSearch(ctx, f, keyword, appFilesV2, searchType, &paging)
+		return searchPage{items: items, offset: paging.offset, windowed: paging.windowed()}, false, err
 	}
-	items, err := runAsyncSearch(ctx, f, keyword, federatedFileSources, searchType, o, onHit)
-	return items, true, err
+	page, err := runAsyncSearch(ctx, f, keyword, federatedFileSources, searchType, o, onHit)
+	return page, true, err
 }
 
-func runAsyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string, sources []string, searchType string, o *pagingOptions, onHit func(asyncIndexedHit) error) ([]resultItem, error) {
+func runAsyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string, sources []string, searchType string, o *pagingOptions, onHit func(asyncIndexedHit) error) (searchPage, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if f == nil {
-		return nil, fmt.Errorf("internal error: search not wired with cmdutil.Factory")
+		return searchPage{}, fmt.Errorf("internal error: search not wired with cmdutil.Factory")
 	}
 
 	rp, err := f.ResolveProfile(ctx)
 	if err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	token, err := f.ValidAccessToken(ctx)
 	if err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	hc, err := f.HTTPClient(ctx)
 	if err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	doer := whoami.NewHTTPClient(hc, rp.DesktopURL, rp.OlaresID)
 
-	conn, err := dialSearchWebSocket(ctx, rp, token)
+	conn, err := openSearchWebSocket(ctx, rp, token)
 	if err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	defer conn.Close()
-
-	if err := loginSearchWebSocket(conn); err != nil {
-		return nil, err
-	}
 
 	reqid := uuid.NewString()
 	defer cancelAsyncSearch(doer, reqid)
@@ -181,23 +192,46 @@ func runAsyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string, sou
 		"sources": sources,
 	}
 	if err := doEnvelope(ctx, doer, "POST", "/api/search/nats/init", initBody, nil); err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 
 	collector := newAsyncHitCollector()
 	finished, err := collectAsyncMessages(ctx, conn, reqid, collector, onHit)
 	if err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	if err := asyncSearchTerminalError(finished); err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 	if err := recoverMissingAsyncHits(ctx, doer, reqid, sources, finished.SourceSummary, collector, onHit); err != nil {
-		return nil, err
+		return searchPage{}, err
 	}
 
-	window := paginateRaw(collector.rows(sources), o.offset, o.limit)
-	return decodeResultRows(window)
+	rows := collector.rows(sources)
+	items, err := decodeResultRows(paginateRaw(rows, o.offset, o.limit))
+	if err != nil {
+		return searchPage{}, err
+	}
+	return searchPage{
+		items:    items,
+		offset:   o.offset,
+		total:    asyncTotalHits(sources, finished.SourceSummary, len(rows)),
+		windowed: o.windowed(),
+	}, nil
+}
+
+// asyncTotalHits is the size of the whole federated result set: what the job
+// reported per source, but never less than what actually arrived, so a backend
+// that omits the summary still yields an honest count.
+func asyncTotalHits(sources []string, summaries map[string]asyncSourceSummary, collected int) int {
+	total := 0
+	for _, source := range sources {
+		total += summaries[source].HitCount
+	}
+	if total < collected {
+		return collected
+	}
+	return total
 }
 
 func asyncSearchTerminalError(message asyncSearchMessage) error {
@@ -213,12 +247,106 @@ func asyncSearchTerminalError(message asyncSearchMessage) error {
 	}
 }
 
+// openSearchWebSocket returns a connection that has already completed the
+// login round trip, retrying dial and login together while the failure looks
+// transient: a socket that never acknowledges the login is as unusable as one
+// that never opened, and both fail the same way when the relay is congested.
+func openSearchWebSocket(ctx context.Context, rp *credential.ResolvedProfile, token string) (*websocket.Conn, error) {
+	var lastErr error
+	for attempt := 0; attempt < asyncSearchDialAttempts; attempt++ {
+		if attempt > 0 {
+			if err := waitBeforeSearchDialRetry(ctx, attempt); err != nil {
+				return nil, lastErr
+			}
+		}
+		conn, err := dialSearchWebSocket(ctx, rp, token)
+		if err == nil {
+			if err = loginSearchWebSocket(conn); err == nil {
+				return conn, nil
+			}
+			conn.Close()
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if !isTransientSearchDialError(err) {
+			return nil, err
+		}
+		lastErr = err
+		if attempt+1 < asyncSearchDialAttempts {
+			fmt.Fprintf(os.Stderr, "search: connection attempt %d/%d failed (%v); retrying\n",
+				attempt+1, asyncSearchDialAttempts, err)
+		}
+	}
+	return nil, fmt.Errorf("%w (after %d attempts)", lastErr, asyncSearchDialAttempts)
+}
+
+func waitBeforeSearchDialRetry(ctx context.Context, attempt int) error {
+	timer := time.NewTimer(time.Duration(attempt) * asyncSearchDialBackoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isTransientSearchDialError reports whether retrying the connection has a
+// chance of succeeding. Anything the server answered deliberately — a rejected
+// session, a missing route — is final; a stalled or severed connection, and
+// the gateway statuses that mean "no backend right now", are not.
+func isTransientSearchDialError(err error) bool {
+	var handshake *searchHandshakeError
+	if errors.As(err, &handshake) && handshake.status > 0 {
+		switch handshake.status {
+		case http.StatusRequestTimeout, http.StatusTooManyRequests,
+			http.StatusInternalServerError, http.StatusBadGateway,
+			http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
+	}
+	// The dialer enforces HandshakeTimeout with a context deadline, so an
+	// expired handshake surfaces as context.DeadlineExceeded rather than a
+	// net.Error. The caller has already ruled out its own context.
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ETIMEDOUT) || errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) || errors.Is(err, syscall.ENETDOWN)
+}
+
+// searchHandshakeError keeps the status the upgrade was refused with, so retry
+// classification can tell a gateway hiccup from a rejected request.
+type searchHandshakeError struct {
+	status int
+	err    error
+}
+
+func (e *searchHandshakeError) Error() string {
+	if e.status > 0 {
+		return fmt.Sprintf("search WebSocket handshake failed (HTTP %d)", e.status)
+	}
+	return fmt.Sprintf("search WebSocket handshake failed: %v", e.err)
+}
+
+func (e *searchHandshakeError) Unwrap() error { return e.err }
+
 func dialSearchWebSocket(ctx context.Context, rp *credential.ResolvedProfile, token string) (*websocket.Conn, error) {
 	wsURL, err := searchWebSocketURL(rp.DesktopURL)
 	if err != nil {
 		return nil, err
 	}
-	dialer := websocket.Dialer{HandshakeTimeout: asyncSearchLoginTimeout}
+	dialer := websocket.Dialer{HandshakeTimeout: asyncSearchHandshakeTimeout}
 	if rp.InsecureSkipVerify {
 		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- explicit profile opt-in
 	}
@@ -235,9 +363,9 @@ func dialSearchWebSocket(ctx context.Context, rp *credential.ResolvedProfile, to
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == 459 {
 			return nil, fmt.Errorf("search WebSocket authentication failed (HTTP %d); please run: olares-cli profile login", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("search WebSocket handshake failed (HTTP %d)", resp.StatusCode)
+		return nil, &searchHandshakeError{status: resp.StatusCode, err: err}
 	}
-	return nil, fmt.Errorf("search WebSocket handshake failed: %w", err)
+	return nil, &searchHandshakeError{err: err}
 }
 
 func searchWebSocketURL(desktopURL string) (string, error) {

--- a/cli/cmd/ctl/search/async_test.go
+++ b/cli/cmd/ctl/search/async_test.go
@@ -3,12 +3,24 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"reflect"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
+	"github.com/gorilla/websocket"
 	"github.com/spf13/viper"
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
+	"github.com/beclab/Olares/cli/pkg/credential"
 )
 
 func TestSearchWebSocketURL(t *testing.T) {
@@ -132,6 +144,116 @@ func TestSyncSearchSourcesAreCoveredByDrive(t *testing.T) {
 		}
 		if !found {
 			t.Fatalf("source %q is not part of federatedFileSources %#v", source, federatedFileSources)
+		}
+	}
+}
+
+// newFakeSearchWS serves the Desktop /ws endpoint, refusing the first
+// failures upgrades with failStatus and answering the login on the rest.
+func newFakeSearchWS(t *testing.T, failures int, failStatus int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var upgrader websocket.Upgrader
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if int(attempts.Add(1)) <= failures {
+			http.Error(w, "upstream unavailable", failStatus)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		if err := conn.WriteJSON(map[string]string{"event": "pong"}); err != nil {
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &attempts
+}
+
+func TestOpenSearchWebSocketRetriesTransientHandshake(t *testing.T) {
+	server, attempts := newFakeSearchWS(t, 1, http.StatusBadGateway)
+	conn, err := openSearchWebSocket(context.Background(), &credential.ResolvedProfile{DesktopURL: server.URL}, "token")
+	if err != nil {
+		t.Fatalf("openSearchWebSocket: %v", err)
+	}
+	defer conn.Close()
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("upgrade attempts = %d, want 2 (one 502 + one retry)", got)
+	}
+}
+
+// An upgrade the server refused deliberately must fail on the spot: retrying a
+// rejected session only delays the "run profile login" the user needs to see.
+func TestOpenSearchWebSocketDoesNotRetryFinalStatus(t *testing.T) {
+	cases := []struct {
+		status     int
+		wantErrHas string
+	}{
+		{http.StatusUnauthorized, "authentication failed"},
+		{459, "authentication failed"},
+		{http.StatusNotFound, "handshake failed (HTTP 404)"},
+	}
+	for _, tc := range cases {
+		server, attempts := newFakeSearchWS(t, 1, tc.status)
+		conn, err := openSearchWebSocket(context.Background(), &credential.ResolvedProfile{DesktopURL: server.URL}, "token")
+		if err == nil {
+			conn.Close()
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.wantErrHas) {
+			t.Fatalf("status %d: error = %q, want it to contain %q", tc.status, err, tc.wantErrHas)
+		}
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("status %d: upgrade attempts = %d, want 1", tc.status, got)
+		}
+	}
+}
+
+func TestOpenSearchWebSocketGivesUpAfterAttemptLimit(t *testing.T) {
+	server, attempts := newFakeSearchWS(t, asyncSearchDialAttempts, http.StatusServiceUnavailable)
+	conn, err := openSearchWebSocket(context.Background(), &credential.ResolvedProfile{DesktopURL: server.URL}, "token")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected error")
+	}
+	if got := attempts.Load(); int(got) != asyncSearchDialAttempts {
+		t.Fatalf("upgrade attempts = %d, want %d", got, asyncSearchDialAttempts)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("after %d attempts", asyncSearchDialAttempts)) {
+		t.Fatalf("error = %q, want it to report the attempt count", err)
+	}
+}
+
+func TestIsTransientSearchDialError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"handshake timeout", context.DeadlineExceeded, true},
+		{"tcp i/o timeout", &net.OpError{Op: "dial", Err: os.ErrDeadlineExceeded}, true},
+		{"connection refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, true},
+		{"connection reset", fmt.Errorf("read: %w", syscall.ECONNRESET), true},
+		{"truncated response", io.ErrUnexpectedEOF, true},
+		{"bad gateway", &searchHandshakeError{status: http.StatusBadGateway}, true},
+		{"not found", &searchHandshakeError{status: http.StatusNotFound}, false},
+		{"unsupported scheme", errors.New("unsupported Desktop URL scheme"), false},
+		{"cancelled", context.Canceled, false},
+	}
+	for _, tc := range cases {
+		if got := isTransientSearchDialError(tc.err); got != tc.want {
+			t.Fatalf("%s: isTransientSearchDialError = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }

--- a/cli/cmd/ctl/search/common.go
+++ b/cli/cmd/ctl/search/common.go
@@ -101,8 +101,8 @@ func (o *pagingOptions) validate() (Format, error) {
 	if err != nil {
 		return "", err
 	}
-	if o.limit <= 0 {
-		return "", fmt.Errorf("--limit must be a positive integer")
+	if o.limit < 0 {
+		return "", fmt.Errorf("--limit must not be negative (0 prints every result)")
 	}
 	if o.offset < 0 {
 		return "", fmt.Errorf("--offset must not be negative")
@@ -110,8 +110,39 @@ func (o *pagingOptions) validate() (Format, error) {
 	return format, nil
 }
 
-func registerPagingFlags(cmd *cobra.Command, o *pagingOptions) {
-	cmd.Flags().IntVarP(&o.limit, "limit", "l", 20, "maximum number of results")
+// unlimited reports whether every hit should be printed. Only the federated
+// search can honor this: it runs the whole job to completion before anything
+// can be shown, so holding results back would hide work already done.
+func (o *pagingOptions) unlimited() bool {
+	return o.limit <= 0
+}
+
+// windowed reports whether only part of the result set will be printed. It is
+// what separates "you asked for 20" from "the backend owes us the rest".
+func (o *pagingOptions) windowed() bool {
+	return o.offset > 0 || o.limit > 0
+}
+
+// sessionPaging resolves "print everything" down to a page for the synchronous
+// search3 session API. That path pages server-side over a cached result set
+// with no total to work from, so it keeps the page size the Desktop dialog
+// uses rather than walking the cache to its end.
+func (o pagingOptions) sessionPaging() pagingOptions {
+	if o.unlimited() {
+		o.limit = initPageSize
+	}
+	return o
+}
+
+// registerPagingFlags wires the shared paging flags. defaultLimit is per
+// command because only the federated search can print an entire result set:
+// commands that fall back to the session API keep a page.
+func registerPagingFlags(cmd *cobra.Command, o *pagingOptions, defaultLimit int) {
+	usage := "maximum number of results"
+	if defaultLimit <= 0 {
+		usage += " (0 prints every result)"
+	}
+	cmd.Flags().IntVarP(&o.limit, "limit", "l", defaultLimit, usage)
 	cmd.Flags().IntVar(&o.offset, "offset", 0, "result offset for pagination")
 	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "output format: table, json")
 }
@@ -149,6 +180,32 @@ func doEnvelopeAllowing(ctx context.Context, d *whoami.HTTPClient, method, path 
 	return bflenvelope.Data(method, path, env, out, softCodes...)
 }
 
+// searchPage is what will be printed, together with the size of the result set
+// it came from. total lets the footer distinguish a window the user asked for
+// from hits the backend reported but never delivered; it is 0 when the size is
+// genuinely unknown -- the legacy session API pages server-side and never says
+// how much it cached.
+type searchPage struct {
+	items    []resultItem
+	offset   int
+	total    int
+	windowed bool
+}
+
+// remaining reports how many hits past this window the backend still holds,
+// and 0 whenever that cannot be known.
+func (p searchPage) remaining() int {
+	return remainingResults(p.total, p.offset, len(p.items))
+}
+
+func remainingResults(total, offset, shown int) int {
+	rest := total - (offset + shown)
+	if total <= 0 || rest <= 0 {
+		return 0
+	}
+	return rest
+}
+
 // resultItem captures the fields the desktop SPA reads off each result
 // row, across both the /init (Drive/Knowledge/Files) and /sync shapes.
 type resultItem struct {
@@ -157,6 +214,10 @@ type resultItem struct {
 	Path        string          `json:"path,omitempty"`
 	RepoName    string          `json:"repo_name,omitempty"`
 	Highlight   json.RawMessage `json:"highlight,omitempty"`
+	// HighlightField names the field each Highlight entry was produced from,
+	// positionally. Both are `string | string[]` in the Desktop's own type
+	// (apps/packages/app/src/utils/interface/search.ts), hence raw.
+	HighlightField json.RawMessage `json:"highlight_field,omitempty"`
 	// Left raw because `meta` is source-specific: a shape this CLI does not
 	// model must not fail the whole result set.
 	Meta json.RawMessage `json:"meta,omitempty"`
@@ -169,6 +230,62 @@ func (it resultItem) location() string {
 		return it.ResourceURI
 	}
 	return it.Path
+}
+
+// displayTitle is the name to print for a row. The federated index leaves
+// `title` empty on rows that matched on content alone, and the Desktop then
+// falls back to the title excerpt; when there is no excerpt either, the file
+// name is still sitting in the location, and printing that beats "(untitled)"
+// next to a perfectly good path.
+func (it resultItem) displayTitle() string {
+	if it.Title != "" {
+		return it.Title
+	}
+	if titled := it.highlightFor("title"); titled != "" {
+		return titled
+	}
+	if base := locationBase(it.location()); base != "" {
+		return base
+	}
+	return "(untitled)"
+}
+
+// locationBase recovers a file name from a result location, which is a
+// slash-separated path on every source that indexes files.
+func locationBase(location string) string {
+	trimmed := strings.TrimRight(location, "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+	return trimmed
+}
+
+// snippet is the excerpt printed under a result. When the row says which field
+// each excerpt came from, only the content one is worth printing: the title
+// excerpt merely repeats the line above it.
+func (it resultItem) snippet() string {
+	if len(jsonStrings(it.HighlightField)) > 0 {
+		if content := it.highlightFor("content"); content != "" {
+			return content
+		}
+		if it.highlightFor("title") != "" {
+			return ""
+		}
+	}
+	return joinHighlights(jsonStrings(it.Highlight))
+}
+
+// highlightFor returns the excerpt produced for one field. `highlight` is
+// positional against `highlight_field`, which is how the Desktop reads it
+// (apps/packages/app/src/components/search/SearchItemsComponent.vue).
+func (it resultItem) highlightFor(field string) string {
+	entries := jsonStrings(it.Highlight)
+	for i, name := range jsonStrings(it.HighlightField) {
+		if name == field && i < len(entries) {
+			return cleanHighlight(entries[i])
+		}
+	}
+	return ""
 }
 
 // libraryName returns the Sync library's display name when the hit carries one.
@@ -249,12 +366,17 @@ func decodeResultRows(rawRows []json.RawMessage) ([]resultItem, error) {
 	return items, nil
 }
 
-func printSearchResults(format Format, items []resultItem) error {
+func printSearchResults(format Format, page searchPage) error {
 	switch format {
 	case FormatJSON:
-		return printResultsJSON(os.Stdout, items)
+		if err := printResultsJSON(os.Stdout, page.items); err != nil {
+			return err
+		}
+		// stdout stays a plain array of hits for whoever is parsing it; the
+		// note that it is a partial one goes to stderr.
+		return writeTruncationNote(os.Stderr, len(page.items), page.total, page.remaining(), page.windowed)
 	default:
-		return renderResults(os.Stdout, items)
+		return renderResults(os.Stdout, page)
 	}
 }
 
@@ -268,17 +390,14 @@ func printResultsJSON(w io.Writer, items []resultItem) error {
 	return enc.Encode(rows)
 }
 
-func renderResults(w io.Writer, items []resultItem) error {
+func renderResults(w io.Writer, page searchPage) error {
+	items := page.items
 	if len(items) == 0 {
 		_, err := fmt.Fprintln(w, "no results")
 		return err
 	}
 	for i, it := range items {
-		title := it.Title
-		if title == "" {
-			title = "(untitled)"
-		}
-		if _, err := fmt.Fprintf(w, "%d. %s\n", i+1, title); err != nil {
+		if _, err := fmt.Fprintf(w, "%d. %s\n", i+1, it.displayTitle()); err != nil {
 			return err
 		}
 		if loc := it.locationLine(); loc != "" {
@@ -286,32 +405,121 @@ func renderResults(w io.Writer, items []resultItem) error {
 				return err
 			}
 		}
-		if snippet := highlightSnippet(it.Highlight); snippet != "" {
+		if snippet := it.snippet(); snippet != "" {
 			if _, err := fmt.Fprintf(w, "   %s\n", snippet); err != nil {
 				return err
 			}
 		}
 	}
-	_, err := fmt.Fprintf(w, "\n%d result(s)\n", len(items))
+	return writeResultCount(w, len(items), page.total, page.remaining(), page.windowed)
+}
+
+// writeResultCount renders the trailing count. A short window is only worth
+// remarking on when the reader can act on it, and what they can do depends on
+// why it is short: their own --offset/--limit, or hits the job counted but
+// never handed over.
+func writeResultCount(w io.Writer, shown, total, remaining int, windowed bool) error {
+	if remaining <= 0 {
+		_, err := fmt.Fprintf(w, "\n%d result(s)\n", shown)
+		return err
+	}
+	if windowed {
+		_, err := fmt.Fprintf(w, "\n%d of %d result(s); raise --limit or page with --offset for the other %d\n",
+			shown, total, remaining)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n%d of %d result(s); the search reported %d more but never delivered them\n",
+		shown, total, remaining)
 	return err
 }
 
-func highlightSnippet(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
+// writeTruncationNote is writeResultCount's counterpart for JSON output, where
+// the count cannot ride along in the payload without changing its shape.
+func writeTruncationNote(w io.Writer, shown, total, remaining int, windowed bool) error {
+	if remaining <= 0 {
+		return nil
 	}
-	var single string
-	if err := json.Unmarshal(raw, &single); err == nil {
-		return stripHighlightTags(single)
+	if windowed {
+		_, err := fmt.Fprintf(w, "search: printed %d of %d result(s); raise --limit or page with --offset for the other %d\n",
+			shown, total, remaining)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "search: printed %d of %d result(s); the search reported %d more but never delivered them\n",
+		shown, total, remaining)
+	return err
+}
+
+// jsonStrings decodes a `string | string[]` field into a slice. An unmodelled
+// shape yields nothing rather than failing the row.
+func jsonStrings(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
 	}
 	var many []string
 	if err := json.Unmarshal(raw, &many); err == nil {
-		return stripHighlightTags(strings.Join(many, " … "))
+		return many
 	}
-	return ""
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}
+	}
+	return nil
 }
 
-func stripHighlightTags(s string) string {
-	replacer := strings.NewReplacer("<hi>", "", "</hi>", "")
-	return strings.TrimSpace(strings.Join(strings.Fields(replacer.Replace(s)), " "))
+func joinHighlights(entries []string) string {
+	cleaned := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if c := cleanHighlight(entry); c != "" {
+			cleaned = append(cleaned, c)
+		}
+	}
+	return strings.Join(cleaned, highlightEllipsis)
+}
+
+// highlightElision is the marker search3 leaves where it dropped the text
+// between two excerpt windows of the same field. Only a run of exactly this
+// width is one: hashes that are really part of a document must survive, and
+// the cost of guessing wrong is mangled file content.
+const highlightElision = "#######"
+
+const highlightEllipsis = " … "
+
+var highlightTags = strings.NewReplacer("<hi>", "", "</hi>", "")
+
+// cleanHighlight turns one backend excerpt into a printable line. `<hi>` tags
+// are the Desktop's bold markers, and an elision reads as the same ellipsis
+// this CLI already puts between excerpts.
+func cleanHighlight(s string) string {
+	cleaned := replaceElisions(highlightTags.Replace(s))
+	cleaned = strings.TrimSpace(strings.Join(strings.Fields(cleaned), " "))
+	// An excerpt that survives as nothing but elisions says nothing.
+	if strings.Trim(cleaned, "… ") == "" {
+		return ""
+	}
+	return cleaned
+}
+
+func replaceElisions(s string) string {
+	if !strings.Contains(s, highlightElision) {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] != '#' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		end := i
+		for end < len(s) && s[end] == '#' {
+			end++
+		}
+		if end-i == len(highlightElision) {
+			b.WriteString(highlightEllipsis)
+		} else {
+			b.WriteString(s[i:end])
+		}
+		i = end
+	}
+	return b.String()
 }

--- a/cli/cmd/ctl/search/common_test.go
+++ b/cli/cmd/ctl/search/common_test.go
@@ -1,8 +1,10 @@
 package search
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -140,6 +142,197 @@ func TestResultItemLocationLine(t *testing.T) {
 				t.Fatalf("locationLine() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRemainingResults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                 string
+		total, offset, shown int
+		want                 int
+	}{
+		{"default window over a larger set", 57, 0, 20, 37},
+		{"second page", 57, 20, 20, 17},
+		{"last page", 57, 40, 17, 0},
+		{"window covers everything", 12, 0, 12, 0},
+		{"unknown total", 0, 0, 20, 0},
+		{"offset past the end", 57, 100, 0, 0},
+	}
+	for _, tc := range cases {
+		if got := remainingResults(tc.total, tc.offset, tc.shown); got != tc.want {
+			t.Fatalf("%s: remainingResults(%d, %d, %d) = %d, want %d",
+				tc.name, tc.total, tc.offset, tc.shown, got, tc.want)
+		}
+	}
+}
+
+// A default --limit against a bigger result set is exactly the case that made
+// a CLI run look like it disagreed with the Desktop dialog, so the footer has
+// to name the full set.
+func TestRenderResultsNamesTheFullResultSet(t *testing.T) {
+	t.Parallel()
+
+	items, err := decodeResultRows([]json.RawMessage{json.RawMessage(`{"title":"report"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var partial bytes.Buffer
+	if err := renderResults(&partial, searchPage{items: items, total: 57, windowed: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := partial.String(); !strings.Contains(got, "1 of 57 result(s)") || !strings.Contains(got, "--limit") {
+		t.Fatalf("partial window footer = %q", got)
+	}
+
+	// Nothing was held back on purpose here, so pointing at --limit would send
+	// the reader after results that no flag can produce.
+	var undelivered bytes.Buffer
+	if err := renderResults(&undelivered, searchPage{items: items, total: 57}); err != nil {
+		t.Fatal(err)
+	}
+	if got := undelivered.String(); !strings.Contains(got, "reported 56 more but never delivered") ||
+		strings.Contains(got, "--limit") {
+		t.Fatalf("undelivered footer = %q", got)
+	}
+
+	var complete bytes.Buffer
+	if err := renderResults(&complete, searchPage{items: items, total: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if got := complete.String(); !strings.Contains(got, "\n1 result(s)\n") || strings.Contains(got, "--limit") {
+		t.Fatalf("complete window footer = %q", got)
+	}
+
+	// The legacy session API cannot report a total; the footer must not invent one.
+	var unknown bytes.Buffer
+	if err := renderResults(&unknown, searchPage{items: items}); err != nil {
+		t.Fatal(err)
+	}
+	if got := unknown.String(); !strings.Contains(got, "\n1 result(s)\n") {
+		t.Fatalf("unknown-total footer = %q", got)
+	}
+}
+
+func TestAsyncTotalHits(t *testing.T) {
+	t.Parallel()
+
+	sources := []string{appFilesV2, appSeafile}
+	summaries := map[string]asyncSourceSummary{
+		appFilesV2: {Status: "completed", HitCount: 40},
+		appSeafile: {Status: "completed", HitCount: 17},
+		// A source the caller did not ask for must not inflate the total.
+		appDropbox: {Status: "completed", HitCount: 99},
+	}
+	if got := asyncTotalHits(sources, summaries, 57); got != 57 {
+		t.Fatalf("asyncTotalHits = %d, want 57", got)
+	}
+	// A backend that omits the summary still owes an honest count.
+	if got := asyncTotalHits(sources, nil, 12); got != 12 {
+		t.Fatalf("asyncTotalHits without summary = %d, want 12", got)
+	}
+	// Recovery may fall short of what the job claimed; report what arrived.
+	if got := asyncTotalHits(sources, summaries, 50); got != 57 {
+		t.Fatalf("asyncTotalHits with a gap = %d, want 57", got)
+	}
+}
+
+// The rows here are the shapes `search drive` actually printed against a
+// 1.12.7 backend, including the content-only matches that came out as
+// "(untitled)" with the excerpt marker showing through.
+func TestResultItemTitleAndSnippet(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		row         string
+		wantTitle   string
+		wantSnippet string
+	}{
+		{
+			"filename match does not repeat the title in the excerpt",
+			`{"title":"test(1).py","resource_uri":"drive/Common/myxtest/test(1).py",
+			  "highlight":["<hi>test</hi>(1).py","print('<hi>test</hi>')"],
+			  "highlight_field":["title","content"]}`,
+			"test(1).py",
+			"print('test')",
+		},
+		{
+			"content-only match recovers its name from the location",
+			`{"title":"","resource_uri":"drive/Common/myxtest/market&setting-GPU 的 olares-cli 复测(1).xlsx",
+			  "highlight":["running install - market.<hi>test</hi> sglangllmbasev32755#######opped stop"],
+			  "highlight_field":["content"]}`,
+			"market&setting-GPU 的 olares-cli 复测(1).xlsx",
+			"running install - market.test sglangllmbasev32755 … opped stop",
+		},
+		{
+			"title excerpt names a row the backend left untitled",
+			`{"title":"","resource_uri":"drive/Home/notes.md",
+			  "highlight":["<hi>notes</hi>.md"],"highlight_field":"title"}`,
+			"notes.md",
+			"",
+		},
+		{
+			"directory hit drops the trailing slash",
+			`{"title":"","resource_uri":"/sync/2c768a94/myxtest/"}`,
+			"myxtest",
+			"",
+		},
+		{
+			// Rows predating highlight_field must keep rendering their excerpt.
+			"row without highlight_field joins what it has",
+			`{"title":"report.pdf","highlight":["a <hi>test</hi>","another <hi>test</hi>"]}`,
+			"report.pdf",
+			"a test … another test",
+		},
+		{
+			"row with nothing to show",
+			`{"title":""}`,
+			"(untitled)",
+			"",
+		},
+		{
+			"unmodelled highlight shape is ignored",
+			`{"title":"report.pdf","highlight":{"content":"x"},"highlight_field":["content"]}`,
+			"report.pdf",
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			items, err := decodeResultRows([]json.RawMessage{json.RawMessage(tc.row)})
+			if err != nil {
+				t.Fatalf("decodeResultRows: %v", err)
+			}
+			if got := items[0].displayTitle(); got != tc.wantTitle {
+				t.Fatalf("displayTitle() = %q, want %q", got, tc.wantTitle)
+			}
+			if got := items[0].snippet(); got != tc.wantSnippet {
+				t.Fatalf("snippet() = %q, want %q", got, tc.wantSnippet)
+			}
+		})
+	}
+}
+
+// The elision marker is matched at its exact width, so hashes that are really
+// part of a document survive.
+func TestCleanHighlightKeepsGenuineHashes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ in, want string }{
+		{"## Attachment Test #######  Different words", "## Attachment Test … Different words"},
+		{"###### heading six", "###### heading six"},
+		{"######## eight hashes", "######## eight hashes"},
+		{"#######", ""},
+	}
+	for _, tc := range cases {
+		if got := cleanHighlight(tc.in); got != tc.want {
+			t.Fatalf("cleanHighlight(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/cli/cmd/ctl/search/drive.go
+++ b/cli/cmd/ctl/search/drive.go
@@ -32,6 +32,13 @@ With --watch, Olares 1.12.7+ prints each result as soon as its asynchronous
 batch arrives. JSON output is JSONL (one result object per line). Older
 versions have no result stream and print the completed legacy result instead.
 
+The asynchronous search runs the whole job before it can finish, so every hit
+it produced is printed by default. --limit caps that; --offset skips ahead.
+Under --watch the window applies in arrival order, so the same --offset/--limit
+can select different results than a plain run, which windows the completed set
+grouped by source. Olares 1.12.6 and older page server-side and keep printing
+one 20-result page at a time.
+
 Examples:
   olares-cli search drive report
   olares-cli search files report
@@ -53,7 +60,7 @@ Examples:
 		"search mode: aggregate, file_name")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", false,
 		"print results as asynchronous search batches arrive (Olares >= 1.12.7)")
-	registerPagingFlags(cmd, &o.pagingOptions)
+	registerPagingFlags(cmd, &o.pagingOptions, 0)
 	return cmd
 }
 
@@ -73,16 +80,16 @@ func runDriveSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *
 	var watcher *watchResultPrinter
 	var onHit func(asyncIndexedHit) error
 	if o.watch {
-		watcher = newWatchResultPrinter(os.Stdout, format, o.offset, o.limit)
+		watcher = newWatchResultPrinter(os.Stdout, os.Stderr, format, o.offset, o.limit)
 		onHit = watcher.emit
 	}
 
-	items, async, err := runVersionedFileSearch(ctx, f, keyword, searchType, &o.pagingOptions, onHit)
+	page, async, err := runVersionedFileSearch(ctx, f, keyword, searchType, &o.pagingOptions, onHit)
 	if err != nil {
 		return err
 	}
 	if o.watch && async {
-		return watcher.finish()
+		return watcher.finish(page.total)
 	}
-	return printSearchResults(format, items)
+	return printSearchResults(format, page)
 }

--- a/cli/cmd/ctl/search/knowledge.go
+++ b/cli/cmd/ctl/search/knowledge.go
@@ -42,7 +42,7 @@ Examples:
 		},
 	}
 	cmd.SilenceUsage = true
-	registerPagingFlags(cmd, &o.pagingOptions)
+	registerPagingFlags(cmd, &o.pagingOptions, initPageSize)
 	return cmd
 }
 
@@ -62,5 +62,5 @@ func runKnowledgeSearch(ctx context.Context, f *cmdutil.Factory, keyword string,
 	if err != nil {
 		return err
 	}
-	return printSearchResults(format, items)
+	return printSearchResults(format, searchPage{items: items, offset: o.offset, windowed: o.windowed()})
 }

--- a/cli/cmd/ctl/search/knowledge.go
+++ b/cli/cmd/ctl/search/knowledge.go
@@ -58,9 +58,10 @@ func runKnowledgeSearch(ctx context.Context, f *cmdutil.Factory, keyword string,
 		return err
 	}
 
-	items, err := runSessionSearch(ctx, f, keyword, appKnowledge, searchTypeAggregate, &o.pagingOptions)
+	paging := o.sessionPaging()
+	items, err := runSessionSearch(ctx, f, keyword, appKnowledge, searchTypeAggregate, &paging)
 	if err != nil {
 		return err
 	}
-	return printSearchResults(format, searchPage{items: items, offset: o.offset, windowed: o.windowed()})
+	return printSearchResults(format, searchPage{items: items, offset: paging.offset, windowed: paging.windowed()})
 }

--- a/cli/cmd/ctl/search/root_test.go
+++ b/cli/cmd/ctl/search/root_test.go
@@ -30,6 +30,66 @@ func TestSearchCommandExposesFederatedDriveOnly(t *testing.T) {
 	}
 }
 
+// Only the commands that can run the federated job may default to printing
+// everything; `knowledge` never leaves the session API, which pages
+// server-side and has no completed result set to print in full.
+func TestSearchDefaultLimitPerCommand(t *testing.T) {
+	cmd := NewSearchCommand(&cmdutil.Factory{})
+	cases := map[string]string{
+		"drive":     "0",
+		"sync":      "0",
+		"knowledge": "20",
+	}
+	for name, want := range cases {
+		found, _, err := cmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", name, err)
+		}
+		flag := found.Flags().Lookup("limit")
+		if flag == nil {
+			t.Fatalf("%s has no --limit", name)
+		}
+		if flag.DefValue != want {
+			t.Fatalf("%s --limit default = %s, want %s", name, flag.DefValue, want)
+		}
+	}
+}
+
+func TestPagingOptionsSessionFallback(t *testing.T) {
+	t.Parallel()
+
+	// An unlimited request cannot be served by the session API, which pages
+	// blind over a server-side cache; it falls back to that page.
+	unlimited := pagingOptions{limit: 0, offset: 0}
+	if got := unlimited.sessionPaging().limit; got != initPageSize {
+		t.Fatalf("sessionPaging().limit = %d, want %d", got, initPageSize)
+	}
+	if !unlimited.unlimited() || unlimited.windowed() {
+		t.Fatal("an unlimited request must not look windowed")
+	}
+
+	// An explicit window is the user's, and survives untouched.
+	explicit := pagingOptions{limit: 50, offset: 20}
+	resolved := explicit.sessionPaging()
+	if resolved.limit != 50 || resolved.offset != 20 {
+		t.Fatalf("sessionPaging() = %+v, want the request unchanged", resolved)
+	}
+	if !resolved.windowed() {
+		t.Fatal("an explicit window must look windowed")
+	}
+}
+
+func TestPagingOptionsValidateAcceptsUnlimited(t *testing.T) {
+	t.Parallel()
+
+	if _, err := (&pagingOptions{limit: 0, output: "table"}).validate(); err != nil {
+		t.Fatalf("--limit 0 must be accepted: %v", err)
+	}
+	if _, err := (&pagingOptions{limit: -1, output: "table"}).validate(); err == nil {
+		t.Fatal("--limit -1 must be rejected")
+	}
+}
+
 // The Desktop dialog labels the single federated entry "Files", so that name
 // has to reach the same command as `drive` rather than 404 into usage output.
 func TestSearchFilesAliasResolvesToDrive(t *testing.T) {

--- a/cli/cmd/ctl/search/session.go
+++ b/cli/cmd/ctl/search/session.go
@@ -43,27 +43,51 @@ func runSessionSearch(ctx context.Context, f *cmdutil.Factory, keyword, app, sea
 		return nil, err
 	}
 
-	// Honor --offset/--limit client-side. If the requested window already lies
-	// within what init returned -- or init returned a short final page (fewer
-	// than initPageSize hits means the cache holds no more) -- serve it
-	// directly. Otherwise page the exact window via /search/more, whose limit
-	// must stay within the backend's 1-100 range; a past-the-end offset comes
-	// back as codeNoMoreResults, which we treat as an empty result set.
+	// Honor --offset/--limit client-side. /search/more's limit must stay within
+	// the backend's 1-100 range, and a past-the-end offset comes back as
+	// codeNoMoreResults, which we treat as an empty result set.
 	var window []json.RawMessage
-	if needsMorePage(o.offset, o.limit, len(initRows)) {
+	if w := resolveSessionWindow(o, len(initRows)); w.needsMore {
 		moreBody := map[string]interface{}{
 			"reqid":  reqid,
-			"offset": o.offset,
-			"limit":  clampMoreLimit(o.limit),
+			"offset": w.offset,
+			"limit":  clampMoreLimit(w.limit),
 		}
 		if err := doEnvelopeAllowing(ctx, doer, "POST", "/api/search/more", moreBody, &window, codeNoMoreResults); err != nil {
 			return nil, err
 		}
 	} else {
-		window = paginateRaw(initRows, o.offset, o.limit)
+		window = paginateRaw(initRows, w.offset, w.limit)
 	}
 
 	return decodeResultRows(window)
+}
+
+// sessionWindow is how the requested --offset/--limit will be served from a
+// session: out of the rows /search/init already returned, or by asking
+// /search/more for the exact window.
+type sessionWindow struct {
+	offset    int
+	limit     int
+	needsMore bool
+}
+
+// resolveSessionWindow decides how to serve o against an init page of initLen
+// rows. It resolves the window itself rather than trusting the caller to,
+// because every primitive below it assumes a positive limit: "print every
+// result" would otherwise read as a zero-width window that is always already
+// satisfied, and would reach /search/more outside its 1-100 range.
+//
+// A window that lies within what init returned -- or any window at all once
+// init returns a short final page, since fewer than initPageSize hits means
+// the cache holds no more -- is served from the init rows.
+func resolveSessionWindow(o *pagingOptions, initLen int) sessionWindow {
+	paging := o.sessionPaging()
+	return sessionWindow{
+		offset:    paging.offset,
+		limit:     paging.limit,
+		needsMore: needsMorePage(paging.offset, paging.limit, initLen),
+	}
 }
 
 // requireSessionAppBackendVersion is the fail-closed preflight for legacy

--- a/cli/cmd/ctl/search/session_test.go
+++ b/cli/cmd/ctl/search/session_test.go
@@ -4,6 +4,50 @@ import (
 	"testing"
 )
 
+// `--limit 0` means "print every result", which the session API cannot do: it
+// pages blind over a server-side cache. Left unresolved it reads as a
+// zero-width window -- one that the init page always already satisfies, so a
+// truncated first page is served as if it were the whole result set, and that
+// asks /search/more for `limit: 0`, outside the 1-100 the backend accepts.
+func TestResolveSessionWindowServesUnlimitedAsAPage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		offset, limit int
+		initLen       int
+		wantOffset    int
+		wantLimit     int
+		wantNeedsMore bool
+	}{
+		{"unlimited over a full init page", 0, 0, initPageSize, 0, initPageSize, false},
+		{"unlimited over a short init page", 0, 0, 8, 0, initPageSize, false},
+		{"unlimited past the init page", 30, 0, initPageSize, 30, initPageSize, true},
+		{"explicit window inside the init page", 0, 5, initPageSize, 0, 5, false},
+		{"explicit window past the init page", 20, 20, initPageSize, 20, 20, true},
+		{"explicit window larger than the init page", 0, 50, initPageSize, 0, 50, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveSessionWindow(&pagingOptions{offset: tc.offset, limit: tc.limit}, tc.initLen)
+			if got.offset != tc.wantOffset || got.limit != tc.wantLimit || got.needsMore != tc.wantNeedsMore {
+				t.Fatalf("resolveSessionWindow(offset=%d, limit=%d, initLen=%d) = %+v, want {offset:%d limit:%d needsMore:%v}",
+					tc.offset, tc.limit, tc.initLen, got, tc.wantOffset, tc.wantLimit, tc.wantNeedsMore)
+			}
+			if !got.needsMore {
+				return
+			}
+			if sent := clampMoreLimit(got.limit); sent < 1 || sent > moreMaxLimit {
+				t.Fatalf("/search/more would be asked for limit=%d, outside the backend's 1-%d range",
+					sent, moreMaxLimit)
+			}
+		})
+	}
+}
+
 // TestSessionAppConstants pins the search3 source/app wire strings. These must
 // stay aligned with TermiPass ServiceType and the federated search protocol.
 func TestSessionAppConstants(t *testing.T) {

--- a/cli/cmd/ctl/search/sync.go
+++ b/cli/cmd/ctl/search/sync.go
@@ -29,7 +29,8 @@ On Olares 1.12.7 and newer this uses the same asynchronous federated
 search channel as search drive, restricted to the seafile source.
 Olares 1.12.6 and older keep using /api/search/sync.
 
---offset/--limit are applied client-side on both paths.
+--offset/--limit are applied client-side on both paths. The asynchronous
+search prints every hit by default; the legacy path keeps one 20-result page.
 
 Examples:
   olares-cli search sync notes
@@ -46,7 +47,7 @@ Examples:
 		},
 	}
 	cmd.SilenceUsage = true
-	registerPagingFlags(cmd, &o.pagingOptions)
+	registerPagingFlags(cmd, &o.pagingOptions, 0)
 	return cmd
 }
 
@@ -64,11 +65,11 @@ func runSyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string, o *s
 		return err
 	}
 	if useAsync {
-		items, err := runAsyncSearch(ctx, f, keyword, syncSearchSources, searchTypeAggregate, &o.pagingOptions, nil)
+		page, err := runAsyncSearch(ctx, f, keyword, syncSearchSources, searchTypeAggregate, &o.pagingOptions, nil)
 		if err != nil {
 			return err
 		}
-		return printSearchResults(format, items)
+		return printSearchResults(format, page)
 	}
 
 	return runLegacySyncSearch(ctx, f, keyword, o, format)
@@ -90,11 +91,16 @@ func runLegacySyncSearch(ctx context.Context, f *cmdutil.Factory, keyword string
 	if err := doEnvelope(ctx, doer, "POST", "/api/search/sync", body, &rawRows); err != nil {
 		return err
 	}
-	rawRows = paginateRaw(rawRows, o.offset, o.limit)
 
-	items, err := decodeResultRows(rawRows)
+	paging := o.sessionPaging()
+	items, err := decodeResultRows(paginateRaw(rawRows, paging.offset, paging.limit))
 	if err != nil {
 		return err
 	}
-	return printSearchResults(format, items)
+	return printSearchResults(format, searchPage{
+		items:    items,
+		offset:   paging.offset,
+		total:    len(rawRows),
+		windowed: paging.windowed(),
+	})
 }

--- a/cli/cmd/ctl/search/watch.go
+++ b/cli/cmd/ctl/search/watch.go
@@ -9,8 +9,12 @@ import (
 // watchResultPrinter streams unique asynchronous hits in arrival order. This
 // deliberately does not repaint the terminal: output remains useful when
 // redirected to a file or piped into another command.
+//
+// notes carries the trailing count in JSON mode, where stdout has to stay a
+// clean JSONL stream.
 type watchResultPrinter struct {
 	w       io.Writer
+	notes   io.Writer
 	format  Format
 	offset  int
 	limit   int
@@ -18,13 +22,13 @@ type watchResultPrinter struct {
 	printed int
 }
 
-func newWatchResultPrinter(w io.Writer, format Format, offset, limit int) *watchResultPrinter {
-	return &watchResultPrinter{w: w, format: format, offset: offset, limit: limit}
+func newWatchResultPrinter(w, notes io.Writer, format Format, offset, limit int) *watchResultPrinter {
+	return &watchResultPrinter{w: w, notes: notes, format: format, offset: offset, limit: limit}
 }
 
 func (p *watchResultPrinter) emit(hit asyncIndexedHit) error {
 	p.seen++
-	if p.seen <= p.offset || p.printed >= p.limit {
+	if p.seen <= p.offset || (p.limit > 0 && p.printed >= p.limit) {
 		return nil
 	}
 
@@ -39,11 +43,7 @@ func (p *watchResultPrinter) emit(hit asyncIndexedHit) error {
 		return json.NewEncoder(p.w).Encode(item.Raw)
 	}
 
-	title := item.Title
-	if title == "" {
-		title = "(untitled)"
-	}
-	if _, err := fmt.Fprintf(p.w, "%d. [%s] %s\n", p.printed, hit.Source, title); err != nil {
+	if _, err := fmt.Fprintf(p.w, "%d. [%s] %s\n", p.printed, hit.Source, item.displayTitle()); err != nil {
 		return err
 	}
 	if loc := item.locationLine(); loc != "" {
@@ -51,7 +51,7 @@ func (p *watchResultPrinter) emit(hit asyncIndexedHit) error {
 			return err
 		}
 	}
-	if snippet := highlightSnippet(item.Highlight); snippet != "" {
+	if snippet := item.snippet(); snippet != "" {
 		if _, err := fmt.Fprintf(p.w, "   %s\n", snippet); err != nil {
 			return err
 		}
@@ -59,14 +59,21 @@ func (p *watchResultPrinter) emit(hit asyncIndexedHit) error {
 	return nil
 }
 
-func (p *watchResultPrinter) finish() error {
+// finish closes the stream with the count. total is the size of the job's full
+// result set, which only the terminal frame knows; the hits that actually
+// streamed are a floor under it.
+func (p *watchResultPrinter) finish(total int) error {
+	if total < p.seen {
+		total = p.seen
+	}
+	remaining := remainingResults(total, p.offset, p.printed)
+	windowed := p.offset > 0 || p.limit > 0
 	if p.format == FormatJSON {
-		return nil
+		return writeTruncationNote(p.notes, p.printed, total, remaining, windowed)
 	}
 	if p.printed == 0 {
 		_, err := fmt.Fprintln(p.w, "no results")
 		return err
 	}
-	_, err := fmt.Fprintf(p.w, "\n%d result(s)\n", p.printed)
-	return err
+	return writeResultCount(p.w, p.printed, total, remaining, windowed)
 }

--- a/cli/cmd/ctl/search/watch_test.go
+++ b/cli/cmd/ctl/search/watch_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestWatchResultPrinterTableStreamsWindowInArrivalOrder(t *testing.T) {
-	var out bytes.Buffer
-	p := newWatchResultPrinter(&out, FormatTable, 1, 1)
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatTable, 1, 1)
 
 	if err := p.emit(asyncIndexedHit{Source: appFilesV2, Hit: []byte(`{"title":"skip"}`)}); err != nil {
 		t.Fatal(err)
@@ -19,12 +19,12 @@ func TestWatchResultPrinterTableStreamsWindowInArrivalOrder(t *testing.T) {
 	if err := p.emit(asyncIndexedHit{Source: appGoogleDrive, Hit: []byte(`{"title":"past-limit"}`)}); err != nil {
 		t.Fatal(err)
 	}
-	if err := p.finish(); err != nil {
+	if err := p.finish(3); err != nil {
 		t.Fatal(err)
 	}
 
 	got := out.String()
-	for _, want := range []string{"1. [dropbox] report", "dropbox/me/report.pdf", "1 result(s)"} {
+	for _, want := range []string{"1. [dropbox] report", "dropbox/me/report.pdf", "1 of 3 result(s)"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output %q does not contain %q", got, want)
 		}
@@ -34,16 +34,85 @@ func TestWatchResultPrinterTableStreamsWindowInArrivalOrder(t *testing.T) {
 	}
 }
 
-func TestWatchResultPrinterJSONUsesJSONLines(t *testing.T) {
-	var out bytes.Buffer
-	p := newWatchResultPrinter(&out, FormatJSON, 0, 2)
+// A window that covered everything must not be dressed up as a partial one.
+func TestWatchResultPrinterCompleteWindowReportsPlainCount(t *testing.T) {
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatTable, 0, 20)
 
 	for _, title := range []string{"one", "two"} {
 		if err := p.emit(asyncIndexedHit{Source: appFilesV2, Hit: []byte(`{"title":"` + title + `"}`)}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := p.finish(); err != nil {
+	if err := p.finish(2); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "\n2 result(s)\n") {
+		t.Fatalf("output %q does not end with a plain count", got)
+	}
+	if strings.Contains(got, "--limit") {
+		t.Fatalf("output suggests paging a complete result set: %q", got)
+	}
+}
+
+// The point of the asynchronous search is that the job already ran; with no
+// --limit, everything it produced has to reach the terminal.
+func TestWatchResultPrinterUnlimitedStreamsEverything(t *testing.T) {
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatTable, 0, 0)
+
+	for _, title := range []string{"one", "two", "three", "four", "five"} {
+		if err := p.emit(asyncIndexedHit{Source: appFilesV2, Hit: []byte(`{"title":"` + title + `"}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := p.finish(5); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"1. [files_v2] one", "5. [files_v2] five", "\n5 result(s)\n"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output %q does not contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "--limit") {
+		t.Fatalf("an unlimited run must not suggest paging: %q", got)
+	}
+}
+
+// The job's own total can only be trusted as a floor: whatever streamed is
+// already proof the result set is at least that big.
+func TestWatchResultPrinterCountNeverUndercutsStreamedHits(t *testing.T) {
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatTable, 0, 1)
+
+	for _, title := range []string{"one", "two", "three"} {
+		if err := p.emit(asyncIndexedHit{Source: appFilesV2, Hit: []byte(`{"title":"` + title + `"}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := p.finish(0); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "1 of 3 result(s)") {
+		t.Fatalf("output %q does not report the streamed total", got)
+	}
+}
+
+func TestWatchResultPrinterJSONUsesJSONLines(t *testing.T) {
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatJSON, 0, 2)
+
+	for _, title := range []string{"one", "two"} {
+		if err := p.emit(asyncIndexedHit{Source: appFilesV2, Hit: []byte(`{"title":"` + title + `"}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := p.finish(5); err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,12 +123,15 @@ func TestWatchResultPrinterJSONUsesJSONLines(t *testing.T) {
 	if lines[0] != `{"title":"one"}` || lines[1] != `{"title":"two"}` {
 		t.Fatalf("unexpected JSONL output: %q", out.String())
 	}
+	if !strings.Contains(notes.String(), "printed 2 of 5 result(s)") {
+		t.Fatalf("note = %q, want it to report the truncated total", notes.String())
+	}
 }
 
 func TestWatchResultPrinterEmpty(t *testing.T) {
-	var out bytes.Buffer
-	p := newWatchResultPrinter(&out, FormatTable, 0, 20)
-	if err := p.finish(); err != nil {
+	var out, notes bytes.Buffer
+	p := newWatchResultPrinter(&out, &notes, FormatTable, 0, 20)
+	if err := p.finish(0); err != nil {
 		t.Fatal(err)
 	}
 	if got := out.String(); got != "no results\n" {


### PR DESCRIPTION
## Summary

Three defects in `olares-cli search`, all surfaced by the same run of `search drive 'test' -w`.

**The result set was silently truncated.** `search drive` printed 20 hits under a bare `20 result(s)` footer, which reads as "that is everything" and made a CLI run look like it disagreed with the Desktop dialog. The asynchronous federated search runs the whole job to completion before it can return, so holding results back only hides work already done: `drive` and `sync` now print every hit by default. `--limit` becomes an opt-in cap, and the footer names the full set whenever one is applied (`20 of 57 result(s)`), taking the total from the job's `sources_summary` — which was already being fetched for gap recovery and then discarded. The synchronous session API keeps paging with its 20-result default, since it caches server-side and reports no total; `search knowledge` is unchanged, and `drive`/`sync` fall back to that page on Olares 1.12.6 and older.

**Half the rows rendered wrong.** Rows that matched on content alone came out as `(untitled)` even though their location carried the file name, and search3's excerpt separator showed through as `#######` mid-word. Titles now fall back to the title excerpt and then the location's base name. Excerpts are selected by `highlight_field` rather than concatenating the title excerpt onto the content one — the two arrays are positional, which is how the Desktop reads them in `SearchItemsComponent.vue` — so a snippet no longer opens by repeating the filename printed directly above it. An elision renders as the ellipsis already used between excerpts, matched at its exact width so hashes that are genuinely part of a document survive.

**The WebSocket dial was flaky.** `search WebSocket handshake failed: context deadline exceeded` and `dial tcp: i/o timeout` came from a handshake that shared a 15s budget with the login round trip and was attempted once. The handshake now gets the 30s the CLI's other WebSocket dials allow, and dial plus login are retried together (3 attempts, 1s/2s backoff) while the failure looks transient — never when the server refused the session, so `401`/`403`/`459` still fail fast with the "run profile login" hint.

Before and after, on the same four rows:

```
 9. [files_v2] (untitled)                                    3. market&setting-GPU 的 olares-cli 复测(1).xlsx
    drive/Common/myxtest/market&setting-...xlsx                 drive/Common/myxtest/market&setting-...xlsx
    test opennotebook running install -           →             test opennotebook running install -
    market.test sglangllmbasev32755#######opped                 market.test sglangllmbasev32755 … opped

 20 result(s)                                                57 result(s)
```

## Test plan

- [x] `go test ./cmd/ctl/search/` — new coverage for the retry classifier and its two non-retryable classes, the per-command `--limit` defaults, `sessionPaging`'s fallback, the three footer forms (windowed / undelivered / complete), title and excerpt selection against the row shapes this actually printed, and the exact-width elision rule (which caught a `strings.NewReplacer` bug that ate 7 of 8 hashes).
- [ ] Against a live Olares 1.12.7: `search drive 'test' -w` prints every hit with a plain `N result(s)`, and `N` matches the Desktop dialog.
- [ ] `search drive 'test' --limit 20` reports `20 of N result(s)` and points at `--limit`/`--offset`.
- [ ] `search drive 'test' -o json` keeps stdout a plain array; any truncation note goes to stderr.
- [ ] Against an Olares 1.12.6 profile: `search drive` and `search sync` still page 20 at a time, and `search knowledge` is untouched.

## Notes

The empty `title` on content-only matches looks like a backend gap rather than a CLI one: `SearchItemsComponent.vue` falls back to `file.title` for those rows too, so the Desktop dialog should show a blank title in the same place. Worth confirming separately — this PR only stops the CLI from printing `(untitled)` next to a usable path.

Made with [Cursor](https://cursor.com)