### PR TITLE
system-frontend: update image to v1.11.38

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.37
+          image: beclab/system-frontend:v1.11.38
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the system-frontend image version so the system frontend runs v1.11.38 and receives the features and fixes included in this release.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1391

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Helm image tag bump for the frontend init container with no config or runtime logic changes.
> 
> **Overview**
> Bumps the **`beclab/system-frontend`** image on the **`olares-app-init`** init container in the system-apps Helm template from **v1.11.37** to **v1.11.38**.
> 
> That init container still copies bundled frontend assets into the shared **`www`** volume before the nginx **`olares-app`** container starts; only the image tag changes. Related frontend work is tracked in TermiPass PR #1391.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9973afd6c3d2371c627228af27b833108c1935e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->