### PR TITLE
docs: add OrcaRouter as a named model provider in Bifrost use-case

### DIFF
--- a/docs/use-cases/bifrost.md
+++ b/docs/use-cases/bifrost.md
@@ -6,8 +6,8 @@ head:
     - name: keywords
       content: Olares, Bifrost, AI gateway, LLM proxy
 app_version: "1.0.11"
-doc_version: "2.0"
-doc_updated: "2026-08-05"
+doc_version: "2.1"
+doc_updated: "2026-08-28"
 ---
 
 # Set up Bifrost as an AI model gateway
@@ -69,6 +69,27 @@ In Bifrost, a model provider represents the engine hosting your AI models. You c
 
 3. Click **Add**.
 
+### Add OrcaRouter as a model provider
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding OrcaRouter as a provider in Bifrost gives your Olares apps access to that stack without configuring each upstream model individually.
+
+1. Open Bifrost from the Launchpad, go to **Models** > **Model Providers** > **Add provider**, and then select **Custom provider**.
+2. In the **Add Custom Provider** panel, configure the following settings:
+
+   - **Name**: such as `orcarouter`
+   - **Base Format**: Select **OpenAI**.
+   - **Base URL**: Enter `https://api.orcarouter.ai`, excluding the `/v1` suffix.
+   - **Allow Private Network**: Leave it disabled; OrcaRouter is a cloud gateway.
+   - **Is Keyless**: Disable it. Enter your OrcaRouter API key in the **API Key** field. The key starts with `sk-orca-`.
+
+3. Click **Add**.
+
+The models OrcaRouter serves are then available under the Bifrost endpoint, and you can route them to clients such as OpenCode and Open WebUI as shown below.
+
+:::note
+OrcaRouter also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+:::
+
 ## Get the Bifrost endpoint
 
 Client applications connect to Bifrost through the Bifrost endpoint URL, not the model provider URLs you configured earlier.
@@ -112,6 +133,8 @@ In OpenCode, register Bifrost as a custom provider and add your example model un
 4. Go to **Settings** > **Models** > **Olares Bifrost**, and then verify the model you added is enabled.
 
    ![Added models enabled in OpenCode](/images/manual/use-cases/bifrost-opencode-add-model-enabled1.png#bordered){width=70%}
+
+When you added OrcaRouter as a provider, its models are served through the same Bifrost endpoint. In OpenCode, select the OrcaRouter-managed model the same way you would any other Bifrost model.
 
 ### Step 2: Chat and verify
 


### PR DESCRIPTION
**Title:** docs: add OrcaRouter as a named model provider in Bifrost use-case

* **Background**

Olares is an open-source personal cloud OS built to run AI agents and LLMs on hardware you own. The [Bifrost use-case guide](https://github.com/beclab/Olares/blob/main/docs/use-cases/bifrost.md) already walks through adding model providers behind Bifrost's OpenAI-compatible gateway — OpenAI, Anthropic, and local engines such as Ollama.

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named provider option in that guide, mirroring the existing **Custom provider** flow with **Base Format: OpenAI**. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a first-class provider means Olares users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

Changes:

- **`docs/use-cases/bifrost.md`**: add an "Add OrcaRouter as a model provider" section under the existing provider configuration flow, with the `https://api.orcarouter.ai` base URL, the OpenAI base format, and the `sk-orca-` key prefix.
- Note how OrcaRouter models are then served through the same Bifrost endpoint and routed to clients like OpenCode and Open WebUI.
- Bump `doc_version` to `2.1` and `doc_updated` to `2026-08-28`.

Verification:

- `npm run build` in `docs/` succeeds (VitePress build, pages + sitemap).
- Live-tested the OrcaRouter OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1/chat/completions`) returns HTTP 200 with a valid completion using a `sk-orca-` key.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

* **Target Version for Merge**

main

* **Related Issues**

None

* **PRs Involving Sub-Systems**

None

* **Other information**:

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a use-case guide; no application, auth, or runtime code is modified.
> 
> **Overview**
> Updates the Bifrost use-case guide with **OrcaRouter** as a documented custom provider: OpenAI base format, `https://api.orcarouter.ai` (no `/v1`), API key with `sk-orca-` prefix, and cloud vs private-network settings. A short note covers gateway-level agent security; the OpenCode section clarifies that OrcaRouter models are chosen like any other Bifrost-backed model.
> 
> Front matter moves to **`doc_version` 2.1** and **`doc_updated` 2026-08-28**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f100e5f00ae4b73a0bff7e1882e91b560507d9a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->