### PR TITLE
fix(app-service): tell a stop that cannot finish from one that is still working

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.33
+        image: beclab/app-service:0.6.34
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.34
+        image: beclab/app-service:0.6.36
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -705,10 +705,16 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 		}
 
 		for _, np := range networkPolicy.Additional() {
+			var additionalNPFix func(np *netv1.NetworkPolicy)
+			if np.Name == security.SharedEntranceNetworkPolicyName {
+				additionalNPFix = func(np *netv1.NetworkPolicy) {
+					security.AppendNodeTunnelIngressRule(np, security.NodeTunnelRule())
+				}
+			}
 			if err := r.createOrUpdateNetworkPolicy(
 				ctx,
 				np,
-				nil,
+				additionalNPFix,
 				&networkPolicy,
 			); err != nil {
 				return err

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
@@ -19,6 +20,16 @@ import (
 )
 
 const mib = int64(1024 * 1024)
+
+const (
+	// hamiHandshake* mirror the values HAMi writes into its handshake
+	// annotation and the window it lets a request go unanswered before
+	// declaring the node's devices gone (HAMi pkg/util.CheckHealth). They have
+	// to stay in step with HAMi for the two to agree about a node.
+	hamiHandshakeRequesting = "Requesting"
+	hamiHandshakeDeleted    = "Deleted"
+	hamiHandshakeTimeout    = 60 * time.Second
+)
 
 type allocationMutation func(nodes []Node, allocations []Allocation) ([]Allocation, *Allocation, error)
 
@@ -358,6 +369,9 @@ func decodeHAMINvidiaDevices(node *corev1.Node, mode string) []Device {
 	if !strings.Contains(raw, constants.OneContainerMultiDeviceSplitSymbol) {
 		return nil
 	}
+	// A card's own health bit is only as fresh as the annotation carrying it,
+	// so it has to be read together with the node-level signals.
+	nodeUsable := hamiNodeHealth(node) == deviceHealthYes
 
 	var devices []Device
 	for _, encoded := range strings.Split(raw, constants.OneContainerMultiDeviceSplitSymbol) {
@@ -376,7 +390,7 @@ func decodeHAMINvidiaDevices(node *corev1.Node, mode string) []Device {
 			Mode:                  mode,
 			CardModel:             items[4],
 			Memory:                devmem * mib,
-			Health:                boolHealth(healthy),
+			Health:                boolHealth(healthy && nodeUsable),
 			SupportType:           shareModeToSupportType(mode, node.Annotations[shareModeAnnotationKey(items[0])]),
 			AvailableSupportTypes: AvailableSupportTypes(mode),
 		})
@@ -391,6 +405,62 @@ func nodeHealth(node *corev1.Node) string {
 		}
 	}
 	return deviceHealthNo
+}
+
+// hamiNodeHealth reports whether the cards HAMi registered on a node can still
+// be trusted. decodeHAMINvidiaDevices folds it into every card's own health
+// bit, because that bit cannot express the node being gone: it is parsed out of
+// the register annotation, which the device plugin writes while the node is up
+// and which nothing ever clears — not even HAMi's own cleanup path, which marks
+// the handshake Deleted and leaves the stale card list in place (NodeCleanUp ->
+// MarkAnnotationsToDelete). Read on its own, a powered-off node therefore keeps
+// offering healthy cards indefinitely, and an app bound to one is placed on a
+// node HAMi has already dropped from its scheduler, leaving the pod Pending.
+//
+// The two signals combined here cover different failures and neither subsumes
+// the other: NodeReady catches a node that is gone, the handshake catches a
+// node that is up but whose GPU stack has died.
+func hamiNodeHealth(node *corev1.Node) string {
+	if nodeHealth(node) != deviceHealthYes {
+		return deviceHealthNo
+	}
+	return hamiHandshakeHealth(node.Annotations[constants.NodeHandshakeKey])
+}
+
+// hamiHandshakeHealth interprets HAMi's handshake annotation. The exchange it
+// records: the device plugin republishes "Reported <time>" every 30s, HAMi's
+// scheduler answers by stamping "Requesting_<time>" and then waits WITHOUT
+// refreshing that stamp, so a request still unanswered after
+// hamiHandshakeTimeout means no plugin is left to answer it. HAMi reacts by
+// rewriting the value to "Deleted_<time>" and dropping the node.
+//
+// This mirrors HAMi's own util.CheckHealth so the two components cannot
+// disagree about a node, with one deliberate difference: HAMi reports Deleted
+// as healthy because there the branch exists only to stop it re-adding a node
+// it already removed. Read as a statement about the cards, it means the exact
+// opposite, so here it is unhealthy.
+//
+// An empty or unrecognized value is healthy, matching HAMi's own fallback, so a
+// node registered by a plugin that predates the handshake is not taken out of
+// service. Timestamps are compared in UTC, which is what both sides produce as
+// long as neither container sets TZ.
+func hamiHandshakeHealth(handshake string) string {
+	switch {
+	case strings.Contains(handshake, hamiHandshakeDeleted):
+		return deviceHealthNo
+	case strings.Contains(handshake, hamiHandshakeRequesting):
+		_, stamp, ok := strings.Cut(handshake, "_")
+		if !ok {
+			return deviceHealthNo
+		}
+		requestedAt, err := time.Parse(time.DateTime, stamp)
+		if err != nil {
+			return deviceHealthNo
+		}
+		return boolHealth(time.Now().Before(requestedAt.Add(hamiHandshakeTimeout)))
+	default:
+		return deviceHealthYes
+	}
 }
 
 func boolHealth(healthy bool) string {

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -2,9 +2,12 @@ package compute
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -141,6 +144,123 @@ func TestBuildNodeResourceDiscreteGPULabel(t *testing.T) {
 	}
 	if len(n.Devices) != 1 || n.Devices[0].Mode != utils.AMDGPUType {
 		t.Fatalf("expected a single amd-gpu device, got %+v", n.Devices)
+	}
+}
+
+// hamiRegisterAnnotation encodes one card the way HAMi's device plugin does
+// (util.EncodeNodeDevices): ID,Count,Devmem,Devcore,Type,Numa,Health,Index,
+// Mode,Architecture followed by the device separator.
+func hamiRegisterAnnotation(uuid string, memMiB int, healthy bool) string {
+	return fmt.Sprintf("%s,10,%d,100,NVIDIA GeForce RTX 5090,0,%t,0,hami-core,0%s",
+		uuid, memMiB, healthy, constants.OneContainerMultiDeviceSplitSymbol)
+}
+
+func hamiNode(name string, handshake string, healthyCard bool) *corev1.Node {
+	node := k8sNode(name, "32Gi", map[string]string{
+		utils.NodeGPUTypeLabelPrefix + utils.NvidiaCardType: "true",
+	})
+	node.Annotations = map[string]string{
+		constants.NodeNvidiaRegistryKey: hamiRegisterAnnotation("GPU-"+name, 24576, healthyCard),
+	}
+	if handshake != "" {
+		node.Annotations[constants.NodeHandshakeKey] = handshake
+	}
+	return node
+}
+
+func hamiStamp(age time.Duration) string {
+	return time.Now().UTC().Add(-age).Format(time.DateTime)
+}
+
+// TestDecodeHAMINvidiaDevicesNodeLiveness covers the gap that let a powered-off
+// node keep offering GPUs: the health bit inside the register annotation is
+// written by the device plugin while the node is up and is never cleared, so it
+// has to be read together with the node's own liveness signals.
+func TestDecodeHAMINvidiaDevicesNodeLiveness(t *testing.T) {
+	tests := []struct {
+		name       string
+		handshake  string
+		healthyBit bool
+		poweredOff bool
+		want       string
+	}{
+		{name: "plugin reported recently", handshake: "Reported " + time.Now().String(), healthyBit: true, want: deviceHealthYes},
+		{name: "no handshake annotation at all", handshake: "", healthyBit: true, want: deviceHealthYes},
+		{name: "handshake request still within the window", handshake: "Requesting_" + hamiStamp(10*time.Second), healthyBit: true, want: deviceHealthYes},
+		{name: "handshake request went unanswered", handshake: "Requesting_" + hamiStamp(2*time.Minute), healthyBit: true, want: deviceHealthNo},
+		{name: "handshake unparseable", handshake: "Requesting_not-a-timestamp", healthyBit: true, want: deviceHealthNo},
+		{name: "hami already cleaned the node up", handshake: "Deleted_" + hamiStamp(time.Minute), healthyBit: true, want: deviceHealthNo},
+		// The regression: the node is gone but its register annotation, and so
+		// the card's own health bit, still says the card is fine.
+		{name: "node powered off with a stale healthy register", handshake: "Reported " + time.Now().String(), healthyBit: true, poweredOff: true, want: deviceHealthNo},
+		{name: "card reported unhealthy by the plugin", handshake: "Reported " + time.Now().String(), healthyBit: false, want: deviceHealthNo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := hamiNode("gpu-a", tt.handshake, tt.healthyBit)
+			if tt.poweredOff {
+				// What the node controller records once kubelet stops
+				// heartbeating.
+				node.Status.Conditions[0].Status = corev1.ConditionUnknown
+			}
+			devices := decodeHAMINvidiaDevices(node, utils.NvidiaCardType)
+			if len(devices) != 1 {
+				t.Fatalf("expected exactly one decoded card, got %+v", devices)
+			}
+			if devices[0].Health != tt.want {
+				t.Fatalf("card health = %q, want %q", devices[0].Health, tt.want)
+			}
+		})
+	}
+}
+
+// TestPoweredOffNvidiaNodeIsNotPicked drives the whole selection path rather
+// than the decoder alone: install and resume both choose out of
+// listAvailableForLaunch, so a node that is gone must neither be offered to the
+// user nor picked automatically.
+func TestPoweredOffNvidiaNodeIsNotPicked(t *testing.T) {
+	// Both nodes carry an identical, healthy-looking register annotation —
+	// that is the whole point: nothing about the powered-off node's GPU
+	// advertisement changes when it goes down.
+	deadNode := hamiNode("gpu-dead", "Reported "+time.Now().String(), true)
+	deadNode.Status.Conditions[0].Status = corev1.ConditionUnknown
+
+	live := buildNodeResource(hamiNode("gpu-live", "Reported "+time.Now().String(), true))
+	dead := buildNodeResource(deadNode)
+
+	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi}
+	availability := listAvailableForLaunch(req, []Node{live, dead}, PressureSnapshot{})
+
+	for _, node := range availability.Nodes {
+		for _, device := range node.Devices {
+			if node.NodeName == "gpu-dead" && device.Operable {
+				t.Fatalf("a powered-off node's card must not be offered: %+v", device)
+			}
+			if node.NodeName == "gpu-live" && !device.Operable {
+				t.Fatalf("the live node's card should still be offered: %+v", device)
+			}
+		}
+	}
+
+	// Repeated because the picker breaks ties at random: a single run could
+	// pass on the live node by luck even if the dead one were still a
+	// candidate.
+	for i := 0; i < 50; i++ {
+		selections, ok := pickLaunchSelection(req, availability, PressureSnapshot{}, allocationOptions{checkPressure: true})
+		if !ok || len(selections) != 1 {
+			t.Fatalf("expected the live node to be picked, got %+v (ok=%t)", selections, ok)
+		}
+		if selections[0].NodeName != "gpu-live" {
+			t.Fatalf("picked a powered-off node: %+v", selections[0])
+		}
+	}
+
+	// With only the dead node left there must be no placement at all, rather
+	// than a fallback onto its stale cards.
+	deadOnly := listAvailableForLaunch(req, []Node{dead}, PressureSnapshot{})
+	if _, ok := pickLaunchSelection(req, deadOnly, PressureSnapshot{}, allocationOptions{checkPressure: true}); ok {
+		t.Fatal("a cluster whose only GPU node is powered off must not yield a placement")
 	}
 }
 

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -219,6 +219,11 @@ const (
 	ArchLabelKey                       = "kubernetes.io/arch"
 	CudaVersionLabelKey                = "gpu.bytetrade.io/cuda"
 	NodeNvidiaRegistryKey              = "hami.io/node-nvidia-register"
+	// NodeHandshakeKey is the liveness half of the pair HAMi's device plugin
+	// patches onto a node alongside NodeNvidiaRegistryKey. The register
+	// annotation is never cleared once written, so the handshake is the only
+	// thing that says whether the cards it lists are still there.
+	NodeHandshakeKey = "hami.io/node-handshake"
 )
 
 var (

--- a/framework/app-service/pkg/security/shared_entrance_np.go
+++ b/framework/app-service/pkg/security/shared_entrance_np.go
@@ -1,12 +1,18 @@
 package security
 
 import (
+	"reflect"
+
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
+	// SharedEntranceNetworkPolicyName identifies the ingress policy for Shared
+	// entrance workloads.
+	SharedEntranceNetworkPolicyName = "shared-entrance-np"
 	// L4ProxyNamespace hosts the single l4-bfl-proxy replica.
 	L4ProxyNamespace = "os-network"
 	// L4ProxyAppLabel is the app= label on l4-bfl-proxy pods.
@@ -51,6 +57,23 @@ func hasSharedEntranceNotIn(sel *metav1.LabelSelector) bool {
 		}
 	}
 	return false
+}
+
+// AppendNodeTunnelIngressRule adds the current node tunnel peers as one
+// ingress rule. The caller supplies the peers so generation remains separate
+// from policy mutation and can be tested without a Kubernetes client.
+func AppendNodeTunnelIngressRule(np *netv1.NetworkPolicy, peers []netv1.NetworkPolicyPeer) {
+	if np == nil || len(peers) == 0 {
+		return
+	}
+	for _, rule := range np.Spec.Ingress {
+		if reflect.DeepEqual(rule.From, peers) {
+			return
+		}
+	}
+	np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+		From: peers,
+	})
 }
 
 // SharedNamespacePolicies returns the four NetworkPolicies emitted into a

--- a/framework/app-service/pkg/security/shared_entrance_np_test.go
+++ b/framework/app-service/pkg/security/shared_entrance_np_test.go
@@ -45,6 +45,37 @@ func TestExcludeSharedEntrancePodsIdempotent(t *testing.T) {
 	}
 }
 
+func TestAppendNodeTunnelIngressRuleIdempotent(t *testing.T) {
+	np := NPSharedEntrance.DeepCopy()
+	peers := []netv1.NetworkPolicyPeer{
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.98.1/32"}},
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.87.0/32"}},
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.110.0/32"}},
+	}
+
+	AppendNodeTunnelIngressRule(np, peers)
+	AppendNodeTunnelIngressRule(np, peers)
+
+	if len(np.Spec.Ingress) != 2 {
+		t.Fatalf("ingress rules=%d, want 2", len(np.Spec.Ingress))
+	}
+	if !reflect.DeepEqual(np.Spec.Ingress[1].From, peers) {
+		t.Fatalf("node tunnel peers=%v, want %v", np.Spec.Ingress[1].From, peers)
+	}
+}
+
+func TestAppendNodeTunnelIngressRuleNilAndEmpty(t *testing.T) {
+	AppendNodeTunnelIngressRule(nil, []netv1.NetworkPolicyPeer{
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.98.1/32"}},
+	})
+
+	np := NPSharedEntrance.DeepCopy()
+	AppendNodeTunnelIngressRule(np, nil)
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("ingress rules=%d, want 1", len(np.Spec.Ingress))
+	}
+}
+
 func TestNPAppSpaceTemplateUnchanged(t *testing.T) {
 	if hasSharedEntranceNotIn(&NPAppSpace.Spec.PodSelector) {
 		t.Fatal("NPAppSpace package template must stay empty (regular app NS)")

--- a/framework/app-service/pkg/security/templates.go
+++ b/framework/app-service/pkg/security/templates.go
@@ -515,7 +515,7 @@ var (
 
 	NPSharedEntrance = netv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "shared-entrance-np",
+			Name: SharedEntranceNetworkPolicyName,
 		},
 		Spec: netv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{


### PR DESCRIPTION

* **Background**
fix(app-service): tell a stop that cannot finish from one that is still working
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GPU scheduling eligibility and ingress rules for shared-entrance workloads; incorrect handshake parsing or tunnel peers could block placements or cluster traffic.
> 
> **Overview**
> Fixes **GPU placement on nodes that are down or dropped by HAMi** by combining each card’s register annotation health with **node readiness** and HAMi’s **`hami.io/node-handshake`** signal (including `Deleted` and unanswered `Requesting_*` past a 60s window, aligned with HAMi’s health check). Powered-off or cleaned-up nodes no longer surface operable NVIDIA devices in install/resume selection; tests cover decode and `listAvailableForLaunch` / `pickLaunchSelection`.
> 
> **Shared entrance networking:** when reconciling additional network policies, **`shared-entrance-np`** now gets the same **node tunnel ingress peers** as other policies via `AppendNodeTunnelIngressRule` and `NodeTunnelRule()` in the security controller. The policy name is centralized as `SharedEntranceNetworkPolicyName`.
> 
> Deployment bumps **`beclab/app-service`** from **0.6.33** to **0.6.36**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93aa1e1464c8e3d578aa2af37955fd24ec47e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->