### PR TITLE
fix(app-service): allow node tunnel IPs for shared entrance

### DIFF
--- a/framework/app-service/controllers/security_controller.go
+++ b/framework/app-service/controllers/security_controller.go
@@ -705,10 +705,16 @@ func (r *SecurityReconciler) reconcileNetworkPolicy(ctx context.Context, ns *cor
 		}
 
 		for _, np := range networkPolicy.Additional() {
+			var additionalNPFix func(np *netv1.NetworkPolicy)
+			if np.Name == security.SharedEntranceNetworkPolicyName {
+				additionalNPFix = func(np *netv1.NetworkPolicy) {
+					security.AppendNodeTunnelIngressRule(np, security.NodeTunnelRule())
+				}
+			}
 			if err := r.createOrUpdateNetworkPolicy(
 				ctx,
 				np,
-				nil,
+				additionalNPFix,
 				&networkPolicy,
 			); err != nil {
 				return err

--- a/framework/app-service/pkg/security/shared_entrance_np.go
+++ b/framework/app-service/pkg/security/shared_entrance_np.go
@@ -1,12 +1,18 @@
 package security
 
 import (
+	"reflect"
+
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
+	// SharedEntranceNetworkPolicyName identifies the ingress policy for Shared
+	// entrance workloads.
+	SharedEntranceNetworkPolicyName = "shared-entrance-np"
 	// L4ProxyNamespace hosts the single l4-bfl-proxy replica.
 	L4ProxyNamespace = "os-network"
 	// L4ProxyAppLabel is the app= label on l4-bfl-proxy pods.
@@ -51,6 +57,23 @@ func hasSharedEntranceNotIn(sel *metav1.LabelSelector) bool {
 		}
 	}
 	return false
+}
+
+// AppendNodeTunnelIngressRule adds the current node tunnel peers as one
+// ingress rule. The caller supplies the peers so generation remains separate
+// from policy mutation and can be tested without a Kubernetes client.
+func AppendNodeTunnelIngressRule(np *netv1.NetworkPolicy, peers []netv1.NetworkPolicyPeer) {
+	if np == nil || len(peers) == 0 {
+		return
+	}
+	for _, rule := range np.Spec.Ingress {
+		if reflect.DeepEqual(rule.From, peers) {
+			return
+		}
+	}
+	np.Spec.Ingress = append(np.Spec.Ingress, netv1.NetworkPolicyIngressRule{
+		From: peers,
+	})
 }
 
 // SharedNamespacePolicies returns the four NetworkPolicies emitted into a

--- a/framework/app-service/pkg/security/shared_entrance_np_test.go
+++ b/framework/app-service/pkg/security/shared_entrance_np_test.go
@@ -45,6 +45,37 @@ func TestExcludeSharedEntrancePodsIdempotent(t *testing.T) {
 	}
 }
 
+func TestAppendNodeTunnelIngressRuleIdempotent(t *testing.T) {
+	np := NPSharedEntrance.DeepCopy()
+	peers := []netv1.NetworkPolicyPeer{
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.98.1/32"}},
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.87.0/32"}},
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.110.0/32"}},
+	}
+
+	AppendNodeTunnelIngressRule(np, peers)
+	AppendNodeTunnelIngressRule(np, peers)
+
+	if len(np.Spec.Ingress) != 2 {
+		t.Fatalf("ingress rules=%d, want 2", len(np.Spec.Ingress))
+	}
+	if !reflect.DeepEqual(np.Spec.Ingress[1].From, peers) {
+		t.Fatalf("node tunnel peers=%v, want %v", np.Spec.Ingress[1].From, peers)
+	}
+}
+
+func TestAppendNodeTunnelIngressRuleNilAndEmpty(t *testing.T) {
+	AppendNodeTunnelIngressRule(nil, []netv1.NetworkPolicyPeer{
+		{IPBlock: &netv1.IPBlock{CIDR: "10.233.98.1/32"}},
+	})
+
+	np := NPSharedEntrance.DeepCopy()
+	AppendNodeTunnelIngressRule(np, nil)
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("ingress rules=%d, want 1", len(np.Spec.Ingress))
+	}
+}
+
 func TestNPAppSpaceTemplateUnchanged(t *testing.T) {
 	if hasSharedEntranceNotIn(&NPAppSpace.Spec.PodSelector) {
 		t.Fatal("NPAppSpace package template must stay empty (regular app NS)")

--- a/framework/app-service/pkg/security/templates.go
+++ b/framework/app-service/pkg/security/templates.go
@@ -515,7 +515,7 @@ var (
 
 	NPSharedEntrance = netv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "shared-entrance-np",
+			Name: SharedEntranceNetworkPolicyName,
 		},
 		Spec: netv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{


### PR DESCRIPTION
## Summary
- Allow `shared-entrance-np` to admit all current Calico node tunnel IPs as `/32` peers.
- Keep tunnel peers dynamically generated and idempotent during reconciliation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingress rules on a security-critical shared-entrance NetworkPolicy; behavior mirrors existing node-tunnel handling elsewhere and is idempotent on reconcile.
> 
> **Overview**
> **Shared entrance ingress** (`shared-entrance-np`) now gets the same dynamic Calico **node tunnel `/32` peers** as other reconciled policies, so host-network / tunnel-sourced traffic (e.g. `l4-bfl-proxy`) can reach shared-entrance pods.
> 
> During namespace reconcile, the loop over **additional** network policies applies a dedicated fix only for `shared-entrance-np`: it calls new **`AppendNodeTunnelIngressRule`** with **`NodeTunnelRule()`**, instead of passing no fix. That helper appends one ingress rule and **skips duplicates** on repeated reconciles.
> 
> The policy name is centralized as **`SharedEntranceNetworkPolicyName`** (used in the template and controller), with unit tests for idempotent append and nil/empty peers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f900b0c46c9511da7b0326ff6f2d74b0216183f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->