### PR TITLE
feat(cli): narrow market preinstall to Linux and guard the install-phase order

### DIFF
--- a/cli/pkg/phase/cluster/linux.go
+++ b/cli/pkg/phase/cluster/linux.go
@@ -92,7 +92,10 @@ func (l *linuxInstallPhaseBuilder) installTerminus() phase {
 		&terminus.InstallAccountModule{},
 		&terminus.InstallSettingsModule{},
 		&terminus.InstallOsSystemModule{},
-		&preinstall.HFCacheMaterializeModule{},
+		// WSL shares this builder but is not a preinstall target: its system
+		// phase publishes no declaration, so a materialized cache would have
+		// nothing to serve.
+		&preinstall.HFCacheMaterializeModule{Skip: l.runtime.Arg.SystemInfo.IsWsl()},
 		&terminus.InstallLauncherModule{},
 		&terminus.InstallAppsModule{},
 	}

--- a/cli/pkg/phase/cluster/macos.go
+++ b/cli/pkg/phase/cluster/macos.go
@@ -27,7 +27,7 @@ func (m *macosInstallPhaseBuilder) installCluster() phase {
 }
 
 func (m *macosInstallPhaseBuilder) installTerminus() phase {
-	// Offline preinstall (HF cache materialize) only supports Linux/WSL; see linux.go.
+	// Offline preinstall (HF cache materialize) only supports Linux; see linux.go.
 	return []module.Module{
 		&terminus.GetNATGatewayIPModule{},
 		&terminus.InstallAccountModule{},

--- a/cli/pkg/phase/cluster/preinstall_order_test.go
+++ b/cli/pkg/phase/cluster/preinstall_order_test.go
@@ -5,12 +5,30 @@ import (
 	"strings"
 	"testing"
 
+	olarescommon "github.com/beclab/Olares/cli/pkg/common"
+	corecommon "github.com/beclab/Olares/cli/pkg/core/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
 	"github.com/beclab/Olares/cli/pkg/preinstall"
 	"github.com/beclab/Olares/cli/pkg/terminus"
 )
 
+// installTerminus reads the platform to decide whether the HF cache is
+// materialized, so a builder without one cannot be constructed here.
+func runtimeOn(osPlatform string) *olarescommon.KubeRuntime {
+	return &olarescommon.KubeRuntime{
+		Arg: &olarescommon.Argument{
+			SystemInfo: &connector.SystemInfo{
+				HostInfo: &connector.HostInfo{
+					OsType:     corecommon.Linux,
+					OsPlatform: osPlatform,
+				},
+			},
+		},
+	}
+}
+
 func TestLinuxInstallMaterializesHFCacheAfterCommonBeforeApps(t *testing.T) {
-	modules := (&linuxInstallPhaseBuilder{}).installTerminus()
+	modules := (&linuxInstallPhaseBuilder{runtime: runtimeOn("")}).installTerminus()
 	index := func(match func(any) bool) int {
 		for i, module := range modules {
 			if match(module) {
@@ -42,13 +60,36 @@ func TestLinuxInstallMaterializesHFCacheAfterCommonBeforeApps(t *testing.T) {
 	if !(osSystem < hfCache && hfCache < launcher && hfCache < apps) {
 		t.Fatalf("unexpected module order: osSystem=%d hfCache=%d launcher=%d apps=%d", osSystem, hfCache, launcher, apps)
 	}
+	if modules[hfCache].IsSkip() {
+		t.Fatalf("HF cache module is skipped on a plain Linux install: %#v", modules[hfCache])
+	}
+}
+
+// WSL shares the Linux builder, so the module is wired either way and the
+// platform difference is only visible through IsSkip.
+func TestWslInstallSkipsHFCacheMaterialize(t *testing.T) {
+	modules := (&linuxInstallPhaseBuilder{runtime: runtimeOn(corecommon.WSL)}).installTerminus()
+	found := false
+	for _, module := range modules {
+		hfCache, ok := module.(*preinstall.HFCacheMaterializeModule)
+		if !ok {
+			continue
+		}
+		found = true
+		if !hfCache.IsSkip() {
+			t.Fatalf("WSL install must skip HFCacheMaterializeModule: the system phase publishes no declaration, so the cache has nothing to serve")
+		}
+	}
+	if !found {
+		t.Fatalf("HFCacheMaterializeModule missing from WSL install: modules=%#v", modules)
+	}
 }
 
 func TestMacosInstallTerminusNeverMaterializesHFCache(t *testing.T) {
 	modules := (&macosInstallPhaseBuilder{}).installTerminus()
 	for _, module := range modules {
 		if _, ok := module.(*preinstall.HFCacheMaterializeModule); ok {
-			t.Fatalf("macOS installTerminus must not wire HFCacheMaterializeModule: offline preinstall only supports Linux/WSL, modules=%#v", modules)
+			t.Fatalf("macOS installTerminus must not wire HFCacheMaterializeModule: offline preinstall only supports Linux, modules=%#v", modules)
 		}
 	}
 }
@@ -59,7 +100,7 @@ func TestLinuxBuildPlacesHFCacheBeforeInstalledModule(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := string(data)
-	hfCache := strings.Index(source, "&preinstall.HFCacheMaterializeModule{}")
+	hfCache := strings.Index(source, "&preinstall.HFCacheMaterializeModule{")
 	installed := strings.Index(source, "addModule(&terminus.InstalledModule{})")
 	if hfCache < 0 || installed < 0 {
 		t.Fatalf("build markers: hfCache=%d installed=%d", hfCache, installed)

--- a/cli/pkg/phase/system/macos.go
+++ b/cli/pkg/phase/system/macos.go
@@ -17,7 +17,8 @@ type macOsPhaseBuilder struct {
 
 func (m *macOsPhaseBuilder) build() []module.Module {
 	// TODO: install minikube
-	// Offline preinstall only supports Linux/WSL; see linux.go/wsl.go.
+	// Market preinstall only supports Linux; see linux.go. minikube also loads
+	// no images locally, which is why wsl.go keeps the preload this omits.
 	return []module.Module{
 		&kubesphere.CreateMinikubeClusterModule{},
 		&terminus.PreparedModule{},

--- a/cli/pkg/phase/system/preinstall_order_test.go
+++ b/cli/pkg/phase/system/preinstall_order_test.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	olarescommon "github.com/beclab/Olares/cli/pkg/common"
@@ -19,11 +21,54 @@ func TestMacosPhaseBuilderSkipsOfflinePreinstallWiring(t *testing.T) {
 	for _, module := range modules {
 		switch module.(type) {
 		case *images.PreloadImagesModule:
-			t.Fatalf("macOS phase must not include PreloadImagesModule: offline preinstall only supports Linux/WSL")
+			t.Fatalf("macOS phase must not include PreloadImagesModule: minikube installs load no images locally")
 		case *preinstall.PublishDeclarationModule:
-			t.Fatalf("macOS phase must not include PublishDeclarationModule: offline preinstall only supports Linux/WSL")
+			t.Fatalf("macOS phase must not include PublishDeclarationModule: market preinstall only supports Linux")
 		}
 	}
+}
+
+// The two phase builders below are asserted against their source rather than
+// their module lists. Neither can be built here: linuxPhaseBuilder.build()
+// reads the platform through BaseRuntime.GetSystemInfo(), whose backing field
+// is private and reachable only via NewBaseRuntime -- which creates
+// directories and a log file -- and wslPhaseBuilder.build() probes the real
+// GPU on its first line.
+
+func TestLinuxPhasePreloadsImagesBeforePublishingTheDeclaration(t *testing.T) {
+	source := phaseSource(t, "linux.go")
+	preload := strings.Index(source, "&images.PreloadImagesModule{")
+	publish := strings.Index(source, "addModule(marketPreinstallModules(")
+	if preload < 0 || publish < 0 {
+		t.Fatalf("build markers: preload=%d publish=%d", preload, publish)
+	}
+	// Market reads the declaration as soon as it is published, and installing
+	// a local chart needs the images already in containerd.
+	if preload >= publish {
+		t.Fatalf("declaration is published before images are preloaded: preload=%d publish=%d", preload, publish)
+	}
+}
+
+func TestWslPhasePublishesNoDeclarationButStillPreloadsImages(t *testing.T) {
+	source := phaseSource(t, "wsl.go")
+	if strings.Contains(source, "marketPreinstallModules(") {
+		t.Fatalf("WSL phase must not publish a preinstall declaration: market preinstall only supports Linux")
+	}
+	// Preloading is not part of preinstall: an offline WSL install needs the
+	// system's own images in containerd whether or not anything is
+	// preinstalled.
+	if !strings.Contains(source, "&images.PreloadImagesModule{") {
+		t.Fatalf("WSL phase must still preload images: offline installs have no registry to pull from")
+	}
+}
+
+func phaseSource(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func TestMarketPreinstallModulesCarryWhatThePublishNeeds(t *testing.T) {

--- a/cli/pkg/phase/system/wsl.go
+++ b/cli/pkg/phase/system/wsl.go
@@ -101,19 +101,15 @@ func (l *wslPhaseBuilder) build() []module.Module {
 			}
 
 		}).withGPU(l.runtime)...).
+		// Images are preloaded on WSL as on any offline install; the market
+		// preinstall declaration is not published, so nothing is preinstalled
+		// here. See linux.go for the wiring WSL deliberately omits.
 		addModule(&images.PreloadImagesModule{
 			ManifestModule: manifest.ManifestModule{
 				Manifest: l.manifestMap,
 				BaseDir:  l.baseDir,
 			},
 		}).
-		addModule(marketPreinstallModules(
-			l.manifestMap,
-			l.runtime.GetInstallerDir(),
-			l.baseDir,
-			l.runtime.Arg.OlaresVersion,
-			productionPreinstallSelections(l.runtime),
-		)...).
 		addModule(terminusBoxModuleBuilder(func() []module.Module {
 			return []module.Module{
 				&daemon.InstallTerminusdBinaryModule{

--- a/cli/pkg/preinstall/module.go
+++ b/cli/pkg/preinstall/module.go
@@ -54,6 +54,11 @@ func (a *PublishDeclarationAction) Execute(_ connector.Runtime) error {
 
 type HFCacheMaterializeModule struct {
 	common.KubeModule
+	Skip bool
+}
+
+func (m *HFCacheMaterializeModule) IsSkip() bool {
+	return m.Skip
 }
 
 func (m *HFCacheMaterializeModule) Init() {

--- a/docs/developer/install/installation-process.md
+++ b/docs/developer/install/installation-process.md
@@ -159,7 +159,7 @@ The container runtime is a critical component for running containerized applicat
 :::
 ### Materialize the Market preinstall bundle
 
-Offline preinstall currently supports Linux and WSL only. On macOS/minikube installs, the whole pipeline described in this section is skipped: no bundle is published to the host, no Hugging Face cache is copied, and the three production preinstall apps are never triggered; the macOS install otherwise proceeds normally through minikube.
+Offline preinstall currently supports Linux only. On macOS/minikube and WSL installs, the whole pipeline described in this section is skipped: no bundle is published to the host, no Hugging Face cache is copied, and the production preinstall apps are never triggered; the install otherwise proceeds normally. WSL still preloads images, because an offline install needs the system's own images in containerd whether or not anything is preinstalled. An upgrade publishes a declaration on every platform, so a WSL device that started with none has one — holding catalog entries only — after its first upgrade.
 
 Official offline Market bootstrap data may be included in the installation package at `<installerDir>/preinstall/market`. If that directory is absent, preparation is a no-op: an ordinary release continues normally and preserves any existing managed overlay. With preinstall enabled, Market's runtime bootstrap state reports an importer-confirmed missing bundle as `overall_status="no_bundle"` and a fresh malformed importer failure as `overall_status="preinstall_degraded"`, including before any database row exists. After a successful import, persisted bundle revision and managed app rows are authoritative. `enabled=false` separately means the feature is disabled. The initial production target is a three-app chain: a model app with an inference engine and `llm-init` sidecar, `llm-gateway`, and an agent WebUI. The installer and Market read app IDs and install scopes from the bundle; they do not hard-code those production IDs.
 
@@ -213,7 +213,7 @@ Market mount contains no `artifacts/model/...` Source payload:
 The artifact payload is read from installer media during the install phase. Its
 small manifest is available in the Market mount for contract validation.
 
-The publish root is the Olares root directory (`storage.OlaresRootDir`, `/olares`), which is also what the market chart renders as `.Values.rootPath` for its hostPath mount; it is not the installer base directory. On Linux and WSL, all staged Market directories use mode `0555`, every file remains `0444`, and every child directory remains `0555`. Market's `readOnly: true` mount is the runtime write boundary; its existing `/opt/app/data` volume remains writable. If the hostPath is empty, the Market importer fails open and normal Market startup continues. This whole materialization step is Linux/WSL only; macOS/minikube installs skip it entirely and never create this directory (see "Materialize the Market preinstall bundle" above).
+The publish root is the Olares root directory (`storage.OlaresRootDir`, `/olares`), which is also what the market chart renders as `.Values.rootPath` for its hostPath mount; it is not the installer base directory. All staged Market directories use mode `0555`, every file remains `0444`, and every child directory remains `0555`. Market's `readOnly: true` mount is the runtime write boundary; its existing `/opt/app/data` volume remains writable. If the hostPath is empty, the Market importer fails open and normal Market startup continues. On a fresh install this whole materialization step is Linux only; macOS/minikube and WSL installs skip it entirely and never create this directory (see "Materialize the Market preinstall bundle" above). An upgrade runs it on every platform.
 
 Each bundle app may declare `defaultEnvs`. For an air-gapped model app, these
 defaults include `HF_HUB_OFFLINE=1` and llm-init source syntax such as
@@ -372,9 +372,10 @@ local (default)   openebs.io/local   Delete   WaitForFirstConsumer   false   31s
 
 ### Materialize an offline Hugging Face cache
 
-Like the rest of offline preinstall, this step is Linux/WSL only. On
-macOS/minikube installs, `HFCacheMaterializeModule` is never wired into the
-install phase, so no Hugging Face cache is copied there.
+Like the rest of offline preinstall, this step is Linux only. On macOS/minikube
+installs, `HFCacheMaterializeModule` is never wired into the install phase. WSL
+shares the Linux builder, so the module is wired there and skipped through its
+`Skip` field; either way no Hugging Face cache is copied.
 
 Model acquisition and model-app installation are separate operations. During
 the install phase, `InstallOsSystemModule` creates Common and deploys the


### PR DESCRIPTION
## Background

WSL was a market preinstall target by inheritance rather than by decision.

Its system phase wired `marketPreinstallModules`, so it published a declaration
to the host. Its cluster phase materialized the Hugging Face cache too, not
because anything chose that but because `install.go` routes WSL to
`linuxInstallPhaseBuilder` — the same builder Linux uses. Neither path has been
exercised on WSL, and offering an untested preinstall is worse than not
offering it: a declaration that reaches Market is a promise that apps will
appear.

Separately, rule 14 of the preinstall spec — preload images before publishing
the declaration — had nothing behind it in the system phase. The cluster phase
has `cli/pkg/phase/cluster/preinstall_order_test.go`; the install phase had no
counterpart, so the ordering rested entirely on how the modules happen to be
arranged in `linux.go`.

## What this changes

**WSL no longer preinstalls.** Two places, because WSL reaches preinstall two
different ways:

- `cli/pkg/phase/system/wsl.go` drops the `marketPreinstallModules` block, so no
  declaration is published.
- `HFCacheMaterializeModule` gains a `Skip` field, and
  `cli/pkg/phase/cluster/linux.go` sets it from `Arg.SystemInfo.IsWsl()`. Skip
  rather than conditional insertion follows what `installGpuPlugin()` in the
  same file already does for per-platform modules, and it keeps the module in
  the list so the order assertions do not have to change shape.

The platform check reads `Arg.SystemInfo` rather than the `GetSystemInfo()` used
elsewhere in that file. The two are the same object in production —
`kube_runtime.go` passes `arg.SystemInfo` into `NewBaseRuntime` — but
`BaseRuntime.systemInfo` is private and only that constructor can fill it, which
would put directory and log-file creation inside a test. `delete_cluster.go`
already reads `Arg.SystemInfo` this way.

**Images are still preloaded on WSL, and a test says so.**
`PreloadImagesModule` is not part of preinstall: it loads the manifest's images
into containerd, which an offline install needs whether or not anything is
preinstalled. The existing macOS assertion bundled it together with
`PublishDeclarationModule`, which was only ever right because macOS runs
minikube and loads no images locally. A positive assertion now guards it so the
next sweep does not remove it as preinstall leftovers.

**The install-phase order now has a test.**
`TestLinuxPhasePreloadsImagesBeforePublishingTheDeclaration` compares marker
positions in `linux.go` instead of building the module list, and
`TestWslPhasePublishesNoDeclarationButStillPreloadsImages` reads `wsl.go` the
same way. Both are source-level for concrete reasons, noted in the test file:
`linuxPhaseBuilder.build()` reads the platform through
`BaseRuntime.GetSystemInfo()`, whose field can only be filled by
`NewBaseRuntime`, and `wslPhaseBuilder.build()` probes the real GPU on its first
line. This is weaker than an assertion over real modules — moving a module into
a conditional branch would not fail it — and `market/docs/preinstall.md` records
that limit rather than calling the gap closed.

## Deliberately not changed

The upgrade path (`cli/pkg/upgrade/task_set.go`) still publishes on every
platform. So a WSL device installs with no declaration and, after its first
upgrade, has one holding catalog entries only. The inconsistency is known and
written down in both repositories' docs; narrowing the upgrade path is a
separate decision.

## Verification

- `go build ./...`
- `gofmt -l` clean on every touched file
- `go test ./pkg/phase/... ./pkg/preinstall/... ./pkg/upgrade/...` green, before
  and after rebasing onto current `main`

The two existing cluster order tests needed a runtime argument, since
`installTerminus()` now reads the platform; previously they passed a nil one.

Made with [Cursor](https://cursor.com)