### PR TITLE
fix(files): sweep stale transcode cache and fix HLS seek

### DIFF
--- a/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
+++ b/framework/files/.olares/config/cluster/deploy/files_deploy.yaml
@@ -212,7 +212,7 @@ spec:
           command:
             - /samba_share
         - name: files
-          image: beclab/files-server:v0.2.193
+          image: beclab/files-server:v0.2.194
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
## Summary
- Bump files-server to v0.2.194.
- Periodically delete transcode output that no live job owns, so HLS files do not pile up on disk.
- When seek restarts ffmpeg, delete the truncated in-progress segment instead of serving it.
- Anchor the HLS keyframe expression at the starting segment so seek does not force a burst of intra frames.

## Test plan
- [ ] After a transcode session, unused output under the transcode dir is gone within ~45 minutes (15m sweep, 30m age).
- [ ] Seek past the current transcode position and play: no short/broken segment at the old write point.
- [ ] Seek on a long GOP source (e.g. 4K AV1): playback after seek is not a stretch of all-intra frames.

## PRs Involving Sub-Systems
- https://github.com/beclab/files/pull/361

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on the files workload; behavior changes are scoped to transcode cache and HLS playback, with no auth or data-schema changes in this diff.
> 
> **Overview**
> Rolls out **files-server** `v0.2.194` on the `files` DaemonSet by updating the container image in `files_deploy.yaml` (from `v0.2.193`).
> 
> That release carries transcode/HLS fixes: periodic cleanup of orphaned transcode output so HLS cache does not grow unbounded, removal of truncated segments when seek restarts ffmpeg, and a keyframe expression anchored at the seek start segment to avoid post-seek all-intra bursts on long-GOP sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90259ab5dbaa5a50880343ef1dddb879c0defb6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->