### PR TITLE
fix(cli): report pending model app restarts

### DIFF
--- a/cli/cmd/ctl/router/model_spec.go
+++ b/cli/cmd/ctl/router/model_spec.go
@@ -63,9 +63,11 @@ const (
 // Console adds the flags a mode requires and files capability keys it does not
 // know under extensions.
 type specWriteResult struct {
-	Spec           json.RawMessage `json:"spec,omitempty"`
-	Restarted      bool            `json:"restarted"`
-	RestartWarning string          `json:"restart_warning,omitempty"`
+	Spec               json.RawMessage `json:"spec,omitempty"`
+	Restarted          bool            `json:"restarted"`
+	RestartSupervision string          `json:"restart_supervision,omitempty"`
+	RestartWarning     string          `json:"restart_warning,omitempty"`
+	PendingAppRestart  []string        `json:"pending_app_restart,omitempty"`
 }
 
 func newModelSpecCommand(f *cmdutil.Factory, how localAddressing) *cobra.Command {
@@ -448,22 +450,28 @@ func renderSpecWrite(w io.Writer, model string, res *specWriteResult) error {
 			}
 		}
 	}
+	var err error
 	switch {
 	case res.RestartWarning == "run_dir_unset":
-		_, err := fmt.Fprintln(w, "\nThe card is written, but this application cannot signal its engine, "+
+		_, err = fmt.Fprintln(w, "\nThe card is written, but this application cannot signal its engine, "+
 			"so the flags take effect only when the application itself restarts: "+
 			"`olares-cli market restart <app>`.")
-		return err
 	case res.RestartWarning != "":
-		_, err := fmt.Fprintf(w, "\nThe card is written. The engine was not relaunched: %s\n", res.RestartWarning)
-		return err
+		_, err = fmt.Fprintf(w, "\nThe card is written. The engine was not relaunched: %s\n", res.RestartWarning)
 	case res.Restarted:
-		_, err := fmt.Fprintln(w, "\nWritten, and the engine is relaunching. It answers again once the "+
+		_, err = fmt.Fprintln(w, "\nWritten, and the engine is relaunching. It answers again once the "+
 			"model has loaded; `olares-cli router model status <model>` reports how far along that is.")
+	case len(res.PendingAppRestart) == 0:
+		_, err = fmt.Fprintln(w, "\nWritten. Nothing needed relaunching, so this is in effect now. "+
+			"Router's own copy was updated with what the application confirmed.")
+	}
+	if err != nil {
 		return err
 	}
-	_, err := fmt.Fprintln(w, "\nWritten. Nothing needed relaunching, so this is in effect now. "+
-		"Router's own copy was updated with what the application confirmed.")
+	if len(res.PendingAppRestart) > 0 {
+		_, err = fmt.Fprintf(w, "\nSaved, but these fields take effect only after the model application restarts: %s.\n"+
+			"Run `olares-cli market restart <app>`.\n", strings.Join(res.PendingAppRestart, ", "))
+	}
 	return err
 }
 

--- a/cli/cmd/ctl/router/model_spec_test.go
+++ b/cli/cmd/ctl/router/model_spec_test.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -80,6 +82,42 @@ func TestTheConfirmationNamesTheRelaunch(t *testing.T) {
 	withoutArgs := specEditConsequence(map[string]any{"mode": "chat"})
 	if strings.Contains(withoutArgs, "relaunches") {
 		t.Errorf("a mode edit claims a relaunch: %q", withoutArgs)
+	}
+}
+
+func TestSpecWriteResultKeepsPendingAppRestart(t *testing.T) {
+	var result specWriteResult
+	if err := json.Unmarshal([]byte(`{
+		"restarted": false,
+		"restart_supervision": "confirmed",
+		"pending_app_restart": ["extensions.translate"]
+	}`), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.RestartSupervision != "confirmed" {
+		t.Errorf("restart supervision = %q", result.RestartSupervision)
+	}
+	if len(result.PendingAppRestart) != 1 ||
+		result.PendingAppRestart[0] != "extensions.translate" {
+		t.Errorf("pending app restart = %v", result.PendingAppRestart)
+	}
+}
+
+func TestSpecWriteNamesFieldsWaitingForAnAppRestart(t *testing.T) {
+	var out bytes.Buffer
+	err := renderSpecWrite(&out, "translator", &specWriteResult{
+		PendingAppRestart: []string{"extensions.translate"},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{"extensions.translate", "market restart <app>"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output does not mention %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "in effect now") {
+		t.Errorf("pending write claims immediate effect:\n%s", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve `pending_app_restart` and `restart_supervision` from Router model-card writes
- show the fields that require a full model application restart
- avoid claiming a pending card edit is already active

## Test plan

- [x] `go vet ./cmd/ctl/router`
- [x] `go test -count=1 ./cmd/ctl/router`
- [ ] CI

Made with [Cursor](https://cursor.com)