### PR TITLE
fix(gpu): hardcode AMD exporter images in the DaemonSet instead of Helm values

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/amd/device-metrics-exporter/templates/daemonsets.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/amd/device-metrics-exporter/templates/daemonsets.yaml
@@ -87,7 +87,7 @@ spec:
             sleep 2
           done
         {{- end }}
-        image: {{ .Values.image.initContainerImage }}
+        image: beclab/aboveos-busybox:1.37.0
         imagePullPolicy: IfNotPresent
         name: driver-init
         securityContext:
@@ -101,7 +101,7 @@ spec:
         {{- else }}
         - name: amd-device-metrics-exporter-container
         {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: beclab/rocm-device-metrics-exporter:v1.5.1
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-monitor-gpu={{ .Values.monitor.resources.gpu }}"


### PR DESCRIPTION



* **Background**
hardcode AMD exporter images in the DaemonSet instead of Helm values from image scan
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only image pinning for a GPU metrics DaemonSet; no auth or data-path logic changes, though upgrades now require editing the template rather than values.
> 
> **Overview**
> **Pins the AMD device metrics exporter DaemonSet to fixed `beclab` images** instead of `{{ .Values.image.* }}`, so deploys no longer depend on Helm/image-scan overrides for those containers.
> 
> The `driver-init` init container now always uses `beclab/aboveos-busybox:1.37.0`, and the metrics exporter uses `beclab/rocm-device-metrics-exporter:v1.5.1`. `imagePullPolicy` (and other chart values) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df8b027703fddd431ad959284bce402d7fe48d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->