### PR TITLE
system-frontend: update image to v1.11.39

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.38
+          image: beclab/system-frontend:v1.11.39
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the system-frontend image to v1.11.39 to include the changes from the related TermiPass pull request.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1397

* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on a non-runtime init container; behavior unchanged aside from the new frontend bundle version.
> 
> **Overview**
> Bumps the **`olares-app-init`** init container image from `beclab/system-frontend:v1.11.38` to **`v1.11.39`** in the `olares-app` Helm deployment template. That init step still copies bundled frontend assets from `/apps` into the shared `www-dir` volume before nginx serves them.
> 
> The change ships the TermiPass work referenced in **beclab/TermiPass#1397**; no chart logic, env, or other images are modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bbc6289d04914a15840d4034f0c84f8e4a056a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->