### PR TITLE
refactor(cli): remove localSSH, which nothing has ever used

### DIFF
--- a/cli/pkg/common/loader.go
+++ b/cli/pkg/common/loader.go
@@ -84,10 +84,6 @@ func (d *DefaultLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 		}
 	}
 
-	if err := localSSH(osType); err != nil {
-		return nil, err
-	}
-
 	ip := d.arg.SystemInfo.GetLocalIp()
 	hostname := d.arg.SystemInfo.GetHostname()
 
@@ -169,15 +165,12 @@ func normalizedBuildVersion(version string) string {
 }
 
 // Load() runs once per runtime, and a single user-facing command can build
-// several runtimes -- `node join` drives six pipelines in a row. These two steps
-// are idempotent and their outcome cannot change within one process, so they are
-// memoized instead of re-running (and, for localSSH, rewriting authorized_keys)
-// on every one of them.
+// several runtimes -- `node join` drives six pipelines in a row. Installing sudo
+// is idempotent and its outcome cannot change within one process, so it is
+// memoized instead of re-running on every one of them.
 var (
-	sudoOnce    sync.Once
-	sudoErr     error
-	localSSHDo  sync.Once
-	localSSHErr error
+	sudoOnce sync.Once
+	sudoErr  error
 )
 
 func installSUDOIfMissing() error {
@@ -192,22 +185,6 @@ func installSUDOIfMissing() error {
 		}
 	})
 	return sudoErr
-}
-
-func localSSH(osType string) error {
-	if osType == Windows {
-		return nil
-	}
-	localSSHDo.Do(func() {
-		if output, err := exec.Command("/bin/sh", "-c", "if [ ! -f \"$HOME/.ssh/id_rsa\" ]; then mkdir -p \"$HOME/.ssh\" && ssh-keygen -t rsa-sha2-512 -P \"\" -f $HOME/.ssh/id_rsa && ls $HOME/.ssh;fi;").CombinedOutput(); err != nil {
-			localSSHErr = errors.Errorf("Failed to generate public key: %v\n%s", err, string(output))
-			return
-		}
-		if output, err := exec.Command("/bin/sh", "-c", "sudo -E /bin/bash -c 'echo \"\n$(cat $HOME/.ssh/id_rsa.pub)\" >> $HOME/.ssh/authorized_keys' && awk ' !x[$0]++{print > \"'$HOME'/.ssh/authorized_keys.tmp\"}' $HOME/.ssh/authorized_keys && mv $HOME/.ssh/authorized_keys.tmp $HOME/.ssh/authorized_keys").CombinedOutput(); err != nil {
-			localSSHErr = errors.Errorf("Failed to copy public key to authorized_keys: %v\n%s", err, string(output))
-		}
-	})
-	return localSSHErr
 }
 
 // defaultCommonClusterConfig kubernetes version, registry mirrors, container manager, etc.


### PR DESCRIPTION
* **Background**
localSSH generated ~/.ssh/id_rsa on every node and appended the public key to that same node's authorized_keys, so a node could SSH into itself. Nothing has ever needed either half.

A task addressed to the local host never opens a connection : RemoteTask skips the dial when the host address equals the local IP -- which the loader guarantees, filling both Address and InternalAddress from GetLocalIp() -- and LocalTask hardcodes a nil connection, so both run the command through os/exec. The only SSH client in the CLI talks to a master during a multi-node join.

Reaching that master is authenticated by what the operator supplies, not by anything generated here: MASTER_SSH_PASSWORD is a documented alternative to a key, joincluster.sh only forwards those variables, and an operator who authenticates by key makes their own -- which the multi-node guide already assumes when it asks for the public key to be installed on the master before joining.

Generating a key was also actively unhelpful. One created here is not on the master's authorized_keys, so a second `node join` after a failed first one picked it up through defaultPrivateKeyPath(), failed against the master and printed a warning before falling back to asking for a password.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to dropping dead setup that did not participate in local or master SSH; no auth or data-path logic is modified elsewhere in this diff.
> 
> **Overview**
> **Removes automatic local SSH key setup** from the CLI cluster `Load()` path in `loader.go`.
> 
> The deleted `localSSH` flow no longer runs `ssh-keygen` for `~/.ssh/id_rsa` or appends that public key to the same host’s `authorized_keys`. **Load-time memoization is narrowed** to `installSUDOIfMissing` only—the `sync.Once` pair for local SSH is gone along with the function.
> 
> Cluster host config still sets `PrivateKeyPath` to `~/.ssh/id_rsa`, but the loader **no longer creates or mutates** those keys during load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c9f2bc5ae84315633b7aed2ee9afe5d93a9567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->