### PR TITLE
fix(cli): raise Arrow Lake-S (7D67) Intel GPU min kernel to 6.14

### DIFF
--- a/cli/pkg/core/connector/intel_gpu_kernel.go
+++ b/cli/pkg/core/connector/intel_gpu_kernel.go
@@ -71,7 +71,7 @@ type intelGPUSupportRow struct {
 var intelGPUSupportRows = []intelGPUSupportRow{
 	// i915 KMD driver GPUs
 	{ids: []string{"7D51"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-H", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
-	{ids: []string{"7D67"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-S", initial: "Unavailable", full: "Ubuntu 24.04+ (6.7)"},
+	{ids: []string{"7D67"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-S", initial: "Unavailable", full: "Ubuntu 24.04+ (6.14)"},
 	{ids: []string{"7D41"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Arrow Lake-U", initial: "Unavailable", full: "Ubuntu 24.04+ (6.9)"},
 	{ids: []string{"7DD5"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},
 	{ids: []string{"7D45"}, name: "Intel® Graphics", architecture: "Xe-LPG", codename: "Meteor Lake", initial: "Kernel 6.0", full: "Ubuntu 24.04+ (6.7)"},


### PR DESCRIPTION

* **Background**
fix(cli): raise Arrow Lake-S (7D67) Intel GPU min kernel to 6.14
* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single data correction in a static compatibility table; no logic changes, only stricter kernel checks for one PCI ID.
> 
> **Overview**
> Updates the CLI’s Intel GPU kernel compatibility table so **Arrow Lake-S** (PCI ID `7D67`) reports **full support at kernel 6.14** instead of 6.7.
> 
> Because **initial support** for this GPU is **Unavailable**, the connector derives the minimum required kernel from the **full** column via `IntelGPUMinKernel` / `minKernelForSupport`. Hosts on kernels **6.7–6.13** will now be treated as below the minimum for this device; **6.14+** aligns with the revised Intel guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab80b22c0264a48846b65e590640d97fc09c0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->