### PR TITLE
fix(manifest): pin system components to master node

### DIFF
--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-control-plane.yaml
@@ -1228,6 +1228,13 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: linkerd-destination
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
       - name: sp-tls
         secret:
@@ -1573,6 +1580,13 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: linkerd-identity
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
       - name: identity-issuer
         secret:
@@ -1921,6 +1935,13 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
       - configMap:
           name: linkerd-config

--- a/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
+++ b/framework/app-gateway/.olares/config/cluster/deploy/linkerd-pki-guardian-deployment.yaml
@@ -24,6 +24,13 @@ spec:
         linkerd.io/inject: disabled
     spec:
       serviceAccountName: linkerd-pki-guardian
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
+++ b/framework/authelia/.olares/config/cluster/deploy/auth_backend_deploy.yaml
@@ -395,6 +395,13 @@ spec:
       serviceAccountName: os-internal
       serviceAccount: os-internal
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'

--- a/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
+++ b/framework/infisical/.olares/config/cluster/deploy/infisical_deploy.yaml
@@ -135,6 +135,13 @@ spec:
     spec:
       serviceAccountName: infisical-sa
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'

--- a/framework/integration/.olares/config/cluster/deploy/integration_deploy.yaml
+++ b/framework/integration/.olares/config/cluster/deploy/integration_deploy.yaml
@@ -61,6 +61,13 @@ spec:
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       dnsPolicy: ClusterFirst
       priorityClassName: system-cluster-critical
       restartPolicy: Always

--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -133,6 +133,13 @@ spec:
       serviceAccountName: market-sa
       serviceAccount: market-sa
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
         - args:
           - -it

--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -21,6 +21,13 @@ spec:
         app: monitoring-server
     spec:
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       containers:
       - name: monitoring-server
         image: beclab/monitoring-server-v1:v0.3.15

--- a/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
+++ b/framework/notifications/.olares/config/cluster/deploy/notification_deploy.yaml
@@ -122,6 +122,13 @@ spec:
         app: notifications-server
     spec:
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'

--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -226,6 +226,13 @@ spec:
         tier: seafile
     spec:
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: seahub-init
         image: beclab/seahub-init:v0.0.8

--- a/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
+++ b/framework/search3/.olares/config/cluster/deploy/search3_server_deploy.yaml
@@ -199,6 +199,13 @@ spec:
     spec:
       serviceAccountName: os-internal
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
         - name: userspace-dir
           hostPath:

--- a/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
+++ b/framework/system-server/.olares/config/cluster/deploy/system_provider.yaml
@@ -123,6 +123,13 @@ spec:
               - key: files.conf
                 path: files.conf
 
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       dnsPolicy: ClusterFirst
       priorityClassName: system-cluster-critical
       restartPolicy: Always

--- a/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
+++ b/framework/vault/.olares/config/cluster/deploy/vault_server_deploy.yaml
@@ -81,6 +81,13 @@ spec:
         app: vault-server
     spec:
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: init-container
         image: 'postgres:16.0-alpine3.18'

--- a/platform/argo/.olares/config/cluster/deploy/argo_deployment.yaml
+++ b/platform/argo/.olares/config/cluster/deploy/argo_deployment.yaml
@@ -159,6 +159,13 @@ spec:
       serviceAccountName: argo-server
       serviceAccount: argo-server
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
         - emptyDir: {}
           name: tmp
@@ -263,6 +270,13 @@ spec:
         runAsNonRoot: true
       serviceAccountName: argo
       serviceAccount: argo
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
 ---
 apiVersion: v1
 kind: Service

--- a/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
+++ b/platform/fs-lib/.olares/config/cluster/deploy/fsnotify_deploy.yaml
@@ -24,6 +24,13 @@ spec:
       serviceAccountName: os-internal
       serviceAccount: os-internal
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       containers:
         - name: proxy
           image: beclab/fsnotify-proxy:0.1.12

--- a/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks.yaml
+++ b/platform/kubeblocks/.olares/config/cluster/deploy/kubeblocks.yaml
@@ -128,6 +128,11 @@ spec:
       dnsPolicy: ClusterFirst
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
           preferredDuringSchedulingIgnoredDuringExecution:
             - preference:
                 matchExpressions:

--- a/platform/open-telemetry/.olares/config/cluster/deploy/opentelemetry_operator.yaml
+++ b/platform/open-telemetry/.olares/config/cluster/deploy/opentelemetry_operator.yaml
@@ -9907,6 +9907,13 @@ spec:
               protocol: TCP
       serviceAccountName: opentelemetry-operator
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert

--- a/platform/tapr/.olares/config/cluster/deploy/fakes3_deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/fakes3_deployment.yaml
@@ -49,6 +49,13 @@ spec:
         app: tapr-s3
     spec:
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       containers:
       - name: s3-fake-sidecar
         image: beclab/s3rver:latest

--- a/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/lldap-deployment.yaml
@@ -123,6 +123,13 @@ spec:
     spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: os-internal
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
         - name: init-container-check-citus
           image: 'postgres:16.0-alpine3.18'

--- a/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/middleware_deploy.yaml
@@ -42,6 +42,13 @@ spec:
       serviceAccountName: os-internal
       serviceAccount: os-internal
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       volumes:
       - name: dbdata-dir
         hostPath:

--- a/platform/tapr/.olares/config/cluster/deploy/nats_deployment.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/nats_deployment.yaml
@@ -163,6 +163,13 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: nats
       serviceAccount: nats
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       initContainers:
       - name: cm-sidecar
         image: beclab/cm-sidecar:0.0.1

--- a/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
+++ b/platform/tapr/.olares/config/cluster/deploy/sys_event_deploy.yaml
@@ -90,6 +90,13 @@ spec:
       serviceAccountName: tapr-sysevent
       serviceAccount: tapr-sysevent
       priorityClassName: "system-cluster-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       securityContext:
         runAsUser: 0
       containers:


### PR DESCRIPTION
* **Background**
Pin system component pods to the master node to avoid inter components network split in a multi-nodes cluster ifwhen a single node goes down.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad scheduling change for critical system workloads: pods stay Pending if no suitable control-plane capacity exists, and control-plane failure or overload affects more services at once.
> 
> **Overview**
> Adds **required** `nodeAffinity` so affected pods schedule only on nodes with the `node-role.kubernetes.io/control-plane` label, targeting multi-node clusters where worker loss previously left system services split across nodes.
> 
> The same affinity block is applied across framework and platform Olares deploy manifests: Linkerd control plane (destination, identity, proxy-injector) and PKI guardian; auth and secrets (Authelia, Infisical, Vault); app platform (market, notifications, Seafile, search3, system-provider, integration); monitoring; Argo server and workflow-controller; OpenTelemetry operator; fsnotify proxy; Tapr middleware (NATS, LLDAP, fake S3, sysevent, middleware); and **Kubeblocks**, which keeps its existing preferred `kb-controller` affinity but now also requires a control-plane node.
> 
> No application logic or images change—only pod scheduling constraints on rollout/reconcile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c39169ea45d6a2a2599b367d26299481f7bf9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->