### PR TITLE
fix(app-service): add detailed logs in GPU app scheduling process

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.36
+        image: beclab/app-service:0.6.39
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/cmd/app-service/main.go
+++ b/framework/app-service/cmd/app-service/main.go
@@ -42,6 +42,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -86,6 +87,11 @@ func main() {
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
+	// Most of this codebase logs through klog, and a good part of its
+	// diagnostics sit behind klog.V(2)/V(4). Without registering klog's flags
+	// the verbosity is pinned at 0 and there is no way to reach them at all, so
+	// those lines could never be turned on in a running cluster.
+	klog.InitFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,17 +44,41 @@ func listAvailableForLaunchWithOptions(req Requirement, nodes []Node, pressure P
 	if len(result.Nodes) == 0 {
 		result.Schedulable = false
 		result.Reason = "no-matching-node"
-		return result
+	} else {
+		markOperable(result)
+		result.Schedulable, result.Reason = availabilitySummary(req, result.Nodes)
 	}
-	markOperable(result)
-	result.Schedulable, result.Reason = availabilitySummary(req, result.Nodes)
+	// Both flows are built on this view — install picks from it, resume renders
+	// it — so one line here explains either one after the fact.
+	klog.V(2).Infof("compute: placement options for %s: %s",
+		describeRequirement(req), explainPlacement(req, result, pressure))
 	return result
 }
 
+// classifyLaunchNodes classifies the nodes that can still be placed on. A node
+// whose kubelet has stopped heartbeating is dropped outright and is absent from
+// the returned slice; every other node gets an entry, including the ones that
+// end up NodeStatusNotMatch.
 func classifyLaunchNodes(req Requirement, nodes []Node, pressure PressureSnapshot, opts allocationOptions) []NodeOption {
 	out := make([]NodeOption, 0, len(nodes))
 	for _, node := range nodes {
+		// Readiness is a node-level fact and it decides the node on its own:
+		// the devices are not consulted at all. They cannot answer the
+		// question anyway — the register annotation listing them is written
+		// while the node is up and never cleared, so a powered-off node keeps
+		// advertising its last known cards indefinitely. Dropping the node
+		// here covers both flows at once, since install picks out of this list
+		// and resume renders it.
+		if !node.isReady() {
+			klog.Infof("compute: skipping node %s for %s placement: node is not ready", node.NodeName, req.Mode)
+			continue
+		}
 		if !node.SupportsMode(req.Mode) {
+			// NotMatch is filtered out downstream, so this is the only trace of
+			// a node that vanished from the picker for advertising the wrong
+			// accelerator — the "my GPU node isn't even listed" case.
+			klog.V(2).Infof("compute: skipping node %s for %s placement: it advertises %v",
+				node.NodeName, req.Mode, node.GPUTypes)
 			out = append(out, NodeOption{
 				NodeName: node.NodeName,
 				GPUType:  node.primaryGPUType(),
@@ -362,6 +387,12 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		attachBindings(nodes, withoutAppAllocations(existing, appConfig.AppName, appConfig.OwnerName))
 		bound, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 		if !validation.OK {
+			// The user picked these cards by hand and got an error back; record
+			// what they picked and which rule refused it, so a support report
+			// does not depend on the user relaying the code.
+			klog.Infof("compute: resume binding for app %s/%s refused (%s), submitted=%s, %s",
+				appConfig.OwnerName, appConfig.AppName, validation.Code,
+				describeSelections(selections), describeRequirement(req))
 			unavailable = unavailableBindingApplyResult(req, nodes, pressure, validation)
 			return nil, nil, errBindingUnavailable
 		}
@@ -374,6 +405,9 @@ func ApplyBindingSelection(ctx context.Context, c client.Client, appConfig *appc
 		}
 		return nil, err
 	}
+	// Outside the mutation, which is replayed on a write conflict.
+	klog.Infof("compute: app %s/%s bound to %s on resume, %s",
+		appConfig.OwnerName, appConfig.AppName, describeAllocations(allocations), describeRequirement(req))
 	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, allocations); err != nil {
 		return nil, err
 	}
@@ -473,6 +507,14 @@ func ValidateBindingForResume(ctx context.Context, c client.Client, appConfig *a
 	}
 	allocations, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 	if !validation.OK {
+		// This is the dry run the frontend makes before offering the resume
+		// button, so it can be asked many times for one user action and stays
+		// quiet by default. It is still the only record of why the button came
+		// back disabled, which is a question the real-resume log cannot answer
+		// because that resume never happened.
+		klog.V(2).Infof("compute: resume pre-check for app %s/%s says the selection is unusable (%s), submitted=%s, %s",
+			appConfig.OwnerName, appConfig.AppName, validation.Code,
+			describeSelections(selections), describeRequirement(req))
 		return unavailableBindingApplyResult(req, nodes, pressure, validation), nil
 	}
 	// Even when the selection is valid we still hand back the full list of
@@ -672,6 +714,12 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 			amount = item.memory
 		}
 		if amount <= 0 {
+			// Dropping every selection this way is what surfaces later as
+			// "empty-compute-binding", a code that says nothing about which
+			// card went missing or why.
+			klog.Warningf("compute: dropping card %s on node %s from the binding for app %s/%s: nothing left to allocate (card free=%s, requested=%s, remaining budget=%s)",
+				item.device.ID, item.node.NodeName, appConfig.OwnerName, appConfig.AppName,
+				humanBytes(deviceAvailableMemory(item.device)), humanBytes(item.memory), humanBytes(remaining))
 			continue
 		}
 		out = append(out, buildAllocation(appConfig, req, item.node, item.device, amount))

--- a/framework/app-service/pkg/compute/explain.go
+++ b/framework/app-service/pkg/compute/explain.go
@@ -1,0 +1,232 @@
+package compute
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Placement works by elimination: a node that stopped heartbeating never
+// reaches the classifier, a card that does not fit is passed over by the
+// picker, and what is left for the user to see is an app that came up without a
+// GPU. None of the return values along that path carry which candidates existed
+// or why each was dropped, so these helpers render that for the log — enough to
+// settle "why did this app not get a card?" from the log alone, without
+// reproducing the cluster state.
+
+func describeRequirement(req Requirement) string {
+	if req.Mode == utils.NvidiaCardType {
+		return fmt.Sprintf("mode=%s requireVram=%s limitVram=%s multiCards=%t multiNodes=%t",
+			req.Mode, humanBytes(req.RequiredGPU), humanBytes(req.LimitedGPU),
+			req.SupportMultiCards, req.SupportMultiNodes)
+	}
+	return fmt.Sprintf("mode=%s requireMemory=%s limitMemory=%s",
+		req.Mode, humanBytes(req.RequiredMemory), humanBytes(req.LimitedMemory))
+}
+
+// explainPlacement renders every candidate the picker had to choose from, each
+// with the reason it was passed over. The pressure snapshot is the one the
+// decision was made against; it is consulted only to name the resource
+// dimension behind a pressure rejection, which the availability view does not
+// carry on its own.
+func explainPlacement(req Requirement, availability *AvailabilityResult, pressure PressureSnapshot) string {
+	if availability == nil {
+		return "no availability view was built"
+	}
+	head := fmt.Sprintf("scope=%s schedulable=%t reason=%s",
+		availability.Scope, availability.Schedulable, orNone(availability.Reason))
+	if len(availability.Nodes) == 0 {
+		// Either the cluster has no node for this mode, or every node was
+		// dropped before classification — the per-node logs upstream say which.
+		return head + "; no candidate node was left to choose from"
+	}
+	parts := make([]string, 0, len(availability.Nodes)+1)
+	parts = append(parts, head)
+	for _, node := range availability.Nodes {
+		parts = append(parts, describeNodeOption(req, node, pressure))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func describeNodeOption(req Requirement, node NodeOption, pressure PressureSnapshot) string {
+	pressureNote := nodePressureNote(node.NodeName, req, pressure)
+	if len(node.Devices) == 0 {
+		// No status note: with no card at all, "no card is large enough" would
+		// misdescribe why the node is unusable.
+		return fmt.Sprintf("node %s status=%s%s exposes no %s card",
+			node.NodeName, node.Status, pressureNote, node.GPUType)
+	}
+	desc := fmt.Sprintf("node %s status=%s%s%s", node.NodeName, node.Status,
+		nodeStatusNote(req, node.Status), pressureNote)
+	cards := make([]string, 0, len(node.Devices))
+	for _, device := range node.Devices {
+		cards = append(cards, describeDeviceOption(req, node, device, pressureNote != ""))
+	}
+	return desc + " [" + strings.Join(cards, " | ") + "]"
+}
+
+// nodeStatusNote spells out what a node status means in terms of the request,
+// since the status alone reads as a verdict without its reason. NotEnough and
+// NotAvailable are distinct and easy to confuse: the first means the vram is not
+// there at all, the second that it is there but taken. Which vram is compared
+// depends on the request — a multi-card app is judged on the node's total, a
+// single-card one on its largest card — so the note follows suit. When pressure
+// is what turned the node down, the separate overPressure marker says so.
+func nodeStatusNote(req Requirement, status string) string {
+	aggregate := req.Mode == utils.NvidiaCardType && (req.SupportMultiCards || req.SupportMultiNodes)
+	switch status {
+	case NodeStatusNotEnough:
+		if aggregate {
+			return " (its cards do not add up to the request)"
+		}
+		return " (no card on it is large enough for the request)"
+	case NodeStatusNotAvailable:
+		if aggregate {
+			return " (its cards add up to the request but not enough of it is free)"
+		}
+		return " (its cards are large enough but none has enough free)"
+	}
+	return ""
+}
+
+func describeDeviceOption(req Requirement, node NodeOption, device DeviceOption, nodePressured bool) string {
+	desc := fmt.Sprintf("card %s type=%s vram=%s free=%s health=%s fit=%s",
+		device.DeviceID, device.SupportType, humanBytes(device.Capacity),
+		humanBytes(device.Available), device.Health, orNone(device.FitLevel))
+	if len(device.Bindings) > 0 {
+		holders := make([]string, 0, len(device.Bindings))
+		for _, binding := range device.Bindings {
+			holders = append(holders, binding.Owner+"/"+binding.AppName)
+		}
+		desc += " heldBy=" + strings.Join(holders, ",")
+	}
+	if reason := deviceSkipReason(req, node, device, nodePressured); reason != "" {
+		desc += " SKIPPED(" + reason + ")"
+	}
+	return desc
+}
+
+// deviceSkipReason names the first check the auto-picker would have failed on
+// for this card. It reads the facts the view already recorded rather than
+// re-running the fit logic, so it cannot drift out of step with the picker:
+// Operable is exactly "healthy, has free vram, and sits on a node the current
+// scope offers cards from", and FitLevel is empty exactly when the card fits
+// neither the app's limit nor its request.
+//
+// The card's own shortfall is reported before the node verdict on purpose. A
+// card too small for the request is also not Operable, since the node it sits
+// on is NotEnough for the same reason, and blaming the node there just points
+// back at the note the node already carries.
+func deviceSkipReason(req Requirement, node NodeOption, device DeviceOption, nodePressured bool) string {
+	switch {
+	case device.Health != deviceHealthYes:
+		return "the card reports itself unhealthy, or its node is down"
+	case device.Available <= 0:
+		return "the card has no free vram left"
+	case device.FitLevel == "":
+		return "the card does not fit, " + unfitReason(req, device, nodePressured)
+	case !device.Operable:
+		return "the card is not offered because its node is " + node.Status
+	}
+	return ""
+}
+
+// unfitReason explains an empty FitLevel, which is the one skip the card's own
+// numbers do not account for: the card is healthy, has room, and sits on a node
+// that offers cards, yet the fit check still turned it down. Multi-card requests
+// are left out of the size comparison because there a card smaller than the
+// target legitimately contributes only part of it, so its size is not what
+// disqualified it.
+func unfitReason(req Requirement, device DeviceOption, nodePressured bool) string {
+	if nodePressured {
+		return "its node is over the pressure threshold"
+	}
+	if req.SupportMultiCards || req.SupportMultiNodes {
+		return "the aggregate fit check turned it down"
+	}
+	if required := requiredTargetForMode(req); device.Available < required {
+		return fmt.Sprintf("%s free against a %s request", humanBytes(device.Available), humanBytes(required))
+	}
+	return "the fit check turned it down"
+}
+
+// nodePressureNote reports the dimensions that would exceed the pressure
+// threshold once the app's cpu/memory/disk request lands on the node. This is
+// the one rejection reason a card's own numbers cannot explain: a card with
+// plenty of free vram is still refused when its node is too busy.
+func nodePressureNote(nodeName string, req Requirement, pressure PressureSnapshot) string {
+	dimensions := pressure.PressuredDimensions(Node{NodeName: nodeName}, AddedResources{
+		CPU:    req.RequiredCPU,
+		Memory: req.RequiredMemory,
+		Disk:   req.RequiredDisk,
+	})
+	if len(dimensions) == 0 {
+		return ""
+	}
+	over := make([]string, 0, len(dimensions))
+	for _, dimension := range dimensions {
+		over = append(over, fmt.Sprintf("%s at %d%% of capacity",
+			dimension.Resource, percentOf(dimension.Used, dimension.Capacity)))
+	}
+	return fmt.Sprintf(" overPressure=[%s, threshold %d%%]",
+		strings.Join(over, ","), percentOfFloat(pressure.Threshold))
+}
+
+func describeSelections(selections []BindingSelection) string {
+	if len(selections) == 0 {
+		return "none"
+	}
+	out := make([]string, 0, len(selections))
+	for _, selection := range selections {
+		out = append(out, fmt.Sprintf("%s/%s(%s)",
+			selection.NodeName, selection.DeviceID, humanBytes(selection.Memory)))
+	}
+	return strings.Join(out, ",")
+}
+
+func describeAllocations(allocations []Allocation) string {
+	if len(allocations) == 0 {
+		return "none"
+	}
+	out := make([]string, 0, len(allocations))
+	for _, allocation := range allocations {
+		// buildAllocation deliberately persists Memory=0 for the whole-card
+		// modes, so that the HAMI binding omits spec.memory and leaves the pod
+		// unrestricted. Printing "0" would read as "no vram was reserved",
+		// which is the opposite of what happened.
+		amount := humanBytes(allocation.Memory)
+		if allocation.Memory == 0 {
+			amount = "whole card"
+		}
+		out = append(out, fmt.Sprintf("%s/%s(%s)",
+			allocation.NodeName, allocation.DeviceID, amount))
+	}
+	return strings.Join(out, ",")
+}
+
+func humanBytes(value int64) string {
+	return resource.NewQuantity(value, resource.BinarySI).String()
+}
+
+func percentOf(part, whole int64) int {
+	if whole <= 0 {
+		return 100
+	}
+	return int(float64(part) / float64(whole) * 100)
+}
+
+func percentOfFloat(ratio float64) int {
+	if ratio <= 0 {
+		ratio = defaultPressureThreshold
+	}
+	return int(ratio * 100)
+}
+
+func orNone(value string) string {
+	if value == "" {
+		return "none"
+	}
+	return value
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,6 +58,11 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 		return nil, err
 	}
 	if !manage {
+		// Not a failure: the app shares another user's server, which owns the
+		// card. Logged because from the outside it looks the same as an app
+		// that was supposed to get a card and silently didn't.
+		klog.Infof("compute: app %s/%s gets no card of its own, its compute lives on the shared server it consumes",
+			appConfig.OwnerName, appConfig.AppName)
 		return nil, DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
 	}
 	appConfig = targetConfig
@@ -65,6 +71,8 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 		return nil, fmt.Errorf("compute type %s not found in application resources", appConfig.SelectedGpuType)
 	}
 	if req.Mode == utils.CPUType {
+		klog.Infof("compute: app %s/%s runs in cpu mode, so no card is bound",
+			appConfig.OwnerName, appConfig.AppName)
 		return nil, DeleteAllocationsForApp(ctx, c, appConfig.AppName, appConfig.OwnerName)
 	}
 	pressure, err := FetchPressureSnapshot(ctx)
@@ -82,10 +90,21 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 		availability := listAvailableForLaunch(req, nodes, pressure)
 		selections, ok := pickLaunchSelection(req, availability, pressure, allocationOptions{checkPressure: true})
 		if !ok {
+			// The install is about to fail with a one-line error, so spell out
+			// the whole candidate set here: this is the only record of which
+			// cards existed and what disqualified each one.
+			klog.Infof("compute: no card could be picked for app %s/%s, %s: %s",
+				appConfig.OwnerName, appConfig.AppName, describeRequirement(req),
+				explainPlacement(req, availability, pressure))
 			return nil, nil, fmt.Errorf("no available compute resource for type %s", req.Mode)
 		}
 		picked, validation := bindAllocations(appConfig, req, selections, nodes, pressure)
 		if !validation.OK {
+			// The picker and this validation read the same view, so a rejection
+			// here means the two disagree — worth the full dump.
+			klog.Infof("compute: the card picked for app %s/%s was refused by validation (%s), picked=%s: %s",
+				appConfig.OwnerName, appConfig.AppName, validation.Code,
+				describeSelections(selections), explainPlacement(req, availability, pressure))
 			return nil, nil, fmt.Errorf("no available compute resource for type %s: %s", req.Mode, validation.Code)
 		}
 		pickedAllocations = picked
@@ -95,6 +114,11 @@ func AllocateForInstall(ctx context.Context, c client.Client, appConfig *appcfg.
 	if err != nil {
 		return nil, err
 	}
+	// Logged out here, not inside the mutation: that closure is replayed on a
+	// write conflict, so a line printed there could announce a placement that
+	// was then rolled back and re-picked.
+	klog.Infof("compute: app %s/%s placed on %s, %s",
+		appConfig.OwnerName, appConfig.AppName, describeAllocations(pickedAllocations), describeRequirement(req))
 	if err := syncHAMIBindings(ctx, c, appConfig.AppName, appConfig.OwnerName, pickedAllocations); err != nil {
 		return nil, err
 	}
@@ -211,6 +235,23 @@ func pickLaunchSelection(req Requirement, availability *AvailabilityResult, pres
 	if availability == nil || req.Mode == utils.CPUType {
 		return nil, false
 	}
+	selections, ok := pickWithinScope(req, availability, pressure, opts)
+	if !ok {
+		// Deliberately terse: listAvailableForLaunchWithOptions has just logged
+		// the full candidate set at the same verbosity, so repeating it here
+		// would only double the volume. What it cannot say is that the pick
+		// then failed — which happens even when the view reports schedulable,
+		// because node status ignores pressure for nvidia while the fit check
+		// applies it. V(2) rather than Info because preflight runs this against
+		// a simulated cluster and treats a failed pick as a normal answer; the
+		// callers for which it really is a failure log it themselves.
+		klog.V(2).Infof("compute: no card picked for %s out of %d candidate node(s)",
+			describeRequirement(req), len(availability.Nodes))
+	}
+	return selections, ok
+}
+
+func pickWithinScope(req Requirement, availability *AvailabilityResult, pressure PressureSnapshot, opts allocationOptions) ([]BindingSelection, bool) {
 	switch availability.Scope {
 	case AvailabilityScopeCrossNode:
 		return pickAggregateSelection(req, availability.Nodes, pressure, opts, true)

--- a/framework/app-service/pkg/compute/store.go
+++ b/framework/app-service/pkg/compute/store.go
@@ -367,11 +367,21 @@ func nonHAMISupportType(mode, shareMode string) string {
 func decodeHAMINvidiaDevices(node *corev1.Node, mode string) []Device {
 	raw := node.Annotations[constants.NodeNvidiaRegistryKey]
 	if !strings.Contains(raw, constants.OneContainerMultiDeviceSplitSymbol) {
+		// The node carries the GPU label but the device plugin has not
+		// registered anything usable, so it will appear with zero cards. Common
+		// and transient while the plugin starts; persistent means the plugin is
+		// not running there.
+		klog.Warningf("compute: node %s advertises %s but its %s annotation is missing or unusable, so it exposes no card",
+			node.Name, mode, constants.NodeNvidiaRegistryKey)
 		return nil
 	}
 	// A card's own health bit is only as fresh as the annotation carrying it,
 	// so it has to be read together with the node-level signals.
 	nodeUsable := hamiNodeHealth(node) == deviceHealthYes
+	if !nodeUsable {
+		klog.V(2).Infof("compute: every card on node %s is marked unhealthy by node-level signals: nodeReady=%s %s=%q",
+			node.Name, nodeHealth(node), constants.NodeHandshakeKey, node.Annotations[constants.NodeHandshakeKey])
+	}
 
 	var devices []Device
 	for _, encoded := range strings.Split(raw, constants.OneContainerMultiDeviceSplitSymbol) {
@@ -380,6 +390,8 @@ func decodeHAMINvidiaDevices(node *corev1.Node, mode string) []Device {
 		}
 		items := strings.Split(encoded, ",")
 		if len(items) != 7 && len(items) != 9 && len(items) != 10 {
+			klog.Warningf("compute: skipping a card on node %s: its %s entry has %d fields, expected 7, 9 or 10",
+				node.Name, constants.NodeNvidiaRegistryKey, len(items))
 			continue
 		}
 		devmem, _ := strconv.ParseInt(items[2], 10, 64)

--- a/framework/app-service/pkg/compute/store_test.go
+++ b/framework/app-service/pkg/compute/store_test.go
@@ -233,10 +233,10 @@ func TestPoweredOffNvidiaNodeIsNotPicked(t *testing.T) {
 	availability := listAvailableForLaunch(req, []Node{live, dead}, PressureSnapshot{})
 
 	for _, node := range availability.Nodes {
+		if node.NodeName == "gpu-dead" {
+			t.Fatalf("a powered-off node must not appear in the resume picker: %+v", node)
+		}
 		for _, device := range node.Devices {
-			if node.NodeName == "gpu-dead" && device.Operable {
-				t.Fatalf("a powered-off node's card must not be offered: %+v", device)
-			}
 			if node.NodeName == "gpu-live" && !device.Operable {
 				t.Fatalf("the live node's card should still be offered: %+v", device)
 			}
@@ -259,8 +259,48 @@ func TestPoweredOffNvidiaNodeIsNotPicked(t *testing.T) {
 	// With only the dead node left there must be no placement at all, rather
 	// than a fallback onto its stale cards.
 	deadOnly := listAvailableForLaunch(req, []Node{dead}, PressureSnapshot{})
+	if len(deadOnly.Nodes) != 0 {
+		t.Fatalf("a powered-off-only cluster must not list the dead node, got %#v", deadOnly.Nodes)
+	}
 	if _, ok := pickLaunchSelection(req, deadOnly, PressureSnapshot{}, allocationOptions{checkPressure: true}); ok {
 		t.Fatal("a cluster whose only GPU node is powered off must not yield a placement")
+	}
+}
+
+// TestNotReadyNodeIsHiddenFromResumePicker pins the rule on node readiness
+// alone: kubelet has stopped heartbeating, so the node is dropped from both
+// flows no matter what its cards claim. The dead node's card is deliberately
+// left healthy — a shape the cluster cannot actually produce, since
+// decodeHAMINvidiaDevices folds node liveness into every card — so that the
+// test fails if the decision ever starts depending on the devices again.
+func TestNotReadyNodeIsHiddenFromResumePicker(t *testing.T) {
+	req := Requirement{Mode: utils.NvidiaCardType, RequiredGPU: 8 * gi, LimitedGPU: 8 * gi}
+	dead := nvidiaNode("zero0", Device{ID: "gpu-4060", Memory: 16 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice})
+	dead.Health = deviceHealthNo
+	live := nvidiaNode("olares-26", Device{ID: "gpu-5090", Memory: 24 * gi, Health: deviceHealthYes, SupportType: SupportTypeTimeSlice})
+	live.Health = deviceHealthYes
+
+	result := listAvailableForLaunch(req, []Node{dead, live}, PressureSnapshot{})
+	if len(result.Nodes) != 1 || result.Nodes[0].NodeName != "olares-26" {
+		t.Fatalf("NotReady node must be dropped from resume options, got %#v", result.Nodes)
+	}
+
+	// Install auto-picks out of the very same view, so it must not reach the
+	// dead node either. This is the assertion the previous fix was missing:
+	// it only checked the pick and the Operable bit, both of which pass while
+	// the node is still listed. Repeated because ties are broken at random.
+	for i := 0; i < 50; i++ {
+		selections, ok := pickLaunchSelection(req, result, PressureSnapshot{}, allocationOptions{checkPressure: true})
+		if !ok || len(selections) != 1 || selections[0].NodeName != "olares-26" {
+			t.Fatalf("install must pick the live node, got %+v (ok=%t)", selections, ok)
+		}
+	}
+
+	// With the NotReady node alone there is nothing left to offer, and no
+	// devices are reported for it at all.
+	only := listAvailableForLaunch(req, []Node{dead}, PressureSnapshot{})
+	if len(only.Nodes) != 0 || only.Schedulable {
+		t.Fatalf("a NotReady-only cluster must offer nothing, got %#v", only)
 	}
 }
 

--- a/framework/app-service/pkg/compute/types.go
+++ b/framework/app-service/pkg/compute/types.go
@@ -55,6 +55,15 @@ type Device struct {
 	Bindings              []Allocation `json:"bindings,omitempty"`
 }
 
+// isReady reports whether the node's kubelet was still heartbeating when this
+// view was built. buildNodeResource always fills Health in from the NodeReady
+// condition, so in production the answer comes straight from the cluster; an
+// empty Health only occurs in the in-memory node fixtures the tests build, and
+// is read as ready so those fixtures do not all have to spell it out.
+func (n Node) isReady() bool {
+	return n.Health == "" || n.Health == deviceHealthYes
+}
+
 // SupportsMode reports whether the node can host a pod of the given mode. cpu
 // is universal — every node can run cpu workloads — while non-cpu modes must be
 // advertised in GPUTypes.

--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -342,8 +342,11 @@ dcgmExporter:
       #   replacement: $1
     #   action: replace
 
-  nodeSelector: {}
-  # node: gpu
+  # Same gate as the NVIDIA device plugin. An empty selector used to land a
+  # DCGM pod on every node, including Intel-only workers that have no NVML
+  # (they start, log ERROR_LIBRARY_NOT_FOUND, and export nothing).
+  nodeSelector:
+    gpu.bytetrade.io/cuda-supported: "true"
 
   tolerations: []
   # - operator: Exists


### PR DESCRIPTION
**Background**
A node whose kubelet had stopped heartbeating still showed up in the resume
picker, listed as not_enough. Its cards were only ever judged one at a time, and
a card cannot express that its node is gone: the HAMi register annotation
listing them is written while the node is up and never cleared, so the node kept
advertising its last known GPUs indefinitely. Decide it at the node level
instead. classifyLaunchNodes drops a NotReady node before any of its devices are
looked at. Install auto-picks out of that view and resume renders it, so the
single check covers both flows. A node that is Ready behaves exactly as before,
including one whose cards report unhealthy.

Chasing that bug was harder than it should have been. An install or resume that
cannot get a card fails with a single-line error, and nothing recorded which
cards existed or what disqualified each one, so the usual questions — why did my
app get no GPU, why is this node missing from the picker, why is the resume
button refusing the card I picked — could only be answered by reading the code
against a cluster dump. Add a placement explainer that renders the availability
view as one line per node and card, each with the reason it was passed over, and
log it from the paths that make the decision: install when the pick fails or
validation refuses it, resume when a submitted binding is rejected or applied,
and the pre-check the frontend runs before offering the resume button. Warn on
the two skips that were silent until now — a card dropped from a binding with
nothing left to allocate, and a node whose HAMi register annotation is missing
or malformed.

Register klog's flags while doing so. They were never wired up, which pinned
verbosity at 0 and made every klog.V() call in the binary unreachable, so these
diagnostics could not have been turned on in a running cluster at all. The
per-poll lines sit behind V(2); at the default verbosity only the decisions
behind a user-visible failure are printed.

Also pin dcgm-exporter to CUDA nodes: an empty nodeSelector scheduled it onto
Intel-only workers, where NVML is missing and the pod exports nothing.

* **Target Version for Merge**
1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:
none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GPU placement behavior (NotReady nodes excluded) and adds logging around binding/install paths; misclassification could block valid placements or shift scheduling, though behavior for Ready nodes is intended to stay the same.
> 
> **Overview**
> **NotReady nodes no longer appear in GPU install/resume placement.** `classifyLaunchNodes` drops nodes whose kubelet is not ready before any device is considered, so stale HAMi register annotations on powered-off nodes cannot show up in the resume picker or auto-install picks. Tests were tightened to assert the dead node is absent from the list, not only that its cards are non-operable.
> 
> **Placement failures are easier to debug.** A new `explain.go` renders requirements, candidate nodes/cards, and skip reasons into log lines; install, resume, pre-check, and availability paths emit `klog` at Info or V(2). `main` registers `klog.InitFlags` so verbosity can be raised in-cluster. HAMi decode paths warn on missing/malformed registry annotations and bad card entries.
> 
> **Deploy bumps** `beclab/app-service` to **0.6.39**. **dcgm-exporter** in HAMi values now uses `nodeSelector: gpu.bytetrade.io/cuda-supported: "true"` so it does not run on Intel-only workers without NVML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4198af45c3522bd1759ae92ac19aeaa6044f6741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->