### PR TITLE
market: unblock uninstall, repair schema 00019, and stop idling

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -155,7 +155,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.107
+        image: beclab/market-backend:v0.6.108
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
unblock uninstall, repair schema 00019, and stop idling on a ready catalog

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/444


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a cluster-critical app-store backend with uninstall, DB schema repair, and catalog lifecycle behavior changes; rollout risk is limited to the image tag swap in deploy config.
> 
> **Overview**
> **Rolls out `market-backend` v0.6.108** by updating the `appstore-backend` container image in the Market cluster deployment from `v0.6.107` to `v0.6.108`.
> 
> This Olares-side change ships the fixes from [beclab/market#444](https://github.com/beclab/market/pull/444): **unblocked uninstall**, **repair for schema migration 00019**, and **no longer idling when the catalog is already ready**. No other manifest fields change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e59892c5734c984df4cdecbc344f13f147ef91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->