### PR TITLE
fix(cli): skip intel-omix host software stack install

### DIFF
--- a/cli/pkg/gpu/intelgpu/module.go
+++ b/cli/pkg/gpu/intelgpu/module.go
@@ -60,15 +60,6 @@ func PluginTasks() []task.Interface {
 		Retry:   1,
 	}
 
-	// install the discrete-GPU host driver stack; only runs when a discrete Intel
-	// GPU is present, in-tree and kernel-supported
-	installDGPUDrivers := &task.LocalTask{
-		Name:    "InstallIntelDGPUDrivers",
-		Action:  new(InstallIntelDGPUDrivers),
-		Prepare: new(HasQualifyingIntelDGPU),
-		Retry:   1,
-	}
-
 	// nfd.yaml installs CRDs; keep it in its own task and retry so the CRDs are
 	// established before the dependent CR / plugin manifests are applied.
 	applyNFD := &task.LocalTask{
@@ -124,7 +115,6 @@ func PluginTasks() []task.Interface {
 
 	return []task.Interface{
 		labelNode,
-		installDGPUDrivers,
 		applyNFD,
 		applyNodeFeatureRules,
 		applyGPUPlugin,

--- a/cli/pkg/gpu/intelgpu/tasks.go
+++ b/cli/pkg/gpu/intelgpu/tasks.go
@@ -25,9 +25,9 @@ import (
 const intelConfigDir = "wizard/config/gpu/intel"
 
 const (
-	xpumdChartRelDir  = "wizard/config/gpu/intel/xpumd"
-	xpumdReleaseName  = "xpumd"
-	xpumdNamespace    = "kube-system"
+	xpumdChartRelDir = "wizard/config/gpu/intel/xpumd"
+	xpumdReleaseName = "xpumd"
+	xpumdNamespace   = "kube-system"
 )
 
 // intelPlan is the per-node decision derived from the detected Intel GPUs and
@@ -159,95 +159,6 @@ func (p *HasQualifyingIntelDGPU) PreCheck(runtime connector.Runtime) (bool, erro
 		return false, err
 	}
 	return plan.hasQualifyingDGPU, nil
-}
-
-// InstallIntelDGPUDrivers installs the Intel discrete-GPU host driver stack on
-// supported Ubuntu by configuring the Intel GPU repository and installing
-// intel-omix (the unified discrete-GPU driver stack). Only noble / 24.04 is
-// supported. The kobuk-team/intel-graphics PPA is deliberately not used: it
-// ships the same compute libraries at newer pinned versions, which conflict with
-// intel-omix's exact-version dependencies.
-type InstallIntelDGPUDrivers struct {
-	common.KubeAction
-}
-
-func (t *InstallIntelDGPUDrivers) Execute(runtime connector.Runtime) error {
-	si := runtime.GetSystemInfo()
-	if !si.IsUbuntu() {
-		logger.Warn("Intel discrete GPU host packages are only supported on Ubuntu; skipping package installation")
-		return nil
-	}
-	// intel-omix is only published for noble / 24.04.
-	if !si.IsUbuntuVersionEqual(connector.Ubuntu2404) {
-		logger.Warnf("Ubuntu version %s is not supported for intel-omix (requires noble/24.04); skipping Intel discrete GPU driver installation", si.GetOsVersion())
-		return nil
-	}
-
-	run := func(cmd string) error {
-		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
-			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("failed to run %q", cmd))
-		}
-		return nil
-	}
-
-	// A previous install may have configured the kobuk-team/intel-graphics PPA and
-	// installed its newer compute libraries (libze1, libze-intel-gpu1,
-	// intel-opencl-icd, intel-ocloc). Those pinned versions conflict with
-	// intel-omix's exact-version dependencies, so remove any leftover PPA source
-	// before configuring the Intel repository. rm -f is a no-op when absent.
-	if err := run("rm -f /etc/apt/sources.list.d/*kobuk*intel-graphics*.list /etc/apt/sources.list.d/*kobuk*intel-graphics*.sources"); err != nil {
-		return err
-	}
-
-	// Prerequisites for fetching the repository key.
-	if err := run("apt-get update"); err != nil {
-		return err
-	}
-	if err := run("DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget"); err != nil {
-		return err
-	}
-
-	// Install the Intel GPU repository signing key referenced by the apt source.
-	if err := run("install -d -m 0755 /usr/share/keyrings"); err != nil {
-		return err
-	}
-	keyCmd := "wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg"
-	if err := run(keyCmd); err != nil {
-		return err
-	}
-
-	// Configure the Intel GPU repository and install intel-omix (the unified
-	// discrete-GPU driver stack). We intentionally do NOT add the
-	// kobuk-team/intel-graphics PPA: it ships the same compute libraries at newer
-	// pinned versions, which conflict with intel-omix's exact-version dependencies.
-	const codename = "noble"
-	srcLine := fmt.Sprintf("deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu %s/intel-omix/0.2 unified", codename)
-	writeSrc := fmt.Sprintf("echo '%s' | tee /etc/apt/sources.list.d/intel-gpu-%s.list", srcLine, codename)
-	if err := run(writeSrc); err != nil {
-		return err
-	}
-	if err := run("apt-get update"); err != nil {
-		return err
-	}
-
-	// --allow-downgrades lets apt replace any newer kobuk-installed compute libs
-	// left over from a previous run with intel-omix's pinned versions.
-	const installOmix = "DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades intel-omix"
-	if _, err := runtime.GetRunner().SudoCmd(installOmix, false, true); err != nil {
-		// The first attempt can still fail on a machine where the leftover
-		// kobuk-versioned compute libs cannot be downgraded in place. Purge the
-		// conflicting packages (best-effort) and let intel-omix reinstall its own
-		// pinned versions, then retry.
-		logger.Warn("intel-omix install failed; purging leftover conflicting Intel compute packages and retrying")
-		_, _ = runtime.GetRunner().SudoCmd("DEBIAN_FRONTEND=noninteractive apt-get purge -y libze1 libze-dev libze-intel-gpu1 intel-opencl-icd intel-ocloc || true", false, true)
-		_, _ = runtime.GetRunner().SudoCmd("apt-get update", false, true)
-		if err := run(installOmix); err != nil {
-			return err
-		}
-	}
-
-	logger.Info("Intel discrete GPU host packages (intel-omix) installed successfully")
-	return nil
 }
 
 // applyIntelManifest kubectl-applies a single manifest under intelConfigDir.


### PR DESCRIPTION


* **Background**
intel-omix is a host-side compute/driver stack, not required for container Intel GPU access.

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes automated host driver provisioning on nodes with qualifying discrete Intel GPUs, which may affect workloads that depended on intel-omix outside the container plugin path.
> 
> **Overview**
> Stops the CLI Intel GPU install/upgrade path from configuring apt and installing the **intel-omix** host discrete-GPU stack on Ubuntu 24.04.
> 
> The **`InstallIntelDGPUDrivers`** task is removed from **`PluginTasks()`**, along with the task implementation (Intel GPU repo, kobuk PPA cleanup, package install/retry logic). Labeling, NFD, device plugin, and **xpumd** steps are unchanged; **`HasQualifyingIntelDGPU`** still gates discrete-GPU-only work such as xpumd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6140340ebb2c16682b671b775556cd5aeef051d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->