### PR TITLE
fix(cli): omit catalog apps from install-time preinstall declarations

### DIFF
--- a/cli/pkg/phase/system/preinstall.go
+++ b/cli/pkg/phase/system/preinstall.go
@@ -21,6 +21,10 @@ func marketPreinstallModules(
 			RootDir:           storage.OlaresRootDir,
 			OSVersion:         osVersion,
 			ProfileSelections: selections,
+			// An install declares what its medium carries. The catalog apps of
+			// the release are left to the first upgrade, which runs on a device
+			// that can already reach the catalog.
+			CatalogPolicy: preinstall.OmitCatalogApps,
 		},
 	}
 }

--- a/cli/pkg/phase/system/preinstall_order_test.go
+++ b/cli/pkg/phase/system/preinstall_order_test.go
@@ -98,6 +98,13 @@ func TestMarketPreinstallModulesCarryWhatThePublishNeeds(t *testing.T) {
 		materialize.ProfileSelections.DetectedGPUType != gpu.IntelType {
 		t.Fatalf("production selections = %#v", materialize.ProfileSelections)
 	}
+	// An install declares what its medium carries. Declaring the release's
+	// catalog apps here would have a machine that may have no network at all
+	// expected to fetch them.
+	if materialize.CatalogPolicy != preinstall.OmitCatalogApps {
+		t.Fatalf("install catalog policy = %q, want %q",
+			materialize.CatalogPolicy, preinstall.OmitCatalogApps)
+	}
 }
 func TestDetectPreinstallGPUTypeUsesMostSpecificHardware(t *testing.T) {
 	systemInfo := &connector.SystemInfo{

--- a/cli/pkg/preinstall/catalog.go
+++ b/cli/pkg/preinstall/catalog.go
@@ -15,6 +15,26 @@ var catalogAppsData []byte
 
 var catalogApps []DeclarationAppV2
 
+// CatalogPolicy says whether a publish declares the catalog apps of the release
+// it publishes for. It is stated by every caller rather than defaulted: a run
+// that declared the wrong list would still succeed, and the device would be left
+// preinstalling apps nobody asked it to, or none of the ones it was meant to.
+type CatalogPolicy string
+
+const (
+	// DeclareCatalogApps belongs to an upgrade. The device is already running
+	// and can reach the catalog, so the apps this release expects are declared
+	// whether or not any medium carried them.
+	DeclareCatalogApps = CatalogPolicy("declare")
+	// OmitCatalogApps belongs to a CLI install, which declares what the medium
+	// carries and nothing else.
+	OmitCatalogApps = CatalogPolicy("omit")
+)
+
+func (p CatalogPolicy) Valid() bool {
+	return p == DeclareCatalogApps || p == OmitCatalogApps
+}
+
 func init() {
 	var file struct {
 		Apps []DeclarationAppV2 `json:"apps"`

--- a/cli/pkg/preinstall/deployment_contract_test.go
+++ b/cli/pkg/preinstall/deployment_contract_test.go
@@ -91,7 +91,7 @@ func TestMarketDeploymentPinsV2SourceAPIPaths(t *testing.T) {
 func TestMarketPreinstallDeploymentPublishesManifestsButNotPayloads(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
 	artifact, _ := addPublishArtifactFixture(t, installerDir)
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 	target := filepath.Join(baseDir, RuntimeRelativeDir)

--- a/cli/pkg/preinstall/golden_declaration_test.go
+++ b/cli/pkg/preinstall/golden_declaration_test.go
@@ -21,7 +21,7 @@ func TestPublishMatchesGoldenRuntimeDeclaration(t *testing.T) {
 	err := Publish(source, baseDir, testOSVersion, ProfileSelections{
 		HardwareProfile: "nvidia-cuda",
 		DetectedGPUType: "nvidia",
-	})
+	}, OmitCatalogApps)
 	if err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -41,12 +41,13 @@ func TestPublishMatchesGoldenRuntimeDeclaration(t *testing.T) {
 	if app.SelectedGPUType != "nvidia" {
 		t.Fatalf("selectedGpuType = %q", app.SelectedGPUType)
 	}
-	// The catalog apps this version expects are declared alongside whatever the
-	// medium carried, which is the whole point of one file: Market has one list
-	// to read rather than two to reconcile.
-	router := declarationApp(t, declaration, catalogApps[0].AppID)
-	if router.ChartSource != ChartSourceCatalog || router.Version != "" {
-		t.Fatalf("catalog app = %#v", router)
+	// An install declares its medium and nothing else. The catalog apps this
+	// version expects belong to the upgrade, which publishes them for the trunk
+	// it upgrades to.
+	for _, entry := range declaration.Apps {
+		if entry.ChartSource == ChartSourceCatalog {
+			t.Fatalf("install declared catalog app = %#v", entry)
+		}
 	}
 }
 

--- a/cli/pkg/preinstall/module.go
+++ b/cli/pkg/preinstall/module.go
@@ -14,6 +14,7 @@ type PublishDeclarationModule struct {
 	RootDir           string
 	OSVersion         string
 	ProfileSelections ProfileSelections
+	CatalogPolicy     CatalogPolicy
 }
 
 func (m *PublishDeclarationModule) Init() {
@@ -26,6 +27,7 @@ func (m *PublishDeclarationModule) Init() {
 				RootDir:           m.RootDir,
 				OSVersion:         m.OSVersion,
 				ProfileSelections: m.ProfileSelections,
+				CatalogPolicy:     m.CatalogPolicy,
 			},
 		},
 	}
@@ -34,22 +36,25 @@ func (m *PublishDeclarationModule) Init() {
 // PublishDeclarationAction declares what this version expects a device to have.
 //
 // InstallerDir is the one field whose emptiness means something: no medium was
-// brought, which is the ordinary shape of an upgrade, and the catalog apps of the
-// release being installed are declared all the same. The other two are required
-// -- Publish refuses an empty version, and an empty root would write the
-// declaration where nothing mounts it -- so every caller states them rather than
-// falling through to a default here, where the caller's reason for the value is
-// no longer visible.
+// brought, which is the ordinary shape of an upgrade. The others are required --
+// Publish refuses an empty version and an unstated catalog policy, and an empty
+// root would write the declaration where nothing mounts it -- so every caller
+// states them rather than falling through to a default here, where the caller's
+// reason for the value is no longer visible.
+//
+// Both an install and an upgrade run this same action; the catalog policy is
+// what tells the two apart.
 type PublishDeclarationAction struct {
 	action.BaseAction
 	InstallerDir      string
 	RootDir           string
 	OSVersion         string
 	ProfileSelections ProfileSelections
+	CatalogPolicy     CatalogPolicy
 }
 
 func (a *PublishDeclarationAction) Execute(_ connector.Runtime) error {
-	return Publish(a.InstallerDir, a.RootDir, a.OSVersion, a.ProfileSelections)
+	return Publish(a.InstallerDir, a.RootDir, a.OSVersion, a.ProfileSelections, a.CatalogPolicy)
 }
 
 type HFCacheMaterializeModule struct {

--- a/cli/pkg/preinstall/module_test.go
+++ b/cli/pkg/preinstall/module_test.go
@@ -16,6 +16,7 @@ func TestPublishDeclarationModuleUsesProvidedPathsAndSelections(t *testing.T) {
 		InstallerDir:      "/installer",
 		RootDir:           "/olares",
 		ProfileSelections: selections,
+		CatalogPolicy:     OmitCatalogApps,
 	}
 
 	module.Init()
@@ -38,6 +39,11 @@ func TestPublishDeclarationModuleUsesProvidedPathsAndSelections(t *testing.T) {
 	if action.InstallerDir != "/installer" || action.RootDir != "/olares" ||
 		action.ProfileSelections.HardwareProfile != "fixture" {
 		t.Fatalf("action = %#v", action)
+	}
+	// Publish refuses a policy it was not given, so a module that dropped this
+	// one would fail the install rather than declare the wrong list.
+	if action.CatalogPolicy != OmitCatalogApps {
+		t.Fatalf("action catalog policy = %q", action.CatalogPolicy)
 	}
 }
 

--- a/cli/pkg/preinstall/publish.go
+++ b/cli/pkg/preinstall/publish.go
@@ -18,14 +18,25 @@ import (
 // Olares root directory the market chart mounts from, not the installer base
 // directory.
 //
-// An empty installerDir, or one carrying no bundle, still publishes: the catalog
-// apps this version expects are declared either way, and an upgrade that brought
-// no medium is the ordinary case rather than a reason to leave Market with no
-// declaration for the release it is now running.
-func Publish(installerDir, rootDir, osVersion string, selections ProfileSelections) error {
+// An empty installerDir means no medium was brought, which is the ordinary shape
+// of an upgrade: what that publishes is then the catalog apps of the release
+// being installed, and nothing local.
+//
+// The catalog policy decides whether those catalog apps are declared at all. A
+// run that ends up with nothing to declare writes no file, so the runtime
+// directory holds a declaration only for a release that expects something.
+func Publish(
+	installerDir, rootDir, osVersion string,
+	selections ProfileSelections,
+	catalog CatalogPolicy,
+) error {
 	trunk := TrunkVersion(osVersion)
 	if trunk == "" {
 		return fmt.Errorf("publish declaration: no Olares version to name it after")
+	}
+	if !catalog.Valid() {
+		return fmt.Errorf("publish declaration: catalog policy must be %q or %q",
+			DeclareCatalogApps, OmitCatalogApps)
 	}
 	source, err := openStaticBundle(installerDir)
 	if err != nil {
@@ -40,9 +51,20 @@ func Publish(installerDir, rootDir, osVersion string, selections ProfileSelectio
 			return err
 		}
 	}
-	declaration, err := BuildDeclaration(source.bundle, selections, catalogDeclarationApps())
+	var catalogEntries []DeclarationAppV2
+	if catalog == DeclareCatalogApps {
+		catalogEntries = catalogDeclarationApps()
+	}
+	declaration, err := BuildDeclaration(source.bundle, selections, catalogEntries)
 	if err != nil {
 		return err
+	}
+	if len(declaration.Apps) == 0 {
+		// Nothing is expected of this device, and an empty list says that no
+		// better than an absent file does. Declarations are one per trunk, so
+		// writing none here leaves the next release -- and a later publish for
+		// this one -- free to write its own.
+		return nil
 	}
 	return publishDeclaration(source, rootDir, trunk, declaration)
 }

--- a/cli/pkg/preinstall/publish_test.go
+++ b/cli/pkg/preinstall/publish_test.go
@@ -18,26 +18,44 @@ const (
 	testBundledAppID = "app-a"
 )
 
-// A medium with no bundle of its own still has something to say: every device
-// running this version is expected to have the catalog apps, and a declaration
-// is the only place that is written down.
-func TestPublishWithoutAStaticBundlePublishesTheCatalogApps(t *testing.T) {
+// An install with no bundle expects nothing of the device, and an empty list
+// says that no better than an absent file does. The apps this release expects
+// from the catalog are declared by the first upgrade instead.
+func TestPublishOnAnInstallWithoutABundleWritesNoDeclaration(t *testing.T) {
 	root := t.TempDir()
 	baseDir := filepath.Join(root, "base")
 
-	if err := Publish(filepath.Join(root, "installer"), baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(filepath.Join(root, "installer"), baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	target := filepath.Join(baseDir, RuntimeRelativeDir)
+	t.Cleanup(func() { _ = makeWritable(target) })
+	if _, err := os.Lstat(filepath.Join(target, DeclarationFileName(testOSVersion))); !os.IsNotExist(err) {
+		t.Fatalf("a publish with nothing to declare wrote a declaration: %v", err)
+	}
+}
+
+// An install declares what its medium carries. A machine being installed cannot
+// be assumed to reach the catalog, so the release's catalog apps wait for the
+// upgrade, which runs on a device that is already up.
+func TestPublishOnAnInstallDeclaresTheMediumAloneWithoutTheCatalogApps(t *testing.T) {
+	installerDir, baseDir := writeStaticBundle(t)
+
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 
 	target := filepath.Join(baseDir, RuntimeRelativeDir)
 	t.Cleanup(func() { _ = makeWritable(target) })
 	declaration := readPublishedDeclaration(t, target, testOSVersion)
-	if len(declaration.Apps) != len(catalogApps) {
-		t.Fatalf("declared apps = %#v, want the catalog apps alone", declaration.Apps)
+	for _, app := range declaration.Apps {
+		if app.ChartSource != ChartSourceLocal {
+			t.Fatalf("declared app %q chartSource = %q, want the medium's entries alone",
+				app.AppID, app.ChartSource)
+		}
 	}
-	if _, err := os.Stat(filepath.Join(target, "chart")); !os.IsNotExist(err) {
-		t.Fatalf("a declaration with no local entry staged a chart directory: %v", err)
-	}
+	declarationApp(t, declaration, testBundledAppID)
 }
 
 // One file per trunk, so publishing one release's declaration must leave every
@@ -54,7 +72,7 @@ func TestPublishAddsThisReleaseBesideTheOnesAlreadyThere(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = makeWritable(target) })
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 
@@ -68,7 +86,7 @@ func TestPublishAddsThisReleaseBesideTheOnesAlreadyThere(t *testing.T) {
 // acted on it must not be handed a second answer.
 func TestPublishLeavesThisTrunksDeclarationAloneOnceItExists(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("first Publish() error = %v", err)
 	}
 	target := filepath.Join(baseDir, RuntimeRelativeDir)
@@ -81,7 +99,7 @@ func TestPublishLeavesThisTrunksDeclarationAloneOnceItExists(t *testing.T) {
 
 	err = Publish(installerDir, baseDir, testOSVersion+"-rc.2", ProfileSelections{
 		Apps: map[string]AppSelection{testBundledAppID: {Envs: map[string]string{"WORKER_COUNT": "9"}}},
-	})
+	}, OmitCatalogApps)
 
 	if err != nil {
 		t.Fatalf("second Publish() error = %v", err)
@@ -102,7 +120,7 @@ func TestPublishRejectsOversizedBundle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err == nil ||
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil ||
 		!strings.Contains(err.Error(), "bundle.json exceeds") {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -142,7 +160,7 @@ func TestPublishRejectsOversizedChartTotal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err == nil ||
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil ||
 		!strings.Contains(err.Error(), "total chart size exceeds") {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -160,7 +178,7 @@ func TestPublishFoldsSelectionsIntoTheDeclaration(t *testing.T) {
 		},
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, selections); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, selections, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 
@@ -180,7 +198,7 @@ func TestPublishPublishesArtifactManifestWithoutPayload(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
 	artifact, manifestData := addPublishArtifactFixture(t, installerDir)
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 
@@ -250,7 +268,7 @@ func TestPublishRejectsArtifactManifestSymlinks(t *testing.T) {
 			artifact, _ := addPublishArtifactFixture(t, installerDir)
 			tt.replace(t, filepath.Join(installerDir, StaticRelativeDir), artifact)
 
-			err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{})
+			err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps)
 
 			if err == nil || !strings.Contains(err.Error(), "symlink") {
 				t.Fatalf("Publish() error = %v, want symlink rejection", err)
@@ -279,7 +297,7 @@ func TestPublishRejectsSymlinkWithoutPublishingADeclaration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err == nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil {
 		t.Fatal("Publish() error = nil, want symlink rejection")
 	}
 	if got, err := os.ReadFile(marker); err != nil || string(got) != "existing" {
@@ -303,7 +321,7 @@ func TestPublishRejectsSymlinkedStaticInputParent(t *testing.T) {
 	target := filepath.Join(baseDir, RuntimeRelativeDir)
 	t.Cleanup(func() { _ = makeWritable(target) })
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err == nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil {
 		t.Fatal("Publish() error = nil, want symlinked parent rejection")
 	}
 }
@@ -315,7 +333,7 @@ func TestPublishRejectsSymlinkedInstallerAndBasePaths(t *testing.T) {
 		if err := os.Symlink(realInstaller, link); err != nil {
 			t.Fatal(err)
 		}
-		if err := Publish(link, baseDir, testOSVersion, ProfileSelections{}); err == nil {
+		if err := Publish(link, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil {
 			t.Fatal("Publish() error = nil, want installer symlink rejection")
 		}
 	})
@@ -326,7 +344,7 @@ func TestPublishRejectsSymlinkedInstallerAndBasePaths(t *testing.T) {
 		if err := os.Symlink(realBase, link); err != nil {
 			t.Fatal(err)
 		}
-		if err := Publish(installerDir, link, testOSVersion, ProfileSelections{}); err == nil {
+		if err := Publish(installerDir, link, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil {
 			t.Fatal("Publish() error = nil, want base symlink rejection")
 		}
 	})
@@ -343,7 +361,7 @@ func TestPublishAllowsSymlinkedAncestorDirectories(t *testing.T) {
 		installerDir := filepath.Join(link, filepath.Base(realInstaller))
 		t.Cleanup(func() { _ = makeWritable(baseDir) })
 
-		if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+		if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 			t.Fatalf("Publish() through symlinked installer ancestor error = %v", err)
 		}
 		readPublishedDeclaration(t, filepath.Join(baseDir, RuntimeRelativeDir), testOSVersion)
@@ -360,7 +378,7 @@ func TestPublishAllowsSymlinkedAncestorDirectories(t *testing.T) {
 		baseDir := filepath.Join(link, "base")
 		t.Cleanup(func() { _ = makeWritable(realParent) })
 
-		if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+		if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 			t.Fatalf("Publish() through symlinked base ancestor error = %v", err)
 		}
 		readPublishedDeclaration(t, filepath.Join(realParent, "base", RuntimeRelativeDir), testOSVersion)
@@ -376,7 +394,7 @@ func TestPublishRejectsSymlinkedRuntimeParent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err == nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err == nil {
 		t.Fatal("Publish() error = nil, want runtime parent symlink rejection")
 	}
 }
@@ -384,10 +402,25 @@ func TestPublishRejectsSymlinkedRuntimeParent(t *testing.T) {
 func TestPublishRefusesAPublishWithNoVersionToNameItAfter(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
 
-	err := Publish(installerDir, baseDir, "  ", ProfileSelections{})
+	err := Publish(installerDir, baseDir, "  ", ProfileSelections{}, OmitCatalogApps)
 
 	if err == nil || !strings.Contains(err.Error(), "no Olares version") {
 		t.Fatalf("Publish() error = %v, want a missing version rejection", err)
+	}
+}
+
+// Whether the release's catalog apps belong in the declaration is the caller's
+// to say, and the two callers say different things. A run that left it out would
+// otherwise publish a list nobody chose.
+func TestPublishRefusesAnUnstatedCatalogPolicy(t *testing.T) {
+	installerDir, baseDir := writeStaticBundle(t)
+
+	for _, policy := range []CatalogPolicy{"", "maybe"} {
+		err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, policy)
+
+		if err == nil || !strings.Contains(err.Error(), "catalog policy") {
+			t.Fatalf("Publish() with policy %q error = %v, want a catalog policy rejection", policy, err)
+		}
 	}
 }
 
@@ -436,7 +469,7 @@ func TestPublishRemovesStagingLeftBehindByAnInterruptedRun(t *testing.T) {
 		}
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 	t.Cleanup(func() { _ = makeWritable(target) })
@@ -478,7 +511,7 @@ func TestPublishSupportsNestedChartPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}); err != nil {
+	if err := Publish(installerDir, baseDir, testOSVersion, ProfileSelections{}, OmitCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 	target := filepath.Join(baseDir, RuntimeRelativeDir)
@@ -493,7 +526,7 @@ func TestPublishSupportsNestedChartPaths(t *testing.T) {
 func TestPublishWithNoMediumDeclaresTheCatalogAppsAlone(t *testing.T) {
 	baseDir := canonicalTempDir(t)
 
-	if err := Publish("", baseDir, testNextOSTrunk+"-20260731", ProfileSelections{}); err != nil {
+	if err := Publish("", baseDir, testNextOSTrunk+"-20260731", ProfileSelections{}, DeclareCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 
@@ -525,7 +558,7 @@ func TestPublishWithNoMediumIgnoresABundleInTheWorkingDirectory(t *testing.T) {
 	installerDir, baseDir := writeStaticBundle(t)
 	t.Chdir(installerDir)
 
-	if err := Publish("", baseDir, testNextOSTrunk+"-20260731", ProfileSelections{}); err != nil {
+	if err := Publish("", baseDir, testNextOSTrunk+"-20260731", ProfileSelections{}, DeclareCatalogApps); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
 

--- a/cli/pkg/preinstall/testdata/materialized-declaration/golden/preinstall-1.12.7.json
+++ b/cli/pkg/preinstall/testdata/materialized-declaration/golden/preinstall-1.12.7.json
@@ -33,13 +33,6 @@
         "version": "1.0.0",
         "cfgType": "app"
       }
-    },
-    {
-      "appId": "f3395cd5",
-      "appName": "router",
-      "installScope": "shared",
-      "installOrder": 20,
-      "chartSource": "catalog"
     }
   ]
 }

--- a/cli/pkg/upgrade/preinstall_declaration_test.go
+++ b/cli/pkg/upgrade/preinstall_declaration_test.go
@@ -64,6 +64,12 @@ func TestTheUpgradePublishBringsNoMediumAndSaysWhichVersionItDeclares(t *testing
 	if published.RootDir != storage.OlaresRootDir {
 		t.Errorf("writes under %q, want %q", published.RootDir, storage.OlaresRootDir)
 	}
+	// The catalog apps are the whole of what an upgrade declares: it brought no
+	// medium, so leaving them out would publish nothing at all.
+	if published.CatalogPolicy != preinstall.DeclareCatalogApps {
+		t.Errorf("declares catalog apps as %q, want %q",
+			published.CatalogPolicy, preinstall.DeclareCatalogApps)
+	}
 }
 
 func TestOneTwelveSevenIsBreakingBoundaryForSuccessor(t *testing.T) {

--- a/cli/pkg/upgrade/task_set.go
+++ b/cli/pkg/upgrade/task_set.go
@@ -73,14 +73,16 @@ const cacheRebootNeeded = "reboot.needed"
 // No installer directory is given: an upgrade brings no medium, so the
 // declaration names the catalog apps of the version being upgraded to and
 // nothing local. That version is this binary's, which is what performs the
-// upgrade.
+// upgrade. Those catalog apps are the whole of what an upgrade declares, which
+// is why it is the upgrade rather than the install that asks for them.
 func publishMarketPreinstallDeclaration() []task.Interface {
 	return []task.Interface{
 		&task.LocalTask{
 			Name: "PublishMarketPreinstallDeclaration",
 			Action: &preinstall.PublishDeclarationAction{
-				RootDir:   storage.OlaresRootDir,
-				OSVersion: version.VERSION,
+				RootDir:       storage.OlaresRootDir,
+				OSVersion:     version.VERSION,
+				CatalogPolicy: preinstall.DeclareCatalogApps,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Install-time market preinstall now declares only what the installer medium carries (`OmitCatalogApps`), so a machine that may have no network is not expected to fetch release catalog apps.
- Upgrade still declares the catalog apps of the target release (`DeclareCatalogApps`); `Publish` requires an explicit catalog policy and writes no declaration when the resulting app list is empty.
- Golden install declaration no longer includes catalog-sourced apps; tests cover both install and upgrade callers.

## Test plan
- [ ] `go test ./cli/pkg/preinstall/ ./cli/pkg/phase/system/ ./cli/pkg/upgrade/` (or the equivalent CLI package tests for preinstall/publish)
- [ ] Confirm a CLI install publishes a declaration with medium-carried apps only
- [ ] Confirm an upgrade with no installer medium publishes the release catalog apps
- [ ] Confirm `Publish` with an empty/invalid catalog policy fails rather than defaulting


Made with [Cursor](https://cursor.com)