### PR TITLE
fix(app-service): forward Upgrade/Connection in mesh-in-agent

### DIFF
--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
@@ -110,6 +110,12 @@ func RenderNginxConf(in NginxConfInput) string {
 		lb.WriteString("      proxy_set_header Host $host;\n")
 		lb.WriteString("      proxy_set_header X-Forwarded-Proto $scheme;\n")
 		lb.WriteString("      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n")
+		// Connection/Upgrade are hop-by-hop: nginx drops them unless a location
+		// forwards them explicitly, which silently downgrades every WebSocket
+		// handshake routed through this hop (e.g. cross-instance Shared audio
+		// streams) into a plain request the callee answers with a non-101 status.
+		lb.WriteString("      proxy_set_header Upgrade $http_upgrade;\n")
+		lb.WriteString("      proxy_set_header Connection $connection_upgrade;\n")
 		lb.WriteString(fmt.Sprintf("      proxy_set_header %s $mesh_in_caller_jwt;\n", callerjwt.CallerJWTHeaderName))
 		lb.WriteString("      proxy_pass_request_headers on;\n")
 		lb.WriteString(fmt.Sprintf("      proxy_pass http://%s:%d;\n", in.GatewayHost, in.GatewayHTTPPort))
@@ -141,6 +147,13 @@ func RenderNginxConf(in NginxConfInput) string {
 	b.WriteString(fmt.Sprintf("  # tls-hosts: %s\n", in.TLSHostsFile))
 	b.WriteString("  js_set $tls_cert_path main.pickCert;\n")
 	b.WriteString("  js_set $tls_key_path main.pickKey;\n")
+	// Echoing $http_upgrade back as Connection is not enough: a plain request
+	// would then carry "Connection: upgrade" too, so map it -- "upgrade" only
+	// when the client actually asked for a handshake, "close" otherwise.
+	b.WriteString("  map $http_upgrade $connection_upgrade {\n")
+	b.WriteString("    default upgrade;\n")
+	b.WriteString("    ''      close;\n")
+	b.WriteString("  }\n")
 	b.WriteString("  server {\n")
 	b.WriteString(fmt.Sprintf("    listen %d;\n", in.HTTPListenPort))
 	b.WriteString("    server_name _;\n")

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -26,6 +26,9 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 		JWTSecretMountPath + "/token",
 		"app-gateway-data.os-gateway.svc",
 		"proxy_pass http://app-gateway-data.os-gateway.svc:80",
+		"map $http_upgrade $connection_upgrade",
+		"proxy_set_header Upgrade $http_upgrade",
+		"proxy_set_header Connection $connection_upgrade",
 		"fail-closed",
 		"js_set $mesh_in_host_ok",
 		"js_set $mesh_in_caller_jwt",
@@ -63,6 +66,15 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 	}
 	if strings.Count(got, "proxy_pass http://app-gateway-data.os-gateway.svc:80") < 2 {
 		t.Fatal("expected HTTP and HTTPS terminate servers both proxy to gateway:80")
+	}
+	if strings.Count(got, "proxy_set_header Upgrade $http_upgrade;") < 2 {
+		t.Fatal("expected HTTP and HTTPS terminate locations both forward Upgrade")
+	}
+	if strings.Count(got, "proxy_set_header Connection $connection_upgrade;") < 2 {
+		t.Fatal("expected HTTP and HTTPS terminate locations both forward Connection")
+	}
+	if at, firstServer := strings.Index(got, "map $http_upgrade $connection_upgrade"), strings.Index(got, "  server {"); at < 0 || firstServer < 0 || at > firstServer {
+		t.Fatalf("connection_upgrade map must sit in http {} before the first server block:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Forward Upgrade/Connection headers through mesh-in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy header behavior for all mesh-in east-west traffic; the pattern is standard for nginx WebSockets but affects every request through the sidecar hop.
> 
> **Overview**
> **Mesh-in-agent** nginx config now forwards WebSocket handshake headers on the path to the app gateway, fixing cases where cross-instance Shared audio streams (and similar) never got a **101** response.
> 
> Each proxy `location` in `RenderNginxConf` adds `proxy_set_header Upgrade` and `proxy_set_header Connection` using a new `http`-level `map` from `$http_upgrade` to `$connection_upgrade` (empty upgrade → `close`, otherwise `upgrade`), so non-WebSocket requests do not get a bogus `Connection: upgrade`.
> 
> Tests assert the map appears before the first `server` block and that both plain HTTP and TLS-offload locations include the new headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f52d947d8a86225bbb1c58491b15eefe02897a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->