### PR TITLE
fix(app-service): mesh-in WS fix, GPU sizing fix, bump image to 0.6.41

### DIFF
--- a/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
+++ b/framework/app-service/.olares/config/cluster/deploy/appservice_deploy.yaml
@@ -180,7 +180,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       containers:
       - name: app-service
-        image: beclab/app-service:0.6.39
+        image: beclab/app-service:0.6.41
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6755

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -119,6 +119,10 @@ func classifyNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, o
 // one node, so the node's status is taken from its best card the way
 // classifyNvidiaNode does — listing only the first one would hide the rest from
 // both the resume picker and install's auto-pick.
+//
+// The capacity a card is judged against comes from requiredTargetForMode, so a
+// discrete Intel/AMD card is compared with the app's GPU-memory quota while the
+// unified-memory modes keep being compared with the pod memory request.
 func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot, opts allocationOptions) NodeOption {
 	option := NodeOption{NodeName: node.NodeName, GPUType: req.Mode}
 	if len(node.Devices) == 0 {
@@ -146,7 +150,7 @@ func classifyNonNvidiaNode(req Requirement, node Node, pressure PressureSnapshot
 		option.Status = NodeStatusNotAvailable
 		return option
 	}
-	option.Status = nodeStatusFromCapacity(req.RequiredMemory, maxCapacity, maxAvailable)
+	option.Status = nodeStatusFromCapacity(requiredTargetForMode(req), maxCapacity, maxAvailable)
 	if option.Status == NodeStatusAvailable && nodeWouldPressure(req, node, pressure, opts) {
 		option.Status = NodeStatusNotAvailable
 	}
@@ -574,22 +578,23 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 			return invalidBinding("gpu-type-mismatch")
 		}
 		available := deviceAvailableMemory(item.device)
-		if req.Mode == utils.NvidiaCardType {
-			switch item.device.SupportType {
-			case SupportTypeExclusive:
-				if len(item.device.Bindings) > 0 {
-					return invalidBinding("exclusive-already-bound:" + item.device.ID)
-				}
-			case SupportTypeMemorySlice:
-				if item.memory <= 0 {
-					return invalidBinding("memory-required:" + item.device.ID)
-				}
-				if item.memory > available {
-					return invalidBinding("device-vram-insufficient:" + item.device.ID)
-				}
-				totalAssignable += item.memory
-				continue
+		// An Exclusive device hands the whole card to one pod, so a second
+		// binding has to be rejected whatever the mode. The capacity check
+		// below cannot stand in for this: it passes an already-bound card
+		// (available 0) whenever the app's target is also 0, which a
+		// dedicated-VRAM app reaches legitimately (see targetForMode).
+		if item.device.SupportType == SupportTypeExclusive && len(item.device.Bindings) > 0 {
+			return invalidBinding("exclusive-already-bound:" + item.device.ID)
+		}
+		if req.Mode == utils.NvidiaCardType && item.device.SupportType == SupportTypeMemorySlice {
+			if item.memory <= 0 {
+				return invalidBinding("memory-required:" + item.device.ID)
 			}
+			if item.memory > available {
+				return invalidBinding("device-vram-insufficient:" + item.device.ID)
+			}
+			totalAssignable += item.memory
+			continue
 		}
 		totalAssignable += available
 	}
@@ -597,7 +602,7 @@ func validateResolvedBindingSelection(req Requirement, resolved []resolvedSelect
 		if totalAssignable < req.RequiredGPU {
 			return invalidBinding("aggregate-vram-insufficient")
 		}
-	} else if req.Mode == utils.NvidiaCardType {
+	} else if utils.HasDedicatedGPUMemory(req.Mode) {
 		if totalAssignable < req.RequiredGPU {
 			return invalidBinding("device-vram-insufficient")
 		}
@@ -680,10 +685,7 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 		}
 		return resolved[i].node.NodeName < resolved[j].node.NodeName
 	})
-	target := req.RequiredMemory
-	if req.Mode == utils.NvidiaCardType {
-		target = req.RequiredGPU
-	}
+	target := requiredTargetForMode(req)
 	out := make([]Allocation, 0, len(resolved))
 	remaining := target
 	for _, item := range resolved {

--- a/framework/app-service/pkg/compute/dedicated_gpu_memory_test.go
+++ b/framework/app-service/pkg/compute/dedicated_gpu_memory_test.go
@@ -1,0 +1,247 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
+	"github.com/beclab/Olares/framework/app-service/pkg/utils"
+)
+
+const gib = int64(1 << 30)
+
+// dedicatedModeRequirement is the requirement a manifest produces for a
+// discrete card: a GPU-memory quota well above the pod memory request, so any
+// check that reads the wrong one is off by a visible margin.
+func dedicatedModeRequirement(mode string) Requirement {
+	return RequirementFromMode(appcfg.ResourceMode{
+		Mode: mode,
+		ResourceRequirement: appcfg.ResourceRequirement{
+			RequiredCPU:    "1",
+			LimitedCPU:     "2",
+			RequiredMemory: "2Gi",
+			LimitedMemory:  "4Gi",
+			RequiredDisk:   "1Gi",
+			LimitedDisk:    "2Gi",
+			RequiredGPU:    "16Gi",
+			LimitedGPU:     "20Gi",
+		},
+	})
+}
+
+func exclusiveDevice(mode string, memory int64, bindings ...Allocation) Device {
+	return Device{
+		ID:          "card0",
+		NodeName:    "n1",
+		Mode:        mode,
+		Memory:      memory,
+		Health:      deviceHealthYes,
+		SupportType: SupportTypeExclusive,
+		Bindings:    bindings,
+	}
+}
+
+func singleDeviceNode(device Device) Node {
+	return Node{
+		NodeName: device.NodeName,
+		GPUTypes: []string{device.Mode},
+		Devices:  []Device{device},
+	}
+}
+
+// The discrete-GPU modes own VRAM separate from system RAM, so their fit target
+// is the manifest's GPU-memory quota. Only the unified-memory modes may fall
+// back to the pod memory request. Before this was fixed every non-nvidia mode
+// took the fallback, so a discrete Intel/AMD card was sized against pod memory
+// and the declared VRAM was parsed and then ignored.
+func TestFitTargetPerMode(t *testing.T) {
+	tests := []struct {
+		name             string
+		mode             string
+		wantRequired     int64
+		wantLimit        int64
+		wantDedicatedGPU bool
+	}{
+		{"nvidia uses gpu quota", utils.NvidiaCardType, 16 * gib, 20 * gib, true},
+		{"amd discrete uses gpu quota", utils.AMDGPUType, 16 * gib, 20 * gib, true},
+		{"intel discrete uses gpu quota", utils.IntelGPUType, 16 * gib, 20 * gib, true},
+		{"amd integrated uses pod memory", utils.AMDType, 2 * gib, 4 * gib, false},
+		{"intel integrated uses pod memory", utils.IntelType, 2 * gib, 4 * gib, false},
+		{"gb10 uses pod memory", utils.GB10ChipType, 2 * gib, 4 * gib, false},
+		{"apple m uses pod memory", utils.AppleMChipType, 2 * gib, 4 * gib, false},
+		{"moore soc uses pod memory", utils.MooreSocType, 2 * gib, 4 * gib, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := dedicatedModeRequirement(tt.mode)
+			if got := utils.HasDedicatedGPUMemory(tt.mode); got != tt.wantDedicatedGPU {
+				t.Fatalf("HasDedicatedGPUMemory(%s) = %v, want %v", tt.mode, got, tt.wantDedicatedGPU)
+			}
+			if got := targetForMode(req, FitLevelRequired); got != tt.wantRequired {
+				t.Errorf("targetForMode(%s, required) = %d, want %d", tt.mode, got, tt.wantRequired)
+			}
+			if got := targetForMode(req, FitLevelLimit); got != tt.wantLimit {
+				t.Errorf("targetForMode(%s, limit) = %d, want %d", tt.mode, got, tt.wantLimit)
+			}
+			if got := requiredTargetForMode(req); got != tt.wantRequired {
+				t.Errorf("requiredTargetForMode(%s) = %d, want %d", tt.mode, got, tt.wantRequired)
+			}
+		})
+	}
+}
+
+// Install-time capacity has to reject a discrete card smaller than the app's
+// declared VRAM. It used to accept one whenever the card cleared the much
+// smaller pod memory request, so an app needing 16Gi was reported installable
+// against an 8Gi card and only failed later at runtime.
+func TestInstallCapacityFitsSizesDiscreteCardsByGPUQuota(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		cardMemory int64
+		want       bool
+	}{
+		{"amd discrete card below gpu quota", utils.AMDGPUType, 8 * gib, false},
+		{"amd discrete card above gpu quota", utils.AMDGPUType, 24 * gib, true},
+		{"intel discrete card below gpu quota", utils.IntelGPUType, 8 * gib, false},
+		{"intel discrete card above gpu quota", utils.IntelGPUType, 24 * gib, true},
+		{"nvidia card below gpu quota", utils.NvidiaCardType, 8 * gib, false},
+		{"nvidia card above gpu quota", utils.NvidiaCardType, 24 * gib, true},
+		// The unified-memory modes have no VRAM of their own, so they keep
+		// being sized against the 2Gi pod memory request.
+		{"intel integrated above pod memory", utils.IntelType, 8 * gib, true},
+		{"intel integrated below pod memory", utils.IntelType, gib, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := dedicatedModeRequirement(tt.mode)
+			node := singleDeviceNode(exclusiveDevice(tt.mode, tt.cardMemory))
+			if got := installCapacityFits(req, []Node{node}); got != tt.want {
+				t.Fatalf("installCapacityFits(%s, card=%dGi) = %v, want %v",
+					tt.mode, tt.cardMemory/gib, got, tt.want)
+			}
+		})
+	}
+}
+
+// The node/device availability view feeds both the resume picker and install's
+// auto-pick, so it has to reach the same verdict as the capacity check: a
+// discrete card too small for the declared VRAM is not-enough, not available.
+func TestAvailabilityStatusForDiscreteCards(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		cardMemory int64
+		wantStatus string
+	}{
+		{"amd discrete card below gpu quota", utils.AMDGPUType, 8 * gib, NodeStatusNotEnough},
+		{"amd discrete card above gpu quota", utils.AMDGPUType, 24 * gib, NodeStatusAvailable},
+		{"intel discrete card below gpu quota", utils.IntelGPUType, 8 * gib, NodeStatusNotEnough},
+		{"intel discrete card above gpu quota", utils.IntelGPUType, 24 * gib, NodeStatusAvailable},
+		{"intel integrated sized by pod memory", utils.IntelType, 8 * gib, NodeStatusAvailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := dedicatedModeRequirement(tt.mode)
+			node := singleDeviceNode(exclusiveDevice(tt.mode, tt.cardMemory))
+			result := listAvailableForLaunch(req, []Node{node}, PressureSnapshot{})
+			if len(result.Nodes) != 1 {
+				t.Fatalf("expected 1 classified node, got %d", len(result.Nodes))
+			}
+			if result.Nodes[0].Status != tt.wantStatus {
+				t.Fatalf("node status = %s, want %s", result.Nodes[0].Status, tt.wantStatus)
+			}
+			if wantSchedulable := tt.wantStatus == NodeStatusAvailable; result.Schedulable != wantSchedulable {
+				t.Fatalf("schedulable = %v, want %v (reason %q)",
+					result.Schedulable, wantSchedulable, result.Reason)
+			}
+		})
+	}
+}
+
+// A manually submitted binding goes through the same VRAM judgement, so a
+// discrete card that cannot hold the declared GPU memory has to be rejected
+// with the VRAM code rather than being waved through on pod memory.
+func TestValidateBindingSelectionForDiscreteCards(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		cardMemory int64
+		wantOK     bool
+		wantCode   string
+	}{
+		{"amd discrete card below gpu quota", utils.AMDGPUType, 8 * gib, false, "device-vram-insufficient"},
+		{"amd discrete card above gpu quota", utils.AMDGPUType, 24 * gib, true, BindingValidationReasonValid},
+		{"intel discrete card below gpu quota", utils.IntelGPUType, 8 * gib, false, "device-vram-insufficient"},
+		{"intel discrete card above gpu quota", utils.IntelGPUType, 24 * gib, true, BindingValidationReasonValid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := dedicatedModeRequirement(tt.mode)
+			node := singleDeviceNode(exclusiveDevice(tt.mode, tt.cardMemory))
+			selections := []BindingSelection{{NodeName: node.NodeName, DeviceID: node.Devices[0].ID}}
+			result := ValidateBindingSelection(req, selections, []Node{node}, PressureSnapshot{})
+			if result.OK != tt.wantOK || result.Code != tt.wantCode {
+				t.Fatalf("validation = (ok=%v, code=%q), want (ok=%v, code=%q)",
+					result.OK, result.Code, tt.wantOK, tt.wantCode)
+			}
+		})
+	}
+}
+
+// A discrete-GPU app can legitimately declare no GPU-memory quota: the field is
+// only mandatory for modes listed under spec.resources, and an auto-resource
+// sentinel resolves to zero when the chart carries no nvidia.com/gpumem. Its
+// fit target is then zero, which must not let it onto a card another app
+// already holds exclusively — the capacity comparison alone would allow that,
+// since an exhausted card reports zero available.
+func TestValidateBindingSelectionRejectsBoundExclusiveCardWithoutGPUQuota(t *testing.T) {
+	for _, mode := range []string{utils.AMDGPUType, utils.IntelGPUType, utils.NvidiaCardType, utils.IntelType} {
+		t.Run(mode, func(t *testing.T) {
+			req := RequirementFromMode(appcfg.ResourceMode{
+				Mode: mode,
+				ResourceRequirement: appcfg.ResourceRequirement{
+					RequiredCPU: "1", RequiredDisk: "1Gi",
+				},
+			})
+			device := exclusiveDevice(mode, 24*gib, Allocation{
+				AppName: "incumbent", Mode: mode, NodeName: "n1", DeviceID: "card0",
+			})
+			node := singleDeviceNode(device)
+			selections := []BindingSelection{{NodeName: node.NodeName, DeviceID: device.ID}}
+			result := ValidateBindingSelection(req, selections, []Node{node}, PressureSnapshot{})
+			if result.OK || result.Code != "exclusive-already-bound:"+device.ID {
+				t.Fatalf("validation = (ok=%v, code=%q), want rejection with exclusive-already-bound",
+					result.OK, result.Code)
+			}
+		})
+	}
+}
+
+// The allocation records what the app took from the card, which the compute
+// listing shows back to the user. For a discrete card that is the VRAM quota;
+// recording the pod memory request instead reported a host-RAM number as the
+// card's allocated video memory.
+func TestAllocationRecordsGPUQuotaForDiscreteCards(t *testing.T) {
+	for _, mode := range []string{utils.AMDGPUType, utils.IntelGPUType} {
+		t.Run(mode, func(t *testing.T) {
+			req := dedicatedModeRequirement(mode)
+			node := singleDeviceNode(exclusiveDevice(mode, 24*gib))
+			appConfig := &appcfg.ApplicationConfig{AppName: "app", OwnerName: "owner"}
+			allocations, ok := PickAllocations(appConfig, req, []Node{node}, PressureSnapshot{})
+			if !ok {
+				t.Fatal("expected the app to be placed on a card larger than its quota")
+			}
+			if len(allocations) != 1 {
+				t.Fatalf("expected 1 allocation, got %d", len(allocations))
+			}
+			if allocations[0].Memory != req.RequiredGPU {
+				t.Fatalf("allocation memory = %d, want the declared gpu quota %d",
+					allocations[0].Memory, req.RequiredGPU)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -300,22 +300,13 @@ func installCapacityFits(req Requirement, nodes []Node) bool {
 		}
 		return false
 	}
-	if req.Mode == utils.NvidiaCardType {
-		for _, node := range nodes {
-			for _, device := range node.Devices {
-				if device.Memory >= req.RequiredGPU {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	// Non-nvidia modes are scheduled one device at a time, but a node can still
-	// expose several of them (nvidia-gb10 cards, discrete Intel GPUs), so every
-	// device gets a look rather than just the first.
+	// Every remaining mode is scheduled one device at a time, but a node can
+	// still expose several of them (nvidia cards, nvidia-gb10 cards, discrete
+	// Intel GPUs), so every device gets a look rather than just the first.
+	target := requiredTargetForMode(req)
 	for _, node := range nodes {
 		for _, device := range node.Devices {
-			if device.Memory >= req.RequiredMemory {
+			if device.Memory >= target {
 				return true
 			}
 		}
@@ -468,15 +459,29 @@ func levelAddedResources(req Requirement, level string, options allocationOption
 	}
 }
 
+// targetForMode is the amount of device memory the app needs from a single
+// device at the given fit level. Dedicated-VRAM modes (nvidia / amd-gpu /
+// intel-gpu) are sized by the manifest's GPU-memory quota, which is the only
+// quantity that describes their separate memory pool; the unified-memory modes
+// have no such quota and are sized by the pod memory request, which for them
+// covers the VRAM too because it is the same RAM.
+//
+// A dedicated-VRAM app may still land here with a zero target: the quota is
+// only mandatory for manifests that declare the mode under spec.resources, and
+// an auto-resource sentinel resolves to zero whenever the chart carries no
+// nvidia.com/gpumem. A zero target means "no declared demand" and lets the app
+// take whatever the device has free, so it must not be read as "needs nothing
+// and fits anywhere" — see the Exclusive guard in
+// validateResolvedBindingSelection.
 func targetForMode(req Requirement, level string) int64 {
-	if req.Mode == utils.NvidiaCardType {
+	if utils.HasDedicatedGPUMemory(req.Mode) {
 		return targetGPU(req, level)
 	}
 	return levelMemory(req, level)
 }
 
 func requiredTargetForMode(req Requirement) int64 {
-	if req.Mode == utils.NvidiaCardType {
+	if utils.HasDedicatedGPUMemory(req.Mode) {
 		return req.RequiredGPU
 	}
 	return req.RequiredMemory

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf.go
@@ -110,6 +110,12 @@ func RenderNginxConf(in NginxConfInput) string {
 		lb.WriteString("      proxy_set_header Host $host;\n")
 		lb.WriteString("      proxy_set_header X-Forwarded-Proto $scheme;\n")
 		lb.WriteString("      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n")
+		// Connection/Upgrade are hop-by-hop: nginx drops them unless a location
+		// forwards them explicitly, which silently downgrades every WebSocket
+		// handshake routed through this hop (e.g. cross-instance Shared audio
+		// streams) into a plain request the callee answers with a non-101 status.
+		lb.WriteString("      proxy_set_header Upgrade $http_upgrade;\n")
+		lb.WriteString("      proxy_set_header Connection $connection_upgrade;\n")
 		lb.WriteString(fmt.Sprintf("      proxy_set_header %s $mesh_in_caller_jwt;\n", callerjwt.CallerJWTHeaderName))
 		lb.WriteString("      proxy_pass_request_headers on;\n")
 		lb.WriteString(fmt.Sprintf("      proxy_pass http://%s:%d;\n", in.GatewayHost, in.GatewayHTTPPort))
@@ -141,6 +147,13 @@ func RenderNginxConf(in NginxConfInput) string {
 	b.WriteString(fmt.Sprintf("  # tls-hosts: %s\n", in.TLSHostsFile))
 	b.WriteString("  js_set $tls_cert_path main.pickCert;\n")
 	b.WriteString("  js_set $tls_key_path main.pickKey;\n")
+	// Echoing $http_upgrade back as Connection is not enough: a plain request
+	// would then carry "Connection: upgrade" too, so map it -- "upgrade" only
+	// when the client actually asked for a handshake, "close" otherwise.
+	b.WriteString("  map $http_upgrade $connection_upgrade {\n")
+	b.WriteString("    default upgrade;\n")
+	b.WriteString("    ''      close;\n")
+	b.WriteString("  }\n")
 	b.WriteString("  server {\n")
 	b.WriteString(fmt.Sprintf("    listen %d;\n", in.HTTPListenPort))
 	b.WriteString("    server_name _;\n")

--- a/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshinagent/nginx_conf_test.go
@@ -26,6 +26,9 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 		JWTSecretMountPath + "/token",
 		"app-gateway-data.os-gateway.svc",
 		"proxy_pass http://app-gateway-data.os-gateway.svc:80",
+		"map $http_upgrade $connection_upgrade",
+		"proxy_set_header Upgrade $http_upgrade",
+		"proxy_set_header Connection $connection_upgrade",
 		"fail-closed",
 		"js_set $mesh_in_host_ok",
 		"js_set $mesh_in_caller_jwt",
@@ -63,6 +66,15 @@ func TestRenderNginxConfContainsListenAndJWT(t *testing.T) {
 	}
 	if strings.Count(got, "proxy_pass http://app-gateway-data.os-gateway.svc:80") < 2 {
 		t.Fatal("expected HTTP and HTTPS terminate servers both proxy to gateway:80")
+	}
+	if strings.Count(got, "proxy_set_header Upgrade $http_upgrade;") < 2 {
+		t.Fatal("expected HTTP and HTTPS terminate locations both forward Upgrade")
+	}
+	if strings.Count(got, "proxy_set_header Connection $connection_upgrade;") < 2 {
+		t.Fatal("expected HTTP and HTTPS terminate locations both forward Connection")
+	}
+	if at, firstServer := strings.Index(got, "map $http_upgrade $connection_upgrade"), strings.Index(got, "  server {"); at < 0 || firstServer < 0 || at > firstServer {
+		t.Fatalf("connection_upgrade map must sit in http {} before the first server block:\n%s", got)
 	}
 }
 

--- a/framework/app-service/pkg/utils/dedicated_gpu_memory_test.go
+++ b/framework/app-service/pkg/utils/dedicated_gpu_memory_test.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestHasDedicatedGPUMemory(t *testing.T) {
+	tests := []struct {
+		mode string
+		want bool
+	}{
+		{NvidiaCardType, true},
+		{AMDGPUType, true},
+		{IntelGPUType, true},
+		{GB10ChipType, false},
+		{AppleMChipType, false},
+		{IntelType, false},
+		{AMDType, false},
+		{MooreSocType, false},
+		{CPUType, false},
+		{"", false},
+		{"strix-halo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			if got := HasDedicatedGPUMemory(tt.mode); got != tt.want {
+				t.Fatalf("HasDedicatedGPUMemory(%q) = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// oacGPUMemoryModesPath locates the manifest validator's own list of modes that
+// may declare a GPU-memory quota. It is the schema authority: a manifest is
+// rejected for declaring requiredGPUMemory on a mode outside that list, and
+// rejected for omitting it on a mode inside it. Our dedicatedGPUMemoryTypes has
+// to name the same modes or app-service will size an app against a quantity the
+// manifest was never allowed to carry.
+const oacGPUMemoryModesPath = "../../../oac/internal/manifest/resources.go"
+
+var (
+	gpuMemoryModesBlock = regexp.MustCompile(`(?s)gpuMemoryModes = map\[string\]struct\{\}\{(.*?)\n\}`)
+	resourceModeEntry   = regexp.MustCompile(`(ResourceMode\w+):\s*\{\}`)
+	resourceModeConst   = regexp.MustCompile(`(ResourceMode\w+)\s*=\s*"([^"]+)"`)
+)
+
+// The two sets live in separately versioned modules and oac keeps its copy in
+// an internal package, so app-service cannot import it and has to duplicate the
+// membership. This test reads oac's source directly to catch the duplicate
+// drifting — the failure mode it guards against is silent: a mode added to oac
+// alone would have its declared VRAM parsed and then ignored at scheduling
+// time, exactly the bug this list was introduced to fix.
+//
+// It skips rather than fails when oac is not on disk, since app-service also
+// builds from a context that contains only its own module.
+func TestDedicatedGPUMemoryTypesMatchOAC(t *testing.T) {
+	path, err := filepath.Abs(oacGPUMemoryModesPath)
+	if err != nil {
+		t.Fatalf("resolve oac resources.go path: %v", err)
+	}
+	source, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		t.Skipf("oac module not present at %s; nothing to compare against", path)
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	block := gpuMemoryModesBlock.FindSubmatch(source)
+	if block == nil {
+		t.Fatalf("could not find the gpuMemoryModes map in %s; if it was renamed or restructured, "+
+			"update this test and re-check dedicatedGPUMemoryTypes against it", path)
+	}
+
+	modeValues := make(map[string]string)
+	for _, m := range resourceModeConst.FindAllSubmatch(source, -1) {
+		modeValues[string(m[1])] = string(m[2])
+	}
+
+	want := make(map[string]struct{})
+	entries := resourceModeEntry.FindAllSubmatch(block[1], -1)
+	if len(entries) == 0 {
+		t.Fatalf("parsed no modes out of the gpuMemoryModes map in %s", path)
+	}
+	for _, entry := range entries {
+		name := string(entry[1])
+		value, ok := modeValues[name]
+		if !ok {
+			t.Fatalf("gpuMemoryModes references %s but no constant defines its value in %s", name, path)
+		}
+		want[value] = struct{}{}
+	}
+
+	if !reflect.DeepEqual(want, dedicatedGPUMemoryTypes) {
+		t.Fatalf("dedicatedGPUMemoryTypes = %v, but oac's gpuMemoryModes = %v; "+
+			"the two must name the same modes", keysOf(dedicatedGPUMemoryTypes), keysOf(want))
+	}
+}
+
+func keysOf(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return sortedCopy(out)
+}

--- a/framework/app-service/pkg/utils/gpu_types.go
+++ b/framework/app-service/pkg/utils/gpu_types.go
@@ -37,6 +37,33 @@ const (
 	MooreSocType   = "moore-soc"   // Moore Threads SoC
 )
 
+// dedicatedGPUMemoryTypes are the modes whose devices own a GPU memory pool
+// separate from system RAM, so an app sizes itself against the manifest's
+// requiredGPUMemory / limitedGPUMemory rather than its pod memory request. The
+// remaining accelerators (nvidia-gb10, apple-m, intel, amd, moore-soc) are
+// unified memory and draw from system RAM.
+//
+// This mirrors gpuMemoryModes in the manifest validator
+// (framework/oac/internal/manifest/resources.go), which is the schema authority
+// deciding for which modes a manifest may — and must — declare a GPU-memory
+// quota. That set lives in an internal package of a separately versioned
+// module, so it cannot be imported here; TestDedicatedGPUMemoryTypesMatchOAC
+// guards the two against drifting apart.
+var dedicatedGPUMemoryTypes = map[string]struct{}{
+	NvidiaCardType: {},
+	AMDGPUType:     {},
+	IntelGPUType:   {},
+}
+
+// HasDedicatedGPUMemory reports whether devices of this mode carry their own
+// VRAM. Callers use it to pick which manifest quantity expresses the app's
+// demand for a device: the GPU-memory request for dedicated cards, the pod
+// memory request for the unified-memory modes.
+func HasDedicatedGPUMemory(mode string) bool {
+	_, ok := dedicatedGPUMemoryTypes[mode]
+	return ok
+}
+
 // canonicalGPUTypes is the ordered set of non-cpu modes the system recognizes
 // as node-labelable. It is the only set scanned for the existence-based
 // per-mode labels, so unrelated keys under the gpu.bytetrade.io/ prefix


### PR DESCRIPTION
## Summary
- Fix mesh-in dropping WebSocket Upgrade/Connection headers on its proxy hop
  (cross-instance WS handshakes were failing with 502).
- Fix discrete Intel/AMD GPU sizing to use `requiredGPUMemory` instead of the
  wrong field, so scheduling picks cards with enough memory.
- Bump shipped app-service image to 0.6.41.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compute placement and binding rules for Intel/AMD discrete GPUs and mesh-in proxy behavior; mis-sizing or header regressions would affect installs, resume picks, and cross-instance WebSockets.
> 
> **Overview**
> Fixes **mesh-in** so WebSocket handshakes survive the proxy hop: generated nginx config now maps `$http_upgrade` to `$connection_upgrade` and forwards **Upgrade** / **Connection** on HTTP and TLS terminate paths (cross-instance Shared streams were failing with non-101 responses).
> 
> **Discrete GPU scheduling** now treats `intel-gpu` and `amd-gpu` like NVIDIA for VRAM: `HasDedicatedGPUMemory` drives install capacity, availability, binding validation, allocations, and fit targets via `requiredGPUMemory` instead of pod memory. Unified-memory modes still use pod memory. **Exclusive** cards already bound are rejected for all modes (not only when a zero GPU quota would pass capacity). Shipped image bumped to **beclab/app-service:0.6.41**.
> 
> Regression tests cover discrete sizing, mesh-in nginx snippets, and parity with OAC’s `gpuMemoryModes` list when present in the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556113e8bc7dd1ceafa8e1d63006ffc8f3029ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->