### PR TITLE
system-frontend: update image to v1.11.42

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.41
+          image: beclab/system-frontend:v1.11.42
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the system-frontend image to v1.11.42 to pick up compute-binding fixes that read `requiredGpu` for intel-gpu and amd-gpu VRAM requirements, plus related market UI loading-state fixes from TermiPass.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1410

* **Other information**:
None

Made with [Cursor](https://cursor.com)