### PR TITLE
Fail preinstall check when bundled chart images are not preloaded

### DIFF
--- a/cli/cmd/ctl/chart/lint.go
+++ b/cli/cmd/ctl/chart/lint.go
@@ -1,14 +1,10 @@
 package chart
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"strings"
 
+	pkgchart "github.com/beclab/Olares/cli/pkg/chart"
 	oac "github.com/beclab/Olares/framework/oac"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +75,7 @@ Examples:
 }
 
 func runLint(input string, o *lintOpts) error {
-	chartDir, cleanup, err := resolveChartDir(input)
+	chartDir, cleanup, err := pkgchart.ResolveDir(input)
 	if err != nil {
 		return err
 	}
@@ -132,144 +128,4 @@ func buildOACOptions(o *lintOpts) []oac.Option {
 		opts = append(opts, oac.WithSecurityContextCheck())
 	}
 	return opts
-}
-
-// resolveChartDir turns a directory or a .tgz / .tar.gz package path into a
-// chart directory that oac.Lint can consume. The returned cleanup must be
-// called by the caller (via defer) and is always non-nil.
-func resolveChartDir(input string) (string, func(), error) {
-	noop := func() {}
-	info, err := os.Stat(input)
-	if err != nil {
-		return "", noop, fmt.Errorf("cannot access %q: %w", input, err)
-	}
-	if info.IsDir() {
-		return input, noop, nil
-	}
-	lower := strings.ToLower(info.Name())
-	if !strings.HasSuffix(lower, ".tgz") && !strings.HasSuffix(lower, ".tar.gz") {
-		return "", noop, fmt.Errorf("unsupported file format: expected directory, .tgz, or .tar.gz")
-	}
-
-	tmpDir, err := os.MkdirTemp("", "olares-chart-*")
-	if err != nil {
-		return "", noop, fmt.Errorf("create temp dir: %w", err)
-	}
-	cleanup := func() { _ = os.RemoveAll(tmpDir) }
-
-	if err := extractTarGz(input, tmpDir); err != nil {
-		cleanup()
-		return "", noop, fmt.Errorf("extract %q: %w", input, err)
-	}
-
-	chartDir, err := locateChartRoot(tmpDir)
-	if err != nil {
-		cleanup()
-		return "", noop, err
-	}
-	return chartDir, cleanup, nil
-}
-
-// extractTarGz unpacks a gzipped tar archive at src into dst, refusing any
-// entry whose final destination escapes dst (zip-slip guard) and silently
-// skipping non-regular non-directory entries (symlinks, devices, ...).
-func extractTarGz(src, dst string) error {
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	gr, err := gzip.NewReader(f)
-	if err != nil {
-		return fmt.Errorf("gzip: %w", err)
-	}
-	defer gr.Close()
-
-	dstAbs, err := filepath.Abs(dst)
-	if err != nil {
-		return err
-	}
-
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("tar: %w", err)
-		}
-		if hdr == nil || hdr.Name == "" {
-			continue
-		}
-
-		// zip-slip: reject ".." traversal and absolute paths.
-		clean := filepath.Clean(hdr.Name)
-		if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
-			return fmt.Errorf("invalid tar entry %q: escapes archive root", hdr.Name)
-		}
-		target := filepath.Join(dstAbs, clean)
-		if !strings.HasPrefix(target, dstAbs+string(filepath.Separator)) && target != dstAbs {
-			return fmt.Errorf("invalid tar entry %q: escapes archive root", hdr.Name)
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0o755); err != nil {
-				return err
-			}
-		case tar.TypeReg, tar.TypeRegA:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-				return err
-			}
-			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(out, tr); err != nil {
-				out.Close()
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		default:
-			// Skip symlinks / hardlinks / devices etc — Olares charts have no
-			// legitimate use for them and accepting them is a foot-gun.
-		}
-	}
-}
-
-// locateChartRoot picks the directory that should be passed to oac.Lint.
-// Helm packaging puts every chart file under a single top-level directory
-// named after the chart, so the common case is "exactly one subdirectory
-// containing Chart.yaml". We also accept Chart.yaml directly at the
-// extraction root for hand-rolled tarballs.
-func locateChartRoot(dir string) (string, error) {
-	if fileExists(filepath.Join(dir, "Chart.yaml")) {
-		return dir, nil
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return "", err
-	}
-	var subDirs []string
-	for _, e := range entries {
-		if e.IsDir() {
-			subDirs = append(subDirs, e.Name())
-		}
-	}
-	if len(subDirs) == 1 {
-		candidate := filepath.Join(dir, subDirs[0])
-		if fileExists(filepath.Join(candidate, "Chart.yaml")) {
-			return candidate, nil
-		}
-	}
-	return "", fmt.Errorf("tarball does not contain a single chart root (no Chart.yaml found at the expected location)")
-}
-
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
 }

--- a/cli/cmd/ctl/preinstall/check.go
+++ b/cli/cmd/ctl/preinstall/check.go
@@ -3,12 +3,18 @@ package preinstall
 import (
 	"fmt"
 
+	"github.com/beclab/Olares/cli/pkg/manifest"
 	pkgpreinstall "github.com/beclab/Olares/cli/pkg/preinstall"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdPreinstallCheck() *cobra.Command {
-	var full bool
+	var (
+		full           bool
+		installationMF string
+		imagesDir      string
+		gpuModes       []string
+	)
 	cmd := &cobra.Command{
 		Use:   "check <path>",
 		Short: "Validate a static Market preinstall bundle directory",
@@ -20,7 +26,6 @@ By default the command runs contract-level checks that mirror the
 installer prepare path:
 
   - decode and semantically validate bundle.json
-  - build a default install profile and validate it against the bundle
   - verify each chart exists, is a regular file within size limits,
     and matches chartSha256
   - validate unique Hugging Face cache targets
@@ -30,18 +35,45 @@ Pass --full to also verify artifact payload trees under each artifact's
 source directory against the manifest (entry types and digests). This can
 be slow for large model payloads.
 
+Pass --installation-manifest to additionally render every bundled chart
+and require the medium to preload the images they need. This catches the
+case where a bundled chart was updated but the image list was not, which
+on an offline device means the app cannot start at all. Add --images-dir
+to also require the image payload to be present, which is what prepare
+reads. Both checks are offline; neither contacts a registry or a CDN.
+
 Examples:
   olares-cli preinstall check ./preinstall/market
-  olares-cli preinstall check ./preinstall/market --full`,
+  olares-cli preinstall check ./preinstall/market --full
+  olares-cli preinstall check ./preinstall/market \
+    --installation-manifest ./installation.manifest --images-dir ./images`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := pkgpreinstall.CheckStaticBundle(args[0], pkgpreinstall.CheckOptions{Full: full}); err != nil {
+			opts := pkgpreinstall.CheckOptions{
+				Full:      full,
+				ImagesDir: imagesDir,
+				GPUModes:  gpuModes,
+			}
+			if installationMF != "" {
+				installation, err := manifest.ReadAll(installationMF)
+				if err != nil {
+					return fmt.Errorf("read installation manifest %q: %w", installationMF, err)
+				}
+				opts.InstallationManifest = installation
+			} else if imagesDir != "" {
+				return fmt.Errorf("--images-dir requires --installation-manifest")
+			}
+			if err := pkgpreinstall.CheckStaticBundle(args[0], opts); err != nil {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "ok")
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&full, "full", false, "also verify artifact payload trees against manifests")
+	fs := cmd.Flags()
+	fs.BoolVar(&full, "full", false, "also verify artifact payload trees against manifests")
+	fs.StringVar(&installationMF, "installation-manifest", "", "path to installation.manifest; enables the bundled-chart image check")
+	fs.StringVar(&imagesDir, "images-dir", "", "directory holding preloaded image payloads (normally <baseDir>/images); requires --installation-manifest")
+	fs.StringSliceVar(&gpuModes, "gpu-modes", nil, "GPU families to render charts under (default: no-override plus all known families)")
 	return cmd
 }

--- a/cli/pkg/chart/archive.go
+++ b/cli/pkg/chart/archive.go
@@ -1,0 +1,170 @@
+package chart
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MaxExtractedBytes caps the total size an archive may expand to. Olares charts
+// are a few kilobytes of templates; the cap only exists so a hostile .tgz cannot
+// fill the disk of whatever runs lint or the preinstall image gate.
+const MaxExtractedBytes int64 = 512 << 20
+
+// MaxExtractedEntries caps how many members an archive may contain, for the same
+// reason as MaxExtractedBytes.
+const MaxExtractedEntries = 100_000
+
+// ResolveDir turns a directory or a .tgz / .tar.gz package path into a chart
+// directory that oac can consume. The returned cleanup must be called by the
+// caller (via defer) and is always non-nil.
+func ResolveDir(input string) (string, func(), error) {
+	noop := func() {}
+	info, err := os.Stat(input)
+	if err != nil {
+		return "", noop, fmt.Errorf("cannot access %q: %w", input, err)
+	}
+	if info.IsDir() {
+		return input, noop, nil
+	}
+	lower := strings.ToLower(info.Name())
+	if !strings.HasSuffix(lower, ".tgz") && !strings.HasSuffix(lower, ".tar.gz") {
+		return "", noop, fmt.Errorf("unsupported file format: expected directory, .tgz, or .tar.gz")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "olares-chart-*")
+	if err != nil {
+		return "", noop, fmt.Errorf("create temp dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	if err := ExtractTarGz(input, tmpDir); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("extract %q: %w", input, err)
+	}
+
+	chartDir, err := LocateRoot(tmpDir)
+	if err != nil {
+		cleanup()
+		return "", noop, err
+	}
+	return chartDir, cleanup, nil
+}
+
+// ExtractTarGz unpacks a gzipped tar archive at src into dst, refusing any entry
+// whose final destination escapes dst (zip-slip guard) and silently skipping
+// non-regular non-directory entries (symlinks, devices, ...).
+func ExtractTarGz(src, dst string) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gr.Close()
+
+	dstAbs, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+
+	var (
+		entries   int
+		remaining = MaxExtractedBytes
+	)
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("tar: %w", err)
+		}
+		if hdr == nil || hdr.Name == "" {
+			continue
+		}
+		entries++
+		if entries > MaxExtractedEntries {
+			return fmt.Errorf("archive holds more than %d entries", MaxExtractedEntries)
+		}
+
+		// zip-slip: reject ".." traversal and absolute paths.
+		clean := filepath.Clean(hdr.Name)
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+			return fmt.Errorf("invalid tar entry %q: escapes archive root", hdr.Name)
+		}
+		target := filepath.Join(dstAbs, clean)
+		if !strings.HasPrefix(target, dstAbs+string(filepath.Separator)) && target != dstAbs {
+			return fmt.Errorf("invalid tar entry %q: escapes archive root", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				return err
+			}
+			written, err := io.Copy(out, io.LimitReader(tr, remaining+1))
+			out.Close()
+			if err != nil {
+				return err
+			}
+			if written > remaining {
+				return fmt.Errorf("archive expands beyond %d bytes", MaxExtractedBytes)
+			}
+			remaining -= written
+		default:
+			// Skip symlinks / hardlinks / devices etc — Olares charts have no
+			// legitimate use for them and accepting them is a foot-gun.
+		}
+	}
+}
+
+// LocateRoot picks the directory that should be passed to oac. Helm packaging
+// puts every chart file under a single top-level directory named after the
+// chart, so the common case is "exactly one subdirectory containing
+// Chart.yaml". Chart.yaml directly at the extraction root is also accepted, for
+// hand-rolled tarballs.
+func LocateRoot(dir string) (string, error) {
+	if fileExists(filepath.Join(dir, "Chart.yaml")) {
+		return dir, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var subDirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			subDirs = append(subDirs, e.Name())
+		}
+	}
+	if len(subDirs) == 1 {
+		candidate := filepath.Join(dir, subDirs[0])
+		if fileExists(filepath.Join(candidate, "Chart.yaml")) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("tarball does not contain a single chart root (no Chart.yaml found at the expected location)")
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/cli/pkg/preinstall/check.go
+++ b/cli/pkg/preinstall/check.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/beclab/Olares/cli/pkg/manifest"
 )
 
 // CheckOptions controls how thoroughly CheckStaticBundle inspects a
@@ -12,6 +14,24 @@ type CheckOptions struct {
 	// Full also verifies artifact payload trees under each artifact's
 	// source directory against the corresponding manifest entries.
 	Full bool
+
+	// InstallationManifest enables the image gate. When set, every image the
+	// bundled charts render must appear in it, because LoadImages and
+	// PinImages both iterate the manifest and ignore anything absent from it.
+	// Leaving it empty keeps the contract-only behaviour.
+	InstallationManifest manifest.InstallationManifest
+
+	// ImagesDir is the directory holding the preloaded image payloads,
+	// normally <baseDir>/images. When set, an image the manifest lists must
+	// also have its tarball on the medium, which is the second half of what
+	// prepare needs and a separate failure from a stale image list.
+	ImagesDir string
+
+	// GPUModes overrides the .Values.GPU.Type values the charts are rendered
+	// under. Empty means the no-override branch plus every known family; see
+	// imageRenderModes for why that, and not the bundle's allowedGpuTypes, is
+	// the default.
+	GPUModes []string
 }
 
 // CheckStaticBundle validates a static market bundle directory — the
@@ -22,6 +42,8 @@ type CheckOptions struct {
 // By default it checks the V1 JSON contract, chart presence/size/SHA-256,
 // and artifact manifests. With opts.Full it also verifies each artifact
 // source tree entries declared by its manifest (entry types and digests).
+// With opts.InstallationManifest it additionally renders every bundled chart
+// and requires the medium to preload each image they need.
 func CheckStaticBundle(dir string, opts CheckOptions) error {
 	dir = filepath.Clean(dir)
 	root, err := openDirectoryNoSymlink(dir)
@@ -53,19 +75,19 @@ func CheckStaticBundle(dir string, opts CheckOptions) error {
 	}
 	for _, app := range bundle.Apps {
 		for _, artifact := range app.Artifacts {
-			manifest, err := LoadArtifactManifest(root, artifact)
+			artifactManifest, err := LoadArtifactManifest(root, artifact)
 			if err != nil {
 				return fmt.Errorf("bundle app %q artifact manifest: %w", app.AppID, err)
 			}
 			if !opts.Full {
 				continue
 			}
-			if err := verifyArtifactSource(root, artifact, manifest); err != nil {
+			if err := verifyArtifactSource(root, artifact, artifactManifest); err != nil {
 				return fmt.Errorf("bundle app %q artifact %q: %w", app.AppID, artifact.Source, err)
 			}
 		}
 	}
-	return nil
+	return checkBundleImages(root, bundle, opts)
 }
 
 func verifyChartDigest(root *os.Root, app BundleAppV1, totalRemaining int64) (int64, error) {

--- a/cli/pkg/preinstall/images.go
+++ b/cli/pkg/preinstall/images.go
@@ -1,0 +1,310 @@
+package preinstall
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/distribution/reference"
+
+	pkgchart "github.com/beclab/Olares/cli/pkg/chart"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+	"github.com/beclab/Olares/cli/pkg/utils"
+	oac "github.com/beclab/Olares/framework/oac"
+)
+
+// chartArchiveName is where a bundled chart lands inside the scratch directory
+// before it is unpacked. The bundle's own path is not reused: it may name
+// subdirectories, and the scratch tree only ever holds one chart.
+const chartArchiveName = "chart.tgz"
+
+// imageTarSuffixes are the archive extensions LoadImages accepts for a preloaded
+// image payload. The gate has to agree with it exactly, or it will pass a medium
+// prepare then refuses.
+var imageTarSuffixes = []string{".tar.gz", ".tgz", ".tar"}
+
+// ImageGapKind separates the two ways a bundled chart's image fails to be
+// preloaded. They are reported apart because they are fixed apart: one needs a
+// line in images.mf, the other needs the payload to actually ship.
+type ImageGapKind string
+
+const (
+	// ImageGapUnlisted means installation.manifest never names the image.
+	// LoadImages iterates the manifest, so nothing imports it and PinImages
+	// never pins it; at install time the cluster falls back to pulling from a
+	// registry, which an offline device cannot do.
+	ImageGapUnlisted ImageGapKind = "missing from installation.manifest"
+	// ImageGapNoPayload means the manifest names the image but the medium
+	// carries no tarball for it. Prepare aborts in LoadImages with
+	// "image %s not found in %s".
+	ImageGapNoPayload ImageGapKind = "no image payload on the medium"
+)
+
+// ImageGap is one image a bundled chart needs that the installation medium will
+// not preload.
+type ImageGap struct {
+	AppID   string
+	AppName string
+	// Image is spelled the way installation.manifest and the CDN object names
+	// spell it: the familiar form, without the docker.io/ prefix. Payload
+	// filenames are md5 of this exact string, so a line added to images.mf in
+	// any other spelling resolves to a tarball that was never uploaded.
+	Image string
+	Kind  ImageGapKind
+}
+
+func (g ImageGap) String() string {
+	return fmt.Sprintf("app %s (%s): %s: %s", g.AppName, g.AppID, g.Image, g.Kind)
+}
+
+// imageGapError renders every gap in one error. Reporting the first one only
+// would hide the shape of the problem: a stale image list usually misses one
+// image per app, and the build needs to see all of them in a single run.
+func imageGapError(gaps []ImageGap) error {
+	if len(gaps) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(gaps)+1)
+	lines = append(lines, fmt.Sprintf("%d preinstall image(s) will not be preloaded:", len(gaps)))
+	for _, gap := range gaps {
+		lines = append(lines, "  "+gap.String())
+	}
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+}
+
+// checkBundleImages reports every image the bundled charts need that the medium
+// will not preload. An empty manifest disables the whole check, which is what
+// keeps CheckStaticBundle's contract-only mode working unchanged.
+func checkBundleImages(root *os.Root, bundle BundleV1, opts CheckOptions) error {
+	if len(opts.InstallationManifest) == 0 {
+		return nil
+	}
+	listed := listedImages(opts.InstallationManifest)
+	var (
+		gaps  []ImageGap
+		total int64
+	)
+	for _, app := range bundle.Apps {
+		images, consumed, err := chartImages(root, app, opts.GPUModes, MaxTotalChartBytes-total)
+		if err != nil {
+			return fmt.Errorf("bundle app %q: %w", app.AppID, err)
+		}
+		total += consumed
+		for _, image := range images {
+			gap, ok := imageGapFor(app, image, listed, opts.ImagesDir)
+			if ok {
+				gaps = append(gaps, gap)
+			}
+		}
+	}
+	return imageGapError(gaps)
+}
+
+// imageGapFor answers, for one image of one app, whether the medium will
+// preload it. The image arrives normalized; `listed` maps normalized refs back
+// to the manifest's own spelling, which is both what names the payload file and
+// what a fix has to be written as.
+func imageGapFor(app BundleAppV1, image string, listed map[string]string, imagesDir string) (ImageGap, bool) {
+	raw, ok := listed[image]
+	if !ok {
+		return ImageGap{
+			AppID:   app.AppID,
+			AppName: app.AppName,
+			Image:   familiarImageRef(image),
+			Kind:    ImageGapUnlisted,
+		}, true
+	}
+	if imagesDir == "" || imagePayloadExists(imagesDir, raw) {
+		return ImageGap{}, false
+	}
+	return ImageGap{
+		AppID:   app.AppID,
+		AppName: app.AppName,
+		Image:   raw,
+		Kind:    ImageGapNoPayload,
+	}, true
+}
+
+// listedImages indexes installation.manifest by normalized ref so a chart's
+// docker.io/beclab/x:1 matches the manifest's beclab/x:1. The value keeps the
+// manifest's original spelling because that is what md5s into the payload
+// filename.
+func listedImages(installation manifest.InstallationManifest) map[string]string {
+	_, refs := installation.GetImageList()
+	listed := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		normalized, err := normalizeImageRef(ref)
+		if err != nil {
+			continue
+		}
+		listed[normalized] = ref
+	}
+	return listed
+}
+
+// imagePayloadExists mirrors how LoadImages finds a preloaded image: a file in
+// the images directory whose name starts with the md5 of the manifest's ref and
+// carries an archive suffix.
+func imagePayloadExists(imagesDir, rawRef string) bool {
+	prefix := utils.MD5(rawRef)
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		lower := strings.ToLower(entry.Name())
+		for _, suffix := range imageTarSuffixes {
+			if strings.HasSuffix(lower, suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// chartImages renders an app's bundled chart under every requested GPU mode and
+// returns the normalized images it needs, plus the chart bytes it consumed
+// against the bundle's total budget.
+//
+// Rendering rather than scanning templates is not optional: a chart may name its
+// image through .Values, and a textual scan would return the template string
+// instead of the image that will actually be pulled.
+func chartImages(root *os.Root, app BundleAppV1, modes []string, totalRemaining int64) ([]string, int64, error) {
+	dir, consumed, cleanup, err := extractBundledChart(root, app, totalRemaining)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cleanup()
+
+	refs, err := oac.ListImagesFromOACForModes(dir, imageRenderModes(modes))
+	if err != nil {
+		return nil, 0, fmt.Errorf("render chart %q: %w", app.Chart, err)
+	}
+	seen := make(map[string]struct{}, len(refs))
+	images := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		normalized, err := normalizeImageRef(ref)
+		if err != nil {
+			return nil, 0, fmt.Errorf("chart %q: %w", app.Chart, err)
+		}
+		if err := rejectFloatingTag(normalized); err != nil {
+			return nil, 0, fmt.Errorf("chart %q: %w", app.Chart, err)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		images = append(images, normalized)
+	}
+	sort.Strings(images)
+	return images, consumed, nil
+}
+
+// imageRenderModes decides which GPU families the chart is rendered under.
+//
+// The default is every family plus the no-override branch, and deliberately not
+// the bundle's allowedGpuTypes: that field gates which env and GPU selections an
+// operator may make, while the branch a chart actually takes comes from
+// .Values.GPU.Type, which app-service fills in from the hardware it finds. One
+// image ships to many machines, so the medium has to satisfy all of them.
+func imageRenderModes(modes []string) []string {
+	if len(modes) == 0 {
+		return []string{"", oac.AllModes}
+	}
+	return modes
+}
+
+// extractBundledChart unpacks one bundled chart into a scratch directory and
+// returns the chart root. The archive is copied out through the same verified
+// path publish uses, so the size ceilings and the digest in bundle.json are
+// enforced before anything is unpacked.
+func extractBundledChart(root *os.Root, app BundleAppV1, totalRemaining int64) (string, int64, func(), error) {
+	noop := func() {}
+	spec, err := chartVerifiedCopy(root, app.Chart, app.ChartSHA256, totalRemaining)
+	if err != nil {
+		return "", 0, noop, err
+	}
+	spec.Target = chartArchiveName
+
+	scratch, err := os.MkdirTemp("", "olares-preinstall-chart-*")
+	if err != nil {
+		return "", 0, noop, fmt.Errorf("create chart scratch directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(scratch) }
+
+	scratchRoot, err := os.OpenRoot(scratch)
+	if err != nil {
+		cleanup()
+		return "", 0, noop, fmt.Errorf("open chart scratch directory: %w", err)
+	}
+	copied, err := copyVerifiedRegularFile(root, scratchRoot, spec)
+	closeErr := scratchRoot.Close()
+	if err != nil {
+		cleanup()
+		return "", 0, noop, err
+	}
+	if closeErr != nil {
+		cleanup()
+		return "", 0, noop, fmt.Errorf("close chart scratch directory: %w", closeErr)
+	}
+
+	dir, unpackCleanup, err := pkgchart.ResolveDir(filepath.Join(scratch, chartArchiveName))
+	if err != nil {
+		cleanup()
+		return "", 0, noop, fmt.Errorf("unpack chart %q: %w", app.Chart, err)
+	}
+	return dir, copied, func() {
+		unpackCleanup()
+		cleanup()
+	}, nil
+}
+
+// normalizeImageRef puts a reference in the canonical fully-qualified form so
+// that beclab/x:1 and docker.io/beclab/x:1 compare equal. installation.manifest
+// uses the short spelling and charts generally use the long one, so without this
+// every image would look absent.
+func normalizeImageRef(ref string) (string, error) {
+	parsed, err := reference.ParseNormalizedNamed(strings.TrimSpace(ref))
+	if err != nil {
+		return "", fmt.Errorf("parse image reference %q: %w", ref, err)
+	}
+	return parsed.String(), nil
+}
+
+// familiarImageRef spells a normalized reference the way installation.manifest
+// and the CDN object names do, so a reported gap can be pasted into images.mf
+// as-is.
+func familiarImageRef(normalized string) string {
+	parsed, err := reference.ParseNormalizedNamed(normalized)
+	if err != nil {
+		return normalized
+	}
+	return reference.FamiliarString(parsed)
+}
+
+// rejectFloatingTag refuses images that do not pin what they resolve to. A
+// preloaded :latest is a lie: the tag the medium froze and the tag the registry
+// serves later are different images, and app-service pulls rather than reusing
+// the local copy.
+func rejectFloatingTag(normalized string) error {
+	parsed, err := reference.ParseNormalizedNamed(normalized)
+	if err != nil {
+		return fmt.Errorf("parse image reference %q: %w", normalized, err)
+	}
+	if _, ok := parsed.(reference.Canonical); ok {
+		return nil
+	}
+	tagged, ok := parsed.(reference.Tagged)
+	if !ok {
+		return fmt.Errorf("image %q has no tag", familiarImageRef(normalized))
+	}
+	if tagged.Tag() == "latest" {
+		return fmt.Errorf("image %q uses the latest tag", familiarImageRef(normalized))
+	}
+	return nil
+}

--- a/cli/pkg/preinstall/images_test.go
+++ b/cli/pkg/preinstall/images_test.go
@@ -1,0 +1,352 @@
+package preinstall
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pkgchart "github.com/beclab/Olares/cli/pkg/chart"
+	"github.com/beclab/Olares/cli/pkg/manifest"
+	"github.com/beclab/Olares/cli/pkg/utils"
+)
+
+func TestCheckStaticBundleWithoutInstallationManifestSkipsImageGate(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+
+	if err := CheckStaticBundle(dir, CheckOptions{}); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+}
+
+func TestCheckStaticBundleImageGateAcceptsListedImage(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0")}
+
+	if err := CheckStaticBundle(dir, opts); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+}
+
+// A chart may name its image through .Values, so the gate has to render rather
+// than scan: a textual scan would compare the template string, never the image
+// that gets pulled.
+func TestCheckStaticBundleImageGateResolvesValuesTemplatedImage(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{
+		name:   "gateway",
+		image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}",
+		values: "image:\n  repository: docker.io/beclab/router\n  tag: v2.5.0\n",
+	})
+
+	if err := CheckStaticBundle(dir, CheckOptions{
+		InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0"),
+	}); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+
+	err := CheckStaticBundle(dir, CheckOptions{
+		InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.4.0"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "beclab/router:v2.5.0") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the rendered tag reported", err)
+	}
+}
+
+// installation.manifest writes docker.io images short and charts generally write
+// them long. Both spellings name the same image, so neither may be reported as a
+// gap.
+func TestCheckStaticBundleImageGateNormalizesRegistryPrefix(t *testing.T) {
+	tests := []struct {
+		name          string
+		chartImage    string
+		manifestImage string
+	}{
+		{"long chart, short manifest", "docker.io/beclab/router:v2.5.0", "beclab/router:v2.5.0"},
+		{"short chart, long manifest", "beclab/router:v2.5.0", "docker.io/beclab/router:v2.5.0"},
+		{"non-docker registry", "ghcr.io/beclab/router:v2.5.0", "ghcr.io/beclab/router:v2.5.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := buildImageBundle(t, imageApp{name: "gateway", image: tt.chartImage})
+			opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, tt.manifestImage)}
+			if err := CheckStaticBundle(dir, opts); err != nil {
+				t.Fatalf("CheckStaticBundle() error = %v", err)
+			}
+		})
+	}
+}
+
+// The reported spelling is the one that md5s into the uploaded payload name, so
+// a gap has to be printed the way images.mf writes it, never fully qualified.
+func TestCheckStaticBundleImageGateReportsUnlistedImageInManifestSpelling(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "model", image: "docker.io/beclab/llama.cpp:b10548"})
+	opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0")}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil {
+		t.Fatal("CheckStaticBundle() error = nil, want an unlisted image")
+	}
+	if !strings.Contains(err.Error(), "beclab/llama.cpp:b10548") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the image named", err)
+	}
+	if strings.Contains(err.Error(), "docker.io/beclab/llama.cpp") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the manifest spelling", err)
+	}
+	if !strings.Contains(err.Error(), string(ImageGapUnlisted)) {
+		t.Fatalf("CheckStaticBundle() error = %v, want kind %q", err, ImageGapUnlisted)
+	}
+}
+
+// A manifest line is only half of what prepare needs: LoadImages still has to
+// find a tarball named after the md5 of that line, or it aborts.
+func TestCheckStaticBundleImageGateRequiresImagePayload(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{
+		InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0"),
+		ImagesDir:            t.TempDir(),
+	}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil || !strings.Contains(err.Error(), string(ImageGapNoPayload)) {
+		t.Fatalf("CheckStaticBundle() error = %v, want kind %q", err, ImageGapNoPayload)
+	}
+
+	writeImagePayload(t, opts.ImagesDir, "beclab/router:v2.5.0")
+	if err := CheckStaticBundle(dir, opts); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+}
+
+// A stale image list usually misses one image per app, so a single run has to
+// show the whole shape of the problem rather than the first app that trips.
+func TestCheckStaticBundleImageGateAggregatesAcrossApps(t *testing.T) {
+	dir := buildImageBundle(t,
+		imageApp{name: "model", image: "docker.io/beclab/llama.cpp:b10548"},
+		imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"},
+	)
+	opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/unrelated:v1")}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil {
+		t.Fatal("CheckStaticBundle() error = nil, want both apps reported")
+	}
+	for _, want := range []string{"beclab/llama.cpp:b10548", "beclab/router:v2.5.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("CheckStaticBundle() error = %v, want %q reported", err, want)
+		}
+	}
+}
+
+func TestCheckStaticBundleImageGateRejectsFloatingTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{"explicit latest", "docker.io/beclab/router:latest", "latest tag"},
+		{"implicit latest", "docker.io/beclab/router", "has no tag"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := buildImageBundle(t, imageApp{name: "gateway", image: tt.image})
+			opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0")}
+			err := CheckStaticBundle(dir, opts)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("CheckStaticBundle() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckStaticBundleImageGateFailsOnUnrenderableChart(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "{{ .Values.missing.repository }}"})
+	opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0")}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil || !strings.Contains(err.Error(), "render chart") {
+		t.Fatalf("CheckStaticBundle() error = %v, want a render failure", err)
+	}
+}
+
+type imageApp struct {
+	name   string
+	image  string
+	values string
+}
+
+// buildImageBundle writes a static market bundle whose charts each run one
+// container, so a test can state the image set it wants the gate to see.
+func buildImageBundle(t *testing.T, apps ...imageApp) string {
+	t.Helper()
+	dir := filepath.Join(canonicalTempDir(t), "market")
+	chartDir := filepath.Join(dir, "chart")
+	if err := os.MkdirAll(chartDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle := BundleV1{
+		SchemaVersion: SupportedSchemaVersion,
+		SourceID:      OfficialSourceID,
+		CatalogHash:   "image-gate-fixture",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+	}
+	for i, app := range apps {
+		archive := packageImageChart(t, chartDir, app)
+		bundle.Apps = append(bundle.Apps, BundleAppV1{
+			AppID:        fmt.Sprintf("app-%d", i),
+			AppName:      app.name,
+			Version:      "1.0.0",
+			InstallScope: InstallScopeShared,
+			Chart:        "chart/" + filepath.Base(archive),
+			ChartSHA256:  fileSHA256(t, archive),
+			InstallOrder: (i + 1) * 10,
+			AppEntry:     json.RawMessage(fmt.Sprintf(`{"id":"app-%d","name":%q,"version":"1.0.0","cfgType":"app"}`, i, app.name)),
+		})
+	}
+
+	data, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, BundleFileName), append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func packageImageChart(t *testing.T, outputDir string, app imageApp) string {
+	t.Helper()
+	source := filepath.Join(t.TempDir(), app.name)
+	if err := os.MkdirAll(filepath.Join(source, "templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	values := app.values
+	if values == "" {
+		values = "{}\n"
+	}
+	files := map[string]string{
+		"Chart.yaml":                fmt.Sprintf("apiVersion: v2\nname: %s\nversion: 1.0.0\n", app.name),
+		"values.yaml":               values,
+		"OlaresManifest.yaml":       imageChartManifest(app.name),
+		"templates/deployment.yaml": imageChartDeployment(app.name, app.image),
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(source, filepath.FromSlash(name)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	archive, err := pkgchart.Package(source, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return archive
+}
+
+func imageChartManifest(name string) string {
+	return fmt.Sprintf(`olaresManifest.version: "0.13.0"
+olaresManifest.type: app
+apiVersion: v3
+metadata:
+  name: %[1]s
+  version: 1.0.0
+  title: %[1]s
+  description: Image gate fixture
+  icon: https://example.com/icon.png
+entrances:
+  - name: %[1]s
+    port: 80
+    host: %[1]s
+    title: %[1]s
+spec:
+  onlyAdmin: true
+  supportArch:
+    - amd64
+  requiredCpu: 50m
+  limitedCpu: 500m
+  requiredMemory: 20Mi
+  limitedMemory: 100Mi
+  requiredDisk: 50Mi
+  limitedDisk: 100Mi
+workloadReplicas:
+  %[1]s: 1
+options:
+  dependencies:
+    - name: olares
+      type: system
+      version: ">=1.12.6-0"
+  shared: true
+`, name)
+}
+
+func imageChartDeployment(name, image string) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %[1]s
+  template:
+    metadata:
+      labels:
+        app: %[1]s
+    spec:
+      containers:
+        - name: %[1]s
+          image: %[2]s
+          resources:
+            requests:
+              cpu: 50m
+              memory: 20Mi
+            limits:
+              cpu: 500m
+              memory: 100Mi
+`, name, image)
+}
+
+// buildInstallationManifest writes the image rows the way build-manifest.sh does
+// and parses them back, so the gate is tested against the real line format
+// rather than a hand-built map.
+func buildInstallationManifest(t *testing.T, images ...string) manifest.InstallationManifest {
+	t.Helper()
+	lines := make([]string, 0, len(images))
+	for _, image := range images {
+		lines = append(lines, fmt.Sprintf(
+			"%s.tar.gz,images,images.mf,https://cdn/amd64,amd64sum,https://cdn/arm64,arm64sum,%s",
+			utils.MD5(image), image,
+		))
+	}
+	path := filepath.Join(t.TempDir(), "installation.manifest")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	installation, err := manifest.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return installation
+}
+
+func writeImagePayload(t *testing.T, imagesDir, image string) {
+	t.Helper()
+	name := utils.MD5(image) + ".tar.gz"
+	if err := os.WriteFile(filepath.Join(imagesDir, name), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Problem

An offline device can only start a preinstalled app if every image its chart names was already imported into containerd by `prepare`. `LoadImages` and `PinImages` iterate `installation.manifest` and ignore anything absent from it, and `installation.manifest` is built by `build/image-manifest.sh`, which scans this repository's modules. It never looks at the charts a preinstall bundle carries. Nothing connected the two, so a bundle could ship charts whose images the medium had never heard of and no build step would say so.

That is not hypothetical. On a freshly ISO-installed 1.12.7 machine:

| chart wants | medium carries |
| --- | --- |
| `beclab/ggml-org-llama.cpp:server-cuda12-b10548` | `...:server-cuda12-b10068` |
| `beclab/router:v2.5.0` | nothing (only `router-frontend:v2.5.0`) |
| `beclab/docker:29.3.0-dind` | nothing |

The model app fell back to pulling over the network and took 28.5 minutes. The gateway and WebUI sit behind it on the `installOrder` barrier, so for that whole time the desktop showed one app installing and no sign the other two existed.

## What this adds

`olares-cli preinstall check --installation-manifest <path>` renders every bundled chart and reports the images the medium will not preload. Adding `--images-dir <path>` also requires the payload tarball to be on disk, which is the second thing `prepare` needs and a distinct failure from a stale image list. Both flags are opt-in and fully offline — neither contacts a registry or a CDN. Without them the command behaves exactly as before.

Run against the bundle and manifest taken off the affected machine, it reproduces the incident:

```
$ olares-cli preinstall check ./preinstall/market \
    --installation-manifest ./installation.manifest --images-dir ./images
Error: 3 preinstall image(s) will not be preloaded:
  app llamacppqwen3827bggufv3 (366ada1d): beclab/ggml-org-llama.cpp:server-cuda12-b10548: missing from installation.manifest
  app router (f3395cd5): beclab/router:v2.5.0: missing from installation.manifest
  app lares (489966aa): beclab/docker:29.3.0-dind: missing from installation.manifest
```

The three charts render 8 distinct images between them; the other 5 match and are not reported, so the normalization below is doing real work rather than the gate simply failing everything.

## Design notes

**Charts are rendered, not scanned.** A chart may name its image through `.Values`, and a textual scan would compare the template string instead of the image that actually gets pulled. This reuses `framework/oac`'s `ListImagesFromOACForModes`.

**Rendering covers the no-override branch plus every GPU family**, deliberately not the bundle's `allowedGpuTypes`. That field gates which selections an operator may make; the branch a chart takes comes from `.Values.GPU.Type`, which app-service fills in from the hardware it finds. One image ships to many machines, so the medium has to satisfy all of them. `--gpu-modes` overrides this if a build ever needs to narrow it.

**Images are compared normalized and reported familiar.** Charts spell docker.io images long (`docker.io/beclab/x:1`) and `installation.manifest` spells them short (`beclab/x:1`); without normalization every image would look absent. But the payload filename is the md5 of the manifest's exact string — verified against real data, `md5("beclab/lares:0.24.0")` is exactly the `.tar.gz` name the manifest carries — so a reported gap has to be printed the way `images.mf` writes it, or the line someone adds resolves to a tarball that was never uploaded.

**Floating tags are rejected.** A preloaded `:latest` is a lie: the tag the medium froze and the tag the registry serves later are different images.

**Gaps are aggregated.** A stale image list usually misses one image per app, and the build needs to see the whole shape in one run.

## Also in here

The first commit moves the zip-slip guard and chart-root lookup out of the `chart lint` command into `cli/pkg/chart`, so this check and lint share one copy rather than growing two implementations of the same security-sensitive path. It also caps total expanded size and entry count while it is there.

## Test plan

- [x] `go build ./...`, `go vet ./...` (the two `pkg/upgrade` warnings are pre-existing and untouched)
- [x] `go test ./pkg/preinstall/... ./pkg/chart/...`
- [x] New `images_test.go` covers: gate off without a manifest, listed image accepted, `.Values`-templated image resolved to its rendered tag, registry prefix normalized in both directions plus a non-docker registry, unlisted image reported in manifest spelling, payload required and then satisfied, gaps aggregated across apps, explicit and implicit `:latest` rejected, unrenderable chart is a hard error
- [x] Existing golden-fixture bundle tests still pass, confirming the contract-only path is unchanged
- [x] End-to-end against the real 1.12.7 ISO bundle and manifest pulled off the affected machine, both failure kinds and both flag guards

## Follow-up, not in this PR

The ISO build pipeline lives outside this repository and needs to call the new gate for it to have teeth. Separately, the desktop showing nothing at all for apps held behind the `installOrder` barrier is a UI gap worth fixing on its own.

Made with [Cursor](https://cursor.com)