### PR TITLE
fix(app-service,gpu): bind discrete AMD/Intel cards as whole cards on resume

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_install.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_install.go
@@ -29,7 +29,6 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"helm.sh/helm/v3/pkg/time"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -995,13 +994,13 @@ func (h *installHandlerHelper) resolveAutoResources(ctx context.Context) (err er
 func backfillAutoResourceMode(appConfig *appcfg.ApplicationConfig, totals utils.WorkloadResourceTotals) {
 	// GPU memory is conventionally declared only as a limit; fall back across
 	// requests/limits so a sentinel on either side resolves to a usable value.
-	gpuReq := totals.RequestsGPUMem
+	gpuReq := totals.RequestsGPUMemBytes
 	if gpuReq.IsZero() {
-		gpuReq = totals.LimitsGPUMem
+		gpuReq = totals.LimitsGPUMemBytes
 	}
-	gpuLim := totals.LimitsGPUMem
+	gpuLim := totals.LimitsGPUMemBytes
 	if gpuLim.IsZero() {
-		gpuLim = totals.RequestsGPUMem
+		gpuLim = totals.RequestsGPUMemBytes
 	}
 
 	for i := range appConfig.Accelerator {
@@ -1022,25 +1021,15 @@ func backfillAutoResourceMode(appConfig *appcfg.ApplicationConfig, totals utils.
 		if appcfg.IsAutoResource(rr.LimitedMemory) {
 			rr.LimitedMemory = totals.LimitsMemory.String()
 		}
+		// Already in bytes, the unit requiredGPUMemory / limitedGPUMemory are
+		// parsed as, so the total goes in as-is.
 		if appcfg.IsAutoResource(rr.RequiredGPU) {
-			rr.RequiredGPU = gpuMemMiBToByteString(gpuReq)
+			rr.RequiredGPU = gpuReq.String()
 		}
 		if appcfg.IsAutoResource(rr.LimitedGPU) {
-			rr.LimitedGPU = gpuMemMiBToByteString(gpuLim)
+			rr.LimitedGPU = gpuLim.String()
 		}
 	}
-}
-
-// gpuMemMiBToByteString converts a summed pod nvidia.com/gpumem quantity (a
-// plain integer count in MiB, the HAMi convention for the extended resource)
-// into a byte-quantity string suitable for the resource mode's
-// requiredGPUMemory/limitedGPUMemory fields, which the compute scheduler and
-// the gpu-inject webhook interpret as bytes. e.g. 8000 (MiB) -> "8000Mi".
-func gpuMemMiBToByteString(mib apiresource.Quantity) string {
-	if mib.IsZero() {
-		return mib.String()
-	}
-	return apiresource.NewQuantity(mib.Value()*1024*1024, apiresource.BinarySI).String()
 }
 
 func (h *installHandlerHelperV2) setAppConfig(req *api.InstallRequest, appName string) {

--- a/framework/app-service/pkg/compute/availability.go
+++ b/framework/app-service/pkg/compute/availability.go
@@ -696,7 +696,7 @@ func allocationsFromResolvedSelection(appConfig *appcfg.ApplicationConfig, req R
 			// frontend always sends a positive Memory for them (enforced by
 			// validateResolvedBindingSelection).
 			amount = item.memory
-		case isWholeCardMode(req.Mode, item.device.SupportType):
+		case isWholeCardSupportType(item.device.SupportType):
 			// Exclusive / TimeSlice hand the pod the whole card and
 			// buildAllocation records Memory=0, so every selected card must
 			// produce its own binding. These must never be gated on the

--- a/framework/app-service/pkg/compute/dedicated_gpu_memory_test.go
+++ b/framework/app-service/pkg/compute/dedicated_gpu_memory_test.go
@@ -238,9 +238,56 @@ func TestAllocationRecordsGPUQuotaForDiscreteCards(t *testing.T) {
 			if len(allocations) != 1 {
 				t.Fatalf("expected 1 allocation, got %d", len(allocations))
 			}
-			if allocations[0].Memory != req.RequiredGPU {
-				t.Fatalf("allocation memory = %d, want the declared gpu quota %d",
-					allocations[0].Memory, req.RequiredGPU)
+			// AvailableSupportTypes makes every discrete Intel/AMD card
+			// Exclusive-only, so the app holds the card outright and the
+			// allocation records Memory=0 ("whole card") the way an Exclusive
+			// nvidia card does. Writing the quota here instead would claim a
+			// partition of a card that cannot be partitioned, and would suggest
+			// the remaining VRAM is up for grabs when exclusive-already-bound
+			// refuses every further binding.
+			if allocations[0].Memory != 0 {
+				t.Fatalf("allocation memory = %d, want 0 (whole card) for an exclusive %s card",
+					allocations[0].Memory, mode)
+			}
+		})
+	}
+}
+
+// A discrete Intel/AMD app that declares no GPU-memory quota still has to get a
+// binding out of resume. Its fit target is zero — requiredGPUMemory is only
+// mandatory for modes listed under spec.resources, and the auto-resource
+// sentinel resolves to zero whenever the rendered chart carries neither
+// nvidia.com/gpumem nor the GPU-memory pod annotation — and the frontend sends
+// no per-card memory for a whole-card mode. That combination used to fall
+// through every branch of allocationsFromResolvedSelection and drop the card,
+// which reached the user as "empty-compute-binding" on an idle, healthy card.
+func TestResumeBindsDiscreteCardWithoutGPUQuota(t *testing.T) {
+	for _, mode := range []string{utils.AMDGPUType, utils.IntelGPUType} {
+		t.Run(mode, func(t *testing.T) {
+			req := RequirementFromMode(appcfg.ResourceMode{
+				Mode: mode,
+				ResourceRequirement: appcfg.ResourceRequirement{
+					RequiredCPU: "1", RequiredMemory: "2Gi", RequiredDisk: "1Gi",
+				},
+			})
+			if req.RequiredGPU != 0 {
+				t.Fatalf("precondition: expected a zero gpu quota, got %d", req.RequiredGPU)
+			}
+			device := exclusiveDevice(mode, 24*gib)
+			node := singleDeviceNode(device)
+			appConfig := &appcfg.ApplicationConfig{AppName: "app", OwnerName: "owner"}
+
+			// Memory is left at zero exactly as the resume picker submits it.
+			selections := []BindingSelection{{NodeName: node.NodeName, DeviceID: device.ID}}
+			allocations, validation := bindAllocations(appConfig, req, selections, []Node{node}, PressureSnapshot{})
+			if !validation.OK {
+				t.Fatalf("resume binding refused: %s", validation.Code)
+			}
+			if len(allocations) != 1 {
+				t.Fatalf("expected 1 allocation, got %d", len(allocations))
+			}
+			if allocations[0].DeviceID != device.ID {
+				t.Fatalf("allocation bound to %q, want %q", allocations[0].DeviceID, device.ID)
 			}
 		})
 	}

--- a/framework/app-service/pkg/compute/scheduler.go
+++ b/framework/app-service/pkg/compute/scheduler.go
@@ -502,15 +502,21 @@ func levelMemory(req Requirement, level string) int64 {
 }
 
 func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node Node, device Device, memory int64) Allocation {
-	// In Exclusive / TimeSlice modes the pod has access to the entire
+	// On an Exclusive / TimeSlice device the pod has access to the entire
 	// card (Exclusive: solo binding; TimeSlice: full memory during the
 	// pod's time slice). Recording a per-pod memory amount here would
 	// cap the pod via the HAMI binding's spec.memory annotation, even
 	// though no slicing is happening. Persist 0 so createHAMIBinding
 	// omits spec.memory and HAMI treats the pod as unrestricted. The
 	// scheduler's accounting (deviceAvailableMemory / remainingMemory)
-	// never reads Allocation.Memory for these modes, so this is safe.
-	if isWholeCardMode(req.Mode, device.SupportType) {
+	// never reads Allocation.Memory for these devices, so this is safe.
+	//
+	// The discrete AMD/Intel cards are Exclusive-only and build no HAMI
+	// binding at all, so for them the 0 is purely the allocation ledger
+	// saying "this app holds the whole card" — which is the only thing it
+	// could truthfully say, since exclusive-already-bound refuses every
+	// further binding whatever the app's quota.
+	if isWholeCardSupportType(device.SupportType) {
 		memory = 0
 	}
 	return Allocation{
@@ -524,15 +530,23 @@ func buildAllocation(appConfig *appcfg.ApplicationConfig, req Requirement, node 
 	}
 }
 
-// isWholeCardMode reports whether binding a pod to a device with this NVIDIA
-// support type grants it the entire card: Exclusive (solo binding) or
-// TimeSlice (full memory during the pod's slice). buildAllocation records
-// Memory=0 for these, and they are always one-binding-per-card, so allocation
-// distribution must emit a separate binding for every selected card instead of
-// folding several of them into a single shared VRAM budget.
-func isWholeCardMode(mode, supportType string) bool {
-	return mode == utils.NvidiaCardType &&
-		(supportType == SupportTypeExclusive || supportType == SupportTypeTimeSlice)
+// isWholeCardSupportType reports whether binding a pod to a device with this
+// support type grants it the entire card: Exclusive (solo binding) or TimeSlice
+// (full memory during the pod's slice). buildAllocation records Memory=0 for
+// these, and they are always one-binding-per-card, so allocation distribution
+// must emit a separate binding for every selected card instead of folding
+// several of them into a single shared VRAM budget.
+//
+// The support type answers this on its own, for every mode — which is why the
+// mode is no longer a parameter. Gating it on nvidia left the discrete
+// AMD/Intel cards in a state no branch of allocationsFromResolvedSelection
+// covered: AvailableSupportTypes makes them Exclusive-only, requiredTargetForMode
+// judges them against a GPU-memory quota, and an app that declares no quota
+// therefore has a zero target with the whole-card branch closed to it. Its card
+// was dropped from its own binding as "nothing left to allocate", which reached
+// the user as empty-compute-binding on resume.
+func isWholeCardSupportType(supportType string) bool {
+	return supportType == SupportTypeExclusive || supportType == SupportTypeTimeSlice
 }
 
 func supportTypeOrder(mode string) []string {

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -139,6 +139,27 @@ const (
 	AMDGPU    = "amd.com/gpu"
 	IntelIGPU = "gpu.intel.com/i915"
 	IntelGPU  = "gpu.intel.com/xe"
+
+	// PodRequiredGPUMemory / PodLimitedGPUMemory are pod-template annotations a
+	// chart uses to declare its GPU-memory quota for the auto-resource ("-1")
+	// sentinel. They exist because only nvidia can carry that quota as a
+	// container resource: nvidia.com/gpumem is exempted from the scheduler's
+	// capacity check by HAMi's extender (managedResources.ignoredByScheduler),
+	// and no such exemption exists for the discrete AMD/Intel cards, whose
+	// device plugins advertise a card count and nothing else. A chart that put
+	// amd.com/gpumem in resources would leave the pod Pending on
+	// "Insufficient amd.com/gpumem" forever, and reusing nvidia.com/gpumem is
+	// no better: the gpu-limit webhook strips it from limits for a non-nvidia
+	// mode but never touches requests, and the apiserver then rejects the pod
+	// with "Limit must be set for non overcommitable resources".
+	//
+	// An annotation is inert to the scheduler, so it carries the number without
+	// any of that. The value is a plain Kubernetes quantity ("23Gi"), read the
+	// same way as the manifest's requiredGPUMemory it backfills — unlike
+	// nvidia.com/gpumem, which HAMi defines as a bare MiB count.
+	PodRequiredGPUMemory = "gpu.bytetrade.io/required-gpu-memory"
+	PodLimitedGPUMemory  = "gpu.bytetrade.io/limited-gpu-memory"
+
 	// NodeIntelRegisterKey is the node annotation written by the Intel GPU
 	// device plugin. Its value lists each Intel card as
 	// "<igpu|dgpu>,<cardN>,<i915|xe>,<name>,<architecture>,<codename>,<mem>"

--- a/framework/app-service/pkg/utils/workload_gpu_memory_chart_test.go
+++ b/framework/app-service/pkg/utils/workload_gpu_memory_chart_test.go
@@ -1,0 +1,134 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeChart lays down a one-Deployment chart whose pod template is filled in
+// from tmpl, so a test can drive the real helm render that install performs.
+func writeChart(t *testing.T, podTemplate string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "templates"), 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	files := map[string]string{
+		"Chart.yaml": "apiVersion: v2\nname: gpumem\nversion: 0.1.0\n",
+		"templates/deploy.yaml": `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: engine
+  template:
+` + podTemplate,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// TestGetWorkloadResourcesFromChartGPUMemory drives the whole install-time path
+// — helm render, workload walk, GPU-memory read — the way resolveAutoResources
+// does, rather than the podGPUMemoryBytes helper on its own. It is the check
+// that a chart written the way a discrete AMD/Intel app has to write it comes
+// back with a usable quota instead of the zero that left its card unbindable.
+func TestGetWorkloadResourcesFromChartGPUMemory(t *testing.T) {
+	const nvidiaStylePod = `    metadata:
+      labels:
+        app: engine
+    spec:
+      containers:
+      - name: engine
+        image: busybox
+        resources:
+          requests:
+            cpu: 200m
+            memory: 2Gi
+            nvidia.com/gpumem: 23552
+          limits:
+            cpu: "6"
+            memory: 35Gi
+            nvidia.com/gpumem: 23552
+`
+
+	// What amd-gpu / intel-gpu must render instead: no memory extended
+	// resource anywhere, the quota on the pod template annotation.
+	const annotatedPod = `    metadata:
+      labels:
+        app: engine
+      annotations:
+        gpu.bytetrade.io/required-gpu-memory: "23552Mi"
+        gpu.bytetrade.io/limited-gpu-memory: "32Gi"
+    spec:
+      containers:
+      - name: engine
+        image: busybox
+        resources:
+          requests:
+            cpu: 200m
+            memory: 2Gi
+          limits:
+            cpu: "6"
+            memory: 35Gi
+`
+
+	// The pre-fix shape for a discrete card: the mode has no way to declare a
+	// quota, so nothing reaches the compute layer.
+	const barePod = `    metadata:
+      labels:
+        app: engine
+    spec:
+      containers:
+      - name: engine
+        image: busybox
+        resources:
+          requests:
+            cpu: 200m
+            memory: 2Gi
+          limits:
+            cpu: "6"
+            memory: 35Gi
+`
+
+	tests := []struct {
+		name    string
+		pod     string
+		wantReq int64
+		wantLim int64
+	}{
+		{"nvidia gpumem resource", nvidiaStylePod, 23 * gib, 23 * gib},
+		{"discrete card annotation", annotatedPod, 23 * gib, 32 * gib},
+		{"nothing declared", barePod, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			totals, err := GetWorkloadResourcesFromChart(writeChart(t, tt.pod), map[string]interface{}{})
+			if err != nil {
+				t.Fatalf("render chart: %v", err)
+			}
+			if got := totals.RequestsGPUMemBytes.Value(); got != tt.wantReq {
+				t.Errorf("requests gpu memory = %d bytes, want %d", got, tt.wantReq)
+			}
+			if got := totals.LimitsGPUMemBytes.Value(); got != tt.wantLim {
+				t.Errorf("limits gpu memory = %d bytes, want %d", got, tt.wantLim)
+			}
+			// The ordinary quantities must survive the same walk untouched.
+			if got := totals.RequestsMemory.String(); got != "2Gi" {
+				t.Errorf("requests memory = %s, want 2Gi", got)
+			}
+			if got := totals.LimitsCPU.String(); got != "6" {
+				t.Errorf("limits cpu = %s, want 6", got)
+			}
+		})
+	}
+}

--- a/framework/app-service/pkg/utils/workload_gpu_memory_test.go
+++ b/framework/app-service/pkg/utils/workload_gpu_memory_test.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const gib = int64(1 << 30)
+
+func annotatedMeta(pairs ...string) metav1.ObjectMeta {
+	annotations := map[string]string{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		annotations[pairs[i]] = pairs[i+1]
+	}
+	return metav1.ObjectMeta{Annotations: annotations}
+}
+
+func gpuMemResourceList(mib string) corev1.ResourceList {
+	return corev1.ResourceList{nvidiaGPUMem: apiresource.MustParse(mib)}
+}
+
+// The two channels a chart can declare its GPU-memory quota through disagree on
+// units, which is the whole reason the totals are normalized to bytes:
+// nvidia.com/gpumem is a bare MiB count (HAMi's convention) while the pod
+// annotation is an ordinary quantity, read the same way as the manifest's
+// requiredGPUMemory it ends up backfilling.
+func TestPodGPUMemoryBytesSources(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     metav1.ObjectMeta
+		requests corev1.ResourceList
+		limits   corev1.ResourceList
+		wantReq  int64
+		wantLim  int64
+	}{
+		{
+			name:     "nvidia gpumem resource is a MiB count",
+			meta:     metav1.ObjectMeta{},
+			requests: gpuMemResourceList("23552"),
+			limits:   gpuMemResourceList("23552"),
+			wantReq:  23 * gib,
+			wantLim:  23 * gib,
+		},
+		{
+			name: "annotation is a plain quantity",
+			meta: annotatedMeta(
+				constants.PodRequiredGPUMemory, "23Gi",
+				constants.PodLimitedGPUMemory, "32Gi",
+			),
+			wantReq: 23 * gib,
+			wantLim: 32 * gib,
+		},
+		{
+			// A template rendered for amd-gpu may still carry the
+			// nvidia.com/gpumem of its nvidia branch. Counting both would
+			// double the app's declared demand.
+			name: "annotation wins over the resource",
+			meta: annotatedMeta(
+				constants.PodRequiredGPUMemory, "23Gi",
+				constants.PodLimitedGPUMemory, "23Gi",
+			),
+			requests: gpuMemResourceList("4096"),
+			limits:   gpuMemResourceList("4096"),
+			wantReq:  23 * gib,
+			wantLim:  23 * gib,
+		},
+		{
+			name:    "neither channel declares anything",
+			meta:    metav1.ObjectMeta{},
+			wantReq: 0,
+			wantLim: 0,
+		},
+		{
+			// A typo must not fail the install; it degrades to "no declared
+			// demand", which is where such an app stood before the annotation
+			// existed.
+			name:    "unparseable annotation is ignored",
+			meta:    annotatedMeta(constants.PodRequiredGPUMemory, "23 gigabytes"),
+			wantReq: 0,
+			wantLim: 0,
+		},
+		{
+			name:    "non-positive annotation is ignored",
+			meta:    annotatedMeta(constants.PodRequiredGPUMemory, "-1"),
+			wantReq: 0,
+			wantLim: 0,
+		},
+		{
+			name:     "annotation on one side only leaves the other to the resource",
+			meta:     annotatedMeta(constants.PodLimitedGPUMemory, "32Gi"),
+			requests: gpuMemResourceList("23552"),
+			limits:   gpuMemResourceList("23552"),
+			wantReq:  23 * gib,
+			wantLim:  32 * gib,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReq, gotLim := podGPUMemoryBytes(tt.meta, tt.requests, tt.limits)
+			if gotReq.Value() != tt.wantReq {
+				t.Errorf("request = %d bytes, want %d", gotReq.Value(), tt.wantReq)
+			}
+			if gotLim.Value() != tt.wantLim {
+				t.Errorf("limit = %d bytes, want %d", gotLim.Value(), tt.wantLim)
+			}
+		})
+	}
+}
+
+// The discrete AMD/Intel cards have no memory extended resource to carry the
+// quota, so without the annotation channel a chart for them has no way to
+// declare one and the auto-resource sentinel resolves to zero — the state that
+// left a healthy card unbindable on resume.
+func TestAnnotationIsTheOnlyChannelWithoutNvidiaGPUMem(t *testing.T) {
+	meta := annotatedMeta(constants.PodRequiredGPUMemory, "23Gi")
+	req, _ := podGPUMemoryBytes(meta, corev1.ResourceList{}, corev1.ResourceList{})
+	if req.Value() != 23*gib {
+		t.Fatalf("request = %d bytes, want %d", req.Value(), 23*gib)
+	}
+
+	bare, _ := podGPUMemoryBytes(metav1.ObjectMeta{}, corev1.ResourceList{}, corev1.ResourceList{})
+	if bare.Value() != 0 {
+		t.Fatalf("without the annotation the quota should be unknown, got %d bytes", bare.Value())
+	}
+}

--- a/framework/app-service/pkg/utils/workload_resources.go
+++ b/framework/app-service/pkg/utils/workload_resources.go
@@ -1,32 +1,41 @@
 package utils
 
 import (
+	"strings"
+
+	"github.com/beclab/Olares/framework/app-service/pkg/constants"
 	v1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 )
 
-// nvidiaGPUMem is the HAMi per-pod GPU-memory extended resource key. Declared
-// locally to keep this file free of an extra package dependency.
+// nvidiaGPUMem is the HAMi per-pod GPU-memory extended resource key.
 const nvidiaGPUMem corev1.ResourceName = "nvidia.com/gpumem"
+
+// mib is the unit HAMi defines nvidia.com/gpumem in: the resource carries a
+// bare count of MiB, not a byte quantity.
+const mib = 1024 * 1024
 
 // WorkloadResourceTotals is the per-pod sum (across every rendered workload's
 // pod template) of the container resource requests and limits relevant to
 // install-time auto-resource resolution.
 //
-// GPUMem is summed from the per-pod nvidia.com/gpumem extended resource. The
-// remaining fields are standard k8s quantities (cpu, memory) and are summed in
-// their declared representation.
+// cpu and memory are summed in their declared representation. GPU memory is
+// normalized to bytes, because its two sources disagree on units: the
+// nvidia.com/gpumem resource is a bare MiB count while the pod annotation is a
+// plain quantity. Bytes is also what the manifest field these totals backfill
+// (requiredGPUMemory) is parsed as, so the value needs no further conversion.
 type WorkloadResourceTotals struct {
-	RequestsCPU    apiresource.Quantity
-	LimitsCPU      apiresource.Quantity
-	RequestsMemory apiresource.Quantity
-	LimitsMemory   apiresource.Quantity
-	RequestsGPUMem apiresource.Quantity
-	LimitsGPUMem   apiresource.Quantity
+	RequestsCPU         apiresource.Quantity
+	LimitsCPU           apiresource.Quantity
+	RequestsMemory      apiresource.Quantity
+	LimitsMemory        apiresource.Quantity
+	RequestsGPUMemBytes apiresource.Quantity
+	LimitsGPUMemBytes   apiresource.Quantity
 }
 
 // GetWorkloadResourcesFromChart renders the chart at chartPath with the given
@@ -62,14 +71,15 @@ func GetWorkloadResourcesFromChart(chartPath string, values map[string]interface
 	// per pod from RequiredGPU, and node-pressure adds the requirement to a
 	// single node. The compute package never multiplies by replica count, so
 	// neither do we — replicas are intentionally ignored here.
-	accumulate := func(podSpec corev1.PodSpec) {
+	accumulate := func(meta metav1.ObjectMeta, podSpec corev1.PodSpec) {
 		req, lim := effectivePodResources(podSpec)
 		add(&totals.RequestsCPU, *req.Cpu())
 		add(&totals.LimitsCPU, *lim.Cpu())
 		add(&totals.RequestsMemory, *req.Memory())
 		add(&totals.LimitsMemory, *lim.Memory())
-		add(&totals.RequestsGPUMem, req[nvidiaGPUMem])
-		add(&totals.LimitsGPUMem, lim[nvidiaGPUMem])
+		gpuReq, gpuLim := podGPUMemoryBytes(meta, req, lim)
+		add(&totals.RequestsGPUMemBytes, gpuReq)
+		add(&totals.LimitsGPUMemBytes, gpuLim)
 	}
 
 	for _, r := range resources {
@@ -80,40 +90,95 @@ func GetWorkloadResourcesFromChart(chartPath string, values map[string]interface
 			if err := scheme.Scheme.Convert(r.Object, &d, nil); err != nil {
 				return totals, err
 			}
-			accumulate(d.Spec.Template.Spec)
+			accumulate(d.Spec.Template.ObjectMeta, d.Spec.Template.Spec)
 		case "StatefulSet":
 			var s v1.StatefulSet
 			if err := scheme.Scheme.Convert(r.Object, &s, nil); err != nil {
 				return totals, err
 			}
-			accumulate(s.Spec.Template.Spec)
+			accumulate(s.Spec.Template.ObjectMeta, s.Spec.Template.Spec)
 		case "DaemonSet":
 			var ds v1.DaemonSet
 			if err := scheme.Scheme.Convert(r.Object, &ds, nil); err != nil {
 				return totals, err
 			}
-			accumulate(ds.Spec.Template.Spec)
+			accumulate(ds.Spec.Template.ObjectMeta, ds.Spec.Template.Spec)
 		case "ReplicaSet":
 			var rs v1.ReplicaSet
 			if err := scheme.Scheme.Convert(r.Object, &rs, nil); err != nil {
 				return totals, err
 			}
-			accumulate(rs.Spec.Template.Spec)
+			accumulate(rs.Spec.Template.ObjectMeta, rs.Spec.Template.Spec)
 		case "Job":
 			var j batchv1.Job
 			if err := scheme.Scheme.Convert(r.Object, &j, nil); err != nil {
 				return totals, err
 			}
-			accumulate(j.Spec.Template.Spec)
+			accumulate(j.Spec.Template.ObjectMeta, j.Spec.Template.Spec)
 		case "Pod":
 			var p corev1.Pod
 			if err := scheme.Scheme.Convert(r.Object, &p, nil); err != nil {
 				return totals, err
 			}
-			accumulate(p.Spec)
+			accumulate(p.ObjectMeta, p.Spec)
 		}
 	}
 	return totals, nil
+}
+
+// podGPUMemoryBytes reports one pod's declared GPU-memory request and limit in
+// bytes, taken from whichever of the two channels the chart used: the
+// nvidia.com/gpumem container resource, or the pod annotations that carry the
+// same number for the modes which cannot express it as a resource (see
+// constants.PodRequiredGPUMemory).
+//
+// The annotation wins when a pod carries both. A chart that sets it is
+// declaring the quota for the mode it was rendered for, whereas the
+// nvidia.com/gpumem alongside it belongs to the nvidia branch of the same
+// template and would otherwise be double-counted.
+func podGPUMemoryBytes(meta metav1.ObjectMeta, req, lim corev1.ResourceList) (apiresource.Quantity, apiresource.Quantity) {
+	gpuReq := gpuMemResourceBytes(req)
+	gpuLim := gpuMemResourceBytes(lim)
+	if q, ok := annotatedGPUMemory(meta, constants.PodRequiredGPUMemory); ok {
+		gpuReq = q
+	}
+	if q, ok := annotatedGPUMemory(meta, constants.PodLimitedGPUMemory); ok {
+		gpuLim = q
+	}
+	return gpuReq, gpuLim
+}
+
+// gpuMemResourceBytes converts a pod's nvidia.com/gpumem entry into bytes. The
+// resource is a bare MiB count by HAMi's convention, so it cannot be read as a
+// byte quantity the way the annotation can.
+func gpuMemResourceBytes(list corev1.ResourceList) apiresource.Quantity {
+	q, ok := list[nvidiaGPUMem]
+	if !ok || q.IsZero() {
+		return apiresource.Quantity{}
+	}
+	return *apiresource.NewQuantity(q.Value()*mib, apiresource.BinarySI)
+}
+
+// annotatedGPUMemory reads one of the GPU-memory pod annotations. An
+// unparseable or non-positive value is dropped with a log line instead of
+// failing the install: the sentinel then stays unresolved and the app is
+// treated as declaring no GPU-memory demand, which is exactly where it stood
+// before the annotation existed.
+func annotatedGPUMemory(meta metav1.ObjectMeta, key string) (apiresource.Quantity, bool) {
+	raw := strings.TrimSpace(meta.Annotations[key])
+	if raw == "" {
+		return apiresource.Quantity{}, false
+	}
+	q, err := apiresource.ParseQuantity(raw)
+	if err != nil {
+		klog.Warningf("workload resources: ignoring pod annotation %s=%q, not a valid quantity: %v", key, raw, err)
+		return apiresource.Quantity{}, false
+	}
+	if q.Sign() <= 0 {
+		klog.Warningf("workload resources: ignoring pod annotation %s=%q, must be positive", key, raw)
+		return apiresource.Quantity{}, false
+	}
+	return q, true
 }
 
 // effectivePodResources computes the pod-level effective resource requests and


### PR DESCRIPTION
## What was wrong

Resuming an app pinned to a discrete AMD or Intel card failed with `empty-compute-binding`, while **installing that same app onto that same card succeeded**. The card was idle and healthy; nothing about it had changed between the two operations.

Two independent defects had to line up to produce this.

### 1. `isWholeCardMode` was gated on nvidia

```go
func isWholeCardMode(mode, supportType string) bool {
	return mode == utils.NvidiaCardType &&
		(supportType == SupportTypeExclusive || supportType == SupportTypeTimeSlice)
}
```

That gate left the discrete AMD/Intel cards in a state no branch of `allocationsFromResolvedSelection` covered:

- `AvailableSupportTypes` makes those cards **Exclusive-only**;
- `requiredTargetForMode` judges them against a **GPU-memory quota** (as of #4070);
- the resume picker submits `Memory=0`, because a whole-card mode has no per-card amount to submit.

So an app whose quota resolved to zero had a zero target *with the whole-card branch closed to it*, and its own card was dropped from its own binding as "nothing left to allocate".

Install escaped this only by accident: `selectDevice` falls back to `option.Available` when the assigned amount is `<= 0`. Resume has no such fallback, which is the whole reason the two paths disagreed.

### 2. The auto-resource sentinel had no channel to resolve through

The quota resolved to zero in the first place because `requiredGPUMemory: "-1"` is backfilled from the rendered chart, and the only channel `GetWorkloadResourcesFromChart` read was `nvidia.com/gpumem`.

Discrete AMD/Intel device plugins advertise a card count and nothing else, so those charts have **no resource that can carry the number**:

| approach | outcome |
| --- | --- |
| `amd.com/gpumem` / `intel.com/gpumem` in resources | Pod `Pending` on `Insufficient amd.com/gpumem` forever — no plugin advertises it, and no extender exempts it |
| reuse `nvidia.com/gpumem` | apiserver **rejects the Deployment**: the `gpu-limit` webhook strips it from `limits` for a non-nvidia mode but never touches `requests`, so `Limit must be set for non overcommitable resources` |

`nvidia.com/gpumem` works for nvidia only because HAMi's extender exempts it from the node capacity check via `managedResources.ignoredByScheduler`. There is no equivalent for the other two.

This is why the two base template apps (`vllmllmbasev3`, `llamacppllmbasev3`) declare `requiredGPUMemory: "-1"` for `amd-gpu` / `intel-gpu` and had nothing at all to resolve it from.

## What changed

**Decide whole-card by support type alone.** `isWholeCardMode` → `isWholeCardSupportType`, dropping the mode parameter: Exclusive/TimeSlice means the pod holds the entire card in *every* mode. `buildAllocation` records `Memory=0` and distribution emits one binding per selected card, matching what nvidia already did.

For the discrete cards that `0` is purely the allocation ledger saying "this app holds the whole card" — they build no HAMi binding at all, and `exclusive-already-bound` refuses every further binding whatever the quota says.

**Give the sentinel a channel that is inert to the scheduler.** New pod-template annotations, read alongside `nvidia.com/gpumem`:

```
gpu.bytetrade.io/required-gpu-memory
gpu.bytetrade.io/limited-gpu-memory
```

The annotation wins when a pod carries both, so the nvidia branch of the same template is not double-counted. An unparseable or non-positive value is logged and dropped rather than failing the install, leaving the app exactly where it stood before the annotation existed.

**Unify GPU memory on bytes across `pkg/utils`.** The two channels disagree on units — `nvidia.com/gpumem` is a bare MiB count by HAMi convention, the annotation is a plain quantity — and bytes is what the manifest field these totals backfill is parsed as. `RequestsGPUMem` → `RequestsGPUMemBytes` (same for limits), and the MiB→byte conversion that used to sit in the apiserver layer is gone; left there, it would have silently mis-scaled the annotation by 1024².

## Verification

**The new test reproduces the production symptom.** Reverting `isWholeCardSupportType` to return `false` for these cards:

```
--- FAIL: TestResumeBindsDiscreteCardWithoutGPUQuota/amd-gpu
    resume binding refused: empty-compute-binding
--- FAIL: TestAllocationRecordsGPUQuotaForDiscreteCards/amd-gpu
    allocation memory = 17179869184, want 0 (whole card) for an exclusive amd-gpu card
```

— the exact string users saw. Restored, `pkg/compute` is green.

**Measured end-to-end against the real `vllmllmbasev3` base chart**, calling `GetWorkloadResourcesFromChart` with `VLLM_REQUIRED_GPU_MEMORY: 23Gi` and the chart-side annotation patch applied:

| mode | `requiredGPUMemory` resolves to (before) | (after) |
| --- | --- | --- |
| `nvidia` | 23Gi | 23Gi |
| `amd-gpu` | **0** | **23Gi** |
| `intel-gpu` | **0** | **23Gi** |
| `nvidia-gb10` | 0 | 0 |

`nvidia-gb10` staying at 0 is correct — that mode declares no `requiredGPUMemory` and sizes itself through pod memory instead.

**The `nvidia.com/gpumem` rejection was confirmed on a live cluster**, not inferred: server-side dry-runs showed the apiserver refusing a Deployment that carried `nvidia.com/gpumem` under `amd-gpu`, and accepting the annotation-based one.

`go build ./...`, `go vet` and the tests for the four touched packages pass. `pkg/utils` has one pre-existing failure, `TestMatchVersion` (semver rejects `latest`), which fails identically on a clean worktree at the base commit; `gofmt` likewise flags a pre-existing alignment issue in an unrelated const block of `constants.go`. Neither is touched here.

## Companion change

app-service can now *read* the annotation, but the charts have to *emit* it. The base template apps need the matching `terminus-apps` patch before `amd-gpu` / `intel-gpu` resolve to anything — `vllmllmbasev3` is done, `llamacppllmbasev3` needs the identical three-line change. Nothing here regresses without it: those modes resolve to 0 exactly as they do today, and the whole-card fix alone already repairs the resume failure.

## Target Version for Merge

`module-appservice`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compute resume/install binding and install-time resource resolution for GPU modes; behavior changes for AMD/Intel exclusive cards and auto-resource backfill, though scoped to app-service compute and chart parsing with new tests.
> 
> **Overview**
> Fixes **resume** failing with `empty-compute-binding` for discrete **AMD/Intel** apps that install fine on the same idle card.
> 
> **Compute binding:** Whole-card handling no longer requires `nvidia` mode. `isWholeCardMode` becomes **`isWholeCardSupportType`** (Exclusive / TimeSlice only), so exclusive discrete cards get a binding even when the app’s GPU-memory target is **zero** and the picker sends `Memory=0`. Allocations for those cards record **`Memory=0`** (whole card), matching NVIDIA exclusive behavior.
> 
> **Auto-resource (`-1`) backfill:** Chart workload scanning now normalizes GPU memory to **bytes** (`RequestsGPUMemBytes` / `LimitsGPUMemBytes`), reading **`nvidia.com/gpumem`** (MiB count) and new pod-template annotations **`gpu.bytetrade.io/required-gpu-memory`** / **`limited-gpu-memory`** (plain quantities; annotation wins over gpumem to avoid double-counting). Install backfill writes those byte totals directly and drops the apiserver MiB→byte helper.
> 
> Tests cover resume without a GPU quota, discrete whole-card allocations, and helm-rendered annotation vs NVIDIA resource paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00382a05dc5bfd22ea6bd7e14ed3d8ae3d5a8fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->