### PR TITLE
Revert "fix(app-service): keep Scale and ApplyEnv on the installed helm chart"

### DIFF
--- a/framework/app-service/controllers/appenv_controller.go
+++ b/framework/app-service/controllers/appenv_controller.go
@@ -128,8 +128,7 @@ func (r *AppEnvController) reconcileAppEnv(ctx context.Context, appEnv *sysv1alp
 			return ctrl.Result{}, err
 		}
 
-		// An applyEnv runs UpgradeReleaseCharts (helm upgrade of the current
-		// release chart) that re-renders the workload. When the
+		// An applyEnv runs a helm upgrade that re-renders the workload. When the
 		// app is stopped, the outcome depends on how its replicas are controlled:
 		//   - No workloadReplicas (replicas hardcoded in the chart): stop only
 		//     patched the live workload to replicas=0, so the upgrade re-renders

--- a/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_applyenv.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *HelmOps) ApplyEnv() error {
-	rel, err := h.status()
+	_, err := h.status()
 	if err != nil {
 		klog.Errorf("get release status failed %v", err)
 		return err
@@ -21,11 +21,10 @@ func (h *HelmOps) ApplyEnv() error {
 		return err
 	}
 
-	// UpgradeReleaseCharts: only env-related overrides change; keep the
-	// current release chart (no LocateChart) and merge over previous values.
-	err = helm.UpgradeReleaseCharts(h.ctx, h.actionConfig, h.app.AppName, h.app.Namespace, rel.Chart, values)
+	// ReuseValues: only env-related overrides change; do not absorb new chart defaults.
+	err = helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings, h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace, values, helm.ReuseValues)
 	if err != nil {
-		klog.Errorf("Failed to apply env to chart name=%s err=%v", h.app.AppName, err)
+		klog.Errorf("Failed to upgrade chart name=%s err=%v", h.app.AppName, err)
 		return err
 	}
 

--- a/framework/app-service/pkg/appinstaller/helm_ops_install.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_install.go
@@ -70,8 +70,7 @@ type HelmOpsInterface interface {
 	Install() error
 	// Upgrade is the action for upgrade a release.
 	Upgrade() error
-	// ApplyEnv upgrades only environment variables against the current
-	// release chart (UpgradeReleaseCharts), reusing existing values.
+	// ApplyEnv upgrades only environment variables, reusing existing values.
 	ApplyEnv() error
 	// RollBack is the action for rollback a release.
 	RollBack() error

--- a/framework/app-service/pkg/appinstaller/helm_ops_scale.go
+++ b/framework/app-service/pkg/appinstaller/helm_ops_scale.go
@@ -13,11 +13,11 @@ import (
 // workloads to their final size.
 //
 // The implementation only sends the .workloads sub-tree and relies on
-// helm UpgradeReleaseCharts to merge it over the previous release's values —
-// every other input (admin / userspace / domain / service) is
-// preserved. The chart comes from the current Helm release, not
-// ChartsName on disk, so Scale cannot pick up template or chart default
-// changes from a newer local package. Behavior by argument:
+// helm UpgradeCharts(ReuseValues) to merge it over the previous release's
+// values — every other input (admin / userspace / domain / service) is
+// preserved. ReuseValues (not ResetThenReuseValues) is intentional: Scale
+// must not pick up new chart defaults (e.g. image) just because the chart
+// on disk changed. Behavior by argument:
 //
 //   - replicas >= 0: every workload is forced to this exact value. Used
 //     by suspending_app to scale to 0, and by upgrading_app to land an
@@ -35,23 +35,19 @@ import (
 // error so the upgrade-from-Stopped tail in upgrading_app stays
 // version-agnostic.
 //
-// HelmOpsV2 leaves Scale as a no-op; callers should branch on
-// appcfg.IsV2() first.
+// Scale is unsupported for v2 apps; HelmOpsV2 overrides this to return
+// an explicit error and callers should branch on appcfg.IsV2() first.
 func (h *HelmOps) Scale(replicas int32) error {
 	if !h.app.HasWorkloadReplicas() {
 		klog.V(4).Infof("Scale no-op for app=%s (no workloadReplicas declared)", h.app.AppName)
 		return nil
 	}
-	rel, err := h.status()
-	if err != nil {
-		return err
-	}
-
 	values := make(map[string]interface{})
 	values["workloads"] = buildWorkloadsValues(h.app.WorkloadReplicas, replicas)
 
-	if err := helm.UpgradeReleaseCharts(h.ctx, h.actionConfig,
-		h.app.AppName, h.app.Namespace, rel.Chart, values); err != nil {
+	if err := helm.UpgradeCharts(h.ctx, h.actionConfig, h.settings,
+		h.app.AppName, h.app.ChartsName, h.app.RepoURL, h.app.Namespace,
+		values, helm.ReuseValues); err != nil {
 		klog.Errorf("Failed to scale chart appName=%s replicas=%d err=%v", h.app.AppName, replicas, err)
 		return err
 	}

--- a/framework/app-service/pkg/constants/constants.go
+++ b/framework/app-service/pkg/constants/constants.go
@@ -37,24 +37,24 @@ const (
 	// UserspaceUID / UserspaceGID are the ownership and access identity
 	// Olares fixes for everything under a user's space. Both the
 	// directories on disk and the app processes converge on this pair.
-	UserspaceUID                int64 = 1000
-	UserspaceGID                int64 = 1000
-	ApplicationVersionLabel           = "applications.app.bytetrade.io/version"
-	ApplicationSourceLabel            = "applications.app.bytetrade.io/source"
-	ApplicationTailScaleKey           = "applications.app.bytetrade.io/tailscale"
-	ApplicationRequiredGPU            = "applications.app.bytetrade.io/required_gpu"
-	AppPodGPUConsumePolicy            = "gpu.bytetrade.io/app-pod-consume-policy"
-	ApplicationPolicies               = "applications.app.bytetrade.io/policies"
-	ApplicationMobileSupported        = "applications.app.bytetrade.io/mobile_supported"
-	ApplicationClusterDep             = "applications.app.bytetrade.io/need_cluster_scoped_app"
-	ApplicationGroupClusterDep        = "applications.app.bytetrade.io/need_cluster_scoped_group"
-	UserContextAttribute              = "username"
-	KubeSphereClientAttribute         = "ksclient"
-	MarketSource                      = "X-Market-Source"
-	MarketUser                        = "X-Market-User"
-	StudioSource                      = "devbox"
-	ApplicationInstallUserLabel       = "applications.app.bytetrade.io/install_user"
-	BflUserKey                        = "X-Bfl-User"
+	UserspaceUID int64 = 1000
+	UserspaceGID int64 = 1000
+	ApplicationVersionLabel       = "applications.app.bytetrade.io/version"
+	ApplicationSourceLabel        = "applications.app.bytetrade.io/source"
+	ApplicationTailScaleKey       = "applications.app.bytetrade.io/tailscale"
+	ApplicationRequiredGPU        = "applications.app.bytetrade.io/required_gpu"
+	AppPodGPUConsumePolicy        = "gpu.bytetrade.io/app-pod-consume-policy"
+	ApplicationPolicies           = "applications.app.bytetrade.io/policies"
+	ApplicationMobileSupported    = "applications.app.bytetrade.io/mobile_supported"
+	ApplicationClusterDep         = "applications.app.bytetrade.io/need_cluster_scoped_app"
+	ApplicationGroupClusterDep    = "applications.app.bytetrade.io/need_cluster_scoped_group"
+	UserContextAttribute          = "username"
+	KubeSphereClientAttribute     = "ksclient"
+	MarketSource                  = "X-Market-Source"
+	MarketUser                    = "X-Market-User"
+	StudioSource                  = "devbox"
+	ApplicationInstallUserLabel   = "applications.app.bytetrade.io/install_user"
+	BflUserKey                    = "X-Bfl-User"
 
 	InstanceIDLabel         = "workflows.argoproj.io/controller-instanceid"
 	WorkflowOwnerLabel      = "workflows.app.bytetrade.io/owner"

--- a/framework/app-service/pkg/helm/helm.go
+++ b/framework/app-service/pkg/helm/helm.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart"
 	helmLoader "helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/downloader"
@@ -121,36 +120,6 @@ func UpgradeCharts(ctx context.Context, actionConfig *action.Configuration, sett
 		client.RepoURL = repoURL
 	}
 	r, err := runUpgrade(ctx, []string{appName, chartName}, client, settings, vals)
-	if err != nil {
-		return err
-	}
-	logReleaseUpgrade(r)
-	return nil
-}
-
-// UpgradeReleaseCharts upgrades a release with an already-loaded chart,
-// which is expected to be the chart stored on the release being
-// upgraded. Unlike UpgradeCharts it never calls LocateChart, so no
-// chart is read from disk or from a repo and the release keeps its
-// current templates and chart defaults; vals is merged over the
-// previous release's values.
-//
-// Used by Scale (replica retarget) and ApplyEnv (env-only overrides).
-// Picking up a newer chart package would be a bug rather than an upgrade.
-func UpgradeReleaseCharts(ctx context.Context, actionConfig *action.Configuration,
-	appName, namespace string, chrt *chart.Chart, vals map[string]interface{}) error {
-	if chrt == nil {
-		return errors.Errorf("no chart on current release of %s", appName)
-	}
-	ctrl.Log.Info("helm action config", "reachable", actionConfig.KubeClient.IsReachable())
-	client := action.NewUpgrade(actionConfig)
-	client.Namespace = namespace
-	client.Timeout = 300 * time.Second
-	client.MaxHistory = 10
-	client.Recreate = false
-	client.ReuseValues = true
-
-	r, err := client.RunWithContext(ctx, appName, chrt, vals)
 	if err != nil {
 		return err
 	}

--- a/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_test.go
+++ b/framework/app-service/pkg/sandbox/sidecar/nested_iface_bypass_test.go
@@ -24,14 +24,14 @@ func hostPathVol(name, path string) corev1.Volume {
 
 func TestResolveNestedIfaceBypass(t *testing.T) {
 	cases := []struct {
-		name   string
-		pod    *corev1.Pod
-		wantOK bool
-		wantIF []string
+		name    string
+		pod     *corev1.Pod
+		wantOK  bool
+		wantIF  []string
 	}{
 		{
-			name:   "annot CSV",
-			pod:    linkerdPod(map[string]string{AnnotMeshBypassInterfaces: "docker, br0"}, corev1.PodSpec{}),
+			name: "annot CSV",
+			pod: linkerdPod(map[string]string{AnnotMeshBypassInterfaces: "docker, br0"}, corev1.PodSpec{}),
 			wantOK: true, wantIF: []string{"docker", "br0"},
 		},
 		{


### PR DESCRIPTION
Reverts beclab/Olares#4081

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scale and ApplyEnv again render from the located chart package, which can diverge from the chart revision pinned on the release and affect stopped-app env apply behavior documented in AppEnvController.
> 
> **Overview**
> Reverts **#4081**, undoing the path that upgraded **Scale** and **ApplyEnv** against the Helm release’s already-installed chart via `UpgradeReleaseCharts`.
> 
> **ApplyEnv** and **Scale** again call **`helm.UpgradeCharts`** with **`ReuseValues`**, resolving the chart from **`ChartsName` / `RepoURL`** (and merging env or workload replica overrides on top of prior release values). The dedicated **`UpgradeReleaseCharts`** helper is removed from `pkg/helm`.
> 
> Comments in the AppEnv controller and scale/apply paths are adjusted to describe a generic helm upgrade rather than release-chart-only upgrades. **`constants.go`** and a sandbox test file only have formatting tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc545375e77ccae310a46dc00e752b25739e8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->