### PR TITLE
market: generate shared entrance URLs via OAC

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -155,7 +155,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.108
+        image: beclab/market-backend:v0.6.110
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
generate shared entrance URLs via OAC

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/445


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump on a deployment; behavior changes come from the new backend release, not from cluster config edits here.
> 
> **Overview**
> **Bumps the Market appstore backend** in `market_deploy.yaml` from `beclab/market-backend:v0.6.108` to **`v0.6.110`**, so clusters pick up the newer backend image (including shared entrance URL generation via OAC described in the related market change).
> 
> No other manifest, env, or RBAC changes in this PR—only the container image tag on the `appstore-backend` deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfdc2ddb58fa5bd8e561bd321196f5e39e5cb058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->