### PR TITLE
fix(download-server): route yt-dlp URLs via the daemon's real extractor set , keep metadata-less renditions

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.14"
+        image: "beclab/download-server:v1.0.15"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
The manager decided "should yt-dlp handle this URL?" purely from a static allow-list derived from ytdlp.config (extractor descriptions). That list cannot express sites whose extractor key doesn't map cleanly to their domain, so those URLs silently fell through to aria2 even though yt-dlp supports them.
This PR makes the yt-dlp daemon the single source of truth for support, routes the manager through it (with caching + graceful degradation), and fixes two adjacent issues found while verifying: an inspect bug that dropped metadata-less-but-downloadable renditions #, and a cold-start latency spike on the first support/inspect scan.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in deployment config; risk is limited to whatever behavior ships in the new container release.
> 
> **Overview**
> Updates the **download** DaemonSet deploy manifest so the `download-server` sidecar uses **`beclab/download-server:v1.0.15`** instead of **v1.0.14**. No other manifest fields change in this diff—clusters pick up the new image on rollout via `imagePullPolicy: IfNotPresent` once the tag is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7828b85724c805e571ddfbb73abcc193cdb195ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->