### PR TITLE
fix(gpu): inject NODE_NAME into the AMD device plugin and roll it out on upgrade

### DIFF
--- a/cli/pkg/upgrade/1_12_7_20260904.go
+++ b/cli/pkg/upgrade/1_12_7_20260904.go
@@ -1,0 +1,25 @@
+package upgrade
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/beclab/Olares/cli/pkg/core/task"
+)
+
+type upgrader_1_12_7_20260904 struct {
+	breakingUpgraderBase
+}
+
+func (u upgrader_1_12_7_20260904) Version() *semver.Version {
+	return semver.MustParse("1.12.7-20260904")
+}
+
+func (u upgrader_1_12_7_20260904) UpgradeSystemComponents() []task.Interface {
+	tasks := make([]task.Interface, 0)
+	tasks = append(tasks, upgradeAmdDevicePlugin()...)
+	tasks = append(tasks, u.upgraderBase.UpgradeSystemComponents()...)
+	return tasks
+}
+
+func init() {
+	registerDailyUpgrader(upgrader_1_12_7_20260904{})
+}

--- a/infrastructure/gpu/.olares/config/gpu/amd/amdgpu-device-plugin.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/amd/amdgpu-device-plugin.yaml
@@ -32,6 +32,12 @@ spec:
               mountPath: /var/lib/kubelet/device-plugins
             - name: sys
               mountPath: /sys
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+                  apiVersion: v1
       volumes:
         - name: dp
           hostPath:


### PR DESCRIPTION




* **Background**
The plugin needs the Kubernetes node name from the downward API

* **Target Version for Merge**
v1.12.7
* **Related Issues**
None
* **PRs Involving Sub-Systems** 
None

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small manifest and upgrade-hook change in kube-system GPU plumbing; no auth or data-path changes beyond redeploying an existing privileged DaemonSet.
> 
> **Overview**
> The AMD GPU device plugin DaemonSet now sets **`NODE_NAME`** from the Kubernetes downward API (`spec.nodeName`) so the plugin can read the node identity at runtime.
> 
> A new daily upgrader **`1.12.7-20260904`** reapplies the AMD device plugin during system upgrades (via `upgradeAmdDevicePlugin()` ahead of the default system-component tasks), so clusters pick up the manifest change without a manual rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9bf6dc0821b139e21c342cdadf3af5d18cff6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->