### PR TITLE
docs(olares-files): clarify Public-link host is share.<user-hostname>

### DIFF
--- a/cli/skills/olares-files/references/olares-files-share.md
+++ b/cli/skills/olares-files/references/olares-files-share.md
@@ -105,7 +105,7 @@ SHARE_ID=$(olares-cli files share public drive/Home/Photos/ --expire-days 7 --pa
 echo "Share link: https://share.${USER_HOST}/sharable-link/${SHARE_ID}/"
 ```
 
-The Public-link host is `share.<user-hostname>`, **not** `files.<hostname>` (the files-backend API host) and **not** `larepass.<hostname>` (the LarePass app itself). For Olares ID `alice@olares.com` the share host is `share.alice.olares.com`.
+The Public-link host is `share.<user-hostname>` with a public authentication level. For Olares ID `alice@olares.com` the share host is `share.alice.olares.com`.
 
 ### Add a member to an existing Internal share without dropping existing ones
 

--- a/cli/skills/olares-files/references/olares-files-share.md
+++ b/cli/skills/olares-files/references/olares-files-share.md
@@ -10,7 +10,7 @@ Create and manage shares for directories. **All three flavors are directory-only
 | Flavor | Audience | Recipient model | Update verb |
 |---|---|---|---|
 | `internal` | Other Olares users on the same node | Olares user names → per-user permission | `set-members` |
-| `public` | Anyone with the link + password | Opaque link, recipients open it at `<host>/sharable-link/<id>/` | `set-password` |
+| `public` | Anyone with the link + password | Opaque link, recipients open it at `share.<user-hostname>/sharable-link/<id>/` | `set-password` |
 | `smb` | Local network (Finder / Explorer / etc.) | SMB-account IDs (managed via `smb-users`), or `--public` for "anyone on the LAN" | `set-smb` |
 
 ## Per-flavor namespace allow-list
@@ -38,7 +38,7 @@ POST /api/share/share_path/<fileType>/<extend><subPath>/
 body: {name, share_type, permission, password, ...}
 ```
 
-Response carries the new `share id`, plus per-flavor extras (`smb_link` / `smb_user` / `smb_password` for SMB; the Public-link URL is constructed by the LarePass app's `shareBaseUrl + /sharable-link/<id>/` pattern).
+Response carries the new `share id`, plus per-flavor extras (`smb_link` / `smb_user` / `smb_password` for SMB; the Public-link URL is constructed as `shareBaseUrl + /sharable-link/<id>/`, where `shareBaseUrl = https://share.<user-hostname>` — for an Olares ID `alice@olares.com`, the resulting share URL is `https://share.alice.olares.com/sharable-link/<id>/`).
 
 Management verbs (`list` / `get` / `rm`) take the share id and are share-type-agnostic.
 
@@ -99,11 +99,13 @@ olares-cli files share rm <share-id>
 ### Create a Public share and reply with the URL
 
 ```bash
+# Derive the share host from the active profile's Olares ID (everything after '@').
+USER_HOST=$(olares-cli profile list | awk '/^\*/{print $2}' | sed 's/.*@//')
 SHARE_ID=$(olares-cli files share public drive/Home/Photos/ --expire-days 7 --password "$PW" --json | jq -r '.id')
-echo "Share link: https://<your-host>/sharable-link/$SHARE_ID/"
+echo "Share link: https://share.${USER_HOST}/sharable-link/${SHARE_ID}/"
 ```
 
-The `<your-host>` part is read from the LarePass app's `shareBaseUrl`; if the user doesn't already know it, point them at LarePass settings.
+The Public-link host is `share.<user-hostname>`, **not** `files.<hostname>` (the files-backend API host) and **not** `larepass.<hostname>` (the LarePass app itself). For Olares ID `alice@olares.com` the share host is `share.alice.olares.com`.
 
 ### Add a member to an existing Internal share without dropping existing ones
 

--- a/cli/skills/olares-files/references/olares-files-share.md
+++ b/cli/skills/olares-files/references/olares-files-share.md
@@ -38,7 +38,7 @@ POST /api/share/share_path/<fileType>/<extend><subPath>/
 body: {name, share_type, permission, password, ...}
 ```
 
-Response carries the new `share id`, plus per-flavor extras (`smb_link` / `smb_user` / `smb_password` for SMB; the Public-link URL is constructed as `shareBaseUrl + /sharable-link/<id>/`, where `shareBaseUrl = https://share.<user-hostname>` — for an Olares ID `alice@olares.com`, the resulting share URL is `https://share.alice.olares.com/sharable-link/<id>/`).
+Response carries the new `share id`, plus per-flavor extras (`smb_link` / `smb_user` / `smb_password` for SMB; the Public-link URL is constructed as `shareBaseUrl + /sharable-link/<id>/`, where `shareBaseUrl = https://share.<user-hostname>`).
 
 Management verbs (`list` / `get` / `rm`) take the share id and are share-type-agnostic.
 


### PR DESCRIPTION
## Summary

The olares-files share docs leave `shareBaseUrl` ambiguous, leaving agents to guess between `files.<hostname>` (the files-backend API host) and `larepass.<hostname>` (the LarePass app itself).

The actual pattern is `share.<user-hostname>`, derived from the active profile's Olares ID (e.g. `alice@olares.com` → `share.alice.olares.com`).

## Changes

- `cli/skills/olares-files/references/olares-files-share.md`:
  - Replace placeholder `<host>` / `<your-host>` with the literal `share.<user-hostname>`
  - Explain why it's not `files.<hostname>` or `larepass.<hostname>`
  - Add a worked example for deriving `USER_HOST` from `olares-cli profile list`

## Test plan

Walked through the full Public-link flow end-to-end on a test directory and verified the constructed URL matches what LarePass actually serves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI skill reference; no runtime or API behavior is modified.
> 
> **Overview**
> Updates **`olares-files-share.md`** so Public share URLs are documented as **`https://share.<user-hostname>/sharable-link/<id>/`**, replacing vague `<host>` / `<your-host>` placeholders and spelling out that **`shareBaseUrl` is `https://share.<user-hostname>`** (not `files.*` or `larepass.*`).
> 
> The **agent flow** for creating a Public share now includes a shell snippet to derive **`USER_HOST`** from the active profile Olares ID (`olares-cli profile list`) and echoes the link with **`share.${USER_HOST}`**, plus a concrete example (`alice@olares.com` → `share.alice.olares.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113576be04bd4415750788da53fa66cbcdf50340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->