### PR TITLE
Allow preinstall check against a source-tree Olares.yaml

### DIFF
--- a/cli/cmd/ctl/preinstall/check.go
+++ b/cli/cmd/ctl/preinstall/check.go
@@ -12,6 +12,7 @@ func NewCmdPreinstallCheck() *cobra.Command {
 	var (
 		full           bool
 		installationMF string
+		olaresYAML     string
 		imagesDir      string
 		gpuModes       []string
 	)
@@ -40,15 +41,30 @@ and require the medium to preload the images they need. This catches the
 case where a bundled chart was updated but the image list was not, which
 on an offline device means the app cannot start at all. Add --images-dir
 to also require the image payload to be present, which is what prepare
-reads. Both checks are offline; neither contacts a registry or a CDN.
+reads.
+
+Pass --olares-yaml instead of --installation-manifest to run the same
+chart-image check against output.containers in a source-tree Olares.yaml,
+without packing an installer first. The two flags are mutually exclusive.
+--images-dir is a packed-medium check and requires --installation-manifest.
+
+All image checks are offline; none contact a registry or a CDN.
 
 Examples:
   olares-cli preinstall check ./preinstall/market
   olares-cli preinstall check ./preinstall/market --full
   olares-cli preinstall check ./preinstall/market \
+    --olares-yaml ./path/to/Olares.yaml
+  olares-cli preinstall check ./preinstall/market \
     --installation-manifest ./installation.manifest --images-dir ./images`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if installationMF != "" && olaresYAML != "" {
+				return fmt.Errorf("--installation-manifest and --olares-yaml are mutually exclusive")
+			}
+			if imagesDir != "" && installationMF == "" {
+				return fmt.Errorf("--images-dir requires --installation-manifest")
+			}
 			opts := pkgpreinstall.CheckOptions{
 				Full:      full,
 				ImagesDir: imagesDir,
@@ -60,8 +76,13 @@ Examples:
 					return fmt.Errorf("read installation manifest %q: %w", installationMF, err)
 				}
 				opts.InstallationManifest = installation
-			} else if imagesDir != "" {
-				return fmt.Errorf("--images-dir requires --installation-manifest")
+			}
+			if olaresYAML != "" {
+				images, err := pkgpreinstall.ReadOlaresYAMLContainers(olaresYAML)
+				if err != nil {
+					return fmt.Errorf("read olares.yaml %q: %w", olaresYAML, err)
+				}
+				opts.OlaresImages = images
 			}
 			if err := pkgpreinstall.CheckStaticBundle(args[0], opts); err != nil {
 				return err
@@ -72,7 +93,8 @@ Examples:
 	}
 	fs := cmd.Flags()
 	fs.BoolVar(&full, "full", false, "also verify artifact payload trees against manifests")
-	fs.StringVar(&installationMF, "installation-manifest", "", "path to installation.manifest; enables the bundled-chart image check")
+	fs.StringVar(&installationMF, "installation-manifest", "", "path to installation.manifest; enables the bundled-chart image check against the packed medium")
+	fs.StringVar(&olaresYAML, "olares-yaml", "", "path to a source-tree Olares.yaml; enables the bundled-chart image check against output.containers")
 	fs.StringVar(&imagesDir, "images-dir", "", "directory holding preloaded image payloads (normally <baseDir>/images); requires --installation-manifest")
 	fs.StringSliceVar(&gpuModes, "gpu-modes", nil, "GPU families to render charts under (default: no-override plus all known families)")
 	return cmd

--- a/cli/pkg/preinstall/check.go
+++ b/cli/pkg/preinstall/check.go
@@ -18,8 +18,16 @@ type CheckOptions struct {
 	// InstallationManifest enables the image gate. When set, every image the
 	// bundled charts render must appear in it, because LoadImages and
 	// PinImages both iterate the manifest and ignore anything absent from it.
-	// Leaving it empty keeps the contract-only behaviour.
+	// Leaving it empty keeps the contract-only behaviour. Mutually exclusive
+	// with a non-nil OlaresImages.
 	InstallationManifest manifest.InstallationManifest
+
+	// OlaresImages is output.containers[].name from a source-tree Olares.yaml.
+	// A non-nil slice (including empty) enables the same chart-image gate
+	// against that list, so a developer can check before packing
+	// installation.manifest. Nil leaves the gate off. Mutually exclusive
+	// with InstallationManifest.
+	OlaresImages []string
 
 	// ImagesDir is the directory holding the preloaded image payloads,
 	// normally <baseDir>/images. When set, an image the manifest lists must
@@ -42,8 +50,9 @@ type CheckOptions struct {
 // By default it checks the V1 JSON contract, chart presence/size/SHA-256,
 // and artifact manifests. With opts.Full it also verifies each artifact
 // source tree entries declared by its manifest (entry types and digests).
-// With opts.InstallationManifest it additionally renders every bundled chart
-// and requires the medium to preload each image they need.
+// With opts.InstallationManifest or a non-nil opts.OlaresImages it
+// additionally renders every bundled chart and requires each image they
+// need to appear in that list.
 func CheckStaticBundle(dir string, opts CheckOptions) error {
 	dir = filepath.Clean(dir)
 	root, err := openDirectoryNoSymlink(dir)

--- a/cli/pkg/preinstall/images.go
+++ b/cli/pkg/preinstall/images.go
@@ -36,6 +36,10 @@ const (
 	// never pins it; at install time the cluster falls back to pulling from a
 	// registry, which an offline device cannot do.
 	ImageGapUnlisted ImageGapKind = "missing from installation.manifest"
+	// ImageGapUnlistedOlaresYAML means the source-tree Olares.yaml never names
+	// the image in output.containers, so packing would omit it from
+	// installation.manifest and the same registry fallback would happen.
+	ImageGapUnlistedOlaresYAML ImageGapKind = "missing from olares.yaml"
 	// ImageGapNoPayload means the manifest names the image but the medium
 	// carries no tarball for it. Prepare aborts in LoadImages with
 	// "image %s not found in %s".
@@ -74,14 +78,19 @@ func imageGapError(gaps []ImageGap) error {
 	return fmt.Errorf("%s", strings.Join(lines, "\n"))
 }
 
-// checkBundleImages reports every image the bundled charts need that the medium
-// will not preload. An empty manifest disables the whole check, which is what
-// keeps CheckStaticBundle's contract-only mode working unchanged.
+// checkBundleImages reports every image the bundled charts need that the listed
+// source will not cover. Neither an empty InstallationManifest nor a nil
+// OlaresImages enables the check, which is what keeps CheckStaticBundle's
+// contract-only mode working unchanged. A non-nil OlaresImages, even empty,
+// does enable it: the caller asked for the source-tree gate.
 func checkBundleImages(root *os.Root, bundle BundleV1, opts CheckOptions) error {
-	if len(opts.InstallationManifest) == 0 {
+	listed, unlistedKind, imagesDir, enabled, err := listedFromOptions(opts)
+	if err != nil {
+		return err
+	}
+	if !enabled {
 		return nil
 	}
-	listed := listedImages(opts.InstallationManifest)
 	var (
 		gaps  []ImageGap
 		total int64
@@ -93,7 +102,7 @@ func checkBundleImages(root *os.Root, bundle BundleV1, opts CheckOptions) error 
 		}
 		total += consumed
 		for _, image := range images {
-			gap, ok := imageGapFor(app, image, listed, opts.ImagesDir)
+			gap, ok := imageGapFor(app, image, listed, unlistedKind, imagesDir)
 			if ok {
 				gaps = append(gaps, gap)
 			}
@@ -102,18 +111,33 @@ func checkBundleImages(root *os.Root, bundle BundleV1, opts CheckOptions) error 
 	return imageGapError(gaps)
 }
 
-// imageGapFor answers, for one image of one app, whether the medium will
-// preload it. The image arrives normalized; `listed` maps normalized refs back
-// to the manifest's own spelling, which is both what names the payload file and
-// what a fix has to be written as.
-func imageGapFor(app BundleAppV1, image string, listed map[string]string, imagesDir string) (ImageGap, bool) {
+func listedFromOptions(opts CheckOptions) (map[string]string, ImageGapKind, string, bool, error) {
+	hasManifest := len(opts.InstallationManifest) > 0
+	hasYAML := opts.OlaresImages != nil
+	if hasManifest && hasYAML {
+		return nil, "", "", false, fmt.Errorf("installation manifest and olares.yaml image lists are mutually exclusive")
+	}
+	if hasManifest {
+		return listedImages(opts.InstallationManifest), ImageGapUnlisted, opts.ImagesDir, true, nil
+	}
+	if hasYAML {
+		return listedFromRefs(opts.OlaresImages), ImageGapUnlistedOlaresYAML, "", true, nil
+	}
+	return nil, "", "", false, nil
+}
+
+// imageGapFor answers, for one image of one app, whether the listed source will
+// cover it. The image arrives normalized; `listed` maps normalized refs back
+// to the source's own spelling, which is both what names a packed payload file
+// and what a fix has to be written as.
+func imageGapFor(app BundleAppV1, image string, listed map[string]string, unlistedKind ImageGapKind, imagesDir string) (ImageGap, bool) {
 	raw, ok := listed[image]
 	if !ok {
 		return ImageGap{
 			AppID:   app.AppID,
 			AppName: app.AppName,
 			Image:   familiarImageRef(image),
-			Kind:    ImageGapUnlisted,
+			Kind:    unlistedKind,
 		}, true
 	}
 	if imagesDir == "" || imagePayloadExists(imagesDir, raw) {
@@ -133,6 +157,14 @@ func imageGapFor(app BundleAppV1, image string, listed map[string]string, images
 // filename.
 func listedImages(installation manifest.InstallationManifest) map[string]string {
 	_, refs := installation.GetImageList()
+	return listedFromRefs(refs)
+}
+
+// listedFromRefs indexes image references by normalized form so a chart's
+// docker.io/beclab/x:1 matches a list's beclab/x:1. The value keeps the
+// original spelling so a reported gap can be pasted back into images.mf or
+// Olares.yaml as-is.
+func listedFromRefs(refs []string) map[string]string {
 	listed := make(map[string]string, len(refs))
 	for _, ref := range refs {
 		normalized, err := normalizeImageRef(ref)

--- a/cli/pkg/preinstall/images_test.go
+++ b/cli/pkg/preinstall/images_test.go
@@ -23,6 +23,90 @@ func TestCheckStaticBundleWithoutInstallationManifestSkipsImageGate(t *testing.T
 	}
 }
 
+func TestCheckStaticBundleOlaresYAMLAcceptsListedImage(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{OlaresImages: []string{"beclab/router:v2.5.0"}}
+
+	if err := CheckStaticBundle(dir, opts); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+}
+
+func TestCheckStaticBundleOlaresYAMLIgnoresExtraDeclaredImages(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{OlaresImages: []string{"beclab/router:v2.5.0", "beclab/unrelated:v1"}}
+
+	if err := CheckStaticBundle(dir, opts); err != nil {
+		t.Fatalf("CheckStaticBundle() error = %v", err)
+	}
+}
+
+func TestCheckStaticBundleOlaresYAMLReportsUnlistedImage(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "model", image: "docker.io/beclab/llama.cpp:b10548"})
+	opts := CheckOptions{OlaresImages: []string{"beclab/router:v2.5.0"}}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil {
+		t.Fatal("CheckStaticBundle() error = nil, want an unlisted image")
+	}
+	if !strings.Contains(err.Error(), "beclab/llama.cpp:b10548") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the image named", err)
+	}
+	if strings.Contains(err.Error(), "docker.io/beclab/llama.cpp") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the familiar spelling", err)
+	}
+	if !strings.Contains(err.Error(), string(ImageGapUnlistedOlaresYAML)) {
+		t.Fatalf("CheckStaticBundle() error = %v, want kind %q", err, ImageGapUnlistedOlaresYAML)
+	}
+	if strings.Contains(err.Error(), string(ImageGapUnlisted)) {
+		t.Fatalf("CheckStaticBundle() error = %v, want the olares.yaml kind, not the manifest kind", err)
+	}
+}
+
+func TestCheckStaticBundleOlaresYAMLNormalizesRegistryPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		chartImage string
+		yamlImage  string
+	}{
+		{"long chart, short yaml", "docker.io/beclab/router:v2.5.0", "beclab/router:v2.5.0"},
+		{"short chart, long yaml", "beclab/router:v2.5.0", "docker.io/beclab/router:v2.5.0"},
+		{"non-docker registry", "ghcr.io/beclab/router:v2.5.0", "ghcr.io/beclab/router:v2.5.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := buildImageBundle(t, imageApp{name: "gateway", image: tt.chartImage})
+			opts := CheckOptions{OlaresImages: []string{tt.yamlImage}}
+			if err := CheckStaticBundle(dir, opts); err != nil {
+				t.Fatalf("CheckStaticBundle() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckStaticBundleOlaresYAMLEmptyListReportsEveryChartImage(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{OlaresImages: []string{}}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil || !strings.Contains(err.Error(), "beclab/router:v2.5.0") {
+		t.Fatalf("CheckStaticBundle() error = %v, want the chart image reported", err)
+	}
+}
+
+func TestCheckStaticBundleRejectsBothImageListSources(t *testing.T) {
+	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
+	opts := CheckOptions{
+		InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0"),
+		OlaresImages:         []string{"beclab/router:v2.5.0"},
+	}
+
+	err := CheckStaticBundle(dir, opts)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("CheckStaticBundle() error = %v, want mutually exclusive sources", err)
+	}
+}
+
 func TestCheckStaticBundleImageGateAcceptsListedImage(t *testing.T) {
 	dir := buildImageBundle(t, imageApp{name: "gateway", image: "docker.io/beclab/router:v2.5.0"})
 	opts := CheckOptions{InstallationManifest: buildInstallationManifest(t, "beclab/router:v2.5.0")}

--- a/cli/pkg/preinstall/olares_yaml.go
+++ b/cli/pkg/preinstall/olares_yaml.go
@@ -1,0 +1,44 @@
+package preinstall
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type olaresYAMLFile struct {
+	Output olaresYAMLOutput `yaml:"output"`
+}
+
+type olaresYAMLOutput struct {
+	Containers []olaresYAMLContainer `yaml:"containers"`
+}
+
+type olaresYAMLContainer struct {
+	Name string `yaml:"name"`
+}
+
+// ReadOlaresYAMLContainers returns output.containers[].name from a
+// source-tree Olares.yaml. The returned slice is always non-nil so callers
+// can distinguish "the file was read" from an unset CheckOptions.OlaresImages.
+func ReadOlaresYAMLContainers(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var parsed olaresYAMLFile
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	names := make([]string, 0, len(parsed.Output.Containers))
+	for _, c := range parsed.Output.Containers {
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}

--- a/cli/pkg/preinstall/olares_yaml_test.go
+++ b/cli/pkg/preinstall/olares_yaml_test.go
@@ -1,0 +1,62 @@
+package preinstall
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestReadOlaresYAMLContainers(t *testing.T) {
+	path := writeOlaresYAML(t, `apiVersion: v1
+target: prebuilt
+output:
+  containers:
+    - name: beclab/router:v2.5.0
+    - name: "  "
+    -
+      name: docker.io/beclab/llama.cpp:b10548
+`)
+
+	got, err := ReadOlaresYAMLContainers(path)
+	if err != nil {
+		t.Fatalf("ReadOlaresYAMLContainers() error = %v", err)
+	}
+	want := []string{"beclab/router:v2.5.0", "docker.io/beclab/llama.cpp:b10548"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReadOlaresYAMLContainers() = %v, want %v", got, want)
+	}
+}
+
+func TestReadOlaresYAMLContainersEmptyIsNonNil(t *testing.T) {
+	path := writeOlaresYAML(t, "apiVersion: v1\noutput: {}\n")
+
+	got, err := ReadOlaresYAMLContainers(path)
+	if err != nil {
+		t.Fatalf("ReadOlaresYAMLContainers() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ReadOlaresYAMLContainers() = nil, want a non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("ReadOlaresYAMLContainers() = %v, want empty", got)
+	}
+}
+
+func TestReadOlaresYAMLContainersRejectsInvalidYAML(t *testing.T) {
+	path := writeOlaresYAML(t, "output: [\n")
+
+	_, err := ReadOlaresYAMLContainers(path)
+	if err == nil {
+		t.Fatal("ReadOlaresYAMLContainers() error = nil, want decode failure")
+	}
+}
+
+func writeOlaresYAML(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "Olares.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- Add `--olares-yaml` to `olares-cli preinstall check` so bundled chart images can be validated against `output.containers` in a source-tree Olares.yaml, without packing `installation.manifest` first.
- Keep the existing `--installation-manifest` / `--images-dir` packed-medium gate; the two image-list flags are mutually exclusive.
- Report missing images as `missing from olares.yaml` using familiar refs so they can be pasted back into `containers[].name`.

## Test plan
- [ ] `olares-cli preinstall check ./preinstall/market` still skips the image gate
- [ ] `olares-cli preinstall check ./preinstall/market --olares-yaml ./path/to/Olares.yaml` passes when every rendered chart image is listed in `output.containers`
- [ ] The same command fails with `missing from olares.yaml` and familiar image names when a chart image is absent
- [ ] Passing both `--olares-yaml` and `--installation-manifest` is rejected
- [ ] `--images-dir` still requires `--installation-manifest`
- [ ] `go test ./pkg/preinstall/` in `cli/`


Made with [Cursor](https://cursor.com)