### PR TITLE
market: update image to v0.6.111

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -155,7 +155,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.110
+        image: beclab/market-backend:v0.6.111
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
Bumps the Market backend image to `v0.6.111`.

## What is in this release

[beclab/market#447](https://github.com/beclab/market/pull/447) fixes an upload deadlock in the Market's Local Sources → Upload bucket.

An uploaded app could end up invisible in the UI and impossible to re-upload at the same time. Two pieces of state can disagree:

- The version check that refuses an upload comes from chart-repo's in-memory cache, which is rebuilt at startup from the artifacts on disk. As long as `<app>-<version>.tgz` is still under `/opt/app/data/v3/upload/`, that version counts as taken.
- The listing shows only rows that rendered successfully. Once a definition's render failed 20 consecutive times it hit `maxDefinitionRenderFailures` and was permanently excluded from retries, so it never healed and never appeared in any list.

The result: the artifact keeps reserving the version, the definition can never be repaired, and the user is stuck with no way out except changing the version number.

The fix lets a re-upload replace an artifact whose version is not backed by a usable definition, and adds a one-time migration that clears the failure counter on definitions that already hit the cap, so they re-enter the render queue after the upgrade. A published version stays immutable: re-uploading over a definition that did render successfully is still refused with HTTP 409.

## Verification

Verified on a 1.12.7 cluster by reproducing the deadlock (definition forced to `failed` with the failure counter at the cap, artifact left on disk):

| Case | v0.6.110 | v0.6.111 |
| --- | --- | --- |
| Definition `failed` at the cap, re-upload same version | HTTP 409 | upload succeeds, then re-renders to `success` |
| Definition `success`, re-upload same version | HTTP 409 | HTTP 409 (version stays immutable) |
| Restart carrying a definition stuck at the cap | stuck permanently | migration clears the counter, re-renders to `success` |

The image is published for `linux/amd64` and `linux/arm64`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolls out Market chart-repo and definition-render behavior changes via a single image swap; low manifest risk but affects local upload and version conflict handling.
> 
> **Overview**
> Updates the Market cluster deployment so `appstore-backend` runs **`beclab/market-backend:v0.6.111`** instead of `v0.6.110` in `market_deploy.yaml`. No other manifest fields change.
> 
> **v0.6.111** ships the backend fix from [beclab/market#447](https://github.com/beclab/market/pull/447): Local Sources uploads can recover when a version is blocked on disk but the app definition failed rendering at the permanent failure cap. Re-upload can replace artifacts without a usable definition; startup migration clears capped failure counters so stuck definitions retry. Successfully rendered published versions still return HTTP 409 on duplicate upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856325f8e8b9f975f455322cc7977603cc3c9251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->