### PR TITLE
fix: seafile-server tolerate trailing CRLF after multipart close-delimiter

### DIFF
--- a/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
+++ b/framework/seahub/.olares/config/cluster/deploy/seafile_deploy.yaml
@@ -257,7 +257,7 @@ spec:
 
       containers:
       - name: seafile-server
-        image: beclab/pg_seafile_server:v0.0.22
+        image: beclab/pg_seafile_server:v0.0.23
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8082


### PR DESCRIPTION
Background
- fix: seafile-server tolerate trailing CRLF after multipart close-delimiter

Target Version for Merge
- 1.12.7

Related Issues
- none

PRs Involving Sub-Systems
- https://github.com/beclab/seafile-server/pull/8

Other information:
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in the Seafile deployment; behavior change is limited to the upstream multipart parsing fix at rollout.
> 
> **Overview**
> Rolls out the **seafile-server** fix for uploads that fail when clients send **trailing CRLF after the multipart close-delimiter** by updating the cluster deployment image from `beclab/pg_seafile_server:v0.0.22` to **`v0.0.23`** in `seafile_deploy.yaml`.
> 
> No other manifest, env, or routing changes—only the container image tag on the `seafile-server` container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3b25d93e3b8cec3a37cf5fe1b1e8b678c88807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->