### PR TITLE
fix(app-service): disable mesh-out agent sidecar injection

### DIFF
--- a/framework/app-service/pkg/gateway/meshoutagent/eligible.go
+++ b/framework/app-service/pkg/gateway/meshoutagent/eligible.go
@@ -25,10 +25,12 @@ func HasProviderPermission(perms []appcfg.ProviderPermission) bool {
 }
 
 // ShouldInject reports whether the mesh-out agent should replace envoy outbound
-// for this workload. Shared inbound-only pods never receive the agent.
+// for this workload.
+//
+// Injection is disabled: provider access via permission.provider is retired,
+// so no application needs the mesh-out agent and nothing is injected.
 func ShouldInject(isSharedApp bool, perms []appcfg.ProviderPermission) bool {
-	if isSharedApp {
-		return false
-	}
-	return HasProviderPermission(perms)
+	_ = isSharedApp
+	_ = perms
+	return false
 }

--- a/framework/app-service/pkg/gateway/meshoutagent/eligible_test.go
+++ b/framework/app-service/pkg/gateway/meshoutagent/eligible_test.go
@@ -6,10 +6,13 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 )
 
-func TestShouldInjectMeshOutAgentProviderPod(t *testing.T) {
+func TestShouldInjectDisabledForProviderPod(t *testing.T) {
 	perms := []appcfg.ProviderPermission{{AppName: "system-server", ProviderName: "api"}}
-	if !ShouldInject(false, perms) {
-		t.Fatal("T-EGR-1: provider pod should receive mesh-out agent")
+	if !HasProviderPermission(perms) {
+		t.Fatal("provider permission should still be detected")
+	}
+	if ShouldInject(false, perms) {
+		t.Fatal("provider pod must not receive mesh-out agent while injection is disabled")
 	}
 }
 

--- a/framework/app-service/pkg/gateway/meshoutagent/nginx_conf_test.go
+++ b/framework/app-service/pkg/gateway/meshoutagent/nginx_conf_test.go
@@ -50,8 +50,8 @@ func TestShouldInject(t *testing.T) {
 	if ShouldInject(false, nil) {
 		t.Fatal("no provider must not inject")
 	}
-	if !ShouldInject(false, []appcfg.ProviderPermission{{AppName: "x"}}) {
-		t.Fatal("provider must inject")
+	if ShouldInject(false, []appcfg.ProviderPermission{{AppName: "x"}}) {
+		t.Fatal("provider must not inject while mesh-out injection is disabled")
 	}
 }
 


### PR DESCRIPTION
Provider access via permission.provider is retired, so no application needs the mesh-out agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod mutation in the admission webhook path (no mesh-out init/container/volume injection), which affects outbound egress behavior for workloads that previously relied on the agent.
> 
> **Overview**
> **Disables mesh-out agent sidecar injection** for all workloads now that provider access via `permission.provider` is retired.
> 
> `ShouldInject` in `meshoutagent` no longer checks shared-app or provider-permission eligibility—it always returns `false`, with a short comment documenting the policy. `HasProviderPermission` is unchanged so permission detection can still be validated separately.
> 
> Tests were updated so provider and shared-app cases all expect **no** injection, including the renamed provider-pod test and `nginx_conf_test`’s `TestShouldInject`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 050327c0686dfd2b871a1fdab6115af719b3167d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->