### PR TITLE
system-frontend: update image to v1.11.44

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.42
+          image: beclab/system-frontend:v1.11.44
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the system-frontend image to v1.11.44 to pick up market/compute fixes from TermiPass: VRAM quota seeding that ceils to the displayable step (so resume no longer opens as Insufficient VRAM), hiding dead Open actions for middleware apps with no entrance, and filtering deprecated studio/cli market sources on ingress.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1413

* **Other information**:
None

Made with [Cursor](https://cursor.com)