### PR TITLE
fix(cli): download generated media atomically

### DIFF
--- a/cli/cmd/ctl/router/call_media.go
+++ b/cli/cmd/ctl/router/call_media.go
@@ -3,13 +3,17 @@ package router
 import (
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -385,7 +389,12 @@ func runMedia(ctx context.Context, f *cmdutil.Factory, kind mediaKind, opts medi
 	if err != nil {
 		return err
 	}
-	pc, err := prepare(ctx, f)
+	// Polling can run for minutes, and generated audio/video artifacts are often
+	// tens or hundreds of MiB.  The standard authenticated client has a 30s
+	// whole-request deadline, which can truncate an otherwise healthy content
+	// download.  Keep authentication and refresh handling, but use the streaming
+	// client whose lifetime is governed by the command context and --timeout.
+	pc, err := prepareLongRequest(ctx, f)
 	if err != nil {
 		return err
 	}
@@ -557,8 +566,8 @@ func fetchGenerationContent(ctx context.Context, dp *routerClient, kind mediaKin
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
+		defer resp.Body.Close()
 		raw, _ := io.ReadAll(resp.Body)
 		return callErr(dp.formatErr("GET", path, resp.StatusCode, raw))
 	}
@@ -567,17 +576,11 @@ func fetchGenerationContent(ctx context.Context, dp *routerClient, kind mediaKin
 	if target == "" {
 		target = gen.ID + extForContentType(resp.Header.Get("Content-Type"), kind.defaultExt)
 	}
-	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	written, err := saveGenerationContent(target, resp, func(offset int64) (*http.Response, error) {
+		return dp.withHeader("Range", fmt.Sprintf("bytes=%d-", offset)).do(ctx, "GET", path, nil, "")
+	})
 	if err != nil {
-		return fmt.Errorf("create %s: %w", target, err)
-	}
-	written, copyErr := io.Copy(file, resp.Body)
-	closeErr := file.Close()
-	if copyErr != nil {
-		return fmt.Errorf("write %s: %w", target, copyErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close %s: %w", target, closeErr)
+		return err
 	}
 	if _, err := fmt.Printf("wrote %s (%s)\n", target, humanBytes(written)); err != nil {
 		return err
@@ -586,6 +589,143 @@ func fetchGenerationContent(ctx context.Context, dp *routerClient, kind mediaKin
 		_, err := fmt.Fprintf(os.Stderr, "this generation has %d outputs (%s); --output-id names one\n",
 			len(others), strings.Join(others, " "))
 		return err
+	}
+	return nil
+}
+
+// saveGenerationContent keeps an incomplete transfer away from the requested
+// path. A short read is resumed when the content endpoint supports Range; a
+// server that ignores Range restarts the same temporary file from byte zero.
+// Only a byte-complete payload is atomically renamed into place.
+func saveGenerationContent(target string, first *http.Response, resume func(int64) (*http.Response, error)) (int64, error) {
+	directory := filepath.Dir(target)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(target)+"-*.partial")
+	if err != nil {
+		_ = first.Body.Close()
+		return 0, fmt.Errorf("create temporary download for %s: %w", target, err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = first.Body.Close()
+		_ = temporary.Close()
+		return 0, fmt.Errorf("secure temporary download for %s: %w", target, err)
+	}
+
+	response := first
+	expected := response.ContentLength
+	contentType := response.Header.Get("Content-Type")
+	written := int64(0)
+	for attempt := 0; attempt < 3; attempt++ {
+		copied, copyErr := io.Copy(temporary, response.Body)
+		closeErr := response.Body.Close()
+		written += copied
+		complete := copyErr == nil && (expected < 0 || written == expected)
+		if complete {
+			if closeErr != nil {
+				_ = temporary.Close()
+				return 0, fmt.Errorf("close response for %s: %w", target, closeErr)
+			}
+			break
+		}
+		if written > expected && expected >= 0 {
+			_ = temporary.Close()
+			return 0, fmt.Errorf("download %s exceeded Content-Length: got %d bytes, expected %d", target, written, expected)
+		}
+		if attempt == 2 || resume == nil {
+			_ = temporary.Close()
+			if copyErr != nil {
+				return 0, fmt.Errorf("write %s: %w", target, copyErr)
+			}
+			return 0, fmt.Errorf("download %s was truncated: got %d bytes, expected %d", target, written, expected)
+		}
+
+		next, resumeErr := resume(written)
+		if resumeErr != nil {
+			_ = temporary.Close()
+			return 0, fmt.Errorf("resume %s at byte %d: %w", target, written, resumeErr)
+		}
+		response = next
+		switch response.StatusCode {
+		case http.StatusPartialContent:
+			start, total, ok := parseContentRange(response.Header.Get("Content-Range"))
+			if !ok || start != written {
+				_ = response.Body.Close()
+				_ = temporary.Close()
+				return 0, fmt.Errorf("resume %s returned an invalid Content-Range", target)
+			}
+			expected = total
+		case http.StatusOK:
+			if err := temporary.Truncate(0); err != nil {
+				_ = response.Body.Close()
+				_ = temporary.Close()
+				return 0, fmt.Errorf("restart download %s: %w", target, err)
+			}
+			if _, err := temporary.Seek(0, io.SeekStart); err != nil {
+				_ = response.Body.Close()
+				_ = temporary.Close()
+				return 0, fmt.Errorf("restart download %s: %w", target, err)
+			}
+			written = 0
+			expected = response.ContentLength
+		default:
+			_ = response.Body.Close()
+			_ = temporary.Close()
+			return 0, fmt.Errorf("resume %s returned HTTP %d", target, response.StatusCode)
+		}
+	}
+
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return 0, fmt.Errorf("sync %s: %w", target, err)
+	}
+	if err := validateDownloadedContent(temporary, written, contentType, target); err != nil {
+		_ = temporary.Close()
+		return 0, fmt.Errorf("validate %s: %w", target, err)
+	}
+	if err := temporary.Close(); err != nil {
+		return 0, fmt.Errorf("close %s: %w", target, err)
+	}
+	if err := os.Rename(temporaryPath, target); err != nil {
+		return 0, fmt.Errorf("finish %s: %w", target, err)
+	}
+	return written, nil
+}
+
+func parseContentRange(value string) (start, total int64, ok bool) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "bytes ") {
+		return 0, 0, false
+	}
+	rangeAndTotal := strings.Split(strings.TrimPrefix(value, "bytes "), "/")
+	if len(rangeAndTotal) != 2 || rangeAndTotal[1] == "*" {
+		return 0, 0, false
+	}
+	bounds := strings.Split(rangeAndTotal[0], "-")
+	if len(bounds) != 2 {
+		return 0, 0, false
+	}
+	start, errStart := strconv.ParseInt(bounds[0], 10, 64)
+	end, errEnd := strconv.ParseInt(bounds[1], 10, 64)
+	total, errTotal := strconv.ParseInt(rangeAndTotal[1], 10, 64)
+	return start, total, errStart == nil && errEnd == nil && errTotal == nil && start >= 0 && end >= start && total > end
+}
+
+func validateDownloadedContent(file *os.File, size int64, contentType, target string) error {
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	if mediaType != "audio/wav" && mediaType != "audio/x-wav" && !strings.EqualFold(filepath.Ext(target), ".wav") {
+		return nil
+	}
+	header := make([]byte, 12)
+	if _, err := file.ReadAt(header, 0); err != nil {
+		return fmt.Errorf("read WAV header: %w", err)
+	}
+	if string(header[:4]) != "RIFF" || string(header[8:12]) != "WAVE" {
+		return fmt.Errorf("response is not a RIFF/WAVE file")
+	}
+	declared := int64(binary.LittleEndian.Uint32(header[4:8])) + 8
+	if declared != size {
+		return fmt.Errorf("WAV header declares %d bytes but received %d", declared, size)
 	}
 	return nil
 }

--- a/cli/cmd/ctl/router/call_media_generations_test.go
+++ b/cli/cmd/ctl/router/call_media_generations_test.go
@@ -1,9 +1,14 @@
 package router
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +16,73 @@ import (
 
 	"github.com/beclab/Olares/cli/pkg/cmdutil"
 )
+
+func testWAV(payload []byte) []byte {
+	result := make([]byte, 12+len(payload))
+	copy(result[:4], "RIFF")
+	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
+	copy(result[8:12], "WAVE")
+	copy(result[12:], payload)
+	return result
+}
+
+func TestGenerationDownloadResumesAndAtomicallyPublishesWAV(t *testing.T) {
+	raw := testWAV([]byte("generated-audio"))
+	directory := t.TempDir()
+	target := filepath.Join(directory, "song.wav")
+	first := &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: int64(len(raw)),
+		Header:        http.Header{"Content-Type": []string{"audio/wav"}},
+		Body:          io.NopCloser(bytes.NewReader(raw[:10])),
+	}
+	resumes := 0
+	written, err := saveGenerationContent(target, first, func(offset int64) (*http.Response, error) {
+		resumes++
+		if offset != 10 {
+			t.Fatalf("resume offset=%d", offset)
+		}
+		return &http.Response{
+			StatusCode:    http.StatusPartialContent,
+			ContentLength: int64(len(raw)) - offset,
+			Header:        http.Header{"Content-Range": []string{"bytes 10-" + fmt.Sprint(len(raw)-1) + "/" + fmt.Sprint(len(raw))}},
+			Body:          io.NopCloser(bytes.NewReader(raw[offset:])),
+		}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || !bytes.Equal(got, raw) || written != int64(len(raw)) || resumes != 1 {
+		t.Fatalf("written=%d resumes=%d err=%v body=%q", written, resumes, err, got)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, "*.partial"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("partial downloads remain: %v err=%v", matches, err)
+	}
+}
+
+func TestGenerationDownloadRejectsTruncatedWAVWithoutReplacingTarget(t *testing.T) {
+	raw := testWAV([]byte("generated-audio"))
+	directory := t.TempDir()
+	target := filepath.Join(directory, "song.wav")
+	if err := os.WriteFile(target, []byte("previous"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first := &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: int64(len(raw)),
+		Header:        http.Header{"Content-Type": []string{"audio/wav"}},
+		Body:          io.NopCloser(bytes.NewReader(raw[:10])),
+	}
+	if _, err := saveGenerationContent(target, first, nil); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("expected truncation error, got %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "previous" {
+		t.Fatalf("target was replaced: %q err=%v", got, err)
+	}
+}
 
 func mediaVerb(t *testing.T, name string) *cobra.Command {
 	t.Helper()


### PR DESCRIPTION
## Summary
- use the long-request authenticated client for generated media collection
- download into a private temporary file and atomically rename only after validation
- resume short reads with HTTP Range and restart safely when the server ignores Range
- verify Content-Length and RIFF/WAVE declared size so truncated music is never reported as complete

## Verification
- cd cli && go test ./cmd/ctl/router

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download and file I/O behavior for all media `call` verbs; logic is localized and tested but mishandling could still affect large or interrupted transfers.
> 
> **Overview**
> **Generated media downloads** (image/video/music/3d) now use the long-request HTTP client so multi-minute polls and large artifact transfers are not cut off by the default 30s request deadline.
> 
> **Content is written safely** via `saveGenerationContent`: bytes land in a private `*.partial` temp file, truncated transfers can resume with HTTP `Range` (or restart from zero if the server ignores Range), WAV payloads get a RIFF/size check, and only a complete file is atomically renamed to `--out`.
> 
> Tests cover Range resume end-to-end and ensuring a failed truncated download does not overwrite an existing target file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b6c73e829b95223f7a0692b786fbf37303709f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->