### PR TITLE
system-frontend: update image to v1.11.46

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.44
+          image: beclab/system-frontend:v1.11.46
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**
Upgrade the system-frontend image to v1.11.46 to pick up the Launchpad fix where a crashed entrance (`running` + `notReady`) keeps its full-color icon. Grayscale now applies only to failed app-level states, so the red dot remains the entrance-level crash signal and matches Settings.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1416

* **Other information**:
None

Made with [Cursor](https://cursor.com)