### PR TITLE
chore(hami): bump hami core version to v2.6.28

### DIFF
--- a/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
+++ b/infrastructure/gpu/.olares/config/gpu/hami/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
-version: "v2.6.27"
+version: "v2.6.28"
 
 # Nvidia GPU Parameters
 resourceName: "nvidia.com/gpu"

--- a/platform/hami/.olares/Olares.yaml
+++ b/platform/hami/.olares/Olares.yaml
@@ -3,7 +3,7 @@ target: prebuilt
 output:
   containers:
     - 
-      name: beclab/hami:v2.6.27
+      name: beclab/hami:v2.6.28
     - 
       name: beclab/hami-webui-fe-oss:v1.0.8
     - 


### PR DESCRIPTION
* **Background**
bump hami core version to v2.6.28

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bump with no logic or config changes beyond the image tag; rollout risk is limited to HAMI component behavior in v2.6.28.
> 
> **Overview**
> Bumps the **HAMI** (vGPU scheduler/device plugin) core release from **v2.6.27** to **v2.6.28** in deployment config and prebuilt image manifests.
> 
> The Helm default `version` in `infrastructure/gpu/.olares/config/gpu/hami/values.yaml` is updated so scheduler and device plugin images resolve to the new tag. `platform/hami/.olares/Olares.yaml` lists `beclab/hami:v2.6.28` for prebuilt output; web UI and DCGM exporter image pins are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e297093afb4e2ac649fcf99d8580809d3a5e12af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->