### PR TITLE
system-frontend, user-service: update images to v1.11.47 and v0.1.18

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.46
+          image: beclab/system-frontend:v1.11.47
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -365,7 +365,7 @@ spec:
             - name: NATS_SUBJECT_VAULT
               value: os.vault.{{ .Values.bfl.username}}
         - name: user-service
-          image: beclab/user-service:v0.1.17
+          image: beclab/user-service:v0.1.18
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
* **Background**
Upgrade the `system-apps` chart images so 1.12.7 picks up TermiPass v1.11.47 and user-service v0.1.18. Chart-only change: two image tags in `olares-app.yaml`.

**system-frontend (`v1.11.46` → `v1.11.47`)**

1. **Dashboard detail overlays no longer cover the left drawer** (TermiPass [#1417](https://github.com/beclab/TermiPass/pull/1417)). `FullPageWithBack` with `fixed-full` was positioning against the viewport, which hid the drawer. The scrollable main content is now wrapped in `layout-content-wrapper` with `transform: translate(0)` so the overlay becomes the containing block — matching ControlHub's `MainLayout`. Overlays sit over the page container (respecting `q-page-container` padding) while the drawer stays visible.
2. **Public Market listings keep their description and install flags** (TermiPass [#1425](https://github.com/beclab/TermiPass/pull/1425)). `AppSimpleWire` never declared `app_description`, `allowMultipleInstall`, `templateOnly` or `shared`, so the listing projection discarded the description map and every public app read as single-instance / non-template.
3. **Fetch/transfer on mobile** (TermiPass [#1422](https://github.com/beclab/TermiPass/pull/1422), [#1419](https://github.com/beclab/TermiPass/pull/1419)). Magnet paste no longer misreads tracker hosts as URLs; upload destinations match the share sheet; bulk Cancel and Delete are split; a Fetch row whose task is gone is removable after reinstall; iOS clipboard and torrent-picker fixes.
4. **Settings hides System update on a multi-node Olares** (TermiPass [#1402](https://github.com/beclab/TermiPass/pull/1402)). A cluster upgrades as a whole, so the per-machine entry is hidden when `nodes.total > 1`.
5. **Hosts and Fetch copy** (TermiPass [#1420](https://github.com/beclab/TermiPass/pull/1420), [#1400](https://github.com/beclab/TermiPass/pull/1400)). The hosts sidebar CTA is shortened so the landscape banner no longer overflows, and Fetch/i18n copy is aligned across locales.

Windows ARM64 installer and updater-channel work (TermiPass [#1407](https://github.com/beclab/TermiPass/pull/1407), [#1423](https://github.com/beclab/TermiPass/pull/1423)) rides along in the tag range but does not change the web bundle this image ships.

**user-service (`v0.1.17` → `v0.1.18`)**

1. **AbilitiesService reports install state and the router ability** (user-service [#108](https://github.com/beclab/user-service/pull/108)). Adds `AbilityState` (`running` / `stopped` / `uninstalled`), includes the router ability on the Abilities interface, and sets each ability's state and entrance on init.

* **Target Version for Merge**
1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1417
https://github.com/beclab/TermiPass/pull/1425
https://github.com/beclab/TermiPass/pull/1422
https://github.com/beclab/TermiPass/pull/1419
https://github.com/beclab/TermiPass/pull/1402
https://github.com/beclab/TermiPass/pull/1420
https://github.com/beclab/TermiPass/pull/1400
https://github.com/beclab/user-service/pull/108

* **Other information**:
None

Made with [Cursor](https://cursor.com)