### PR TITLE
market(fix): report why app-service refused an operation

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -155,7 +155,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.111
+        image: beclab/market-backend:v0.6.112
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
- report why app-service refused an operation
- fix preinstall skip opted-out shared app installs

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/449
https://github.com/beclab/market/pull/451


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump with no deployment manifest changes beyond version; operational risk is limited to whatever is in the new backend release.
> 
> **Overview**
> **Rolls out `market-backend` v0.6.112** in the Market cluster deployment by updating the `appstore-backend` container image from `v0.6.111` to `v0.6.112` in `market_deploy.yaml`.
> 
> No other manifest or config changes in this repo; the new image is intended to carry the Market fixes described for this release (clearer reporting when app-service rejects an operation, and corrected preinstall handling for opted-out shared app installs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812a32c0751a2dcf4fb5cbc3797cf198e5aee8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->