### PR TITLE
feat(cli/router): mark shared KV pools on AT ONCE

### DIFF
--- a/cli/cmd/ctl/router/capacity_test.go
+++ b/cli/cmd/ctl/router/capacity_test.go
@@ -113,6 +113,74 @@ func TestTheWidthColumnAppearsOnlyWhereItIsKnown(t *testing.T) {
 	}
 }
 
+// A pool smaller than window × width is one cache the slots share, not a
+// private window for each, so the width is marked rather than looking exclusive.
+func TestASharedKVPoolIsMarkedOnTheWidth(t *testing.T) {
+	model := providerModelRow{
+		Name: "qwen3", Mode: "chat", Enabled: true, Status: "active",
+		MaxConcurrency: 2, ContextSize: 102400, KVPoolTokens: 102400,
+	}
+	local := []adminModelRow{{
+		ProviderName: "Olares", ProviderType: "openai-compatible", ProviderSource: "olares",
+		ProviderStatus: "active",
+		Model:          model,
+	}}
+	var list bytes.Buffer
+	if err := renderModelList(&list, local, 1, 100, 0); err != nil {
+		t.Fatalf("renderModelList: %v", err)
+	}
+	if !strings.Contains(list.String(), "2 shared") {
+		t.Fatalf("expected a shared width, got:\n%s", list.String())
+	}
+
+	var detail bytes.Buffer
+	if err := renderProviderGet(&detail, &providerDetail{
+		providerRow: providerRow{Name: "Olares", Source: "olares", Status: "active"},
+		Models:      []providerModelRow{model},
+	}); err != nil {
+		t.Fatalf("renderProviderGet: %v", err)
+	}
+	if !strings.Contains(detail.String(), "2 shared") {
+		t.Fatalf("expected a shared width on the provider table, got:\n%s", detail.String())
+	}
+}
+
+// Window × width that fits in the pool is a split cache, even when the numbers
+// look like they were copied from one field to another.
+func TestASplitKVPoolIsNotMarkedShared(t *testing.T) {
+	model := providerModelRow{
+		Name: "qwen3", Mode: "chat", Enabled: true, Status: "active",
+		MaxConcurrency: 2, ContextSize: 51200, KVPoolTokens: 102400,
+	}
+	local := []adminModelRow{{
+		ProviderName: "Olares", ProviderType: "openai-compatible", ProviderSource: "olares",
+		ProviderStatus: "active",
+		Model:          model,
+	}}
+	var list bytes.Buffer
+	if err := renderModelList(&list, local, 1, 100, 0); err != nil {
+		t.Fatalf("renderModelList: %v", err)
+	}
+	out := list.String()
+	if strings.Contains(out, "2 shared") {
+		t.Fatalf("a pool that covers the width is not shared, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2") {
+		t.Fatalf("expected the width, got:\n%s", out)
+	}
+
+	var detail bytes.Buffer
+	if err := renderProviderGet(&detail, &providerDetail{
+		providerRow: providerRow{Name: "Olares", Source: "olares", Status: "active"},
+		Models:      []providerModelRow{model},
+	}); err != nil {
+		t.Fatalf("renderProviderGet: %v", err)
+	}
+	if strings.Contains(detail.String(), "2 shared") {
+		t.Fatalf("a pool that covers the width is not shared on the provider table, got:\n%s", detail.String())
+	}
+}
+
 func TestOneModelReportsItsWidth(t *testing.T) {
 	var buf bytes.Buffer
 	err := renderProviderModel(&buf,

--- a/cli/cmd/ctl/router/model_list.go
+++ b/cli/cmd/ctl/router/model_list.go
@@ -579,7 +579,7 @@ func renderModelList(w io.Writer, items []adminModelRow, total, limit, offset in
 			summarizeSupports(it.Model.Supports),
 		}
 		if wide {
-			cells = append(cells, intOrDash(it.Model.MaxConcurrency))
+			cells = append(cells, atOnceLabel(it.Model))
 		}
 		cells = append(cells, it.callableNote(), clip(it.routeNote(), 30))
 		t.row(cells...)
@@ -593,7 +593,8 @@ func renderModelList(w io.Writer, items []adminModelRow, total, limit, offset in
 	if wide {
 		if _, err := fmt.Fprintln(w, "\nAT ONCE is how many requests that model's engine was launched to "+
 			"work on at the same time. It is only known for a local engine whose launch flags said so; "+
-			"`router provider get <app>` reads the engine's current queue beside it."); err != nil {
+			"`router provider get <app>` reads the engine's current queue beside it. shared means those "+
+			"slots share one KV pool smaller than (window × width)."); err != nil {
 			return err
 		}
 	}

--- a/cli/cmd/ctl/router/provider.go
+++ b/cli/cmd/ctl/router/provider.go
@@ -131,6 +131,7 @@ type providerModelRow struct {
 	// number an admin typed would be a width the engine never agreed to.
 	// Absent on a cloud model, which has no engine of ours to be launched.
 	MaxConcurrency int       `json:"max_concurrency,omitempty"`
+	KVPoolTokens   int       `json:"kv_pool_tokens,omitempty"`
 	EngineArgs     string    `json:"engine_args,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`

--- a/cli/cmd/ctl/router/provider_get.go
+++ b/cli/cmd/ctl/router/provider_get.go
@@ -120,7 +120,7 @@ func renderProviderGet(w io.Writer, d *providerDetail) error {
 			intOrDash(m.ContextSize),
 		}
 		if wide {
-			cells = append(cells, intOrDash(m.MaxConcurrency))
+			cells = append(cells, atOnceLabel(*m))
 		}
 		cells = append(cells, summarizeSupports(m.Supports))
 		mt.row(cells...)
@@ -131,7 +131,8 @@ func renderProviderGet(w io.Writer, d *providerDetail) error {
 	if wide {
 		_, err := fmt.Fprintln(w, "\nAT ONCE is how many requests the engine was launched to work on at "+
 			"the same time. A request beyond that waits its turn, which looks like a slow model rather "+
-			"than a queue — ENGINE LOAD above is what tells the two apart.")
+			"than a queue — ENGINE LOAD above is what tells the two apart. shared means those slots "+
+			"share one KV pool smaller than (window × width).")
 		return err
 	}
 	return nil
@@ -142,4 +143,12 @@ func intOrDash(v int) string {
 		return "-"
 	}
 	return strconv.Itoa(v)
+}
+
+func atOnceLabel(m providerModelRow) string {
+	if m.ContextSize > 0 && m.MaxConcurrency > 1 && m.KVPoolTokens > 0 &&
+		int64(m.ContextSize)*int64(m.MaxConcurrency) > int64(m.KVPoolTokens) {
+		return strconv.Itoa(m.MaxConcurrency) + " shared"
+	}
+	return intOrDash(m.MaxConcurrency)
 }


### PR DESCRIPTION
## Summary
- When `context_size × max_concurrency` exceeds Router's `kv_pool_tokens`, `router model list` and `router provider get` mark AT ONCE as `N shared` so the width is not read as exclusive per slot.
- Depends on Router projecting `kv_pool_tokens` on admin model rows ([beclab/router#100](https://github.com/beclab/router/pull/100)). Older Router versions omit the field and the column stays a plain number.

## Test plan
- [x] `go test ./cmd/ctl/router/ -count=1` from `cli/`
- [ ] After Router #100 is deployed: `router model list` / `router provider get <app>` show `shared` only when the KV pool is smaller than window × width


Made with [Cursor](https://cursor.com)