### PR TITLE
fix(cli): remove catalog apps from preinstall configuration

### DIFF
--- a/cli/pkg/preinstall/catalog-apps.json
+++ b/cli/pkg/preinstall/catalog-apps.json
@@ -1,10 +1,3 @@
 {
-  "apps": [
-    {
-      "appId": "f3395cd5",
-      "appName": "router",
-      "installScope": "shared",
-      "installOrder": 20
-    }
-  ]
+  "apps": []
 }


### PR DESCRIPTION
* **Background**
Remove catalog apps from preinstall configuration

* **Target Version for Merge**
v1.12.7

* **Related Issues**
none

* **PRs Involving Sub-Systems** 
none

* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to the embedded preinstall app list; no runtime logic changes in this diff.
> 
> **Overview**
> Clears the embedded **preinstall catalog** in `catalog-apps.json` by removing the `router` entry so `apps` is empty.
> 
> Devices upgrading with **DeclareCatalogApps** will no longer get catalog apps merged from this release-bound list; only what the install/upgrade path explicitly carries or declares elsewhere will apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9920e5dcb0b066174170f3a8188c1031471530e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->