### PR TITLE
fix(download-server): preserve publication timestamps and yt-dlp content metadata

### DIFF
--- a/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
+++ b/framework/download-server/.olares/config/cluster/deploy/download_deploy.yaml
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
             
       - name: download-server
-        image: "beclab/download-server:v1.0.15"
+        image: "beclab/download-server:v1.0.16"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
Background
Currently, the content update pipeline—particularly during progress synchronization, file-move operations, and torrent lifecycle events—unconditionally overwrites core metadata fields such as published_at, author, and description.
This design introduces two critical data integrity issues:
Timestamp Contamination (System vs. Content): The published_at field, which should represent the original content creation date sourced from yt-dlp, is frequently reset to the system's processing time (e.g., progress polling time or file move completion time). This makes it impossible to distinguish between "when the content was published" and "when the system processed the file," breaking downstream sorting and display logic.
Silent Metadata Loss During Incremental Updates: When partial updates occur (e.g., a progress sync that lacks author or description payloads), the existing valid values are erroneously overwritten with null or empty strings. This erases valuable yt-dlp-extracted information, forcing users to re-fetch metadata manually and degrading the overall data completeness.

Target Version for Merge
v1.12.7

PRs Involving Sub-Systems
none

Other information:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in Helm/deploy config; behavior change is confined to the new server image version.
> 
> **Overview**
> This PR **bumps the `download-server` container image** in the cluster DaemonSet manifest from `beclab/download-server:v1.0.15` to **`v1.0.16`**, rolling out the release that addresses metadata handling described in the PR (preserving yt-dlp `published_at`, author, and description instead of overwriting them during progress sync, file moves, and partial updates).
> 
> No application source changes appear in the diff—only the deploy image tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1078bfc3de481a2835e64ce24731d9050761d8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->