### PR TITLE
olares: bump system-frontend to v1.11.48

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.47
+          image: beclab/system-frontend:v1.11.48
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image in the `system-apps` chart so that the v1.12.7 release ships the latest LarePass/TermiPass web bundle. It is a chart-only change: one image tag, no Olares-side logic touched.

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.47` | `beclab/system-frontend:v1.11.48` |

  `user-service` stays on `v0.1.18` from the previous bump ([#4108](https://github.com/beclab/Olares/pull/4108)).

  **What the new `system-frontend` image contains**

  1. **Vault no longer filters the item list by a query that is not on screen** (TermiPass [#1424](https://github.com/beclab/TermiPass/pull/1424)). The search query lived in two places: the input inside `ItemListSearch`, which dies with the component, and `ItemList`'s own `filterInput`, which actually drives the filtering and was never cleared. Switching directory closes the search header, so the list kept being filtered by a query nothing on screen showed any more — clicking **All Vaults** listed the previous search's matches, and reopening search showed an empty box over a filtered list. `filterInput` is now cleared whenever the default header takes over, which covers every way the search header goes away, including entering multi-select from an open search. Selecting still works on a filtered list; leaving multi-select clears the query and restores the full folder.

  2. **Market re-reads app versions when the catalogue changes** (TermiPass [#1429](https://github.com/beclab/TermiPass/pull/1429)). "Update all" on the Updates page could send a version the catalogue no longer offers. The version comes from `appSimpleInfoMap`, and nothing refreshed that map after a `catalog_changed` push: the frontend treated `catalog_changed` as a storefront-only signal and re-read the taxonomy plus the current category's rows, which carry versions only for the apps inside them. An installed app that was off-screen therefore kept whatever version it last learned for the rest of the session, since `fetchAppState` otherwise runs only at init and on socket reconnect, with no poll. A catalogue-carrying browse refresh now also re-reads `/market/statesimple`, ordered last so the version authority wins over the inline simple info written by storefront blocks, gated on `needCatalogue` so a plain tab-focus refresh does not trigger it, and skipped on public builds which have no such endpoint. This is a client-side backstop and does not replace the `new_app_ready` push.

  3. **Wise reading progress, feed body visibility, and one schema per table** (TermiPass [#1427](https://github.com/beclab/TermiPass/pull/1427)). Eight reported Wise bugs, plus a database consolidation:
     - Three reading-progress symptoms shared one cause: a crawled RSS entry can arrive with an empty `file_type`, which the loose lookup resolved to the article descriptor while the strict lookup returned `undefined`, so every progress call site fell back to `scrollStrategy: 'none'`. The entry rendered as an article while tracking nothing — the progress bar never moved, no position was saved, and the auto-read threshold was unreachable. Short entries now mark read deterministically (`setTotalProgress` is armed from the article-body-ready watcher instead of depending on a scroll emit landing after `full_content`), and mark-unread now clears the stored progress locally and remotely and resets the live session, so an entry no longer flips straight back to read on the next open.
     - List behaviour: the reading selection now carries the list it came from, so highlight and scroll restore no longer leak into any other menu containing the same entry; and the cover fallback is a tested chain (entry cover → feed icon → file icon → placeholder) where a load failure advances to the next candidate instead of dropping straight to the placeholder.
     - Feed bodies injected with `v-html` were hidden at most window widths: Reddit wraps every post body in `<div class="md">`, and Quasar's responsive visibility helpers define a bare `.md` as visible only in the 1024–1439px band. Global utility class names are now stripped from the parsed document before it becomes the rendered content, keeping the classes the reader actually depends on.
     - Each of the five Wise tables previously maintained its column list up to six times, and had already drifted: stray commas in the `entries` DDL produced two junk columns literally named `TEXT` and `INTEGER` that rode along on every `SELECT entries.*`. A table is now declared once as a `TableSchema` and every statement derives from it. **Operational note:** `DATABASE_VERSION` goes 13 → 14, which is what makes the fix reach an existing OPFS database, so Wise does a full local rebuild and re-sync on first launch after the upgrade.
     - Copy and i18n: the "Use RSS feed content" label is no longer ellipsized, the manual feed-refresh tooltip no longer renders the literal string `base.update`, and the reader's fetch button is translated in all seven locales. The RSS Feeds manager's "Last updated" column now reads the new `feeds.rss_updated_at` (when the source last produced content) instead of the local record mtime, which moved on any edit.

  4. **In-page translation is served by Olares, and the client learns about the `router` ability** (TermiPass [#1418](https://github.com/beclab/TermiPass/pull/1418)). A KISS-Translator port lands in the LarePass browser extension with Hy-MT2 through Router alongside the legacy MTranServer, so translation runs on the user's own Olares. The side panel scopes its engine list and hints to the selected engine, gates translation on Router route verdicts and the app abilities, and no longer raises false "reload the page" prompts; a new settings surface covers providers, site rules, blocklist, advanced limits and custom styles, with `bex.*` strings across all locales. The part that reaches this image is the shared abilities layer: `AbilityState` (`running` / `stopped` / `uninstalled`) and a per-app `entrance` list are now modelled client-side, with a `router` ability added to `AbilityData`. Both are read defensively — `state` falls back to `running` and `abilityEntranceId` returns `undefined` rather than guessing — so the client stays correct against an Olares older than 1.12.7. This is the client half of the `AbilitiesService` change that shipped in `user-service` v0.1.18 ([user-service#108](https://github.com/beclab/user-service/pull/108)).

  5. **Destructive-action copy points at Olares Support first** (TermiPass [#1426](https://github.com/beclab/TermiPass/pull/1426)). Factory reset now states plainly that the data loss is permanent and irreversible and links to Ticket / Olares Space support; uninstall is reframed as restoring factory settings rather than removing a device from a list; and the reactivation notifications get clearer titles and support-first guidance instead of offering **Reactivate** as the first move. Strings-only, updated across all locales.

  Also in the `v1.11.47...v1.11.48` range but outside the web bundle this image ships: the ARM64 `vcruntime140.dll` vendored next to the Windows natives so upload/download works without the VC++ redist (TermiPass [#1428](https://github.com/beclab/TermiPass/pull/1428)), and routing **Upload torrent file** on iOS through the native document picker (TermiPass [#1430](https://github.com/beclab/TermiPass/pull/1430)).

* **Target Version for Merge**
v1.12.7

* **Related Issues**
 None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1418
https://github.com/beclab/TermiPass/pull/1424
https://github.com/beclab/TermiPass/pull/1429

* **Other information**
 Full Changelog: 
https://github.com/beclab/TermiPass/compare/v1.11.47...v1.11.48

Made with [Cursor](https://cursor.com)
