### PR TITLE
feat(appservice): allow selective overrides of existing app envs during upgrade

### DIFF
--- a/framework/app-service/go.mod
+++ b/framework/app-service/go.mod
@@ -3,6 +3,7 @@ module github.com/beclab/Olares/framework/app-service
 go 1.25.0
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/apecloud/kubeblocks v1.0.0
 	github.com/argoproj/argo-workflows/v3 v3.7.10
@@ -65,7 +66,6 @@ require (
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	cloud.google.com/go/storage v1.55.0 // indirect
-	dario.cat/mergo v1.0.2 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/framework/app-service/pkg/utils/app/app.go
+++ b/framework/app-service/pkg/utils/app/app.go
@@ -11,9 +11,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
+	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 
 	sysv1alpha1 "github.com/beclab/api/api/sys.bytetrade.io/v1alpha1"
@@ -231,7 +233,8 @@ func UpdateAppMgrStatus(name string, status v1alpha1.ApplicationManagerStatus, m
 
 // ApplyAppEnv applies the environment variable configuration of the app:
 // if no existing AppEnv is found for the app, the AppEnv is created
-// if existing AppEnv is found for the app, any new configured env is added to the AppEnv
+// if existing AppEnv is found, new envs are added and existing envs have empty
+// fields filled from the configuration. Defaults always follow the configuration.
 func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.ApplicationConfig) (*sysv1alpha1.AppEnv, error) {
 	if appConfig == nil {
 		return nil, fmt.Errorf("app config is nil")
@@ -295,13 +298,27 @@ func ApplyAppEnv(ctx context.Context, c client.Client, appConfig *appcfg.Applica
 	updated := false
 
 	if len(desiredAppEnvs) > 0 {
-		existingEnvs := make(map[string]struct{}, len(appEnv.Envs))
-		for _, e := range appEnv.Envs {
-			existingEnvs[e.EnvName] = struct{}{}
+		existingEnvs := make(map[string]int, len(appEnv.Envs))
+		for i, e := range appEnv.Envs {
+			existingEnvs[e.EnvName] = i
 		}
 		for _, e := range desiredAppEnvs {
-			if _, ok := existingEnvs[e.EnvName]; !ok {
+			i, ok := existingEnvs[e.EnvName]
+			if !ok {
+				existingEnvs[e.EnvName] = len(appEnv.Envs)
 				appEnv.Envs = append(appEnv.Envs, e)
+				updated = true
+				continue
+			}
+			existing := &appEnv.Envs[i]
+			previous := existing.DeepCopy()
+			// set previously unset and now non-empty fields from the new configuration
+			if err := mergo.Merge(existing, e); err != nil {
+				return nil, fmt.Errorf("merge app env %s: %w", e.EnvName, err)
+			}
+			// override default value with the new configuration, whether empty previously or not
+			existing.Default = e.Default
+			if !reflect.DeepEqual(previous, existing) {
 				updated = true
 			}
 		}


### PR DESCRIPTION
* **Background**

Allow app upgrades to selectively override existing environment variable configuration: fill empty fields with non-empty incoming values and update changed defaults, including clearing them. Preserve other non-empty fields and patch only when changes are detected.

* **Target Version for Merge**

1.12.7

* **Related Issues**

none

* **PRs Involving Sub-Systems**

none

* **Other information**:

Validation: `go mod tidy`, `go test ./pkg/utils/app`, and `CGO_ENABLED=0 go build ./...` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upgrade-time persistence of `AppEnv` CRs (defaults always follow manifest; other fields merge into empty slots), which can alter stored env metadata on upgrade.
> 
> **Overview**
> **App upgrades now reconcile existing `AppEnv` entries** instead of only appending new variable names. When an `AppEnv` CR already exists, `ApplyAppEnv` still adds missing envs, but for matching names it **merges** the incoming chart/manifest config into the stored entry with `mergo` (filling previously empty fields from config) and **always sets `Default` from the new configuration**, including clearing it.
> 
> Patches are applied only when `reflect.DeepEqual` detects a change. **`dario.cat/mergo`** is promoted to a direct module dependency for this merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5a158d039eef93c23ed5380bea13ba9792e968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->