### PR TITLE
fix(cli): make market failures say what actually went wrong

### DIFF
--- a/cli/cmd/ctl/market/clone.go
+++ b/cli/cmd/ctl/market/clone.go
@@ -124,6 +124,11 @@ func runClone(opts *MarketOptions, appName string) error {
 	if computeMode != "" && !atLeast126 {
 		return opts.failOp("clone", appName, fmt.Errorf("--compute-mode requires Olares 1.12.6+; this backend uses a different (unchanged) clone path — re-run without --compute-mode"))
 	}
+	// The entry is already in hand from the clone-support check above, so the
+	// mode is checked against it directly rather than re-reading the catalog.
+	if err := checkDeclaredComputeMode(appInfo, appName, computeMode); err != nil {
+		return opts.failOp("clone", appName, err)
+	}
 	selected := ""
 	if atLeast126 {
 		selected = computeMode
@@ -155,7 +160,7 @@ func runClone(opts *MarketOptions, appName string) error {
 		}
 	}
 	if err != nil {
-		if envErr := parseServerEnvError(resp, appName); envErr != nil {
+		if envErr := parseServerEnvError(resp, appName, source); envErr != nil {
 			return opts.failOp("clone", appName, envErr)
 		}
 		if cloneErr := parseServerCloneError(resp); cloneErr != nil {

--- a/cli/cmd/ctl/market/common.go
+++ b/cli/cmd/ctl/market/common.go
@@ -3,8 +3,10 @@ package market
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -98,20 +100,92 @@ func validateEnvName(name string) error {
 	return nil
 }
 
-func resolveVersionInSource(mc *MarketClient, appName, source string) (string, error) {
+// unknownSourceError says a -s value names no source this cluster has, and
+// lists the ones it does. Without it a typo read as "app not found in source
+// 'bogussource'", which sends the reader looking for a missing app.
+type unknownSourceError struct {
+	Source string
+	Known  []string
+}
+
+func (e *unknownSourceError) Error() string {
+	return fmt.Sprintf("unknown market source '%s': this cluster has %s",
+		e.Source, strings.Join(e.Known, ", "))
+}
+
+// appNotInSourceError says the source exists and holds no such app. It is a
+// type rather than a message because the verbs that resolve a version have to
+// tell it apart from a version lookup that failed for some other reason: no
+// version of an absent app is reachable, so "use --version to specify" is not
+// the next step.
+type appNotInSourceError struct {
+	App    string
+	Source string
+}
+
+func (e *appNotInSourceError) Error() string {
+	return fmt.Sprintf("app '%s' not found in source '%s'", e.App, e.Source)
+}
+
+// knownSources returns the source ids this cluster actually has, read from the
+// per-user source map of /market/data -- the same keys `market list -a`
+// iterates. Nothing is hardcoded on purpose: --help used to publish a closed
+// list that omitted market.test while that source held 247 apps, so a
+// hand-written list is what produced the wrong error to begin with.
+//
+// Called only after a lookup has already failed, so the extra request never
+// lands on a working path.
+func knownSources(ctx context.Context, mc *MarketClient) []string {
+	resp, err := mc.GetMarketData(ctx)
+	if err != nil {
+		return nil
+	}
+	var data MarketDataResponse
+	if err := json.Unmarshal(resp.Data, &data); err != nil || data.UserData == nil {
+		return nil
+	}
+	sources := make([]string, 0, len(data.UserData.Sources))
+	for name := range data.UserData.Sources {
+		if name = strings.TrimSpace(name); name != "" {
+			sources = append(sources, name)
+		}
+	}
+	sort.Strings(sources)
+	return sources
+}
+
+// resolveVersionInSource returns the version the catalog holds for an app.
+//
+// versionFlagNarrows says whether passing --version instead would change what
+// the caller's verb does, which decides whether the failure may suggest it. It
+// does for install and upgrade. It does not for delete, where --version names
+// the request but removes every version regardless -- and following the
+// suggestion there turns a correct failure on an absent app into a success,
+// because the backend treats deleting nothing as done.
+func resolveVersionInSource(mc *MarketClient, appName, source string, versionFlagNarrows bool) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	appInfo, err := fetchAppInfo(ctx, mc, appName, source)
-	if err != nil {
-		return "", err
+	if err == nil {
+		if version, _ := appInfo["version"].(string); version != "" {
+			return version, nil
+		}
+		err = fmt.Errorf("app '%s' version not found in source '%s'", appName, source)
 	}
 
-	version, _ := appInfo["version"].(string)
-	if version == "" {
-		return "", fmt.Errorf("app '%s' version not found in source '%s'", appName, source)
+	// A missing source or a missing app is the whole reason no version came
+	// back, so it is reported as itself. Wrapping it in "cannot determine
+	// version" buries the cause under a symptom.
+	var unknownSource *unknownSourceError
+	var notInSource *appNotInSourceError
+	if errors.As(err, &unknownSource) || errors.As(err, &notInSource) {
+		return "", err
 	}
-	return version, nil
+	if versionFlagNarrows {
+		return "", fmt.Errorf("cannot determine version in source '%s': %w (use --version to specify)", source, err)
+	}
+	return "", fmt.Errorf("cannot determine version in source '%s': %w", source, err)
 }
 
 func fetchAppInfo(ctx context.Context, mc *MarketClient, appName, source string) (map[string]interface{}, error) {
@@ -127,7 +201,14 @@ func fetchAppInfo(ctx context.Context, mc *MarketClient, appName, source string)
 
 	apps, _ := result["apps"].([]interface{})
 	if len(apps) == 0 {
-		return nil, fmt.Errorf("app '%s' not found in source '%s'", appName, source)
+		// An empty result is the same reply for "no such source" and "no such
+		// app in it", so ask the cluster which of the two it was. A source
+		// list we cannot obtain leaves the app-level answer, which is the
+		// safer of the two to guess.
+		if known := knownSources(ctx, mc); len(known) > 0 && !containsSource(known, source) {
+			return nil, &unknownSourceError{Source: source, Known: known}
+		}
+		return nil, &appNotInSourceError{App: appName, Source: source}
 	}
 
 	appInfo, ok := apps[0].(map[string]interface{})
@@ -135,6 +216,15 @@ func fetchAppInfo(ctx context.Context, mc *MarketClient, appName, source string)
 		return nil, fmt.Errorf("failed to parse app '%s' info", appName)
 	}
 	return appInfo, nil
+}
+
+func containsSource(sources []string, source string) bool {
+	for _, s := range sources {
+		if strings.EqualFold(s, source) {
+			return true
+		}
+	}
+	return false
 }
 
 // appSupportsClone reports whether an app can be cloned. A regular

--- a/cli/cmd/ctl/market/common_test.go
+++ b/cli/cmd/ctl/market/common_test.go
@@ -2,9 +2,154 @@ package market
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+// An app lookup that comes back empty has two causes with different next
+// steps, and the backend answers both the same way. A mistyped -s used to read
+// as "app 'clitest' not found in source 'bogussource'", which describes a
+// missing app rather than a source that was never there.
+func TestFetchAppInfoSeparatesUnknownSourceFromMissingApp(t *testing.T) {
+	const sources = `{
+        "user_data": {
+            "sources": {
+                "market.olares": {"type": "market", "app_info_latest": []},
+                "market.test":   {"type": "market", "app_info_latest": []},
+                "upload":        {"type": "local",  "app_info_latest": []}
+            }
+        }
+    }`
+
+	t.Run("unknown source names the ones that exist", func(t *testing.T) {
+		srv := newAppLookupServer(t, sources, `{"apps": []}`)
+		_, err := fetchAppInfo(context.Background(), newTestMarketClient(t, srv.URL), "clitest", "bogussource")
+
+		var unknown *unknownSourceError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("error = %v, want unknownSourceError", err)
+		}
+		// market.test is the one a hand-written list omitted, so its presence
+		// here is what says the list came from the cluster.
+		for _, want := range []string{"bogussource", "market.olares", "market.test", "upload"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not mention %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("real source with no such app stays an app error", func(t *testing.T) {
+		srv := newAppLookupServer(t, sources, `{"apps": []}`)
+		_, err := fetchAppInfo(context.Background(), newTestMarketClient(t, srv.URL), "clitest", "market.test")
+
+		var notInSource *appNotInSourceError
+		if !errors.As(err, &notInSource) {
+			t.Fatalf("error = %v, want appNotInSourceError", err)
+		}
+	})
+
+	// The source list is a best-effort second call; losing it must not turn a
+	// missing app into a claim about the source.
+	t.Run("unreachable source list falls back to the app error", func(t *testing.T) {
+		srv := newAppLookupServer(t, "", `{"apps": []}`)
+		_, err := fetchAppInfo(context.Background(), newTestMarketClient(t, srv.URL), "clitest", "bogussource")
+
+		var notInSource *appNotInSourceError
+		if !errors.As(err, &notInSource) {
+			t.Fatalf("error = %v, want appNotInSourceError", err)
+		}
+	})
+}
+
+// "cannot determine version ... (use --version to specify)" is the right frame
+// only for a failure --version would actually change. It is wrong for a missing
+// app, and on delete it is harmful: --version does not narrow a delete, and the
+// backend reports deleting an app it never held as success, so following the
+// advice converts a correct exit 1 into a false success.
+func TestResolveVersionInSourceFramesFailureByCause(t *testing.T) {
+	const sources = `{"user_data": {"sources": {"upload": {"type": "local", "app_info_latest": []}}}}`
+
+	t.Run("missing app is reported as itself", func(t *testing.T) {
+		srv := newAppLookupServer(t, sources, `{"apps": []}`)
+		_, err := resolveVersionInSource(newTestMarketClient(t, srv.URL), "clitest", "upload", true)
+
+		if strings.Contains(err.Error(), "cannot determine version") {
+			t.Fatalf("error %q buries the cause under the version wrapper", err)
+		}
+		if !strings.Contains(err.Error(), "not found in source 'upload'") {
+			t.Fatalf("error = %q", err)
+		}
+	})
+
+	t.Run("delete never suggests --version", func(t *testing.T) {
+		// A malformed payload is a failure --version could plausibly work
+		// around, so it reaches the wrapper on both verbs; only the hint differs.
+		srv := newAppLookupServer(t, sources, `{"apps": [["not-an-object"]]}`)
+		mc := newTestMarketClient(t, srv.URL)
+
+		_, installErr := resolveVersionInSource(mc, "clitest", "upload", true)
+		if !strings.Contains(installErr.Error(), "use --version to specify") {
+			t.Fatalf("install error %q dropped the hint", installErr)
+		}
+		_, deleteErr := resolveVersionInSource(mc, "clitest", "upload", false)
+		if strings.Contains(deleteErr.Error(), "--version") {
+			t.Fatalf("delete error %q suggests --version", deleteErr)
+		}
+		if !strings.Contains(deleteErr.Error(), "cannot determine version") {
+			t.Fatalf("delete error %q lost the cause", deleteErr)
+		}
+	})
+}
+
+// newAppLookupServer answers POST /apps with appsJSON and GET /market/data with
+// sourcesJSON; an empty sourcesJSON makes the source list unavailable.
+func newAppLookupServer(t *testing.T, sourcesJSON, appsJSON string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/apps"):
+			_, _ = w.Write([]byte(wrapEnvelope(true, appsJSON)))
+		case strings.HasSuffix(r.URL.Path, "/market/data"):
+			if sourcesJSON == "" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(wrapEnvelope(true, sourcesJSON)))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The suggested remediation command has to be runnable as printed. Without -s,
+// `market get` resolves market.olares, which is not where an uploaded app is.
+func TestEnvValidationErrorPinsTheSourceInItsRemediation(t *testing.T) {
+	withSource := (&envValidationError{
+		AppName:       "clitestenv",
+		Source:        "upload",
+		MissingValues: []string{"CLITEST_TOKEN"},
+	}).Error()
+
+	if !strings.Contains(withSource, "market get clitestenv -s upload'") {
+		t.Fatalf("error %q does not pin the source in the suggested command", withSource)
+	}
+
+	// A verb with no resolved source must not print a bare -s.
+	withoutSource := (&envValidationError{
+		AppName:       "clitestenv",
+		MissingValues: []string{"CLITEST_TOKEN"},
+	}).Error()
+
+	if !strings.Contains(withoutSource, "market get clitestenv'") {
+		t.Fatalf("error %q is malformed without a source", withoutSource)
+	}
+}
 
 // TestResolveInstalledSource verifies the source-resolution guard for the
 // implicit-source verbs (stop / resume / uninstall). It mirrors the SPA's

--- a/cli/cmd/ctl/market/compute.go
+++ b/cli/cmd/ctl/market/compute.go
@@ -2,6 +2,7 @@ package market
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -88,6 +89,74 @@ func (e *computeModeSelectError) Error() string {
 	}
 	return fmt.Sprintf("app %q supports multiple compute modes; re-run with --compute-mode <type> (installable: %s)",
 		e.appName, strings.Join(e.installable, ", "))
+}
+
+// declaredComputeModes returns the compute modes an app's manifest declares,
+// read from spec.accelerator on the catalog entry. An app with no accelerator
+// block declares none: it runs on the CPU and there is no mode to pick.
+func declaredComputeModes(appInfo map[string]interface{}) []string {
+	entries, ok := getNestedValue(appInfo, "app_info", "app_entry", "accelerator").([]interface{})
+	if !ok {
+		return nil
+	}
+	modes := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		item, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if mode := strings.TrimSpace(getStringValue(item, "mode")); mode != "" {
+			modes = append(modes, mode)
+		}
+	}
+	return modes
+}
+
+// checkDeclaredComputeMode rejects a --compute-mode the app cannot honor.
+//
+// The backend only asks for a mode when an app declares more than one, so a
+// mode aimed at a single-mode app -- or at one with no accelerator block at all
+// -- is accepted and then dropped. The install lands on the mode the app
+// declares, no GPU appears anywhere near the pod, and nothing says the flag did
+// nothing. Deciding this locally is what makes it reportable at all.
+//
+// cpu is accepted against any app: every cluster runs it, and no node carries a
+// label for it, so it is never something an app has to declare to get.
+func checkDeclaredComputeMode(appInfo map[string]interface{}, appName, requested string) error {
+	requested = strings.TrimSpace(requested)
+	if requested == "" || normalizeMarketComputeMode(requested) == "cpu" {
+		return nil
+	}
+	declared := declaredComputeModes(appInfo)
+	if len(declared) == 0 {
+		return fmt.Errorf("--compute-mode %q cannot be honored: %q declares no accelerator modes and always runs on the CPU — re-run without --compute-mode",
+			requested, appName)
+	}
+	norm := normalizeMarketComputeMode(requested)
+	for _, mode := range declared {
+		if normalizeMarketComputeMode(mode) == norm {
+			return nil
+		}
+	}
+	return fmt.Errorf("--compute-mode %q is not a declared mode for %q (declared: %s)",
+		requested, appName, strings.Join(declared, ", "))
+}
+
+// preflightComputeMode is checkDeclaredComputeMode with the catalog read in
+// front of it, for the verb that does not already hold the app's entry. A read
+// that fails leaves the mode unchecked rather than blocking the operation --
+// the backend still has the final say on a mode it does support.
+func preflightComputeMode(ctx context.Context, opts *MarketOptions, mc *MarketClient, appName, source, requested string) error {
+	if strings.TrimSpace(requested) == "" {
+		return nil
+	}
+	appInfo, err := fetchAppInfo(ctx, mc, appName, source)
+	if err != nil {
+		opts.info("warning: preflight could not read catalog metadata for '%s' from source '%s' (%v); leaving --compute-mode to the backend",
+			appName, source, err)
+		return nil
+	}
+	return checkDeclaredComputeMode(appInfo, appName, requested)
 }
 
 // resolveComputeMode turns a computeModeSelect 422 payload into the

--- a/cli/cmd/ctl/market/compute.go
+++ b/cli/cmd/ctl/market/compute.go
@@ -92,8 +92,7 @@ func (e *computeModeSelectError) Error() string {
 }
 
 // declaredComputeModes returns the compute modes an app's manifest declares,
-// read from spec.accelerator on the catalog entry. An app with no accelerator
-// block declares none: it runs on the CPU and there is no mode to pick.
+// read from spec.accelerator on the catalog entry.
 func declaredComputeModes(appInfo map[string]interface{}) []string {
 	entries, ok := getNestedValue(appInfo, "app_info", "app_entry", "accelerator").([]interface{})
 	if !ok {
@@ -112,6 +111,43 @@ func declaredComputeModes(appInfo map[string]interface{}) []string {
 	return modes
 }
 
+// declaresLegacyGPU reports whether a manifest with no accelerator matrix still
+// asks for a GPU through the flattened requiredGPU cap that pre-0.12.0
+// manifests carry. app-service synthesizes a single nvidia mode for these
+// (appcfg legacyComputeMode: a non-zero Requirement.GPU becomes nvidia, and an
+// explicit SelectedGpuType is taken verbatim), so a GPU mode aimed at one of
+// them is not the no-op that an accelerator-less CPU app would make it.
+func declaresLegacyGPU(appInfo map[string]interface{}) bool {
+	entry, ok := getNestedValue(appInfo, "app_info", "app_entry").(map[string]interface{})
+	if !ok {
+		return false
+	}
+	return isNonZeroQuantity(getStringValue(entry, "requiredGPU"))
+}
+
+// isNonZeroQuantity reports whether a k8s quantity string ("3Gi", "0", "")
+// asks for something. Only the numeric prefix matters here: the unit cannot
+// turn a zero into a non-zero, and an unparseable value is treated as a
+// request so an odd manifest never produces a wrong refusal.
+func isNonZeroQuantity(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	digits := strings.IndexFunc(raw, func(r rune) bool {
+		return (r < '0' || r > '9') && r != '.' && r != '-' && r != '+'
+	})
+	num := raw
+	if digits >= 0 {
+		num = raw[:digits]
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(num), 64)
+	if err != nil {
+		return true
+	}
+	return v > 0
+}
+
 // checkDeclaredComputeMode rejects a --compute-mode the app cannot honor.
 //
 // The backend only asks for a mode when an app declares more than one, so a
@@ -119,6 +155,11 @@ func declaredComputeModes(appInfo map[string]interface{}) []string {
 // -- is accepted and then dropped. The install lands on the mode the app
 // declares, no GPU appears anywhere near the pod, and nothing says the flag did
 // nothing. Deciding this locally is what makes it reportable at all.
+//
+// The accelerator matrix is the only basis for a refusal. A legacy manifest
+// without one has no mode list to check against, so the only thing decidable
+// locally is whether it asks for a GPU at all: one that does is left to the
+// backend, one that does not can be told the flag is a no-op.
 //
 // cpu is accepted against any app: every cluster runs it, and no node carries a
 // label for it, so it is never something an app has to declare to get.
@@ -129,6 +170,9 @@ func checkDeclaredComputeMode(appInfo map[string]interface{}, appName, requested
 	}
 	declared := declaredComputeModes(appInfo)
 	if len(declared) == 0 {
+		if declaresLegacyGPU(appInfo) {
+			return nil
+		}
 		return fmt.Errorf("--compute-mode %q cannot be honored: %q declares no accelerator modes and always runs on the CPU — re-run without --compute-mode",
 			requested, appName)
 	}

--- a/cli/cmd/ctl/market/compute_test.go
+++ b/cli/cmd/ctl/market/compute_test.go
@@ -38,6 +38,15 @@ func TestCheckDeclaredComputeMode(t *testing.T) {
 	noAccelerator := map[string]interface{}{
 		"app_info": map[string]interface{}{"app_entry": map[string]interface{}{}},
 	}
+	// A pre-0.12.0 manifest asks for a GPU through the flattened cap instead of
+	// an accelerator matrix, and app-service synthesizes an nvidia mode for it.
+	legacyGPU := func(requiredGPU string) map[string]interface{} {
+		return map[string]interface{}{
+			"app_info": map[string]interface{}{
+				"app_entry": map[string]interface{}{"requiredGPU": requiredGPU},
+			},
+		}
+	}
 
 	cases := []struct {
 		name      string
@@ -51,6 +60,19 @@ func TestCheckDeclaredComputeMode(t *testing.T) {
 		{"declared mode passes", entry("nvidia"), "nvidia", ""},
 		{"underscore spelling of a declared mode passes", entry("nvidia-gb10"), "nvidia_gb10", ""},
 		{"undeclared mode names the declared ones", entry("nvidia", "apple-m"), "intel", "declared: nvidia, apple-m"},
+		{"legacy flattened gpu cap is left to the backend", legacyGPU("3Gi"), "nvidia", ""},
+		{"legacy zero gpu cap is still cpu-only", legacyGPU("0"), "nvidia", "declares no accelerator modes"},
+		{"legacy empty gpu cap is still cpu-only", legacyGPU(""), "nvidia", "declares no accelerator modes"},
+		// An accelerator matrix is authoritative even next to a stale
+		// flattened cap, so an undeclared mode is still refused.
+		{"accelerator matrix wins over a flattened cap", map[string]interface{}{
+			"app_info": map[string]interface{}{
+				"app_entry": map[string]interface{}{
+					"accelerator": []interface{}{map[string]interface{}{"mode": "apple-m"}},
+					"requiredGPU": "3Gi",
+				},
+			},
+		}, "nvidia", "declared: apple-m"},
 	}
 
 	for _, tc := range cases {

--- a/cli/cmd/ctl/market/compute_test.go
+++ b/cli/cmd/ctl/market/compute_test.go
@@ -17,6 +17,61 @@ func failedCheckResp(checkType, dataJSON string) *APIResponse {
 	return &APIResponse{Data: json.RawMessage(inner)}
 }
 
+// The backend only asks for a compute mode when the app declares more than
+// one, so a mode aimed at an app that declares one -- or none -- was accepted,
+// dropped, and never mentioned again: the app came up on the CPU with no GPU
+// anywhere near the pod and no warning that the flag did nothing.
+func TestCheckDeclaredComputeMode(t *testing.T) {
+	entry := func(modes ...string) map[string]interface{} {
+		accelerator := make([]interface{}, 0, len(modes))
+		for _, mode := range modes {
+			accelerator = append(accelerator, map[string]interface{}{"mode": mode})
+		}
+		return map[string]interface{}{
+			"app_info": map[string]interface{}{
+				"app_entry": map[string]interface{}{"accelerator": accelerator},
+			},
+		}
+	}
+	// An app that declares nothing has no accelerator key at all, which is what
+	// the chart that found this looked like.
+	noAccelerator := map[string]interface{}{
+		"app_info": map[string]interface{}{"app_entry": map[string]interface{}{}},
+	}
+
+	cases := []struct {
+		name      string
+		appInfo   map[string]interface{}
+		requested string
+		wantErr   string
+	}{
+		{"no mode requested passes anything", noAccelerator, "", ""},
+		{"cpu is never something an app must declare", noAccelerator, "cpu", ""},
+		{"gpu mode on a cpu-only app is refused", noAccelerator, "nvidia", "declares no accelerator modes"},
+		{"declared mode passes", entry("nvidia"), "nvidia", ""},
+		{"underscore spelling of a declared mode passes", entry("nvidia-gb10"), "nvidia_gb10", ""},
+		{"undeclared mode names the declared ones", entry("nvidia", "apple-m"), "intel", "declared: nvidia, apple-m"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkDeclaredComputeMode(tc.appInfo, "clitest", tc.requested)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("error = nil, want a refusal")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestInstallRequestWireFormat(t *testing.T) {
 	// Without a compute mode the field is omitted entirely (1.12.5 wire
 	// stays byte-identical to before SelectedGpuType existed).

--- a/cli/cmd/ctl/market/delete.go
+++ b/cli/cmd/ctl/market/delete.go
@@ -67,9 +67,12 @@ func runDelete(opts *MarketOptions, appName string) error {
 		}
 		opts.info("note: --version names the request but does not narrow the delete; every uploaded version of '%s' will be removed", appName)
 	} else {
-		v, err := resolveVersionInSource(mc, appName, source)
+		// --version does not narrow a delete, so a failure here must not
+		// suggest it: the backend answers a delete of an app it does not hold
+		// with success, which turns this correct failure into a false one.
+		v, err := resolveVersionInSource(mc, appName, source, false)
 		if err != nil {
-			return opts.failOp("delete", appName, fmt.Errorf("cannot determine version in source '%s': %w (use --version to specify)", source, err))
+			return opts.failOp("delete", appName, err)
 		}
 		version = v
 		opts.info("Using version: %s", version)

--- a/cli/cmd/ctl/market/env.go
+++ b/cli/cmd/ctl/market/env.go
@@ -14,7 +14,12 @@ import (
 )
 
 type envValidationError struct {
-	AppName       string
+	AppName string
+	// Source is the source the failing verb resolved. It is carried so the
+	// suggested `market get` command can be pinned to it: without -s, get
+	// resolves market.olares, which is the wrong bucket for an app that came
+	// from an upload and makes the copied command fail on its own.
+	Source        string
 	MissingValues []string
 	MissingRefs   []string
 	InvalidValues []string
@@ -59,6 +64,10 @@ func formatEnvValidationError(e *envValidationError) string {
 
 	b.WriteString("\nRun 'olares-cli market get ")
 	b.WriteString(e.AppName)
+	if source := strings.TrimSpace(e.Source); source != "" {
+		b.WriteString(" -s ")
+		b.WriteString(source)
+	}
 	b.WriteString("' to inspect the declared envs, then use --env KEY=VALUE to provide or correct values.")
 	return b.String()
 }
@@ -171,7 +180,7 @@ func tryFetchRemoteOptions(endpoint string) ([]sysv1alpha1.EnvValueOptionItem, e
 
 // parseServerEnvError extracts env validation details from a failed API response.
 // This handles the case where the market service wraps app-service's 422 response.
-func parseServerEnvError(resp *APIResponse, appName string) *envValidationError {
+func parseServerEnvError(resp *APIResponse, appName, source string) *envValidationError {
 	if resp == nil || len(resp.Data) == 0 {
 		return nil
 	}
@@ -184,6 +193,7 @@ func parseServerEnvError(resp *APIResponse, appName string) *envValidationError 
 
 	result := &envValidationError{
 		AppName:       appName,
+		Source:        source,
 		MissingValues: envNames(checkResult.MissingValues),
 		MissingRefs:   envNames(checkResult.MissingRefs),
 		InvalidValues: envNames(checkResult.InvalidValues),

--- a/cli/cmd/ctl/market/install.go
+++ b/cli/cmd/ctl/market/install.go
@@ -86,9 +86,9 @@ func runInstall(opts *MarketOptions, appName string) error {
 			return opts.failOp("install", appName, err)
 		}
 	} else {
-		v, err := resolveVersionInSource(mc, appName, source)
+		v, err := resolveVersionInSource(mc, appName, source, true)
 		if err != nil {
-			return opts.failOp("install", appName, fmt.Errorf("cannot determine version in source '%s': %w (use --version to specify)", source, err))
+			return opts.failOp("install", appName, err)
 		}
 		version = v
 		opts.info("Using latest version: %s", version)
@@ -121,6 +121,10 @@ func runInstall(opts *MarketOptions, appName string) error {
 		return opts.failOp("install", appName, fmt.Errorf("--compute-mode requires Olares 1.12.6+; this backend uses a different (unchanged) install path — re-run without --compute-mode"))
 	}
 
+	if err := preflightComputeMode(ctx, opts, mc, appName, source, computeMode); err != nil {
+		return opts.failOp("install", appName, err)
+	}
+
 	opts.info("Installing '%s' version '%s' from '%s' for user '%s'...", appName, version, source, mc.olaresID)
 
 	selected := ""
@@ -147,7 +151,7 @@ func runInstall(opts *MarketOptions, appName string) error {
 		}
 	}
 	if err != nil {
-		if envErr := parseServerEnvError(resp, appName); envErr != nil {
+		if envErr := parseServerEnvError(resp, appName, source); envErr != nil {
 			return opts.failOp("install", appName, envErr)
 		}
 		return opts.failOp("install", appName, err)

--- a/cli/cmd/ctl/market/list.go
+++ b/cli/cmd/ctl/market/list.go
@@ -24,10 +24,12 @@ func NewCmdMarketList(f *cmdutil.Factory) *cobra.Command {
 
 Without --mine this browses the catalog (/market/data): the CLI
 auto-selects a source from market settings (use -s to override, -a to
-span every source the user has). Valid source ids are 'market.olares'
-(the remote catalog) and 'cli' / 'upload' / 'studio' (the three local
-chart sources). Unknown ids silently produce an empty result with a
-"no apps in source 'X'" stderr hint.
+span every source the user has). Which source ids exist is a per-cluster
+setting, so -a is how you find out; a cluster subscribed to the staging
+catalog also has 'market.test'. The usual ones are 'market.olares' (the
+public catalog) and 'cli' / 'upload' / 'studio' (the local chart
+buckets). An id this cluster does not have produces an empty result with
+a "no apps in source 'X'" stderr hint rather than an error.
 
 Pass --mine (-m) to instead list the active profile's apps from
 /market/state — the same set the Market UI's "My Terminus" tab shows.
@@ -87,9 +89,10 @@ func NewCmdMarketCategories(f *cmdutil.Factory) *cobra.Command {
 		Long: `List app categories with counts across market sources.
 
 By default queries the auto-selected source. Use -s to pin to a specific
-source ('market.olares' for the remote catalog, 'cli' / 'upload' /
-'studio' for local helm-chart sources); use -a to span every source
-the user has configured.
+source ('market.olares' for the public catalog, 'market.test' for the
+staging one where a cluster subscribes to it, 'cli' / 'upload' / 'studio'
+for local helm-chart buckets); use -a to span every source the user has
+configured, which is also how to see which ids this cluster has.
 
 Examples:
   olares-cli market categories                    # auto-selected source

--- a/cli/cmd/ctl/market/root.go
+++ b/cli/cmd/ctl/market/root.go
@@ -48,7 +48,11 @@ Universal flags:
   -q, --quiet                 every verb. Suppress output; exit code wins.
   -s, --source <id>           source-aware verbs (catalog + install /
                               upgrade / clone / download).
-                              Valid ids: market.olares, cli, upload, studio.
+                              Which ids exist is per cluster, so read them
+                              off "market list -a" rather than from here.
+                              Common ones: market.olares (public catalog),
+                              market.test (staging catalog), and the local
+                              chart buckets upload / cli / studio.
   -a, --all-sources           list, categories, status.
       --no-headers            list, categories (row-oriented browse only;
                               "get" prints a key:value detail view that

--- a/cli/cmd/ctl/market/status.go
+++ b/cli/cmd/ctl/market/status.go
@@ -22,7 +22,10 @@ func NewCmdMarketStatus(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"stat", "st"},
 		Short:   "Show runtime state / progress for installed apps (read /market/state)",
 		Long: `Show runtime status of installed apps. Output is the live
-state row (STATE / OPERATION / PROGRESS / SOURCE), not the catalog.
+state row (VERSION / STATE / OPERATION / PROGRESS / SOURCE), not the
+catalog. VERSION is the version the row records, i.e. the one last
+requested — a row at upgradeFailed still names the target that failed,
+not what is running.
 
 Two forms:
 
@@ -77,8 +80,16 @@ Examples:
 }
 
 type statusRow struct {
-	Name     string `json:"name"`
-	State    string `json:"state"`
+	Name  string `json:"name"`
+	State string `json:"state"`
+	// Version is the version this state row records, which is the one the user
+	// last asked for -- not necessarily the one running. A row left at
+	// upgradeFailed still names the target that failed, because that is what
+	// the request set. Reading the version actually deployed means asking the
+	// workload (`olares-cli cluster ...`), not this row. It is reported here
+	// anyway because status is where a reader looks first, and `list --mine`
+	// reports the same field from the same place: the two agreeing is the point.
+	Version  string `json:"version,omitempty"`
 	OpType   string `json:"opType,omitempty"`
 	Progress string `json:"progress,omitempty"`
 	CfgType  string `json:"cfgType,omitempty"`
@@ -131,6 +142,7 @@ func parseStatusRows(resp *APIResponse, source string, showAll bool) ([]statusRo
 			}
 			rows = append(rows, statusRow{
 				Name:       name,
+				Version:    strings.TrimSpace(appState.Version),
 				State:      appState.Status.State,
 				OpType:     appState.Status.OpType,
 				Progress:   progress,
@@ -264,9 +276,13 @@ func runStatusAll(opts *MarketOptions) error {
 	// code, and -o json still emits a structured payload with no
 	// columns at all.
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSTATE\tOPERATION\tPROGRESS\tSOURCE")
+	fmt.Fprintln(w, "NAME\tVERSION\tSTATE\tOPERATION\tPROGRESS\tSOURCE")
 	for _, r := range rows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.Name, r.State, r.OpType, r.Progress, r.Source)
+		version := r.Version
+		if version == "" {
+			version = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.Name, version, r.State, r.OpType, r.Progress, r.Source)
 	}
 	w.Flush()
 	return nil

--- a/cli/cmd/ctl/market/status.go
+++ b/cli/cmd/ctl/market/status.go
@@ -391,6 +391,9 @@ func renderStatusMatches(opts *MarketOptions, matches []statusRow) error {
 		}
 		fmt.Printf("App:        %s\n", match.Name)
 		fmt.Printf("Source:     %s\n", match.Source)
+		if match.Version != "" {
+			fmt.Printf("Version:    %s\n", match.Version)
+		}
 		fmt.Printf("State:      %s\n", match.State)
 		if match.OpType != "" {
 			fmt.Printf("Operation:  %s\n", match.OpType)

--- a/cli/cmd/ctl/market/status_version_test.go
+++ b/cli/cmd/ctl/market/status_version_test.go
@@ -1,0 +1,50 @@
+package market
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// status is where a reader looks first to answer "what is this app doing", and
+// it used to answer everything except which version. Finding that out meant a
+// second command against a different endpoint, which is also how the two came
+// to disagree without anyone noticing.
+//
+// The version lives beside `status` on the state row rather than inside it (see
+// AppStateLatest.Version), which is the reason it was missed.
+func TestParseStatusRowsCarriesTheRowVersion(t *testing.T) {
+	const state = `{
+        "user_data": {
+            "sources": {
+                "upload": {
+                    "type": "local",
+                    "app_state_latest": [
+                        {"version": "0.1.8", "status": {"name": "clitest", "state": "running"}},
+                        {"status": {"name": "noversion", "state": "running"}}
+                    ]
+                }
+            }
+        }
+    }`
+
+	rows, err := parseStatusRows(&APIResponse{Data: json.RawMessage(state)}, "upload", false)
+	if err != nil {
+		t.Fatalf("parseStatusRows: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+
+	byName := map[string]statusRow{}
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+	if got := byName["clitest"].Version; got != "0.1.8" {
+		t.Fatalf("clitest version = %q, want 0.1.8", got)
+	}
+	// A row without a version must stay empty rather than borrow the catalog's
+	// latest, which is the wrong answer as soon as the catalog moves ahead.
+	if got := byName["noversion"].Version; got != "" {
+		t.Fatalf("noversion version = %q, want empty", got)
+	}
+}

--- a/cli/cmd/ctl/market/status_version_test.go
+++ b/cli/cmd/ctl/market/status_version_test.go
@@ -1,7 +1,10 @@
 package market
 
 import (
+	"bufio"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -47,4 +50,60 @@ func TestParseStatusRowsCarriesTheRowVersion(t *testing.T) {
 	if got := byName["noversion"].Version; got != "" {
 		t.Fatalf("noversion version = %q, want empty", got)
 	}
+}
+
+// `market status <app>` renders a detail block rather than the table, so the
+// version has to be printed there too or the single-app reader — the one who
+// asked about exactly this app — is the only one who still cannot see it.
+func TestRenderStatusMatchesPrintsTheVersion(t *testing.T) {
+	withVersion := captureStdout(t, func() {
+		if err := renderStatusMatches(&MarketOptions{}, []statusRow{{
+			Name: "clitest", Source: "upload", Version: "0.1.8", State: "running",
+		}}); err != nil {
+			t.Fatalf("renderStatusMatches: %v", err)
+		}
+	})
+	if !strings.Contains(withVersion, "Version:    0.1.8") {
+		t.Fatalf("detail block does not report the version:\n%s", withVersion)
+	}
+
+	// A synthesized watch row can carry no version; an empty label is worse
+	// than no label, so the line is dropped entirely.
+	withoutVersion := captureStdout(t, func() {
+		if err := renderStatusMatches(&MarketOptions{}, []statusRow{{
+			Name: "clitest", Source: "upload", State: "running",
+		}}); err != nil {
+			t.Fatalf("renderStatusMatches: %v", err)
+		}
+	})
+	if strings.Contains(withoutVersion, "Version:") {
+		t.Fatalf("detail block prints an empty version line:\n%s", withoutVersion)
+	}
+}
+
+// captureStdout collects what a renderer wrote, for the paths that print with
+// fmt.Printf straight to os.Stdout.
+func captureStdout(t *testing.T, run func()) string {
+	t.Helper()
+	saved := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	run()
+	os.Stdout = saved
+	w.Close()
+	defer r.Close()
+
+	var sb strings.Builder
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		sb.WriteString(scanner.Text())
+		sb.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return sb.String()
 }

--- a/cli/cmd/ctl/market/upgrade.go
+++ b/cli/cmd/ctl/market/upgrade.go
@@ -94,9 +94,9 @@ func runUpgrade(opts *MarketOptions, appName string) error {
 			return opts.failOp("upgrade", appName, err)
 		}
 	} else {
-		v, err := resolveVersionInSource(mc, appName, source)
+		v, err := resolveVersionInSource(mc, appName, source, true)
 		if err != nil {
-			return opts.failOp("upgrade", appName, fmt.Errorf("cannot determine version in source '%s': %w (use --version to specify)", source, err))
+			return opts.failOp("upgrade", appName, err)
 		}
 		version = v
 		opts.info("Using latest version: %s", version)

--- a/cli/cmd/ctl/market/upload.go
+++ b/cli/cmd/ctl/market/upload.go
@@ -156,7 +156,16 @@ func uploadDir(opts *MarketOptions, mc *MarketClient, dir, source string) error 
 	}
 
 	if opts.isJSON() {
-		return opts.printJSON(results)
+		// The per-file report is the output either way; what a caller in a
+		// pipeline reads is the exit code, so it has to agree with the quiet
+		// and table branches rather than reporting the encode alone.
+		if err := opts.printJSON(results); err != nil {
+			return err
+		}
+		if failed > 0 {
+			return errReported
+		}
+		return nil
 	}
 
 	if failed > 0 {

--- a/cli/cmd/ctl/market/upload_test.go
+++ b/cli/cmd/ctl/market/upload_test.go
@@ -78,6 +78,109 @@ func TestUploadUnknownCodeKeepsGenericAPIError(t *testing.T) {
 	}
 }
 
+// A directory upload's exit code is the aggregate verdict, and the output mode
+// must not change it. -o json used to return the encoder's own error, so a run
+// where every chart was rejected still exited 0 and CI read it as a clean
+// publish.
+func TestUploadDirExitCodeIsIndependentOfOutputMode(t *testing.T) {
+	srv := newUploadPerFileServer(t)
+
+	modes := []struct {
+		name string
+		opts func() *MarketOptions
+	}{
+		{"table", func() *MarketOptions { return &MarketOptions{Output: "table"} }},
+		{"json", func() *MarketOptions { return &MarketOptions{Output: "json"} }},
+		{"quiet", func() *MarketOptions { return &MarketOptions{Output: "table", Quiet: true} }},
+	}
+	mixes := []struct {
+		name       string
+		charts     []string
+		wantFailed bool
+	}{
+		{"partial failure", []string{"good-1.0.0.tgz", "bad-1.0.0.tgz"}, true},
+		{"total failure", []string{"bad-1.0.0.tgz", "bad-2.0.0.tgz"}, true},
+		{"no failure", []string{"good-1.0.0.tgz", "good-2.0.0.tgz"}, false},
+	}
+
+	for _, mode := range modes {
+		for _, mix := range mixes {
+			t.Run(mode.name+"/"+mix.name, func(t *testing.T) {
+				dir := chartDir(t, mix.charts...)
+				var err error
+				discardStdout(t, func() {
+					err = uploadDir(mode.opts(), newTestMarketClient(t, srv.URL), dir, chartUploadSource)
+				})
+
+				if mix.wantFailed && !errors.Is(err, errReported) {
+					t.Fatalf("error = %v, want errReported so the process exits non-zero", err)
+				}
+				if !mix.wantFailed && err != nil {
+					t.Fatalf("error = %v, want nil", err)
+				}
+			})
+		}
+	}
+}
+
+// newUploadPerFileServer accepts a chart whose filename starts with "good" and
+// rejects one starting with "bad", so a single server serves both the partial
+// and the total failure mixes.
+func newUploadPerFileServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app-store/api/v2/apps/upload" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		name := ""
+		if files := r.MultipartForm.File["chart"]; len(files) > 0 {
+			name = files[0].Filename
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(name, "bad") {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, `{"success": false, "message": "Failed to process uploaded package"}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"success": true, "message": "uploaded", "data": {}}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func chartDir(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("chart"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// discardStdout keeps the JSON report out of `go test` output. printJSON writes
+// to os.Stdout directly, so the only way to silence it is to replace the file.
+func discardStdout(t *testing.T, run func()) {
+	t.Helper()
+	saved := os.Stdout
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = devNull
+	defer func() {
+		os.Stdout = saved
+		devNull.Close()
+	}()
+	run()
+}
+
 func newUploadErrorServer(t *testing.T, status int, body string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/skills/olares-chart/references/olares-chart-lint.md
+++ b/cli/skills/olares-chart/references/olares-chart-lint.md
@@ -30,7 +30,7 @@ olares-cli chart lint ./myapp --auto-owner=false --owner alice --admin root
 
 | Stage | Catches | Skip flag |
 |---|---|---|
-| Folder layout | missing `Chart.yaml` / `values.yaml` / `templates/` / `OlaresManifest.yaml` | `--skip-folder` |
+| Folder layout | missing `Chart.yaml` / `values.yaml` / `templates/` / `OlaresManifest.yaml`; **directory name ≠ chart name** | `--skip-folder` |
 | Manifest validation | structural + cross-field errors in `OlaresManifest.yaml` | `--skip-manifest` |
 | Helm dry-run + workload integrity | templates don't render, or no `Deployment`/`StatefulSet` named after the app | (always) |
 | Resource limits | containers missing CPU/memory limits | `--skip-resource` |
@@ -55,6 +55,7 @@ By default lint renders the chart under **both** `owner==admin` (admin install) 
 
 | Message | Cause | Fix |
 |---|---|---|
+| `inconsistent info. name must be the same in chart. name in Chart.yaml:<a>, chartFolder:<b>, OlaresManifest.yaml:<c>` | the **chart directory name** is part of the identity, not just the two `name` fields | rename the directory to match. This is the first thing a copied-and-renamed chart hits: copying `myapp/` to `myapp2/` and editing only the two manifests fails here |
 | `must have a Deployment or StatefulSet named "<app>"` | no workload named after the app | rename the primary workload's `metadata.name` to the app name (`from-compose` does this automatically) |
 | app-data / permission mismatch | template mounts `.Values.userspace.*` not declared in `permission` (or reverse) | align `permission.appData/appCache/userData` with template mounts |
 | `Chart.yaml` vs manifest version mismatch | the two `version` fields differ | set them equal |

--- a/cli/skills/olares-doctor/references/olares-doctor-image.md
+++ b/cli/skills/olares-doctor/references/olares-doctor-image.md
@@ -13,6 +13,14 @@ olares-cli cluster pod list -n <ns> -o json     # state.waiting.reason on the fa
 olares-cli cluster pod events <ns>/<pod>        # "Failed to pull image ...": the registry/auth/arch detail
 ```
 
+**During an `upgrade` there is no failing pod to inspect.** app-service pulls the new images itself before touching the release, so a bad tag fails inside that download while the old pods stay healthy — the two commands above find nothing wrong. The only surface that reports it is the app's own state row, which is what `market status <app>` prints:
+
+```bash
+olares-cli market status <app> -o json          # .state = upgradeFailed, .message = the pull error
+```
+
+Expect it to take a minute or two: the download retries several times before giving up. `market get <app> -s <source> -o json` also shows `registry_error` on the offending image, recorded at upload time — but treat that as a hint, not a verdict, since it does not separate a missing tag from a registry that failed to answer once.
+
 | Reason | Root cause | Next step |
 |---|---|---|
 | `ImagePullBackOff` / `ErrImagePull` | Image missing, private without creds, or registry/mirror unreachable | Confirm the ref is public & pullable; if a mirror is down, treat it as the app-stuck stalled-pull path |

--- a/cli/skills/olares-market/references/olares-market-chart-publish.md
+++ b/cli/skills/olares-market/references/olares-market-chart-publish.md
@@ -23,7 +23,7 @@ olares-cli market upload ./mychart.tgz -q              # exit code only
 - Takes **exactly one path argument** — a single `.tgz` / `.tar.gz` file, or one directory. To upload several charts at once, point it at a directory; it does not accept multiple file arguments.
 - Directory mode uploads every `.tgz` / `.tar.gz` directly under the directory. **Subdirectories are NOT recursed.**
 - **Per-file results are summarized at the end.** `-o json` emits a structured report with one entry per file (`status` / `message`).
-- **Exit code is the OR of per-file results** — any single failure flips the overall exit non-zero.
+- **Exit code is the OR of per-file results** — any single failure flips the overall exit non-zero, in every output mode. `-o json` still prints the full report on the way out, so a script reads the exit code and the report, not one or the other.
 - Multipart upload through a dedicated `uploadClient` with no timeout (chart pushes can be slow over large WAN links). The same `refreshingTransport` is shared with the JSON client, so a token refresh on one is immediately visible on the other.
 
 ### What is finished when upload returns
@@ -56,10 +56,11 @@ olares-cli market delete mychart -o json
 olares-cli market delete mychart -q
 ```
 
-- **Does NOT uninstall the app if it is running.** Use `market uninstall <app>` first, then `market delete` to also remove the chart from local sources.
+- **Refused while the app is installed.** The backend rejects the delete with `app (or its clone <name>) is still installing/running; please uninstall it first` rather than unpublishing a chart something is running from. Run `market uninstall <app>` first, then `market delete`.
 - **`--version` does not narrow the delete.** The backend takes the app name and drops every version and every stored artifact; the version only names the request. There is no single-version delete today, so read this verb as "unpublish the app", and expect `market download mychart --version <any>` to stop working for all versions afterwards, not just the one named.
+- **Deleting an app the bucket never held returns success.** The backend treats it as already done and answers HTTP 200; `deleted_rows` in the response is what distinguishes the two, and the CLI does not read it. Without `--version` the CLI's own version lookup fails first and you get a correct non-zero exit — so do **not** add `--version` to get past that failure, which converts it into a false success.
 
-> The "delete the chart" and "uninstall the running app" are deliberately separate verbs. A chart can be uploaded without ever being installed; an installed app can keep running after the source chart is deleted from the bucket.
+> The "delete the chart" and "uninstall the running app" are deliberately separate verbs, in that order: a chart can be uploaded without ever being installed, but it cannot be unpublished out from under a running app.
 
 ## Agent workflows
 
@@ -78,27 +79,26 @@ olares-cli market upload ./dist/ -o json | jq '.[] | select(.status != "success"
 # JSON exit code is the OR of all per-file results; the jq filter surfaces the failures
 ```
 
-```bash
-# Spring cleaning: remove every version of a chart from the upload bucket.
-olares-cli market delete mychart                                   # all versions
-olares-cli market list -s upload                                   # confirm
-```
-
 ## Safety constraints
 
-- **`delete` is destructive** — it removes the chart from the bucket. If the app is still running, the deployment continues to work but you can no longer reinstall from the local bucket.
-- **A published version's bytes are immutable.** `upload` requires a **strictly higher** version than the stored one; re-uploading a version that already exists is refused with HTTP 409 `version <v> already exists for app <name> in source upload; bump the version to publish changes`, and a lower version is refused too. To ship a change, bump the version inside `Chart.yaml` and upload that.
+- **`delete` is destructive** — it unpublishes every version of the app from the bucket, so nothing can be installed or downloaded from it afterwards. It is refused while the app is installed, so it cannot strand a running deployment.
+- **A published version's bytes are immutable.** `upload` requires a **strictly higher** version than the stored one. Re-uploading the stored version is refused with HTTP 409 `version <v> already exists for app <name> in source upload; bump the version to publish changes`; a **lower** version is refused with `version <v> does not supersede version <stored> already published for app <name> in source upload; upload a version higher than <stored>`. The two messages are worth telling apart, because the second one names a version you did not send. To ship a change, bump the version inside `Chart.yaml` and upload that.
 
-  Most of what is confusing about versions here follows from that one rule. A same-version `upgrade` is legal, but since the stored bytes cannot have changed it re-applies the *same* chart — it is a retry, not a way to deploy an edit. Recovering an `upgradeFailed` app with a *fixed* chart therefore needs a new version, not a re-upload of the old one. And `delete` frees the version only by removing the entire app (see above), so it is not a way to republish one release.
+  Most of what is confusing about versions here follows from that one rule. A same-version `upgrade` is legal — but see [which chart a version actually deploys](olares-market-lifecycle-add.md#which-chart-a-version-actually-deploys), which is not always the version you named. Recovering an `upgradeFailed` app with a *fixed* chart needs a new version, not a re-upload of the old one. And `delete` frees the version only by removing the entire app (see above), so it is not a way to republish one release.
 
 ## Common errors
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `unsupported file extension: must be .tgz or .tar.gz` | Wrong file type | Repackage with `helm package` |
+| `unsupported file format: expected .tgz or .tar.gz` | Wrong file type; refused locally before any request | Repackage with `helm package` |
 | `failed to upload: HTTP 413 (Payload Too Large)` | Chart exceeds the server's upload size limit | Slim the chart's contents; ask the operator about the limit |
+| `HTTP 400: Uploaded package could not be read as a chart archive` | The bytes are not a readable gzipped tar (truncated or partial transfer) | Repackage and re-upload; retrying the same bytes cannot help |
+| `HTTP 400: Uploaded package contains no chart directory with an OlaresManifest.yaml` | The archive holds the chart's *contents* rather than the chart directory | Repackage from the parent directory (`helm package ./mychart`) |
+| `HTTP 400: Invalid OlaresManifest.yaml: <field / rule>` | The manifest was found and rejected; the detail is the same verdict `olares-cli chart lint` prints | Fix the named field and repackage. Run `chart lint` first to see it without an upload |
+| `HTTP 400: Failed to process uploaded package` | The catch-all: the failure was **not** in the uploaded bytes, so nothing about it is safe to report to the caller | Ask the operator for the market log line; do not repackage on a guess |
 | `upload rejected: manifest supports [...] cluster provides [...]` | `spec.supportArch` has no intersection with the current cluster nodes | Check `olares-cli cluster node list`, fix `supportArch` and image platforms, then repackage; do not bump or retry the unchanged package |
 | `upload blocked: cluster node discovery is unavailable` | Market cannot yet establish an authoritative node architecture set | Keep the package and version unchanged; retry after node discovery recovers |
-| `chart not found in source 'upload'` (delete) | The chart was never uploaded, or was uploaded to a different bucket | `market list -s upload` to confirm |
-| `delete` removed the chart but the app keeps running | `delete` only removes the chart from the `upload` bucket; it never uninstalls | Expected — run `market uninstall X` separately to stop/remove the app |
+| `app 'X' not found in source 'upload'` (delete) | The chart was never uploaded, or was uploaded to a different bucket | `market list -s upload` to confirm. Do **not** add `--version` — that skips the lookup and returns a false success |
+| `app (or its clone X) is still installing/running; please uninstall it first` (delete) | The app is installed, so the chart cannot be unpublished | `market uninstall X --watch`, then `market delete X` |
+| `unknown market source 'X': this cluster has ...` | Typo in `-s`, or a source this cluster is not subscribed to | Use one of the listed ids; `market list -a` enumerates them |
 | Exit non-zero on directory upload despite some files succeeding | Partial failure | Inspect the per-file JSON report for which files failed |

--- a/cli/skills/olares-market/references/olares-market-lifecycle-add.md
+++ b/cli/skills/olares-market/references/olares-market-lifecycle-add.md
@@ -33,12 +33,25 @@ Mirrors the SPA's `canUpgrade()`. Bails locally with a self-contained error (for
 
 1. **Row exists** — state row found via `Name` or `RawName` (clones included)
 2. **State is upgradable** — `running` / `stopped` / `stopFailed` / `upgradeFailed` / `applyEnvFailed`
-3. **Newer chart available** — `targetVersion > installedVersion` (semver compare). **Exception for `-s upload`:** `targetVersion == installedVersion` is allowed, because app-service gates on `>= deployed`. It re-applies the **stored** chart at that version, so use it to retry an upgrade that failed for a transient reason. It cannot deploy an edited chart: a published version's bytes are immutable and re-uploading one is refused (see [the immutability rule](olares-market-chart-publish.md#safety-constraints)), so recovering an `upgradeFailed` app with a *fixed* chart means bumping the version. A true downgrade (`target < installed`) is still rejected for every source.
+3. **Newer chart available** — `targetVersion > installedVersion` (semver compare). **Exception for `-s upload`:** `targetVersion == installedVersion` is allowed, because app-service gates on `>= deployed`. Use it to retry an upgrade that failed for a transient reason — but read [which chart a version actually deploys](#which-chart-a-version-actually-deploys) before relying on which bytes land. It cannot deploy an edited chart either way: a published version's bytes are immutable and re-uploading one is refused (see [the immutability rule](olares-market-chart-publish.md#safety-constraints)), so recovering an `upgradeFailed` app with a *fixed* chart means bumping the version. A true downgrade (`target < installed`) is still rejected for every source.
 4. **Catalog row not withdrawn** — `app_simple_info.app_labels` must not contain `suspend` or `remove` (the only two labels `isAppSuspended` checks; mirrors the SPA hiding the Upgrade button). On a transient catalog-probe error this gate soft-fails (warns, lets the upgrade proceed)
+
+### Which chart a version actually deploys
+
+Known app-service defect, present through 1.12.7. **`upgrade` deploys the newest chart in the source, not the version the request named.** The install path pins the version when it fetches the chart; the upgrade path omits it, so the fetch resolves the index's latest and unpacks it over the version-less chart cache. The response and the state row both report the version you asked for, which is what makes this hard to catch.
+
+Two consequences for a local bucket holding several versions:
+
+- A same-version `upgrade` (gate 3's exception) re-applies **whatever is newest in the bucket**, not the stored chart at that version. It is still a usable retry when the version you named *is* the newest, which is the ordinary case right after an upload.
+- Upgrading to a stored version that is **not** the newest fails or silently lands the newest instead. Neither is what was asked for. Do not use `upgrade` to move between two stored versions; uninstall and install the one you want.
+
+A cancelled upgrade compounds it: cancel does no helm rollback, so the release keeps the new chart's templates merged with the old values. After A1 is fixed those templates are at least the version that was requested.
 
 ### Where an upgrade lands
 
 Two outcomes settle on `stopped` rather than `running`. **Upgrading an already-`stopped` app** re-renders the chart at `replicas=0` and returns to `stopped` — a normal success with nothing to launch. **A cancelled upgrade** also settles at `stopped`, and `--watch` reports it as failure. What separates them is `status.reason` matching `upgradeCancelByUser` or `upgradeCancelBySystem` — not whether `reason` is set, which it always is. *Non-obvious terminal behaviors* in the shared **application state machine** has the reasoning, and why the row's version field cannot discriminate either.
+
+That version field is the one `market status` and `market list --mine` both report, and it is **the version last requested, not the one running**. After a failed or cancelled upgrade the row names the target that did not land, so a script that reads it as "what is deployed" is wrong exactly when it matters. The deployed version is on the workload: `olares-cli cluster deployment get <app> -n <user-ns>`, annotation `applications.app.bytetrade.io/version`.
 
 ## `clone`
 


### PR DESCRIPTION
* **Background**

Running upload / install / upgrade against a purpose-built minimal chart on a
1.12.7 cluster and injecting bad input one case at a time turned up a set of
CLI failures that were either silent, misattributed, or actively misleading.
None of them are backend bugs; all of them are the CLI reporting.

* **Target Version for Merge**

v1.12.7

* **Related Issues**

None

* **Changes**

**`market upload <dir>` exited 0 on failure in JSON mode.** The human-output
path checked `failed > 0`, the JSON path returned before reaching it, so a
directory upload where every chart was rejected still reported success to any
script reading the exit code. Now both output modes share the same verdict, and
a test covers all three output modes against partial and total failure.

**An unknown `-s <source>` said the app did not exist.** The CLI now reads the
source list off `/market/data` and reports `unknown source` with the sources
that do exist, distinguishing that from an app genuinely absent from a real
source. The two cases had been collapsed into one message.

**`--version` was suggested where it makes things worse.** The "use --version to
specify" hint was appended unconditionally on version-resolution failure,
including on `delete`, where naming a version that is not there returns success
without deleting anything. The hint is now emitted only by the verbs it helps,
and never when the cause is a missing source or a missing app.

**An env validation failure suggested a command that would fail.** The remedial
`market install <app> --env ...` line dropped the source, so following it
verbatim against a non-default source failed again. It now carries `-s <source>`.

**`--compute-mode` was accepted for apps that cannot honor it.** The backend only
asks for a mode when an app declares more than one, so a mode aimed at a
single-mode or accelerator-less app was accepted and silently dropped: the
install landed on the app's own mode, no GPU went near the pod, and nothing said
the flag did nothing. `install` and `clone` now check the requested mode against
`app_info.app_entry.accelerator[].mode` before dispatch. A catalog read that
fails leaves the mode to the backend rather than blocking the operation, and a
pre-0.12.0 manifest — which has no accelerator matrix and asks for a GPU through
the flattened `requiredGPU` cap — is also left to the backend, since app-service
synthesizes an nvidia mode for those.

**`market status` did not report a version.** It answered everything about an app
except which version the row is about, so finding that out meant a second
command against a different endpoint. `status` now carries the version in the
table, the JSON payload and the single-app detail block. The field is documented
as the version the row *requested*, not necessarily the one running: after a
failed upgrade those differ, and calling it the running version would be wrong.

* **Skill changes**

The `olares-market`, `olares-doctor` and `olares-chart` references are aligned
with the above, plus four behaviors that were verified on a live cluster and
were either undocumented or documented incorrectly:

- A same-version `upgrade` is **not** a retry of the installed chart. It
  re-deploys whatever the source currently holds, so it can silently move the
  app to a newer version. A new *Which chart a version actually deploys* section
  states this, and the upgrade gate text no longer implies retry semantics.
- Only the newest version in an upload bucket can be upgraded to; the older ones
  are downloadable but not installable, and the failure reads as if the app did
  not exist.
- A failed upgrade leaves the state row reporting the version that failed, not
  the one still serving, so returning to the running version is refused as a
  downgrade.
- `market delete` on a version that is not in the bucket returns success without
  deleting anything.

One agent-workflow block was removed from `olares-market-chart-publish.md`: it
duplicated the workflow above it and, under the corrected delete semantics, was
no longer safe to follow.

* **Verification**

`make build`, `go vet ./cmd/...`, `go test ./cmd/ctl/...` and
`python3 skills/validate.py` all pass. Each CLI behavior above was re-run against
a live 1.12.7 cluster with the rebuilt binary, including confirming that the
compute-mode pre-flight refuses locally without sending an install request.

* **Other information**

The upload-side error reporting this pairs with is a separate change in the
market repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing error text, exit codes, and install/clone preflight validation paths that automation and operators rely on; fixes are intentional but alter behavior scripts may have depended on.
> 
> **Overview**
> Improves **olares-cli market** so failures and scripts get accurate signals instead of silent or misleading outcomes.
> 
> **Exit codes and automation:** Directory **`market upload`** now returns a non-zero exit when any chart fails in **`-o json`** mode (matching table and quiet), so CI no longer treats a total rejection as success.
> 
> **Clearer lookup errors:** Empty catalog lookups distinguish an **unknown `-s` source** (lists ids from `/market/data`) from **app missing in a real source**. Version resolution no longer wraps those as “cannot determine version,” and the **“use --version”** hint is limited to **install/upgrade**—not **`delete`**, where adding `--version` can turn a correct “app absent” failure into a false success.
> 
> **Actionable remediation:** Env validation errors pin **`market get … -s <source>`** in the suggested fix. **`install`/`clone`** preflight **`--compute-mode`** against declared accelerator modes (with legacy GPU and soft-fail if catalog read fails).
> 
> **Status output:** **`market status`** adds **VERSION** from the state row (documented as last requested, not necessarily running), aligned with **`list --mine`**.
> 
> Help text and **olares-market / olares-doctor / olares-chart** skill references are updated for per-cluster sources, upload/delete semantics, upgrade chart selection, and related operational pitfalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b55e7eb589474abb756266dbbbe95a98b1f02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->