### PR TITLE
fix(app-service): upgrade the chart version the request asked for

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -355,12 +355,19 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 	if appMgr.Spec.RawAppName != "" {
 		rawAppName = appMgr.Spec.RawAppName
 	}
+	// Version must be passed here. This is the only call on the upgrade path
+	// that reaches GetIndexAndDownloadChart, and that download is what fills
+	// ./charts/{rawAppName} — the version-less directory every later read
+	// resolves against. Omitting it resolves the index's latest instead, so the
+	// Version the helpers below carry describes a chart that is no longer on
+	// disk.
 	apiVersion, err := apputils.GetAppConfigVersion(req.Request.Context(), &apputils.ConfigOptions{
 		App:          app,
 		RawAppName:   rawAppName,
 		Owner:        prevCfg.OwnerName,
 		RepoURL:      request.RepoURL,
 		MarketSource: marketSource,
+		Version:      request.Version,
 	})
 	if err != nil {
 		klog.Errorf("Failed to get api version err=%v", err)

--- a/framework/app-service/pkg/utils/app/app_test.go
+++ b/framework/app-service/pkg/utils/app/app_test.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/beclab/Olares/framework/app-service/pkg/appcfg"
 	"gotest.tools/v3/assert"
 )
 
@@ -93,5 +96,36 @@ func TestGetFirstSubDir(t *testing.T) {
 		if result != tt.expected {
 			assert.Equal(t, tt.expected, result)
 		}
+	}
+}
+
+// ConfigOptions.Version only reaches the chart repo through
+// GetIndexAndDownloadChart, so it is inert whenever NeedDownloadChart is false:
+// the config is read from ./charts/{RawAppName}, a path that carries no version.
+// A caller who sets Version there gets whatever the last download left on disk
+// while believing it pinned a version, which is how a versioned upgrade came to
+// deploy a different version's templates.
+func TestVersionIsInertWithoutNeedDownloadChart(t *testing.T) {
+	// A missing manifest is fine: getAppConfigFromConfigurationFile returns the
+	// resolved chartPath alongside the error, which is the value under test.
+	// RepoURL stays empty to prove nothing tried to reach the repo.
+	resolve := func(version string) string {
+		_, chartPath, err := getAppConfigFromRepo(context.Background(), &ConfigOptions{
+			App:        "clitest",
+			RawAppName: "clitest",
+			Version:    version,
+		})
+		assert.Assert(t, err != nil, "expected the missing manifest to surface an error")
+		return chartPath
+	}
+
+	want := appcfg.AppChartPath("clitest")
+	for _, version := range []string{"", "0.1.2", "0.1.3"} {
+		if got := resolve(version); got != want {
+			t.Fatalf("Version %q resolved chart path %q, want %q", version, got, want)
+		}
+	}
+	if strings.Contains(want, "0.1.") {
+		t.Fatalf("chart path %q is version-scoped; this test no longer describes the code", want)
 	}
 }


### PR DESCRIPTION
* **Background**

A versioned upgrade deploys a different version than the one requested, and
reports the requested one as a success.

Found while injecting bad input into upload / install / upgrade on a 1.12.7
cluster using a purpose-built minimal chart. Each version of that chart hardcodes
a `chartrev` label in the Deployment's pod template, so which chart actually
rendered is directly observable:

```
$ olares-cli market upgrade clitest -s upload --version 0.1.2 --watch -o json
{"status": "success", "version": "0.1.2", "finalState": "running"}

$ olares-cli cluster workload get clitest -n clitest-yaotest004 --kind deployment -o json | jq ...
{"annVer": "0.1.3", "chartrev": "v0-1-3"}
```

0.1.2 was requested with 0.1.2 installed and 0.1.3 the newest in the source. The
`chartrev` label rules out this being only a version-accounting error: the
templates that rendered were 0.1.3's.

* **Target Version for Merge**

v1.12.7

* **Related Issues**

None

* **Changes**

**Pass the requested version to the download.**
`handler_installer_upgrade.go` passes `request.Version` to the upgrade helpers
but not to the `GetAppConfigVersion` call above them. That call is the only one
on the upgrade path that reaches `GetIndexAndDownloadChart`, and with an empty
`Version` the index resolves its latest entry. The download then unpacks into
`./charts/{rawAppName}` — a path with no version in it — so every later read
resolves against that chart no matter what version it was asked for. The
`Version` the helpers carry is inert: with `NeedDownloadChart` false,
`getAppConfigFromRepo` reads the version-less directory and ignores it. The
install handler already passes its version to the same call.

A regression test pins that `ConfigOptions.Version` has no effect when
`NeedDownloadChart` is false, because that is the trap — setting `Version` there
reads like pinning a version and is not.

Two things bound the blast radius, both checked rather than assumed:

- **System apps were never affected.** The sysapp branch of `UpgradingApp.exec`
  calls `GetIndexAndDownloadChart` directly and already carries the version from
  the `AppVersionKey` annotation. Only regular apps reach the version-less read.
- **Passing `Version` does not turn versioned upgrades into hard failures.**
  `index.Get` errors on a version the index does not carry, so this would be a
  regression if the repo only advertised the latest one. It does not: market's
  `getStaticIndex` merges the artifact snapshot with the persistent version
  history, so `static-index.yaml` enumerates every version still backed by a
  package on disk.

* **PRs Involving Sub-Systems**

None. Deliberately narrow, in two directions:

- **Not #4081 / #4084.** #4081 moved Scale and ApplyEnv onto the chart stored on
  the helm release, and #4084 reverted it. This PR does not touch either path or
  `pkg/helm`; it only fixes which chart the upgrade's own API-time download
  fetches. The `./charts/{app}` path staying version-less — the reason every
  re-render absorbs the last chart downloaded — is untouched here.
- **Interacts with #4122.** `ApplyAppEnv` receives the upgrade path's
  `h.appConfig`, which today is parsed from whatever the latest-resolving
  download left on disk. So on the current `module-appservice` tip, a versioned
  upgrade can merge the *wrong* version's env defaults into the stored `AppEnv`
  CR and persist them, which then flows into the `olaresEnv` helm values —
  widening the damage from "wrong templates deployed" to "wrong version's
  metadata persisted". This PR removes that: #4122 then reads the manifest the
  user actually asked for.

* **Other information**

Four related findings are **not** addressed here:

- The downgrade guard in `UpgradingApp.exec` is dead code: it compares the
  target version before that variable is read from the annotations, and
  `MatchVersion` returns true for an empty version, so it has never rejected
  anything. Real, but it does not belong in the controller — a refusal there
  lands the app in `UpgradeFailed` with a failed op record instead of returning
  a 400, and `MatchVersion` also refuses anything that is not semver, which
  uploaded and DevBox charts are free to be. Separate PR, at the API layer.
- Only the newest version in an upload bucket can be upgraded to; older ones are
  downloadable but return 404. That is a market-side lookup, not app-service:
  `GetAppUpgradeRow` matches on `orig.metadata->>'version' = ?`, so only the
  single version on the definition row resolves.
- After a failed upgrade the state row reports the version that failed rather
  than the one still serving, which makes returning to the running version look
  like a downgrade. Version accounting, market-side.
- Cancelling an in-flight upgrade leaves a mixed release: templates from the new
  version, values from the old one. There is no helm rollback on this path
  (`RollBack()` in `helm_ops_rollback.go` has no callers) and upgrade uses
  `ResetThenReuseValues`. This is the same root cause as the version-less chart
  path above and is the largest of the four; it is not something to fold into
  this PR.

* **Verification**

`make build`, `go vet ./...` and `make test-unit` all pass. `test-unit` covers
both packages touched here (`./pkg/apiserver/...`, `./pkg/utils/app/...`).
