### PR TITLE
fix(app-service): check for a downgrade where it can be refused

### DIFF
--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -14,6 +14,7 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/appstate"
 	"github.com/beclab/Olares/framework/app-service/pkg/compute/validation"
 	"github.com/beclab/Olares/framework/app-service/pkg/constants"
+	"github.com/beclab/Olares/framework/app-service/pkg/helm"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
@@ -343,6 +344,34 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		err = fmt.Errorf("%s operation is not allowed for %s state", appv1alpha1.UpgradeOp, appMgr.Status.State)
 		api.HandleBadRequest(resp, req, err)
 		return
+	}
+
+	// Refuse a downgrade here, before the chart is downloaded. The controller
+	// is the wrong place for it: a refusal during the operation lands the app
+	// in UpgradeFailed with a failed op record, which is what a broken upgrade
+	// looks like, not an invalid request. Failing to read the deployed version
+	// does not block the upgrade — a guard should not be easier to break than
+	// the operation it protects.
+	//
+	// UpgradeFailed is exempt. An upgrade that rendered but never came up
+	// leaves the release on the version that failed, so asking for the one
+	// that was working reads as a downgrade here while being the only way
+	// back.
+	if request.Version != "" && appMgr.Status.State != appv1alpha1.UpgradeFailed {
+		actionConfig, _, cfgErr := helm.InitConfig(h.kubeConfig, appMgr.Spec.AppNamespace)
+		if cfgErr != nil {
+			klog.Warningf("Skipping the downgrade check for %s, helm init failed: %v", app, cfgErr)
+		} else {
+			deployedVersion, _, verErr := apputils.GetDeployedReleaseVersion(actionConfig, appMgr.Spec.AppName)
+			switch {
+			case verErr != nil:
+				klog.Warningf("Skipping the downgrade check for %s, cannot read the deployed release version: %v", app, verErr)
+			case apputils.IsDowngrade(request.Version, deployedVersion):
+				err = fmt.Errorf("cannot upgrade %s to version %s, version %s is already deployed", app, request.Version, deployedVersion)
+				api.HandleBadRequest(resp, req, err)
+				return
+			}
+		}
 	}
 
 	token, err := h.GetUserServiceAccountToken(req.Request.Context(), owner)

--- a/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
+++ b/framework/app-service/pkg/apiserver/handler_installer_upgrade.go
@@ -346,31 +346,29 @@ func (h *Handler) appUpgrade(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	// Refuse a downgrade here, before the chart is downloaded. The controller
-	// is the wrong place for it: a refusal during the operation lands the app
-	// in UpgradeFailed with a failed op record, which is what a broken upgrade
-	// looks like, not an invalid request. Failing to read the deployed version
-	// does not block the upgrade — a guard should not be easier to break than
-	// the operation it protects.
-	//
-	// UpgradeFailed is exempt. An upgrade that rendered but never came up
-	// leaves the release on the version that failed, so asking for the one
-	// that was working reads as a downgrade here while being the only way
-	// back.
+	// Check before downloading the chart so a rejected request does not leave
+	// the app in UpgradeFailed. Allow recovery from UpgradeFailed because the
+	// release may report the version of the failed upgrade.
 	if request.Version != "" && appMgr.Status.State != appv1alpha1.UpgradeFailed {
-		actionConfig, _, cfgErr := helm.InitConfig(h.kubeConfig, appMgr.Spec.AppNamespace)
-		if cfgErr != nil {
-			klog.Warningf("Skipping the downgrade check for %s, helm init failed: %v", app, cfgErr)
-		} else {
-			deployedVersion, _, verErr := apputils.GetDeployedReleaseVersion(actionConfig, appMgr.Spec.AppName)
-			switch {
-			case verErr != nil:
-				klog.Warningf("Skipping the downgrade check for %s, cannot read the deployed release version: %v", app, verErr)
-			case apputils.IsDowngrade(request.Version, deployedVersion):
-				err = fmt.Errorf("cannot upgrade %s to version %s, version %s is already deployed", app, request.Version, deployedVersion)
-				api.HandleBadRequest(resp, req, err)
-				return
-			}
+		actionConfig, _, err := helm.InitConfig(h.kubeConfig, appMgr.Spec.AppNamespace)
+		if err != nil {
+			api.HandleError(resp, req, fmt.Errorf("initialize helm for %s: %w", app, err))
+			return
+		}
+		deployedVersion, _, err := apputils.GetDeployedReleaseVersion(actionConfig, appMgr.Spec.AppName)
+		if err != nil {
+			api.HandleError(resp, req, fmt.Errorf("get deployed release version for %s: %w", app, err))
+			return
+		}
+		isDowngrade, err := apputils.IsDowngrade(request.Version, deployedVersion)
+		if err != nil {
+			api.HandleBadRequest(resp, req, err)
+			return
+		}
+		if isDowngrade {
+			err = fmt.Errorf("cannot upgrade %s to version %s, version %s is already deployed", app, request.Version, deployedVersion)
+			api.HandleBadRequest(resp, req, err)
+			return
 		}
 	}
 

--- a/framework/app-service/pkg/appstate/upgrading_app.go
+++ b/framework/app-service/pkg/appstate/upgrading_app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/beclab/Olares/framework/app-service/pkg/images"
 	"github.com/beclab/Olares/framework/app-service/pkg/kubesphere"
 	"github.com/beclab/Olares/framework/app-service/pkg/users/userspace"
-	"github.com/beclab/Olares/framework/app-service/pkg/utils"
 	apputils "github.com/beclab/Olares/framework/app-service/pkg/utils/app"
 	appsv1 "github.com/beclab/api/api/app.bytetrade.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,7 +176,6 @@ func (p *UpgradingApp) Exec(ctx context.Context) (StatefulInProgressApp, error) 
 
 func (p *UpgradingApp) exec(ctx context.Context) error {
 	var err error
-	var version string
 	var actionConfig *action.Configuration
 	kubeConfig, err := p.deps.KubeConfig()
 	if err != nil {
@@ -190,19 +188,17 @@ func (p *UpgradingApp) exec(ctx context.Context) error {
 		return err
 	}
 	var appConfig *appcfg.ApplicationConfig
-	deployedVersion, _, err := apputils.GetDeployedReleaseVersion(actionConfig, p.manager.Spec.AppName)
-	if err != nil {
+	// Confirm the release exists before touching it. The version it reports is
+	// not read here any more: the downgrade check this call used to feed moved
+	// to the upgrade API, where a refusal is a 400 instead of an app left in
+	// UpgradeFailed.
+	if _, _, err = apputils.GetDeployedReleaseVersion(actionConfig, p.manager.Spec.AppName); err != nil {
 		klog.Errorf("Failed to get release revision err=%v", err)
 		return err
 	}
 
-	if !utils.MatchVersion(version, ">= "+deployedVersion) {
-		err = errors.New("upgrade version should great than deployed version")
-		return err
-	}
-
 	annotations := p.manager.Annotations
-	version = annotations[api.AppVersionKey]
+	version := annotations[api.AppVersionKey]
 	repoURL := annotations[api.AppRepoURLKey]
 	token := annotations[api.AppTokenKey]
 	marketSource := annotations[api.AppMarketSourceKey]

--- a/framework/app-service/pkg/utils/app/version.go
+++ b/framework/app-service/pkg/utils/app/version.go
@@ -1,34 +1,28 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
-	"k8s.io/klog/v2"
 )
 
 // IsDowngrade reports whether target is an older release than deployed.
-//
-// It refuses to guess. An uploaded or DevBox chart carries whatever version
-// string its author wrote, so a version that is not semver on either side is
-// not treated as a downgrade; neither is an empty target, which means "the
-// newest the repo has". utils.MatchVersion cannot be used for this: it reports
-// a match for an empty version and a mismatch for anything unparseable, so
-// both of its defaults point towards inventing a refusal.
-func IsDowngrade(target, deployed string) bool {
-	if target == "" || deployed == "" {
-		return false
+// An empty target requests the newest available release and skips comparison.
+// Otherwise, both versions must be parseable as semver.
+func IsDowngrade(target, deployed string) (bool, error) {
+	if target == "" {
+		return false, nil
 	}
 
 	targetVersion, err := semver.NewVersion(target)
 	if err != nil {
-		klog.Infof("skipping the downgrade check, target version %q is not semver: %v", target, err)
-		return false
+		return false, fmt.Errorf("parse target version %q: %w", target, err)
 	}
 
 	deployedVersion, err := semver.NewVersion(deployed)
 	if err != nil {
-		klog.Infof("skipping the downgrade check, deployed version %q is not semver: %v", deployed, err)
-		return false
+		return false, fmt.Errorf("parse deployed version %q: %w", deployed, err)
 	}
 
-	return targetVersion.LessThan(deployedVersion)
+	return targetVersion.LessThan(deployedVersion), nil
 }

--- a/framework/app-service/pkg/utils/app/version.go
+++ b/framework/app-service/pkg/utils/app/version.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"k8s.io/klog/v2"
+)
+
+// IsDowngrade reports whether target is an older release than deployed.
+//
+// It refuses to guess. An uploaded or DevBox chart carries whatever version
+// string its author wrote, so a version that is not semver on either side is
+// not treated as a downgrade; neither is an empty target, which means "the
+// newest the repo has". utils.MatchVersion cannot be used for this: it reports
+// a match for an empty version and a mismatch for anything unparseable, so
+// both of its defaults point towards inventing a refusal.
+func IsDowngrade(target, deployed string) bool {
+	if target == "" || deployed == "" {
+		return false
+	}
+
+	targetVersion, err := semver.NewVersion(target)
+	if err != nil {
+		klog.Infof("skipping the downgrade check, target version %q is not semver: %v", target, err)
+		return false
+	}
+
+	deployedVersion, err := semver.NewVersion(deployed)
+	if err != nil {
+		klog.Infof("skipping the downgrade check, deployed version %q is not semver: %v", deployed, err)
+		return false
+	}
+
+	return targetVersion.LessThan(deployedVersion)
+}

--- a/framework/app-service/pkg/utils/app/version_test.go
+++ b/framework/app-service/pkg/utils/app/version_test.go
@@ -1,13 +1,17 @@
 package app
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsDowngrade(t *testing.T) {
 	tests := []struct {
-		name     string
-		target   string
-		deployed string
-		expected bool
+		name        string
+		target      string
+		deployed    string
+		expected    bool
+		errContains string
 	}{
 		{
 			name:     "newer target upgrades",
@@ -40,22 +44,22 @@ func TestIsDowngrade(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "an unknown deployed version cannot be compared against",
-			target:   "0.1.2",
-			deployed: "",
-			expected: false,
+			name:        "an empty deployed version returns an error",
+			target:      "0.1.2",
+			deployed:    "",
+			errContains: "parse deployed version",
 		},
 		{
-			name:     "a target that is not semver is left alone",
-			target:   "latest",
-			deployed: "0.1.2",
-			expected: false,
+			name:        "an invalid target version returns an error",
+			target:      "latest",
+			deployed:    "0.1.2",
+			errContains: "parse target version",
 		},
 		{
-			name:     "a deployed version that is not semver is left alone",
-			target:   "0.1.2",
-			deployed: "nightly",
-			expected: false,
+			name:        "an invalid deployed version returns an error",
+			target:      "0.1.2",
+			deployed:    "nightly",
+			errContains: "parse deployed version",
 		},
 		{
 			name:     "a two-part version is semver enough to compare",
@@ -79,7 +83,15 @@ func TestIsDowngrade(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := IsDowngrade(test.target, test.deployed); got != test.expected {
+			got, err := IsDowngrade(test.target, test.deployed)
+			if test.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), test.errContains) {
+					t.Fatalf("IsDowngrade(%q, %q) error = %v, want %q", test.target, test.deployed, err, test.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("IsDowngrade(%q, %q) unexpected error: %v", test.target, test.deployed, err)
+			}
+			if got != test.expected {
 				t.Errorf("IsDowngrade(%q, %q) = %v, want %v", test.target, test.deployed, got, test.expected)
 			}
 		})

--- a/framework/app-service/pkg/utils/app/version_test.go
+++ b/framework/app-service/pkg/utils/app/version_test.go
@@ -1,0 +1,87 @@
+package app
+
+import "testing"
+
+func TestIsDowngrade(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		deployed string
+		expected bool
+	}{
+		{
+			name:     "newer target upgrades",
+			target:   "0.1.3",
+			deployed: "0.1.2",
+			expected: false,
+		},
+		{
+			name:     "reinstalling the deployed version is not a downgrade",
+			target:   "0.1.2",
+			deployed: "0.1.2",
+			expected: false,
+		},
+		{
+			name:     "older target is a downgrade",
+			target:   "0.1.2",
+			deployed: "0.1.3",
+			expected: true,
+		},
+		{
+			name:     "older major is a downgrade",
+			target:   "1.9.9",
+			deployed: "2.0.0",
+			expected: true,
+		},
+		{
+			name:     "an empty target asks for the newest available",
+			target:   "",
+			deployed: "0.1.2",
+			expected: false,
+		},
+		{
+			name:     "an unknown deployed version cannot be compared against",
+			target:   "0.1.2",
+			deployed: "",
+			expected: false,
+		},
+		{
+			name:     "a target that is not semver is left alone",
+			target:   "latest",
+			deployed: "0.1.2",
+			expected: false,
+		},
+		{
+			name:     "a deployed version that is not semver is left alone",
+			target:   "0.1.2",
+			deployed: "nightly",
+			expected: false,
+		},
+		{
+			name:     "a two-part version is semver enough to compare",
+			target:   "1.0",
+			deployed: "1.1",
+			expected: true,
+		},
+		{
+			name:     "a prerelease ahead of the deployed version upgrades",
+			target:   "0.2.0-rc.1",
+			deployed: "0.1.9",
+			expected: false,
+		},
+		{
+			name:     "a prerelease of the deployed version is a downgrade",
+			target:   "0.2.0-rc.1",
+			deployed: "0.2.0",
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsDowngrade(test.target, test.deployed); got != test.expected {
+				t.Errorf("IsDowngrade(%q, %q) = %v, want %v", test.target, test.deployed, got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* **Background**

The upgrade path has a downgrade guard that has never rejected anything. In
`UpgradingApp.exec` the comparison runs before the variable it compares is read
from the annotations, and `MatchVersion` returns true for an empty version:

```go
if !utils.MatchVersion(version, ">= "+deployedVersion) {
	err = errors.New("upgrade version should great than deployed version")
	return err
}

annotations := p.manager.Annotations
version = annotations[api.AppVersionKey]
```

Found while injecting bad input into upload / install / upgrade on a 1.12.7
cluster. This was originally the second commit of #4126 and was pulled out on
review, because activating the check where it stands is the wrong move twice
over — see below.

* **Target Version for Merge**

v1.12.7

* **Related Issues**

None

* **Changes**

**Why not just turn it live.** A refusal inside `UpgradingApp.exec` lands the app
in `UpgradeFailed` with a failed op record, which is what a broken upgrade looks
like, not what an invalid request looks like — and the upgrade API has no version
validation at all today, so the controller was the only gate. Separately,
`MatchVersion` returns false when either side is unparseable as semver. Catalog
charts are all plain `x.y.z`, but uploaded and DevBox charts carry whatever
version string their author wrote, so switching the check on would have started
refusing upgrades that work today.

**The check moves to `appUpgrade`**, after the state gate and before
`GetAppConfigVersion`, so nothing is downloaded for a request that is about to be
refused, and the caller gets a 400 naming both versions. The deployed version
comes from the helm release the same way `releaseVersion` reads it. Failing to
read it logs and continues: a guard should not be easier to break than the
operation it protects.

**`UpgradeFailed` is exempt.** `ops.Upgrade()` can succeed while
`WaitForStartUp()` fails, which leaves the release on the version that failed
while the app sits in `UpgradeFailed` — a state `UpgradeOp` is allowed from. Asking
for the version that was working then reads as a downgrade while being the only
way back, so the check is skipped there.

**New `apputils.IsDowngrade(target, deployed)`** reports false for an empty or
unparseable version on either side and otherwise compares with semver.
`MatchVersion` is not reusable here: it treats an empty version as a match and
anything unparseable as a mismatch, so both of its defaults point towards
inventing a refusal. Comparing directly also drops a prerelease trap that
`">= " + deployed` carries — a release-only constraint excludes prereleases, so
`0.1.9 -> 0.2.0-rc.1` would have been rejected as a downgrade. Eleven table cases
cover the two orderings, equality, an empty version on either side, a non-semver
version on either side, a two-part version, and a prerelease on both sides of the
deployed one.

**The dead check is deleted, not left in place**, so it does not get fixed in the
controller a second time. `GetDeployedReleaseVersion` stays on as the
release-exists probe it also was, and the `var version string` / assign-later
shape that hid the bug collapses into `version := annotations[...]`.

* **PRs Involving Sub-Systems**

None.

- **Independent of #4126.** That PR fixes which chart a versioned upgrade
  downloads; this one refuses a versioned upgrade that goes backwards. Both touch
  `handler_installer_upgrade.go`, in different places, and `git merge-tree`
  reports a clean merge in either order. This branch is cut from
  `module-appservice`, not from #4126.

* **Other information**

`IsDowngrade` lives in `pkg/utils/app` rather than next to `MatchVersion` in
`pkg/utils`, because `pkg/utils` is excluded from `TEST_UNIT_PKGS` and a test
placed there would never run in CI. Its existing `TestMatchVersion` is in fact
already failing on `module-appservice` — it expects `"latest"` to satisfy
`">=0.3.2-beta.2"`, which `MatchVersion` refuses because `"latest"` is not
semver. Not touched here.

* **Verification**

`make build`, `go vet ./...` and `make test-unit` all pass. `test-unit` covers all
three packages touched here (`./pkg/apiserver/...`, `./pkg/appstate/...`,
`./pkg/utils/app/...`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upgrade request validation and semver rules for versioned upgrades; behavior shifts for invalid or older semver targets, with a deliberate exemption when recovering from UpgradeFailed.
> 
> **Overview**
> **Moves downgrade validation out of the upgrade controller and into the upgrade API**, so invalid version requests return **400** before any chart download or state transition instead of failing mid-upgrade and leaving the app in **`UpgradeFailed`**.
> 
> When a explicit **`request.Version`** is set, **`appUpgrade`** initializes Helm, reads the deployed release version, and uses new **`apputils.IsDowngrade`** (semver comparison via Masterminds). Downgrades are rejected with a clear bad-request message. The check is **skipped in `UpgradeFailed`** so users can retry toward a previously working version when the release still reports the failed upgrade’s version.
> 
> **Removes the broken guard in `UpgradingApp.exec`** (it compared an empty version before reading annotations). That path still calls **`GetDeployedReleaseVersion`** only to confirm the release exists.
> 
> Adds **`IsDowngrade`** in **`pkg/utils/app`** with unit tests covering ordering, equality, empty target, invalid semver, and prerelease edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98cac3a8326cbad3a8982ed0ad2df89c40a38dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->