### PR TITLE
chore(olares-apps): add new namespace

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.48
+          image: beclab/system-frontend:v1.11.49
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
+++ b/framework/monitor/.olares/config/cluster/deploy/ks_server_deploy.yaml
@@ -30,7 +30,7 @@ spec:
                     operator: Exists
       containers:
       - name: monitoring-server
-        image: beclab/monitoring-server-v1:v0.3.15
+        image: beclab/monitoring-server-v1:v0.3.16
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
* **Background**
add namesapce:  os-mesh and os-gateway

* **Target Version for Merge**
v1.12.7

* **Related Issues**
None

* **PRs Involving Sub-Systems** 
https://github.com/beclab/TermiPass/pull/1435


* **Other information**:
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only manifest changes; risk depends on behavior in the new image builds during normal pod rollouts.
> 
> **Overview**
> Bumps two pinned container images in cluster deploy manifests so rollouts pick up newer builds.
> 
> The **olares-app** Helm template updates the `olares-app-init` init container from `beclab/system-frontend:v1.11.48` to **v1.11.49**, which stages frontend assets into the shared `www` volume before nginx starts. The **monitoring-server** deployment updates its main container from `beclab/monitoring-server-v1:v0.3.15` to **v0.3.16**; scheduling, env, and ports are unchanged.
> 
> No chart structure, secrets, or runtime configuration changes—only image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc727625d2f132ab1635817aaca5faf32399c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->