### PR TITLE
cli(fix): restart NVIDIA application pods after runtime upgrade

### DIFF
--- a/cli/pkg/upgrade/1_12_7.go
+++ b/cli/pkg/upgrade/1_12_7.go
@@ -36,6 +36,10 @@ func (u upgrader_1_12_7) AddedBreakingChange() bool {
 func (u upgrader_1_12_7) PrepareForUpgrade() []task.Interface {
 	tasks := migrateContainerdConfigV3()
 	tasks = append(tasks, &task.LocalTask{
+		Name:   "RestartNvidiaApplicationPods",
+		Action: new(restartNvidiaApplicationPods),
+	})
+	tasks = append(tasks, &task.LocalTask{
 		Name:    "CleanupK3sCertsRenewService",
 		Prepare: new(common.OnlyK3s),
 		Action:  new(certs.UninstallAutoRenewCerts),

--- a/cli/pkg/upgrade/restart_nvidia_pods.go
+++ b/cli/pkg/upgrade/restart_nvidia_pods.go
@@ -1,0 +1,73 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/beclab/Olares/cli/pkg/common"
+	"github.com/beclab/Olares/cli/pkg/core/connector"
+	"github.com/beclab/Olares/cli/pkg/core/logger"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type restartNvidiaApplicationPods struct {
+	common.KubeAction
+}
+
+func (a *restartNvidiaApplicationPods) Execute(runtime connector.Runtime) error {
+	kube, err := kubeClientFromRuntime()
+	if err != nil {
+		return fmt.Errorf("create kubernetes client: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	return restartNvidiaPods(ctx, kube)
+}
+
+// Existing GPU containers must be recreated to pick up the upgraded NVIDIA
+// runtime. Match resource consumers, including HAMi GPU memory and init containers.
+func podUsesNvidiaResources(pod *corev1.Pod) bool {
+	usesNvidia := func(containers []corev1.Container) bool {
+		for _, container := range containers {
+			for _, resources := range []corev1.ResourceList{container.Resources.Requests, container.Resources.Limits} {
+				for name, quantity := range resources {
+					if strings.HasPrefix(string(name), "nvidia.com/") && quantity.Sign() > 0 {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+	return usesNvidia(pod.Spec.Containers) || usesNvidia(pod.Spec.InitContainers)
+}
+
+func restartNvidiaPods(ctx context.Context, kube kubernetes.Interface) error {
+	pods, err := kube.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list NVIDIA application pods: %w", err)
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed || !podUsesNvidiaResources(pod) {
+			continue
+		}
+		// Guard against deleting a replacement with the same name (StatefulSets).
+		err := kube.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &pod.UID},
+		})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("restart NVIDIA application pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		logger.Infof("deleted NVIDIA application pod %s/%s for recreation", pod.Namespace, pod.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
* **Background**

Add a task to the 1.12.7 upgrade flow after `RestartContainerd` to recreate pods using non-zero `nvidia.com/` resources, including regular and init containers.

Deletion respects each pod's termination grace period and uses UID preconditions to avoid deleting replacements. Completed and terminating pods are skipped.

* **Target Version for Merge**

1.12.7

* **Related Issues**

none

* **PRs Involving Sub-Systems**

none

* **Other information**:

none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The upgrade deliberately deletes active GPU workload pods cluster-wide, which can cause brief disruption if controllers are slow to recreate them or if deletion preconditions fail unexpectedly.
> 
> **Overview**
> The **1.12.7** upgrade path now runs a **`RestartNvidiaApplicationPods`** step right after the existing containerd v3 migration and **`RestartContainerd`**, so workloads can pick up the updated NVIDIA runtime.
> 
> The new upgrade action lists pods cluster-wide, selects those with non-zero **`nvidia.com/*`** requests or limits on regular or init containers, and deletes them so controllers recreate them. It skips pods that are terminating, succeeded, or failed, uses **UID preconditions** on delete to avoid removing a replacement with the same name (e.g. StatefulSets), and times out after five minutes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9087554c124d61fe6378d7bd96e2ac1e0543fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->