### PR TITLE
market: fix upload, upgrade, crd events, and recovery states

### DIFF
--- a/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
+++ b/framework/market/.olares/config/cluster/deploy/market_deploy.yaml
@@ -155,7 +155,7 @@ spec:
           name: check-appservice
       containers:
       - name: appstore-backend
-        image: beclab/market-backend:v0.6.114
+        image: beclab/market-backend:v0.6.121
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 81


### PR DESCRIPTION
* **Background**
<!-- Provide background information about the changes here -->
Fix upload error reporting, upgrade version accuracy, duplicate CRD state-change events, and recovery operation states.

* **Target Version for Merge**
<!-- Specify the version to which these changes need to be merged -->
v1.12.7

* **Related Issues**
<!-- Reference any related issues here, if applicable -->

* **PRs Involving Sub-Systems** 
<!-- List any PRs involving sub-systems, if applicable -->
https://github.com/beclab/market/pull/455
https://github.com/beclab/market/pull/456
https://github.com/beclab/market/pull/457
https://github.com/beclab/market/pull/458


* **Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single image tag bump in a deployment manifest; behavior changes come from the external image, with typical rollout risk for a backend service update.
> 
> **Overview**
> **Bumps the appstore backend container image** from `beclab/market-backend:v0.6.114` to `v0.6.121` in `market_deploy.yaml`, so cluster deployments pick up the newer Market backend build.
> 
> That image roll aligns with fixes described for upload error reporting, upgrade version accuracy, duplicate CRD state-change events, and recovery operation states (see linked `beclab/market` PRs); this repo change is the version pin only—no application logic changes here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ae88a3e0aeda0e24dfb081cf26ac7474b2af4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->