### PR TITLE
fix(cli): read the OCR submission receipt as a receipt

### DIFF
--- a/cli/cmd/ctl/router/call_ocr.go
+++ b/cli/cmd/ctl/router/call_ocr.go
@@ -52,6 +52,42 @@ func (t *ocrTask) done() bool {
 	return false
 }
 
+// ocrAccepted is the submission answer: a receipt with the task nested under
+// one key, not a task. Read as a task it yields no id, and an id is the only
+// thing the wait loop has to ask about — so the loop polled the list route
+// instead, read no status off it, and waited out the whole timeout on a job the
+// engine had already finished. job_id is the same id one level up, kept as the
+// fallback because a receipt that names the job is still a usable receipt.
+type ocrAccepted struct {
+	JobID  string  `json:"job_id"`
+	Status string  `json:"status"`
+	Task   ocrTask `json:"task"`
+}
+
+// task reads the receipt as the task it is a receipt for.
+func (a ocrAccepted) task() ocrTask {
+	t := a.Task
+	if t.ID == "" {
+		t.ID = a.JobID
+	}
+	if t.Status == "" {
+		t.Status = a.Status
+	}
+	return t
+}
+
+// ocrTaskPath adds the model, when there is one, so the lookup reaches the
+// engine holding the task — the same reason audioTaskPath does it. Without it
+// every poll and cancel goes to whichever model answers the default OCR route,
+// which is not necessarily the one the task was submitted to.
+func ocrTaskPath(path, model string) string {
+	q := url.Values{}
+	if m := strings.TrimSpace(model); m != "" {
+		q.Set("model", m)
+	}
+	return withQuery(path, q)
+}
+
 func newCallOCRCommand(f *cmdutil.Factory) *cobra.Command {
 	var (
 		output      string
@@ -102,6 +138,7 @@ Examples:
 					return fmt.Errorf("--queue lists the board; it takes neither a file nor --task")
 				}
 				return runOCRQueue(c.Context(), f, ocrQueueOptions{
+					Model:  callModel(model, categoryOCR),
 					Status: strings.TrimSpace(queueStatus), Limit: queueLimit,
 					APIKey: apiKey, OutputIn: output,
 				})
@@ -175,7 +212,7 @@ func runCallOCR(ctx context.Context, f *cmdutil.Factory, opts ocrOptions) error 
 	dp := dataPlane(pc, opts.APIKey)
 
 	if opts.TaskID != "" && opts.Cancel {
-		path := epOCRTask(opts.TaskID)
+		path := ocrTaskPath(epOCRTask(opts.TaskID), opts.Model)
 		if err := dp.doJSON(ctx, "DELETE", path, nil, nil); err != nil {
 			return callErr(err)
 		}
@@ -186,7 +223,7 @@ func runCallOCR(ctx context.Context, f *cmdutil.Factory, opts ocrOptions) error 
 	var task ocrTask
 	switch {
 	case opts.TaskID != "":
-		if err := fetchOCRTask(ctx, dp, opts.TaskID, &task); err != nil {
+		if err := fetchOCRTask(ctx, dp, opts.TaskID, opts.Model, &task); err != nil {
 			return err
 		}
 	default:
@@ -211,8 +248,15 @@ func runCallOCR(ctx context.Context, f *cmdutil.Factory, opts ocrOptions) error 
 		if resp.StatusCode/100 != 2 {
 			return callErr(dp.formatErr("POST", epOCR, resp.StatusCode, raw))
 		}
-		if uerr := json.Unmarshal(raw, &task); uerr != nil {
+		var accepted ocrAccepted
+		if uerr := json.Unmarshal(raw, &accepted); uerr != nil {
 			return fmt.Errorf("decode the submission answer: %w (body=%s)", uerr, truncate(string(raw), 200))
+		}
+		task = accepted.task()
+		if task.ID == "" {
+			return fmt.Errorf("the file was accepted but the answer named no task, "+
+				"so there is nothing to wait for or come back to (body=%s)",
+				truncate(string(raw), 200))
 		}
 		if !opts.Wait {
 			if format == FormatJSON {
@@ -225,7 +269,7 @@ func runCallOCR(ctx context.Context, f *cmdutil.Factory, opts ocrOptions) error 
 	}
 
 	if !task.done() {
-		if err := waitForOCRTask(ctx, dp, &task, opts.Timeout, format == FormatTable); err != nil {
+		if err := waitForOCRTask(ctx, dp, &task, opts.Model, opts.Timeout, format == FormatTable); err != nil {
 			return err
 		}
 	}
@@ -257,6 +301,7 @@ type ocrQueue struct {
 }
 
 type ocrQueueOptions struct {
+	Model    string
 	Status   string
 	Limit    int
 	APIKey   string
@@ -277,6 +322,9 @@ func runOCRQueue(ctx context.Context, f *cmdutil.Factory, opts ocrQueueOptions) 
 	}
 	dp := dataPlane(pc, opts.APIKey)
 	q := url.Values{}
+	if m := strings.TrimSpace(opts.Model); m != "" {
+		q.Set("model", m)
+	}
 	if opts.Status != "" {
 		q.Set("status", opts.Status)
 	}
@@ -339,8 +387,8 @@ func ocrTaskAge(task *ocrTask) string {
 	return time.Since(at).Round(time.Second).String() + " ago"
 }
 
-func fetchOCRTask(ctx context.Context, dp *routerClient, id string, out *ocrTask) error {
-	path := epOCRTask(id)
+func fetchOCRTask(ctx context.Context, dp *routerClient, id, model string, out *ocrTask) error {
+	path := ocrTaskPath(epOCRTask(id), model)
 	if err := dp.doJSON(ctx, "GET", path, nil, out); err != nil {
 		return callErr(err)
 	}
@@ -350,7 +398,10 @@ func fetchOCRTask(ctx context.Context, dp *routerClient, id string, out *ocrTask
 // waitForOCRTask polls until the task settles. Progress goes to stderr so the
 // text on stdout stays clean, and a timeout leaves the task running rather than
 // cancelling it: work already done is worth picking up later.
-func waitForOCRTask(ctx context.Context, dp *routerClient, task *ocrTask, timeout time.Duration, verbose bool) error {
+func waitForOCRTask(
+	ctx context.Context, dp *routerClient, task *ocrTask,
+	model string, timeout time.Duration, verbose bool,
+) error {
 	deadline := time.Now().Add(timeout)
 	lastNote := ""
 	for {
@@ -371,7 +422,7 @@ func waitForOCRTask(ctx context.Context, dp *routerClient, task *ocrTask, timeou
 		case <-time.After(time.Second):
 		}
 		var next ocrTask
-		if err := fetchOCRTask(ctx, dp, task.ID, &next); err != nil {
+		if err := fetchOCRTask(ctx, dp, task.ID, model, &next); err != nil {
 			return err
 		}
 		*task = next

--- a/cli/cmd/ctl/router/call_ocr_test.go
+++ b/cli/cmd/ctl/router/call_ocr_test.go
@@ -1,0 +1,206 @@
+// `router call ocr <file>` used to hang until its own timeout on a job the
+// engine had already finished, printing nothing.
+//
+// A submission is answered with a receipt — the task nested under one key,
+// alongside the same id one level up as `job_id` — and the code read that
+// receipt as a bare task. Nothing failed: it got a task with an empty id and an
+// empty status, then polled `/v1/ocr/tasks/` + "" , which is the list route, and
+// read no top-level status off the board it got back. So the wait loop never saw
+// a terminal state, and every poll asked the wrong URL for it.
+
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ocrStub answers the two routes a wait cycle needs and records what was asked.
+// The task settles on the poll numbered settleAfter, so a test can distinguish
+// "read the terminal state" from "gave up".
+type ocrStub struct {
+	mu         sync.Mutex
+	paths      []string
+	polls      int
+	settleFrom int
+}
+
+func (s *ocrStub) serve(w http.ResponseWriter, r *http.Request) {
+	// An id-less lookup addresses `/v1/ocr/tasks/`, and Router's trailing-slash
+	// redirect lands it on the list route — the empty segment is not an id, so
+	// there is no per-task route to reach. Modelling that is the whole point:
+	// the list answer parses fine and says nothing about any one task.
+	id := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/ocr/tasks"), "/")
+
+	s.mu.Lock()
+	s.paths = append(s.paths, r.URL.String())
+	if r.Method == http.MethodGet && id != "" {
+		s.polls++
+	}
+	polls := s.polls
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.Method == http.MethodPost:
+		// The shape OCRAdapter actually answers a submission with.
+		_, _ = w.Write([]byte(`{"job_id":"tsk_abc","status":"queued",` +
+			`"task":{"object":"task","id":"tsk_abc","status":"queued","model":"paddle-hybrid"}}`))
+	case id == "":
+		_, _ = w.Write([]byte(`{"object":"list","capacity":{},"data":[]}`))
+	default:
+		status := "running"
+		if polls >= s.settleFrom {
+			status = "succeeded"
+		}
+		_, _ = w.Write([]byte(`{"object":"task","id":"tsk_abc","status":"` + status +
+			`","model":"paddle-hybrid","result":{"text":"hello"}}`))
+	}
+}
+
+func newOCRStub(t *testing.T, settleFrom int) (*routerClient, *ocrStub) {
+	t.Helper()
+	stub := &ocrStub{settleFrom: settleFrom}
+	srv := httptest.NewServer(http.HandlerFunc(stub.serve))
+	t.Cleanup(srv.Close)
+	return newRouterClient(srv.Client(), srv.URL, "alice@example.com"), stub
+}
+
+func (s *ocrStub) asked() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.paths...)
+}
+
+// The receipt has to be read as a receipt. Decoded as a task it has no id, and
+// the id is the whole of what the wait loop needs.
+func TestOCRSubmissionReceiptYieldsTheTaskID(t *testing.T) {
+	const receipt = `{"job_id":"tsk_abc","status":"queued",` +
+		`"task":{"object":"task","id":"tsk_abc","status":"queued"}}`
+
+	var flat ocrTask
+	if err := json.Unmarshal([]byte(receipt), &flat); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if flat.ID != "" {
+		t.Fatalf("the receipt is not a task after all; this test is describing the wrong bug")
+	}
+
+	var accepted ocrAccepted
+	if err := json.Unmarshal([]byte(receipt), &accepted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	task := accepted.task()
+	if task.ID != "tsk_abc" {
+		t.Errorf("id=%q want %q", task.ID, "tsk_abc")
+	}
+	if task.Status != "queued" {
+		t.Errorf("status=%q want %q", task.Status, "queued")
+	}
+}
+
+// An engine that answers with job_id and no nested task still named the job, so
+// there is still something to come back for.
+func TestOCRSubmissionFallsBackToJobID(t *testing.T) {
+	var accepted ocrAccepted
+	if err := json.Unmarshal([]byte(`{"job_id":"tsk_only","status":"queued"}`), &accepted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	task := accepted.task()
+	if task.ID != "tsk_only" {
+		t.Errorf("id=%q want %q", task.ID, "tsk_only")
+	}
+	if task.Status != "queued" {
+		t.Errorf("status=%q want %q", task.Status, "queued")
+	}
+}
+
+// The loop has to reach a terminal state and stop. With an empty id every poll
+// went to the list route, so this both pins the exit and pins the URL: an id in
+// the path is the difference between reading a status and reading a board.
+func TestOCRWaitStopsWhenTheTaskSettles(t *testing.T) {
+	dp, stub := newOCRStub(t, 2)
+	task := ocrTask{ID: "tsk_abc", Status: "queued"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := waitForOCRTask(ctx, dp, &task, "Olares/paddle-hybrid", 20*time.Second, false); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if task.Status != "succeeded" {
+		t.Errorf("status=%q want %q", task.Status, "succeeded")
+	}
+	for _, p := range stub.asked() {
+		if id := strings.Trim(strings.TrimPrefix(strings.SplitN(p, "?", 2)[0],
+			"/v1/ocr/tasks"), "/"); id == "" {
+			t.Errorf("a poll went to the list route, which carries no status: %q", p)
+		}
+	}
+}
+
+// A task belongs to one engine. Router routes an OCR task lookup by ?model=,
+// so a poll that leaves it out asks whichever model answers the default OCR
+// route — not necessarily the one holding the task.
+func TestOCRPollCarriesTheModel(t *testing.T) {
+	dp, stub := newOCRStub(t, 1)
+	task := ocrTask{ID: "tsk_abc", Status: "queued"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := waitForOCRTask(ctx, dp, &task, "Olares/paddle-hybrid", 20*time.Second, false); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	asked := stub.asked()
+	if len(asked) == 0 {
+		t.Fatal("no request reached the stub")
+	}
+	for _, p := range asked {
+		if !strings.Contains(p, "model=Olares%2Fpaddle-hybrid") {
+			t.Errorf("the poll dropped the model: %q", p)
+		}
+	}
+}
+
+// What the original bug actually cost, kept executable: an id-less task polls
+// the list route and never settles, so the only thing that ends the wait is the
+// timeout. This is the symptom that read as "the engine is slow" for six
+// minutes on a job that finished in under two seconds, and it is why decoding
+// the receipt correctly is not a cosmetic fix.
+func TestOCRWaitWithNoTaskIDCanOnlyTimeOut(t *testing.T) {
+	dp, stub := newOCRStub(t, 1)
+	task := ocrTask{} // what reading the receipt as a task used to produce
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := waitForOCRTask(ctx, dp, &task, "Olares/paddle-hybrid", 2*time.Second, false)
+	if err == nil {
+		t.Fatal("an id-less wait settled, so it is reading a status from somewhere")
+	}
+	if !strings.Contains(err.Error(), "still") {
+		t.Errorf("the wait ended some way other than the timeout: %v", err)
+	}
+	for _, p := range stub.asked() {
+		if id := strings.Trim(strings.TrimPrefix(strings.SplitN(p, "?", 2)[0],
+			"/v1/ocr/tasks"), "/"); id != "" {
+			t.Errorf("an id-less poll somehow addressed task %q: %s", id, p)
+		}
+	}
+}
+
+// An empty model is left out rather than sent blank, the same way audioTaskPath
+// does it: a bare lookup is a different request from one naming no model.
+func TestOCRTaskPathOmitsAnEmptyModel(t *testing.T) {
+	if got := ocrTaskPath("/v1/ocr/tasks/tsk_abc", "  "); got != "/v1/ocr/tasks/tsk_abc" {
+		t.Errorf("path=%q want it unchanged", got)
+	}
+	if got := ocrTaskPath("/v1/ocr/tasks/tsk_abc", "Olares/paddle-hybrid"); !strings.Contains(got, "model=") {
+		t.Errorf("path=%q carries no model", got)
+	}
+}


### PR DESCRIPTION
## Symptom

`olares-cli router call ocr <file>` printed nothing and waited out its whole
10-minute timeout, on a job the engine had finished in under two seconds. The
engine's own log said `worker finished succeeded` 1.7 seconds after the upload;
the spend row stayed `in_progress` until the reaper eventually wrote it off as
`gateway_abandoned`.

Reproduced with a bounded retry, which printed:

```
task : queued
task : -
```

Two blanks where the task id belongs, and a status that went from `queued` to
nothing.

## Cause

A submission is answered with a receipt, not a task:

```json
{"job_id":"tsk_abc","status":"queued",
 "task":{"object":"task","id":"tsk_abc","status":"queued"}}
```

The code decoded that straight into `ocrTask`, whose `id` and `status` are
top-level fields. Nothing failed — `encoding/json` ignores the keys it does not
know — so it came away with a task carrying an empty id and an empty status.

The wait loop then asked `epOCRTask("")`, which is `/v1/ocr/tasks/` + `""`.
Router's trailing-slash redirect lands that on the list route, and a board
parses cleanly into `ocrTask` while carrying no top-level `status`. So each poll
overwrote the initial `queued` with nothing, `done()` never saw a terminal state,
and the only thing that could end the wait was the timeout. `--no-wait` printed
the same emptiness as `submitted as task ` with no id in it.

## Change

`ocrAccepted` reads the receipt as what it is, falling back to `job_id` when
there is no nested task. A receipt naming no job at all is now an error that says
so, rather than a wait with nothing to wait for.

Separately, every OCR task lookup, cancel and queue listing now carries
`?model=`, the way `audioTaskPath` already does. Router's `forwardOCRTask` routes
these by that parameter, so leaving it out asked whichever model answers the
default OCR route rather than the one actually holding the task — invisible on a
single-OCR-model machine and wrong everywhere else.

## Verification

New `call_ocr_test.go`, six assertions against an `httptest` stub that models
Router's trailing-slash behaviour, since that redirect is what turned an empty id
into a parseable answer:

- the receipt yields the task id, with the flat decode's empty id asserted in
  place so the test states the bug it is guarding
- `job_id` serves as the id when there is no nested task
- the wait loop reaches a terminal state and stops, and no poll goes to the list
  route
- an id-less wait can only end by timing out — the original symptom, kept
  executable
- every poll carries the model
- an empty model is left out rather than sent blank

`go test ./cmd/...` is green.

Made with [Cursor](https://cursor.com)