### PR TITLE
fix(cli): wait for the task when keeping a voice returns a receipt

### DIFF
--- a/cli/cmd/ctl/router/call_voice.go
+++ b/cli/cmd/ctl/router/call_voice.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -95,6 +96,58 @@ type voice struct {
 	Description string            `json:"description"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Settings    json.RawMessage   `json:"settings,omitempty"`
+}
+
+// keptVoice is what a route that keeps a voice answers with, which is either the
+// voice or a receipt for the task that is making it.
+//
+// One shape reads both because the route does not say in advance which it will
+// be, and nothing the caller sends decides: making a voice is minutes of work on
+// some engines and instant on others, so `voices/add` and `text-to-voice` each
+// answer inline or with a task depending on who is behind the category. The
+// discriminator is the receipt's own key rather than the status code — these
+// verbs never ask for a task, so a 202 is the engine's choice to report, not the
+// caller's to interpret.
+type keptVoice struct {
+	voice
+	Task *audioTask `json:"task,omitempty"`
+}
+
+// keep resolves an answer to the voice it made, waiting out the task when the
+// answer was a receipt.
+//
+// Read as a voice, a receipt is a voice with no id: the command reports a name
+// that nothing can be spoken with, and — because a submission opens a spend row
+// the settling lookup is supposed to close — Router is left holding a row for
+// work nobody ever came back for.
+func (k keptVoice) keep(ctx context.Context, dp *routerClient, model string,
+	timeout time.Duration, verbose bool) (voice, error) {
+	if k.Task == nil || strings.TrimSpace(k.Task.ID) == "" {
+		return k.voice, nil
+	}
+	task := k.Task
+	if !task.settled() {
+		if err := waitForAudioTask(ctx, dp, task, model, timeout, verbose); err != nil {
+			return voice{}, err
+		}
+	}
+	if !strings.EqualFold(task.Status, "succeeded") {
+		if task.Error != nil && strings.TrimSpace(task.Error.Message) != "" {
+			return voice{}, fmt.Errorf("the voice was not kept: %s", task.Error.Message)
+		}
+		return voice{}, fmt.Errorf("the voice was not kept: task %s ended %s",
+			task.ID, nonEmpty(task.Status))
+	}
+	if len(task.Result) == 0 {
+		return voice{}, fmt.Errorf("task %s finished without naming the voice it made; "+
+			"`olares-cli router call voice list --model %s` shows whether it is there",
+			task.ID, nonEmpty(model))
+	}
+	var made voice
+	if err := json.Unmarshal(task.Result, &made); err != nil {
+		return voice{}, fmt.Errorf("read the voice task %s made: %w", task.ID, err)
+	}
+	return made, nil
 }
 
 func newVoiceListCommand(f *cmdutil.Factory) *cobra.Command {
@@ -236,6 +289,7 @@ func newVoiceAddCommand(f *cmdutil.Factory) *cobra.Command {
 		sample      string
 		description string
 		refText     string
+		timeout     time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "add <name>",
@@ -250,6 +304,10 @@ re-uploading anything.
 --sample is the recording. --ref-text is what is said in it, which some engines
 use to align the clone and all of them ignore harmlessly when they do not.
 
+Some engines store the voice as they answer and some run it as a job; either
+way this waits and prints the id the voice actually has. --timeout bounds the
+wait, and a timeout leaves the job running rather than losing it.
+
 Needs a model declaring supports_tts_clone; without --model this resolves
 default-tts-clone, and a machine with no cloning model says so rather than
 sending the recording somewhere that cannot use it.
@@ -263,20 +321,22 @@ Example:
 				return fmt.Errorf("--sample is required: a voice made from a recording needs the recording")
 			}
 			return runVoiceAdd(c.Context(), f, args[0], sample, description, refText,
-				callModel(model, categoryTTSClone), apiKey, output)
+				callModel(model, categoryTTSClone), apiKey, output, timeout)
 		},
 	}
 	addVoiceModelFlag(cmd, &model, categoryTTSClone)
 	cmd.Flags().StringVar(&sample, "sample", "", "the recording to keep as a voice")
 	cmd.Flags().StringVar(&description, "description", "", "what this voice is, for the person reading the list")
 	cmd.Flags().StringVar(&refText, "ref-text", "", "what is said in the recording")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute,
+		"give up waiting after this long; the model keeps making the voice")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", dataPlaneKeyFlagUsage)
 	addOutputFlag(cmd, &output)
 	return cmd
 }
 
 func runVoiceAdd(ctx context.Context, f *cmdutil.Factory, name, sample, description, refText,
-	model, apiKey, outputRaw string) error {
+	model, apiKey, outputRaw string, timeout time.Duration) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -313,11 +373,18 @@ func runVoiceAdd(ctx context.Context, f *cmdutil.Factory, name, sample, descript
 	if resp.StatusCode/100 != 2 {
 		return callErr(dp.formatErr(http.MethodPost, route, resp.StatusCode, raw))
 	}
-	if format == FormatJSON {
-		return printRawJSON(os.Stdout, raw)
+	var answer keptVoice
+	if err := json.Unmarshal(raw, &answer); err != nil {
+		return fmt.Errorf("read the answer to %s: %w (body=%s)",
+			route, err, truncate(string(raw), 200))
 	}
-	var made voice
-	_ = json.Unmarshal(raw, &made)
+	made, err := answer.keep(ctx, dp, model, timeout, format == FormatTable)
+	if err != nil {
+		return err
+	}
+	if format == FormatJSON {
+		return printJSON(os.Stdout, made)
+	}
 	_, err = fmt.Printf("kept as %s. `olares-cli router call speak \"…\" --voice %s` speaks with it.\n",
 		nonEmpty(made.ID), nonEmpty(made.ID))
 	return err
@@ -331,6 +398,7 @@ func newVoiceDesignCommand(f *cmdutil.Factory) *cobra.Command {
 		text    string
 		save    string
 		outPath string
+		timeout time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "design <description…>",
@@ -360,13 +428,15 @@ Examples:
 				return err
 			}
 			return runVoiceDesign(c.Context(), f, description, text, save, outPath,
-				callModel(model, categoryTTSDesign), apiKey, output)
+				callModel(model, categoryTTSDesign), apiKey, output, timeout)
 		},
 	}
 	addVoiceModelFlag(cmd, &model, categoryTTSDesign)
 	cmd.Flags().StringVar(&text, "text", "", "the line the preview should read")
 	cmd.Flags().StringVar(&save, "save", "", "keep the first preview under this name")
 	cmd.Flags().StringVar(&outPath, "out", "", "write the first preview here")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute,
+		"give up waiting for --save after this long; the model keeps keeping the voice")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", dataPlaneKeyFlagUsage)
 	addOutputFlag(cmd, &output)
 	return cmd
@@ -383,7 +453,7 @@ type voicePreview struct {
 }
 
 func runVoiceDesign(ctx context.Context, f *cmdutil.Factory, description, text, save, outPath,
-	model, apiKey, outputRaw string) error {
+	model, apiKey, outputRaw string, timeout time.Duration) error {
 	format, dp, err := voicePlane(ctx, f, outputRaw, apiKey)
 	if err != nil {
 		return err
@@ -415,18 +485,22 @@ func runVoiceDesign(ctx context.Context, f *cmdutil.Factory, description, text, 
 	}
 
 	if name := strings.TrimSpace(save); name != "" {
-		var kept voice
+		var answer keptVoice
 		if err := dp.doJSON(ctx, http.MethodPost, voicePath(epTextToVoice, model), map[string]any{
 			"generated_voice_id": first.GeneratedVoiceID,
 			"voice_name":         name,
 			"voice_description":  description,
-		}, &kept); err != nil {
+		}, &answer); err != nil {
 			return callErr(err)
+		}
+		kept, err := answer.keep(ctx, dp, model, timeout, format == FormatTable)
+		if err != nil {
+			return err
 		}
 		if format == FormatJSON {
 			return printJSON(os.Stdout, kept)
 		}
-		_, err := fmt.Printf("kept as %s. `olares-cli router call speak \"…\" --voice %s` speaks with it.\n",
+		_, err = fmt.Printf("kept as %s. `olares-cli router call speak \"…\" --voice %s` speaks with it.\n",
 			nonEmpty(kept.ID), nonEmpty(kept.ID))
 		return err
 	}

--- a/cli/cmd/ctl/router/call_voice_keep_test.go
+++ b/cli/cmd/ctl/router/call_voice_keep_test.go
@@ -1,0 +1,171 @@
+// `router call voice add` reported a voice that did not exist yet.
+//
+// A submission that the engine runs as a task is answered with a receipt — the
+// task nested under one key — and the code read that receipt as a voice. Nothing
+// failed: it got a voice with an empty id, printed "kept as " and a blank, and
+// left. The clone was still being made, and the row Router had opened for it was
+// waiting for a lookup that this command was never going to perform.
+
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// voiceKeepStub answers the poll a wait cycle needs. The task settles from the
+// poll numbered settleFrom, carrying finalStatus and finalBody, so a test can
+// tell "read the terminal state" apart from "gave up".
+type voiceKeepStub struct {
+	mu          sync.Mutex
+	paths       []string
+	polls       int
+	settleFrom  int
+	finalStatus string
+	finalTail   string
+}
+
+func (s *voiceKeepStub) serve(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.paths = append(s.paths, r.URL.String())
+	s.polls++
+	polls := s.polls
+	s.mu.Unlock()
+
+	status, tail := "running", ""
+	if polls >= s.settleFrom {
+		status, tail = s.finalStatus, s.finalTail
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"object":"task","id":"atask_1","kind":"engine-task",` +
+		`"cap":"tts_clone","model":"Olares/BreezeBlue/Breeze-TTS-2","status":"` +
+		status + `"` + tail + `}`))
+}
+
+func newVoiceKeepStub(t *testing.T, settleFrom int, finalStatus, finalTail string) (*routerClient, *voiceKeepStub) {
+	t.Helper()
+	stub := &voiceKeepStub{settleFrom: settleFrom, finalStatus: finalStatus, finalTail: finalTail}
+	srv := httptest.NewServer(http.HandlerFunc(stub.serve))
+	t.Cleanup(srv.Close)
+	return newRouterClient(srv.Client(), srv.URL, "alice@example.com"), stub
+}
+
+func (s *voiceKeepStub) asked() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.paths...)
+}
+
+// The receipt has to be read as a receipt. Decoded as a voice it is a voice with
+// no id, and that is the whole of the bug: the command printed the blank and
+// reported success.
+func TestAVoiceReceiptDecodedAsAVoiceHasNoID(t *testing.T) {
+	const receipt = `{"task":{"object":"task","id":"atask_1","kind":"engine-task",` +
+		`"cap":"tts_clone","status":"queued","model":"Olares/BreezeBlue/Breeze-TTS-2"}}`
+
+	var flat voice
+	if err := json.Unmarshal([]byte(receipt), &flat); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if flat.ID != "" {
+		t.Fatalf("the receipt is a voice after all; this test is describing the wrong bug")
+	}
+
+	var answer keptVoice
+	if err := json.Unmarshal([]byte(receipt), &answer); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if answer.Task == nil || answer.Task.ID != "atask_1" {
+		t.Fatalf("task=%+v want the id from the receipt", answer.Task)
+	}
+}
+
+// The wait has to run to the end and read the voice out of the finished task.
+// The id in the result is the only place the real voice_id ever appears.
+func TestKeepingAVoiceWaitsForTheTaskAndReadsWhatItMade(t *testing.T) {
+	dp, stub := newVoiceKeepStub(t, 2, "succeeded", `,"result_kind":"json","result":{"voice_id":"v-mine"}`)
+	answer := keptVoice{Task: &audioTask{ID: "atask_1", Status: "queued"}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	made, err := answer.keep(ctx, dp, "Olares/BreezeBlue/Breeze-TTS-2", 20*time.Second, false)
+	if err != nil {
+		t.Fatalf("keep: %v", err)
+	}
+	if made.ID != "v-mine" {
+		t.Errorf("voice_id=%q want the id the task reported", made.ID)
+	}
+	// A task belongs to one engine, and Router routes the lookup by ?model=.
+	asked := stub.asked()
+	if len(asked) == 0 {
+		t.Fatal("no request reached the stub")
+	}
+	for _, p := range asked {
+		if !strings.Contains(p, "model=Olares%2FBreezeBlue%2FBreeze-TTS-2") {
+			t.Errorf("the poll dropped the model: %q", p)
+		}
+		if !strings.Contains(p, "atask_1") {
+			t.Errorf("the poll did not address the task: %q", p)
+		}
+	}
+}
+
+// An engine that stores the voice inline is left alone. The receipt is the
+// exception, not the shape, and a verb that polled either way would turn one
+// request into two against every engine that never needed a task.
+func TestAnInlineVoiceIsKeptWithoutPollingAnything(t *testing.T) {
+	dp, stub := newVoiceKeepStub(t, 1, "succeeded", "")
+	var answer keptVoice
+	if err := json.Unmarshal([]byte(`{"voice_id":"v-inline","name":"Night Host"}`), &answer); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	made, err := answer.keep(context.Background(), dp, "Olares/BreezeBlue/Breeze-TTS-2", time.Second, false)
+	if err != nil {
+		t.Fatalf("keep: %v", err)
+	}
+	if made.ID != "v-inline" {
+		t.Errorf("voice_id=%q want the id the answer carried", made.ID)
+	}
+	if asked := stub.asked(); len(asked) != 0 {
+		t.Errorf("an inline answer was polled anyway: %v", asked)
+	}
+}
+
+// A task that ends any way but succeeded is a voice that was not kept, and
+// saying so beats printing an id the library does not have.
+func TestKeepingAVoiceReportsATaskThatFailed(t *testing.T) {
+	dp, _ := newVoiceKeepStub(t, 1, "failed",
+		`,"error":{"code":500,"message":"voice clone failed"}`)
+	answer := keptVoice{Task: &audioTask{ID: "atask_1", Status: "queued"}}
+
+	_, err := answer.keep(context.Background(), dp, "Olares/BreezeBlue/Breeze-TTS-2", 20*time.Second, false)
+	if err == nil {
+		t.Fatal("a failed task was reported as a kept voice")
+	}
+	if !strings.Contains(err.Error(), "voice clone failed") {
+		t.Errorf("the engine's own reason is missing: %v", err)
+	}
+}
+
+// A task that succeeded without naming the voice is the empty id again, one step
+// later. The library is the place to look, so the message says so rather than
+// printing a blank.
+func TestASucceededTaskThatNamesNoVoiceIsReportedRatherThanPrintedBlank(t *testing.T) {
+	dp, _ := newVoiceKeepStub(t, 1, "succeeded", "")
+	answer := keptVoice{Task: &audioTask{ID: "atask_1", Status: "queued"}}
+
+	made, err := answer.keep(context.Background(), dp, "Olares/BreezeBlue/Breeze-TTS-2", 20*time.Second, false)
+	if err == nil {
+		t.Fatalf("a task that named no voice yielded %+v", made)
+	}
+	if !strings.Contains(err.Error(), "voice list") {
+		t.Errorf("the message does not say where to look: %v", err)
+	}
+}

--- a/cli/skills/olares-router/references/olares-router-voice.md
+++ b/cli/skills/olares-router/references/olares-router-voice.md
@@ -64,6 +64,10 @@ Reading the table is `default-tts` rather than a category of its own because a c
 
 Every design and every clone is a billed synthesis. Designing four descriptions to compare them costs four calls.
 
+## Keeping a voice may be a task
+
+`voice add` and `voice design --save` each come back one of two ways, and nothing the caller sends decides which: the voice itself, or a receipt for the task making it. Which one arrives depends on the engine behind the category. Both verbs wait the task out and print the real voice id either way, so **an id these verbs print is always addressable** — but against a task engine the verb blocks for as long as the work takes. `--timeout` bounds that wait (10 minutes by default), and a timeout leaves the task running and names the `router call task get` that picks it up.
+
 ## Cloning here versus `call clone`
 
 `call clone me.wav "your build finished" --out done.wav` uploads a recording, speaks one line with it, and forgets the recording. `call voice add "Night Host" --sample me.wav` uploads the same recording and keeps it, so `call speak --voice <id>` reaches it again without another upload.


### PR DESCRIPTION
## The bug

`router call voice add "Night Host" --sample me.wav` printed

```
kept as . `olares-cli router call speak "…" --voice ` speaks with it.
```

and exited 0. The blank is the whole of it: the command reported success for a
voice that did not exist yet, and named nothing that could be spoken with.

## Why

Both routes that keep a voice — `POST /v1/voices/add` and `POST /v1/text-to-voice`
— come back one of two ways, and nothing the caller sends decides which. Some
engines store the voice as they answer; some run it as a job and answer `202`
with a task envelope. The code read the answer as a voice either way:

```go
var made voice
_ = json.Unmarshal(raw, &made)
```

A receipt decoded as a voice is a voice with no id. The unmarshal error was
discarded too, so there was nothing to notice. Meanwhile the submission had
opened a spend row that the settling lookup is supposed to close, and this
command was never going to perform that lookup — so the row sat in flight until
the reaper wrote it off.

`voice design --save` posts to the other keep route and had the same defect.

## The fix

One shape reads both answers:

```go
type keptVoice struct {
	voice
	Task *audioTask `json:"task,omitempty"`
}
```

The discriminator is the receipt's own key rather than the status code. These
verbs never ask for a task, so a `202` is the engine's choice to report and not
the caller's to interpret — and an engine that answered `200` with a receipt
would still be read correctly.

When the answer is a receipt, `keep` waits the task out through the existing
`waitForAudioTask` and reads the voice from `task.result`, which is the only
place the real `voice_id` ever appears. An inline answer is returned without a
single poll, so nothing changes for engines that never needed a task.

Three failures that used to print a blank now say what happened: a task that
ended `failed` reports the engine's own reason, a task that succeeded without
naming a voice points at `voice list`, and an answer that is neither shape
reports the decode error instead of swallowing it.

`--timeout` bounds the wait the way every other waiting verb in this tree does
(`call ocr`, `call chat`, `call music`, `call media`), defaulting to 10 minutes.
A timeout leaves the task running and names the `router call task get` that
picks it up.

## Verification

`call_voice_keep_test.go`, five cases:

- `TestAVoiceReceiptDecodedAsAVoiceHasNoID` — the bug kept executable.
- `TestKeepingAVoiceWaitsForTheTaskAndReadsWhatItMade` — the wait runs to the
  end, reads the id out of the result, and every poll carries the model and the
  task id.
- `TestAnInlineVoiceIsKeptWithoutPollingAnything` — no request reaches the stub.
- `TestKeepingAVoiceReportsATaskThatFailed`
- `TestASucceededTaskThatNamesNoVoiceIsReportedRatherThanPrintedBlank`

Run live against a Breeze-TTS-2 install: `voice add` now prints
`kept as clone09a909d2a94840b09f7a`, and that id is in `speak --voices`.

The `olares-router-voice.md` skill reference gains the two answer shapes and the
`--timeout` bound, since an agent driving these verbs needs to know the call can
block.

The gateway half — a task whose product is a voice never reported a duration, so
Router refused to settle its row — is a separate PR in `beclab/router`. This one
stands on its own: the empty id was printed whether or not the row settled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async voice-keep UX and billing-adjacent task polling for clone/design saves, but reuses established wait patterns and only affects CLI parsing/wait logic—not auth or gateway settlement.
> 
> **Overview**
> Fixes **`router call voice add`** and **`voice design --save`** reporting success with a blank voice id when the engine answers with an async **task receipt** instead of an inline voice.
> 
> Responses are now decoded as **`keptVoice`** (voice fields plus optional **`task`**). **`keep()`** returns inline voices unchanged; when a task is present it **polls via existing `waitForAudioTask`**, reads **`voice_id` from the succeeded task result**, and surfaces clear errors for failed tasks or success without a voice (pointing at **`voice list`**). **`--timeout`** (default 10 minutes) bounds the wait on both commands; timing out leaves the job running.
> 
> JSON output prints the resolved voice rather than the raw receipt. **`call_voice_keep_test.go`** covers receipt vs inline decoding, polling, failures, and missing results. The **olares-router-voice** skill doc notes the two answer shapes and blocking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1badeebef0a97bf94b0f16872ef091edd67a3a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->