### PR TITLE
fix(router): name the model that answered in the usage table

### DIFF
--- a/cli/cmd/ctl/router/usage.go
+++ b/cli/cmd/ctl/router/usage.go
@@ -55,7 +55,13 @@ type spendLog struct {
 	ProviderID      *string `json:"provider_id,omitempty"`
 	ProviderModelID *string `json:"provider_model_id,omitempty"`
 	ModelName       string  `json:"model_name"`
-	Mode            string  `json:"mode"`
+	// ServedModelName is the model that answered, qualified by its provider.
+	// ModelName is what the caller wrote, which is a `default-*` category for
+	// a call that named no model and does not say which engine ran. Empty for
+	// a row with no model to name: a refusal that never reached one, and a
+	// model deleted since the call.
+	ServedModelName string `json:"served_model_name,omitempty"`
+	Mode            string `json:"mode"`
 	// Op is the operation within the mode: which media operation, which
 	// audio route. A mode alone does not say what was asked for.
 	Op            *string `json:"op,omitempty"`
@@ -907,6 +913,11 @@ func newUsageListCommand(f *cmdutil.Factory) *cobra.Command {
 One row per call. WHO is the key, person or application Router billed it to;
 STATUS is the outcome, and a failed call carries the error code Router returned.
 
+MODEL is the model that answered. A call that named no model sent a category
+instead — "default-tts-clone", say — and that is what the row records, so the
+column resolves it to whichever model Router picked. The page says how many rows
+it did that for, and -o json carries both names.
+
 USAGE is the quantity the call was priced by, which is not tokens for most of
 what Router serves: audio is priced by the second, images by the picture, video
 by both, search by the query, OCR by the page and 3D by the object. The column
@@ -996,7 +1007,7 @@ func renderUsageList(ctx context.Context, pc *preparedClient, w io.Writer, items
 		}
 		t.row(
 			it.CreatedAt.Local().Format("2006-01-02 15:04:05"),
-			clip(nonEmpty(it.ModelName), 28), nonEmpty(spendOp(it)),
+			clip(nonEmpty(spendModel(it)), 28), nonEmpty(spendOp(it)),
 			clip(spendActor(it, who), 24), clip(status, 30),
 			spendQuantity(it), spendCost(it),
 			spendDuration(it))
@@ -1008,6 +1019,23 @@ func renderUsageList(ctx context.Context, pc *preparedClient, w io.Writer, items
 		return err
 	}
 	return pageFooter(w, len(items), total, offset)
+}
+
+// spendModel is the MODEL column: which model the call actually ran on.
+//
+// A row stores the name the caller wrote, and a call that named no model wrote
+// a category — `default-tts-clone` is a true record of the request and says
+// nothing about where the time went. Router resolves the model behind it, and
+// this column reports that, with the category kept for the footer note and for
+// `-o json`, where both names are always present.
+//
+// A row with nothing resolved falls back to the name the caller wrote, which is
+// then the whole of what happened: a refusal that never reached a model.
+func spendModel(it *spendLog) string {
+	if name := strings.TrimSpace(it.ServedModelName); name != "" {
+		return name
+	}
+	return it.ModelName
 }
 
 // spendOp is the MODE column: the mode, and the operation within it when Router
@@ -1110,12 +1138,19 @@ func spendCost(it *spendLog) string {
 // spendZeroNotes explains the zeros on the page, because a zero cost has four
 // readings and the column shows one glyph for all of them: still running, priced
 // at nothing, measured with no rate to apply, or moved audio nobody measured.
+//
+// It also owns the one note that is not about a zero: a table is one line per
+// call, so a row showing the model that answered has nowhere to also show the
+// category that was asked for.
 func spendZeroNotes(w io.Writer, items []spendLog) error {
-	var running, unpriced, unmetered int
+	var running, unpriced, unmetered, substituted int
 	for i := range items {
 		it := &items[i]
 		if it.Status == statusInProgress {
 			running++
+		}
+		if name := strings.TrimSpace(it.ServedModelName); name != "" && name != it.ModelName {
+			substituted++
 		}
 		for _, tag := range it.Tags {
 			switch tag {
@@ -1143,6 +1178,12 @@ func spendZeroNotes(w io.Writer, items []spendLog) error {
 			"%d audio %s tagged audio_unmetered: the engine reported no duration, and audio is priced "+
 				"by the second, so nothing could be charged.",
 			unmetered, plural(unmetered, "call is", "calls are")))
+	}
+	if substituted > 0 {
+		notes = append(notes, fmt.Sprintf(
+			"%d %s named a category rather than a model. MODEL is what answered; "+
+				"`-o json` carries the name that was asked for as well.",
+			substituted, plural(substituted, "call", "calls")))
 	}
 	for _, note := range notes {
 		if _, err := fmt.Fprintln(w, note); err != nil {

--- a/cli/cmd/ctl/router/usage_columns_test.go
+++ b/cli/cmd/ctl/router/usage_columns_test.go
@@ -128,6 +128,59 @@ func TestARunningCallHasNoCostYet(t *testing.T) {
 	}
 }
 
+// A row records the name the caller wrote, and a call that named no model wrote
+// a category. Reading `default-tts-clone` off a bill tells nobody which engine
+// spent the time.
+func TestTheModelColumnNamesWhatAnswered(t *testing.T) {
+	cases := map[string]struct {
+		row  spendLog
+		want string
+	}{
+		"a category resolves to the model behind it": {
+			spendLog{ModelName: "default-tts-clone", ServedModelName: "Olares/Breeze-TTS-2"},
+			"Olares/Breeze-TTS-2",
+		},
+		"a named model is shown as named": {
+			spendLog{ModelName: "Olares/Breeze-TTS-2", ServedModelName: "Olares/Breeze-TTS-2"},
+			"Olares/Breeze-TTS-2",
+		},
+		"a refusal that reached no model keeps the caller's own name": {
+			spendLog{ModelName: "default-rerank"},
+			"default-rerank",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := spendModel(&tc.row); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The table is one line per call, so the substitution has to be said somewhere:
+// a reader who cannot find the name they typed would take the page for the
+// wrong account.
+func TestASubstitutedCategoryIsReportedOnce(t *testing.T) {
+	var buf bytes.Buffer
+	rows := []spendLog{
+		{Mode: "tts", Status: "success", ModelName: "default-tts-clone",
+			ServedModelName: "Olares/Breeze-TTS-2"},
+		{Mode: "chat", Status: "success", ModelName: "Olares/Qwen3-8B",
+			ServedModelName: "Olares/Qwen3-8B"},
+	}
+	if err := spendZeroNotes(&buf, rows); err != nil {
+		t.Fatalf("spendZeroNotes: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "1 call named a category") {
+		t.Fatalf("the notes should count the one substituted row, got:\n%s", out)
+	}
+	if strings.Count(out, "named a category") != 1 {
+		t.Fatalf("the note belongs on the page once, got:\n%s", out)
+	}
+}
+
 // Four different facts share one glyph in the money column, so the page says
 // which of them it is showing.
 func TestTheZerosOnThePageAreExplained(t *testing.T) {

--- a/cli/skills/olares-router/references/olares-router-usage.md
+++ b/cli/skills/olares-router/references/olares-router-usage.md
@@ -54,6 +54,10 @@ Three zeros mean three different things and `list` says which under the table:
 - **`unpriced`** — the quantity was measured and the model row carries no rate for it. Music and 3D generation are permanently here today: Router has no price list for either, so the traffic is real and the money is not. Fixing it means putting prices on the model row — a picture rate is per picture, so an image workflow that reads `unpriced` while its pictures are counted has only the tiered rates (resolution, quality) configured and not that one.
 - **`audio_unmetered`** — the engine reported no duration, and audio is charged by the second, so there was nothing to multiply.
 
+**`MODEL` is what answered, not always what was asked for.** A row records the name the caller wrote, and a call that named no model wrote a category — `default-tts-clone`, `default-stt`, `default-ocr`. That is a true record of the request and says nothing about which engine spent the time, so the column resolves the category to the model behind it and the page counts the rows it did that for. `-o json` carries both: `model_name` is what was asked for, `served_model_name` is what ran. A refusal that never reached a model has only the one name, and the column shows it.
+
+Both names matter for different questions. `--model` and `usage summary --by model` group by the model that answered, so a category and the qualified name are one bucket; `model_name` is what somebody searches by when they remember what they typed.
+
 `--session` follows one piece of work across the calls it took. An agent or a split audio job sends a session id, so the six calls that transcribed one recording are one filter apart instead of six rows to spot by timestamp.
 
 A row carries a key only when the call presented one. `router call` presents none by default, so its rows have an empty key and are attributed to the person: **`--key` will not find them, and `--user` is how they are read.** A row with no key is the normal shape for a call made from `olares-cli` or from a browser, not a record that lost its attribution.


### PR DESCRIPTION
## What was wrong

`olares-cli router usage list` printed a MODEL column full of categories:
`default-tts-clone`, `default-stt`, `default-ocr`. A reader could not tell
which engine spent the GPU time.

This CLI is one of the callers that causes it. With no `--model` it resolves
the category client-side and sends `default-tts-clone` as the model, so
Router records exactly that — a true record of the request, and one that
names no engine.

## What changed

Router now resolves `provider_model_id` on the read path and returns
`served_model_name` next to `model_name` (see ADR-73 in the router
repository). The MODEL column shows the model that answered, and the footer
counts the rows where the two names differ, because the table is one line
per call and the substitution has nowhere else to be said:

```
2 calls named a category rather than a model. MODEL is what answered;
`-o json` carries the name that was asked for as well.
```

`-o json` carries both names. A Router that does not send the field yet
leaves the column exactly as it was — that fallback is one of the test
cases rather than an assumption.

The `usage list` help and the `olares-router` skill reference both explain
the two names, and the skill note records which of them `--model` and
`usage summary --by model` group by (the model that answered, so a category
and its qualified name are one bucket).

## Verification

- `go test ./cmd/ctl/router/` green, including `TestTheModelColumnNamesWhatAnswered` (category resolves, a named model is shown once, a refusal that reached no model keeps the caller's own name) and `TestASubstitutedCategoryIsReportedOnce`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and JSON field mapping only; backward-compatible when `served_model_name` is absent.
> 
> **Overview**
> **`router usage list` now shows the model that actually ran**, not only the `default-*` category the caller sent when no explicit model was chosen.
> 
> The CLI decodes Router’s new `served_model_name` on spend rows (alongside existing `model_name`). The **MODEL** column uses `spendModel`, preferring `served_model_name` and falling back to `model_name` when the API omits it. **Footer notes** count rows where the served name differs from the requested name and point readers to `-o json` for both fields.
> 
> Help text for `usage list` and the **olares-router** usage reference document the split (`model_name` vs `served_model_name`) and that `--model` / `summary --by model` group by what answered. Tests cover resolution, unchanged named models, refusals with no served model, and the single substitution note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b29c859d0a14ce074ac6be5d0664c7e7841d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->