### PR TITLE
olares: bump system-frontend to v1.11.50

### DIFF
--- a/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
+++ b/apps/.olares/config/user/helm-charts/system-apps/templates/olares-app.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: check-auth
         - name: olares-app-init
-          image: beclab/system-frontend:v1.11.49
+          image: beclab/system-frontend:v1.11.50
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
* **Background**

  This PR bumps the `olares-app-init` image in the `system-apps` chart so that the v1.12.7 release ships the latest LarePass/TermiPass web bundle. It is a chart-only change: one image tag, no Olares-side logic touched.

  | Chart / manifest | Container | Before | After |
  | --- | --- | --- | --- |
  | `apps/.olares/.../system-apps` | `olares-app-init` | `beclab/system-frontend:v1.11.49` | `beclab/system-frontend:v1.11.50` |

  `user-service` stays on `v0.1.18` from the previous bump ([#4108](https://github.com/beclab/Olares/pull/4108)).

  **What the new `system-frontend` image contains**

  1. **Market copy is shortened so status labels and dialogs fit the UI** (TermiPass [#1440](https://github.com/beclab/TermiPass/pull/1440)). Long progressive-tense strings in German, French, and Italian were overflowing Market status chips and action buttons (`Wird installiert` → `Installation…`, `Installation en cours` → `Installation…`, `Riavvio in corso` → `Riavvio…`). The same pass shortens the in-progress labels (`installing`, `initializing`, `applying`, `stopping`, `resuming`, `removing`, `uninstalling`, `updating`, `canceling`, `reviewing`) and the running-state label (`Wird ausgeführt` → `Läuft`, `En cours d'exécution` / `En ejecución` → `Active` / `Activa`). Market detail and dialog strings are tightened so they no longer wrap or truncate in constrained layouts: German resource labels (`Benötigter RAM` / `Benötigter Speicher`), VRAM unit placeholder (`VRAM-Zuweisung in {unit} eingeben`), and shorter CTAs (`Alle updaten`, `Später`); French `N/D`, `Juridique`, `Tout actualiser`, `Traitement des données…`, `Plus tard` / `Installer`; Italian `Spazio richiesto`, `Elaborazione dati…`, `Più tardi`, `Vedi`. Japanese install-confirm copy now asks whether to install after adding to the local source, and the public-entrance description matches the English source instead of repeating the background-service text. Settings French wallpaper copy uses `Importer une image` for upload.

  2. **Startup no longer throws when `connected` is read before the vault is ready** (TermiPass [#1436](https://github.com/beclab/TermiPass/pull/1436)). `userStore.connected` asserted both `this.users` and the `items.get(current_id)` lookup with `!`. Two boot-time states break those assertions: `current_id` is restored from storage before the vault is loaded, and the restored id can point at a user that is no longer in the vault. Until now nothing read the getter that early. #1412 added `installAppIntentRetryWatcher`, which watches `connected` from `appLoadPrepare`; Vue evaluates the getter immediately, so the app threw `Cannot read properties of undefined (reading 'items')` and `Cannot read properties of null (reading 'setup_finished')` during startup. The getter now goes through `current_user`, which already guards both the missing vault and the missing user, and returns `false` in either case. Watchers that only act on a `true` value are unchanged.

  3. **Settings keeps "Enable local service domain" visible off the LAN, explains why it cannot run, and withholds Linux again** (TermiPass [#1441](https://github.com/beclab/TermiPass/pull/1441)). Settings hid the whole hosts section whenever the LAN probe settled as `remote`, so a user who was not on the Olares network had no way to discover the feature. Leaving the LAN also blinked the section out for the ~2s `confirming` window. `resolveHostsUi` now keeps Enable on for every settled probe state while the feature is off; the verdict is applied at click time. `useHostsCta` intercepts an Enable click while `localState !== 'local'` and shows a "Same network required" dialog instead of a bare `not_ready` toast, with copy in all seven LarePass locales. The sidebar banner is unchanged: it still only offers Enable when the probe says `local`. With the feature on, `confirming` keeps the `local` UI so Update / Disable no longer vanish and return; `unknown` (cold start) stays hidden. Linux is gated off again in `isHostsFeatureSupportedOs` — #1378 withheld it because the elevation path depends on the desktop environment, and the reachability refactor in #1383 silently reverted that line. The gate also keeps the store inert on Linux, so nothing polls the hosts file and `publicHostsWritten` cannot strand the VPN toggle. `supportsLocalDomainSet` is untouched, so what Windows writes does not change.

* **Target Version for Merge**
v1.12.7

* **Related Issues**
 None

* **PRs Involving Sub-Systems**
https://github.com/beclab/TermiPass/pull/1440

* **Other information**
 Full Changelog: 
https://github.com/beclab/TermiPass/compare/v1.11.49...v1.11.50

Made with [Cursor](https://cursor.com)