### PR TITLE
fix(cli): follow the rename to a generation speed in router usage

### DIFF
--- a/cli/cmd/ctl/router/usage.go
+++ b/cli/cmd/ctl/router/usage.go
@@ -87,8 +87,14 @@ type spendLog struct {
 	// only for a stream. QueueMS is the part of the latency the engine did
 	// not spend working, and only a local engine reports the timings it is
 	// derived from.
-	TTFTMS   *int64 `json:"ttft_ms,omitempty"`
-	QueueMS  *int64 `json:"queue_ms,omitempty"`
+	TTFTMS  *int64 `json:"ttft_ms,omitempty"`
+	QueueMS *int64 `json:"queue_ms,omitempty"`
+	// DecodeMS is the part of the latency the model spent writing, and it is
+	// what the reported generation speed divides by. Nil means no span could
+	// be established -- a buffered answer from an upstream that reports no
+	// timings has no first-token moment to subtract -- and such a call is
+	// left out of that speed rather than counted at its wall clock.
+	DecodeMS *int64 `json:"decode_ms,omitempty"`
 	Streamed bool   `json:"streamed"`
 
 	AudioInputSeconds  *float64 `json:"audio_input_seconds,omitempty"`
@@ -157,7 +163,12 @@ type spendTotals struct {
 	TotalQueries      int64   `json:"total_queries"`
 	TotalPages        int64   `json:"total_pages"`
 	TotalObjects      int64   `json:"total_objects"`
-	AvgTPS            float64 `json:"avg_tps"`
+	// Generation speed, not the speed of a whole request: the denominator is
+	// the time the models spent writing, so the prompt read and the engine's
+	// queue are outside it. Zero means no call in the window could be
+	// measured that way, which is why it is reported as absent rather than
+	// as a speed of nothing.
+	AvgDecodeTPS float64 `json:"avg_decode_tps"`
 }
 
 type spendSummary struct {
@@ -870,8 +881,8 @@ func renderSummaryTotals(w io.Writer, tot *spendTotals) error {
 	if _, err := fmt.Fprintf(w, ", %s", strings.Join(quantities, ", ")); err != nil {
 		return err
 	}
-	if tot.AvgTPS > 0 {
-		if _, err := fmt.Fprintf(w, ", averaging %.1f tokens/s", tot.AvgTPS); err != nil {
+	if tot.AvgDecodeTPS > 0 {
+		if _, err := fmt.Fprintf(w, ", generating at %.1f tokens/s", tot.AvgDecodeTPS); err != nil {
 			return err
 		}
 	}

--- a/cli/cmd/ctl/router/usage_columns_test.go
+++ b/cli/cmd/ctl/router/usage_columns_test.go
@@ -28,6 +28,7 @@ const liveSpendRow = `{
   "job_ms": 273000,
   "ttft_ms": 800,
   "queue_ms": 120,
+  "decode_ms": 9800,
   "streamed": false,
   "videos": 1,
   "video_seconds": 5.5,
@@ -55,6 +56,9 @@ func TestASpendRowDecodesTheColumnsRouterAnswersWith(t *testing.T) {
 	}
 	if it.JobMS == nil || *it.JobMS != 273000 {
 		t.Fatalf("job_ms did not decode: %+v", it.JobMS)
+	}
+	if it.DecodeMS == nil || *it.DecodeMS != 9800 {
+		t.Fatalf("decode_ms did not decode: %+v", it.DecodeMS)
 	}
 	if it.Videos == nil || *it.Videos != 1 {
 		t.Fatalf("videos did not decode: %+v", it.Videos)

--- a/cli/skills/olares-router/references/olares-router-usage.md
+++ b/cli/skills/olares-router/references/olares-router-usage.md
@@ -48,6 +48,8 @@ An asynchronous generation is counted by what it delivered rather than by the re
 
 **`TOOK` is not how long the request was open.** An asynchronous call — a diarization, a video, a long synthesis — is accepted, worked on, and collected later, so the request that returns the result is a JSON forward measured in milliseconds while the work took minutes. The row therefore carries both: `latency_ms` is the request and `job_ms` is the work, and `TOOK` shows the work when there is one. A row with no `job_ms` was synchronous and its request time is the whole story. This matters when reading a slow report: a 273-second diarization used to appear as five milliseconds, which made the engine look idle.
 
+**The speed `summary` reports is a generation speed, not a throughput.** `avg_decode_tps` divides the tokens the models wrote by `decode_ms`, the time they spent writing — so reading the prompt, the engine's queue, a failed attempt and the trip back are all outside it, and the figure is comparable to the tokens/s a model's own benchmark quotes. Only `chat` and `responses` calls can contribute; a translation's tokens are a side effect of other work and would make the number mean two things at once. A call whose decode span cannot be established sits the speed out instead of being counted at its wall clock, so a window with none reports no speed rather than a slow one. Read the whole of a window's cost from the token and cost columns, never from this.
+
 Three zeros mean three different things and `list` says which under the table:
 
 - **still running** — priced when it ends, as above.


### PR DESCRIPTION
Router 2.7.41 changed what the `t/s` on the usage summary means: it divides the tokens a model wrote by the time it spent writing, rather than by how long the whole request took. The field was renamed `avg_tps` → `avg_decode_tps` to say so.

The CLI still read `avg_tps`. A missing float is not an error, so `router usage summary` reported a speed of **zero** over a window holding 1197 calls and 3.98M tokens — and `printJSON` re-serializes the CLI's own struct, so `-o json` published that zero too.

```
$ olares-cli router usage summary --since 7d -o json   # before
avg_tps = 0 | total_requests = 1197 | total_tokens = 3980637
```

This follows the rename and reworks the human-readable line to match the meaning (`averaging N tokens/s` → `generating at N tokens/s`).

It also carries `decode_ms` on the detail row. The CSV export already has it; `usage list` did not, and it is the denominator — whether a row contributed to that speed, and why one did not, is only explicable next to it. Without it the same `-o json` dropped the column even when the server sent it.

`references/olares-router-usage.md` gains a paragraph in the section that already separates `latency_ms` from `job_ms`, saying this is a generation speed rather than a throughput, that only `chat` and `responses` can contribute, and that a window with no measurable call reports no speed instead of a slow one.

Verified against a live Olares running Router 2.7.42: the summary figure now matches an independent recomputation over the same rows to six decimal places, and the detail rows show the engine-reported span (`predicted_ms`) where there is one and the `latency_ms - ttft_ms` fallback otherwise.

Made with [Cursor](https://cursor.com)