### PR TITLE
fix(cli): stop profile cache writes from reverting `profile use`

### DIFF
--- a/cli/internal/lockfile/lockfile.go
+++ b/cli/internal/lockfile/lockfile.go
@@ -1,8 +1,12 @@
 // Package lockfile is a tiny wrapper over github.com/gofrs/flock that adds
-// context-cancelable acquisition and a single deterministic lock-directory
-// layout under cliconfig.Home(). It exists so the rest of the codebase
+// context-cancelable acquisition. It exists so the rest of the codebase
 // doesn't import flock directly — keeping the dependency surface small and
 // letting us swap the backend without touching every call site.
+//
+// Lock paths are built by the packages that own them (cliconfig.LockPath),
+// not here: cliconfig has to be able to lock its own file, and a package
+// that knew the config-directory layout could not be imported by the
+// package that defines it.
 //
 // The locks are advisory file locks (flock(2) on darwin/linux, LockFileEx on
 // windows). Two olares-cli processes contending for the same olaresId's
@@ -21,8 +25,6 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-
-	"github.com/beclab/Olares/cli/pkg/cliconfig"
 )
 
 // dirPerm matches cliconfig's 0700 — the lock dir lives next to config.json
@@ -67,25 +69,16 @@ func Acquire(ctx context.Context, path string) (release func() error, err error)
 	}
 }
 
-// RefreshLockPath returns the per-olaresId refresh lock path under
-// cliconfig.Home()/locks/. The olaresId is sanitized for filesystem use
-// (slashes / null / colon / control chars are replaced with '_'); '@' and
-// '.' are left intact since they are valid on every supported OS and
-// preserve the original olaresId in directory listings, which is useful for
-// debugging.
-func RefreshLockPath(olaresID string) (string, error) {
-	home, err := cliconfig.Home()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, "locks", sanitize(olaresID)+".refresh.lock"), nil
-}
-
-// sanitize replaces any character that's problematic on at least one of our
-// target filesystems with '_'. We deliberately allow '@' and '.' through
-// (they are legal on darwin/linux/windows file names) so the resulting file
-// name is still a recognizable olaresId.
-func sanitize(s string) string {
+// Sanitize turns an arbitrary identifier (typically an olaresId) into a
+// single path element safe to use as a lock file name. Slashes, null and
+// control characters are replaced with '_'; '@' and '.' are left intact
+// since they are valid on every supported OS and preserve the original
+// identifier in directory listings, which is useful for debugging.
+//
+// Production olaresIds look like "alice@olares.com" and need no rewriting.
+// The point is that a malformed override (e.g. from $OLARES_PROFILE) cannot
+// escape the lock directory.
+func Sanitize(s string) string {
 	if s == "" {
 		return "_"
 	}

--- a/cli/internal/lockfile/lockfile_test.go
+++ b/cli/internal/lockfile/lockfile_test.go
@@ -134,28 +134,24 @@ func TestAcquire_ConcurrentInProcess(t *testing.T) {
 	t.Logf("maxConcurrent observed: %d (expected 1 across processes, ≤ %d within one process)", maxConcurrent.Load(), n)
 }
 
-// TestRefreshLockPath_Sanitization ensures path-unsafe characters in
-// the olaresId are replaced rather than reaching the filesystem.
-// Production olaresIds look like "alice@olares.com", which is fine on
-// every supported OS — but defensive sanitization keeps a malformed
-// override (e.g. from $OLARES_PROFILE) from causing a path-traversal.
-func TestRefreshLockPath_Sanitization(t *testing.T) {
-	t.Setenv("OLARES_CLI_HOME", t.TempDir())
+// TestSanitize ensures path-unsafe characters in a lock name are replaced
+// rather than reaching the filesystem. Production olaresIds look like
+// "alice@olares.com", which is fine on every supported OS — but defensive
+// sanitization keeps a malformed override (e.g. from $OLARES_PROFILE) from
+// causing a path-traversal.
+func TestSanitize(t *testing.T) {
 	for _, tc := range []struct {
-		in       string
-		mustHave string
+		in   string
+		want string
 	}{
-		{"alice@olares.com", "alice@olares.com.refresh.lock"},
-		{"weird/id", "weird_id.refresh.lock"},
-		{"with\x00null", "with_null.refresh.lock"},
-		{"", "_.refresh.lock"},
+		{"alice@olares.com", "alice@olares.com"},
+		{"weird/id", "weird_id"},
+		{"with\x00null", "with_null"},
+		{"../../escape", ".._.._escape"},
+		{"", "_"},
 	} {
-		got, err := RefreshLockPath(tc.in)
-		if err != nil {
-			t.Fatalf("RefreshLockPath(%q): %v", tc.in, err)
-		}
-		if filepath.Base(got) != tc.mustHave {
-			t.Errorf("RefreshLockPath(%q) base = %q, want %q", tc.in, filepath.Base(got), tc.mustHave)
+		if got := Sanitize(tc.in); got != tc.want {
+			t.Errorf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/cli/pkg/cliconfig/backend_version_test.go
+++ b/cli/pkg/cliconfig/backend_version_test.go
@@ -1,12 +1,14 @@
 package cliconfig
 
 import (
+	"context"
 	"testing"
 )
 
 func TestSetBackendVersion(t *testing.T) {
 	// Isolate the config dir to a temp location.
 	t.Setenv(homeEnv, t.TempDir())
+	ctx := context.Background()
 
 	const id = "alice@olares.com"
 	seed := &MultiProfileConfig{}
@@ -16,11 +18,7 @@ func TestSetBackendVersion(t *testing.T) {
 	}
 
 	// First write: empty -> version reports changed.
-	cfg, err := LoadMultiProfileConfig()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	changed, err := cfg.SetBackendVersion(id, "1.12.5", 1000)
+	changed, err := SetBackendVersion(ctx, id, "1.12.5", 1000)
 	if err != nil {
 		t.Fatalf("set: %v", err)
 	}
@@ -39,19 +37,23 @@ func TestSetBackendVersion(t *testing.T) {
 	}
 
 	// Same version again: not changed (but timestamp still updated).
-	changed, err = reloaded.SetBackendVersion(id, "1.12.5", 2000)
+	changed, err = SetBackendVersion(ctx, id, "1.12.5", 2000)
 	if err != nil {
 		t.Fatalf("set same: %v", err)
 	}
 	if changed {
 		t.Error("rewriting the same version should report changed=false")
 	}
+	reloaded, err = LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
 	if reloaded.FindByOlaresID(id).BackendVersionRefreshedAt != 2000 {
 		t.Error("refreshedAt should update even when version is unchanged")
 	}
 
 	// Upgrade detected: 1.12.5 -> 1.12.6 reports changed.
-	changed, err = reloaded.SetBackendVersion(id, "1.12.6", 3000)
+	changed, err = SetBackendVersion(ctx, id, "1.12.6", 3000)
 	if err != nil {
 		t.Fatalf("set upgrade: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestSetBackendVersion(t *testing.T) {
 	}
 
 	// Unknown profile errors.
-	if _, err := reloaded.SetBackendVersion("bob@olares.com", "1.12.6", 4000); err == nil {
+	if _, err := SetBackendVersion(ctx, "bob@olares.com", "1.12.6", 4000); err == nil {
 		t.Error("setting version for an unknown profile should error")
 	}
 }

--- a/cli/pkg/cliconfig/config.go
+++ b/cli/pkg/cliconfig/config.go
@@ -1,13 +1,16 @@
 package cliconfig
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/beclab/Olares/cli/internal/lockfile"
 	"github.com/beclab/Olares/cli/pkg/olares"
 )
 
@@ -271,99 +274,151 @@ func (m *MultiProfileConfig) Upsert(p ProfileConfig) *ProfileConfig {
 	return &m.Profiles[len(m.Profiles)-1]
 }
 
-// SetOwnerRole atomically updates the OwnerRole + WhoamiRefreshedAt fields
-// for the profile keyed by olaresID, then persists config.json.
+// configLockTimeout bounds the wait for config.lock. The critical section is
+// a small read, an in-memory edit and a rename, so anything approaching this
+// means a peer died holding the lock rather than that we are queued behind
+// honest work.
+const configLockTimeout = 10 * time.Second
+
+// MutateProfile applies fn to the profile keyed by olaresID and persists the
+// result, serializing the whole read-modify-write cycle on config.lock and
+// re-reading config.json from disk inside it.
+//
+// Re-reading under the lock is the entire point, and the reason these are
+// package functions rather than methods on MultiProfileConfig. Every field
+// the Set* helpers below touch is a cache that some command refreshes
+// mid-flight, while CurrentProfile / PreviousProfile on the same struct are
+// what `profile use` writes. A caller that edited one field of a config it
+// loaded at process start and saved the whole struct would also write back
+// the active profile as it was at load time, silently undoing a
+// `profile use` that landed in between: atomicWriteFile gives us atomicity,
+// not isolation. Taking a MultiProfileConfig receiver here would let that
+// bug back in, so there is deliberately nothing to pass.
+//
+// A missing profile is an error rather than a silent no-op: every caller
+// only gets here after a successful API call against that olaresID, so the
+// profile disappearing means something else removed it and the caller
+// should say so.
+func MutateProfile(ctx context.Context, olaresID string, fn func(*ProfileConfig) error) error {
+	if olaresID == "" {
+		return errors.New("cliconfig: empty olaresID")
+	}
+	lockPath, err := LockPath(configLockFilename)
+	if err != nil {
+		return err
+	}
+	lockCtx, cancel := context.WithTimeout(ctx, configLockTimeout)
+	defer cancel()
+	release, err := lockfile.Acquire(lockCtx, lockPath)
+	if err != nil {
+		return fmt.Errorf("acquire config lock: %w", err)
+	}
+	defer release() //nolint:errcheck // best-effort lock release
+
+	cfg, err := LoadMultiProfileConfig()
+	if err != nil {
+		return err
+	}
+	target := cfg.FindByOlaresID(olaresID)
+	if target == nil {
+		return fmt.Errorf("profile %q not found", olaresID)
+	}
+	if err := fn(target); err != nil {
+		return err
+	}
+	if err := SaveMultiProfileConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	return nil
+}
+
+// SetOwnerRole updates the OwnerRole + WhoamiRefreshedAt fields for the
+// profile keyed by olaresID.
 //
 // Returns:
 //   - changed: true iff OwnerRole transitioned to a different non-empty
 //     value (used by callers to decide whether to print a "role changed"
 //     notice). A first-time write (empty → role) also reports changed=true
 //     because that's a new piece of information from the user's perspective.
-//   - err:     any I/O / serialization error from SaveMultiProfileConfig.
-//
-// If no profile matches olaresID we return (false, error) — callers should
-// surface this rather than silently writing nothing, because every code
-// path here only runs after a successful API call against that olaresID.
+//     The comparison is against the value on disk, not against whatever the
+//     caller last read.
+//   - err:     any lock / I/O / serialization error.
 //
 // refreshedAt is the wall-clock the caller observed the API success at;
 // passed in (rather than re-read here) so test code and replay-style
 // flows can pin it deterministically.
-func (m *MultiProfileConfig) SetOwnerRole(olaresID, role string, refreshedAt int64) (changed bool, err error) {
-	target := m.FindByOlaresID(olaresID)
-	if target == nil {
-		return false, fmt.Errorf("profile %q not found", olaresID)
+func SetOwnerRole(ctx context.Context, olaresID, role string, refreshedAt int64) (changed bool, err error) {
+	err = MutateProfile(ctx, olaresID, func(p *ProfileConfig) error {
+		changed = role != "" && p.OwnerRole != role
+		p.OwnerRole = role
+		p.WhoamiRefreshedAt = refreshedAt
+		return nil
+	})
+	if err != nil {
+		return false, err
 	}
-	prev := target.OwnerRole
-	target.OwnerRole = role
-	target.WhoamiRefreshedAt = refreshedAt
-	if err := SaveMultiProfileConfig(m); err != nil {
-		return false, fmt.Errorf("save config: %w", err)
-	}
-	return role != "" && prev != role, nil
+	return changed, nil
 }
 
-// SetClusterContext atomically updates the ClusterContext +
-// ClusterContextRefreshedAt fields for the profile keyed by olaresID, then
-// persists config.json. Mirrors SetOwnerRole's contract.
+// SetClusterContext updates the ClusterContext + ClusterContextRefreshedAt
+// fields for the profile keyed by olaresID. Mirrors SetOwnerRole's contract.
 //
 // Returns:
 //   - changed: true iff GlobalRole transitioned to a different non-empty
 //     value (used by `cluster context` to print a "role changed" notice).
 //     A first-time write (cache was nil) also reports changed=true.
-//   - err:     any I/O / serialization error from SaveMultiProfileConfig.
+//   - err:     any lock / I/O / serialization error.
 //
-// `ctx` is the freshly-decoded snapshot to persist; passing nil is treated
+// `cache` is the freshly-decoded snapshot to persist; passing nil is treated
 // as an explicit "clear the cache" (used by tests / future eviction).
 //
 // IMPORTANT: this writes a snapshot of identity/role/visibility metadata
 // only — the cache MUST NOT be consulted to decide whether a verb is
 // allowed to run. See ProfileConfig.ClusterContext doc.
-func (m *MultiProfileConfig) SetClusterContext(olaresID string, ctx *ClusterContextCache, refreshedAt int64) (changed bool, err error) {
-	target := m.FindByOlaresID(olaresID)
-	if target == nil {
-		return false, fmt.Errorf("profile %q not found", olaresID)
-	}
-	prevRole := ""
-	if target.ClusterContext != nil {
-		prevRole = target.ClusterContext.GlobalRole
-	}
-	target.ClusterContext = ctx
-	target.ClusterContextRefreshedAt = refreshedAt
-	if err := SaveMultiProfileConfig(m); err != nil {
-		return false, fmt.Errorf("save config: %w", err)
-	}
+func SetClusterContext(ctx context.Context, olaresID string, cache *ClusterContextCache, refreshedAt int64) (changed bool, err error) {
 	newRole := ""
-	if ctx != nil {
-		newRole = ctx.GlobalRole
+	if cache != nil {
+		newRole = cache.GlobalRole
 	}
-	return newRole != "" && prevRole != newRole, nil
+	err = MutateProfile(ctx, olaresID, func(p *ProfileConfig) error {
+		prevRole := ""
+		if p.ClusterContext != nil {
+			prevRole = p.ClusterContext.GlobalRole
+		}
+		changed = newRole != "" && prevRole != newRole
+		p.ClusterContext = cache
+		p.ClusterContextRefreshedAt = refreshedAt
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
 }
 
-// SetBackendVersion atomically updates the BackendVersion +
-// BackendVersionRefreshedAt fields for the profile keyed by olaresID, then
-// persists config.json. Mirrors SetOwnerRole's contract.
+// SetBackendVersion updates the BackendVersion + BackendVersionRefreshedAt
+// fields for the profile keyed by olaresID. Mirrors SetOwnerRole's contract.
 //
 // Returns:
 //   - changed: true iff BackendVersion transitioned to a different non-empty
 //     value (callers can use this to notice "the backend was upgraded"). A
 //     first-time write (empty → version) also reports changed=true.
-//   - err:     any I/O / serialization error from SaveMultiProfileConfig.
+//   - err:     any lock / I/O / serialization error.
 //
 // refreshedAt is the wall-clock the caller observed the /api/olares-info
 // success at; passed in (rather than re-read here) so test code can pin it
 // deterministically.
-func (m *MultiProfileConfig) SetBackendVersion(olaresID, version string, refreshedAt int64) (changed bool, err error) {
-	target := m.FindByOlaresID(olaresID)
-	if target == nil {
-		return false, fmt.Errorf("profile %q not found", olaresID)
+func SetBackendVersion(ctx context.Context, olaresID, version string, refreshedAt int64) (changed bool, err error) {
+	err = MutateProfile(ctx, olaresID, func(p *ProfileConfig) error {
+		changed = version != "" && p.BackendVersion != version
+		p.BackendVersion = version
+		p.BackendVersionRefreshedAt = refreshedAt
+		return nil
+	})
+	if err != nil {
+		return false, err
 	}
-	prev := target.BackendVersion
-	target.BackendVersion = version
-	target.BackendVersionRefreshedAt = refreshedAt
-	if err := SaveMultiProfileConfig(m); err != nil {
-		return false, fmt.Errorf("save config: %w", err)
-	}
-	return version != "" && prev != version, nil
+	return changed, nil
 }
 
 // Remove deletes a profile by Name or OlaresID. If the removed profile was

--- a/cli/pkg/cliconfig/mutate_test.go
+++ b/cli/pkg/cliconfig/mutate_test.go
@@ -1,0 +1,127 @@
+package cliconfig
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestMutateProfile_PreservesConcurrentProfileSwitch is the regression test
+// for the bug that made `profile use` report success and then silently
+// revert: a command holding a MultiProfileConfig loaded before the switch
+// wrote its own field and saved the whole struct, restoring the active
+// profile as it was at load time.
+//
+// The shape here mirrors what happened on a real machine — `profile use B`
+// lands while a `cluster context --refresh` started under A is in flight —
+// and asserts that the switch survives and the refreshed field still lands.
+func TestMutateProfile_PreservesConcurrentProfileSwitch(t *testing.T) {
+	t.Setenv(homeEnv, t.TempDir())
+	ctx := context.Background()
+
+	const (
+		idA = "a@olares.com"
+		idB = "b@olares.com"
+	)
+	seed := &MultiProfileConfig{CurrentProfile: idA}
+	seed.Upsert(ProfileConfig{OlaresID: idA})
+	seed.Upsert(ProfileConfig{OlaresID: idB})
+	if err := SaveMultiProfileConfig(seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// The in-flight command's view of the world, captured before the
+	// switch happens. Writing through it must not resurrect idA.
+	stale, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("load stale: %v", err)
+	}
+
+	// The switch, performed the way `profile use` does it.
+	switched, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("load for switch: %v", err)
+	}
+	if _, err := switched.SetCurrent(idB); err != nil {
+		t.Fatalf("set current: %v", err)
+	}
+	if err := SaveMultiProfileConfig(switched); err != nil {
+		t.Fatalf("save switch: %v", err)
+	}
+
+	if _, err := SetOwnerRole(ctx, stale.Current().OlaresID, "owner", 1000); err != nil {
+		t.Fatalf("set owner role: %v", err)
+	}
+
+	got, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.CurrentProfile != idB {
+		t.Errorf("currentProfile = %q, want %q — the cache refresh reverted the switch", got.CurrentProfile, idB)
+	}
+	if p := got.FindByOlaresID(idA); p == nil || p.OwnerRole != "owner" {
+		t.Errorf("profile %s = %+v, want ownerRole=owner — the refresh should still land", idA, p)
+	}
+}
+
+// TestMutateProfile_ConcurrentWritersDoNotLoseFields checks that parallel
+// mutations of different fields on the same profile all survive. Without the
+// lock + re-read, the last writer would overwrite the others with the state
+// it loaded before they ran.
+func TestMutateProfile_ConcurrentWritersDoNotLoseFields(t *testing.T) {
+	t.Setenv(homeEnv, t.TempDir())
+	ctx := context.Background()
+
+	const id = "alice@olares.com"
+	seed := &MultiProfileConfig{CurrentProfile: id}
+	seed.Upsert(ProfileConfig{OlaresID: id})
+	if err := SaveMultiProfileConfig(seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 3)
+	for _, write := range []func() error{
+		func() error { _, err := SetOwnerRole(ctx, id, "owner", 1000); return err },
+		func() error { _, err := SetBackendVersion(ctx, id, "1.12.7", 2000); return err },
+		func() error {
+			_, err := SetClusterContext(ctx, id, &ClusterContextCache{GlobalRole: "platform-admin"}, 3000)
+			return err
+		},
+	} {
+		wg.Add(1)
+		go func(fn func() error) {
+			defer wg.Done()
+			if err := fn(); err != nil {
+				errs <- err
+			}
+		}(write)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent write: %v", err)
+	}
+
+	got, err := LoadMultiProfileConfig()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	p := got.FindByOlaresID(id)
+	if p == nil {
+		t.Fatal("profile disappeared")
+	}
+	if p.OwnerRole != "owner" {
+		t.Errorf("ownerRole = %q, want owner", p.OwnerRole)
+	}
+	if p.BackendVersion != "1.12.7" {
+		t.Errorf("backendVersion = %q, want 1.12.7", p.BackendVersion)
+	}
+	if p.ClusterContext == nil || p.ClusterContext.GlobalRole != "platform-admin" {
+		t.Errorf("clusterContext = %+v, want globalRole=platform-admin", p.ClusterContext)
+	}
+	if got.CurrentProfile != id {
+		t.Errorf("currentProfile = %q, want %q", got.CurrentProfile, id)
+	}
+}

--- a/cli/pkg/cliconfig/paths.go
+++ b/cli/pkg/cliconfig/paths.go
@@ -34,6 +34,15 @@ const defaultDir = ".olares-cli"
 // cli/pkg/auth/token_store_keychain.go.
 const configFilename = "config.json"
 
+// lockDir is the subdirectory of Home() holding every advisory lock the CLI
+// takes: this package's config.lock plus the per-olaresId token-refresh
+// locks built by pkg/credential.
+const lockDir = "locks"
+
+// configLockFilename serializes read-modify-write cycles on config.json.
+// See MutateProfile.
+const configLockFilename = "config.lock"
+
 // Permissions for the config dir & file. config.json holds the profile index
 // (no secrets) but we still keep it 0600 because it does carry the
 // `currentProfile` selection and any auth-URL overrides.
@@ -79,4 +88,18 @@ func ConfigFile() (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, configFilename), nil
+}
+
+// LockPath returns the absolute path of the named lock file under
+// Home()/locks/. Neither the directory nor the file is created here —
+// lockfile.Acquire does that when it takes the lock.
+//
+// Callers naming a lock after user input must run it through
+// lockfile.Sanitize first; this function does not validate `name`.
+func LockPath(name string) (string, error) {
+	dir, err := Home()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, lockDir, name), nil
 }

--- a/cli/pkg/clusterctx/clusterctx.go
+++ b/cli/pkg/clusterctx/clusterctx.go
@@ -208,7 +208,7 @@ func FetchAndCache(
 		res.PreviousGlobalRole = target.ClusterContext.GlobalRole
 	}
 
-	changed, err := cfg.SetClusterContext(olaresID, info.toCacheEntry(), res.RefreshedAt)
+	changed, err := cliconfig.SetClusterContext(ctx, olaresID, info.toCacheEntry(), res.RefreshedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/cmdutil/olares_version.go
+++ b/cli/pkg/cmdutil/olares_version.go
@@ -198,10 +198,8 @@ func (f *Factory) fetchBackendVersion(ctx context.Context, rp *credential.Resolv
 
 	// Persist best-effort; a write failure (e.g. an env-only profile that
 	// isn't in config.json) must not break the command.
-	if cfg, lerr := cliconfig.LoadMultiProfileConfig(); lerr == nil {
-		if _, serr := cfg.SetBackendVersion(rp.OlaresID, v.Original(), time.Now().Unix()); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not cache Olares backend version: %v\n", serr)
-		}
+	if _, serr := cliconfig.SetBackendVersion(ctx, rp.OlaresID, v.Original(), time.Now().Unix()); serr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not cache Olares backend version: %v\n", serr)
 	}
 	return v, nil
 }

--- a/cli/pkg/credential/refresher.go
+++ b/cli/pkg/credential/refresher.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/beclab/Olares/cli/internal/lockfile"
 	"github.com/beclab/Olares/cli/pkg/auth"
+	"github.com/beclab/Olares/cli/pkg/cliconfig"
 )
 
 // Refresher is the runtime token-refresh primitive: given a (likely-expired)
@@ -175,7 +176,7 @@ func (r *Refresher) refresh(ctx context.Context, in refreshInput) (string, error
 
 	// Cross-process serialization. Bound the wait so a stuck peer can't
 	// hang us indefinitely.
-	lockPath, err := lockfile.RefreshLockPath(olaresID)
+	lockPath, err := refreshLockPath(olaresID)
 	if err != nil {
 		return "", fmt.Errorf("derive refresh lock path: %w", err)
 	}
@@ -345,4 +346,11 @@ func (r *Refresher) alreadyFresh(olaresID, currentAccessToken string, managed bo
 		return stored.AccessToken, true, nil
 	}
 	return "", false, nil
+}
+
+// refreshLockPath returns the per-olaresId lock that serializes /api/refresh
+// across processes. One lock per identity, not one global lock: two profiles
+// rotating their own tokens have no reason to wait on each other.
+func refreshLockPath(olaresID string) (string, error) {
+	return cliconfig.LockPath(lockfile.Sanitize(olaresID) + ".refresh.lock")
 }

--- a/cli/pkg/whoami/version.go
+++ b/cli/pkg/whoami/version.go
@@ -130,7 +130,7 @@ func FetchAndCacheVersion(
 	if cfg == nil {
 		return res, nil
 	}
-	changed, err := cfg.SetBackendVersion(olaresID, v.Original(), res.RefreshedAt)
+	changed, err := cliconfig.SetBackendVersion(ctx, olaresID, v.Original(), res.RefreshedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/whoami/whoami.go
+++ b/cli/pkg/whoami/whoami.go
@@ -207,7 +207,7 @@ func FetchAndCache(
 	res.PreviousRole = target.OwnerRole
 	res.AlreadyMatchedAt = target.WhoamiRefreshedAt
 
-	changed, err := cfg.SetOwnerRole(olaresID, env.Data.OwnerRole, res.RefreshedAt)
+	changed, err := cliconfig.SetOwnerRole(ctx, olaresID, env.Data.OwnerRole, res.RefreshedAt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What was wrong

`profile use X` printed `switched to profile X` and exited 0, and then the
commands that followed ran against the previous machine. I lost a round of
manual testing to this before noticing the target had changed under me.

Every helper that refreshes a per-profile cache — `cluster context --refresh`,
`profile whoami`, the backend-version probe — mutated one field of the
`MultiProfileConfig` it had loaded at process start and then saved the whole
struct. That write includes `CurrentProfile` and `PreviousProfile`, so it
reinstated the active profile as it was at load time and silently undid a
`profile use` that landed in between. `atomicWriteFile` gives us atomicity,
not isolation, and nothing in the output showed that the switch had been
rolled back.

Reproducer, 3/3 before this change:

```bash
olares-cli profile use A@olares.com
olares-cli cluster context --refresh &
sleep 0.15
olares-cli profile use B@olares.com
wait
olares-cli profile list | rg '^\*'   # was A, must be B
```

## The fix

`cliconfig.MutateProfile` takes `config.lock`, re-reads `config.json` inside
it, applies the edit to the target profile and saves. `SetOwnerRole`,
`SetClusterContext` and `SetBackendVersion` move from methods on
`*MultiProfileConfig` to package functions: with no config struct to pass,
a caller cannot reintroduce the bug by handing over a stale one. Their
`changed` results now compare against what is on disk rather than against
whatever the caller last read.

`cmdutil.fetchBackendVersion` had worked around this by re-loading the config
immediately before its write. That is no longer needed, and the convention it
encoded no longer lives only in one call site's comment.

To let `cliconfig` lock its own file, `lockfile` gives up `RefreshLockPath`
and its `cliconfig` import — it was the only thing making the dependency
circular. Lock paths are now built by the packages that own them, through the
new `cliconfig.LockPath`, and `lockfile` exports `Sanitize` for names derived
from user input.

## Verification

- New `TestMutateProfile_PreservesConcurrentProfileSwitch` reproduces the
  real-machine sequence. I confirmed it discriminates by temporarily
  replicating the old write pattern: that reverts `currentProfile`, the new
  one holds.
- New `TestMutateProfile_ConcurrentWritersDoNotLoseFields` runs the three
  setters in parallel and asserts all three fields survive.
- The reproducer above is 3/3 clean, and the concurrent refresh still lands
  (the refreshed profile's `clusterContextRefreshedAt` updates), so this
  serializes the writes rather than dropping one.
- `go build ./...`, `go vet`, `go test` on the changed packages, `make build`.

## Notes for review

Four call sites move to the package functions, not three — `pkg/whoami/version.go`
also wrote through a caller-supplied config.

No behavior change for an env-only profile that has no row in `config.json`:
that already produced a "profile not found" warning, because the previous code
also reached the not-found branch after loading an empty or unrelated config.

Made with [Cursor](https://cursor.com)