### PR TITLE
fix(cli): improve log upload recovery and ticket creation reliability

### DIFF
--- a/cli/cmd/ctl/os/logs_upload.go
+++ b/cli/cmd/ctl/os/logs_upload.go
@@ -2,10 +2,14 @@ package os
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,8 +38,18 @@ const (
 	ticketEndpointEnv     = "OLARES_TICKET_API"
 	defaultTicketEndpoint = "https://ticket.olares.com"
 	gzipMimeType          = "application/gzip"
-	presignPath       = "/v1/olares-cli/attachments/presigned-upload"
-	ticketPath        = "/v1/olares-cli/tickets"
+	presignPath           = "/v1/olares-cli/attachments/presigned-upload"
+	ticketPath            = "/v1/olares-cli/tickets"
+	headerIdempotencyKey  = "Idempotency-Key"
+
+	// JSON calls (presign / create ticket) are tiny; a long shared timeout
+	// is only for the S3 PUT. Mixing them on one Client also reuses the
+	// Cloudflare connection after a minutes-long upload, which surfaces as
+	// "unexpected EOF" on the follow-up POST.
+	jsonRequestTimeout   = 30 * time.Second
+	tlsHandshakeTimeout  = 45 * time.Second
+	maxTransientAttempts = 3
+	defaultUploadTimeout = 30 * time.Minute
 )
 
 type presignRequest struct {
@@ -73,7 +87,7 @@ type ticketResponse struct {
 }
 
 func newCmdLogsUpload() *cobra.Command {
-	options := &logUploadOptions{Timeout: 30 * time.Minute}
+	options := &logUploadOptions{Timeout: defaultUploadTimeout}
 
 	cmd := &cobra.Command{
 		Use:   "upload",
@@ -85,7 +99,9 @@ only credential required: together with your Olares ID it authorizes this
 upload, no login token is needed.
 
 If --file is omitted, logs are collected first (requires root) and the
-resulting archive is uploaded.`,
+resulting archive is uploaded. If upload or ticket creation fails after
+collection, the archive is kept; retry with --file to skip collecting
+again.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Endpoint = resolveTicketEndpoint(options.Endpoint)
 			if err := runLogsUpload(options); err != nil {
@@ -100,7 +116,7 @@ resulting archive is uploaded.`,
 	cmd.Flags().StringVar(&options.File, "file", "", "Path to an existing log archive to upload; if empty, logs are collected first")
 	cmd.Flags().StringVar(&options.Description, "description", "", "Optional ticket description")
 	cmd.Flags().StringVar(&options.OlaresVersion, "olares-version", "", "Optional Olares version recorded on the ticket")
-	cmd.Flags().DurationVar(&options.Timeout, "timeout", options.Timeout, "HTTP timeout for each upload/API call, raise it for large archives on slow links")
+	cmd.Flags().DurationVar(&options.Timeout, "timeout", options.Timeout, "HTTP timeout for the archive upload to storage, raise it for large archives on slow links")
 
 	_ = cmd.MarkFlagRequired("olares-id")
 	_ = cmd.MarkFlagRequired("code")
@@ -121,51 +137,69 @@ func resolveTicketEndpoint(flagValue string) string {
 }
 
 func runLogsUpload(options *logUploadOptions) error {
+	collected := false
 	archivePath := options.File
+	var cleanup func()
 	if archivePath == "" {
-		collected, cleanup, err := collectForUpload()
-		if cleanup != nil {
-			defer cleanup()
-		}
+		collectedPath, collectedCleanup, err := collectForUpload()
+		cleanup = collectedCleanup
 		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
 			return err
 		}
-		archivePath = collected
+		archivePath = collectedPath
+		collected = true
 	}
 
 	info, err := os.Stat(archivePath)
 	if err != nil {
-		return fmt.Errorf("failed to stat archive %s: %v", archivePath, err)
+		return keepArchiveHint(archivePath, collected, fmt.Errorf("failed to stat archive %s: %v", archivePath, err))
 	}
 	if info.IsDir() {
-		return fmt.Errorf("archive %s is a directory, expected a file", archivePath)
+		return keepArchiveHint(archivePath, collected, fmt.Errorf("archive %s is a directory, expected a file", archivePath))
 	}
 
 	endpoint := strings.TrimRight(options.Endpoint, "/")
 	timeout := options.Timeout
 	if timeout <= 0 {
-		timeout = 30 * time.Minute
+		timeout = defaultUploadTimeout
 	}
-	client := &http.Client{Timeout: timeout}
+	apiClient := newAPIClient()
+	storageClient := newStorageClient(timeout)
 
 	fmt.Fprintln(os.Stderr, "requesting upload URL...")
-	presign, err := requestPresign(client, endpoint, options, filepath.Base(archivePath), info.Size())
+	presign, err := requestPresign(apiClient, endpoint, options, filepath.Base(archivePath), info.Size())
 	if err != nil {
-		return err
+		return keepArchiveHint(archivePath, collected, err)
 	}
 
-	if err := putArchive(client, presign, archivePath, info.Size()); err != nil {
-		return err
+	if err := putArchive(storageClient, presign, archivePath, info.Size()); err != nil {
+		return keepArchiveHint(archivePath, collected, err)
 	}
 
 	fmt.Fprintln(os.Stderr, "creating ticket...")
-	ticket, err := createTicket(client, endpoint, options, presign.AttachmentID)
+	ticket, err := createTicket(apiClient, endpoint, options, presign.AttachmentID, newIdempotencyKey())
 	if err != nil {
-		return err
+		return keepArchiveHint(archivePath, collected, err)
 	}
 
+	if cleanup != nil {
+		cleanup()
+	}
 	fmt.Fprintf(os.Stderr, "logs uploaded, ticket created: %s (%s)\n", ticket.TicketNumber, ticket.TicketID)
 	return nil
+}
+
+// keepArchiveHint leaves a collected temp archive on disk so the user can retry
+// with --file instead of gathering logs again, and points them at that path.
+func keepArchiveHint(archivePath string, collected bool, err error) error {
+	if !collected {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "archive kept at %s\nretry with --file %s to skip collecting again\n", archivePath, archivePath)
+	return err
 }
 
 // collectForUpload runs a full local collection into a temp directory and
@@ -206,7 +240,7 @@ func requestPresign(client *http.Client, endpoint string, options *logUploadOpti
 		IsLargeLog: true,
 	}
 	var resp presignResponse
-	if err := postJSON(client, endpoint+presignPath, reqBody, &resp); err != nil {
+	if err := postJSON(client, endpoint+presignPath, reqBody, nil, &resp); err != nil {
 		return nil, fmt.Errorf("request presigned upload: %w", err)
 	}
 	if resp.UploadURL == "" || resp.AttachmentID == "" {
@@ -216,6 +250,25 @@ func requestPresign(client *http.Client, endpoint string, options *logUploadOpti
 }
 
 func putArchive(client *http.Client, presign *presignResponse, path string, size int64) error {
+	var last error
+	for attempt := 1; attempt <= maxTransientAttempts; attempt++ {
+		if attempt > 1 {
+			fmt.Fprintf(os.Stderr, "retrying upload (attempt %d/%d)...\n", attempt, maxTransientAttempts)
+			sleep(time.Duration(attempt-1) * time.Second)
+		}
+		err := putArchiveOnce(client, presign, path, size)
+		if err == nil {
+			return nil
+		}
+		last = err
+		if !isTransientNetErr(err) {
+			return err
+		}
+	}
+	return last
+}
+
+func putArchiveOnce(client *http.Client, presign *presignResponse, path string, size int64) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("open archive: %v", err)
@@ -229,6 +282,7 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	body, finish := uploadBody(f, size)
 	req, err := http.NewRequest(method, presign.UploadURL, body)
 	if err != nil {
+		finish()
 		return fmt.Errorf("build upload request: %v", err)
 	}
 	req.ContentLength = size
@@ -250,8 +304,8 @@ func putArchive(client *http.Client, presign *presignResponse, path string, size
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("upload archive: storage returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload archive: storage returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 	return nil
 }
@@ -338,7 +392,7 @@ func humanBytes(n int64) string {
 	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
-func createTicket(client *http.Client, endpoint string, options *logUploadOptions, attachmentID string) (*ticketResponse, error) {
+func createTicket(client *http.Client, endpoint string, options *logUploadOptions, attachmentID, idempotencyKey string) (*ticketResponse, error) {
 	reqBody := ticketRequest{
 		OlaresID:      options.OlaresID,
 		Code:          options.Code,
@@ -346,19 +400,50 @@ func createTicket(client *http.Client, endpoint string, options *logUploadOption
 		OlaresVersion: options.OlaresVersion,
 		Attachments:   []attachmentRef{{AttachmentID: attachmentID}},
 	}
+	headers := map[string]string{}
+	if idempotencyKey != "" {
+		headers[headerIdempotencyKey] = idempotencyKey
+	}
 	var resp ticketResponse
-	if err := postJSON(client, endpoint+ticketPath, reqBody, &resp); err != nil {
+	if err := postJSON(client, endpoint+ticketPath, reqBody, headers, &resp); err != nil {
 		return nil, fmt.Errorf("create ticket: %w", err)
 	}
 	return &resp, nil
 }
 
-func postJSON(client *http.Client, url string, payload any, out any) error {
+func postJSON(client *http.Client, url string, payload any, headers map[string]string, out any) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal request: %v", err)
 	}
-	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+	var last error
+	for attempt := 1; attempt <= maxTransientAttempts; attempt++ {
+		if attempt > 1 {
+			sleep(time.Duration(attempt-1) * time.Second)
+		}
+		err := postJSONOnce(client, url, body, headers, out)
+		if err == nil {
+			return nil
+		}
+		last = err
+		if !isTransientNetErr(err) {
+			return err
+		}
+	}
+	return last
+}
+
+func postJSONOnce(client *http.Client, url string, body []byte, headers map[string]string, out any) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -374,6 +459,60 @@ func postJSON(client *http.Client, url string, payload any, out any) error {
 		}
 	}
 	return nil
+}
+
+func newAPIClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DisableKeepAlives = true
+	tr.TLSHandshakeTimeout = tlsHandshakeTimeout
+	return &http.Client{Timeout: jsonRequestTimeout, Transport: tr}
+}
+
+func newStorageClient(timeout time.Duration) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSHandshakeTimeout = tlsHandshakeTimeout
+	return &http.Client{Timeout: timeout, Transport: tr}
+}
+
+func newIdempotencyKey() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("cli-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// sleep is time.Sleep so tests can skip the retry backoff.
+var sleep = time.Sleep
+
+func isTransientNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "tls handshake timeout"):
+		return true
+	case strings.Contains(msg, "unexpected eof"):
+		return true
+	case strings.Contains(msg, "connection reset"):
+		return true
+	case strings.Contains(msg, "broken pipe"):
+		return true
+	case strings.Contains(msg, "http2: server sent goaway"):
+		return true
+	case strings.Contains(msg, "connection refused"):
+		return true
+	default:
+		return false
+	}
 }
 
 // apiError turns a non-2xx ticket API response into a friendly message, adding

--- a/cli/cmd/ctl/os/logs_upload_test.go
+++ b/cli/cmd/ctl/os/logs_upload_test.go
@@ -2,10 +2,14 @@ package os
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // captureStderr swaps os.Stderr for a pipe (never a TTY) and returns whatever
@@ -82,5 +86,123 @@ func TestProgressReaderFinishNoOpWhenNothingDrawn(t *testing.T) {
 	out := captureStderr(t, p.finish)
 	if out != "\n" {
 		t.Errorf("finish after a draw wrote %q, want a single newline", out)
+	}
+}
+
+func TestIsTransientNetErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{io.ErrUnexpectedEOF, true},
+		{io.EOF, true},
+		{fmt.Errorf("upload archive: Put \"https://s3\": net/http: TLS handshake timeout"), true},
+		{fmt.Errorf("create ticket: Post \"https://ticket.olares.com/v1/olares-cli/tickets\": unexpected EOF"), true},
+		{fmt.Errorf("read tcp 10.0.0.1:443: connection reset by peer"), true},
+		{apiError(400, []byte(`{"message":"bad"}`)), false},
+	}
+	for _, tc := range cases {
+		if got := isTransientNetErr(tc.err); got != tc.want {
+			t.Errorf("isTransientNetErr(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestNewIdempotencyKeyFitsTicketAPI(t *testing.T) {
+	a := newIdempotencyKey()
+	b := newIdempotencyKey()
+	if a == b {
+		t.Fatal("expected distinct keys")
+	}
+	if len(a) < 8 || len(a) > 64 {
+		t.Fatalf("key length %d outside ticket API 8–64 bound", len(a))
+	}
+}
+
+func TestPostJSONRetriesTransientThenSucceeds(t *testing.T) {
+	orig := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = orig }()
+
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			conn.Close()
+			return
+		}
+		if got := r.Header.Get(headerIdempotencyKey); got != "retry-key-1" {
+			t.Errorf("Idempotency-Key = %q, want retry-key-1", got)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ticket_id":"id-1","ticket_number":"TKT-1"}`))
+	}))
+	defer srv.Close()
+
+	var out ticketResponse
+	err := postJSON(srv.Client(), srv.URL, map[string]string{"x": "y"}, map[string]string{headerIdempotencyKey: "retry-key-1"}, &out)
+	if err != nil {
+		t.Fatalf("postJSON: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if out.TicketNumber != "TKT-1" {
+		t.Fatalf("ticket_number = %q, want TKT-1", out.TicketNumber)
+	}
+}
+
+func TestPostJSONDoesNotRetryClientErrors(t *testing.T) {
+	orig := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = orig }()
+
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"bad","message":"nope"}`))
+	}))
+	defer srv.Close()
+
+	err := postJSON(srv.Client(), srv.URL, map[string]string{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry on 400)", attempts)
+	}
+}
+
+func TestNewAPIClientDisablesKeepAlives(t *testing.T) {
+	c := newAPIClient()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type %T", c.Transport)
+	}
+	if !tr.DisableKeepAlives {
+		t.Fatal("API client must not reuse connections after a long S3 PUT")
+	}
+	if tr.TLSHandshakeTimeout != tlsHandshakeTimeout {
+		t.Fatalf("TLSHandshakeTimeout = %s, want %s", tr.TLSHandshakeTimeout, tlsHandshakeTimeout)
+	}
+}
+
+func TestKeepArchiveHintOnlyWhenCollected(t *testing.T) {
+	err := fmt.Errorf("upload archive: unexpected EOF")
+	if got := keepArchiveHint("/tmp/x.tar.gz", false, err); got != err {
+		t.Fatalf("not collected: got %v, want original err", got)
+	}
+	out := captureStderr(t, func() {
+		_ = keepArchiveHint("/tmp/x.tar.gz", true, err)
+	})
+	if !strings.Contains(out, "--file /tmp/x.tar.gz") {
+		t.Fatalf("hint missing --file path: %q", out)
 	}
 }


### PR DESCRIPTION
## Summary

Log uploads can fail during ticket creation after the archive has already reached storage. This change improves network recovery and avoids advising an unsafe manual retry when the ticket may already exist.

- Use separate transports for ticket API requests and storage uploads, disable API connection reuse, and increase the storage TLS handshake timeout.
- Retry transient network errors up to three times. Reuse one `Idempotency-Key` across automatic ticket-creation retries.
- Preserve response-body read errors so a truncated 2xx response triggers a retry instead of becoming a JSON decoding error.
- Retain automatically collected archives when upload or ticket creation fails. After a ticket-creation failure, report the attachment ID and ask the user to check AssistHub before retrying.
- Require both `ticket_id` and `ticket_number` before treating ticket creation as confirmed and cleaning up the collected archive.

Manual invocations still generate a new attachment and idempotency key; this change does not add cross-process resume. The CLI help and failure messages make that distinction explicit.

## Validation

- `go test ./cmd/ctl/os` passed with Go 1.25.6.
- Regression tests cover truncated response recovery, stable idempotency keys across retries, exhausted retries retaining the archive without an unconditional retry hint, and missing ticket confirmation fields.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external ticket-platform and storage upload behavior (retries, idempotency, connection handling); misclassification of errors could still cause duplicate tickets or confusing failures, though the change aims to reduce that risk.
> 
> **Overview**
> Hardens **`olares-cli logs upload`** when presign, storage PUT, or ticket creation fails mid-flow—especially after a long upload when the ticket POST hits stale connections or truncated responses.
> 
> **HTTP behavior:** Ticket API calls use a dedicated client (30s timeout, **keep-alives disabled**, longer TLS handshake) separate from the storage upload client (user `--timeout`, default 30m). **Transient network errors** (EOF, timeouts, resets, etc.) retry up to three times on both archive upload and JSON POSTs; **4xx responses are not retried**.
> 
> **Ticket creation:** Sends an **`Idempotency-Key`** (random hex) on create-ticket, **reused across automatic retries** in the same run. Empty or partial JSON on 2xx is treated as failure (body read errors propagate) so truncated success responses can retry instead of silently “succeeding.” Success requires both **`ticket_id` and `ticket_number`** before deleting a collected temp archive.
> 
> **User-facing recovery:** Auto-collected archives are **kept** on presign/upload failure with a **`--file` retry hint**. After ticket creation cannot be confirmed, stderr reports the **attachment ID** and warns to **check AssistHub** before retrying—**no** blanket `--file` advice, to avoid duplicate tickets. Help text documents this split.
> 
> Tests cover upload/JSON retries, idempotency header stability, API client keep-alive settings, archive hints, truncated ticket responses, and end-to-end uncertain-ticket behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80baff38f9179422a5181a82cfcaf959a720bef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->